### PR TITLE
postgres: lower initialDelay and timeout for readiness probe

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.5.0
+version: 0.5.1
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -44,7 +44,8 @@ spec:
             - -c
             - exec pg_isready --host $POD_IP
           initialDelaySeconds: 60
-          timeoutSeconds: 3
+          timeoutSeconds: 5
+          failureThreshold: 6
         readinessProbe:
           exec:
             command:
@@ -52,7 +53,8 @@ spec:
             - -c
             - exec pg_isready --host $POD_IP
           initialDelaySeconds: 5
-          timeoutSeconds: 1
+          timeoutSeconds: 3
+          periodSeconds: 5
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -32,21 +32,27 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: postgres-password
+        - name: POD_IP
+          valueFrom: { fieldRef: { fieldPath: status.podIP } }
         ports:
         - name: postgresql
           containerPort: 5432
         livenessProbe:
           exec:
             command:
-            - pg_isready
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
           initialDelaySeconds: 60
           timeoutSeconds: 3
         readinessProbe:
           exec:
             command:
-            - pg_isready
-          initialDelaySeconds: 60
-          timeoutSeconds: 3
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:


### PR DESCRIPTION
The `timeout` and `initialDelay` of the `readinessProbe` should be much lower than that of the `livenessProbe` for the following reasons:
 
- Kubernetes will send traffic to the pod as soon as it become ready. Waiting for `60` seconds simply delays the deployment. At the same time it contributes to deployment delays in any chart that depend on this chart.
- Similarly kubernetes will stop sending traffic to the pod when the readiness probe fails for allowing it to recover for the failure (in case the failure is temporary). 
- A `livenessProbe` simply restarts a pod when it fails. Having identical tests and timeouts for the `liveness` and `readiness` probes renders the `readinessProbe` useless cause the pod will be restarted by the `livenessProbe` when it fails, rendering the readiness probe useless.

This PR sets the `initialDelay` and `timout` of the `readinessProbe` to `5` and `1` second respectively and also bumps the chart version to `0.2.2`.

/cc @gtaylor 