### PR TITLE
Allow custom image in postgresql chart

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.2.0
+version: 0.2.1
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -45,7 +45,8 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 
 | Parameter                  | Description                                | Default                                                    |
 | -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
-| `imageTag`                 | `postgres` image tag                       | `9.5.4`                                           |
+| `image`                    | `postgres` image repository                | `postgres`                                                 |
+| `imageTag`                 | `postgres` image tag                       | `9.5.4`                                                    |
 | `imagePullPolicy`          | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
 | `postgresUser`             | Username of new user to create.            | `postgres`                                                 |
 | `postgresPassword`         | Password for the new user.                 | random 10 characters                                       |

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "postgres:{{ .Values.imageTag }}"
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
         - name: POSTGRES_USER

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -1,3 +1,5 @@
+## postgres image repository
+image: "postgres"
 ## postgres image version
 ## ref: https://hub.docker.com/r/library/postgres/tags/
 ##


### PR DESCRIPTION
This allows to use the chart with a customised postgres image.
It also allows to deploy postgresql from a local registry if you don't want to depend on docker hub.