### PR TITLE
Mongodb - Fixed installation example

### DIFF
--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -62,7 +62,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```bash
 $ helm install --name my-release \
-  --set mongodbRootPassword=secretpassword,mongodbUser=my-user,mongodbPassword=my-password,mongodbDatabase=my-database \
+  --set mongodbRootPassword=secretpassword,mongodbUsername=my-user,mongodbPassword=my-password,mongodbDatabase=my-database \
     stable/mongodb
 ```
 


### PR DESCRIPTION
The commandline flag in the example should be `--mongodbUsername` instead of `mongodbUser`. (See: https://github.com/kubernetes/charts/blob/master/stable/mongodb/templates/deployment.yaml#L27 )