### PR TITLE
Use beta PVC annotation when supplying storageClass

### DIFF
--- a/incubator/cockroachdb/Chart.yaml
+++ b/incubator/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.1.0
+version: 0.2.0
 description: CockroachDB Helm chart for Kubernetes.
 sources:
   - https://github.com/cockroachdb/cockroach

--- a/incubator/cockroachdb/README.md
+++ b/incubator/cockroachdb/README.md
@@ -35,16 +35,16 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
 | `Name`                  | Chart name                         | `cockroachdb`                                              |
 | `Image`                 | Container image name               | `cockroachdb/cockroach`                                    |
-| `ImageTag`              | Container image tag                | `latest`                                                    |
+| `ImageTag`              | Container image tag                | `latest`                                                   |
 | `ImagePullPolicy`       | Container pull policy              | `Always`                                                   |
 | `Replicas`              | k8s petset replicas                | `3`                                                        |
 | `Component`             | k8s selector key                   | `cockroachdb`                                              |
-| `GrpcPort`              | CockroachDB primary serving port   | `26257`                                                     |
+| `GrpcPort`              | CockroachDB primary serving port   | `26257`                                                    |
 | `HttpPort`              | CockroachDB HTTP port              | `8080`                                                     |
 | `Cpu`                   | Container requested cpu            | `100m`                                                     |
 | `Memory`                | Container requested memory         | `512Mi`                                                    |
 | `Storage`               | Persistent volume size             | `1Gi`                                                      |
-| `StorageClass`          | Persistent volume class            | `anything`                                                      |
+| `StorageClass`          | Persistent volume class            | `volume.alpha.kubernetes.io/storage-class: default`        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/cockroachdb/templates/cockroachdb-petset.yaml
+++ b/incubator/cockroachdb/templates/cockroachdb-petset.yaml
@@ -179,7 +179,11 @@ spec:
   - metadata:
       name: datadir
       annotations:
