### PR TITLE
WIP: changes for kubernetes v1.5.1

### DIFF
--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
 FROM jenkins:2.19.3
-RUN /usr/local/bin/install-plugins.sh kubernetes:0.8 workflow-aggregator:2.4 credentials-binding:1.9 git:3.0.0 \
+RUN /usr/local/bin/install-plugins.sh kubernetes:0.10 workflow-aggregator:2.4 credentials-binding:1.9 git:3.0.0 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -28,7 +28,7 @@ data:
           <name>default</name>
           <templates>
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
-              <name>default</name>
+              <name>jnlp</name>
               <image>{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}</image>
               <privileged>false</privileged>
               <alwaysPullImage>false</alwaysPullImage>


### PR DESCRIPTION
This v1.5 kubernetes upgrade broke a bunch of stuff for me.

There is a new version of kubernetes-plugin that looks like it was targeting support for v1.5.1

Changes (?) in the plugin require user to create a container called "jnlp" in the pod, or it will create one for you.  If you are upgrading from an older kubernetes-plugin with no other changes, this is almost certainly not what you want.

I am sure this is on purpose as there are other Docker cloud providers that don't require you to build JNLP slave into your test container.  But the default pod definition brings up a slave container with jnlp worker and nothing else on it.  I used a custom pod definition and was caught off guard by this "jnlp" container that was missing all of my project's custom dependencies.  Could not figure out how this was intended to be used, and it doesn't seem to be mentioned in the docs, but when I named my container "jnlp" in the pod definition, it prevented this other container from being created and that just fixed everything for me.

Marked as WIP because I'm not sure that kubernetes-plugin:v0.10 is really a finished product, or so sure that I actually know what I'm doing, so someone who knows more about this than I do should probably do some review before pushing the button to merge.  Might be other changes needed.

It kind of looks like they (kubernetes-plugin) wanted to get something pushed out the door that works with 1.5, since 1.5 is already out now.