### PR TITLE
Prometheus: add kube-state-metrics

### DIFF
--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -55,13 +55,19 @@ The following tables lists the configurable parameters of the Spartakus chart an
 | `alertmanager.persistentVolume.enabled` | If true, AlertManager will create a Persistent Volume Claim | `true` |
 | `alertmanager.persistentVolume.accessModes` | AlertManager data Persistent Volume access modes | `[ReadWriteOnce]` |
 | `alertmanager.persistentVolume.size` | AlertManager data Persistent Volume size | `2Gi` |
-| `server.persistentVolume.storageClass` | AlertManager data Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default` |
+| `alertmanager.persistentVolume.storageClass` | AlertManager data Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default` |
 | `alertmanager.resources` | Alertmanager resource requests and limits (YAML) |`requests: {cpu: 10m, memory: 32Mi}` |
 | `alertmanager.serviceType` | Alertmanager service type | `ClusterIP` |
 | `alertmanager.storagePath` | Alertmanager data storage path | `/data` |
 | `configmapReload.image` | Configmap-reload Docker image | `jimmidyson/configmap-reload:${VERSION}` |
 | `configmapReload.name` | Configmap-reload container name | `configmap-reload` |
 | `imagePullPolicy` | Global image pull policy | `Always` if image tag is latest, else `IfNotPresent` |
+| `kubeStateMetrics.httpPort` | Kube-state-metrics service port | `80` |
+| `kubeStateMetrics.httpPortName` | Kube-state-metrics service port name | `http` |
+| `kubeStateMetrics.image` | Kube-state-metrics Docker image| `gcr.io/google_containers/kube-state-metrics:v0.3.0` |
+| `kubeStateMetrics.name` | Kube-state-metrics container name | `kube-state-metrics` |
+| `kubeStateMetrics.resources` | Kube-state-metrics resource requests and limits (YAML) | `requests: {cpu: 10m, memory:16Mi}` |
+| `kubeStateMetrics.serviceType` | Kube-state-metrics service type | `ClusterIP` |
 | `server.annotations` | Server Pod annotations | `[]` |
 | `server.extraArgs` | Additional Server container arguments | `[]` |
 | `server.httpPort` | Server service port | `80` |

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -3,30 +3,38 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 -}}
 {{- end -}}
 
 {{/*
 Create a fully qualified alertmanager name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "alertmanager.fullname" -}}
-{{- printf "%s-%s" .Release.Name "alerts" | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name "alerts" | trunc 63 -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified kube-state-metrics name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kubeStateMetrics.fullname" -}}
+{{- printf "%s-%s" .Release.Name "kube-state-metrics" | trunc 63 -}}
 {{- end -}}
 
 {{/*
 Create a fully qualified server name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "server.fullname" -}}
-{{- printf "%s-%s" .Release.Name "server" | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name "server" | trunc 63 -}}
 {{- end -}}

--- a/stable/prometheus/templates/alertmanager-ingress.yaml
+++ b/stable/prometheus/templates/alertmanager-ingress.yaml
@@ -23,7 +23,7 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: {{ printf "%s-%s" $releaseName "alerts" | trunc 24 }}
+              serviceName: {{ printf "%s-%s" $releaseName "alerts" | trunc 63 }}
               servicePort: {{ $servicePort }}
   {{- end -}}
   {{- if .Values.alertmanager.ingress.tls }}

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.kubeStateMetrics.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "kubeStateMetrics.fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        component: "{{ .Values.kubeStateMetrics.name }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+        - name: {{ template "name" . }}-{{ .Values.kubeStateMetrics.name }}
+          image: "{{ .Values.kubeStateMetrics.image }}"
+          imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+          ports:
+            - containerPort: 8080
+          resources:
+{{ toYaml .Values.alertmanager.resources | indent 12 }}

--- a/stable/prometheus/templates/kube-state-metrics-svc.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-svc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.kubeStateMetrics.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "kubeStateMetrics.fullname" . }}
+spec:
+  ports:
+    - port: {{ .Values.kubeStateMetrics.httpPort }}
+      name: {{ default "http" .Values.kubeStateMetrics.httpPortName | quote }}
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: {{ template "fullname" . }}
+    component: "{{ .Values.kubeStateMetrics.name }}"
+  type: "{{ .Values.kubeStateMetrics.serviceType }}"

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -23,7 +23,7 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: {{ printf "%s-%s" $releaseName "server" | trunc 24 }}
+              serviceName: {{ printf "%s-%s" $releaseName "server" | trunc 63 }}
               servicePort: {{ $servicePort }}
   {{- end -}}
   {{- if .Values.server.ingress.tls }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -106,6 +106,39 @@ configmapReload:
 ##
 # imagePullPolicy:
 
+kubeStateMetrics:
+  ## Kube-state-metrics service port
+  ##
+  httpPort: 80
+
+  ## Kube-state-metrics service port name
+  ## Default: 'http'
+  ##
+  # httpPortName: http
+
+  ## Kube-state-metrics Docker image
+  ##
+  image: gcr.io/google_containers/kube-state-metrics:v0.3.0
+
+  ## Kube-state-metrics container name
+  ##
+  name: kube-state-metrics
+
+  ## Kube-state-metrics resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    # limits:
+    #   cpu: 10m
+    #   memory: 16Mi
+    requests:
+      cpu: 10m
+      memory: 16Mi
+
+  ## Kube-state-metrics service type
+  ##
+  serviceType: ClusterIP
+
 server:
   ## Server Pod annotations:
   ##


### PR DESCRIPTION
As mentioned in #229.

From https://github.com/kubernetes/kube-state-metrics:
> kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.

Also increased truncation to 63 characters.