-        volume.alpha.kubernetes.io/storage-class: "{{.Values.StorageClass}}"
+      {{- if .Values.StorageClass }}
+        volume.beta.kubernetes.io/storage-class: "{{.Values.StorageClass}}"
+      {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+      {{- end }}
     spec:
       accessModes:
         - "ReadWriteOnce"

--- a/incubator/cockroachdb/values.yaml
+++ b/incubator/cockroachdb/values.yaml
@@ -18,4 +18,6 @@ Resources:
     cpu: "100m"
     memory: "512Mi"
 Storage: "1Gi"
-StorageClass: "anything"
+# If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+# Default: volume.alpha.kubernetes.io/storage-class: default
+# StorageClass: "anything"

--- a/incubator/consul/Chart.yaml
+++ b/incubator/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 0.1.2
+version: 0.2.0
 description: Hashicorp Consul Helm chart for Kubernetes.
 sources:
   - https://github.com/kelseyhightower/consul-on-kubernetes

--- a/incubator/consul/README.md
+++ b/incubator/consul/README.md
@@ -40,6 +40,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | `Cpu`                   | container requested cpu               | `100m`                                                     |
 | `Memory`                | container requested memory            | `512Mi`                                                    |
 | `Storage`               | Persistent volume size                | `1Gi`                                                      |
+| `StorageClass`          | Persistent volume class               | `volume.alpha.kubernetes.io/storage-class: default`        |
 | `HttpPort`              | Consul http listening port            | `8500`                                                     |
 | `RpcPort`               | Consul rpc listening port             | `8400`                                                     |
 | `SerflanPort`           | Container serf lan listening port     | `8301`                                                     |

--- a/incubator/consul/templates/consul-petset.yaml
+++ b/incubator/consul/templates/consul-petset.yaml
@@ -167,7 +167,11 @@ spec:
   - metadata:
       name: datadir
       annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
+      {{- if .Values.StorageClass }}
+        volume.beta.kubernetes.io/storage-class: "{{.Values.StorageClass}}"
+      {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+      {{- end }}
     spec:
       accessModes:
         - "ReadWriteOnce"

--- a/incubator/consul/values.yaml
+++ b/incubator/consul/values.yaml
@@ -20,3 +20,6 @@ ImagePullPolicy: "Always"
 Cpu: "100m"
 Memory: "512Mi"
 Storage: "1Gi"
+# If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+# Default: volume.alpha.kubernetes.io/storage-class: default
+# StorageClass: "anything"

--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.1.1
+version: 0.2.0
 description: Etcd Helm chart for Kubernetes.
 sources:
   - https://github.com/coreos/etcd

--- a/incubator/etcd/README.md
+++ b/incubator/etcd/README.md
@@ -48,6 +48,7 @@ The following tables lists the configurable parameters of the etcd chart and the
 | `ClientPort`            | k8s service port                   | `2379`                                                     |
 | `PeerPorts`             | Container listening port           | `2380`                                                     |
 | `Storage`               | Persistent volume size             | `1Gi`                                                      |
+| `StorageClass`          | Persistent volume class            | `volume.alpha.kubernetes.io/storage-class: default`        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/etcd/templates/etcd-petset.yaml
+++ b/incubator/etcd/templates/etcd-petset.yaml
@@ -202,7 +202,11 @@ spec:
   - metadata:
       name: datadir
       annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
+      {{- if .Values.StorageClass }}
+        volume.beta.kubernetes.io/storage-class: "{{.Values.StorageClass}}"
+      {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+      {{- end }}
     spec:
       accessModes:
         - "ReadWriteOnce"

--- a/incubator/etcd/values.yaml
+++ b/incubator/etcd/values.yaml
@@ -14,3 +14,6 @@ ImagePullPolicy: "Always"
 Cpu: "100m"
 Memory: "512Mi"
 Storage: "1Gi"
+# If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+# Default: volume.alpha.kubernetes.io/storage-class: default
+# StorageClass: "anything"

--- a/incubator/grafana/Chart.yaml
+++ b/incubator/grafana/Chart.yaml
@@ -1,3 +1,3 @@
 description: A Helm chart for Kubernetes
 name: grafana
-version: 0.1.2
+version: 0.2.0

--- a/incubator/grafana/README.md
+++ b/incubator/grafana/README.md
@@ -13,14 +13,14 @@ $ helm install --name my-release incubator/grafana
 
 ## Configuration
 
-| Parameter                  | Description                                       | Default                  |
-|----------------------------|---------------------------------------------------|--------------------------|
-| `imageName`                | Container image to run                            | grafana/grafana          |
-| `adminUser`                | Admin user username                               | admin                    |
-| `adminPassword`            | Admin user password                               | admin                    |
-| `persistence.enabled`      | Create a volume to store data                     | true                     |
-| `persistence.size`         | Size of persistent volume claim                   | 1Gi RW                   |
-| `persistence.storageClass` | Type of persistent volume claim                   | generic                  |
-| `persistence.accessMode`   | ReadWriteOnce or ReadOnly                         | ReadWriteOnce            |
-| `cpu`                      | Container requested cpu                           | 100m                     |
-| `memory`                   | Container requested memory                        | 100M                     |
+| Parameter                    | Description                                         | Default                                             |
+| ---------------------------- | --------------------------------------------------- | --------------------------------------------------- |
+| `imageName`                  | Container image to run                              | grafana/grafana                                     |
+| `adminUser`                  | Admin user username                                 | admin                                               |
+| `adminPassword`              | Admin user password                                 | admin                                               |
+| `persistence.enabled`        | Create a volume to store data                       | true                                                |
+| `persistence.size`           | Size of persistent volume claim                     | 1Gi RW                                              |
+| `persistence.storageClass`   | Type of persistent volume claim                     | `volume.alpha.kubernetes.io/storage-class: default` |
+| `persistence.accessMode`     | ReadWriteOnce or ReadOnly                           | ReadWriteOnce                                       |
+| `cpu`                        | Container requested cpu                             | 100m                                                |
+| `memory`                     | Container requested memory                          | 100M                                                |

--- a/incubator/grafana/templates/pvc.yaml
+++ b/incubator/grafana/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{template "fullname" .}}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/incubator/grafana/values.yaml
+++ b/incubator/grafana/values.yaml
@@ -5,7 +5,9 @@ adminPassword: "admin"
 # Persist data to a persitent volume
 persistence:
   enabled: true
-  storageClass: generic
+  # If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  # Default: volume.alpha.kubernetes.io/storage-class: default
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: "1Gi"
 

--- a/incubator/mongodb-replicaset/Chart.yaml
+++ b/incubator/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 0.1.1
+version: 0.2.0
 description: MongoDB Helm chart for Kubernetes.
 sources:
   - https://github.com/mongodb/mongo

--- a/incubator/mongodb-replicaset/README.md
+++ b/incubator/mongodb-replicaset/README.md
@@ -35,18 +35,19 @@ $ helm install --name my-release incubator/mongodb-replicaset
 
 The following tables lists the configurable parameters of the mongodb chart and their default values.
 
-|     Parameter     |        Description         |       Default        |
-|-------------------|----------------------------|----------------------|
-| `Name`            | Name of the chart          | `mongodb-replicaset` |
-| `Image`           | Container image name       | `mongo`              |
-| `ImageTag`        | Container image tag        | `3.2`                |
-| `ImagePullPolicy` | Container pull policy      | `Always`             |
-| `Replicas`        | k8s petset replicas        | `3`                  |
-| `Component`       | k8s selector key           | `mongodb`            |
-| `Cpu`             | container requested cpu    | `100m`               |
-| `Memory`          | container requested memory | `512Mi`              |
-| `PeerPort`        | Container listening port   | `27017`              |
-| `Storage`         | Persistent volume size     | `10Gi`               |
+| Parameter           | Description                  | Default                                             |
+| ------------------- | ---------------------------- | --------------------------------------------------- |
+| `Name`              | Name of the chart            | `mongodb-replicaset`                                |
+| `Image`             | Container image name         | `mongo`                                             |
+| `ImageTag`          | Container image tag          | `3.2`                                               |
+| `ImagePullPolicy`   | Container pull policy        | `Always`                                            |
+| `Replicas`          | k8s petset replicas          | `3`                                                 |
+| `Component`         | k8s selector key             | `mongodb`                                           |
+| `Cpu`               | container requested cpu      | `100m`                                              |
+| `Memory`            | container requested memory   | `512Mi`                                             |
+| `PeerPort`          | Container listening port     | `27017`                                             |
+| `Storage`           | Persistent volume size       | `10Gi`                                              |
+| `StorageClass`      | Persistent volume class      | `volume.alpha.kubernetes.io/storage-class: default` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/mongodb-replicaset/templates/mongodb-petset.yaml
+++ b/incubator/mongodb-replicaset/templates/mongodb-petset.yaml
@@ -128,7 +128,11 @@ spec:
   - metadata:
       name: datadir
       annotations:
-        volume.alpha.kubernetes.io/storage-class: {{.Values.StorageClass}}
+      {{- if .Values.StorageClass }}
+        volume.beta.kubernetes.io/storage-class: "{{.Values.StorageClass}}"
+      {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/incubator/mongodb-replicaset/values.yaml
+++ b/incubator/mongodb-replicaset/values.yaml
@@ -15,5 +15,6 @@ ImagePullPolicy: "Always"
 Cpu: "100m"
 Memory: "512Mi"
 Storage: "10Gi"
-StorageClass: generic
-
+# If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+# Default: volume.alpha.kubernetes.io/storage-class: default
+# StorageClass: generic

--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: "Highly available elephant herd: HA PostgreSQL cluster."
-version: 0.1.5
+version: 0.2.0
 home: https://github.com/zalando/patroni
 sources:
   - https://github.com/zalando/patroni

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -50,21 +50,22 @@ postgres=>
 
 The following tables lists the configurable parameters of the patroni chart and their default values.
 
-|       Parameter         |           Description               |                         Default                     |
-|-------------------------|-------------------------------------|-----------------------------------------------------|
-| `Name`                  | Service name                        | `patroni`                                           |
-| `Spilo.Image`           | Container image name                | `registry.opensource.zalan.do/acid/spilo-9.5`       |
-| `Spilo.Version`         | Container image tag                 | `1.0-p5`                                            |
-| `ImagePullPolicy`       | Container pull policy               | `IfNotPresent`                                      |
-| `Replicas`              | k8s petset replicas                 | `5`                                                 |
-| `Component`             | k8s selector key                    | `patroni`                                           |
-| `Resources.Cpu`         | container requested cpu             | `100m`                                              |
-| `Resources.Memory`      | container requested memory          | `512Mi`                                             |
-| `Resources.Storage`     | Persistent volume size              | `1Gi`                                               |
-| `Credentials.Superuser` | password for the superuser          | `tea`                                               |
-| `Credentials.Admin`     | password for the admin user         | `cola`                                              |
-| `Credentials.Standby`   | password for the replication user   | `pinacolada`                                        |
-| `Etcd.Discovery`        | domain name of etcd cluster         | `<release-name>-etcd.<namespace>.svc.cluster.local` |
+| Parameter                 | Description                           | Default                                               |
+| ------------------------- | ------------------------------------- | ----------------------------------------------------- |
+| `Name`                    | Service name                          | `patroni`                                             |
+| `Spilo.Image`             | Container image name                  | `registry.opensource.zalan.do/acid/spilo-9.5`         |
+| `Spilo.Version`           | Container image tag                   | `1.0-p5`                                              |
+| `ImagePullPolicy`         | Container pull policy                 | `IfNotPresent`                                        |
+| `Replicas`                | k8s petset replicas                   | `5`                                                   |
+| `Component`               | k8s selector key                      | `patroni`                                             |
+| `Resources.Cpu`           | container requested cpu               | `100m`                                                |
+| `Resources.Memory`        | container requested memory            | `512Mi`                                               |
+| `Resources.Storage`       | Persistent volume size                | `1Gi`                                                 |
+| `Resources.StorageClass`  | Persistent volume class               | `volume.alpha.kubernetes.io/storage-class: default`   |
+| `Credentials.Superuser`   | password for the superuser            | `tea`                                                 |
+| `Credentials.Admin`       | password for the admin user           | `cola`                                                |
+| `Credentials.Standby`     | password for the replication user     | `pinacolada`                                          |
+| `Etcd.Discovery`          | domain name of etcd cluster           | `<release-name>-etcd.<namespace>.svc.cluster.local`   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/patroni/templates/ps-patroni.yaml
+++ b/incubator/patroni/templates/ps-patroni.yaml
@@ -77,7 +77,11 @@ spec:
   - metadata:
       name: pgdata
       annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
+      {{- if .Values.Resources.StorageClass }}
+        volume.beta.kubernetes.io/storage-class: "{{.Values.Resources.StorageClass}}"
+      {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -17,6 +17,9 @@ Resources:
   Cpu: 100m
   Memory: 512Mi
   Storage: 1Gi
+  # If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  # Default: volume.alpha.kubernetes.io/storage-class: default
+  # StorageClass: "anything"
 
 # Credentials used by Patroni
 # * more information: https://github.com/zalando/patroni/blob/master/docs/SETTINGS.rst#postgresql

--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.1.1
+version: 0.2.0
 description: Zookeeper Helm chart for Kubernetes.
 sources:
   - https://github.com/apache/zookeeper

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -45,6 +45,7 @@ The following tables lists the configurable parameters of the zookeeper chart an
 | `PeerPort`              | k8s service port                   | `2888`                                                     |
 | `LeaderElectionPort`    | Container listening port           | `3888`                                                     |
 | `Storage`               | Persistent volume size             | `1Gi`                                                      |
+| `StorageClass`          | Persistent volume class            | `volume.alpha.kubernetes.io/storage-class: default`        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/zookeeper/templates/zookeeper-petset.yaml
+++ b/incubator/zookeeper/templates/zookeeper-petset.yaml
@@ -129,7 +129,11 @@ spec:
   - metadata:
       name: datadir
       annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
+      {{- if .Values.StorageClass }}
+        volume.beta.kubernetes.io/storage-class: "{{.Values.StorageClass}}"
+      {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -15,3 +15,6 @@ ImagePullPolicy: "Always"
 Cpu: "100m"
 Memory: "512Mi"
 Storage: "1Gi"
+# If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+# Default: volume.alpha.kubernetes.io/storage-class: default
+# StorageClass: "anything"

--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.3.8
+version: 0.4.0
 description: One of the most versatile open source content management systems.
 keywords:
 - drupal

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -55,10 +55,10 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                     |
 | `serviceType`                     | Kubernetes Service type               | `LoadBalancer`                                            |
 | `persistence.enabled`             | Enable persistence using PVC          | `true`                                                    |
-| `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `generic`                                                 |
+| `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.apache.accessMode`   | PVC Access Mode for Apache volume     | `ReadWriteOnce`                                           |
 | `persistence.apache.size`         | PVC Storage Request for Apache volume | `1Gi`                                                     |
-| `persistence.drupal.storageClass` | PVC Storage Class for Drupal volume   | `generic`                                                 |
+| `persistence.drupal.storageClass` | PVC Storage Class for Drupal volume   | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.drupal.accessMode`   | PVC Access Mode for Drupal volume     | `ReadWriteOnce`                                           |
 | `persistence.drupal.size`         | PVC Storage Request for Drupal volume | `8Gi`                                                     |
 | `resources`                       | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                              |

--- a/stable/drupal/templates/apache-pvc.yaml
+++ b/stable/drupal/templates/apache-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-apache
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/drupal/templates/drupal-pvc.yaml
+++ b/stable/drupal/templates/drupal-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-drupal
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.drupal.storageClass | quote }}
+  {{- if .Values.persistence.drupal.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.drupal.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.drupal.accessMode | quote }}

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -38,7 +38,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -53,11 +56,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   drupal:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 

--- a/stable/factorio/Chart.yaml
+++ b/stable/factorio/Chart.yaml
@@ -1,5 +1,5 @@
 name: factorio
-version: 0.1.1
+version: 0.2.0
 description: Factorio dedicated server.
 keywords:
 - game

--- a/stable/factorio/templates/mods-pvc.yaml
+++ b/stable/factorio/templates/mods-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-mods
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/stable/factorio/templates/saves-pvc.yaml
+++ b/stable/factorio/templates/saves-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-savedgames
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/stable/factorio/values.yaml
+++ b/stable/factorio/values.yaml
@@ -48,7 +48,9 @@ factorio:
     password: your.password
 
 persistence:
-  storageClass: generic
+  # If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  # Default: volume.alpha.kubernetes.io/storage-class: default
+  # storageClass: generic
   savedGames:
     # Set this to false if you don't care to persist saved games between restarts.
     enabled: true

--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 0.4.0
+version: 0.5.0
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:
 - ghost

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -59,7 +59,7 @@ The following tables lists the configurable parameters of the Ghost chart and th
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                                | `nil`                                                     |
 | `serviceType`                     | Kubernetes Service type                               | `LoadBalancer`                                            |
 | `persistence.enabled`             | Enable persistence using PVC                          | `true`                                                    |
-| `persistence.storageClass`        | PVC Storage Class for Ghost volume                    | `generic`                                                 |
+| `persistence.storageClass`        | PVC Storage Class for Ghost volume                    | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.accessMode`          | PVC Access Mode for Ghost volume                      | `ReadWriteOnce`                                           |
 | `persistence.size`                | PVC Storage Request for Ghost volume                  | `8Gi`                                                     |
 | `resources`                       | CPU/Memory resource requests/limits                   | Memory: `512Mi`, CPU: `300m`                              |

--- a/stable/ghost/templates/pvc.yaml
+++ b/stable/ghost/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -68,7 +68,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -82,7 +85,10 @@ serviceType: LoadBalancer
 ##
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
 

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.1.1
+version: 0.2.0
 description: A Jenkins Helm chart for Kubernetes.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/templates/home-pvc.yaml
+++ b/stable/jenkins/templates/home-pvc.yaml
@@ -5,7 +5,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.Persistence.StorageClass | quote }}
+  {{- if .Values.Persistence.StorageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.Persistence.StorageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.Persistence.AccessMode | quote }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -29,6 +29,8 @@ Agent:
 
 Persistence:
   Enabled: true
-  StorageClass: generic
+  # If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  # Default: volume.alpha.kubernetes.io/storage-class: default
+  # StorageClass: generic
   AccessMode: ReadWriteOnce
   Size: 8Gi

--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 0.4.0
+version: 0.5.0
 description: PHP content management system (CMS) for publishing web content
 keywords:
 - joomla

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -61,10 +61,10 @@ The following tables lists the configurable parameters of the Joomla! chart and 
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                 | `nil`                                                     |
 | `serviceType`                     | Kubernetes Service type                | `LoadBalancer`                                            |
 | `persistence.enabled`             | Enable persistence using PVC           | `true`                                                    |
-| `persistence.apache.storageClass` | PVC Storage Class for Apache volume    | `generic`                                                 |
+| `persistence.apache.storageClass` | PVC Storage Class for Apache volume    | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.apache.accessMode`   | PVC Access Mode for Apache volume      | `ReadWriteOnce`                                           |
 | `persistence.apache.size`         | PVC Storage Request for Apache volume  | `1Gi`                                                     |
-| `persistence.joomla.storageClass` | PVC Storage Class for Joomla! volume   | `generic`                                                 |
+| `persistence.joomla.storageClass` | PVC Storage Class for Joomla! volume   | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.joomla.accessMode`   | PVC Access Mode for Joomla! volume     | `ReadWriteOnce`                                           |
 | `persistence.joomla.size`         | PVC Storage Request for Joomla! volume | `8Gi`                                                     |
 | `resources`                       | CPU/Memory resource requests/limits    | Memory: `512Mi`, CPU: `300m`                              |

--- a/stable/joomla/templates/apache-pvc.yaml
+++ b/stable/joomla/templates/apache-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-apache
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/joomla/templates/joomla-pvc.yaml
+++ b/stable/joomla/templates/joomla-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-joomla
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.joomla.storageClass | quote }}
+    {{- if .Values.persistence.joomla.storageClass }}
+      volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.joomla.storageClass | quote }}
+    {{- else }}
+      volume.alpha.kubernetes.io/storage-class: default
+    {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.joomla.accessMode | quote }}

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -49,7 +49,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -64,11 +67,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   joomla:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 

--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.5.4
+version: 0.6.0
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -46,7 +46,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following tables lists the configurable parameters of the MariaDB chart and their default values.
 
 | Parameter                  | Description                                | Default                                                    |
-| -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
+| -------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
 | `image`                    | MariaDB image                              | `bitnami/mariadb:{VERSION}`                                |
 | `imagePullPolicy`          | Image pull policy.                         | `Always` if `imageTag` is `latest`, else `IfNotPresent`.   |
 | `mariadbRootPassword`      | Password for the `root` user.              | `nil`                                                      |
@@ -54,7 +54,7 @@ The following tables lists the configurable parameters of the MariaDB chart and 
 | `mariadbPassword`          | Password for the new user.                 | `nil`                                                      |
 | `mariadbDatabase`          | Name for new database to create.           | `nil`                                                      |
 | `persistence.enabled`      | Use a PVC to persist data                  | `true`                                                     |
-| `persistence.storageClass` | Storage class of backing PVC               | `generic`                                                  |
+| `persistence.storageClass` | Storage class of backing PVC               | `volume.alpha.kubernetes.io/storage-class: default`        |
 | `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                            |
 | `persistence.size`         | Size of data volume                        | `8Gi`                                                      |
 | `resources`                | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `250m`                               |

--- a/stable/mariadb/templates/pvc.yaml
+++ b/stable/mariadb/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -31,7 +31,10 @@ image: bitnami/mariadb:10.1.19-r2
 ##
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
 

--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 0.4.0
+version: 0.5.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 keywords:
 - mediawiki

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -45,29 +45,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MediaWiki chart and their default values.
 
-|              Parameter               |               Description                |                         Default                         |
-|--------------------------------------|------------------------------------------|---------------------------------------------------------|
-| `image`                              | MediaWiki image                          | `bitnami/mediawiki:{VERSION}`                           |
-| `imagePullPolicy`                    | Image pull policy                        | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `mediawikiUser`                      | User of the application                  | `user`                                                  |
-| `mediawikiPassword`                  | Application password                     | _random 10 character long alphanumeric string_          |
-| `mediawikiEmail`                     | Admin email                              | `user@example.com`                                      |
-| `mediawikiName`                      | Name for the wiki                        | `Bitnami MediaWiki`                                     |
-| `smtpHost`                           | SMTP host                                | `nil`                                                   |
-| `smtpPort`                           | SMTP port                                | `nil`                                                   |
-| `smtpHostID`                         | SMTP host ID                             | `nil`                                                   |
-| `smtpUser`                           | SMTP user                                | `nil`                                                   |
-| `smtpPassword`                       | SMTP password                            | `nil`                                                   |
-| `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                                   |
-| `serviceType`                        | Kubernetes Service type                  | `LoadBalancer`                                          |
-| `persistence.enabled`                | Enable persistence using PVC             | `true`                                                  |
-| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `generic`                                               |
-| `persistence.apache.accessMode`      | PVC Access Mode for Apache volume        | `ReadWriteOnce`                                         |
-| `persistence.apache.size`            | PVC Storage Request for Apache volume    | `1Gi`                                                   |
-| `persistence.mediawiki.storageClass` | PVC Storage Class for MediaWiki volume   | `generic`                                               |
-| `persistence.mediawiki.accessMode`   | PVC Access Mode for MediaWiki volume     | `ReadWriteOnce`                                         |
-| `persistence.mediawiki.size`         | PVC Storage Request for MediaWiki volume | `8Gi`                                                   |
-| `resources`                          | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`                            |
+| Parameter                              | Description                                | Default                                                   |
+| -------------------------------------- | ------------------------------------------ | --------------------------------------------------------- |
+| `image`                                | MediaWiki image                            | `bitnami/mediawiki:{VERSION}`                             |
+| `imagePullPolicy`                      | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
+| `mediawikiUser`                        | User of the application                    | `user`                                                    |
+| `mediawikiPassword`                    | Application password                       | _random 10 character long alphanumeric string_            |
+| `mediawikiEmail`                       | Admin email                                | `user@example.com`                                        |
+| `mediawikiName`                        | Name for the wiki                          | `Bitnami MediaWiki`                                       |
+| `smtpHost`                             | SMTP host                                  | `nil`                                                     |
+| `smtpPort`                             | SMTP port                                  | `nil`                                                     |
+| `smtpHostID`                           | SMTP host ID                               | `nil`                                                     |
+| `smtpUser`                             | SMTP user                                  | `nil`                                                     |
+| `smtpPassword`                         | SMTP password                              | `nil`                                                     |
+| `mariadb.mariadbRootPassword`          | MariaDB admin password                     | `nil`                                                     |
+| `serviceType`                          | Kubernetes Service type                    | `LoadBalancer`                                            |
+| `persistence.enabled`                  | Enable persistence using PVC               | `true`                                                    |
+| `persistence.apache.storageClass`      | PVC Storage Class for Apache volume        | `volume.alpha.kubernetes.io/storage-class: default`       |
+| `persistence.apache.accessMode`        | PVC Access Mode for Apache volume          | `ReadWriteOnce`                                           |
+| `persistence.apache.size`              | PVC Storage Request for Apache volume      | `1Gi`                                                     |
+| `persistence.mediawiki.storageClass`   | PVC Storage Class for MediaWiki volume     | `volume.alpha.kubernetes.io/storage-class: default`       |
+| `persistence.mediawiki.accessMode`     | PVC Access Mode for MediaWiki volume       | `ReadWriteOnce`                                           |
+| `persistence.mediawiki.size`           | PVC Storage Request for MediaWiki volume   | `8Gi`                                                     |
+| `resources`                            | CPU/Memory resource requests/limits        | Memory: `512Mi`, CPU: `300m`                              |
 
 The above parameters map to the env variables defined in [bitnami/mediawiki](http://github.com/bitnami/bitnami-docker-mediawiki). For more information please refer to the [bitnami/mediawiki](http://github.com/bitnami/bitnami-docker-mediawiki) image documentation.
 

--- a/stable/mediawiki/templates/apache-pvc.yaml
+++ b/stable/mediawiki/templates/apache-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-apache
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/mediawiki/templates/mediawiki-pvc.yaml
+++ b/stable/mediawiki/templates/mediawiki-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-mediawiki
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.mediawiki.storageClass | quote }}
+  {{- if .Values.persistence.mediawiki.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.mediawiki.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.mediawiki.accessMode | quote }}

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -53,7 +53,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -68,11 +71,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   mediawiki:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 

--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,5 +1,5 @@
 name: minecraft
-version: 0.1.0
+version: 0.2.0
 description: Minecraft server
 keywords:
 - game

--- a/stable/minecraft/templates/datadir-pvc.yaml
+++ b/stable/minecraft/templates/datadir-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-datadir
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -81,7 +81,9 @@ minecraftServer:
     serviceType: LoadBalancer
 
 persistence:
-  storageClass: generic
+  # If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  # Default: volume.alpha.kubernetes.io/storage-class: default
+  # storageClass: generic
   dataDir:
     # Set this to false if you don't care to persist state between restarts.
     enabled: true

--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 0.4.0
+version: 0.5.0
 description: Chart for MongoDB
 keywords:
 - mongodb

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -43,18 +43,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MongoDB chart and their default values.
 
-|         Parameter          |             Description             |                         Default                          |
-|----------------------------|-------------------------------------|----------------------------------------------------------|
-| `image`                    | MongoDB image                       | `bitnami/mongodb:{VERSION}`                              |
-| `imagePullPolicy`          | Image pull policy                   | `Always` if `imageTag` is `latest`, else `IfNotPresent`. |
-| `mongodbRootPassword`      | MongoDB admin password              | `nil`                                                    |
-| `mongodbUsername`          | MongoDB custom user                 | `nil`                                                    |
-| `mongodbPassword`          | MongoDB custom user password        | `nil`                                                    |
-| `mongodbDatabase`          | Database to create                  | `nil`                                                    |
-| `persistence.enabled`      | Use a PVC to persist data           | `true`                                                   |
-| `persistence.storageClass` | Storage class of backing PVC        | `generic`                                                |
-| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite | `ReadWriteOnce`                                          |
-| `persistence.size`         | Size of data volume                 | `8Gi`                                                    |
+| Parameter                    | Description                           | Default                                                    |
+| ---------------------------- | ------------------------------------- | ---------------------------------------------------------- |
+| `image`                      | MongoDB image                         | `bitnami/mongodb:{VERSION}`                                |
+| `imagePullPolicy`            | Image pull policy                     | `Always` if `imageTag` is `latest`, else `IfNotPresent`.   |
+| `mongodbRootPassword`        | MongoDB admin password                | `nil`                                                      |
+| `mongodbUsername`            | MongoDB custom user                   | `nil`                                                      |
+| `mongodbPassword`            | MongoDB custom user password          | `nil`                                                      |
+| `mongodbDatabase`            | Database to create                    | `nil`                                                      |
+| `persistence.enabled`        | Use a PVC to persist data             | `true`                                                     |
+| `persistence.storageClass`   | Storage class of backing PVC          | `volume.alpha.kubernetes.io/storage-class: default`        |
+| `persistence.accessMode`     | Use volume as ReadOnly or ReadWrite   | `ReadWriteOnce`                                            |
+| `persistence.size`           | Size of data volume                   | `8Gi`                                                      |
 
 The above parameters map to the env variables defined in [bitnami/mongodb](http://github.com/bitnami/bitnami-docker-mongodb). For more information please refer to the [bitnami/mongodb](http://github.com/bitnami/bitnami-docker-mongodb) image documentation.
 

--- a/stable/mongodb/templates/pvc.yaml
+++ b/stable/mongodb/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -26,7 +26,10 @@ image: bitnami/mongodb:3.2.10-r1
 ##
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
 

--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.2.1
+version: 0.3.0
 description: Chart for MySQL
 keywords:
 - mysql

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -44,19 +44,19 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MySQL chart and their default values.
 
-| Parameter                  | Description                        | Default                                                    |
-| -----------------------    | ---------------------------------- | ---------------------------------------------------------- |
-| `imageTag`                 | `mysql` image tag.                 | Most recent release                                        |
-| `imagePullPolicy`          | Image pull policy                  | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `mysqlRootPassword`        | Password for the `root` user.      | `nil`                                                      |
-| `mysqlUser`                | Username of new user to create.    | `nil`                                                      |
-| `mysqlPassword`            | Password for the new user.         | `nil`                                                      |
-| `mysqlDatabase`            | Name for new database to create.   | `nil`                                                      |
-| `persistence.enabled`      | Create a volume to store data      | true                                                       |
-| `persistence.size`         | Size of persistent volume claim    | 8Gi RW                                                     |
-| `persistence.storageClass` | Type of persistent volume claim    | generic                                                    |
-| `persistence.accessMode`   | ReadWriteOnce or ReadOnly          | ReadWriteOnce                                              |
-| `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                              |
+| Parameter                  | Description                         | Default                                                    |
+| -----------------------    | ----------------------------------  | ---------------------------------------------------------- |
+| `imageTag`                 | `mysql` image tag.                  | Most recent release                                        |
+| `imagePullPolicy`          | Image pull policy                   | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `mysqlRootPassword`        | Password for the `root` user.       | `nil`                                                      |
+| `mysqlUser`                | Username of new user to create.     | `nil`                                                      |
+| `mysqlPassword`            | Password for the new user.          | `nil`                                                      |
+| `mysqlDatabase`            | Name for new database to create.    | `nil`                                                      |
+| `persistence.enabled`      | Create a volume to store data       | true                                                       |
+| `persistence.size`         | Size of persistent volume claim     | 8Gi RW                                                     |
+| `persistence.storageClass` | Type of persistent volume claim     | `volume.alpha.kubernetes.io/storage-class: default`        |
+| `persistence.accessMode`   | ReadWriteOnce or ReadOnly           | ReadWriteOnce                                              |
+| `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                               |
 
 Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).
 

--- a/stable/mysql/templates/pvc.yaml
+++ b/stable/mysql/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -30,7 +30,10 @@ imageTag: "5.7.14"
 ## Persist data to a persitent volume
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
 

--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 0.4.0
+version: 0.5.0
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - owncloud

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -57,10 +57,10 @@ The following tables lists the configurable parameters of the ownCloud chart and
 | `mariadb.mariadbRootPassword`       | MariaDB admin password                                | `nil`                                                     |
 | `serviceType`                       | Kubernetes Service type                               | `LoadBalancer`                                            |
 | `persistence.enabled`               | Enable persistence using PVC                          | `true`                                                    |
-| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume                   | `generic`                                                 |
+| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume                   | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.apache.accessMode`     | PVC Access Mode for Apache volume                     | `ReadWriteOnce`                                           |
 | `persistence.apache.size`           | PVC Storage Request for Apache volume                 | `1Gi`                                                     |
-| `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume                 | `generic`                                                 |
+| `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume                 | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume                   | `ReadWriteOnce`                                           |
 | `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume               | `8Gi`                                                     |
 | `resources`                         | CPU/Memory resource requests/limits                   | Memory: `512Mi`, CPU: `300m`                              |

--- a/stable/owncloud/templates/apache-pvc.yaml
+++ b/stable/owncloud/templates/apache-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-apache
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/owncloud/templates/owncloud-pvc.yaml
+++ b/stable/owncloud/templates/owncloud-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-owncloud
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.owncloud.storageClass | quote }}
+  {{- if .Values.persistence.owncloud.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.owncloud.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.owncloud.accessMode | quote }}

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -49,7 +49,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -64,11 +67,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   owncloud:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 

