### PR TITLE
Remove whitespace trimming

### DIFF
--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
-  {{- if .Values.alertmanager.persistentVolume.storageClass -}}
+  {{- if .Values.alertmanager.persistentVolume.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.alertmanager.persistentVolume.storageClass }}
   {{ else }}
     volume.alpha.kubernetes.io/storage-class: default

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
-  {{- if .Values.server.persistentVolume.storageClass -}}
+  {{- if .Values.server.persistentVolume.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass }}
   {{ else }}
     volume.alpha.kubernetes.io/storage-class: default


### PR DESCRIPTION
If a custom storage class is used, installation of the chart fails with the following error, because whitespace is trimmed:

```
error validating "": error validating data: found invalid field annotations:volume.beta.kubernetes.io/storage-class for v1.ObjectMeta
```

The following JSON would be generated:

```
metadata:
  annotations:volume.beta.kubernetes.io/storage-class: standard
```

With this PR, the resulting JSON is generated correctly:

```
metadata:
  annotations:
    volume.beta.kubernetes.io/storage-class: standard
```
