### PR TITLE
Using 2.19.1 LTS from jenkins.io

### DIFF
--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:2.7.4
+FROM jenkins:2.19.1
 RUN /usr/local/bin/install-plugins.sh kubernetes:0.8 workflow-aggregator:2.4 credentials-binding:1.9 git:3.0.0 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch


### PR DESCRIPTION
# Why

`2.19.1` is latest [LTS](https://jenkins.io/changelog-stable/) from https://jenkins.io. 

Hence the PR.
