### PR TITLE
use correct port names for SRV records

### DIFF
--- a/incubator/etcd/templates/etcd-petset.yaml
+++ b/incubator/etcd/templates/etcd-petset.yaml
@@ -15,9 +15,9 @@ metadata:
 spec:
   ports:
   - port: {{.Values.PeerPort}}
-    name: peer
+    name: etcd-server
   - port: {{.Values.ClientPort}}
-    name: client
+    name: etcd-client
   clusterIP: None
   selector:
     component: "{{.Release.Name}}-{{.Values.Component}}"


### PR DESCRIPTION
according to https://coreos.com/etcd/docs/latest/clustering.html DNS SRV records should be formatted like:

```
_etcd-server-ssl._tcp.example.com
_etcd-server._tcp.example.com
_etcd-client._tcp.example.com
_etcd-client-ssl._tcp.example.com
```

changing the port names on the service accomplishes that.

```
$ dig +noall +answer SRV _etcd-server._tcp.luminous-leopard-etcd.default.svc.cluster.local
_etcd-server._tcp.luminous-leopard-etcd.default.svc.cluster.local. 30 IN SRV 10 20 2379 luminous-leopard-etcd-1.luminous-leopard-etcd.default.svc.cluster.local.
...

$ ./etcdctl -discovery-srv luminous-leopard-etcd.default.svc.cluster.local set /foo bar
bar
```

could make sense to also change it on the petset spec to keep it consistent.
