### PR TITLE
Bump Drupal image version to 8.2.3-r0

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.3.7
+version: 0.3.8
 description: One of the most versatile open source content management systems.
 keywords:
 - drupal

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Drupal image version
 ## ref: https://hub.docker.com/r/bitnami/drupal/tags/
 ##
-image: bitnami/drupal:8.2.2-r2
+image: bitnami/drupal:8.2.3-r0
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
- Bump Drupal image version to 8.2.2-r2
- Fixed security issues (Ref DRUPAL-CORE-2016-005).