### PR TITLE
Separate postgres resource requests/limits.

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.1.1
+version: 0.2.0
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -54,6 +54,7 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 | `persistence.storageClass` | Storage class of backing PVC               | `generic`                                                  |
 | `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                            |
 | `persistence.size`         | Size of data volume                        | `8Gi`                                                      |
+| `resources`                | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `100m`                               |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -31,13 +31,6 @@ spec:
       - name: {{ template "fullname" . }}
         image: "postgres:{{ .Values.imageTag }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
-        resources:
-          requests:
-            cpu: "{{.Values.cpu}}"
-            memory: "{{.Values.memory}}"
-          limits:
-            cpu: "{{.Values.cpu}}"
-            memory: "{{.Values.memory}}"
         env:
         - name: POSTGRES_USER
           value: {{ default "postgres" .Values.postgresUser | quote }}
@@ -68,6 +61,8 @@ spec:
             - pg_isready
           initialDelaySeconds: 60
           timeoutSeconds: 3
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: data
           mountPath: /var/lib/postgresql/data/pgdata

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -2,8 +2,6 @@
 ## ref: https://hub.docker.com/r/library/postgres/tags/
 ##
 imageTag: "9.5.4"
-cpu: 100m
-memory: 256Mi
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
@@ -27,3 +25,11 @@ persistence:
   storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 100m


### PR DESCRIPTION
Also bring them in line with our toYaml resources pattern that a growing number of charts are using.

Bumped the minor version to 0.2.0 since this is backwards-incompatible with those using the old combo limit/request values.

:eyeglasses: @swordbeta @viglesiasce 