### PR TITLE
mariadb: support custom my.cnf config in values

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.4.0
+version: 0.5.0
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -89,7 +89,7 @@ $ helm install --name my-release -f values.yaml mariadb-x.x.x.tgz
 ### Custom my.cnf configuration
 
 The Bitnami MariaDB image allows you to provide a custom `my.cnf` file for configuring MariaDB.
-This Chart uses the `config` value to mount a custom `my.cnf` using a ConfigMap.
+This Chart uses the `config` value to mount a custom `my.cnf` using a [ConfigMap](http://kubernetes.io/docs/user-guide/configmap/).
 You can configure this by creating a YAML file that defines the `config` property as a multi-line string in the format of a `my.cnf` file.
 For example:
 

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -52,18 +52,19 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MariaDB chart and their default values.
 
-| Parameter               | Description                        | Default                                                    |
-| ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
-| `image`                 | MariaDB image                      | `bitnami/mariadb:{VERSION}`                                |
-| `imagePullPolicy`       | Image pull policy.                 | `Always` if `imageTag` is `latest`, else `IfNotPresent`.   |
-| `mariadbRootPassword`   | Password for the `root` user.      | `nil`                                                      |
-| `mariadbUser`           | Username of new user to create.    | `nil`                                                      |
-| `mariadbPassword`       | Password for the new user.         | `nil`                                                      |
-| `mariadbDatabase`       | Name for new database to create.   | `nil`                                                      |
-| `persistence.enabled`          | Use a PVC to persist data           | `true`                                       |
-| `persistence.storageClass`     | Storage class of backing PVC        | `generic`                                    |
-| `persistence.accessMode`       | Use volume as ReadOnly or ReadWrite | `ReadWriteOnce`                              |
-| `persistence.size`             | Size of data volume                 | `8Gi`                                        |
+| Parameter                  | Description                                | Default                                                    |
+| -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
+| `image`                    | MariaDB image                              | `bitnami/mariadb:{VERSION}`                                |
+| `imagePullPolicy`          | Image pull policy.                         | `Always` if `imageTag` is `latest`, else `IfNotPresent`.   |
+| `mariadbRootPassword`      | Password for the `root` user.              | `nil`                                                      |
+| `mariadbUser`              | Username of new user to create.            | `nil`                                                      |
+| `mariadbPassword`          | Password for the new user.                 | `nil`                                                      |
+| `mariadbDatabase`          | Name for new database to create.           | `nil`                                                      |
+| `persistence.enabled`      | Use a PVC to persist data                  | `true`                                                     |
+| `persistence.storageClass` | Storage class of backing PVC               | `generic`                                                  |
+| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                            |
+| `persistence.size`         | Size of data volume                        | `8Gi`                                                      |
+| `config`                   | Multi-line string for my.cnf configuration | `nil`                                                      |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 
@@ -84,6 +85,28 @@ $ helm install --name my-release -f values.yaml mariadb-x.x.x.tgz
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Custom my.cnf configuration
+
+The Bitnami MariaDB image allows you to provide a custom `my.cnf` file for configuring MariaDB.
+This Chart uses the `config` value to mount a custom `my.cnf` using a ConfigMap.
+You can configure this by creating a YAML file that defines the `config` property as a multi-line string in the format of a `my.cnf` file.
+For example:
+
+```bash
+cat > mariadb-values.yaml <<EOF
+config: |-
+  [mysqld]
+  max_allowed_packet = 64M
+  sql_mode=STRICT_ALL_TABLES
+  ft_stopword_file=/etc/mysql/stopwords.txt
+  ft_min_word_len=3
+  ft_boolean_syntax=' |-><()~*:""&^'
+  innodb_buffer_pool_size=2G
+EOF
+
+helm install --name my-release -f mariadb-values.yaml mariadb-x.x.x.tgz
+```
 
 ## Persistence
 

--- a/stable/mariadb/templates/configmap.yaml
+++ b/stable/mariadb/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  my.cnf: |-
+{{ .Values.config | indent 4 }}

--- a/stable/mariadb/templates/configmap.yaml
+++ b/stable/mariadb/templates/configmap.yaml
@@ -9,4 +9,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   my.cnf: |-
+{{- if .Values.config }}
 {{ .Values.config | indent 4 }}
+{{- end -}}

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -15,6 +15,25 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+      annotations:
+        pod.alpha.kubernetes.io/init-containers: '
+          [
+            {
+              "name": "copy-custom-config",
+              "image": "{{ .Values.image }}",
+              "command": ["sh", "-c", "mkdir -p /bitnami/mariadb/conf && cp -n /bitnami/mariadb_config/my.cnf /bitnami/mariadb/conf/my_custom.cnf"],
+              "volumeMounts": [
+                {
+                  "name": "config",
+                  "mountPath": "/bitnami/mariadb_config"
+                },
+                {
+                  "name": "data",
+                  "mountPath": "/bitnami/mariadb"
+                }
+              ]
+            }
+          ]'
     spec:
       containers:
       - name: {{ template "fullname" . }}
@@ -56,6 +75,9 @@ spec:
         - name: data
           mountPath: /bitnami/mariadb
       volumes:
+      - name: config
+        configMap:
+          name: {{ template "fullname" . }}
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -26,9 +26,18 @@ image: bitnami/mariadb:10.1.17-r1
 ##
 # mariadbDatabase:
 
-## Persist data to a persitent volume
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
 persistence:
   enabled: true
   storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
+
+## Configure MariaDB with a custom my.cnf file
+## ref: https://mariadb.com/kb/en/mariadb/configuring-mariadb-with-mycnf/#example-of-configuration-file
+##
+# config: |-
+  # [mysqld]
+  # innodb_buffer_pool_size=2G


### PR DESCRIPTION
Adds the config property to `Values.yaml` that gets embedded in a
configMap and mounted as a custom `my.cnf` file.

Closes #71
