### PR TITLE
add helm v2 chart for patroni with petset

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,0 +1,12 @@
+name: patroni
+description: "Highly available elephant herd: HA PostgreSQL cluster."
+version: 0.1.0
+home: https://github.com/zalando/patroni
+sources:
+  - https://github.com/zalando/patroni
+  - https://github.com/zalando/spilo
+maintainers:
+  - name: Team ACID @ Zalando SE
+    email: team-acid@zalando.de
+  - name: Team Teapot @ Zalando SE
+    email: team-teapot@zalando.de

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -26,7 +26,7 @@ Download the latest release of the chart from the [releases](../../../releases) 
 
 Alternatively, clone the repo if you wish to use the development snapshot:
 
-```bash
+```console
 $ git clone https://github.com/kubernetes/charts.git
 ```
 
@@ -34,7 +34,7 @@ $ git clone https://github.com/kubernetes/charts.git
 
 To install the chart with the release name `my-release`:
 
-```bash
+```console
 $ helm install --name my-release patroni-x.x.x.tgz
 ```
 
@@ -65,7 +65,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
-```bash
+```console
 $ helm install --name my-release -f values.yaml patroni-x.x.x.tgz
 ```
 
@@ -75,7 +75,7 @@ $ helm install --name my-release -f values.yaml patroni-x.x.x.tgz
 
 In order to remove everything you created a simple `helm delete <release-name>` isn't enough (as of now), but you can do the following:
 
-```bash
 $ helm delete <release-name>
 $ kubectl delete petset,po,pvc,svc,secret -l release=<release-name>
+```console
 ```

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -57,7 +57,7 @@ The following tables lists the configurable parameters of the patroni chart and 
 | `Credentials.Superuser` | password for the superuser          | `tea`                                               |
 | `Credentials.Admin`     | password for the admin user         | `cola`                                              |
 | `Credentials.Standby`   | password for the replication user   | `pinacolada`                                        |
-| `Etcd.Discovery`        | domain name serving DNS records for etcd              | `etcd.default.svc.cluster.local`  |
+| `Etcd.Discovery`        | domain name of etcd cluster         | `<release-name>-etcd.<namespace>.svc.cluster.local` |
 | `GCS.Credentials`       | Google service account key file for authentication    | `<needs to be defined>`           |
 | `GCS.Bucket`            | GCS bucket name to stream WAL files and base backups  | `some-google-bucket`              |
 
@@ -70,3 +70,12 @@ $ helm install --name my-release -f values.yaml patroni-x.x.x.tgz
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Cleanup
+
+In order to remove everything you created a simple `helm delete <release-name>` isn't enough (as of now), but you can do the following:
+
+```bash
+$ helm delete <release-name>
+$ kubectl delete petset,po,pvc,svc,secret -l release=<release-name>
+```

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -100,3 +100,20 @@ $ kubectl delete petset,po -l release=$release
 $ sleep $grace
 $ kubectl delete pvc -l release=$release
 ```
+
+## Internals
+
+Patroni is responsible for electing a Postgres master pod by leveraging etcd.
+It then exports this master via a Kubernetes service and a label query that filters for `spilo-role=master`.
+This label is dynamically set on the pod that acts as the master and removed from all other pods.
+Consequently, the service endpoint will point to the current master.
+
+```console
+$ kubectl get pods -l spilo-role -L spilo-role
+NAME                   READY     STATUS    RESTARTS   AGE       SPILO-ROLE
+my-release-patroni-0   1/1       Running   0          9m        replica
+my-release-patroni-1   1/1       Running   0          9m        master
+my-release-patroni-2   1/1       Running   0          8m        replica
+my-release-patroni-3   1/1       Running   0          8m        replica
+my-release-patroni-4   1/1       Running   0          8m        replica
+```

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -38,6 +38,23 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release patroni-x.x.x.tgz
 ```
 
