### PR TITLE
patroni: assume etcd to be in same namespace by default

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: "Highly available elephant herd: HA PostgreSQL cluster."
-version: 0.1.4
+version: 0.1.5
 home: https://github.com/zalando/patroni
 sources:
   - https://github.com/zalando/patroni

--- a/incubator/patroni/templates/ps-patroni.yaml
+++ b/incubator/patroni/templates/ps-patroni.yaml
@@ -44,7 +44,7 @@ spec:
               name: {{ template "fullname" . }}
               key: password-standby
         - name: ETCD_DISCOVERY_DOMAIN
-          value: {{default (printf "%s-etcd" .Release.Name) .Values.Etcd.Discovery }}
+          value: {{default (printf "%s-etcd" .Release.Name | trunc 24) .Values.Etcd.Discovery }}
         - name: SCOPE
           value: {{ template "fullname" . }}
         - name: USE_WALE

--- a/incubator/patroni/templates/ps-patroni.yaml
+++ b/incubator/patroni/templates/ps-patroni.yaml
@@ -44,7 +44,7 @@ spec:
               name: {{ template "fullname" . }}
               key: password-standby
         - name: ETCD_DISCOVERY_DOMAIN
-          value: {{default (printf "%s-etcd.%s.svc.cluster.local" .Release.Name .Release.Namespace) .Values.Etcd.Discovery }}
+          value: {{default (printf "%s-etcd" .Release.Name) .Values.Etcd.Discovery }}
         - name: SCOPE
           value: {{ template "fullname" . }}
         - name: USE_WALE


### PR DESCRIPTION
https://github.com/kubernetes/charts/pull/137 broke the `patroni` chart as it depended on the namespace being defined in `values.yaml`.

this fixes it by telling `patroni` to lookup `etcd` in its own namespace by default.
