### PR TITLE
[stable/wordpress] Bump WordPress version

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.4.0
+version: 0.4.1
 description: Web publishing platform for building blogs and websites.
 keywords:
 - wordpress

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-image: bitnami/wordpress:4.7-r0
+image: bitnami/wordpress:4.7.1-r0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
- Update WordPress image version to `4.7.1-r0`
- Update chart to `0.4.1`