--- a/stable/phpbb/Chart.yaml
+++ b/stable/phpbb/Chart.yaml
@@ -1,5 +1,5 @@
 name: phpbb
-version: 0.4.0
+version: 0.5.0
 description: Community forum that supports the notion of users and groups, file attachments, full-text search, notifications and more.
 keywords:
 - phpbb

--- a/stable/phpbb/README.md
+++ b/stable/phpbb/README.md
@@ -45,27 +45,27 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the phpBB chart and their default values.
 
-|             Parameter             |              Description              |                         Default                         |
-|-----------------------------------|---------------------------------------|---------------------------------------------------------|
-| `image`                           | phpBB image                           | `bitnami/phpbb:{VERSION}`                               |
-| `imagePullPolicy`                 | Image pull policy                     | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `phpbbUser`                       | User of the application               | `user`                                                  |
-| `phpbbPassword`                   | Application password                  | _random 10 character long alphanumeric string_          |
-| `phpbbEmail`                      | Admin email                           | `user@example.com`                                      |
-| `smtpHost`                        | SMTP host                             | `nil`                                                   |
-| `smtpPort`                        | SMTP port                             | `nil`                                                   |
-| `smtpUser`                        | SMTP user                             | `nil`                                                   |
-| `smtpPassword`                    | SMTP password                         | `nil`                                                   |
-| `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                   |
-| `serviceType`                     | Kubernetes Service type               | `LoadBalancer`                                          |
-| `persistence.enabled`             | Enable persistence using PVC          | `true`                                                  |
-| `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `generic`                                               |
-| `persistence.apache.accessMode`   | PVC Access Mode for Apache volume     | `ReadWriteOnce`                                         |
-| `persistence.apache.size`         | PVC Storage Request for Apache volume | `1Gi`                                                   |
-| `persistence.phpbb.storageClass`  | PVC Storage Class for phpBB volume    | `generic`                                               |
-| `persistence.phpbb.accessMode`    | PVC Access Mode for phpBB volume      | `ReadWriteOnce`                                         |
-| `persistence.phpbb.size`          | PVC Storage Request for phpBB volume  | `8Gi`                                                   |
-| `resources`                       | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                            |
+| Parameter                           | Description                             | Default                                                   |
+| ----------------------------------- | --------------------------------------- | --------------------------------------------------------- |
+| `image`                             | phpBB image                             | `bitnami/phpbb:{VERSION}`                                 |
+| `imagePullPolicy`                   | Image pull policy                       | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
+| `phpbbUser`                         | User of the application                 | `user`                                                    |
+| `phpbbPassword`                     | Application password                    | _random 10 character long alphanumeric string_            |
+| `phpbbEmail`                        | Admin email                             | `user@example.com`                                        |
+| `smtpHost`                          | SMTP host                               | `nil`                                                     |
+| `smtpPort`                          | SMTP port                               | `nil`                                                     |
+| `smtpUser`                          | SMTP user                               | `nil`                                                     |
+| `smtpPassword`                      | SMTP password                           | `nil`                                                     |
+| `mariadb.mariadbRootPassword`       | MariaDB admin password                  | `nil`                                                     |
+| `serviceType`                       | Kubernetes Service type                 | `LoadBalancer`                                            |
+| `persistence.enabled`               | Enable persistence using PVC            | `true`                                                    |
+| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume     | `volume.alpha.kubernetes.io/storage-class: default`       |
+| `persistence.apache.accessMode`     | PVC Access Mode for Apache volume       | `ReadWriteOnce`                                           |
+| `persistence.apache.size`           | PVC Storage Request for Apache volume   | `1Gi`                                                     |
+| `persistence.phpbb.storageClass`    | PVC Storage Class for phpBB volume      | `volume.alpha.kubernetes.io/storage-class: default`       |
+| `persistence.phpbb.accessMode`      | PVC Access Mode for phpBB volume        | `ReadWriteOnce`                                           |
+| `persistence.phpbb.size`            | PVC Storage Request for phpBB volume    | `8Gi`                                                     |
+| `resources`                         | CPU/Memory resource requests/limits     | Memory: `512Mi`, CPU: `300m`                              |
 
 The above parameters map to the env variables defined in [bitnami/phpbb](http://github.com/bitnami/bitnami-docker-phpbb). For more information please refer to the [bitnami/phpbb](http://github.com/bitnami/bitnami-docker-phpbb) image documentation.
 

--- a/stable/phpbb/templates/apache-pvc.yaml
+++ b/stable/phpbb/templates/apache-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-apache
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/phpbb/templates/phpbb-pvc.yaml
+++ b/stable/phpbb/templates/phpbb-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-phpbb
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.phpbb.storageClass | quote }}
+  {{- if .Values.persistence.phpbb.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.phpbb.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.phpbb.accessMode | quote }}

