### PR TITLE
fix(*): include version in chart name

### DIFF
--- a/stable/factorio/Chart.yaml
+++ b/stable/factorio/Chart.yaml
@@ -1,5 +1,5 @@
 name: factorio
-version: 0.1.1
+version: 0.1.2
 description: Factorio dedicated server.
 keywords:
 - game

--- a/stable/factorio/templates/factorio-svc.yaml
+++ b/stable/factorio/templates/factorio-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/factorio/templates/rcon-svc.yaml
+++ b/stable/factorio/templates/rcon-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "{{ template "fullname" . }}-rcon"
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,5 +1,5 @@
 name: minecraft
-version: 0.1.0
+version: 0.1.1
 description: Minecraft server
 keywords:
 - game

--- a/stable/minecraft/templates/minecraft-svc.yaml
+++ b/stable/minecraft/templates/minecraft-svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/minecraft/templates/rcon-svc.yaml
+++ b/stable/minecraft/templates/rcon-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "{{ template "fullname" . }}-rcon"
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 0.3.5
+version: 0.3.6
 description: A flexible project management web application.
 keywords:
 - redmine

--- a/stable/redmine/templates/deployment.yaml
+++ b/stable/redmine/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/redmine/templates/secrets.yaml
+++ b/stable/redmine/templates/secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/redmine/templates/svc.yaml
+++ b/stable/redmine/templates/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:


### PR DESCRIPTION
some charts (factorio, minecraft, redmine) use `"{{ .Chart.Name }}-{{ .Chart.Name }}"` as the value for the `chart` label, whereas the majority of charts use `"{{ .Chart.Name }}-{{ .Chart.Version }}"` which makes more sense to me as well.

I think the duplicate `{{ .Chart.Name }}` is just a mistake in those charts and propose to change it here while also increasing the respective patch versions.