### PR TITLE
[NEW] AWS cluster autoscaler

### DIFF
--- a/stable/aws-cluster-autoscaler/.helmignore
+++ b/stable/aws-cluster-autoscaler/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-description: Scales worker nodes within an autoscaling group.
+description: Scales worker nodes within autoscaling groups.
 name: aws-cluster-autoscaler
-version: 0.1.4
+version: 0.1.5
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Scales worker nodes within an autoscaling group.
 name: aws-cluster-autoscaler
-version: 0.1.2
+version: 0.1.4
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 name: aws-cluster-autoscaler
-version: 0.1.5
+version: 0.1.6
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 name: aws-cluster-autoscaler
-version: 0.1.6
+version: 0.2.0
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Scales worker nodes within an autoscaling group.
 name: aws-cluster-autoscaler
-version: 0.1.0
+version: 0.1.1
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+description: Scales worker nodes within an autoscaling group.
+name: aws-cluster-autoscaler
+version: 0.1.0
+sources:
+  - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
+maintainers:
+  - name: Michael Goodness
+    email: mgoodness@gmail.com
+engine: gotpl

--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Scales worker nodes within an autoscaling group.
 name: aws-cluster-autoscaler
-version: 0.1.1
+version: 0.1.2
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -45,10 +45,10 @@ The following tables lists the configurable parameters of the aws-cluster-autosc
 Parameter | Description | Default
 --- | --- | ---
 `annotations` | annotations to add to each pod | none
-`autoscalingGroups.maxSize` | maximum autoscaling group size | `2`
+`autoscalingGroups.maxSize` | maximum autoscaling group size | `1`
 `autoscalingGroups.minSize` | minimum autoscaling group size | `1`
 `autoscalingGroups.name` | autoscaling group name | none
-`autoscalingGroups.region` | AWS region | `us-east-1`
+`awsRegion` | AWS region | `us-east-1`
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
 `image.tag` | Image tag | `v0.4.0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
@@ -72,3 +72,24 @@ $ helm install --name my-release -f values.yaml stable/aws-cluster-autoscaler
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## IAM Permissions
+The worker running the cluster autoscaler will need access to certain resources and actions:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:TerminateInstanceInAutoScalingGroup"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+Unfortunately AWS does not support ARNs for autoscaling groups yet so you must use "*" as the resource. More information [here](http://docs.aws.amazon.com/autoscaling/latest/userguide/IAM.html#UsingWithAutoScaling_Actions).

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -20,7 +20,7 @@ This chart bootstraps an aws-cluster-autoscaler deployment on a [Kubernetes](htt
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/aws-cluster-autoscaler
+$ helm install stable/aws-cluster-autoscaler --name my-release
 ```
 
 The command deploys aws-cluster-autoscaler on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -43,23 +43,25 @@ The following tables lists the configurable parameters of the aws-cluster-autosc
 
 Parameter | Description | Default
 --- | --- | ---
-`autoscalingGroups[].maxSize` | maximum autoscaling group size | `1`
-`autoscalingGroups[].minSize` | minimum autoscaling group size | `1`
 `autoscalingGroups[].name` | autoscaling group name | none
+`autoscalingGroups[].maxSize` | maximum autoscaling group size | none
+`autoscalingGroups[].minSize` | minimum autoscaling group size | none
 `awsRegion` | AWS region | `us-east-1`
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
 `image.tag` | Image tag | `v0.4.0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
-`podAnnotations` | annotations to add to each pod | none
-`resources.limits.cpu` | CPU limit | `100m`
-`resources.limits.memory` | Memory limit | `300Mi`
-`resources.requests.cpu` | CPU request | `100m`
-`resources.requests.memory` | Memory request | `300Mi`
+`extraArgs` | additional container arguments | `{}`
+`podAnnotations` | annotations to add to each pod | {}
+`replicaCount` | desired number of pods | `1`
+`resources` | pod resource requests & limits | `limits: {cpu: 100m, memory: 300Mi}, requests: {cpu: 100m, memory: 300Mi}`
 `scaleDownDelay` | time to wait between scaling operations | `10m` (10 minutes)
 `service.annotations` | annotations to add to service | none
 `service.clusterIP` | IP address to assign to service | `""`
-`service.containerPort` | container port to expose | `8085`
+`service.externalIPs` | service external IP addresses | `[]`
+`service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `service.servicePort` | service port to expose | `8085`
+`service.type` | type of service to create | `ClusterIP`
 `skipNodes.withLocalStorage` | don't terminate nodes running pods that use local storage | `false`
 `skipNodes.withSystemPods` | don't terminate nodes running pods in the `kube-system` namespace | `true`
 
