### PR TITLE
Fix elasticsearch quoting

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.1.0
+version: 0.1.1
 description: Elasticsearch chart for Kubernetes
 sources:
   - https://www.elastic.co/products/elasticsearch

--- a/incubator/elasticsearch/templates/elasticsearch-client-deployment.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-client-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/created: {{.Release.Time.Seconds | quote }}
 spec:
-  replicas: {{default 2 .Values.ClientReplicas | quote }}
+  replicas: {{default 2 .Values.ClientReplicas }}
   template:
     metadata:
       labels:

--- a/incubator/elasticsearch/templates/elasticsearch-data-petset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-petset.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/created: {{.Release.Time.Seconds | quote }}
 spec:
   serviceName: "{{ printf "%s-data-%s" .Release.Name .Values.Name | trunc 24 }}"
-  replicas: {{default 3 .Values.DataReplicas | quote }}
+  replicas: {{default 3 .Values.DataReplicas }}
   template:
     metadata:
       labels:

--- a/incubator/elasticsearch/templates/elasticsearch-master-deployment.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-master-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     helm.sh/created: {{.Release.Time.Seconds | quote }}
 spec:
-  replicas: {{default 2 .Values.MasterReplicas | quote }}
+  replicas: {{default 2 .Values.MasterReplicas }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
There were some constraints added in the Kubernetes 1.4 release that caused quoted integers to be rejected when an integer is expected. This fixes those issues in the elasticsearch chart.
