### PR TITLE
factorio: use correct env var name for game password

### DIFF
--- a/stable/factorio/templates/deployment.yaml
+++ b/stable/factorio/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: {{ .Values.factorioServer.autosave.slots | quote }}
 
         {{- if .Values.factorioServer.password }}
-        - name: FACTORIO_SERVER_GAME_PASSWORD
+        - name: FACTORIO_GAME_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "fullname" . }}


### PR DESCRIPTION
The factorio chart sets the wrong environment variable for the game password which results in creating games without any password.

According to [the image's documentation](https://github.com/games-on-k8s/docker-factorio#environment-variable-reference) and [code](https://github.com/games-on-k8s/docker-factorio/search?utf8=%E2%9C%93&q=FACTORIO_GAME_PASSWORD) the variable needs to be called `FACTORIO_GAME_PASSWORD` instead of `FACTORIO_SERVER_GAME_PASSWORD`.

I tested it with a self-built image for the latest version using the provided build script (`quay.io/linki/factorio:0.14.21`). I think the behaviour is equally broken for version `0.14.19` which is defined in the chart.