### PR TITLE
Add configurable loadBalancerSourceRanges for jenkins chart

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.1.6
+version: 0.1.7
 description: A Jenkins Helm chart for Kubernetes.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -26,18 +26,19 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 
 ### Jenkins Master
 
-| Parameter                  | Description                        | Default                                                    |
-| -----------------------    | ---------------------------------- | ---------------------------------------------------------- |
-| `Master.Name`              | Jenkins master name                | `jenkins-master`                                           |
-| `Master.Image`             | Master image name                  | `gcr.io/kubernetes-charts-ci/jenkins-master-k8s`           |
-| `Master.ImageTag`          | Master image tag                   | `v0.1.0`                                                   |
-| `Master.ImagePullPolicy`   | Master image pull policy           | `Always`                                                   |
-| `Master.Component`         | k8s selector key                   | `jenkins-master`                                           |
-| `Master.Cpu`               | Master requested cpu               | `200m`                                                     |
-| `Master.Memory`            | Master requested memory            | `256Mi`                                                    |
-| `Master.ServicePort`       | k8s service port                   | `8080`                                                     |
-| `Master.ContainerPort`     | Master listening port              | `8080`                                                     |
-| `Master.SlaveListenerPort` | Listening port for agents          | `50000`                                                    |
+| Parameter                         | Description                        | Default                                                    |
+| -----------------------           | ---------------------------------- | ---------------------------------------------------------- |
+| `Master.Name`                     | Jenkins master name                | `jenkins-master`                                           |
+| `Master.Image`                    | Master image name                  | `gcr.io/kubernetes-charts-ci/jenkins-master-k8s`           |
+| `Master.ImageTag`                 | Master image tag                   | `v0.1.0`                                                   |
+| `Master.ImagePullPolicy`          | Master image pull policy           | `Always`                                                   |
+| `Master.Component`                | k8s selector key                   | `jenkins-master`                                           |
+| `Master.Cpu`                      | Master requested cpu               | `200m`                                                     |
+| `Master.Memory`                   | Master requested memory            | `256Mi`                                                    |
+| `Master.ServicePort`              | k8s service port                   | `8080`                                                     |
+| `Master.ContainerPort`            | Master listening port              | `8080`                                                     |
+| `Master.SlaveListenerPort`        | Listening port for agents          | `50000`                                                    |
+| `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses       | `0.0.0.0/0`                                                |
 
 ### Jenkins Agent
 

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -20,3 +20,4 @@ spec:
   selector:
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
   type: {{.Values.Master.ServiceType}}
+  loadBalancerSourceRanges: {{.Values.Master.LoadBalancerSourceRanges}}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -20,6 +20,8 @@ Master:
   ServiceType: LoadBalancer
   ContainerPort: 8080
   SlaveListenerPort: 50000
+  LoadBalancerSourceRanges:
+  - 0.0.0.0/0
 
 Agent:
   Image: jenkinsci/jnlp-slave


### PR DESCRIPTION
Adds an option to the Jenkins chart that allows modification of the externally accessible default for services. See: https://github.com/kubernetes/kubernetes.github.io/blob/master/docs/user-guide/services-firewalls.md#restrict-access-for-loadbalancer-service