### PR TITLE
Datadog: Expose TAGS env var as a value

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.1.0
+version: 0.2.0
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -34,6 +34,8 @@ spec:
             value: docker
           - name: NON_LOCAL_TRAFFIC
             value: {{ default "" .Values.datadog.nonLocalTraffic | quote }}
+          - name: TAGS
+            value: {{ default "" .Values.datadog.tags | quote }}
           - name: KUBERNETES
             value: "yes"
         volumeMounts:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -20,6 +20,11 @@ datadog:
   ##
   # nonLocalTraffic: true
 
+  ## Set host tags.
+  ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
+  ##
+  # tags:
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
This allows chart users to specify host tags.