### PR TITLE
Bump helm version to 2.1.3

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -44,7 +44,7 @@ gcloud container clusters get-credentials jenkins --project kubernetes-charts-ci
 
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.0.0-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.1.3-linux-amd64.tar.gz
 INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 pushd /opt
   wget -q ${HELM_URL}/${HELM_TARBALL}


### PR DESCRIPTION
This is needed as a pre-cursor to upgrading to GKE 1.5.1 for the test cluster.