### PR TITLE
Parameterize postgres chart's imagePullPolicy.

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.1.0
+version: 0.1.1
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -46,6 +46,7 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 | Parameter                  | Description                                | Default                                                    |
 | -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
 | `imageTag`                 | `postgres` image tag                       | `9.5.4`                                           |
+| `imagePullPolicy`          | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
 | `postgresUser`             | Username of new user to create.            | `potgres`                                                  |
 | `postgresPassword`         | Password for the new user.                 | random 10 characters                                       |
 | `postgresDatabase`         | Name for new database to create.           | `postgres`                                                 |

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: {{ template "fullname" . }}
         image: "postgres:{{ .Values.imageTag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         resources:
           requests:
             cpu: "{{.Values.cpu}}"

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -5,6 +5,12 @@ imageTag: "9.5.4"
 cpu: 100m
 memory: 256Mi
 
+## Specify a imagePullPolicy
+## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
+
 ## Create a database user
 ## Default: postgres
 # postgresUser:


### PR DESCRIPTION
The postgres chart is unusual in its imagePullPolicy being hardcoded to `Always`. We probably don't want to do this by default unless there are really compelling reasons to do so, especially for stable charts.

This PR parameterizes the imagePullPolicy in a way that is consistent with a growing number of our charts. The default is also now the Kubernetes default of IfNotPresent.

:eyeglasses: @swordbeta @viglesiasce @prydonius 