### PR TITLE
Upgrade Traefik to v1.1.1

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.1.0-a
+version: 1.1.1-a
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -68,7 +68,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 
 | Parameter                       | Description                                                          | Default                                   |
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
-| `imageTag`                      | The version of the official Traefik image to use                     | `v1.1.0`                                  |
+| `imageTag`                      | The version of the official Traefik image to use                     | `v1.1.1`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,5 +1,5 @@
 # Default values for Traefik
-imageTag: v1.1.0
+imageTag: v1.1.1
 serviceType: LoadBalancer
 cpuRequest: 100m
 memoryRequest: 20Mi


### PR DESCRIPTION
Traefik released v1.1.1 this morning, which includes some fixes that are especially relevant to its use as a k8s ingress controller.

~~This should _not_ be merged yet because the v1.1.1 build hasn't made it up to Dockerhub yet. This PR is just a placeholder until then.~~