### PR TITLE
fixed Prometheus Ingress path rules

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 1.4.3
+version: 2.0.0
 description: A Prometheus Helm chart for Kubernetes. Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 sources:

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 1.4.2
+version: 1.4.3
 description: A Prometheus Helm chart for Kubernetes. Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 sources:

--- a/stable/prometheus/templates/alertmanager-ingress.yaml
+++ b/stable/prometheus/templates/alertmanager-ingress.yaml
@@ -21,8 +21,7 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: /
-            backend:
+          - backend:
               serviceName: {{ printf "%s-%s" $releaseName "alerts" | trunc 63 }}
               servicePort: {{ $servicePort }}
   {{- end -}}

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -21,8 +21,7 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: /
-            backend:
+          - backend:
               serviceName: {{ printf "%s-%s" $releaseName "server" | trunc 63 }}
               servicePort: {{ $servicePort }}
   {{- end -}}


### PR DESCRIPTION
Currently, the Ingress created only matches the `/` path. That means, that any other path (`/graph` for example) is not matched.