### PR TITLE
MySQL fails to start without persistence enabled

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.1.1
+version: 0.1.2
 description: Chart for MySQL
 keywords:
 - mysql

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
               {
                   "name": "remove-lost-found",
                   "image": "busybox:1.25.0",
-                  "command": ["rmdir", "/var/lib/mysql/lost+found"],
+                  "command": ["rm", "-fr", "/var/lib/mysql/lost+found"],
                   "volumeMounts": [
                       {
                           "name": "data",


### PR DESCRIPTION
When `persistance.enabled` is set to `false`, `emptyDir` volume is mounted as `/var/lib/mysql` and `rmdir /var/lib/mysql/lost+found` fails because the directory is not there.

```
  2m    5s  12  {kubelet minikube}                      Warning FailedSync  Error syncing pod, skipping: [failed to "InitContainer" for "remove-lost-found" with RunInitContainerError: "init container \"remove-lost-found\" exited with 1", failed to "StartContainer" for "remove-lost-found" with CrashLoopBackOff: "Back-off 5m0s restarting failed container=remove-lost-found pod=pruning-bunny-mysql-3645202232-9md2n_default(c5e4252e-9699-11e6-97b4-da01ddf400ca)"
```