+## Connecting to Postgres
+
+Your access point is a cluster IP. In order to access it spin up another pod:
+
+```console
+$ kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il
+```
+
+Then, from inside the pod, connect to postgres:
+
+```console
+$ apt-get update && apt-get install postgresql-client -y
+$ psql -U admin -h my-release-patroni.default.svc.cluster.local postgres
+<admin password from values.yaml>
+postgres=>
+```
+
 ## Configuration
 
 The following tables lists the configurable parameters of the patroni chart and their default values.

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -75,7 +75,11 @@ $ helm install --name my-release -f values.yaml patroni-x.x.x.tgz
 
 In order to remove everything you created a simple `helm delete <release-name>` isn't enough (as of now), but you can do the following:
 
-$ helm delete <release-name>
-$ kubectl delete petset,po,pvc,svc,secret -l release=<release-name>
 ```console
+$ release=<release-name>
+$ helm delete $release
+$ grace=$(kubectl get po $release-patroni-0 --template '{{.spec.terminationGracePeriodSeconds}}')
+$ kubectl delete petset,po -l release=$release
+$ sleep $grace
+$ kubectl delete pvc -l release=$release
 ```

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -75,8 +75,6 @@ The following tables lists the configurable parameters of the patroni chart and 
 | `Credentials.Admin`     | password for the admin user         | `cola`                                              |
 | `Credentials.Standby`   | password for the replication user   | `pinacolada`                                        |
 | `Etcd.Discovery`        | domain name of etcd cluster         | `<release-name>-etcd.<namespace>.svc.cluster.local` |
