### PR TITLE
Prometheus: default to alpha dynamic PV annotation

### DIFF
--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of the Spartakus chart an
 | `alertmanager.persistentVolume.enabled` | If true, AlertManager will create a Persistent Volume Claim | `true` |
 | `alertmanager.persistentVolume.accessModes` | AlertManager data Persistent Volume access modes | `[ReadWriteOnce]` |
 | `alertmanager.persistentVolume.size` | AlertManager data Persistent Volume size | `2Gi` |
+| `server.persistentVolume.storageClass` | AlertManager data Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default` |
 | `alertmanager.resources` | Alertmanager resource requests and limits (YAML) |`requests: {cpu: 10m, memory: 32Mi}` |
 | `alertmanager.serviceType` | Alertmanager service type | `ClusterIP` |
 | `alertmanager.storagePath` | Alertmanager data storage path | `/data` |
@@ -75,6 +76,7 @@ The following tables lists the configurable parameters of the Spartakus chart an
 | `server.persistentVolume.accessModes` | Server data Persistent Volume access modes | `[ReadWriteOnce]` |
 | `server.persistentVolume.annotations` | Server data Persistent Volume annotations | `[]` |
 | `server.persistentVolume.size` | Server data Persistent Volume size | `8Gi` |
+| `server.persistentVolume.storageClass` | Server data Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default` |
 | `server.resources` | Server resource requests and limits | `requests: {cpu: 500m, memory: 512Mi}` |
 | `server.serviceType` | Server service type | `ClusterIP` |
 | `server.storageLocalPath` | Server local data storage path | `/data` |

--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.alertmanager.persistentVolume.storageClass -}}
     volume.beta.kubernetes.io/storage-class: {{ .Values.alertmanager.persistentVolume.storageClass }}
   {{ else }}
-    volume.alpha.kubernetes.io/storage-class: ''
+    volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
   {{- range $key, $value := .Values.alertmanager.persistentVolume.annotations }}
     {{ $key }}: {{ $value }}

--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
+  {{- if .Values.alertmanager.persistentVolume.storageClass -}}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.alertmanager.persistentVolume.storageClass }}
+  {{ else }}
+    volume.alpha.kubernetes.io/storage-class: ''
+  {{- end }}
   {{- range $key, $value := .Values.alertmanager.persistentVolume.annotations }}
     {{ $key }}: {{ $value }}
   {{- end }}

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.server.persistentVolume.storageClass -}}
     volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass }}
   {{ else }}
-    volume.alpha.kubernetes.io/storage-class: ''
+    volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
   {{- range $key, $value := .Values.server.persistentVolume.annotations }}
     {{ $key }}: {{ $value }}

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
+  {{- if .Values.server.persistentVolume.storageClass -}}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass }}
+  {{ else }}
+    volume.alpha.kubernetes.io/storage-class: ''
+  {{- end }}
   {{- range $key, $value := .Values.server.persistentVolume.annotations }}
     {{ $key }}: {{ $value }}
   {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -56,12 +56,15 @@ alertmanager:
 
     ## AlertManager data Persistent Volume annotations
     ##
-    annotations:
-      volume.beta.kubernetes.io/storage-class: standard
+    # annotations:
 
     ## AlertManager data Persistent Volume size
     ##
     size: 2Gi
+
+    ## AlertManager data Persistent Volume Storage Class
+    ##
+    # storageClass:
 
   ## Alertmanager resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -168,12 +171,15 @@ server:
 
     ## Server data Persistent Volume annotations
     ##
-    annotations:
-      volume.beta.kubernetes.io/storage-class: standard
+    # annotations:
 
     ## Server data Persistent Volume size
     ##
     size: 8Gi
+
+    ## AlertManager data Persistent Volume Storage Class
+    ##
+    # storageClass:
 
   ## Server resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -63,6 +63,8 @@ alertmanager:
     size: 2Gi
 
     ## AlertManager data Persistent Volume Storage Class
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
     ##
     # storageClass:
 
@@ -178,6 +180,8 @@ server:
     size: 8Gi
 
     ## AlertManager data Persistent Volume Storage Class
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
     ##
     # storageClass:
 


### PR DESCRIPTION
Addresses #227, based on input from #116.

Alpha dynamic provisioner only looks for annotation, not value. To enable the beta provisioner, operator provides `.Values.{alertmanager|server}.persistentVolume.storageClass`.