### PR TITLE
Add gitlab-ce chart to stable.

### DIFF
--- a/stable/gitlab-ce/.helmignore
+++ b/stable/gitlab-ce/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,0 +1,16 @@
+name: gitlab-ce
+version: 0.1.0
+description: GitLab Community Edition
+keywords:
+- git
+- ci
+- deploy
+- issue tracker
+- code review
+- wiki
+sources:
+- https://hub.docker.com/r/gitlab/gitlab-ce/
+- https://docs.gitlab.com/omnibus/
+maintainers:
+- name: Greg Taylor
+  email: gtaylor@gc-taylor.com

--- a/stable/gitlab-ce/README.md
+++ b/stable/gitlab-ce/README.md
@@ -1,0 +1,67 @@
+# GitLab Community Edition
+
+[GitLab Community Edition](https://about.gitlab.com/) is an application to code, test, and deploy code together. It provides Git repository management with fine grained access controls, code reviews, issue tracking, activity feeds, wikis, and continuous integration. 
+
+## Introduction
+
+This chart stands up a GitLab Community Edition install. This includes:
+
+- A [GitLab Omnibus](https://docs.gitlab.com/omnibus/) Pod
+- Redis
+- Postgresql
+
+## Prerequisites
+
+- _At least_ 3 GB of RAM available on your cluster, in chunks of 1 GB
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+- The ability to point a DNS entry or URL at your GitLab install
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` run:
+
+```bash
+$ helm install --name my-release \
+    --set externalUrl=http://your-domain.com/ stable/gitlab-ce
+```
+
+Note that you _must_ pass in externalUrl, or you'll end up with a non-functioning release.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Refer to [values.yaml](values.yaml) for the full run-down on defaults. These are a mixture of Kubernetes and GitLab-related directives.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set externalUrl=http://your-domain.com/,gitlabRootPassword=pass1234 \
+    stable/gitlab-ce
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/gitlab-ce
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+By default, persistence of GitLab data and configuration happens using PVCs. If you know that you'll need a larger amount of space, make _sure_ to look at the `persistence` section in [values.yaml](values.yaml).
+
+> *"If you disable persistence, the contents of your volume(s) will only last as long as the Pod does. Upgrading or changing certain settings may lead to data loss without persistence."*

--- a/stable/gitlab-ce/requirements.lock
+++ b/stable/gitlab-ce/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: http://kubernetes-charts.storage.googleapis.com
   version: 0.4.1
 - name: postgresql
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: http://kubernetes-charts.storage.googleapis.com
   version: 0.1.1
 digest: sha256:15072cb8756660047cf5f13e61d29c810e796e91c7a9e9a56927d7430de34226
 generated: 2016-11-04T23:15:05.755476969-07:00

--- a/stable/gitlab-ce/requirements.lock
+++ b/stable/gitlab-ce/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.4.1
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.1.1
 digest: sha256:15072cb8756660047cf5f13e61d29c810e796e91c7a9e9a56927d7430de34226
 generated: 2016-11-04T23:15:05.755476969-07:00

--- a/stable/gitlab-ce/requirements.lock
+++ b/stable/gitlab-ce/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: redis
+  repository: http://storage.googleapis.com/kubernetes-charts
+  version: 0.4.1
+- name: postgresql
+  repository: http://storage.googleapis.com/kubernetes-charts
+  version: 0.1.1
+digest: sha256:15072cb8756660047cf5f13e61d29c810e796e91c7a9e9a56927d7430de34226
+generated: 2016-11-04T23:15:05.755476969-07:00

--- a/stable/gitlab-ce/requirements.lock
+++ b/stable/gitlab-ce/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  repository: http://kubernetes-charts.storage.googleapis.com
+  repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.4.1
 - name: postgresql
-  repository: http://kubernetes-charts.storage.googleapis.com
+  repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.1.1
 digest: sha256:15072cb8756660047cf5f13e61d29c810e796e91c7a9e9a56927d7430de34226
 generated: 2016-11-04T23:15:05.755476969-07:00

--- a/stable/gitlab-ce/requirements.yaml
+++ b/stable/gitlab-ce/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: redis
   version: 0.4.1
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: http://kubernetes-charts.storage.googleapis.com
 - name: postgresql
   version: 0.1.1
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: http://kubernetes-charts.storage.googleapis.com

--- a/stable/gitlab-ce/requirements.yaml
+++ b/stable/gitlab-ce/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: redis
   version: 0.4.1
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://kubernetes-charts.storage.googleapis.com/
 - name: postgresql
   version: 0.1.1
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/gitlab-ce/requirements.yaml
+++ b/stable/gitlab-ce/requirements.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- name: redis
+  version: 0.4.1
+  repository: http://storage.googleapis.com/kubernetes-charts
+- name: postgresql
+  version: 0.1.1
+  repository: http://storage.googleapis.com/kubernetes-charts

--- a/stable/gitlab-ce/requirements.yaml
+++ b/stable/gitlab-ce/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: redis
   version: 0.4.1
-  repository: http://kubernetes-charts.storage.googleapis.com
+  repository: https://kubernetes-charts.storage.googleapis.com
 - name: postgresql
   version: 0.1.1
-  repository: http://kubernetes-charts.storage.googleapis.com
+  repository: https://kubernetes-charts.storage.googleapis.com

--- a/stable/gitlab-ce/templates/NOTES.txt
+++ b/stable/gitlab-ce/templates/NOTES.txt
@@ -42,7 +42,7 @@
 
 {{- else -}}
 ##############################################################################
-##  ERROR: You did not specify an externalUrl in your 'helm install' call.  ##
+## WARNING: You did not specify an externalUrl in your 'helm install' call. ##
 ##############################################################################
 
 This deployment will be incomplete until you provide the URL that your

--- a/stable/gitlab-ce/templates/NOTES.txt
+++ b/stable/gitlab-ce/templates/NOTES.txt
@@ -1,0 +1,53 @@
+{{- if default "" .Values.externalUrl }}
+1. Get your GitLab URL by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP/
+
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc -w {{ template "fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP/
+{{- else if contains "ClusterIP"  .Values.serviceType }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}
+
+{{- if default "" .Values.gitlabRootPassword }}
+
+2. Login as the root user:
+
+  Username: admin
+  Password: {{ .Values.gitlabRootPassword }}
+{{ else }}
+
+2. Set your admin user's password on your first visit to your install. Then
+   login as:
+
+   Username: admin
+   Password: <whatever value you entered>
+{{- end }}
+
+3. Point a DNS entry at your install to ensure that your specified
+   external URL is reachable:
+
+   {{ default "UNSPECIFIED" .Values.externalUrl }}
+
+{{- else -}}
+##############################################################################
+##  ERROR: You did not specify an externalUrl in your 'helm install' call.  ##
+##############################################################################
+
+This deployment will be incomplete until you provide the URL that your
+GitLab install will be reachable to your users under:
+
+    helm upgrade {{ .Release.Name }} \
+        --set externalUrl=http://your-domain.com stable/gitlab-ce
+{{- end -}}

--- a/stable/gitlab-ce/templates/_helpers.tpl
+++ b/stable/gitlab-ce/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified postgresql name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- printf "%s-%s" .Release.Name "postgresql" | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified redis name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "redis.fullname" -}}
+{{- printf "%s-%s" .Release.Name "redis" | trunc 24 -}}
+{{- end -}}

--- a/stable/gitlab-ce/templates/configmap.yaml
+++ b/stable/gitlab-ce/templates/configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  ## This is used by GitLab Omnibus as the primary means of configuration.
+  ## ref: https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template
+  ##
+  gitlab_omnibus_config: |
+    external_url ENV['EXTERNAL_URL'];
+    root_pass = ENV['GITLAB_ROOT_PASSWORD'];
+    gitlab_rails['initial_root_password'] = root_pass unless root_pass.to_s == '';
+    postgresql['enable'] = false;
+    gitlab_rails['db_host'] = ENV['DB_HOST'];
+    gitlab_rails['db_password'] = ENV['DB_PASSWORD'];
+    gitlab_rails['db_username'] = ENV['DB_USER'];
+    gitlab_rails['db_database'] = ENV['DB_DATABASE'];
+    redis['enable'] = false;
+    gitlab_rails['redis_host'] = ENV['REDIS_HOST'];
+    gitlab_rails['redis_password'] = ENV['REDIS_PASSWORD'];
+    unicorn['worker_processes'] = 2;
+    manage_accounts['enable'] = true;
+    manage_storage_directories['manage_etc'] = false;
+    gitlab_shell['auth_file'] = '/gitlab-data/ssh/authorized_keys';
+    git_data_dir '/gitlab-data/git-data';
+    gitlab_rails['shared_path'] = '/gitlab-data/shared';
+    gitlab_rails['uploads_directory'] = '/gitlab-data/uploads';
+    gitlab_ci['builds_directory'] = '/gitlab-data/builds';

--- a/stable/gitlab-ce/templates/data-pvc.yaml
+++ b/stable/gitlab-ce/templates/data-pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.persistence.gitlabData.enabled }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-data
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.gitlabData.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.gitlabData.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.gitlabData.size | quote }}
+{{- end }}

--- a/stable/gitlab-ce/templates/deployment.yaml
+++ b/stable/gitlab-ce/templates/deployment.yaml
@@ -1,0 +1,118 @@
+{{- if default "" .Values.externalUrl }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}
+        image: {{ .Values.image }}
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        env:
+        ## General GitLab Configs
+        ##
+        # This is a free-form env var that GitLab Omnibus uses to configure
+        # everything. We're passing this in from a configmap and pulling some
+        # of the values from the env vars defined below. This is done to
+        # avoid leaving secrets visible in kubectl.
+        - name: GITLAB_OMNIBUS_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}
+              key: gitlab_omnibus_config
+        - name: GITLAB_ROOT_PASSWORD
+        {{- if default "" .Values.gitlabRootPassword }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: gitlab-root-password
+        {{ end }}
+        - name: EXTERNAL_URL
+          value: {{ default "" .Values.externalUrl | quote }}
+        ## DB configuration
+        ##
+        - name: DB_HOST
+          value: {{ template "postgresql.fullname" . }}
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: db-user
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: db-password
+        - name: DB_DATABASE
+          value: {{ .Values.postgresql.postgresDatabase | quote }}
+        ## Redis configuration
+        ##
+        - name: REDIS_HOST
+          value: {{ template "redis.fullname" . }}
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: redis-password
+        ports:
+        - name: ssh
+          containerPort: 22
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+        livenessProbe:
+          httpGet:
+            path: /help
+            port: http
+          # This pod takes a very long time to start up. Be cautious when
+          # lowering this value to avoid Pod death during startup.
+          initialDelaySeconds: 200
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 10
+        readinessProbe:
+          httpGet:
+            path: /help
+            port: http
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
+        - name: gitlab-etc
+          mountPath: /etc/gitlab
+        - name: gitlab-data
+          mountPath: /gitlab-data
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      volumes:
+      - name: gitlab-etc
+      {{- if .Values.persistence.gitlabEtc.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-etc
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      - name: gitlab-data
+      {{- if .Values.persistence.gitlabData.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-data
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+{{ else }}
+{{ end }}

--- a/stable/gitlab-ce/templates/etc-pvc.yaml
+++ b/stable/gitlab-ce/templates/etc-pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.persistence.gitlabEtc.enabled }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-etc
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.gitlabEtc.storageClass | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.gitlabEtc.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.gitlabEtc.size | quote }}
+{{- end }}

--- a/stable/gitlab-ce/templates/secrets.yaml
+++ b/stable/gitlab-ce/templates/secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{- if default "" .Values.gitlabRootPassword }}
+  # Defaulting to a non-sensical value to silence b64enc warning. We'll never
+  # actually use this default due to the if statement.
+  gitlab-root-password: {{ default "ignore" .Values.gitlabRootPassword | b64enc | quote }}
+  {{ end }}
+  db-user: {{ .Values.postgresql.postgresUser | b64enc | quote }}
+  db-password: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
+  redis-password: {{ .Values.redis.redisPassword | b64enc | quote }}

--- a/stable/gitlab-ce/templates/svc.yaml
+++ b/stable/gitlab-ce/templates/svc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.serviceType }}
+  ports:
+  - name: ssh
+    port: 22
+    targetPort: ssh
+  - name: http
+    port: 80
+    targetPort: http
+  - name: https
+    port: 443
+    targetPort: https
+  selector:
+    app: {{ template "fullname" . }}

--- a/stable/gitlab-ce/values.yaml
+++ b/stable/gitlab-ce/values.yaml
@@ -1,0 +1,89 @@
+## GitLab CE image
+## ref: https://hub.docker.com/r/gitlab/gitlab-ce/tags/
+##
+image: gitlab/gitlab-ce:8.13.3-ce.0
+
+## Specify a imagePullPolicy
+## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
+
+## The URL (with protocol) that your users will use to reach the install.
+## ref: https://docs.gitlab.com/omnibus/settings/configuration.html#configuring-the-external-url-for-gitlab
+##
+#externalUrl: http://your-domain.com/
+
+## Change the initial default admin password if set. If not set, you'll be
+## able to set it when you first visit your install.
+##
+#gitlabRootPassword: ""
+
+## For minikube, set this to NodePort, elsewhere use LoadBalancer
+## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
+##
+serviceType: LoadBalancer
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  ## GitLab requires a good deal of resources. We have split out Postgres and
+  ## redis, which helps some. Refer to the guidelines for larger installs.
+  ## ref: https://docs.gitlab.com/ce/install/requirements.html#hardware-requirements
+  requests:
+    memory: 1Gi
+    cpu: 500m
+  limits:
+    memory: 2Gi
+    cpu: 1
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+## ref: https://docs.gitlab.com/ce/install/requirements.html#storage
+##
+persistence:
+  ## This volume persists generated configuration files, keys, and certs.
+  ##
+  gitlabEtc:
+    enabled: true
+    size: 1Gi
+    storageClass: generic
+    accessMode: ReadWriteOnce
+  ## This volume is used to store git data and other project files.
+  ## ref: https://docs.gitlab.com/omnibus/settings/configuration.html#storing-git-data-in-an-alternative-directory
+  ##
+  gitlabData:
+    enabled: true
+    size: 10Gi
+    storageClass: generic
+    accessMode: ReadWriteOnce
+
+## Configuration values for the postgresql dependency.
+## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
+##
+postgresql:
+  # 9.4 is currently used in the official OpenShift manifests.
+  imageTag: "9.4"
+  cpu: 1000m
+  memory: 1Gi
+
+  postgresUser: gitlab
+  postgresPassword: gitlab
+  postgresDatabase: gitlab
+
+  persistence:
+    size: 10Gi
+
+## Configuration values for the redis dependency.
+## ref: https://github.com/kubernetes/charts/blob/master/stable/redis/README.md
+##
+redis:
+  redisPassword: "gitlab"
+
+  resources:
+    requests:
+      memory: 1Gi
+
+  persistence:
+    size: 10Gi


### PR DESCRIPTION
This PR adds a basic GitLab Community Edition chart. This is the barest of bones out of the gates. Most of the values and the structure are based off of GitLab's official [OpenShift template](https://gitlab.com/gitlab-org/omnibus-gitlab/raw/master/docker/openshift-template.json).

We'll need to see how people use this and what we need to make configurable. I suspect that serious users are going to end up needing to fork this chart on their own, though. The sheer number of configurable values is high enough that we may never obtain and maintain full coverage without getting convoluted or out of date with upstream.

Some implementation notes:

* The GitLab omnibus Docker image uses a `GITLAB_OMNIBUS_CONFIG` env var for the vast majority of its config. I had initially created a ConfigMap and substituted values in via templating, but this left sensitive secrets exposed. I ended up sticking Ruby `ENV['blah']` calls in the ConfigMap and passing the values and secrets in there. This should give us the `kubectl describe pod <>` output that most expect, while "protecting" our secrets (if k8s fixes up Secrets!).
* This chart requires an `externalUrl` be passed in at installation. NOTES.txt and deployments.yaml work similarly to the minecraft chart's EULA enforcer in that they'll get a big error and a non-functioning deploy if they don't pass it in. Instructions are included on how to get out of this state.
* There are going to be a ton of configurable values, so I'm punting on listing these all in README.md. It's going to get looooong as we go.

:eyeglasses: @viglesiasce @prydonius @stanhun001 