### PR TITLE
Fix formatting of Uchiwa deployment resource limit

### DIFF
--- a/stable/uchiwa/templates/deployment.yaml
+++ b/stable/uchiwa/templates/deployment.yaml
@@ -18,7 +18,8 @@ spec:
       - name: uchiwa
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.pullPolicy }}
-{{ toYaml .Values.resources | indent 8 }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         livenessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Uchiwa deploy was failing with [found invalid field limits for v1.Container, found invalid field requests for v1.Container]. This commit fixes the deployment template to correctly format the resource requests.

Output of current Uchiwa deploy with default values:

```
# Source: uchiwa/templates/deployment.yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: uchiwa-system-uchiwa
  labels:
    heritage: "Tiller"
    release: "uchiwa-system"
    chart: "uchiwa-0.1.0"
spec:
  replicas: 1  
  template:
    metadata:
      labels:
        app: uchiwa-system-uchiwa
        release: "uchiwa-system"
    spec:
      containers:
      - name: uchiwa
        image: "sstarcher/uchiwa:0.19"
        imagePullPolicy: IfNotPresent
        limits:
          memory: 50Mi
        requests:
          cpu: 10m
          memory: 50Mi
        
        livenessProbe:
          httpGet:
            path: /
            port: 3000
        readinessProbe:
          httpGet:
            path: /
            port: 3000
        ports:
        - containerPort: 3000
        volumeMounts:
        - name: config
          mountPath: /config/
      volumes:
      - name: config
        configMap:
          name: uchiwa-system-uchiwa
          items:
            - path: config.json.tmpl
              key: config.json.tmpl
```

As you can see, `limits` is improperly positioned as `resources:` never gets printed.

See [the redis chart](https://github.com/kubernetes/charts/blob/master/stable/redis/templates/deployment.yaml#L43) for an example of this formatted correctly.