### PR TITLE
Redmine: Update chart to 0.3.7

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 0.3.6
+version: 0.3.7
 description: A flexible project management web application.
 keywords:
 - redmine

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Redmine image version
 ## ref: https://hub.docker.com/r/bitnami/redmine/tags/
 ##
-image: bitnami/redmine:3.3.1-r2
+image: bitnami/redmine:3.3.1-r8
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
The chart has been updated to the latest publicly available version of the Bitnami Redmine Container.
The last version fixes a minor issue, where a warning would appear when installing a plugin as the "bitnami" user, because of permission issues writing to the `production.log` file.