### PR TITLE
RabbitMQ: Change deployment nodeName to fix a bug when a pod is restarted

### DIFF
--- a/stable/rabbitmq/templates/deployment.yaml
+++ b/stable/rabbitmq/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: RABBITMQ_NODE_TYPE
           value: {{ default "stats" .Values.rabbitmqNodeType | quote }}
         - name: RABBITMQ_NODE_NAME
-          value: {{ default "rabbit" .Values.rabbitmqNodeName | quote }}
+          value: {{ printf "%s@%s" (default "rabbit" .Values.rabbitmqNodeName) "localhost" | quote }}
         - name: RABBITMQ_CLUSTER_NODE_NAME
           value: {{ default "" .Values.rabbitmqClusterNodeName | quote }}
         - name: RABBITMQ_VHOST


### PR DESCRIPTION
If it is not specified, RabbitMQ uses `$HOSTNAME` as host for the name node (`rabbit@$HOSTNAME` by default). See https://www.rabbitmq.com/configure.html#define-environment-variables.

The proposed fix prevents the follow error to happen in single-node deployments:

```
Pod #1: nasal-lynx-rabbitmq-1490159514-45b92

after restart/delete pod #1

Pod #2: nasal-lynx-rabbitmq-1490159514-ge3xd

so RabbitMQ tries to connect to #1 (nasal-lynx-rabbitmq-1490159514-45b92)

{could_not_start,rabbit,
    {{failed_to_cluster_with,
         [rabbit@nasal-lynx-rabbitmq-1490159514-45b92],
        "Mnesia could not connect to any nodes."},
     {rabbit,start,[normal,[]]}}}
```

In cluster deployments, this should be handled in same another way: RabbitMQ nodes require a stronger notion of identity so I would say PetSets is the right option.