### PR TITLE
removed unneeded trim from Prometheus charts

### DIFF
--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
-  {{- if .Values.alertmanager.persistentVolume.storageClass -}}
+  {{- if .Values.alertmanager.persistentVolume.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.alertmanager.persistentVolume.storageClass }}
   {{ else }}
     volume.alpha.kubernetes.io/storage-class: default

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
-  {{- if .Values.server.persistentVolume.storageClass -}}
+  {{- if .Values.server.persistentVolume.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass }}
   {{ else }}
     volume.alpha.kubernetes.io/storage-class: default


### PR DESCRIPTION
The dash at the end left-trims the next line which result in something like `annotations:volume.beta.kubernetes.io/storage-class: ...`.