### PR TITLE
MariaDB: fixes imagePullPolicy problem in 1.5 #307

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.5.5
+version: 0.5.6
 description: Chart for MariaDB
 keywords:
 - mariadb

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -48,7 +48,7 @@ The following tables lists the configurable parameters of the MariaDB chart and 
 | Parameter                  | Description                                | Default                                                    |
 | -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
 | `image`                    | MariaDB image                              | `bitnami/mariadb:{VERSION}`                                |
-| `imagePullPolicy`          | Image pull policy.                         | `Always` if `imageTag` is `latest`, else `IfNotPresent`.   |
+| `imagePullPolicy`          | Image pull policy.                         | `IfNotPresent`                                             |
 | `mariadbRootPassword`      | Password for the `root` user.              | `nil`                                                      |
 | `mariadbUser`              | Username of new user to create.            | `nil`                                                      |
 | `mariadbPassword`          | Password for the new user.                 | `nil`                                                      |

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
             {
               "name": "copy-custom-config",
               "image": "{{ .Values.image }}",
+              "imagePullPolicy": {{ .Values.imagePullPolicy | quote }},
               "command": ["sh", "-c", "mkdir -p /bitnami/mariadb/conf && cp -n /bitnami/mariadb_config/my.cnf /bitnami/mariadb/conf/my_custom.cnf"],
               "volumeMounts": [
                 {
@@ -35,7 +36,7 @@ spec:
       containers:
       - name: {{ template "fullname" . }}
         image: "{{ .Values.image }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -4,11 +4,10 @@
 ## Default: none
 image: bitnami/mariadb:10.1.19-r2
 
-## Specify a imagePullPolicy
-## Default to 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
-## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-##
-# imagePullPolicy:
+## Specify an imagePullPolicy (Required)
+## It's recommended to change this to 'Always' if the image tag is 'latest'
+## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+imagePullPolicy: IfNotPresent
 
 ## Specify password for root user
 ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run


### PR DESCRIPTION
Setting default value for imagePullPolicy both in values.yaml and deployment as well as adding it to the init container. Modified descriptions and incremented the chart version to reflect the changes.