### PR TITLE
Update Jenkins version to current LTS (2.19.4) and Kubernetes Plugin to 0.10

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.1.6
+version: 0.1.7
 description: A Jenkins Helm chart for Kubernetes.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
 FROM jenkins:2.19.4
-RUN /usr/local/bin/install-plugins.sh kubernetes:0.8 workflow-aggregator:2.4 credentials-binding:1.9 git:3.0.0 \
+RUN /usr/local/bin/install-plugins.sh kubernetes:0.10 workflow-aggregator:2.4 credentials-binding:1.10 git:3.0.1 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch

--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:2.19.3
+FROM jenkins:2.19.4
 RUN /usr/local/bin/install-plugins.sh kubernetes:0.8 workflow-aggregator:2.4 credentials-binding:1.9 git:3.0.0 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -7,7 +7,7 @@ data:
     <?xml version='1.0' encoding='UTF-8'?>
     <hudson>
       <disabledAdministrativeMonitors/>
-      <version>2.7.3</version>
+      <version>2.19.4</version>
       <numExecutors>0</numExecutors>
       <mode>NORMAL</mode>
       <useSecurity>true</useSecurity>
@@ -24,28 +24,38 @@ data:
       <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
       <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
       <clouds>
-        <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@0.8">
+        <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@0.10">
           <name>default</name>
           <templates>
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+              <inheritFrom></inheritFrom>
               <name>default</name>
-              <image>{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}</image>
-              <privileged>false</privileged>
-              <alwaysPullImage>false</alwaysPullImage>
-              <command></command>
-              <args></args>
-              <remoteFs>/home/jenkins</remoteFs>
               <instanceCap>2147483647</instanceCap>
+              <idleMinutes>0</idleMinutes>
               <label></label>
               <nodeSelector></nodeSelector>
-              <resourceRequestCpu>{{.Values.Agent.Cpu}}</resourceRequestCpu>
-              <resourceRequestMemory>{{.Values.Agent.Memory}}</resourceRequestMemory>
-              <resourceLimitCpu>{{.Values.Agent.Cpu}}</resourceLimitCpu>
-              <resourceLimitMemory>{{.Values.Agent.Memory}}</resourceLimitMemory>
               <volumes/>
+              <containers>
+                <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+                  <name>jnlp</name>
+                  <image>{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}</image>
+                  <privileged>false</privileged>
+                  <alwaysPullImage>false</alwaysPullImage>
+                  <workingDir>/home/jenkins</workingDir>
+                  <command></command>
+                  <args>${computer.jnlpmac} ${computer.name}</args>
+                  <ttyEnabled>false</ttyEnabled>
+                  <resourceRequestCpu>{{.Values.Agent.Cpu}}</resourceRequestCpu>
+                  <resourceRequestMemory>{{.Values.Agent.Memory}}</resourceRequestMemory>
+                  <resourceLimitCpu>{{.Values.Agent.Cpu}}</resourceLimitCpu>
+                  <resourceLimitMemory>{{.Values.Agent.Memory}}</resourceLimitMemory>
+                  <envVars/>
+                </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+              </containers>
               <envVars/>
               <annotations/>
               <imagePullSecrets/>
+              <nodeProperties/>
             </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
           </templates>
           <serverUrl>https://kubernetes.default</serverUrl>
@@ -55,6 +65,8 @@ data:
           <jenkinsTunnel>{{ template "fullname" . }}:50000</jenkinsTunnel>
           <containerCap>10</containerCap>
           <retentionTimeout>5</retentionTimeout>
+          <connectTimeout>0</connectTimeout>
+          <readTimeout>0</readTimeout>
         </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
       </clouds>
       <quietPeriod>5</quietPeriod>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -6,7 +6,7 @@
 Master:
   Name: jenkins-master
   Image: "gcr.io/kubernetes-charts-ci/jenkins-master-k8s"
-  ImageTag: "v0.5.0"
+  ImageTag: "v0.6.0"
   ImagePullPolicy: "Always"
   Component: "jenkins-master"
   AdminUser: admin


### PR DESCRIPTION
The current LTS release of Jenkins is 2.19.4, released 2016-11-23.

Also updating the Jenkins plugins, and config.xml for Kubernetes Plugin 0.10

 - Kubernetes 0.10
 - Credentials Binding 1.10
 - Git 3.0.1
