### PR TITLE
[stable/traefik] Enable HTTP authentication for the dashboard

### DIFF
--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -87,6 +87,9 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `acme.persistence.size`         | Minimum size of the volume requested                                 | `1Gi`                                     |
 | `dashboard.enabled`             | Whether to enable the Traefik dashboard                              | `false`                                   |
 | `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |
+| `dashboard.address`             | Address for the Traefik dashboard service                            | `:8080`                                   |
+| `dashboard.public`              | Whether the Traefik dashboard should be exposed via an Ingress       | `true`                                    |
+| `dashboard.http_auth`           | List of user/password combinations to be used via HTTP Auth          | none                                      |
 | `gzip.enabled`                  | Whether to use gzip compression                                      | `true`                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -89,7 +89,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |
 | `dashboard.address`             | Address for the Traefik dashboard service                            | `:8080`                                   |
 | `dashboard.public`              | Whether the Traefik dashboard should be exposed via an Ingress       | `true`                                    |
-| `dashboard.http_auth`           | List of user/password combinations to be used via HTTP Auth          | none                                      |
+| `dashboard.httpAuth`            | List of user/password combinations to be used via HTTP Auth          | none                                      |
 | `gzip.enabled`                  | Whether to use gzip compression                                      | `true`                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -46,5 +46,13 @@ data:
     {{- end }}
     {{- if .Values.dashboard.enabled }}
     [web]
-    address = ":8080"
+      {{- if .Values.dashboard.address }}
+      address = "{{ .Values.dashboard.address }}"
+      {{- else }}
+      address = ":8080"
+      {{- end }}
+      {{- if .Values.dashboard.http_auth }}
+      [web.auth.basic]
+        users = {{ .Values.dashboard.http_auth }}
+      {{- end }}
     {{- end }}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -51,8 +51,8 @@ data:
       {{- else }}
       address = ":8080"
       {{- end }}
-      {{- if .Values.dashboard.http_auth }}
+      {{- if .Values.dashboard.httpAuth }}
       [web.auth.basic]
-        users = {{ .Values.dashboard.http_auth }}
+        users = {{ .Values.dashboard.httpAuth }}
       {{- end }}
     {{- end }}

--- a/stable/traefik/templates/dashboard-ingress.yaml
+++ b/stable/traefik/templates/dashboard-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dashboard.enabled }}
+{{- if and .Values.dashboard.enabled .Values.dashboard.public }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -27,6 +27,6 @@ dashboard:
   address: :8080
   public: true
   # Optional list of authenticated users, refer to the documentation for further details http://docs.traefik.io/toml/
-  # http_auth: ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
+  # httpAuth: ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
 gzip:
   enabled: true

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -24,5 +24,9 @@ acme:
 dashboard:
   enabled: false
   domain: traefik.example.com
+  address: :8080
+  public: true
+  # Optional list of authenticated users, refer to the documentation for further details http://docs.traefik.io/toml/
+  # http_auth: ["test:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/", "test2:$apr1$d9hr9HBB$4HxwgUir3HP4EsggP/QNo0"]
 gzip:
   enabled: true


### PR DESCRIPTION
Also allow configuration of the dashboard's service address and whether the Ingress should be generated.