### PR TITLE
feat(mysql): add chart name as prefix to fullname

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.2.3
+version: 0.3.3
 description: Chart for MySQL
 keywords:
 - mysql

--- a/stable/mysql/templates/NOTES.txt
+++ b/stable/mysql/templates/NOTES.txt
@@ -1,9 +1,9 @@
 MySQL can be accessed via port 3306 on the following DNS name from within your cluster:
-{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ template "$name.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To get your root password run:
 
-    printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.mysql-root-password[*]}"`);echo
+    printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "$name.fullname" . }} -o jsonpath="{.data.mysql-root-password[*]}"`);echo
 
 To connect to your database:
 
@@ -16,4 +16,4 @@ To connect to your database:
     $ apt-get update && apt-get install mysql-client -y
 
 3. Connect using the mysql cli, then provide your password:
-    $ mysql -h {{ template "fullname" . }} -p
+    $ mysql -h {{ template "$name.fullname" . }} -p

--- a/stable/mysql/templates/_helpers.tpl
+++ b/stable/mysql/templates/_helpers.tpl
@@ -3,14 +3,14 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "$name.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "$name.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "$name.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "$name.fullname" . }}
       annotations:
         pod.beta.kubernetes.io/init-containers: '[
               {
@@ -29,7 +29,7 @@ spec:
           ]'
     spec:
       containers:
-      - name: {{ template "fullname" . }}
+      - name: {{ template "$name.fullname" . }}
         image: "mysql:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         resources:
@@ -42,12 +42,12 @@ spec:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "$name.fullname" . }}
               key: mysql-root-password
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "$name.fullname" . }}
               key: mysql-password
         {{- end }}
         - name: MYSQL_USER
@@ -78,7 +78,7 @@ spec:
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
+          claimName: {{ template "$name.fullname" . }}
       {{- else }}
         emptyDir: {}
       {{- end -}}

--- a/stable/mysql/templates/pvc.yaml
+++ b/stable/mysql/templates/pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "$name.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "$name.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/mysql/templates/secrets.yaml
+++ b/stable/mysql/templates/secrets.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "$name.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "$name.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/mysql/templates/svc.yaml
+++ b/stable/mysql/templates/svc.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "$name.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "$name.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -13,4 +13,4 @@ spec:
     port: 3306
     targetPort: mysql
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "$name.fullname" . }}


### PR DESCRIPTION
This will namespace the `fullname` template using the chart's name. In
this case it would be `mysql.fullname`. This makes it easier for charts
depending on this to call it without having to define a custom template
in it's _helpers.tpl file.

It also lengthens the truncate to 63 chars to make conflicts less likely
when a `.Release.Name` gets too long and might create multiple 
resources with the same name for each subchart used.