### PR TITLE
redmine 0.3.1

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 0.3.0
+version: 0.3.1
 description: A flexible project management web application.
 keywords:
 - redmine

--- a/stable/redmine/charts/mariadb/Chart.yaml
+++ b/stable/redmine/charts/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.3.0
+version: 0.3.1
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/stable/redmine/charts/mariadb/README.md
+++ b/stable/redmine/charts/mariadb/README.md
@@ -52,14 +52,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MariaDB chart and their default values.
 
-|       Parameter       |           Description            |                         Default                          |
-|-----------------------|----------------------------------|----------------------------------------------------------|
-| `imageTag`            | `bitnami/mariadb` image tag.     | Most recent release                                      |
-| `imagePullPolicy`     | Image pull policy.               | `Always` if `imageTag` is `latest`, else `IfNotPresent`. |
-| `mariadbRootPassword` | Password for the `root` user.    | `nil`                                                    |
-| `mariadbUser`         | Username of new user to create.  | `nil`                                                    |
-| `mariadbPassword`     | Password for the new user.       | `nil`                                                    |
-| `mariadbDatabase`     | Name for new database to create. | `nil`                                                    |
+| Parameter               | Description                        | Default                                                    |
+| ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
+| `image`                 | MariaDB image                      | `bitnami/mariadb:{VERSION}`                                |
+| `imagePullPolicy`       | Image pull policy.                 | `Always` if `imageTag` is `latest`, else `IfNotPresent`.   |
+| `mariadbRootPassword`   | Password for the `root` user.      | `nil`                                                      |
+| `mariadbUser`           | Username of new user to create.    | `nil`                                                      |
+| `mariadbPassword`       | Password for the new user.         | `nil`                                                      |
+| `mariadbDatabase`       | Name for new database to create.   | `nil`                                                      |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 

--- a/stable/redmine/charts/mariadb/templates/_helpers.tpl
+++ b/stable/redmine/charts/mariadb/templates/_helpers.tpl
@@ -14,18 +14,3 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
 {{- end -}}
-
-{{/*
-Get the imagePullPolicy.
-*/}}
-{{- define "imagePullPolicy" -}}
-  {{- if .Values.imagePullPolicy -}}
-    {{- .Values.imagePullPolicy -}}
-  {{- else -}}
-    {{- if eq .Values.imageTag "latest" -}}
-      {{- "Always" -}}
-    {{- else -}}
-      {{- "IfNotPresent" -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}

--- a/stable/redmine/charts/mariadb/templates/deployment.yaml
+++ b/stable/redmine/charts/mariadb/templates/deployment.yaml
@@ -18,8 +18,8 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "bitnami/mariadb:{{ .Values.imageTag }}"
-        imagePullPolicy: {{ template "imagePullPolicy" . }}
+        image: "{{ .Values.image }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:

--- a/stable/redmine/charts/mariadb/values.yaml
+++ b/stable/redmine/charts/mariadb/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
 ## Default: none
-imageTag: 10.1.14-r3
+image: bitnami/mariadb:10.1.17-r1
 
 ## Specify a imagePullPolicy
 ## Default to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Redmine image version
 ## ref: https://hub.docker.com/r/bitnami/redmine/tags/
 ##
-image: bitnami/redmine:3.3.0-r2
+image: bitnami/redmine:3.3.0-r3
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Updates Redmine image version to 3.3.0-r3 and MariaDB dependency
including fixes for the OpenSSL security update
(https://www.openssl.org/news/secadv/20160922.txt)
