### PR TITLE
[NEW] Kubernetes Operational View

### DIFF
--- a/incubator/kube-ops-view/.helmignore
+++ b/incubator/kube-ops-view/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/kube-ops-view/Chart.yaml
+++ b/incubator/kube-ops-view/Chart.yaml
@@ -1,0 +1,14 @@
+name: kube-ops-view
+version: 0.1.0
+description: Kubernetes Operational View - read-only system dashboard for multiple K8s clusters
+keywords:
+  - kubernetes
+  - dashboard
+  - operations
+home: https://github.com/hjacobs/kube-ops-view
+sources:
+  - https://github.com/hjacobs/kube-ops-view
+maintainers:
+  - name: Henning Jacobs
+    email: henning@jacobs1.de
+

--- a/incubator/kube-ops-view/Chart.yaml
+++ b/incubator/kube-ops-view/Chart.yaml
@@ -11,4 +11,3 @@ sources:
 maintainers:
   - name: Henning Jacobs
     email: henning@jacobs1.de
-

--- a/incubator/kube-ops-view/README.md
+++ b/incubator/kube-ops-view/README.md
@@ -1,0 +1,31 @@
+# Kubernetes Operational View Helm Chart
+
+[Kubernetes Operational View](https://github.com/hjacobs/kube-ops-view) provides a read-only system dashboard for multiple K8s clusters
+
+## Installing the Chart
+
+To install the chart with the release name my-release:
+
+```console
+$ helm install --name=my-release incubator/kube-ops-view
+```
+
+The command deploys Kubernetes Operational View on the Kubernetes cluster in the default configuration.
+
+## Accessing the UI
+
+```console
+$ kubectl proxy
+```
+
+Assuming you used `my-release` for installation, you can now access the UI in your browser by opening http://localhost:8001/api/v1/proxy/namespaces/default/services/my-release-kube-ops-view/
+
+## Uninstalling the Chart
+
+To uninstall/delete the my-release deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/incubator/kube-ops-view/templates/NOTES.txt
+++ b/incubator/kube-ops-view/templates/NOTES.txt
@@ -7,3 +7,5 @@ To access the Kubernetes Operational View UI:
 2. Now open the following URL in your browser:
 
    http://localhost:8001/api/v1/proxy/namespaces/{{ .Release.Namespace }}/services/{{ template "fullname" . }}/
+
+Please try reloading the page if you see "ServiceUnavailable / no endpoints available for service", pod creation might take a moment.

--- a/incubator/kube-ops-view/templates/NOTES.txt
+++ b/incubator/kube-ops-view/templates/NOTES.txt
@@ -1,0 +1,9 @@
+To access the Kubernetes Operational View UI:
+
+1. First start the kubectl proxy:
+
+   kubectl proxy
+
+2. Now open the following URL in your browser:
+
+   http://localhost:8001/api/v1/proxy/namespaces/{{ .Release.Namespace }}/services/{{ template "fullname" . }}/

--- a/incubator/kube-ops-view/templates/_helpers.tpl
+++ b/incubator/kube-ops-view/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/kube-ops-view/templates/_helpers.tpl
+++ b/incubator/kube-ops-view/templates/_helpers.tpl
@@ -3,14 +3,14 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/incubator/kube-ops-view/templates/deployment.yaml
+++ b/incubator/kube-ops-view/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.service.internalPort }}
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.service.internalPort }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/incubator/kube-ops-view/templates/service.yaml
+++ b/incubator/kube-ops-view/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/incubator/kube-ops-view/templates/service.yaml
+++ b/incubator/kube-ops-view/templates/service.yaml
@@ -10,6 +10,5 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
   selector:
     app: {{ template "fullname" . }}

--- a/incubator/kube-ops-view/values.yaml
+++ b/incubator/kube-ops-view/values.yaml
@@ -5,7 +5,6 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 service:
-  name: kube-ops-view
   type: ClusterIP
   externalPort: 80
   internalPort: 8080

--- a/incubator/kube-ops-view/values.yaml
+++ b/incubator/kube-ops-view/values.yaml
@@ -1,0 +1,19 @@
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: hjacobs/kube-ops-view
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  name: kube-ops-view
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8080
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 80m
+    memory: 64Mi
+


### PR DESCRIPTION
Create Helm Chart for [Kubernetes Operational View](https://github.com/hjacobs/kube-ops-view).

![screenshot](https://cloud.githubusercontent.com/assets/510328/21957691/a4c0a2de-da9c-11e6-8005-43d30712da9d.png)

The Chart should work, tested with helm 2.1.3 and Kubernetes 1.5.2 :smile: 

NOTE:
* the Chart does not yet expose "advanced" configurations to monitor multiple clusters (i.e. it only shows the cluster it currently runs in)
* the Chart does not yet configure a Redis backend, i.e. it uses a memory-only backend for message pub/sub which only works correctly for `replicaCount=1`.
