### PR TITLE
kube2iam: Don't quote .Values.host.interface; it breaks iptables wildcard support

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.1.0
+version: 0.1.1
 description: Provide IAM credentials to containers running inside a kubernetes cluster based on annotations.
 keywords:
 - kube2iam

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
         args:
         - --app-port={{ default 8181 .Values.containerPort }}
         - --iptables={{ default false .Values.host.iptables }}
-        - --host-interface={{ default "docker0" .Values.host.interface | quote }}
+        - --host-interface={{ default "docker0" .Values.host.interface }}
         {{- if .Values.host.iptables }}
         - --host-ip={{ default "$(HOST_IP)" .Values.host.ip }}
         {{- end }}


### PR DESCRIPTION
In some network configurations we have to handle traffic to the metadata api
from multiple interfaces - typically the node side of several veth pairs, where the
other ends of the pairs live inside Pod network namespaces.  We could use the wildcard
functionality in iptables to do this, but setting `host.interface: veth+` (if our interface names all start with `veth`) in this chart doesn't work.
This is because the interface parameter is quoted in the DaemonSet template and from what I can understand,  kube2iam ends up sending this parameter - still quoted - to
`execvp("iptables", ...)`, which means that the parameter stays quoted all the
way into the actual iptables rule. So you end up with a rule that looks like
this:

```shell
$ iptables -t nat -S PREROUTING | grep 169.254.169.254
-A PREROUTING -d 169.254.169.254/32 -i "veth+" -p tcp -m tcp --dport 80 -j DNAT --to-destination 10.0.0.1:8181
```

this rule only matches an interface named exactly `veth+` since the wildcard
character apparently isn't expanded when the interface name is quoted. If we
remove the quoting we can support iptables wildcards and I don't see why it
shouldn't work for exact matching the interface name still.

Note that in the latest version of kube2iam specifying interface name with a wildcard doesn't work due to https://github.com/jtblin/kube2iam/issues/37. kube2iam up to and including version 0.2.2 works though, since they don't include the check for the interface existing which fails in later versions.