### PR TITLE
Add NOTES.txt for patroni chart

### DIFF
--- a/incubator/patroni/templates/NOTES.txt
+++ b/incubator/patroni/templates/NOTES.txt
@@ -1,0 +1,29 @@
+Getting Started:
+
+Patroni can be accessed via port 5432 on the following DNS name from within your cluster:
+{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+To get your password for superuser or admin run:
+
+    # admin user password
+    printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.password-admin[*]}"`);echo
+
+    # superuser password
+    printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.password-superuser[*]}"`);echo
+
+To connect to your database:
+
+1. Run an Ubuntu pod that you can use as a client:
+
+    kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il
+
+2. Install the postgres client:
+
+    $ apt-get update && apt-get install postgresql-client -y
+
+3. Connect using the psql cli, then provide your password:
+    # login as admin
+    $ psql -U admin -h {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
+
+    # login as superuser
+    $ psql -U superuser -h {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres

--- a/incubator/patroni/templates/NOTES.txt
+++ b/incubator/patroni/templates/NOTES.txt
@@ -4,24 +4,22 @@ Patroni can be accessed via port 5432 on the following DNS name from within your
 To get your password for superuser or admin run:
 
     # admin user password
-    printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.password-admin[*]}"`);echo
+    PGPASSWORD_ADMIN=$(printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.password-admin[*]}"`);echo)
 
     # superuser password
-    printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.password-superuser[*]}"`);echo
+    PGPASSWORD_SUPERUSER=$(printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.password-superuser[*]}"`);echo)
 
 To connect to your database:
 
-1. Run an Ubuntu pod that you can use as a client:
-
-    kubectl run -i --tty ubuntu --image=ubuntu:16.04 --restart=Never -- bash -il
-
-2. Install the postgres client:
-
-    $ apt-get update && apt-get install postgresql-client -y
-
-3. Connect using the psql cli, then provide your password:
+1. Run a postgres pod and connect using the psql cli:
     # login as admin
-    $ psql -U admin -h {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
+    kubectl run -i --tty --rm psql --image=postgres \
+      --env "PGPASSWORD=$PGPASSWORD_ADMIN" \
+      --command -- psql -U admin \
+      -h {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
 
     # login as superuser
-    $ psql -U superuser -h {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
+    kubectl run -i --tty --rm psql --image=postgres \
+      --env "PGPASSWORD=$PGPASSWORD_SUPERUSER" \
+      --command -- psql -U superuser \
+      -h {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres

--- a/incubator/patroni/templates/NOTES.txt
+++ b/incubator/patroni/templates/NOTES.txt
@@ -1,5 +1,3 @@
-Getting Started:
-
 Patroni can be accessed via port 5432 on the following DNS name from within your cluster:
 {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 

--- a/incubator/patroni/templates/_helpers.tpl
+++ b/incubator/patroni/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- printf "%s-%s" .Release.Name .Values.Name | trunc 24 -}}
+{{- end -}}

--- a/incubator/patroni/templates/ps-patroni.yaml
+++ b/incubator/patroni/templates/ps-patroni.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1alpha1
 kind: PetSet
 metadata:
-  name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+  name: {{ template "fullname" . }}
   namespace: {{ .Values.Namespace }}
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -11,11 +11,11 @@ metadata:
   annotations:
     "helm.sh/created": {{ .Release.Time.Seconds | quote }}
 spec:
-  serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  serviceName: {{ template "fullname" . }}
   replicas: {{default 5 .Values.Replicas | quote }}
   template:
     metadata:
-      name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+      name: {{ template "fullname" . }}
       labels:
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}
@@ -32,22 +32,22 @@ spec:
         - name: PGPASSWORD_SUPERUSER
           valueFrom:
             secretKeyRef:
-              name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
-              key: password.superuser
+              name: {{ template "fullname" . }}
+              key: password-superuser
         - name: PGPASSWORD_ADMIN
           valueFrom:
             secretKeyRef:
-              name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
-              key: password.admin
+              name: {{ template "fullname" . }}
+              key: password-admin
         - name: PGPASSWORD_STANDBY
           valueFrom:
             secretKeyRef:
-              name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
-              key: password.standby
+              name: {{ template "fullname" . }}
+              key: password-standby
         - name: ETCD_DISCOVERY_DOMAIN
           value: {{default (printf "%s-etcd.%s.svc.cluster.local" .Release.Name .Values.Namespace) .Values.Etcd.Discovery }}
         - name: SCOPE
-          value: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+          value: {{ template "fullname" . }}
         - name: USE_WALE
           value: ""
         - name: PGROOT
@@ -73,7 +73,7 @@ spec:
       volumes:
       - name: patroni-config
         secret:
-          secretName: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+          secretName: {{ template "fullname" . }}
   volumeClaimTemplates:
   - metadata:
       name: pgdata

--- a/incubator/patroni/templates/sec-patroni.yaml
+++ b/incubator/patroni/templates/sec-patroni.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ printf "%s-%s" .Release.Name .Values.Name }}"
+  name: {{ template "fullname" . }}
   namespace: {{ .Values.Namespace }}
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -12,6 +12,6 @@ metadata:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 type: Opaque
 data:
-  password.superuser: {{ .Values.Credentials.Superuser | b64enc }}
-  password.admin: {{ .Values.Credentials.Admin | b64enc }}
-  password.standby: {{ .Values.Credentials.Standby | b64enc }}
+  password-superuser: {{ .Values.Credentials.Superuser | b64enc }}
+  password-admin: {{ .Values.Credentials.Admin | b64enc }}
+  password-standby: {{ .Values.Credentials.Standby | b64enc }}

--- a/incubator/patroni/templates/svc-patroni.yaml
+++ b/incubator/patroni/templates/svc-patroni.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
+  name: {{ template "fullname" . }}
   namespace: {{ .Values.Namespace }}
   labels:
     heritage: {{ .Release.Service | quote }}


### PR DESCRIPTION
This adds a `NOTES.txt` to the patroni chart. It desribes how to get password
and connect to the DB both as the admin and superuser users.

I also created a template for the full name definition so it was easier to
reuse in the NOTES.txt template.

Close #83

(@linki is on vacation these days, that's why you get a PR from me instead.)
