### PR TITLE
Jenkins: imagePullPolicy in initContainers

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.1.5
+version: 0.1.6
 description: A Jenkins Helm chart for Kubernetes.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -28,6 +28,7 @@ spec:
               {
                   "name": "copy-default-config",
                   "image": "{{.Values.Master.Image}}:{{.Values.Master.ImageTag}}",
+                  "imagePullPolicy": "{{.Values.Master.ImagePullPolicy}}",
                   "command": ["cp", "-n", "/var/jenkins_config/config.xml", "/var/jenkins_home"],
                   "volumeMounts": [
                       {


### PR DESCRIPTION
API require imagePullPolicy in initContainers now.

+ And the default imagepullpolicy isn't set by default due to the following bug.

https://github.com/kubernetes/kubernetes/issues/38542