### PR TITLE
Bump gitlab-ce default image from 8.13.3-ce.0 to 8.14.4-ce.0.

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,5 +1,5 @@
 name: gitlab-ce
-version: 0.1.0
+version: 0.1.1
 description: GitLab Community Edition
 keywords:
 - git

--- a/stable/gitlab-ce/values.yaml
+++ b/stable/gitlab-ce/values.yaml
@@ -1,7 +1,7 @@
 ## GitLab CE image
 ## ref: https://hub.docker.com/r/gitlab/gitlab-ce/tags/
 ##
-image: gitlab/gitlab-ce:8.13.3-ce.0
+image: gitlab/gitlab-ce:8.14.4-ce.0
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
As per @stanhu (GitLab)'s [suggestion](https://github.com/kubernetes/charts/pull/202#discussion-diff-92000269R4), this PR bumps the default gitlab-ce image to the most recent stable 8.14.4.

cc @maxlazio