### PR TITLE
Fix quoting for etcd, mongodb, spark and zookeeper

### DIFF
--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.1.0
+version: 0.1.1
 description: Etcd Helm chart for Kubernetes.
 sources:
   - https://github.com/coreos/etcd

--- a/incubator/etcd/templates/etcd-petset.yaml
+++ b/incubator/etcd/templates/etcd-petset.yaml
@@ -35,7 +35,7 @@ metadata:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
-  replicas: {{default 3 .Values.Replicas | quote }}
+  replicas: {{default 3 .Values.Replicas}}
   template:
     metadata:
       name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"

--- a/incubator/mongodb/Chart.yaml
+++ b/incubator/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb
 home: https://github.com/mongodb/mongo
-version: 0.1.0
+version: 0.1.1
 description: MongoDB Helm chart for Kubernetes.
 sources:
   - https://github.com/mongodb/mongo

--- a/incubator/mongodb/templates/mongodb-petset.yaml
+++ b/incubator/mongodb/templates/mongodb-petset.yaml
@@ -32,7 +32,7 @@ metadata:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
-  replicas: {{default 3 .Values.Replicas | quote }}
+  replicas: {{default 3 .Values.Replicas}}
   template:
     metadata:
       labels:

--- a/incubator/spark/Chart.yaml
+++ b/incubator/spark/Chart.yaml
@@ -1,6 +1,6 @@
 name: spark
 home: http://spark.apache.org/
-version: 0.1.0
+version: 0.1.1
 description: A Apache Spark Helm chart for Kubernetes. Apache Spark is a fast and general-purpose cluster computing system
 sources:
   - https://github.com/kubernetes/kubernetes/tree/master/examples/spark

--- a/incubator/spark/templates/spark-master-deployment.yaml
+++ b/incubator/spark/templates/spark-master-deployment.yaml
@@ -47,7 +47,7 @@ metadata:
   annotations:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
-  replicas: {{default 1 .Values.Master.Replicas | quote }}
+  replicas: {{default 1 .Values.Master.Replicas}}
   strategy:
     type: RollingUpdate
   selector:

--- a/incubator/spark/templates/spark-worker-deployment.yaml
+++ b/incubator/spark/templates/spark-worker-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
-  replicas: {{default 1 .Values.Worker.Replicas | quote }}
+  replicas: {{default 1 .Values.Worker.Replicas}}
   strategy:
     type: RollingUpdate
   selector:

--- a/incubator/spark/templates/spark-zeppelin-deployment.yaml
+++ b/incubator/spark/templates/spark-zeppelin-deployment.yaml
@@ -29,7 +29,7 @@ metadata:
   annotations:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
-  replicas: {{default 1 .Values.Zeppelin.Replicas | quote }}
+  replicas: {{default 1 .Values.Zeppelin.Replicas}}
   strategy:
     type: RollingUpdate
   selector:

--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.1.0
+version: 0.1.1
 description: Zookeeper Helm chart for Kubernetes.
 sources:
   - https://github.com/apache/zookeeper

--- a/incubator/zookeeper/templates/zookeeper-petset.yaml
+++ b/incubator/zookeeper/templates/zookeeper-petset.yaml
@@ -33,7 +33,7 @@ metadata:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
-  replicas: {{default 3 .Values.Replicas | quote }}
+  replicas: {{default 3 .Values.Replicas}}
   template:
     metadata:
       labels:


### PR DESCRIPTION
There were some constraints added in the Kubernetes 1.4 release that
caused quoted integers to be rejected when an integer is expected.
This fixes those issues in these charts.
