### PR TITLE
Update repository URLs in requirement files and ci scripts

### DIFF
--- a/incubator/patroni/requirements.lock
+++ b/incubator/patroni/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: etcd
-  repository: http://storage.googleapis.com/kubernetes-charts-incubator
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   version: 0.1.1
-digest: sha256:868fc97296df4ebb094503a97822cca6726beb932defc41e142410980bd3e50e
-generated: 2016-10-20T18:39:33.583071612-07:00
+digest: sha256:dcf52049f032719c91e8df35b8b107b113cc303631de97cfffed8ecbc13f3fde
+generated: 2016-11-18T16:09:05.607060717-08:00

--- a/incubator/patroni/requirements.yaml
+++ b/incubator/patroni/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: etcd
   version: 0.1.1
-  repository: http://storage.googleapis.com/kubernetes-charts-incubator
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/

--- a/stable/drupal/requirements.lock
+++ b/stable/drupal/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-20T17:55:13.834613554-07:00
+digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
+generated: 2016-11-18T16:08:14.043414269-08:00

--- a/stable/drupal/requirements.yaml
+++ b/stable/drupal/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 0.5.2
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/ghost/requirements.lock
+++ b/stable/ghost/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-20T17:55:13.834613554-07:00
+digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
+generated: 2016-11-18T16:08:14.342458493-08:00

--- a/stable/ghost/requirements.yaml
+++ b/stable/ghost/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 0.5.2
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/joomla/requirements.lock
+++ b/stable/joomla/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-26T14:49:03.028344205-07:00
+digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
+generated: 2016-11-18T16:08:14.660962404-08:00

--- a/stable/joomla/requirements.yaml
+++ b/stable/joomla/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 0.5.2
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-26T14:49:03.028344205-07:00
+digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
+generated: 2016-11-18T16:08:14.967212355-08:00

--- a/stable/mediawiki/requirements.yaml
+++ b/stable/mediawiki/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 0.5.2
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/phpbb/requirements.lock
+++ b/stable/phpbb/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-26T14:49:03.028344205-07:00
+digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
+generated: 2016-11-18T16:08:15.350208134-08:00

--- a/stable/phpbb/requirements.yaml
+++ b/stable/phpbb/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 0.5.2
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-20T18:20:59.008186552-07:00
+digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
+generated: 2016-11-18T16:08:15.781788252-08:00

--- a/stable/redmine/requirements.yaml
+++ b/stable/redmine/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 0.5.2
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-26T14:49:03.028344205-07:00
+digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
+generated: 2016-11-18T16:08:16.150784632-08:00

--- a/stable/testlink/requirements.yaml
+++ b/stable/testlink/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 0.5.2
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-20T18:26:31.997399191-07:00
+digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
+generated: 2016-11-18T16:08:16.520834727-08:00

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
   version: 0.5.2
-  repository: http://storage.googleapis.com/kubernetes-charts
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/test/changed.sh
+++ b/test/changed.sh
@@ -45,7 +45,7 @@ gcloud container clusters get-credentials jenkins --project kubernetes-charts-ci
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
 HELM_TARBALL=helm-v2.0.0-linux-amd64.tar.gz
-INCUBATOR_REPO_URL=http://storage.googleapis.com/kubernetes-charts-incubator
+INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 pushd /opt
   wget -q ${HELM_URL}/${HELM_TARBALL}
   tar xzfv ${HELM_TARBALL}

--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -17,7 +17,7 @@
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
 HELM_TARBALL=helm-canary-linux-amd64.tar.gz
 STABLE_REPO_URL=http://storage.googleapis.com/kubernetes-charts
-INCUBATOR_REPO_URL=http://storage.googleapis.com/kubernetes-charts-incubator
+INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 wget -q ${HELM_URL}/${HELM_TARBALL}
 tar xzfv ${HELM_TARBALL}
 PATH=`pwd`/linux-amd64/:$PATH


### PR DESCRIPTION
Helm 2.0.0 release changed the default repository URL from http://storage.googleapis.com/kubernetes-charts to https://kubernetes-charts-incubator.storage.googleapis.com/ which is causing the CI to fail as it cannot find a matching repository. This updates all charts to point to the new repository URLs, and updates the CI script to use the root-level domain for adding the incubator repository.