### PR TITLE
updated to beta storage class annotation for redis PVC

### DIFF
--- a/stable/redis/templates/pvc.yaml
+++ b/stable/redis/templates/pvc.yaml
@@ -9,7 +9,11 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -20,7 +20,10 @@ image: bitnami/redis:3.2.5-r0
 ##
 persistence:
   enabled: true
-  storageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass: generic
   accessMode: ReadWriteOnce
   size: 8Gi
 


### PR DESCRIPTION
Alpha version annotation is deprecated and might result in volumes created in another zone than the Kubernetes cluster (at least on GKE).
This might break existing clients as the beta version annotation assumes a `StorageClass` with the name specified in the annotation exists. More info: http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html