### PR TITLE
Spartakus - static container name

### DIFF
--- a/stable/spartakus/README.md
+++ b/stable/spartakus/README.md
@@ -44,8 +44,7 @@ The following tables lists the configurable parameters of the Spartakus chart an
 
 | Parameter                            | Description                              | Default                                                    |
 | -------------------------------      | -------------------------------          | ---------------------------------------------------------- |
-| `containerImage`                              | Container image                          | `gcr.io/google_containers/spartakus-amd64:{VERSION}`                              |
-| `containerName`                              | Container name                          | `spartakus`                              |
+| `image`                              | Container image                          | `gcr.io/google_containers/spartakus-amd64:{VERSION}`                              |
 | `imagePullPolicy`                    | Image pull policy                        | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
 | `resources.requests.cpu`            | CPU resource request    | `2m`                                                      |
 | `resources.requests.memory` | Memory resource request   | `8Mi`                                                  |

--- a/stable/spartakus/README.md
+++ b/stable/spartakus/README.md
@@ -44,11 +44,12 @@ The following tables lists the configurable parameters of the Spartakus chart an
 
 | Parameter                            | Description                              | Default                                                    |
 | -------------------------------      | -------------------------------          | ---------------------------------------------------------- |
-| `image`                              | Spartakus image                          | `gcr.io/google_containers/spartakus-amd64:{VERSION}`                              |
+| `containerImage`                              | Container image                          | `gcr.io/google_containers/spartakus-amd64:{VERSION}`                              |
+| `containerName`                              | Container name                          | Dynamically generated based on the chart & release names                              |
 | `imagePullPolicy`                    | Image pull policy                        | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
-| `resources.requests.cpu`            | CPU resource request    | `1m`                                                      |
+| `resources.requests.cpu`            | CPU resource request    | `2m`                                                      |
 | `resources.requests.memory` | Memory resource request   | `8Mi`                                                  |
-| `uuid` | Unique cluster ID   | Dynamically-generated using `uuidv4` template function                                                  |
+| `uuid` | Unique cluster ID   | Dynamically generated using `uuidv4` template function                                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/spartakus/README.md
+++ b/stable/spartakus/README.md
@@ -45,7 +45,7 @@ The following tables lists the configurable parameters of the Spartakus chart an
 | Parameter                            | Description                              | Default                                                    |
 | -------------------------------      | -------------------------------          | ---------------------------------------------------------- |
 | `containerImage`                              | Container image                          | `gcr.io/google_containers/spartakus-amd64:{VERSION}`                              |
-| `containerName`                              | Container name                          | Dynamically generated based on the chart & release names                              |
+| `containerName`                              | Container name                          | `spartakus`                              |
 | `imagePullPolicy`                    | Image pull policy                        | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
 | `resources.requests.cpu`            | CPU resource request    | `2m`                                                      |
 | `resources.requests.memory` | Memory resource request   | `8Mi`                                                  |

--- a/stable/spartakus/templates/deployment.yaml
+++ b/stable/spartakus/templates/deployment.yaml
@@ -16,8 +16,8 @@ spec:
         release: "{{ .Release.Name }}"
     spec:
       containers:
-        - name: spartakus
-          image: "{{ .Values.image }}"
+        - name: {{ if .Values.containerName }}"{{ .Values.containerName }}"{{ else }}{{ template "fullname" . }}{{ end }}
+          image: "{{ .Values.containerImage }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           args:
             - volunteer

--- a/stable/spartakus/templates/deployment.yaml
+++ b/stable/spartakus/templates/deployment.yaml
@@ -16,8 +16,8 @@ spec:
         release: "{{ .Release.Name }}"
     spec:
       containers:
-        - name: {{ default "spartakus" .Values.containerName | quote }}
-          image: "{{ .Values.containerImage }}"
+        - name: {{ template "name" . }}
+          image: "{{ .Values.image }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           args:
             - volunteer

--- a/stable/spartakus/templates/deployment.yaml
+++ b/stable/spartakus/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         release: "{{ .Release.Name }}"
     spec:
       containers:
-        - name: {{ template "fullname" . }}
+        - name: spartakus
           image: "{{ .Values.image }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           args:

--- a/stable/spartakus/templates/deployment.yaml
+++ b/stable/spartakus/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         release: "{{ .Release.Name }}"
     spec:
       containers:
-        - name: {{ if .Values.containerName }}"{{ .Values.containerName }}"{{ else }}{{ template "fullname" . }}{{ end }}
+        - name: {{ default "spartakus" .Values.containerName | quote }}
           image: "{{ .Values.containerImage }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           args:

--- a/stable/spartakus/values.yaml
+++ b/stable/spartakus/values.yaml
@@ -1,13 +1,20 @@
-image: gcr.io/google_containers/spartakus-amd64:v1.0.0
+## Container image
+##
+containerImage: gcr.io/google_containers/spartakus-amd64:v1.0.0
 
-## Specify a imagePullPolicy
-## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+## Container name
+## If not provided, Helm will template a name based on the chart & release names
+##
+## containerName: spartakus
+
+## Global imagePullPolicy
+## Default: 'Always' if image tag is 'latest', else 'IfNotPresent'
+## Ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##
 # imagePullPolicy:
 
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## Resource requests and limits
+## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
 resources:
   # limits:

--- a/stable/spartakus/values.yaml
+++ b/stable/spartakus/values.yaml
@@ -3,11 +3,11 @@
 containerImage: gcr.io/google_containers/spartakus-amd64:v1.0.0
 
 ## Container name
-## If not provided, Helm will template a name based on the chart & release names
+## Default: 'spartakus'
 ##
-## containerName: spartakus
+## containerName:
 
-## Global imagePullPolicy
+## imagePullPolicy
 ## Default: 'Always' if image tag is 'latest', else 'IfNotPresent'
 ## Ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##

--- a/stable/spartakus/values.yaml
+++ b/stable/spartakus/values.yaml
@@ -1,11 +1,6 @@
 ## Container image
 ##
-containerImage: gcr.io/google_containers/spartakus-amd64:v1.0.0
-
-## Container name
-## Default: 'spartakus'
-##
-## containerName:
+image: gcr.io/google_containers/spartakus-amd64:v1.0.0
 
 ## imagePullPolicy
 ## Default: 'Always' if image tag is 'latest', else 'IfNotPresent'


### PR DESCRIPTION
My company aggregates container logs by container name, with each stream named after the pod itself. Naming both the pod & the container dynamically based on the release name breaks that pattern between different deployments. 