@@ -67,7 +69,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install stable/aws-cluster-autoscaler --name my-release \
-    --set asg.name=kubernetes-workers    
+    --set awsRegion=us-west-1
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -48,7 +48,6 @@ Parameter | Description | Default
 `autoscalingGroups[].minSize` | minimum autoscaling group size | `1`
 `autoscalingGroups[].name` | autoscaling group name | none
 `awsRegion` | AWS region | `us-east-1`
-`expander` | algorithm to use when scaling | `least-waste`
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
 `image.tag` | Image tag | `v0.4.0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
@@ -75,16 +74,6 @@ $ helm install --name my-release -f values.yaml stable/aws-cluster-autoscaler
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
-
-## Expanders
-From the upstream [docs](https://github.com/kubernetes/contrib/blob/master/cluster-autoscaler/expander/EXPANDERS.md):
-> Currently cluster-autoscaler has 3 expanders, but we anticipate more in the future:
->
-`random` - this is the default expander, and should be used when you don't have a particular need for the node groups to scale differently
->
-`most-pods` - this selects the node group that would be able to schedule the most pods when scaling up. This is useful when you are using nodeSelector to make sure certain pods land on certain nodes. Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can grow multiple smaller nodes at once
->
-`least-waste` - this selects the node group that will have the least idle CPU (and if tied, unused Memory) node group when scaling up. This is useful when you have different classes of nodes, for example, high CPU or high Memory nodes, and only want to expand those when pods that need those requirements are to be launched.
 
 ## IAM Permissions
 The worker running the cluster autoscaler will need access to certain resources and actions:

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -48,6 +48,7 @@ Parameter | Description | Default
 `autoscalingGroups[].minSize` | minimum autoscaling group size | `1`
 `autoscalingGroups[].name` | autoscaling group name | none
 `awsRegion` | AWS region | `us-east-1`
+`expander` | algorithm to use when scaling | `least-waste`
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
 `image.tag` | Image tag | `v0.4.0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
@@ -55,6 +56,9 @@ Parameter | Description | Default
 `resources.limits.memory` | Memory limit | `300Mi`
 `resources.requests.cpu` | CPU request | `100m`
 `resources.requests.memory` | Memory request | `300Mi`
