### PR TITLE
Add google cloud endpoints chart

### DIFF
--- a/stable/gcloud-endpoints/Chart.yaml
+++ b/stable/gcloud-endpoints/Chart.yaml
@@ -1,0 +1,19 @@
+name: gcloud-endpoints
+version: 0.1.0
+description: Develop, deploy, protect and monitor your APIs with Google Cloud Endpoints.
+keywords:
+- google
+- endpoints
+- nginx
+- gcloud
+- proxy
+- authentication
+- monitoring
+- api
+- swagger
+- open api
+home: https://cloud.google.com/endpoints/
+maintainers:
+- name: Matt Tucker
+  email: mtucker@deis.com
+engine: gotpl

--- a/stable/gcloud-endpoints/README.md
+++ b/stable/gcloud-endpoints/README.md
@@ -1,0 +1,78 @@
+# Google Cloud Endpoints
+
+[Google Cloud Endpoints](https://cloud.google.com/endpoints/) is an NGINX-based proxy used to develop, deploy, protect, and monitor APIs running on Google Cloud.
+
+Note: This Helm Chart was created using Google documentation, but it is not an officially supported or maintained Google product.
+
+## TL;DR;
+
+```console
+$ helm install stable/gcloud-endpoints --set service=project-id.appspot.com,version=version-number,backend=backendapi.default.svc.cluster.local
+```
+
+## Introduction
+
+This chart creates a Google Cloud Endpoints deployment and service on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+- Kubernetes cluster on Google Container Engine (GKE)
+- API with Open API (swagger) specification yaml file
+- Deploy your Open API spec using `gcloud beta service-management deploy swagger.yaml` and note the Project ID and version
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/gcloud-endpoints --set service=project-id.appspot.com,version=version-number,backend=backendapi.svc.cluster.local
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Drupal chart and their default values.
+
+| Parameter                         | Description                            | Default                                                   |
+| --------------------------------- | -------------------------------------- | --------------------------------------------------------- |
+| `image`                           | Endpoints image                        | `b.gcr.io/endpoints/endpoints-runtime:0.3`                |
+| `imagePullPolicy`                 | Image pull policy                      | `Always` if `image` tag is `latest`, else `IfNotPresent`  |
+| `backend`                         | Backend API in which to proxy requests |                                                           |
+| `service`                         | Name of the Endpoints service          |                                                           |
+| `serviceConfigURL`                | URL to fetch the service configuration |                                                           |
+| `httpPort`                        | Port to accept HTTP/1.x connections    | `8080` if `http2Port` and `sslPort` are not provided      |
+| `http2Port`                       | Port to accept HTTP/2 connections      |                                                           |
+| `sslPort`                         | Port to accept HTTPS connections       |                                                           |
+| `statusPort`                      | Port for status/health (not exposed)   | `8090`                                                    |
+| `version`                         | Config version of Endpoints service    |                                                           |
+| `serviceAccountKey`               | Service account key JSON file          |                                                           |
+| `nginxConfig`                     | Custom NGINX config file               |                                                           |
+| `serviceType`                     | Kubernetes Service type                | `LoadBalancer`                                            |
+| `resources`                       | CPU/Memory resource requests/limits    | Memory: `128Mi`, CPU: `100m`                              |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/gcloud-endpoints
+```
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Documentation
+
+- [Generic information about Google Cloud Endpoints](https://cloud.google.com/endpoints/)
+- [Google Cloud Endpoints documentation](https://cloud.google.com/endpoints/docs/)
+- [Google Cloud Endpoints on Kubernetes](https://cloud.google.com/endpoints/docs/kubernetes-concept)
+- [Google Cloud Endpoints as a Docker container](https://cloud.google.com/endpoints/docs/quickstart-compute-engine-docker#running_the_api_and_extensible_service_proxy_in_a_docker_container)

--- a/stable/gcloud-endpoints/templates/NOTES.txt
+++ b/stable/gcloud-endpoints/templates/NOTES.txt
@@ -1,0 +1,30 @@
+For general information about Google Cloud Endpoints, see
+https://cloud.google.com/endpoints/
+
+For more details about running Cloud Endpoints on Kubernetes, see Google's
+documentation: https://cloud.google.com/endpoints/docs/kubernetes-concept
+
+For details about running Google Cloud Endpoints as a Docker container, see
+Google's documentation: https://cloud.google.com/endpoints/docs/quickstart-compute-engine-docker#running_the_api_and_extensible_service_proxy_in_a_docker_container
+
+1. Get the Endpoints URL by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/
+
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc -w {{ template "fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP/
+{{- else if contains "ClusterIP"  .Values.serviceType }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/stable/gcloud-endpoints/templates/_helpers.tpl
+++ b/stable/gcloud-endpoints/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}
+
+{{- define "toYaml" -}}
+  {{- range $key, $value := . -}}
+    {{- $map := kindIs "map" $value -}}
+    {{- if $map }}
+{{ $key }}:
+  {{- include "toYaml" $value | indent 2 }}
+    {{- else }}
+{{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end -}}
+{{- end -}}

--- a/stable/gcloud-endpoints/templates/deployment.yaml
+++ b/stable/gcloud-endpoints/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+        - name: endpoints
+          image: "{{ .Values.image }}"
+          imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+          args: [
+{{- if (.Values.httpPort) }}
+            "--http_port", {{ default "" .Values.httpPort | quote }},
+{{- end }}
+{{- if (.Values.http2Port) }}
+            "--http2_port", {{ default "" .Values.http2Port | quote }},
+{{- end }}
+{{- if (.Values.sslPort) }}
+            "--ssl_port", {{ default "" .Values.sslPort | quote }},
+{{- end }}
+{{- if (.Values.backend) }}
+            "--backend", {{ default "" .Values.backend | quote }},
+{{- end }}
+{{- if (.Values.service) }}
+            "--service", {{ default "" .Values.service | quote }},
+{{- end }}
+{{- if (.Values.version) }}
+            "--version", {{ default "" .Values.version | quote }},
+{{- end }}
+{{- if (.Values.serviceAccountKey) }}
+            "--service_account_key", {{ default "" .Values.serviceAccountKey | quote }},
+{{- end }}
+{{- if (.Values.nginxConfig) }}
+            "--nginx_config", {{ default "" .Values.nginxConfig | quote }},
+{{- end }}
+{{- if (.Values.statusPort) }}
+            "--status_port", {{ default "" .Values.statusPort | quote }},
+{{- end }}
+          ]
+          ports:
+{{- if (.Values.httpPort) }}
+            - containerPort: {{ default "0" .Values.httpPort }}
+              name: http
+{{- else if and (not .Values.http2Port) (not .Values.sslPort) }}
+            - containerPort: 8080
+              name: http
+{{- end }}
+{{- if (.Values.http2Port) }}
+            - containerPort: {{ default "0" .Values.http2Port }}
+              name: http2
+{{- end }}
+{{- if (.Values.sslPort) }}
+            - containerPort: {{ default "0" .Values.sslPort }}
+              name: https
+{{- end }}
+{{- if (.Values.statusPort) }}
+            - containerPort: {{ default "0" .Values.statusPort }}
+              name: status
+          livenessProbe:
+            httpGet:
+              path: /endpoints_status
+              port: {{ default "0" .Values.statusPort }}
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /endpoints_status
+              port: {{ default "0" .Values.statusPort }}
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+{{- end }}
+          resources:
+            {{ include "toYaml" .Values.resources | indent 12 }}

--- a/stable/gcloud-endpoints/templates/service.yaml
+++ b/stable/gcloud-endpoints/templates/service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+spec:
+  ports:
+{{- if (.Values.httpPort) }}
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+{{- else if and (not .Values.http2Port) (not .Values.sslPort) }}
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+{{- end }}
+{{- if (.Values.http2Port) }}
+  - port: 81
+    targetPort: http2
+    protocol: TCP
+    name: http2
+{{- end }}
+{{- if (.Values.sslPort) }}
+  - port: 443
+    targetPort: https
+    protocol: TCP
+    name: https
+{{- end }}
+  selector:
+    app: {{ template "fullname" . }}
+  type: {{ .Values.serviceType }}
+

--- a/stable/gcloud-endpoints/values.yaml
+++ b/stable/gcloud-endpoints/values.yaml
@@ -1,0 +1,75 @@
+## Google Cloud Endpoints Runtime image
+## ref: https://cloud.google.com/endpoints/docs/quickstart-container-engine#deploying_the_sample_api_to_the_cluster
+image: b.gcr.io/endpoints/endpoints-runtime:1
+
+## Specify a imagePullPolicy
+## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
+
+## Set the application server address to which ESP proxies the requests. For
+## GRPC backends, please use grpc:// prefix, e.g. grpc://localhost:8081.
+## (default: localhost:8081)
+## 
+# backend: 
+
+## Set the name of the Endpoints service. If omitted and serviceConfigURL not
+## specified, ESP contacts the metadata service to fetch the service name.
+## (default: None)
+## 
+# service: 
+
+## Specify the URL to fetch the service configuration. (default: None)
+##
+# serviceConfigURL: 
+
+## Expose a port to accept HTTP/1.x connections. Note that if you do not
+## specify httpPort, http2Port, and sslPort, then the default httpPort 8080 is
+## set. (default: None)
+##
+# httpPort: 8080
+
+## Expose a port to accept HTTP/2 connections. Note that this cannot be the
+## same port as HTTP/1.x port. (default: None)
+##
+# http2Port:
+
+## Expose a port for HTTPS requests. Accepts both HTTP/1.x and HTTP/2
+## connections. (default: None)
+##
+# sslPort: 
+
+## Set the ESP status port. Status information is available at
+## /endpoints_status location over HTTP/1.x. (default: 8090)
+##
+statusPort: 8090
+
+## Set the config version of the Endpoints service. If omitted and
+## serviceConfigURL not specified, ESP contacts the metadata service to fetch
+## the service version. (default: None)
+##
+# version: 
+
+## Set the service account key JSON file. Used to access the service control
+## and the service management. If the option is omitted, ESP contacts the
+## metadata service to fetch an access token. (default: None)
+##
+# serviceAccountKey: 
+
+## Set a custom nginx config file. (default: None)
+##
+# nginxConfig: 
+
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer
+##
+serviceType: ClusterIP
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 128Mi
+    cpu: 100m


### PR DESCRIPTION
Two things about this chart which might prevent it from being accepted:

1. `Must successfully launch with default values (helm install .)`
What if the chart is useless without a customized value? I notice the minecraft chart requires you to set a variable to accept the EULA, so this doesn't seem like a completely strict requirement. Cloud Endpoints proxies API requests to a backend API. Without information about the location of that API, this chart does not function.

2. `Must include source GitHub repositories for images used in the Chart`
What if the image is provided by Google and there is no known source? I have no idea where the source for the endpoints image is :/


