### PR TITLE
patroni: remove configurable namespace

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: "Highly available elephant herd: HA PostgreSQL cluster."
-version: 0.1.2
+version: 0.1.3
 home: https://github.com/zalando/patroni
 sources:
   - https://github.com/zalando/patroni

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -53,7 +53,6 @@ The following tables lists the configurable parameters of the patroni chart and 
 |       Parameter         |           Description               |                         Default                     |
 |-------------------------|-------------------------------------|-----------------------------------------------------|
 | `Name`                  | Service name                        | `patroni`                                           |
-| `Namespace`             | Service namespace                   | `default`                                           |
 | `Spilo.Image`           | Container image name                | `registry.opensource.zalan.do/acid/spilo-9.5`       |
 | `Spilo.Version`         | Container image tag                 | `1.0-p5`                                            |
 | `ImagePullPolicy`       | Container pull policy               | `IfNotPresent`                                      |

--- a/incubator/patroni/templates/ps-patroni.yaml
+++ b/incubator/patroni/templates/ps-patroni.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1alpha1
 kind: PetSet
 metadata:
   name: {{ template "fullname" . }}
-  namespace: {{ .Values.Namespace }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/incubator/patroni/templates/sec-patroni.yaml
+++ b/incubator/patroni/templates/sec-patroni.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "fullname" . }}
-  namespace: {{ .Values.Namespace }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/incubator/patroni/templates/svc-patroni.yaml
+++ b/incubator/patroni/templates/svc-patroni.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "fullname" . }}
-  namespace: {{ .Values.Namespace }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -1,5 +1,4 @@
 Name: patroni
-Namespace: default
 
 Component: patroni
 ImagePullPolicy: IfNotPresent


### PR DESCRIPTION
This should be configured using the `--namespace` option in `helm
install`, not as a value in the chart.