--- a/stable/phpbb/values.yaml
+++ b/stable/phpbb/values.yaml
@@ -47,7 +47,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -62,11 +65,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   phpbb:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 

--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.2.0
+version: 0.3.0
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -43,18 +43,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the PostgresSQL chart and their default values.
 
-| Parameter                  | Description                                | Default                                                    |
-| -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
-| `imageTag`                 | `postgres` image tag                       | `9.5.4`                                           |
-| `imagePullPolicy`          | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `postgresUser`             | Username of new user to create.            | `postgres`                                                 |
-| `postgresPassword`         | Password for the new user.                 | random 10 characters                                       |
-| `postgresDatabase`         | Name for new database to create.           | `postgres`                                                 |
-| `persistence.enabled`      | Use a PVC to persist data                  | `true`                                                     |
-| `persistence.storageClass` | Storage class of backing PVC               | `generic`                                                  |
-| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                            |
-| `persistence.size`         | Size of data volume                        | `8Gi`                                                      |
-| `resources`                | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `100m`                               |
+| Parameter                  | Description                         | Default                                                    |
+| -----------------------    | ----------------------------------  | ---------------------------------------------------------- |
+| `imageTag`                 | `postgres` image tag                | `9.5.4`                                                    |
+| `imagePullPolicy`          | Image pull policy                   | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `postgresUser`             | Username of new user to create.     | `postgres`                                                 |
+| `postgresPassword`         | Password for the new user.          | random 10 characters                                       |
+| `postgresDatabase`         | Name for new database to create.    | `postgres`                                                 |
+| `persistence.enabled`      | Use a PVC to persist data           | `true`                                                     |
+| `persistence.storageClass` | Storage class of backing PVC        | `volume.alpha.kubernetes.io/storage-class: default`        |
+| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite | `ReadWriteOnce`                                            |
+| `persistence.size`         | Size of data volume                 | `8Gi`                                                      |
+| `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                               |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 

--- a/stable/postgresql/templates/pvc.yaml
+++ b/stable/postgresql/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -22,7 +22,10 @@ imageTag: "9.5.4"
 ## Persist data to a persitent volume
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
 

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 1.3.1
+version: 1.4.0
 description: A Prometheus Helm chart for Kubernetes. Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 sources:

--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
-  {{- if .Values.alertmanager.persistentVolume.storageClass -}}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.alertmanager.persistentVolume.storageClass }}
-  {{ else }}
+  {{- if .Values.alertmanager.persistentVolume.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.alertmanager.persistentVolume.storageClass | quote }}
+  {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
   {{- range $key, $value := .Values.alertmanager.persistentVolume.annotations }}

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
-  {{- if .Values.server.persistentVolume.storageClass -}}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass }}
-  {{ else }}
+  {{- if .Values.server.persistentVolume.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass | quote }}
+  {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
   {{- range $key, $value := .Values.server.persistentVolume.annotations }}

--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.4.0
+version: 0.5.0
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:
 - rabbitmq

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -43,23 +43,23 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the RabbitMQ chart and their default values.
 
-|         Parameter          |                       Description                       |                         Default                          |
-|----------------------------|---------------------------------------------------------|----------------------------------------------------------|
-| `image`                    | RabbitMQ image                                          | `bitnami/rabbitmq:{VERSION}`                             |
-| `imagePullPolicy`          | Image pull policy                                       | `Always` if `imageTag` is `latest`, else `IfNotPresent`. |
-| `rabbitmqUsername`         | RabbitMQ application username                           | `user`                                                   |
-| `rabbitmqPassword`         | RabbitMQ application password                           | _random 10 character long alphanumeric string_           |
-| `rabbitmqErlangCookie`     | Erlang cookie                                           | _random 32 character long alphanumeric string_           |
-| `rabbitmqNodePort`         | Node port                                               | `5672`                                                   |
-| `rabbitmqNodeType`         | Node type                                               | `stats`                                                  |
-| `rabbitmqNodeName`         | Node name                                               | `rabbit`                                                 |
-| `rabbitmqClusterNodeName`  | Node name to cluster with. e.g.: `clusternode@hostname` | `nil`                                                    |
-| `rabbitmqVhost`            | RabbitMQ application vhost                              | `/`                                                      |
-| `rabbitmqManagerPort`      | RabbitMQ Manager port                                   | `15672`                                                  |
-| `persistence.enabled`      | Use a PVC to persist data                               | `true`                                                   |
-| `persistence.storageClass` | Storage class of backing PVC                            | `generic`                                                |
-| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite                     | `ReadWriteOnce`                                          |
-| `persistence.size`         | Size of data volume                                     | `8Gi`                                                    |
+| Parameter                    | Description                                               | Default                                                    |
+| ---------------------------- | --------------------------------------------------------- | ---------------------------------------------------------- |
+| `image`                      | RabbitMQ image                                            | `bitnami/rabbitmq:{VERSION}`                               |
+| `imagePullPolicy`            | Image pull policy                                         | `Always` if `imageTag` is `latest`, else `IfNotPresent`.   |
+| `rabbitmqUsername`           | RabbitMQ application username                             | `user`                                                     |
+| `rabbitmqPassword`           | RabbitMQ application password                             | _random 10 character long alphanumeric string_             |
+| `rabbitmqErlangCookie`       | Erlang cookie                                             | _random 32 character long alphanumeric string_             |
+| `rabbitmqNodePort`           | Node port                                                 | `5672`                                                     |
+| `rabbitmqNodeType`           | Node type                                                 | `stats`                                                    |
+| `rabbitmqNodeName`           | Node name                                                 | `rabbit`                                                   |
+| `rabbitmqClusterNodeName`    | Node name to cluster with. e.g.: `clusternode@hostname`   | `nil`                                                      |
+| `rabbitmqVhost`              | RabbitMQ application vhost                                | `/`                                                        |
+| `rabbitmqManagerPort`        | RabbitMQ Manager port                                     | `15672`                                                    |
+| `persistence.enabled`        | Use a PVC to persist data                                 | `true`                                                     |
+| `persistence.storageClass`   | Storage class of backing PVC                              | `volume.alpha.kubernetes.io/storage-class: default`        |
+| `persistence.accessMode`     | Use volume as ReadOnly or ReadWrite                       | `ReadWriteOnce`                                            |
+| `persistence.size`           | Size of data volume                                       | `8Gi`                                                      |
 
 The above parameters map to the env variables defined in [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq). For more information please refer to the [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq) image documentation.
 

--- a/stable/rabbitmq/templates/pvc.yaml
+++ b/stable/rabbitmq/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -56,7 +56,10 @@ rabbitmqManagerPort: 15672
 
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
 

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.4.1
+version: 0.5.0
 description: Chart for Redis
 keywords:
 - redis

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -49,7 +49,7 @@ The following tables lists the configurable parameters of the Redis chart and th
 | `imagePullPolicy`          | Image pull policy                   | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
 | `redisPassword`            | Redis password                      | Randomly generated                                        |
 | `persistence.enabled`      | Use a PVC to persist data           | `true`                                                    |
-| `persistence.storageClass` | Storage class of backing PVC        | `generic`                                                 |
+| `persistence.storageClass` | Storage class of backing PVC        | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite | `ReadWriteOnce`                                           |
 | `persistence.size`         | Size of data volume                 | `8Gi`                                                     |
 | `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                              |

