### PR TITLE
Adding ingress support stable/wordpress

### DIFF
--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -109,3 +109,4 @@ The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) ima
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -57,31 +57,33 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the WordPress chart and their default values.
 
-| Parameter                            | Description                              | Default                                                    |
-| -------------------------------      | -------------------------------          | ---------------------------------------------------------- |
-| `image`                              | WordPress image                          | `bitnami/wordpress:{VERSION}`                              |
-| `imagePullPolicy`                    | Image pull policy                        | `IfNotPresent`                                             |
-| `wordpressUsername`                  | User of the application                  | `user`                                                     |
-| `wordpressPassword`                  | Application password                     | _random 10 character long alphanumeric string_             |
-| `wordpressEmail`                     | Admin email                              | `user@example.com`                                         |
-| `wordpressFirstName`                 | First name                               | `FirstName`                                                |
-| `wordpressLastName`                  | Last name                                | `LastName`                                                 |
-| `wordpressBlogName`                  | Blog name                                | `User's Blog!`                                             |
-| `smtpHost`                           | SMTP host                                | `nil`                                                      |
-| `smtpPort`                           | SMTP port                                | `nil`                                                      |
-| `smtpUser`                           | SMTP user                                | `nil`                                                      |
-| `smtpPassword`                       | SMTP password                            | `nil`                                                      |
-| `smtpUsername`                       | User name for SMTP emails                | `nil`                                                      |
-| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]             | `nil`                                                      |
-| `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                                      |
-| `serviceType`                        | Kubernetes Service type                  | `LoadBalancer`                                             |
-| `persistence.enabled`                | Enable persistence using PVC             | `true`                                                     |
-| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `nil` (uses alpha storage class annotation)                |
-| `persistence.apache.accessMode`      | PVC Access Mode for Apache volume        | `ReadWriteOnce`                                            |
-| `persistence.apache.size`            | PVC Storage Request for Apache volume    | `1Gi`                                                      |
-| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume   | `nil` (uses alpha storage class annotation)                |
-| `persistence.wordpress.accessMode`   | PVC Access Mode for WordPress volume     | `ReadWriteOnce`                                            |
-| `persistence.wordpress.size`         | PVC Storage Request for WordPress volume | `8Gi`                                                      |
+| Parameter                            | Description                                | Default                                                    |
+| -------------------------------      | -------------------------------            | ---------------------------------------------------------- |
+| `image`                              | WordPress image                            | `bitnami/wordpress:{VERSION}`                              |
+| `imagePullPolicy`                    | Image pull policy                          | `IfNotPresent`                                             |
+| `wordpressUsername`                  | User of the application                    | `user`                                                     |
+| `wordpressPassword`                  | Application password                       | _random 10 character long alphanumeric string_             |
+| `wordpressEmail`                     | Admin email                                | `user@example.com`                                         |
+| `wordpressFirstName`                 | First name                                 | `FirstName`                                                |
+| `wordpressLastName`                  | Last name                                  | `LastName`                                                 |
+| `wordpressBlogName`                  | Blog name                                  | `User's Blog!`                                             |
+| `smtpHost`                           | SMTP host                                  | `nil`                                                      |
+| `smtpPort`                           | SMTP port                                  | `nil`                                                      |
+| `smtpUser`                           | SMTP user                                  | `nil`                                                      |
+| `smtpPassword`                       | SMTP password                              | `nil`                                                      |
+| `smtpUsername`                       | User name for SMTP emails                  | `nil`                                                      |
+| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]               | `nil`                                                      |
+| `mariadb.mariadbRootPassword`        | MariaDB admin password                     | `nil`                                                      |
+| `serviceType`                        | Kubernetes Service type                    | `LoadBalancer`                                             |
+| `ingress.enabled`                    | Enable ingress controller resource         | `false`                                                    |
+| `ingress.hostname`                   | URL to address your WordPress installation | `wordpress.local`                                          |
+| `persistence.enabled`                | Enable persistence using PVC               | `true`                                                     |
+| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume        | `nil` (uses alpha storage class annotation)                |
+| `persistence.apache.accessMode`      | PVC Access Mode for Apache volume          | `ReadWriteOnce`                                            |
+| `persistence.apache.size`            | PVC Storage Request for Apache volume      | `1Gi`                                                      |
+| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume     | `nil` (uses alpha storage class annotation)                |
+| `persistence.wordpress.accessMode`   | PVC Access Mode for WordPress volume       | `ReadWriteOnce`                                            |
+| `persistence.wordpress.size`         | PVC Storage Request for WordPress volume   | `8Gi`                                                      |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 
@@ -110,3 +112,6 @@ The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) ima
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
 
+## Ingress
+
+This chart provides support for Ingress resource. If you have available an Ingress Controller such as Nginx or Traefik you maybe want to set up `ingress.enabled` to true and choose a `ingress.hostname` for the URL. Then, you should be able to access the installation using that address.

--- a/stable/wordpress/templates/NOTES.txt
+++ b/stable/wordpress/templates/NOTES.txt
@@ -6,6 +6,14 @@
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/admin
 
+{{- if .Values.ingress.enabled }}
+
+  You also can access your installation with:
+
+  http://{{- .Values.ingress.hostname }}
+
+{{- end }}
+
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.

--- a/stable/wordpress/templates/ingress.yaml
+++ b/stable/wordpress/templates/ingress.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+ name: {{template "fullname" .}}
+ labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+ rules:
+   - host: {{ .Values.hostname }}
+     http:
+       paths:
+         - path: /
+           backend:
+             serviceName: {{template "fullname" .}}
+             servicePort: 80
+{{- end -}}
+

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -75,6 +75,14 @@ mariadb:
 ##
 serviceType: LoadBalancer
 
+## Configure ingress resource that allow you to access the
+## Wordpress instalation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+    enabled: false
+    hostname: wordpress.local
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
I've added ingress resource support adding a new namespace `ingress` in values to enable or not the resource. If enabled you should be able to address WP install throught .Values.ingress.hostname.