+`scaleDownDelay` | time to wait between scaling operations | `10m` (10 minutes)
+`skipNodes.withLocalStorage` | don't terminate nodes running pods that use local storage | `false`
+`skipNodes.withSystemPods` | don't terminate nodes running pods in the `kube-system` namespace | `true`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -71,6 +75,16 @@ $ helm install --name my-release -f values.yaml stable/aws-cluster-autoscaler
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Expanders
+From the upstream [docs](https://github.com/kubernetes/contrib/blob/master/cluster-autoscaler/expander/EXPANDERS.md):
+> Currently cluster-autoscaler has 3 expanders, but we anticipate more in the future:
+>
+`random` - this is the default expander, and should be used when you don't have a particular need for the node groups to scale differently
+>
+`most-pods` - this selects the node group that would be able to schedule the most pods when scaling up. This is useful when you are using nodeSelector to make sure certain pods land on certain nodes. Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can grow multiple smaller nodes at once
+>
+`least-waste` - this selects the node group that will have the least idle CPU (and if tied, unused Memory) node group when scaling up. This is useful when you have different classes of nodes, for example, high CPU or high Memory nodes, and only want to expand those when pods that need those requirements are to be launched.
 
 ## IAM Permissions
 The worker running the cluster autoscaler will need access to certain resources and actions:

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -43,7 +43,6 @@ The following tables lists the configurable parameters of the aws-cluster-autosc
 
 Parameter | Description | Default
 --- | --- | ---
-`annotations` | annotations to add to each pod | none
 `autoscalingGroups[].maxSize` | maximum autoscaling group size | `1`
 `autoscalingGroups[].minSize` | minimum autoscaling group size | `1`
 `autoscalingGroups[].name` | autoscaling group name | none
@@ -51,6 +50,7 @@ Parameter | Description | Default
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
 `image.tag` | Image tag | `v0.4.0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
+`podAnnotations` | annotations to add to each pod | none
 `resources.limits.cpu` | CPU limit | `100m`
 `resources.limits.memory` | Memory limit | `300Mi`
 `resources.requests.cpu` | CPU request | `100m`

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -13,8 +13,7 @@ $ helm install stable/aws-cluster-autoscaler
 This chart bootstraps an aws-cluster-autoscaler deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
-
-- Kubernetes 1.3+ with Beta APIs enabled
+  - Kubernetes 1.3+ with Beta APIs enabled
 
 ## Installing the Chart
 
@@ -45,9 +44,9 @@ The following tables lists the configurable parameters of the aws-cluster-autosc
 Parameter | Description | Default
 --- | --- | ---
 `annotations` | annotations to add to each pod | none
-`autoscalingGroups.maxSize` | maximum autoscaling group size | `1`
-`autoscalingGroups.minSize` | minimum autoscaling group size | `1`
-`autoscalingGroups.name` | autoscaling group name | none
+`autoscalingGroups[].maxSize` | maximum autoscaling group size | `1`
+`autoscalingGroups[].minSize` | minimum autoscaling group size | `1`
+`autoscalingGroups[].name` | autoscaling group name | none
 `awsRegion` | AWS region | `us-east-1`
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
 `image.tag` | Image tag | `v0.4.0`

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -44,10 +44,10 @@ The following tables lists the configurable parameters of the aws-cluster-autosc
 
 Parameter | Description | Default
 --- | --- | ---
-`asg.maxSize` | maximum autoscaling group size | `2`
-`asg.minSize` | minimum autoscaling group size | `1`
-`asg.name` | autoscaling group name | none
-`awsRegion` | AWS region | `us-east-1`
+`autoscalingGroups.maxSize` | maximum autoscaling group size | `2`
+`autoscalingGroups.minSize` | minimum autoscaling group size | `1`
+`autoscalingGroups.name` | autoscaling group name | none
+`autoscalingGroups.region` | AWS region | `us-east-1`
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
 `image.tag` | Image tag | `v0.4.0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -66,15 +66,14 @@ Parameter | Description | Default
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release \
-  --set asg.name=kubernetes-workers \
-    stable/aws-cluster-autoscaler
+$ helm install stable/aws-cluster-autoscaler --name my-release \
+    --set asg.name=kubernetes-workers    
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml stable/aws-cluster-autoscaler
+$ helm install stable/aws-cluster-autoscaler --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -56,6 +56,10 @@ Parameter | Description | Default
 `resources.requests.cpu` | CPU request | `100m`
 `resources.requests.memory` | Memory request | `300Mi`
 `scaleDownDelay` | time to wait between scaling operations | `10m` (10 minutes)
+`service.annotations` | annotations to add to service | none
+`service.clusterIP` | IP address to assign to service | `""`
+`service.containerPort` | container port to expose | `8085`
+`service.servicePort` | service port to expose | `8085`
 `skipNodes.withLocalStorage` | don't terminate nodes running pods that use local storage | `false`
 `skipNodes.withSystemPods` | don't terminate nodes running pods in the `kube-system` namespace | `true`
 

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -44,6 +44,7 @@ The following tables lists the configurable parameters of the aws-cluster-autosc
 
 Parameter | Description | Default
 --- | --- | ---
+`annotations` | annotations to add to each pod | none
 `autoscalingGroups.maxSize` | maximum autoscaling group size | `2`
 `autoscalingGroups.minSize` | minimum autoscaling group size | `1`
 `autoscalingGroups.name` | autoscaling group name | none

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -1,0 +1,73 @@
+# aws-cluster-autoscaler
+
+[The cluster autoscaler on AWS](https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws) scales worker nodes within an autoscaling group.
+
+## TL;DR;
+
+```console
+$ helm install stable/aws-cluster-autoscaler
+```
+
+## Introduction
+
+This chart bootstraps an aws-cluster-autoscaler deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.3+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/aws-cluster-autoscaler
+```
+
+The command deploys aws-cluster-autoscaler on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the aws-cluster-autoscaler chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`asg.maxSize` | maximum autoscaling group size | `2`
+`asg.minSize` | minimum autoscaling group size | `1`
+`asg.name` | autoscaling group name | none
+`awsRegion` | AWS region | `us-east-1`
+`image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
+`image.tag` | Image tag | `v0.4.0`
+`image.pullPolicy` | Image pull policy | `IfNotPresent`
+`resources.limits.cpu` | CPU limit | `100m`
+`resources.limits.memory` | Memory limit | `300Mi`
+`resources.requests.cpu` | CPU request | `100m`
+`resources.requests.memory` | Memory request | `300Mi`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+  --set asg.name=kubernetes-workers \
+    stable/aws-cluster-autoscaler
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/aws-cluster-autoscaler
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/aws-cluster-autoscaler/templates/NOTES.txt
+++ b/stable/aws-cluster-autoscaler/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that aws-cluster-autoscaler has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "name" . }},release={{ .Release.Name }}"

