### PR TITLE
.status.loadBalancer.ingress[0].ip is empty in AWS

### DIFF
--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -10,7 +10,7 @@
 {{- else if contains "LoadBalancer" .Values.Master.ServiceType }}
 **** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
 ****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
-  export SERVICE_IP=$(kubectl get svc {{ template "fullname" . }} --namespace {{ .Release.Namespace }} --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
+  export SERVICE_IP=$(kubectl get svc {{ template "fullname" . }} --namespace {{ .Release.Namespace }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}/login
   
 {{- else if contains "ClusterIP"  .Values.Master.ServiceType }}

--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -10,12 +10,8 @@
 {{- else if contains "LoadBalancer" .Values.Master.ServiceType }}
 **** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
 ****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc {{ template "fullname" . }} --namespace {{ .Release.Namespace }} --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
   echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}/login
-  
-If you're running Kubernetes in AWS, the ingress has not ip, but you can use the Hostname
-  export SERVICE_HOSTNAME=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].Hostname}')
-  echo http://$SERVICE_HOSTNAME:{{ .Values.Master.ServicePort }}/login
   
 {{- else if contains "ClusterIP"  .Values.Master.ServiceType }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "fullname" . }}-master" -o jsonpath="{.items[0].metadata.name}")

--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -12,6 +12,11 @@
 ****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}/login
+  
+If you're running Kubernetes in AWS, the ingress has not ip, but you can use the Hostname
+  export SERVICE_HOSTNAME=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].Hostname}')
+  echo http://$SERVICE_HOSTNAME:{{ .Values.Master.ServicePort }}/login
+  
 {{- else if contains "ClusterIP"  .Values.Master.ServiceType }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "fullname" . }}-master" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:{{ .Values.Master.ServicePort }}


### PR DESCRIPTION
Fixes #237

`.status.loadBalancer.ingress[0].ip}` has no value in AWS since the ELB only returns the hostname. I've added instructions to get the jenkins url using the hostname of the eLB instead of the IP.