### PR TITLE
Bumped jenkins version. Update/include baseline plugins

### DIFF
--- a/incubator/jenkins/master-image/Dockerfile
+++ b/incubator/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:2.7.3
-RUN /usr/local/bin/install-plugins.sh kubernetes:0.8 workflow-aggregator:2.3 \
+FROM jenkins:2.7.4
+RUN /usr/local/bin/install-plugins.sh kubernetes:0.8 workflow-aggregator:2.4 credentials-binding:1.9 git:3.0.0 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch


### PR DESCRIPTION
- workflow-aggregator:2.4
- credentials-binding:1.9 - Allows credentials to be bound to environment variables for use from miscellaneous build steps. -- https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Binding+Plugin
- git - Allow git as a source of pipeline jobs. Doesn't appear to be covered by wf-aggregator plugin

Test image available here -- docker pull quay.io/lachie83/jenkins-master-k8s:v0.1.1