--- a/stable/aws-cluster-autoscaler/templates/_helpers.tpl
+++ b/stable/aws-cluster-autoscaler/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -26,7 +26,6 @@ spec:
           command:
             - ./cluster-autoscaler
             - --cloud-provider=aws
-            - --expander={{ .Values.expander }}
           {{- range .Values.autoscalingGroups }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
           {{- end }}

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -1,35 +1,40 @@
+{{- $root := . -}}
+{{- range .Values.autoscalingGroups }}
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ template "fullname" . }}
+    app: {{ template "name" $root }}
+    asg: "{{ .name }}"
+    chart: {{ $root.Chart.Name }}-{{ $root.Chart.Version }}
+    heritage: {{ $root.Release.Service }}
+    release: {{ $root.Release.Name }}
+  name: {{ template "fullname" $root }}-{{ .name }}
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
-        release: {{ .Release.Name }}
+        app: {{ template "name" $root }}
+        asg: "{{ .name }}"
+        release: {{ $root.Release.Name }}
     spec:
       containers:
-        - name: {{ template "name" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        - name: {{ template "name" $root }}
+          image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}"
+          imagePullPolicy: "{{ $root.Values.image.pullPolicy }}"
           command:
             - ./cluster-autoscaler
             - --cloud-provider=aws
-            - --nodes={{ .Values.asg.minSize }}:{{ .Values.asg.maxSize }}:{{ .Values.asg.name }}
+            - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
             - --skip-nodes-with-local-storage=false
             - --v=4
           env:
             - name: AWS_REGION
-              value: "{{ .Values.awsRegion }}"
+              value: "{{ .region }}"
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml $root.Values.resources | indent 12 }}
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs/ca-certificates.crt
@@ -38,3 +43,4 @@ spec:
         - name: ssl-certs
           hostPath:
             path: /etc/ssl/certs/ca-certificates.crt
+{{- end }}

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -11,9 +11,9 @@ spec:
   replicas: 1
   template:
     metadata:
-    {{- if .Values.annotations }}
+    {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.annotations | indent 8 }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
       labels:
         app: {{ template "name" . }}

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command:
+            - ./cluster-autoscaler
+            - --cloud-provider=aws
+            - --nodes={{ .Values.asg.minSize }}:{{ .Values.asg.maxSize }}:{{ .Values.asg.name }}
+            - --skip-nodes-with-local-storage=false
+            - --v=4
+          env:
+            - name: AWS_REGION
+              value: "{{ .Values.awsRegion }}"
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs/ca-certificates.crt

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -26,10 +26,13 @@ spec:
           command:
             - ./cluster-autoscaler
             - --cloud-provider=aws
