### PR TITLE
fix for init container requiring ImagePullPolicy

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.2.1
+version: 0.2.2
 description: Chart for PostgreSQL
 keywords:
 - postgresql

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
             {
                 "name": "remove-lost-found",
                 "image": "busybox:1.25.0",
+                "imagePullPolicy": "IfNotPresent",
                 "command": ["rm", "-fr", "/var/lib/postgresql/data/pgdata/lost+found"],
                 "volumeMounts": [
                     {


### PR DESCRIPTION

I have found on Kube 1.5 that kube complains if the init containers does not specify a pull policy



