### PR TITLE
Sensu Support

### DIFF
--- a/stable/sensu/.helmignore
+++ b/stable/sensu/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/sensu/Chart.yaml
+++ b/stable/sensu/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+name: sensu
+version: 0.1.0
+description: Sensu monitoring framework backed by the Redis transport
+keywords:
+- sensu
+- monitoring
+home: https://sensuapp.org/
+sources:
+- https://github.com/kubernetes/charts
+- https://github.com/sstarcher/docker-sensu
+- https://github.com/sensu/sensu
+maintainers:
+- name: Shane Starcher
+  email: shane.starcher@gmail.com
+icon: https://raw.githubusercontent.com/sensu/sensu/master/sensu-logo.png
+engine: gotpl

--- a/stable/sensu/README.md
+++ b/stable/sensu/README.md
@@ -1,0 +1,96 @@
+# Sensu
+
+[Sensu](https://sensuapp.org/) is monitoring that doesn't suck.
+
+
+## TL;DR;
+
+```console
+$ helm install stable/sensu
+```
+
+## Introduction
+
+This chart bootstraps a [Sensu](https://github.com/sstarcher/docker-sensu) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+
+## Get this chart
+
+Download the latest release of the chart from the [releases](../../../releases) page.
+
+Alternatively, clone the repo if you wish to use the development snapshot:
+
+```console
+$ git clone https://github.com/kubernetes/charts.git
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/sensu
+```
+
+*Replace the `x.x.x` placeholder with the chart release version.*
+
+The command deploys Sensu on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Sensu chart and their default values.
+
+| Parameter                            | Description                              | Default                                                    |
+| -------------------------------      | -------------------------------          | ---------------------------------------------------------- |
+| `image`                              | Sensu image                          | `sstarcher/sensu`                              |
+| `imageTag`                              | Sensu version                          | `0.26`                              |
+| `imagePullPolicy`                    | Image pull policy                        | `IfNotPresent`   |
+| `replicaCount`         | Number of sensu replicas | `1`  |
+| `httpPort` | Service port for kubernetes | `80` |
+| `deis.routable` | Enables routing through the Deis router | `false` |
+| `deis.domain` | The service name for deis to route | `sensu` |
+| `server.resources.requests.cpu` | CPU request for sensu server | `100m` |
+| `server.resources.requests.memory` | Memory request for sensu server | `100Mi` |
+| `server.resources.limits.cpu` | CPU limit for sensu server | `` |
+| `server.resources.limits.memory` | Memory limit for sensu server | `` |
+| `api.resources.requests.cpu` | CPU request for api server | `50m` |
+| `api.resources.requests.memory` | Memory request for api server | `100Mi` |
+| `api.resources.limits.cpu` | CPU limit for api server | `` |
+| `api.resources.limits.memory` | Memory limit for api server | `` |
+| `REDIS_PORT` | Default port for redis | `6379` |
+| `REDIS_DB` | The Redis instance DB to use/select | `0` |
+| `REDIS_AUTO_RECONNECT` | Reconnect to Redis in the event of a connection failure | `true` |
+| `REDIS_RECONNECT_ON_ERROR` | Reconnect to Redis in the event of a Redis error, e.g. READONLY | `true` |
+
+Configuration reference for sensu [Sensu/Docs](https://sensuapp.org/docs/latest/reference/)
+
+```console
+$ helm install --name my-release \
+  --set imageTag=0.26.5 \
+    stable/sensu
+```
+
+The above command sets the Sensu version to `0.26.5`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/sensu
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/sensu/requirements.lock
+++ b/stable/sensu/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.4.1
+digest: sha256:eb0ce32c8ed56c97ae0469a903c6d62e50b00c3770618bb140ef8b660e3de789
+generated: 2016-11-22T09:09:22.04416797-05:00

--- a/stable/sensu/requirements.yaml
+++ b/stable/sensu/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: redis
+  version: 0.4.1
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/sensu/templates/NOTES.txt
+++ b/stable/sensu/templates/NOTES.txt
@@ -1,0 +1,19 @@
+Getting Started:
+
+
+1. Get the Sensu API URL to visit by running these commands in the same shell:
+{{- if contains "NodePort" .Values.serviceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+**** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
+****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.httpPort }}/login
+{{- else if contains "ClusterIP"  .Values.serviceType }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:4567
+  kubectl port-forward $POD_NAME 4567:4567
+{{- end }}

--- a/stable/sensu/templates/NOTES.txt
+++ b/stable/sensu/templates/NOTES.txt
@@ -13,7 +13,8 @@ Getting Started:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.httpPort }}/login
 {{- else if contains "ClusterIP"  .Values.serviceType }}
+  echo 'API endpoints docs at https://sensuapp.org/docs/0.24/api/health-and-info-api.html'
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:4567
+  echo http://127.0.0.1:4567/info
   kubectl port-forward $POD_NAME 4567:4567
 {{- end }}

--- a/stable/sensu/templates/_helpers.tpl
+++ b/stable/sensu/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "redis.fullname" -}}
+{{- printf "%s-%s" .Release.Name "redis" | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}

--- a/stable/sensu/templates/deployment.yaml
+++ b/stable/sensu/templates/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{template "fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: {{ .Values.replicaCount }}  
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        release: {{ .Release.Name | quote }}
+    spec:
+      containers:
+      - name: server
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        args:
+          - server
+{{ toYaml .Values.server.resources | indent 8 }}
+        env:
+        - name: API_HOST
+          value: localhost
+        - name: API_PORT
+          value: '4567' 
+        - name: REDIS_HOST 
+          value: {{ template "redis.fullname" . }}
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis.fullname" . }}
+              key: redis-password        
+        - name: REDIS_DB 
+          value: {{ .Values.REDIS_DB | quote }}
+        - name: REDIS_AUTO_RECONNECT 
+          value: {{ .Values.REDIS_AUTO_RECONNECT | quote}}
+        - name: REDIS_RECONNECT_ON_ERROR 
+          value: {{ .Values.REDIS_RECONNECT_ON_ERROR | quote }}
+        - name: REDIS_PORT 
+          value: {{ .Values.REDIS_PORT | quote }}        
+      - name: api
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        args:
+          - api        
+{{ toYaml .Values.api.resources | indent 8 }}          
+        env:
+        - name: REDIS_HOST 
+          value: {{ template "redis.fullname" . }}
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis.fullname" . }}
+              key: redis-password        
+        - name: REDIS_DB 
+          value: {{ .Values.REDIS_DB | quote }}
+        - name: REDIS_AUTO_RECONNECT 
+          value: {{ .Values.REDIS_AUTO_RECONNECT | quote}}
+        - name: REDIS_RECONNECT_ON_ERROR 
+          value: {{ .Values.REDIS_RECONNECT_ON_ERROR | quote }}
+        - name: REDIS_PORT 
+          value: {{ .Values.REDIS_PORT | quote }}  
+        ports:
+        - containerPort: 4567
+        readinessProbe:
+          httpGet:
+            path: /info
+            port: 4567
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /info
+            port: 4567
+          initialDelaySeconds: 30
+          timeoutSeconds: 1        
+
+
+

--- a/stable/sensu/templates/svc.yaml
+++ b/stable/sensu/templates/svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  {{ if .Values.deis.routable }}
+    router.deis.io/routable: "true"
+  annotations:
+    router.deis.io/domains: {{ .Values.deis.domains | quote }}
+  {{end}}
+spec:
+  type: {{.Values.serviceType }}
+  ports:
+  - port: {{ .Values.httpPort }}
+    targetPort: 4567
+  selector:
+    app: {{ template "fullname" . }}

--- a/stable/sensu/values.yaml
+++ b/stable/sensu/values.yaml
@@ -1,0 +1,46 @@
+# Docker image name
+image: "sstarcher/sensu"
+# Docker image tag
+imageTag: "0.26"
+
+# Image pull policy for the container
+pullPolicy: "IfNotPresent"
+
+# How many sensu containers to spawn
+replicaCount: 1
+
+# How to publish the service http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
+serviceType: ClusterIP
+
+# Service port to expose Sensu on
+httpPort: 4567
+
+# If set to true, the service will be exposed via the Deis Router if setup https://github.com/deis/router
+deis:
+  routable: false
+  domains: sensu
+
+# CPU and Memory limit and request for Sensu Server
+server:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi  
+# CPU and Memory limit and request for Sensu Api
+api:      
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi      
+
+# Redis configuration
+REDIS_PORT: 6379
+REDIS_DB: 0
+REDIS_AUTO_RECONNECT: true
+REDIS_RECONNECT_ON_ERROR: true
+
+# Redis chart configuration
+redis:
+  persistence:
+    enabled: false
+


### PR DESCRIPTION
Adds https://sensuapp.org chart for Helm.

Sensu is made up of an api server and a worker process.  The worker process requires redis.  Uchiwa is a web interface for these components.  So a full setup requires
* Sensu Server
* Sensu Api Server
* Redis
* Uchiwa

A single Uchiwa setup can reference multiple sensu api servers.  Currently Uchiwa is it's own chart and makes sense for separate sensu environments.

The current setup is the Sensu chart depends on the Uchiwa and the Redis chart.  One difficulty I have is that the Uchiwa chart needs to know the name of the sensu api server to connect.  Which would currently be the svc created by the Sensu chart.  I don't see an easy way to pass this to the Uchiwa chart unless I inverted everything.  Uchiwa chart being the main chart that depends on sensu server, sensu api and redis.

I could also create the sensu server chart as a separate chart and create a sensu_stack or sensu_all chart that depends on uchiwa, redis, sensu?