--- a/stable/redis/templates/pvc.yaml
+++ b/stable/redis/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -20,7 +20,10 @@ image: bitnami/redis:3.2.5-r0
 ##
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
 

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 0.3.5
+version: 0.4.0
 description: A flexible project management web application.
 keywords:
 - redmine

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -61,7 +61,7 @@ The following tables lists the configurable parameters of the Redmine chart and 
 | `mariadb.mariadbRootPassword`   | MariaDB admin password          | `nil`                                                     |
 | `serviceType`                   | Kubernetes Service type         | `LoadBalancer`                                            |
 | `persistence.enabled`           | Enable persistence using PVC    | `true`                                                    |
-| `persistence.storageClass`      | PVC Storage Class               | `generic`                                                 |
+| `persistence.storageClass`      | PVC Storage Class               | `volume.alpha.kubernetes.io/storage-class: default`       |
 | `persistence.accessMode`        | PVC Access Mode                 | `ReadWriteOnce`                                           |
 | `persistence.size`              | PVC Storage Request             | `8Gi`                                                     |
 

--- a/stable/redmine/templates/pvc.yaml
+++ b/stable/redmine/templates/pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -52,7 +52,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -66,6 +69,9 @@ serviceType: LoadBalancer
 ##
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi

--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 0.4.0
+version: 0.5.0
 description: Web-based test management system that facilitates software quality assurance.
 keywords:
 - testlink

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -45,29 +45,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the TestLink chart and their default values.
 
