### PR TITLE
Defaults the service and target ports

### DIFF
--- a/common/replicatedservice/v2/replicatedservice.py
+++ b/common/replicatedservice/v2/replicatedservice.py
@@ -160,8 +160,9 @@ def GenerateServicePorts(context, name):
   Returns:
     A dict containing a port definition
   """
-  service_port = context.properties.get('service_port', None)
-  target_port = context.properties.get('target_port', None)
+  container_port = context.properties.get('container_port', None)
+  target_port = context.properties.get('target_port', container_port)
+  service_port = context.properties.get('service_port', target_port)
   protocol = context.properties.get('protocol')
 
   ports = {}

--- a/common/replicatedservice/v2/replicatedservice.py
+++ b/common/replicatedservice/v2/replicatedservice.py
@@ -160,7 +160,7 @@ def GenerateServicePorts(context, name):
   Returns:
     A dict containing a port definition
   """
-  container_port = context.properties.get('container_port', None)
+  container_port = context.properties['container_port']
   target_port = context.properties.get('target_port', container_port)
   service_port = context.properties.get('service_port', target_port)
   protocol = context.properties.get('protocol')


### PR DESCRIPTION
Since the target port must match the container port, it should default to the container port if not specified. Likewise, if the service port is not specified, it should default to the target port. So, only the container port must be specified to create a replicated service that exposes the container port (e.g., nginx on port 80).
