### PR TITLE
move cockroachdb chart from petset to statefulset

### DIFF
--- a/incubator/cockroachdb/templates/cockroachdb-petset.yaml
+++ b/incubator/cockroachdb/templates/cockroachdb-petset.yaml
@@ -62,8 +62,8 @@ spec:
   selector:
     component: "{{.Release.Name}}-{{.Values.Component}}"
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
   annotations:


### PR DESCRIPTION
Minor change to move the CockroachDB example from PetSet to StatefulSet to fix "the server could not find the requested resource" errors.

I've signed the CLA for k8s, do we need to do it again for charts?