+            - --expander={{ .Values.expander }}
           {{- range .Values.autoscalingGroups }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
           {{- end }}
-            - --skip-nodes-with-local-storage=false
+            - --scale-down-delay={{ .Values.scaleDownDelay }}
+            - --skip-nodes-with-local-storage={{ .Values.skipNodes.withLocalStorage }}
+            - --skip-nodes-with-system-pods={{ .Values.skipNodes.withSystemPods }}
             - --v=4
           env:
             - name: AWS_REGION

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "fullname" . }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
     {{- if .Values.podAnnotations }}
@@ -25,7 +25,6 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           command:
             - ./cluster-autoscaler
-            - address={{ .Values.service.containerPort }}
             - --cloud-provider=aws
           {{- range .Values.autoscalingGroups }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
@@ -34,11 +33,14 @@ spec:
             - --skip-nodes-with-local-storage={{ .Values.skipNodes.withLocalStorage }}
             - --skip-nodes-with-system-pods={{ .Values.skipNodes.withSystemPods }}
             - --v=4
+          {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
           env:
             - name: AWS_REGION
               value: "{{ .Values.awsRegion }}"
           ports:
-            - containerPort: {{ .Values.service.containerPort }}
+            - containerPort: 8085
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -1,42 +1,39 @@
-{{- $root := . -}}
-{{- range .Values.autoscalingGroups }}
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "name" $root }}
-    asg: "{{ .name }}"
-    chart: {{ $root.Chart.Name }}-{{ $root.Chart.Version }}
-    heritage: {{ $root.Release.Service }}
-    release: {{ $root.Release.Name }}
-  name: {{ template "fullname" $root }}-{{ .name }}
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
 spec:
   replicas: 1
   template:
     metadata:
       annotations:
-{{ toYaml $root.Values.annotations | indent 8 }}
+{{ toYaml .Values.annotations | indent 8 }}
       labels:
