### PR TITLE
Fix consul quoting

### DIFF
--- a/incubator/consul/Chart.yaml
+++ b/incubator/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 0.1.0
+version: 0.1.1
 description: Hashicorp Consul Helm chart for Kubernetes.
 sources:
   - https://github.com/kelseyhightower/consul-on-kubernetes

--- a/incubator/consul/templates/consul-petset.yaml
+++ b/incubator/consul/templates/consul-petset.yaml
@@ -57,7 +57,7 @@ metadata:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
-  replicas: {{default 3 .Values.Replicas | quote }}
+  replicas: {{default 3 .Values.Replicas}}
   template:
     metadata:
       name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"


### PR DESCRIPTION
There were some constraints added in the Kubernetes 1.4 release that
caused quoted integers to be rejected when an integer is expected.
This fixes those issues in the consul chart.