-| `GCS.Credentials`       | Google service account key file for authentication    | `<needs to be defined>`           |
-| `GCS.Bucket`            | GCS bucket name to stream WAL files and base backups  | `some-google-bucket`              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -1,0 +1,72 @@
+# Patroni Helm Chart
+
+This directory contains a Kubernetes chart to deploy a five node patroni cluster using a petset.
+
+## Prerequisites Details
+* Kubernetes 1.3 with alpha APIs enable
+* PV support on the underlying infrastructure
+
+## PetSet Details
+* http://kubernetes.io/docs/user-guide/petset/
+
+## PetSet Caveats
+* http://kubernetes.io/docs/user-guide/petset/#alpha-limitations
+
+## Todo
+* Make namespace configurable
+
+## Chart Details
+This chart will do the following:
+
+* Implement a HA scalable PostgreSQL cluster using Kubernetes PetSets
+
+## Get this chart
+
+Download the latest release of the chart from the [releases](../../../releases) page.
+
+Alternatively, clone the repo if you wish to use the development snapshot:
+
+```bash
+$ git clone https://github.com/kubernetes/charts.git
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release patroni-x.x.x.tgz
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the patroni chart and their default values.
+
+|       Parameter         |           Description               |                         Default                     |
+|-------------------------|-------------------------------------|-----------------------------------------------------|
+| `Name`                  | Service name                        | `patroni`                                           |
+| `Namespace`             | Service namespace                   | `default`                                           |
+| `Spilo.Image`           | Container image name                | `registry.opensource.zalan.do/acid/spilo-9.5`       |
+| `Spilo.Version`         | Container image tag                 | `1.0-p5`                                            |
+| `ImagePullPolicy`       | Container pull policy               | `IfNotPresent`                                      |
+| `Replicas`              | k8s petset replicas                 | `5`                                                 |
+| `Component`             | k8s selector key                    | `patroni`                                           |
+| `Resources.Cpu`         | container requested cpu             | `100m`                                              |
+| `Resources.Memory`      | container requested memory          | `512Mi`                                             |
+| `Resources.Storage`     | Persistent volume size              | `1Gi`                                               |
+| `Credentials.Superuser` | password for the superuser          | `tea`                                               |
+| `Credentials.Admin`     | password for the admin user         | `cola`                                              |
+| `Credentials.Standby`   | password for the replication user   | `pinacolada`                                        |
+| `Etcd.Discovery`        | domain name serving DNS records for etcd              | `etcd.default.svc.cluster.local`  |
+| `GCS.Credentials`       | Google service account key file for authentication    | `<needs to be defined>`           |
+| `GCS.Bucket`            | GCS bucket name to stream WAL files and base backups  | `some-google-bucket`              |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml patroni-x.x.x.tgz
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/incubator/patroni/charts/etcd/.helmignore
+++ b/incubator/patroni/charts/etcd/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/patroni/charts/etcd/Chart.yaml
+++ b/incubator/patroni/charts/etcd/Chart.yaml
@@ -1,0 +1,9 @@
+name: etcd
+home: https://github.com/coreos/etcd
+version: 0.1.0
+description: Etcd Helm chart for Kubernetes.
+sources:
+  - https://github.com/coreos/etcd
+maintainers:
+  - name: Lachlan Evenson
+    email: lachlan@deis.com

--- a/incubator/patroni/charts/etcd/README.md
+++ b/incubator/patroni/charts/etcd/README.md
@@ -1,0 +1,178 @@
+# Etcd Helm Chart
+
+Credit to https://github.com/ingvagabund. This is an implementation of that work
+
+* https://github.com/kubernetes/contrib/pull/1295
+
+## Prerequisites Details
+* Kubernetes 1.3 with alpha APIs enable
+* PV support on the underlying infrastructure
+
+## PetSet Details
+* http://kubernetes.io/docs/user-guide/petset/
+
+## PetSet Caveats
+* http://kubernetes.io/docs/user-guide/petset/#alpha-limitations
+
+## Todo
+* Implement SSL
+
+## Chart Details
+This chart will do the following:
+
+* Implemented a dynamically scalable etcd cluster using Kubernetes PetSets
+
+## Get this chart
+
+Download the latest release of the chart from the [releases](../../../releases) page.
+
+Alternatively, clone the repo if you wish to use the development snapshot:
+
+```bash
+$ git clone https://github.com/kubernetes/charts.git
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release etcd-x.x.x.tgz
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the etcd chart and their default values.
+
+|       Parameter       |           Description            |                         Default                          |
+|-----------------------|----------------------------------|----------------------------------------------------------|
+| `Name`         | Spark master name                | `etcd`                                           |
+| `Image`        | Container image name             | `gcr.io/google_containers/etcd-amd64`                         |
+| `ImageTag`     | Container image tag              | `2.2.5`                                               |
+| `ImagePullPolicy`     | Container pull policy     | `Always`                                               |
+| `Replicas`     | k8s petset replicas          | `3`                                                      |
+| `Component`    | k8s selector key                 | `etcd`                                           |
+| `Cpu`          | container requested cpu          | `100m`                                                   |
+| `Memory`    |container requested memory                 | `512Mi`                                           |
+| `ClientPort`  | k8s service port                 | `2379`                                                   |
+| `PeerPorts`| Container listening port         | `2380`                                                   |
+| `Storage`| Persistent volume size         | `1Gi`                                                   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml etcd-x.x.x.tgz
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+# Deep dive
+
+## Cluster Health
+
+```
+$ for i in <0..n>; do kubectl exec <release-podname-$i> -- sh -c 'etcdctl cluster-health'; done
+```
+eg.
+```
+$ for i in {0..9}; do kubectl exec named-lynx-etcd-$i --namespace=etcd -- sh -c 'etcdctl cluster-health'; done
+member 7878c44dabe58db is healthy: got healthy result from http://named-lynx-etcd-7.named-lynx-etcd:2379
+member 19d2ab7b415341cc is healthy: got healthy result from http://named-lynx-etcd-4.named-lynx-etcd:2379
+member 6b627d1b92282322 is healthy: got healthy result from http://named-lynx-etcd-3.named-lynx-etcd:2379
+member 6bb377156d9e3fb3 is healthy: got healthy result from http://named-lynx-etcd-0.named-lynx-etcd:2379
+member 8ebbb00c312213d6 is healthy: got healthy result from http://named-lynx-etcd-8.named-lynx-etcd:2379
+member a32e3e8a520ff75f is healthy: got healthy result from http://named-lynx-etcd-5.named-lynx-etcd:2379
+member dc83003f0a226816 is healthy: got healthy result from http://named-lynx-etcd-2.named-lynx-etcd:2379
+member e3dc94686f60465d is healthy: got healthy result from http://named-lynx-etcd-6.named-lynx-etcd:2379
+member f5ee1ca177a88a58 is healthy: got healthy result from http://named-lynx-etcd-1.named-lynx-etcd:2379
+cluster is healthy
+```
+
+## Failover
+
+If any etcd member fails it gets re-joined eventually.
+You can test the scenario by killing process of one of the pets:
+
+```shell
+$ ps aux | grep etcd-1
+$ kill -9 ETCD_1_PID
+```
+
+```shell
+$ kubectl get pods -l "app=etcd"
+NAME                 READY     STATUS        RESTARTS   AGE
+etcd-0               1/1       Running       0          54s
+etcd-2               1/1       Running       0          51s
+```
+
+After a while:
+
+```shell
+$ kubectl get pods -l "app=etcd"
+NAME                 READY     STATUS    RESTARTS   AGE
+etcd-0               1/1       Running   0          1m
+etcd-1               1/1       Running   0          20s
+etcd-2               1/1       Running   0          1m
+```
+
+You can check state of re-joining from ``etcd-1``'s logs:
+
+```shell
+$ kubectl logs etcd-1
+Waiting for etcd-0.etcd to come up
+Waiting for etcd-1.etcd to come up
+ping: bad address 'etcd-1.etcd'
+Waiting for etcd-1.etcd to come up
+Waiting for etcd-2.etcd to come up
+Re-joining etcd member
+Updated member with ID 7fd61f3f79d97779 in cluster
+2016-06-20 11:04:14.962169 I | etcdmain: etcd Version: 2.2.5
+2016-06-20 11:04:14.962287 I | etcdmain: Git SHA: bc9ddf2
+...
+```
+
+## Scaling using kubectl
+
+This is for reference. Scaling should be managed by `helm upgrade`
+
+The etcd cluster can be scale up by running ``kubectl patch`` or ``kubectl edit``. For instance,
+
+```sh
+$ kubectl get pods -l "app=etcd"
+NAME      READY     STATUS    RESTARTS   AGE
+etcd-0    1/1       Running   0          7m
+etcd-1    1/1       Running   0          7m
+etcd-2    1/1       Running   0          6m
+
+$ kubectl patch petset/etcd -p '{"spec":{"replicas": 5}}'
+"etcd" patched
+
+$ kubectl get pods -l "app=etcd"
+NAME      READY     STATUS    RESTARTS   AGE
+etcd-0    1/1       Running   0          8m
+etcd-1    1/1       Running   0          8m
+etcd-2    1/1       Running   0          8m
+etcd-3    1/1       Running   0          4s
+etcd-4    1/1       Running   0          1s
+```
+
+Scaling-down is similar. For instance, changing the number of pets to ``4``:
+
+```sh
+$ kubectl edit petset/etcd
+petset "etcd" edited
+
+$ kubectl get pods -l "app=etcd"
+NAME      READY     STATUS    RESTARTS   AGE
+etcd-0    1/1       Running   0          8m
+etcd-1    1/1       Running   0          8m
+etcd-2    1/1       Running   0          8m
+etcd-3    1/1       Running   0          4s
+```
+
+Once a pet is terminated (either by running ``kubectl delete pod etcd-ID`` or scaling down),
+content of ``/var/run/etcd/`` directory is cleaned up.
+If any of the etcd pets restarts (e.g. caused by etcd failure or any other),
+the directory is kept untouched so the pet can recover from the failure.

