### PR TITLE
mariadb 0.3.1

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -52,14 +52,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MariaDB chart and their default values.
 
-|       Parameter       |           Description            |                         Default                          |
-|-----------------------|----------------------------------|----------------------------------------------------------|
-| `imageTag`            | `bitnami/mariadb` image tag.     | Most recent release                                      |
-| `imagePullPolicy`     | Image pull policy.               | `Always` if `imageTag` is `latest`, else `IfNotPresent`. |
-| `mariadbRootPassword` | Password for the `root` user.    | `nil`                                                    |
-| `mariadbUser`         | Username of new user to create.  | `nil`                                                    |
-| `mariadbPassword`     | Password for the new user.       | `nil`                                                    |
-| `mariadbDatabase`     | Name for new database to create. | `nil`                                                    |
+| Parameter               | Description                        | Default                                                    |
+| ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
+| `image`                 | MariaDB image                      | `bitnami/mariadb:{VERSION}`                                |
+| `imagePullPolicy`       | Image pull policy.                 | `Always` if `imageTag` is `latest`, else `IfNotPresent`.   |
+| `mariadbRootPassword`   | Password for the `root` user.      | `nil`                                                      |
+| `mariadbUser`           | Username of new user to create.    | `nil`                                                      |
+| `mariadbPassword`       | Password for the new user.         | `nil`                                                      |
+| `mariadbDatabase`       | Name for new database to create.   | `nil`                                                      |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -14,18 +14,3 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
 {{- end -}}
-
-{{/*
-Get the imagePullPolicy.
-*/}}
-{{- define "imagePullPolicy" -}}
-  {{- if .Values.imagePullPolicy -}}
-    {{- .Values.imagePullPolicy -}}
-  {{- else -}}
-    {{- if eq .Values.imageTag "latest" -}}
-      {{- "Always" -}}
-    {{- else -}}
-      {{- "IfNotPresent" -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -18,8 +18,8 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "bitnami/mariadb:{{ .Values.imageTag }}"
-        imagePullPolicy: {{ template "imagePullPolicy" . }}
+        image: "{{ .Values.image }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
 ## Default: none
-imageTag: 10.1.14-r3
+image: bitnami/mariadb:10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## Default to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Updates MariaDB image version to 10.1.17-r1 including fixes for the
OpenSSL security update
(https://www.openssl.org/news/secadv/20160922.txt)
