### PR TITLE
Use values.yaml to configure PVC in mariadb

### DIFF
--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -60,6 +60,9 @@ The following tables lists the configurable parameters of the MariaDB chart and 
 | `mariadbUser`         | Username of new user to create.  | `nil`                                                    |
 | `mariadbPassword`     | Password for the new user.       | `nil`                                                    |
 | `mariadbDatabase`     | Name for new database to create. | `nil`                                                    |
+| `usePersistence`      | Create a volume to store data    | false
+|
+|  `dataVolume`         | Details of persistent volume claim | 
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -99,24 +99,24 @@ You first need to create a persistent disk in the cloud platform your cluster is
 $ gcloud compute disks create --size=500GB --zone=us-central1-a mariadb-data-disk
 ```
 
-### Step 2: Update `templates/deployment.yaml`
+### Step 2: Update `values.yaml`
 
 Replace:
 
 ```yaml
-      volumes:
-      - name: data
-        emptyDir: {}
+# dataVolume:
+#   type: gcePersistentDisk
+#   id: mariadb-data
+#   fsType: ext4
 ```
 
 with
 
 ```yaml
-      volumes:
-      - name: data
-        gcePersistentDisk:
-          pdName: mariadb-data-disk
-          fsType: ext4
+dataVolume:
+   type: gcePersistentDisk
+   id: mariadb-data
+   fsType: ext4
 ```
 
 [Install](#installing-the-chart) the chart after making these changes.

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -62,7 +62,7 @@ The following tables lists the configurable parameters of the MariaDB chart and 
 | `mariadbDatabase`     | Name for new database to create. | `nil`                                                    |
 | `usePersistence`      | Create a volume to store data    | false
 |
-|  `dataVolume`         | Details of persistent volume claim | 
+|  `dataVolume`         | Details of persistent volume claim | 8Gi RW
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 
@@ -94,32 +94,25 @@ As a placeholder, the chart mounts an [emptyDir](http://kubernetes.io/docs/user-
 
 For persistence of the data you should replace the `emptyDir` volume with a persistent [storage volume](http://kubernetes.io/docs/user-guide/volumes/), else the data will be lost if the Pod is shutdown.
 
-### Step 1: Create a persistent disk
+### Step 1: Update `values.yaml` to enable persistence
 
-You first need to create a persistent disk in the cloud platform your cluster is running. For example, on GCE you can use the `gcloud` tool to create a [gcePersistentDisk](http://kubernetes.io/docs/user-guide/volumes/#gcepersistentdisk):
-
-```bash
-$ gcloud compute disks create --size=500GB --zone=us-central1-a mariadb-data-disk
-```
-
-### Step 2: Update `values.yaml`
-
-Replace:
+Replace :
 
 ```yaml
-# dataVolume:
-#   type: gcePersistentDisk
-#   id: mariadb-data
-#   fsType: ext4
+usePersistence: false
 ```
 
 with
 
 ```yaml
