### PR TITLE
grep for correct member name to populate file

### DIFF
--- a/incubator/etcd/templates/etcd-petset.yaml
+++ b/incubator/etcd/templates/etcd-petset.yaml
@@ -103,7 +103,7 @@ spec:
             # store member id into PVC for later member replacement
             collect_member() {
                 while ! etcdctl member list &>/dev/null; do sleep 1; done
-                etcdctl member list | grep ${HOSTNAME}.etcd | cut -d':' -f1 | cut -d'[' -f1 > /var/run/etcd/member_id
+                etcdctl member list | grep http://${HOSTNAME}.${PETSET_NAME}:2380 | cut -d':' -f1 | cut -d'[' -f1 > /var/run/etcd/member_id
                 exit 0
             }
 


### PR DESCRIPTION
rejoining the cluster after a node failure fails with:

```
Re-joining etcd member
Provide an ID and a list of comma separated peerURL (0xabcd http://example.com,http://example1.com)
```

it seems to me the `member list` is grep'd for the wrong member url and therefore `/var/run/etcd/member_id` is empty.

this PR fixed it for me putting the correct member ID in the file. rejoining the cluster succeeds with:

```
Re-joining etcd member
Updated member with ID b7d47b5029da04b0 in cluster
```
