### PR TITLE
Use correct env vars for CI

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -20,7 +20,7 @@ set -o xtrace
 
 git fetch --tags https://github.com/kubernetes/charts master
 
-NAMESPACE="pr-${ghprbPullId}-${BUILD_NUMBER}"
+NAMESPACE="pr-${PULL_NUMBER}-${BUILD_NUMBER}"
 CHANGED_FOLDERS=`git diff --find-renames --name-only FETCH_HEAD stable/ incubator/ | awk -F/ '{print $1"/"$2}' | uniq`
 CURRENT_RELEASE=""
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -26,7 +26,7 @@ IMAGE_NAME=${IMAGE_NAME:-"gcr.io/kubernetes-charts-ci/${IMAGE_VERSION}"}
 docker run -v ${CHART_ROOT}:/src \
            -v "${GOOGLE_APPLICATION_CREDENTIALS}:/service-account.json:ro" \
            -e "GOOGLE_APPLICATION_CREDENTIALS=/service-account.json" \
-           -e "ghprbPullId=$ghprbPullId" \
+           -e "PULL_NUMBER=$PULL_NUMBER" \
            -e "BUILD_NUMBER=$BUILD_NUMBER" \
            ${IMAGE_NAME} /src/test/changed.sh
 echo "Done Testing!"


### PR DESCRIPTION
ghprbPullId is no longer being passed to our CI scripts. This PR changes to use the new ones as implemented in https://github.com/kubernetes/test-infra/pull/1204. This PR can be merged before that PR as we are currently in a broken state either way.