-|              Parameter              |               Description               |                         Default                         |
-|-------------------------------------|-----------------------------------------|---------------------------------------------------------|
-| `image`                             | TestLink image                          | `bitnami/testlink:{VERSION}`                            |
-| `imagePullPolicy`                   | Image pull policy                       | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `testlinkUsername`                  | Admin username                          | `user`                                                  |
-| `testlinkPassword`                  | Admin user password                     | _random 10 character long alphanumeric string_          |
-| `testlinkEmail`                     | Admin user email                        | `user@example.com`                                      |
-| `smtpEnable`                        | Enable SMTP                             | `false`                                                 |
-| `smtpHost`                          | SMTP host                               | `nil`                                                   |
-| `smtpPort`                          | SMTP port                               | `nil`                                                   |
-| `smtpUser`                          | SMTP user                               | `nil`                                                   |
-| `smtpPassword`                      | SMTP password                           | `nil`                                                   |
-| `smtpConnectionMode`                | SMTP connection mode [`ssl`, `tls`]     | `nil`                                                   |
-| `mariadb.mariadbRootPassword`       | MariaDB admin password                  | `nil`                                                   |
-| `serviceType`                       | Kubernetes Service type                 | `LoadBalancer`                                          |
-| `persistence.enabled`               | Enable persistence using PVC            | `true`                                                  |
-| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume     | `generic`                                               |
-| `persistence.apache.accessMode`     | PVC Access Mode for Apache volume       | `ReadWriteOnce`                                         |
-| `persistence.apache.size`           | PVC Storage Request for Apache volume   | `1Gi`                                                   |
-| `persistence.testlink.storageClass` | PVC Storage Class for TestLink volume   | `generic`                                               |
-| `persistence.testlink.accessMode`   | PVC Access Mode for TestLink volume     | `ReadWriteOnce`                                         |
-| `persistence.testlink.size`         | PVC Storage Request for TestLink volume | `8Gi`                                                   |
-| `resources`                         | CPU/Memory resource requests/limits     | Memory: `512Mi`, CPU: `300m`                            |
+| Parameter                             | Description                               | Default                                                   |
+| ------------------------------------- | ----------------------------------------- | --------------------------------------------------------- |
+| `image`                               | TestLink image                            | `bitnami/testlink:{VERSION}`                              |
+| `imagePullPolicy`                     | Image pull policy                         | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
+| `testlinkUsername`                    | Admin username                            | `user`                                                    |
+| `testlinkPassword`                    | Admin user password                       | _random 10 character long alphanumeric string_            |
+| `testlinkEmail`                       | Admin user email                          | `user@example.com`                                        |
+| `smtpEnable`                          | Enable SMTP                               | `false`                                                   |
+| `smtpHost`                            | SMTP host                                 | `nil`                                                     |
+| `smtpPort`                            | SMTP port                                 | `nil`                                                     |
+| `smtpUser`                            | SMTP user                                 | `nil`                                                     |
+| `smtpPassword`                        | SMTP password                             | `nil`                                                     |
+| `smtpConnectionMode`                  | SMTP connection mode [`ssl`, `tls`]       | `nil`                                                     |
+| `mariadb.mariadbRootPassword`         | MariaDB admin password                    | `nil`                                                     |
+| `serviceType`                         | Kubernetes Service type                   | `LoadBalancer`                                            |
+| `persistence.enabled`                 | Enable persistence using PVC              | `true`                                                    |
+| `persistence.apache.storageClass`     | PVC Storage Class for Apache volume       | `volume.alpha.kubernetes.io/storage-class: default`       |
+| `persistence.apache.accessMode`       | PVC Access Mode for Apache volume         | `ReadWriteOnce`                                           |
+| `persistence.apache.size`             | PVC Storage Request for Apache volume     | `1Gi`                                                     |
+| `persistence.testlink.storageClass`   | PVC Storage Class for TestLink volume     | `volume.alpha.kubernetes.io/storage-class: default`       |
+| `persistence.testlink.accessMode`     | PVC Access Mode for TestLink volume       | `ReadWriteOnce`                                           |
+| `persistence.testlink.size`           | PVC Storage Request for TestLink volume   | `8Gi`                                                     |
+| `resources`                           | CPU/Memory resource requests/limits       | Memory: `512Mi`, CPU: `300m`                              |
 
 The above parameters map to the env variables defined in [bitnami/testlink](http://github.com/bitnami/bitnami-docker-testlink). For more information please refer to the [bitnami/testlink](http://github.com/bitnami/bitnami-docker-testlink) image documentation.
 

--- a/stable/testlink/templates/apache-pvc.yaml
+++ b/stable/testlink/templates/apache-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-apache
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/testlink/templates/testlink-pvc.yaml
+++ b/stable/testlink/templates/testlink-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-testlink
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.testlink.storageClass | quote }}
+  {{- if .Values.persistence.testlink.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.testlink.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.testlink.accessMode | quote }}

