### PR TITLE
WordPress updates (0.4.0)

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.3.4
+version: 0.4.0
 description: Web publishing platform for building blogs and websites.
 keywords:
 - wordpress

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -76,10 +76,10 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                                      |
 | `serviceType`                        | Kubernetes Service type                  | `LoadBalancer`                                             |
 | `persistence.enabled`                | Enable persistence using PVC             | `true`                                                     |
-| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `volume.alpha.kubernetes.io/storage-class: default`        |
+| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `nil` (uses alpha storage class annotation)                |
 | `persistence.apache.accessMode`      | PVC Access Mode for Apache volume        | `ReadWriteOnce`                                            |
 | `persistence.apache.size`            | PVC Storage Request for Apache volume    | `1Gi`                                                      |
-| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume   | `volume.alpha.kubernetes.io/storage-class: default`        |
+| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume   | `nil` (uses alpha storage class annotation)                |
 | `persistence.wordpress.accessMode`   | PVC Access Mode for WordPress volume     | `ReadWriteOnce`                                            |
 | `persistence.wordpress.size`         | PVC Storage Request for WordPress volume | `8Gi`                                                      |
 

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -76,10 +76,10 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                                      |
 | `serviceType`                        | Kubernetes Service type                  | `LoadBalancer`                                             |
 | `persistence.enabled`                | Enable persistence using PVC             | `true`                                                     |
-| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `generic`                                                  |
+| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `volume.alpha.kubernetes.io/storage-class: default`        |
 | `persistence.apache.accessMode`      | PVC Access Mode for Apache volume        | `ReadWriteOnce`                                            |
 | `persistence.apache.size`            | PVC Storage Request for Apache volume    | `1Gi`                                                      |
-| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume   | `generic`                                                  |
+| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume   | `volume.alpha.kubernetes.io/storage-class: default`        |
 | `persistence.wordpress.accessMode`   | PVC Access Mode for WordPress volume     | `ReadWriteOnce`                                            |
 | `persistence.wordpress.size`         | PVC Storage Request for WordPress volume | `8Gi`                                                      |
 

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -62,7 +62,7 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `image`                              | WordPress image                          | `bitnami/wordpress:{VERSION}`                              |
 | `imagePullPolicy`                    | Image pull policy                        | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
 | `wordpressUsername`                  | User of the application                  | `user`                                                     |
-| `wordpressPassword`                  | Application password                     | `bitnami`                                                  |
+| `wordpressPassword`                  | Application password                     | _random 10 character long alphanumeric string_             |
 | `wordpressEmail`                     | Admin email                              | `user@example.com`                                         |
 | `wordpressFirstName`                 | First name                               | `FirstName`                                                |
 | `wordpressLastName`                  | Last name                                | `LastName`                                                 |

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -60,7 +60,7 @@ The following tables lists the configurable parameters of the WordPress chart an
 | Parameter                            | Description                              | Default                                                    |
 | -------------------------------      | -------------------------------          | ---------------------------------------------------------- |
 | `image`                              | WordPress image                          | `bitnami/wordpress:{VERSION}`                              |
-| `imagePullPolicy`                    | Image pull policy                        | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
+| `imagePullPolicy`                    | Image pull policy                        | `IfNotPresent`                                             |
 | `wordpressUsername`                  | User of the application                  | `user`                                                     |
 | `wordpressPassword`                  | Application password                     | _random 10 character long alphanumeric string_             |
 | `wordpressEmail`                     | Admin email                              | `user@example.com`                                         |

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.2
-digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
-generated: 2016-11-18T16:08:16.520834727-08:00
+  version: 0.5.6
+digest: sha256:1b3aad03b4383d1a24dfbfef6ba1beb45f7ace2baa399c66f5a4d56d0f7bc717
+generated: 2017-01-05T16:27:48.098725855Z

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.2
+  version: 0.5.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/wordpress/templates/NOTES.txt
+++ b/stable/wordpress/templates/NOTES.txt
@@ -22,5 +22,5 @@
 
 2. Login with the following credentials to see your blog
 
-  Username: {{ .Values.wordpressUsername }}
-  Password: {{ .Values.wordpressPassword }}
+  echo Username: {{ .Values.wordpressUsername }}
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.wordpress-password}" | base64 --decode)

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -20,7 +20,7 @@ Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "mariadb.fullname" -}}
-{{- printf "%s-%s" .Release.Name "mariadb" | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "toYaml" -}}

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -22,15 +22,3 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- define "mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{- define "toYaml" -}}
-  {{- range $key, $value := . -}}
-    {{- $map := kindIs "map" $value -}}
-    {{- if $map }}
-{{ $key }}:
-  {{- include "toYaml" $value | indent 2 }}
-    {{- else }}
-{{ $key }}: {{ $value }}
-    {{- end }}
-  {{- end -}}
-{{- end -}}

--- a/stable/wordpress/templates/apache-pvc.yaml
+++ b/stable/wordpress/templates/apache-pvc.yaml
@@ -9,7 +9,11 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         - name: apache-data
           mountPath: /bitnami/apache
         resources:
-          {{ include "toYaml" .Values.resources | indent 10 }}
+{{ toYaml .Values.resources | indent 10 }}
       volumes:
       - name: wordpress-data
       {{- if .Values.persistence.enabled }}

--- a/stable/wordpress/templates/secrets.yaml
+++ b/stable/wordpress/templates/secrets.yaml
@@ -9,5 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
+  {{ if .Values.wordpressPassword }}
   wordpress-password: {{ default "" .Values.wordpressPassword | b64enc | quote }}
+  {{ else }}
+  wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
   smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}

--- a/stable/wordpress/templates/wordpress-pvc.yaml
+++ b/stable/wordpress/templates/wordpress-pvc.yaml
@@ -9,7 +9,11 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.wordpress.storageClass | quote }}
+  {{- if .Values.persistence.wordpress.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.wordpress.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.wordpress.accessMode | quote }}

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -15,9 +15,10 @@ image: bitnami/wordpress:4.7-r0
 wordpressUsername: user
 
 ## Application password
+## Defaults to a random 10-character alphanumeric string if not set
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
-wordpressPassword: bitnami
+# wordpressPassword:
 
 ## Admin email
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -4,10 +4,9 @@
 image: bitnami/wordpress:4.7-r0
 
 ## Specify a imagePullPolicy
-## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##
-# imagePullPolicy:
+imagePullPolicy: IfNotPresent
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -63,7 +63,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -78,11 +81,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   wordpress:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 


### PR DESCRIPTION
- alpha and beta storageclass annotation support
- use random password if not specified
- update MariaDB dep (fixes 1.5.1 deployments)
- explicitly set imagePullPolicy
- increase resource name truncation and trim '-' suffix