-        app: {{ template "name" $root }}
-        asg: "{{ .name }}"
-        release: {{ $root.Release.Name }}
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ template "name" $root }}
-          image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}"
-          imagePullPolicy: "{{ $root.Values.image.pullPolicy }}"
+        - name: {{ template "name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           command:
             - ./cluster-autoscaler
             - --cloud-provider=aws
+          {{- range .Values.autoscalingGroups }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
+          {{- end }}
             - --skip-nodes-with-local-storage=false
             - --v=4
           env:
             - name: AWS_REGION
-              value: "{{ .region }}"
+              value: "{{ .Values.awsRegion }}"
           resources:
-{{ toYaml $root.Values.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs/ca-certificates.crt
@@ -45,4 +42,3 @@ spec:
         - name: ssl-certs
           hostPath:
             path: /etc/ssl/certs/ca-certificates.crt
-{{- end }}

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           command:
             - ./cluster-autoscaler
+            - address={{ .Values.service.containerPort }}
             - --cloud-provider=aws
           {{- range .Values.autoscalingGroups }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
@@ -36,6 +37,8 @@ spec:
           env:
             - name: AWS_REGION
               value: "{{ .Values.awsRegion }}"
+          ports:
+            - containerPort: {{ .Values.service.containerPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -11,8 +11,10 @@ spec:
   replicas: 1
   template:
     metadata:
+    {{- if .Values.annotations }}
       annotations:
 {{ toYaml .Values.annotations | indent 8 }}
+    {{- end }}
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}

--- a/stable/aws-cluster-autoscaler/templates/deployment.yaml
+++ b/stable/aws-cluster-autoscaler/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+{{ toYaml $root.Values.annotations | indent 8 }}
       labels:
         app: {{ template "name" $root }}
         asg: "{{ .name }}"

--- a/stable/aws-cluster-autoscaler/templates/service.yaml
+++ b/stable/aws-cluster-autoscaler/templates/service.yaml
@@ -12,11 +12,22 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "fullname" . }}
 spec:
-  clusterIP: {{ .Values.service.clusterIP }}
+  clusterIP: "{{ .Values.service.clusterIP }}"
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
   ports:
     - port: {{ .Values.service.servicePort }}
       protocol: TCP
-      targetPort: {{ .Values.service.containerPort }}
+      targetPort: 8085
   selector:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/stable/aws-cluster-autoscaler/templates/service.yaml
+++ b/stable/aws-cluster-autoscaler/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+spec:
+  clusterIP: {{ .Values.service.clusterIP }}
+  ports:
+    - port: {{ .Values.service.servicePort }}
+      protocol: TCP
+      targetPort: {{ .Values.service.containerPort }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+  type: "{{ .Values.service.type }}"

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -1,5 +1,3 @@
-# annotations:
-
 autoscalingGroups:
   - name: ""
     maxSize: 1
@@ -11,6 +9,8 @@ image:
   repository: gcr.io/google_containers/cluster-autoscaler
   tag: v0.4.0
   pullPolicy: IfNotPresent
+
+podAnnotations: {}
 
 resources:
   limits:

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -1,0 +1,19 @@
+asg:
+  maxSize: 2
+  minSize: 1
+  name: ""
+
+awsRegion: us-east-1
+
+image:
+  repository: gcr.io/google_containers/cluster-autoscaler
+  tag: v0.4.0
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 300Mi
+  requests:
+    cpu: 100m
+    memory: 300Mi

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -2,9 +2,10 @@
 
 autoscalingGroups:
   - name: ""
-    maxSize: 2
+    maxSize: 1
     minSize: 1
-    region: us-east-1
+
+awsRegion: us-east-1
 
 image:
   repository: gcr.io/google_containers/cluster-autoscaler

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -6,6 +6,7 @@ autoscalingGroups:
     minSize: 1
 
 awsRegion: us-east-1
+expander: least-waste
 
 image:
   repository: gcr.io/google_containers/cluster-autoscaler
@@ -19,3 +20,9 @@ resources:
   requests:
     cpu: 100m
     memory: 300Mi
+
+scaleDownDelay: 10m
+
+skipNodes:
+  withLocalStorage: false
+  withSystemPods: true

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -1,4 +1,4 @@
-autoscalingGroups:
+autoscalingGroups: []
   # - name: asg1
   #   maxSize: 1
   #   minSize: 1
@@ -10,7 +10,9 @@ image:
   tag: v0.4.0
   pullPolicy: IfNotPresent
 
+extraArgs: []
 podAnnotations: {}
+replicaCount: 1
 
 resources:
   limits:
@@ -23,9 +25,16 @@ resources:
 scaleDownDelay: 10m
 
 service:
-  annotations: ""
+  annotations: {}
   clusterIP: ""
-  containerPort: 8085
+
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
   servicePort: 8085
   type: ClusterIP
 

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -1,3 +1,5 @@
+# annotations:
+
 autoscalingGroups:
   - name: ""
     maxSize: 2

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -1,7 +1,7 @@
 autoscalingGroups:
-  - name: ""
-    maxSize: 1
-    minSize: 1
+  # - name: asg1
+  #   maxSize: 1
+  #   minSize: 1
 
 awsRegion: us-east-1
 

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -22,6 +22,13 @@ resources:
 
 scaleDownDelay: 10m
 
+service:
+  annotations: ""
+  clusterIP: ""
+  containerPort: 8085
+  servicePort: 8085
+  type: ClusterIP
+
 skipNodes:
   withLocalStorage: false
   withSystemPods: true

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -6,7 +6,6 @@ autoscalingGroups:
     minSize: 1
 
 awsRegion: us-east-1
-expander: least-waste
 
 image:
   repository: gcr.io/google_containers/cluster-autoscaler

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -1,9 +1,8 @@
-asg:
-  maxSize: 2
-  minSize: 1
-  name: ""
-
-awsRegion: us-east-1
+autoscalingGroups:
+  - name: ""
+    maxSize: 2
+    minSize: 1
+    region: us-east-1
 
 image:
   repository: gcr.io/google_containers/cluster-autoscaler


### PR DESCRIPTION
Installs the [cluster autoscaler on AWS](https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws) for any number of autoscaling groups.

`autoscalingGroups` is a list. Not sure how that should be notated in the README.