### PR TITLE
traefik: support different repositories

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.1.1-a
+version: 1.1.1-b
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -68,7 +68,8 @@ The following tables lists the configurable parameters of the Traefik chart and 
 
 | Parameter                       | Description                                                          | Default                                   |
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
-| `imageTag`                      | The version of the official Traefik image to use                     | `v1.1.1`                                  |
+| `image.tag`                     | The version of the official Traefik image to use                     | `v1.1.1`                                  |
+| `image.repository`              | Traefik docker image repository                                      | `traefik`                                 |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - image: traefik:{{ .Values.imageTag }}
+      - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         name: {{ template "fullname" . }}
         resources:
           requests:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,5 +1,7 @@
 # Default values for Traefik
-imageTag: v1.1.1
+image:
+  repository: traefik
+  tag: v1.1.1
 serviceType: LoadBalancer
 cpuRequest: 100m
 memoryRequest: 20Mi


### PR DESCRIPTION
Adding traefik repository variable so installations can overwrite it.