### PR TITLE
Add datadog chart to stable.

### DIFF
--- a/stable/datadog/.helmignore
+++ b/stable/datadog/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,0 +1,13 @@
+name: datadog
+version: 0.1.0
+description: DataDog Agent
+keywords:
+- monitoring
+- alerting
+- metric
+sources:
+- https://app.datadoghq.com/account/settings#agent/kubernetes
+- https://github.com/DataDog/docker-dd-agent
+maintainers:
+- name: Greg Taylor
+  email: gtaylor@gc-taylor.com

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -1,0 +1,54 @@
+# Datadog
+
+[Datadog](https://www.datadoghq.com/) is a hosted infrastructure monitoring platform.
+
+## Introduction
+
+This chart adds the DataDog Agent to all nodes in your cluster via a DaemonSet.
+
+## Prerequisites
+
+- Kubernetes 1.2+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`, retrieve your DataDog API key from your [Agent Installation Instructions](https://app.datadoghq.com/account/settings#agent/kubernetes) and run:
+
+```bash
+$ helm install --name my-release \
+    --set datadog.apiKey=YOUR-KEY-HERE stable/datadog
+```
+
+After a few minutes, you should see hosts and metrics being reported in DataDog.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Refer to [values.yaml](values.yaml) for the full run-down on defaults.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set datadog.apiKey=YOUR-KEY-HERE,datadog.logLevel=DEBUG \
+    stable/datadog
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/datadog
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -35,7 +35,19 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-Refer to [values.yaml](values.yaml) for the full run-down on defaults.
+The following tables lists the configurable parameters of the Datadog chart and their default values.
+
+|      Parameter              |          Description               |                         Default           |
+|-----------------------------|------------------------------------|-------------------------------------------|
+| `datadog.apiKey`            | Your Datadog API key               |  `Nil` You must provide your own key      |
+| `image.repository`          | The image repository to pull from  | `datadog/docker-dd-agent`                 |
+| `image.tag`                 | The image tag to pull              | `latest`                                  |
+| `imagePullPolicy`           | Image pull policy                  | `IfNotPresent`                            |
+| `resources.requests.cpu`    | CPU resource requests              | 128M                                      |
+| `resources.limits.cpu`      | CPU resource limits                | 512Mi                                     |
+| `resources.requests.memory` | Memory resource requests           | 100m                                      |
+| `resources.limits.memory`   | Memory resource limits             | 256m                                      |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -11,7 +11,10 @@ No further action should be required.
 ####               ERROR: You did not set a datadog.apiKey.               ####
 ##############################################################################
 
-This deployment will be incomplete until you get your API key from:
+This deployment will be incomplete until you get your API key from Datadog. 
+One can sign up for a free Datadog trial at https://app.datadoghq.com/signup
+
+Once registered you can request an API key at:
 
     https://app.datadoghq.com/account/settings#agent/kubernetes
 

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -1,0 +1,22 @@
+{{- if .Values.datadog.apiKey -}}
+DataDog agents are spinning up on each node in your cluster. After a few
+minutes, you should see your agents starting in your event stream:
+
+    https://app.datadoghq.com/event/stream
+
+No further action should be required.
+
+{{- else -}}
+##############################################################################
+####               ERROR: You did not set a datadog.apiKey.               ####
+##############################################################################
+
+This deployment will be incomplete until you get your API key from:
+
+    https://app.datadoghq.com/account/settings#agent/kubernetes
+
+Then run:
+
+    helm upgrade {{ .Release.Name }} \
+        --set datadog.apiKey=YOUR-KEY-HERE stable/datadog
+{{- end }}

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -30,6 +30,8 @@ spec:
                 key: api-key
           - name: LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}
+          - name: SD_BACKEND
+            value: docker
           - name: NON_LOCAL_TRAFFIC
             value: {{ default "" .Values.datadog.nonLocalTraffic | quote }}
           - name: KUBERNETES

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.datadog.apiKey }}
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+      name: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        env:
+          - name: API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: api-key
+          - name: LOG_LEVEL
+            value: {{ .Values.datadog.logLevel | quote }}
+          - name: NON_LOCAL_TRAFFIC
+            value: {{ default "" .Values.datadog.nonLocalTraffic | quote }}
+          - name: KUBERNETES
+            value: "yes"
+        volumeMounts:
+          - name: dockersocket
+            mountPath: /var/run/docker.sock
+          - name: procdir
+            mountPath: /host/proc
+            readOnly: true
+          - name: cgroups
+            mountPath: /host/sys/fs/cgroup
+            readOnly: true
+      volumes:
+        - hostPath:
+            path: /var/run/docker.sock
+          name: dockersocket
+        - hostPath:
+            path: /proc
+          name: procdir
+        - hostPath:
+            path: /sys/fs/cgroup
+          name: cgroups
+{{ end }}

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  api-key: {{ default "MISSING" .Values.datadog.apiKey | b64enc | quote }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -1,0 +1,29 @@
+# Default values for datadog.
+image:
+  repository: datadog/docker-dd-agent
+  tag: latest
+  pullPolicy: IfNotPresent
+
+datadog:
+  ## You'll need to set this to your Datadog API key before the agent will run.
+  ## ref: https://app.datadoghq.com/account/settings#agent/kubernetes
+  ##
+  # apiKey:
+
+  ## Set logging verbosity.
+  ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
+  ##
+  logLevel: WARNING
+
+  ## Un-comment this to make each node accept non-local statsd traffic.
+  ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
+  ##
+  # nonLocalTraffic: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 256m
+    memory: 512Mi


### PR DESCRIPTION
Adds a [DataDog](https://www.datadoghq.com/) chart. Fairly popular hosted monitoring service that works relatively well on Kubernetes.