### PR TITLE
Unquote Prometheus storage paths

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 1.4.1
+version: 1.4.2
 description: A Prometheus Helm chart for Kubernetes. Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 sources:

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -23,7 +23,7 @@ spec:
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           args:
             - --config.file=/etc/config/alertmanager.yml
-            - --storage.path={{ default "/data" .Values.alertmanager.storagePath | quote }}
+            - --storage.path={{ default "/data" .Values.alertmanager.storagePath }}
           ports:
             - containerPort: 9093
           readinessProbe:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           args:
             - --alertmanager.url=http://{{ template "alertmanager.fullname" . }}:{{ .Values.alertmanager.httpPort }}
             - --config.file=/etc/config/prometheus.yml
-            - --storage.local.path={{ default "/data" .Values.server.storageLocalPath | quote }}
+            - --storage.local.path={{ default "/data" .Values.server.storageLocalPath }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
           {{- range $key, $value := .Values.server.extraArgs }}


### PR DESCRIPTION
When using the default values I ended up with an installation that did not persist prometheus metrics on the mounted volume (AWS EBS) once the pod was restarted. I found out the reason for this was that data was being written to `/prometheus/"/data"` instead of `/data` (the default).

I tested this locally and removing the quote function seems to have done the trick.