### PR TITLE
Adds multi-role elasticsearch cluster chart #petset

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,0 +1,10 @@
+name: elasticsearch
+home: https://www.elastic.co/products/elasticsearch
+version: 0.1.0
+description: Elasticsearch chart for Kubernetes
+sources:
+  - https://www.elastic.co/products/elasticsearch
+  - https://github.com/jetstack/elasticsearch-pet
+maintainers:
+  - name: Christian Simon
+    email: christian@jetstack.io

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -1,0 +1,131 @@
+# Elasticsearch Helm Chart
+
+This image is using Fabric8's great [kubernetes discovery
+plugin](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) for
+elasticsearch and their
+[image](https://hub.docker.com/r/fabric8/elasticsearch-k8s/) as parent.
+
+## Prerequisites Details
+
+* Kubernetes 1.3 with alpha APIs enabled
+* PV dynamic provisioning support on the underlying infrastructure
+
+## PetSet Details
+* http://kubernetes.io/docs/user-guide/petset/
+
+## PetSet Caveats
+* http://kubernetes.io/docs/user-guide/petset/#alpha-limitations
+
+## Todo
+
+* Implement TLS/Auth/Security
+* Smarter upscaling/downscaling
+* Solution for memory locking
+
+## Chart Details
+This chart will do the following:
+
+* Implemented a dynamically scalable elasticsearch cluster using Kubernetes PetSets/Deployments
+* Multi-role deployment: master, client and data nodes
+* PetSet Supports scaling down without degrading the cluster 
+
+## Get this chart
+
+```bash
+$ git clone https://github.com/kubernetes/charts.git
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release charts/incubator/elasticsearch
+```
+
+## Deleting the Charts
+
+Deletion of the PetSet doesn't cascade to deleting associated Pods and PVCs. To delete them:
+
+```
+$ kubectl delete pods -l release=my-release,type=data
+$ kubectl delete pvcs -l release=my-release,type=data
+
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the elasticsearch chart and their default values.
+
+|         Parameter         |           Description             |                         Default                          |
+|---------------------------|-----------------------------------|----------------------------------------------------------|
+| `Image`                   | Container image name              | `jetstack/elasticsearch-pet`                             |
+| `ImageTag`                | Container image tag               | `2.3.4`                                                  |
+| `ImagePullPolicy`         | Container pull policy             | `Always`                                                 |
+| `ClientReplicas`          | Client node replicas (deployment) | `2`                                                      |
+| `ClientCpuRequests`       | Client node requested cpu         | `25m`                                                    |
+| `ClientMemoryRequests`    | Client node requested memory      | `256Mi`                                                  |
+| `ClientCpuLimits`         | Client node requested cpu         | `100m`                                                   |
+| `ClientMemoryLimits`      | Client node requested memory      | `512Mi`                                                  |
+| `ClientHeapSize`          | Client node heap size             | `128m`                                                   |
+| `MasterReplicas`          | Master node replicas (deployment) | `2`                                                      |
+| `MasterCpuRequests`       | Master node requested cpu         | `25m`                                                    |
+| `MasterMemoryRequests`    | Master node requested memory      | `256Mi`                                                  |
+| `MasterCpuLimits`         | Master node requested cpu         | `100m`                                                   |
+| `MasterMemoryLimits`      | Master node requested memory      | `512Mi`                                                  |
+| `MasterHeapSize`          | Master node heap size             | `128m`                                                   |
+| `DataReplicas`            | Data node replicas (petset)       | `3`                                                      |
+| `DataCpuRequests`         | Data node requested cpu           | `250m`                                                   |
+| `DataMemoryRequests`      | Data node requested memory        | `2Gi`                                                    |
+| `DataCpuLimits`           | Data node requested cpu           | `1`                                                      |
+| `DataMemoryLimits`        | Data node requested memory        | `4Gi`                                                    |
+| `DataHeapSize`            | Data node heap size               | `1536m`                                                  |
+| `DataStorage`             | Data persistent volume size       | `30Gi`                                                   |
+| `DataStorageClass`        | Data persistent volume Class      | `anything`                                               |
+| `DataStorageClassVersion` | Version of StorageClass           | `alpha`                                                  |
+| `Component`               | Selector Key                      | `elasticsearch`                                          |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+In terms of Memory resources you should make sure that you follow that equation:
+
+- `${role}HeapSize < ${role}MemoryRequests < ${role}MemoryLimits`
+
+# Deep dive
+
+## Mlocking
+
+This is a limitation in kubernetes right now. There is no way to raise the
+limits of lockable memory, so that these memory areas won't be swapped. This
+would degrade performance heaviliy. The issue is tracked in
+[kubernetes/#3595](https://github.com/kubernetes/kubernetes/issues/3595).
+
+```
+[WARN ][bootstrap] Unable to lock JVM Memory: error=12,reason=Cannot allocate memory
+[WARN ][bootstrap] This can result in part of the JVM being swapped out.
+[WARN ][bootstrap] Increase RLIMIT_MEMLOCK, soft limit: 65536, hard limit: 65536
+```
+
+## Select right storage class for SSD volumes
+
+### GCE + Kubernetes 1.4
+
+Create StorageClass for SSD-PD
+
+```
+$ kubectl create -f - <<EOF
+kind: StorageClass
+apiVersion: extensions/v1beta1
+metadata:
+  name: ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+EOF
+```
+Create cluster with Storage class `ssd` on Kubernetes 1.4+
+
+```
+$ helm install . --name my-release --set DataStorageClass=ssd,DataStorageClassVersion=beta
+
+```

--- a/incubator/elasticsearch/templates/elasticsearch-client-deployment.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-client-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ printf "%s-client-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+    type: client
+  annotations:
+    helm.sh/created: {{.Release.Time.Seconds | quote }}
+spec:
+  replicas: {{default 2 .Values.ClientReplicas | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        component: "{{.Release.Name}}-{{.Values.Component}}"
+        type: client
+    spec:
+      serviceAccountName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+      containers:
+      - name: elasticsearch
+        env:
+        - name: SERVICE
+          value: "{{ printf "%s-cluster-%s" .Release.Name .Values.Name | trunc 24 }}"
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_DATA
+          value: "false"
+        - name: NODE_MASTER
+          value: "false"
+        - name: ES_HEAP_SIZE
+          value: "{{.Values.ClientHeapSize}}"
+        resources:
+          requests:
+            cpu: "{{.Values.ClientCpuRequests}}"
+            memory: "{{.Values.ClientMemoryRequests}}"
+          limits:
+            cpu: "{{.Values.ClientCpuLimits}}"
+            memory: "{{.Values.ClientMemoryLimits}}"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9200
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 9200
+          timeoutSeconds: 5
+        image: "{{.Values.Image}}:{{.Values.ImageTag}}"
+        imagePullPolicy: "{{.Values.ImagePullPolicy}}"
+        ports:
+        - containerPort: 9200
+          name: http
+        - containerPort: 9300
+          name: transport

--- a/incubator/elasticsearch/templates/elasticsearch-cluster-svc.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-cluster-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ printf "%s-cluster-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    helm.sh/created: {{.Release.Time.Seconds | quote }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 9300
+      targetPort: 9300
+  selector:
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+

--- a/incubator/elasticsearch/templates/elasticsearch-data-petset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-petset.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1alpha1
+kind: PetSet
+metadata:
+  name: "{{ printf "%s-data-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+    type: data
+  annotations:
+    helm.sh/created: {{.Release.Time.Seconds | quote }}
+spec:
+  serviceName: "{{ printf "%s-data-%s" .Release.Name .Values.Name | trunc 24 }}"
+  replicas: {{default 3 .Values.DataReplicas | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        component: "{{.Release.Name}}-{{.Values.Component}}"
+        type: data
+      annotations:
+        helm.sh/created: {{.Release.Time.Seconds | quote }}
+        pod.alpha.kubernetes.io/initialized: "true"
+    spec:
+      serviceAccountName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+      containers:
+      - name: elasticsearch
+        env:
+        - name: SERVICE
+          value: "{{ printf "%s-cluster-%s" .Release.Name .Values.Name | trunc 24 }}"
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_MASTER
+          value: "false"
+        - name: ES_HEAP_SIZE
+          value: "{{.Values.DataHeapSize}}"
+        image: "{{.Values.Image}}:{{.Values.ImageTag}}"
+        imagePullPolicy: "{{.Values.ImagePullPolicy}}"
+        ports:
+        - containerPort: 9300
+          name: transport
+        resources:
+          requests:
+            cpu: "{{.Values.DataCpuRequests}}"
+            memory: "{{.Values.DataMemoryRequests}}"
+          limits:
+            cpu: "{{.Values.DataCpuLimits}}"
+            memory: "{{.Values.DataMemoryLimits}}"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9200
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 9200
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /usr/share/elasticsearch/data
+          name: elasticsearch-data
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/bash","/pre-stop-hook.sh"]
+  volumeClaimTemplates:
+  - metadata:
+      name: elasticsearch-data
+      annotations:
+        volume.{{ .Values.DataStorageClassVersion }}.kubernetes.io/storage-class: "{{ .Values.DataStorageClass }}"
+    spec:
+      accessModes: [ ReadWriteOnce ]
+      resources:
+        requests:
+          storage: "{{.Values.DataStorage}}"

--- a/incubator/elasticsearch/templates/elasticsearch-data-svc.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  name: "{{ printf "%s-data-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    helm.sh/created: {{.Release.Time.Seconds | quote }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 9300
+      targetPort: 9300
+  selector:
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+    type: data

--- a/incubator/elasticsearch/templates/elasticsearch-master-deployment.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-master-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ printf "%s-master-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+    type: master
+  annotations:
+    helm.sh/created: {{.Release.Time.Seconds | quote }}
+spec:
+  replicas: {{default 2 .Values.MasterReplicas | quote }}
+  template:
+    metadata:
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        component: "{{.Release.Name}}-{{.Values.Component}}"
+        type: master
+    spec:
+      serviceAccountName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+      containers:
+      - name: elasticsearch
+        env:
+        - name: SERVICE
+          value: "{{ printf "%s-cluster-%s" .Release.Name .Values.Name | trunc 24 }}"
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_DATA
+          value: "false"
+        - name: ES_HEAP_SIZE
+          value: "{{.Values.MasterHeapSize}}"
+        resources:
+          requests:
+            cpu: "{{.Values.MasterCpuRequests}}"
+            memory: "{{.Values.MasterMemoryRequests}}"
+          limits:
+            cpu: "{{.Values.MasterCpuLimits}}"
+            memory: "{{.Values.MasterMemoryLimits}}"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9200
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 9200
+          timeoutSeconds: 5
+        image: "{{.Values.Image}}:{{.Values.ImageTag}}"
+        imagePullPolicy: "{{.Values.ImagePullPolicy}}"
+        ports:
+        - containerPort: 9300
+          name: transport

--- a/incubator/elasticsearch/templates/elasticsearch-service-account.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-service-account.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+    type: master
+  annotations:
+    helm.sh/created: {{.Release.Time.Seconds | quote }}

--- a/incubator/elasticsearch/templates/elasticsearch-svc.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    helm.sh/created: {{.Release.Time.Seconds | quote }}
+spec:
+  ports:
+    - port: 9200
+      targetPort: http
+  selector:
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+    type: client

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -1,0 +1,33 @@
+# Default values for etcd.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+Name: es
+PeerPort: 2380
+ClientPort: 2379
+Component: "elasticsearch"
+Image: "jetstack/elasticsearch-pet"
+ImageTag: "2.3.5"
+ImagePullPolicy: "Always"
+ClientReplicas: 2
+ClientCpuRequests: "25m"
+ClientMemoryRequests: "256Mi"
+ClientCpuLimits: "100m"
+ClientMemoryLimits: "512Mi"
+ClientHeapSize: "128m"
+MasterReplicas: 2
+MasterCpuRequests: "25m"
+MasterMemoryRequests: "256Mi"
+MasterCpuLimits: "100m"
+MasterMemoryLimits: "512Mi"
+MasterHeapSize: "128m"
+DataReplicas: 3
+DataCpuRequests: "250m"
+DataMemoryRequests: "2Gi"
+DataCpuLimits: "1"
+DataMemoryLimits: "4Gi"
+DataHeapSize: "1536m"
+DataStorage: "30Gi"
+DataStorageClass: "anything"
+DataStorageClassVersion: "alpha"


### PR DESCRIPTION
This image is using Fabric8's great work around the [kubernetes plugin](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) for elasticsearch and their [image](https://hub.docker.com/r/fabric8/elasticsearch-k8s/) as parent. 

The PetSet for data nodes is able scale down without data loss (cluster will move data before shutting an instance down). This is implemeted by a simple lifecycle hook:

https://github.com/jetstack/elasticsearch-pet/blob/master/pre-stop-hook.sh

As this is the first chart I have written, it's likely that not everything is according to the standards...

Happy if you could review/test that chart 
