### PR TITLE
Remove extra space in mysql README.md.

### DIFF
--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -78,7 +78,7 @@ $ helm install --name my-release -f values.yaml stable/mysql
 
 ## Persistence
 
-The  [MySQL](https://hub.docker.com/_/mysql/) image stores the MySQL data and configurations at the `/var/lib/mysql` path of the container.
+The [MySQL](https://hub.docker.com/_/mysql/) image stores the MySQL data and configurations at the `/var/lib/mysql` path of the container.
 
 By default a PersistentVolumeClaim is created and mounted into that directory. In order to disable this functionality
 you can change the values.yaml to disable persistence and use an emptyDir instead.


### PR DESCRIPTION
I noticed an extra space in mysql's README.md when I was copypasta'ing it for other charts.

Feex!