--- a/incubator/patroni/charts/etcd/templates/etcd-petset.yaml
+++ b/incubator/patroni/charts/etcd/templates/etcd-petset.yaml
@@ -1,0 +1,212 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+  annotations:
+    "helm.sh/created": {{.Release.Time.Seconds | quote }}
+spec:
+  ports:
+  - port: {{.Values.PeerPort}}
+    name: etcd-server
+  - port: {{.Values.ClientPort}}
+    name: etcd-client
+  clusterIP: None
+  selector:
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+---
+apiVersion: apps/v1alpha1
+kind: PetSet
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+  annotations:
+    "helm.sh/created": {{.Release.Time.Seconds | quote }}
+spec:
+  serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  replicas: {{default 3 .Values.Replicas | quote }}
+  template:
+    metadata:
+      name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        component: "{{.Release.Name}}-{{.Values.Component}}"
+      annotations:
+        "helm.sh/created": {{.Release.Time.Seconds | quote }}
+        pod.alpha.kubernetes.io/initialized: "true"
+    spec:
+      containers:
+      - name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+        image: "{{.Values.Image}}:{{.Values.ImageTag}}"
+        imagePullPolicy: "{{.Values.ImagePullPolicy}}"
+        ports:
+        - containerPort: {{.Values.PeerPort}}
+          name: peer
+        - containerPort: {{.Values.ClientPort}}
+          name: client
+        resources:
+          requests:
+            cpu: "{{.Values.Cpu}}"
+            memory: "{{.Values.Memory}}"
+        env:
+        - name: INITIAL_CLUSTER_SIZE
+          value: {{default 3 .Values.Replicas | quote }}
+        - name: PETSET_NAME
+          value: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+        volumeMounts:
+        - name: datadir
+          mountPath: /var/run/etcd
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - "/bin/sh"
+                - "-ec"
+                - |
+                  EPS=""
+                  for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                      EPS="${EPS}${EPS:+,}http://${PETSET_NAME}-${i}.${PETSET_NAME}:2379"
+                  done
+
+                  HOSTNAME=$(hostname)
+
+                  member_hash() {
+                      etcdctl member list | grep http://${HOSTNAME}.${PETSET_NAME}:2380 | cut -d':' -f1 | cut -d'[' -f1
+                  }
+
+                  echo "Removing ${HOSTNAME} from etcd cluster"
+
+                  ETCDCTL_ENDPOINT=${EPS} etcdctl member remove $(member_hash)
+                  if [ $? -eq 0 ]; then
+                      # Remove everything otherwise the cluster will no longer scale-up
+                      rm -rf /var/run/etcd/*
+                  fi
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            HOSTNAME=$(hostname)
+
+            # store member id into PVC for later member replacement
+            collect_member() {
+                while ! etcdctl member list &>/dev/null; do sleep 1; done
+                etcdctl member list | grep http://${HOSTNAME}.${PETSET_NAME}:2380 | cut -d':' -f1 | cut -d'[' -f1 > /var/run/etcd/member_id
+                exit 0
+            }
+
+            eps() {
+                EPS=""
+                for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                    EPS="${EPS}${EPS:+,}http://${PETSET_NAME}-${i}.${PETSET_NAME}:2379"
+                done
+                echo ${EPS}
+            }
+
+            member_hash() {
+                etcdctl member list | grep http://${HOSTNAME}.${PETSET_NAME}:2380 | cut -d':' -f1 | cut -d'[' -f1
+            }
+
+            # re-joining after failure?
+            if [ -e /var/run/etcd/default.etcd ]; then
+                echo "Re-joining etcd member"
+                member_id=$(cat /var/run/etcd/member_id)
+
+                # re-join member
+                ETCDCTL_ENDPOINT=$(eps) etcdctl member update ${member_id} http://${HOSTNAME}.${PETSET_NAME}:2380
+                exec etcd --name ${HOSTNAME} \
+                    --listen-peer-urls http://${HOSTNAME}.${PETSET_NAME}:2380 \
+                    --listen-client-urls http://${HOSTNAME}.${PETSET_NAME}:2379,http://127.0.0.1:2379 \
+                    --advertise-client-urls http://${HOSTNAME}.${PETSET_NAME}:2379 \
+                    --data-dir /var/run/etcd/default.etcd
+            fi
+
+            # etcd-PET_ID
+            PET_ID=${HOSTNAME:5:${#HOSTNAME}}
+
+            # adding a new member to existing cluster (assuming all initial pets are available)
+            if [ "${PET_ID}" -ge ${INITIAL_CLUSTER_SIZE} ]; then
+                export ETCDCTL_ENDPOINT=$(eps)
+
+                # member already added?
+                MEMBER_HASH=$(member_hash)
+                if [ -n "${MEMBER_HASH}" ]; then
+                    # the member hash exists but for some reason etcd failed
+                    # as the datadir has not be created, we can remove the member
+                    # and retrieve new hash
+                    etcdctl member remove ${MEMBER_HASH}
+                fi
+
+                echo "Adding new member"
+                etcdctl member add ${HOSTNAME} http://${HOSTNAME}.${PETSET_NAME}:2380 | grep "^ETCD_" > /var/run/etcd/new_member_envs
+
+                if [ $? -ne 0 ]; then
+                    echo "Exiting"
+                    rm -f /var/run/etcd/new_member_envs
+                    exit 1
+                fi
+
+                cat /var/run/etcd/new_member_envs
+                source /var/run/etcd/new_member_envs
+
+                collect_member &
+
+                exec etcd --name ${HOSTNAME} \
+                    --listen-peer-urls http://${HOSTNAME}.${PETSET_NAME}:2380 \
+                    --listen-client-urls http://${HOSTNAME}.${PETSET_NAME}:2379,http://127.0.0.1:2379 \
+                    --advertise-client-urls http://${HOSTNAME}.${PETSET_NAME}:2379 \
+                    --data-dir /var/run/etcd/default.etcd \
+                    --initial-advertise-peer-urls http://${HOSTNAME}.${PETSET_NAME}:2380 \
+                    --initial-cluster ${ETCD_INITIAL_CLUSTER} \
+                    --initial-cluster-state ${ETCD_INITIAL_CLUSTER_STATE}
+            fi
+
+            for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                while true; do
+                    echo "Waiting for ${PETSET_NAME}-${i}.${PETSET_NAME} to come up"
+                    ping -W 1 -c 1 ${PETSET_NAME}-${i}.${PETSET_NAME} > /dev/null && break
+                    sleep 1s
+                done
+            done
+
+            PEERS=""
+            for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                PEERS="${PEERS}${PEERS:+,}${PETSET_NAME}-${i}=http://${PETSET_NAME}-${i}.${PETSET_NAME}:2380"
+            done
+
+            collect_member &
+
+            # join member
+            exec etcd --name ${HOSTNAME} \
+                --initial-advertise-peer-urls http://${HOSTNAME}.${PETSET_NAME}:2380 \
+                --listen-peer-urls http://${HOSTNAME}.${PETSET_NAME}:2380 \
+                --listen-client-urls http://${HOSTNAME}.${PETSET_NAME}:2379,http://127.0.0.1:2379 \
+                --advertise-client-urls http://${HOSTNAME}.${PETSET_NAME}:2379 \
+                --initial-cluster-token etcd-cluster-1 \
+                --initial-cluster ${PEERS} \
+                --initial-cluster-state new \
+                --data-dir /var/run/etcd/default.etcd
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          # upstream recommended max is 700M
+          storage: "{{.Values.Storage}}"

--- a/incubator/patroni/charts/etcd/values.yaml
+++ b/incubator/patroni/charts/etcd/values.yaml
@@ -1,0 +1,16 @@
+# Default values for etcd.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+Name: etcd
+PeerPort: 2380
+ClientPort: 2379
+Component: "etcd"
+Replicas: 3
+Image: "gcr.io/google_containers/etcd-amd64"
+ImageTag: "2.2.5"
+ImagePullPolicy: "Always"
+Cpu: "100m"
+Memory: "512Mi"
+Storage: "1Gi"

--- a/incubator/patroni/templates/ps-patroni.yaml
+++ b/incubator/patroni/templates/ps-patroni.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1alpha1
+kind: PetSet
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+  namespace: {{ .Values.Namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+  annotations:
+    "helm.sh/created": {{ .Release.Time.Seconds | quote }}
+spec:
+  serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  replicas: {{default 5 .Values.Replicas | quote }}
+  template:
+    metadata:
+      name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        component: "{{.Release.Name}}-{{.Values.Component}}"
+      annotations:
+        "helm.sh/created": {{.Release.Time.Seconds | quote }}
+        pod.alpha.kubernetes.io/initialized: "true"
+    spec:
+      containers:
+      - name: spilo
+        image: {{ .Values.Spilo.Image }}:{{ .Values.Spilo.Version }}
+        env:
+        - name: PGPASSWORD_SUPERUSER
+          valueFrom:
+            secretKeyRef:
+              name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+              key: password.superuser
+        - name: PGPASSWORD_ADMIN
+          valueFrom:
+            secretKeyRef:
+              name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+              key: password.admin
+        - name: PGPASSWORD_STANDBY
+          valueFrom:
+            secretKeyRef:
+              name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+              key: password.standby
+        - name: ETCD_DISCOVERY_DOMAIN
+          value: {{ .Values.Etcd.Discovery }}
+        - name: SCOPE
+          value: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+        - name: WAL_GCS_BUCKET
+          value: {{ .Values.GCS.Bucket }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/patroni/gcloud-credentials.json
+        - name: PGROOT
+          value: /home/postgres/pgdata/pgroot
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 8008
+        - containerPort: 5432
+        resources:
+          requests:
+            cpu: "{{.Values.Resources.Cpu}}"
+            memory: "{{.Values.Resources.Memory}}"
+        volumeMounts:
+        - name: pgdata
+          mountPath: /home/postgres/pgdata
+        - mountPath: /etc/patroni
+          name: patroni-config
+          readOnly: true
+      volumes:
+      - name: patroni-config
+        secret:
+          secretName: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+  volumeClaimTemplates:
+  - metadata:
+      name: pgdata
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: "{{.Values.Resources.Storage}}"

--- a/incubator/patroni/templates/ps-patroni.yaml
+++ b/incubator/patroni/templates/ps-patroni.yaml
@@ -45,7 +45,7 @@ spec:
               name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
               key: password.standby
         - name: ETCD_DISCOVERY_DOMAIN
-          value: {{ .Values.Etcd.Discovery }}
+          value: {{default (printf "%s-etcd.%s.svc.cluster.local" .Release.Name .Values.Namespace) .Values.Etcd.Discovery }}
         - name: SCOPE
           value: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
         - name: WAL_GCS_BUCKET

--- a/incubator/patroni/templates/ps-patroni.yaml
+++ b/incubator/patroni/templates/ps-patroni.yaml
@@ -48,10 +48,8 @@ spec:
           value: {{default (printf "%s-etcd.%s.svc.cluster.local" .Release.Name .Values.Namespace) .Values.Etcd.Discovery }}
         - name: SCOPE
           value: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
-        - name: WAL_GCS_BUCKET
-          value: {{ .Values.GCS.Bucket }}
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/patroni/gcloud-credentials.json
+        - name: USE_WALE
+          value: ""
         - name: PGROOT
           value: /home/postgres/pgdata/pgroot
         - name: POD_NAMESPACE

--- a/incubator/patroni/templates/sec-patroni.yaml
+++ b/incubator/patroni/templates/sec-patroni.yaml
@@ -12,7 +12,6 @@ metadata:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 type: Opaque
 data:
-  gcloud-credentials.json: {{ .Values.GCS.Credentials | b64enc }}
   password.superuser: {{ .Values.Credentials.Superuser | b64enc }}
   password.admin: {{ .Values.Credentials.Admin | b64enc }}
   password.standby: {{ .Values.Credentials.Standby | b64enc }}

--- a/incubator/patroni/templates/sec-patroni.yaml
+++ b/incubator/patroni/templates/sec-patroni.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+  namespace: {{ .Values.Namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+  annotations:
+    "helm.sh/created": {{.Release.Time.Seconds | quote }}
+type: Opaque
+data:
+  gcloud-credentials.json: {{ .Values.GCS.Credentials | b64enc }}
+  password.superuser: {{ .Values.Credentials.Superuser | b64enc }}
+  password.admin: {{ .Values.Credentials.Admin | b64enc }}
+  password.standby: {{ .Values.Credentials.Standby | b64enc }}

--- a/incubator/patroni/templates/svc-patroni.yaml
+++ b/incubator/patroni/templates/svc-patroni.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  namespace: {{ .Values.Namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+  annotations:
+    "helm.sh/created": {{.Release.Time.Seconds | quote }}
+spec:
+  selector:
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+    spilo-role: master
+  ports:
+  - port: 5432

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -22,7 +22,7 @@ Credentials:
   Standby: pinacolada
 
 Etcd:
-  Discovery: etcd.default.svc.cluster.local
+  Discovery: # leave blank to use vendored etcd chart
 
 GCS:
   Credentials: |

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -29,18 +29,3 @@ Credentials:
 # Patroni depends on etcd, configure it here
 Etcd:
   Discovery: # leave blank to use vendored etcd chart
-
-# Enable backups to Google cloud storage
-# Speeds up the replication process in case of failure
-GCS:
-  # Google credentials for a service account that has
-  # read and write access to the configure GCS bucket
-  Credentials: |
-    {
-      "type": "service_account",
-      "project_id": "...",
-      "private_key_id": "...",
-      ...
-    }
-  # The Google cloud storage bucket to use
-  Bucket: some-google-bucket

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -1,0 +1,35 @@
+Name: patroni
+Namespace: default # TODO: make this actually configurable
+
+Component: patroni
+ImagePullPolicy: IfNotPresent
+
+Spilo:
+  # this image was built from https://github.com/zalando/spilo/tree/master/postgres-appliance
+  Image: registry.opensource.zalan.do/acid/spilo-9.5
+  Version: 1.0-p5
+
+Replicas: 5
+
+Resources:
+  Cpu: 100m
+  Memory: 512Mi
+  Storage: 1Gi
+
+Credentials:
+  Superuser: tea
+  Admin: cola
+  Standby: pinacolada
+
+Etcd:
+  Discovery: etcd.default.svc.cluster.local
+
+GCS:
+  Credentials: |
+    {
+      "type": "service_account",
+      "project_id": "...",
+      "private_key_id": "...",
+      ...
+    }
+  Bucket: some-google-bucket

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -4,27 +4,37 @@ Namespace: default # TODO: make this actually configurable
 Component: patroni
 ImagePullPolicy: IfNotPresent
 
+# The image to use. Spilo is the dockerized Patroni
 Spilo:
   # this image was built from https://github.com/zalando/spilo/tree/master/postgres-appliance
   Image: registry.opensource.zalan.do/acid/spilo-9.5
   Version: 1.0-p5
 
+# How many postgres containers to spawn
 Replicas: 5
 
+# Resource limits per replica
 Resources:
   Cpu: 100m
   Memory: 512Mi
   Storage: 1Gi
 
+# Credentials used by Patroni
+# * more information: https://github.com/zalando/patroni/blob/master/docs/SETTINGS.rst#postgresql
 Credentials:
   Superuser: tea
   Admin: cola
   Standby: pinacolada
 
+# Patroni depends on etcd, configure it here
 Etcd:
   Discovery: # leave blank to use vendored etcd chart
 
+# Enable backups to Google cloud storage
+# Speeds up the replication process in case of failure
 GCS:
+  # Google credentials for a service account that has
+  # read and write access to the configure GCS bucket
   Credentials: |
     {
       "type": "service_account",
@@ -32,4 +42,5 @@ GCS:
       "private_key_id": "...",
       ...
     }
+  # The Google cloud storage bucket to use
   Bucket: some-google-bucket


### PR DESCRIPTION
> Patroni: A Template for PostgreSQL HA with ZooKeeper, etcd or Consul
> 
> Patroni is a template for you to create your own customized, high-availability solution using Python and a distributed configuration store like ZooKeeper, etcd or Consul.

This directory contains a Kubernetes chart to deploy a five node `patroni` cluster using a petset.

It depends on a running `etcd` cluster for distributed shared state which can be installed using the `etcd` chart: https://github.com/kubernetes/charts/tree/master/incubator/etcd

Please find out more about `patroni` at https://github.com/zalando/patroni

Caveat: Currently this chart can only be deployed in Kubernetes' `default` namespace to function.