-dataVolume:
-   type: gcePersistentDisk
-   id: mariadb-data
-   fsType: ext4
+usePersistence: true
 ```
+
+### Step 2: Update `values.yaml` to set the volume size
+```yaml
+  size: 8Gi
+```
+
+with your desired volume size.
 
 [Install](#installing-the-chart) the chart after making these changes.

--- a/mariadb/templates/_helpers.tpl
+++ b/mariadb/templates/_helpers.tpl
@@ -29,36 +29,3 @@ Get the imagePullPolicy.
     {{- end -}}
   {{- end -}}
 {{- end -}}
-
-{{/*
-Get the data volumeType.
-*/}}
-{{- define "volumeType" -}}
-  {{- if .Values.dataVolume -}}
-    {{- printf "%s:" .Values.dataVolume.type -}}
-  {{- else -}}
-    {{- "emptyDir: {}" -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
-Get the data volumeIdentifier.
-*/}}
-{{- define "volumeIdentifier" -}}
-  {{- if .Values.dataVolume -}}
-    {{- printf "pdName: %s" .Values.dataVolume.id -}}
-  {{- else -}}
-    {{- "" -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
-Get the data volumeFsType.
-*/}}
-{{- define "volumeFsType" -}}
-  {{- if .Values.dataVolume -}}
-    {{- printf "fsType: %s" .Values.dataVolume.fsType -}}
-  {{- else -}}
-    {{- "" -}}
-  {{- end -}}
-{{- end -}}

--- a/mariadb/templates/_helpers.tpl
+++ b/mariadb/templates/_helpers.tpl
@@ -29,3 +29,36 @@ Get the imagePullPolicy.
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Get the data volumeType.
+*/}}
+{{- define "volumeType" -}}
+  {{- if .Values.dataVolume -}}
+    {{- printf "%s:" .Values.dataVolume.type -}}
+  {{- else -}}
+    {{- "emptyDir: {}" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Get the data volumeIdentifier.
+*/}}
+{{- define "volumeIdentifier" -}}
+  {{- if .Values.dataVolume -}}
+    {{- printf "pdName: %s" .Values.dataVolume.id -}}
+  {{- else -}}
+    {{- "" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Get the data volumeFsType.
+*/}}
+{{- define "volumeFsType" -}}
+  {{- if .Values.dataVolume -}}
+    {{- printf "fsType: %s" .Values.dataVolume.fsType -}}
+  {{- else -}}
+    {{- "" -}}
+  {{- end -}}
+{{- end -}}

--- a/mariadb/templates/deployment.yaml
+++ b/mariadb/templates/deployment.yaml
@@ -57,4 +57,6 @@ spec:
           mountPath: /bitnami/mariadb
       volumes:
       - name: data
-        emptyDir: {}
+        {{ template "volumeType" . }}
+          {{ template "volumeIdentifier" . }}
+          {{ template "volumeFsType" . }}

--- a/mariadb/templates/deployment.yaml
+++ b/mariadb/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           mountPath: /bitnami/mariadb
       volumes:
       - name: data
-        {{ template "volumeType" . }}
-          {{ template "volumeIdentifier" . }}
-          {{ template "volumeFsType" . }}
+      {{- if .Values.dataVolume }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}

--- a/mariadb/templates/deployment.yaml
+++ b/mariadb/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           mountPath: /bitnami/mariadb
       volumes:
       - name: data
-      {{- if .Values.dataVolume }}
+      {{- if .Values.usePersistence }}
         persistentVolumeClaim:
           claimName: {{ template "fullname" . }}
       {{- else }}

--- a/mariadb/templates/pvc.yaml
+++ b/mariadb/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.usePersistence }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.dataVolume.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.dataVolume.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.dataVolume.size | quote }}
+{{- end }}

--- a/mariadb/values.yaml
+++ b/mariadb/values.yaml
@@ -25,3 +25,9 @@ imageTag: 10.1.14-r3
 ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
 ##
 # mariadbDatabase:
+
+## Persist data to a persitent disk
+# dataVolume:
+#   type: gcePersistentDisk
+#   id: mariadb-data
+#   fsType: ext4

--- a/mariadb/values.yaml
+++ b/mariadb/values.yaml
@@ -27,7 +27,8 @@ imageTag: 10.1.14-r3
 # mariadbDatabase:
 
 ## Persist data to a persitent disk
-# dataVolume:
-#   type: gcePersistentDisk
-#   id: mariadb-data
-#   fsType: ext4
+usePersistence: false
+dataVolume:
+  storageClass: generic
+  accessMode: ReadWriteOnce
+  size: 8Gi


### PR DESCRIPTION
I am opening this mostly to talk through the best practices for configuration of PDs for charts.

The original approach in the MariaDB chart is to have users edit the deployment. While I think this is reasonable, I think it would be better if users were not changing deployment templates and instead only changing things that were explicitly exposed through the values file.

The approach I use here is to have templates for each section of the volume. What I wanted to do (but couldn't figure out with templating/sprig) was to insert the dict as is from values->deployment. If that had worked I would have just had a dataVolume section in values.yaml that listed the exact hierarchy i wanted to nest under the data volume definition.
