### PR TITLE
Update MongoDB to version 3.4.1-r2

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 0.4.3
+version: 0.4.4
 description: Chart for MongoDB
 keywords:
 - mongodb

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MongoDB image version
 ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
 ##
-image: bitnami/mongodb:3.4.1-r0
+image: bitnami/mongodb:3.4.1-r2
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
This version restricts the permissions applied to the configuration, data, and key files