--- a/stable/testlink/values.yaml
+++ b/stable/testlink/values.yaml
@@ -54,7 +54,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -69,11 +72,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   testlink:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.1.0-a
+version: 1.2.0-a
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -66,28 +66,28 @@ release.
 
 The following tables lists the configurable parameters of the Traefik chart and their default values.
 
-| Parameter                       | Description                                                          | Default                                   |
-| ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
-| `imageTag`                      | The version of the official Traefik image to use                     | `v1.1.0`                                  |
-| `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
-| `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
-| `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |
-| `cpuLimit`                      | CPU limit per Traefik pod                                            | `200m`                                    |
-| `memoryLimit`                   | Memory limit per Traefik pod                                         | `30Mi`                                    |
-| `ssl.enabled`                   | Whether to enable HTTPS                                              | `false`                                   |
-| `ssl.enforced`                  | Whether to redirect HTTP requests to HTTPS                           | `false`                                   |
-| `ssl.defaultCert`               | Base64 encoded default certficate                                    | A self-signed certificate                 |
-| `ssl.defaultKey`                | Base64 encoded private key for the certificate above                 | The private key for the certificate above |
-| `acme.enabled`                  | Whether to use Let's Encrypt to obtain certificates                  | `false`                                   |
-| `acme.email`                    | Email address to be used in certificates obtained from Let's Encrypt | `admin@example.com`                       |
-| `acme.staging`                  | Whether to get certs from Let's Encrypt's staging environment        | `true`                                    |
-| `acme.persistence.enabled`      | Create a volume to store ACME certs (if ACME is enabled)             | `true`                                    |
-| `acme.persistence.storageClass` | Type of `StorageClass` to request-- will be cluster-specific         | `generic`                                 |
-| `acme.persistence.accessMode`   | `ReadWriteOnce` or `ReadOnly`                                        | `ReadWriteOnce`                           |
-| `acme.persistence.size`         | Minimum size of the volume requested                                 | `1Gi`                                     |
-| `dashboard.enabled`             | Whether to enable the Traefik dashboard                              | `false`                                   |
-| `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |
-| `gzip.enabled`                  | Whether to use gzip compression                                      | `true`                     |
+| Parameter                       | Description                                                          | Default                                             |
+| ------------------------------- | -------------------------------------------------------------------- | -----------------------------------------           |
+| `imageTag`                      | The version of the official Traefik image to use                     | `v1.1.0`                                            |
+| `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                                      |
+| `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                              |
+| `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                              |
+| `cpuLimit`                      | CPU limit per Traefik pod                                            | `200m`                                              |
+| `memoryLimit`                   | Memory limit per Traefik pod                                         | `30Mi`                                              |
+| `ssl.enabled`                   | Whether to enable HTTPS                                              | `false`                                             |
+| `ssl.enforced`                  | Whether to redirect HTTP requests to HTTPS                           | `false`                                             |
+| `ssl.defaultCert`               | Base64 encoded default certficate                                    | A self-signed certificate                           |
+| `ssl.defaultKey`                | Base64 encoded private key for the certificate above                 | The private key for the certificate above           |
+| `acme.enabled`                  | Whether to use Let's Encrypt to obtain certificates                  | `false`                                             |
+| `acme.email`                    | Email address to be used in certificates obtained from Let's Encrypt | `admin@example.com`                                 |
+| `acme.staging`                  | Whether to get certs from Let's Encrypt's staging environment        | `true`                                              |
+| `acme.persistence.enabled`      | Create a volume to store ACME certs (if ACME is enabled)             | `true`                                              |
+| `acme.persistence.storageClass` | Type of `StorageClass` to request-- will be cluster-specific         | `volume.alpha.kubernetes.io/storage-class: default` |
+| `acme.persistence.accessMode`   | `ReadWriteOnce` or `ReadOnly`                                        | `ReadWriteOnce`                                     |
+| `acme.persistence.size`         | Minimum size of the volume requested                                 | `1Gi`                                               |
+| `dashboard.enabled`             | Whether to enable the Traefik dashboard                              | `false`                                             |
+| `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                               |
+| `gzip.enabled`                  | Whether to use gzip compression                                      | `true`                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/traefik/templates/acme-pvc.yaml
+++ b/stable/traefik/templates/acme-pvc.yaml
@@ -9,7 +9,11 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.acme.persistence.storageClass | quote }}
+  {{- if .Values.acme.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.acme.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.acme.persistence.accessMode | quote }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -18,7 +18,9 @@ acme:
   # certs every time a pod (re-)starts and you WILL be rate limited!
   persistence:
     enabled: true
-    storageClass: generic
+    # If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    # Default: volume.alpha.kubernetes.io/storage-class: default
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
 dashboard:

--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.3.2
+version: 0.4.0
 description: Web publishing platform for building blogs and websites.
 keywords:
 - wordpress

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -76,10 +76,10 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                                      |
 | `serviceType`                        | Kubernetes Service type                  | `LoadBalancer`                                             |
 | `persistence.enabled`                | Enable persistence using PVC             | `true`                                                     |
-| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `generic`                                                  |
+| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `volume.alpha.kubernetes.io/storage-class: default`        |
 | `persistence.apache.accessMode`      | PVC Access Mode for Apache volume        | `ReadWriteOnce`                                            |
 | `persistence.apache.size`            | PVC Storage Request for Apache volume    | `1Gi`                                                      |
-| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume   | `generic`                                                  |
+| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume   | `volume.alpha.kubernetes.io/storage-class: default`        |
 | `persistence.wordpress.accessMode`   | PVC Access Mode for WordPress volume     | `ReadWriteOnce`                                            |
 | `persistence.wordpress.size`         | PVC Storage Request for WordPress volume | `8Gi`                                                      |
 

--- a/stable/wordpress/templates/apache-pvc.yaml
+++ b/stable/wordpress/templates/apache-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-apache
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/wordpress/templates/wordpress-pvc.yaml
+++ b/stable/wordpress/templates/wordpress-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-wordpress
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.wordpress.storageClass | quote }}
+  {{- if .Values.persistence.wordpress.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.wordpress.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.wordpress.accessMode | quote }}

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -63,7 +63,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -78,11 +81,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   wordpress:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 


### PR DESCRIPTION
Updates all charts to use the beta annotation when a storageClass is
provided through values.

Tested fully with MariaDB, but I've only tested other charts by inspecting the generated YAML (`--debug --dry-run`).

A follow up PR will be needed to update dependencies for patroni and all the charts that depend on mariadb.