### PR TITLE
[stable/owncloud] revision 0.4.2

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 0.4.1
+version: 0.4.2
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:
 - owncloud

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -45,25 +45,25 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the ownCloud chart and their default values.
 
-| Parameter                           | Description                                           | Default                                                   |
-| ---------------------------------   | ----------------------------------------------------- | --------------------------------------------------------- |
-| `image`                             | ownCloud image                                        | `bitnami/owncloud:{VERSION}`                              |
-| `imagePullPolicy`                   | Image pull policy                                     | `Always` if `image` tag is `latest`, else `IfNotPresent`  |
-| `owncloudHost`                      | ownCloud host to create application URLs              | `nil`                                                     |
-| `owncloudLoadBalancerIP`            | `loadBalancerIP` for the owncloud Service             | `nil`                                                     |
-| `owncloudUsername`                  | User of the application                               | `user`                                                    |
-| `owncloudPassword`                  | Application password                                  | Randomly generated                                        |
-| `owncloudEmail`                     | Admin email                                           | `user@example.com`                                        |
-| `mariadb.mariadbRootPassword`       | MariaDB admin password                                | `nil`                                                     |
-| `serviceType`                       | Kubernetes Service type                               | `LoadBalancer`                                            |
-| `persistence.enabled`               | Enable persistence using PVC                          | `true`                                                    |
-| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume                   | `generic`                                                 |
-| `persistence.apache.accessMode`     | PVC Access Mode for Apache volume                     | `ReadWriteOnce`                                           |
-| `persistence.apache.size`           | PVC Storage Request for Apache volume                 | `1Gi`                                                     |
-| `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume                 | `generic`                                                 |
-| `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume                   | `ReadWriteOnce`                                           |
-| `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume               | `8Gi`                                                     |
-| `resources`                         | CPU/Memory resource requests/limits                   | Memory: `512Mi`, CPU: `300m`                              |
+|              Parameter              |                Description                |           Default            |
+|-------------------------------------|-------------------------------------------|------------------------------|
+| `image`                             | ownCloud image                            | `bitnami/owncloud:{VERSION}` |
+| `imagePullPolicy`                   | Image pull policy                         | `IfNotPresent`               |
+| `owncloudHost`                      | ownCloud host to create application URLs  | `nil`                        |
+| `owncloudLoadBalancerIP`            | `loadBalancerIP` for the owncloud Service | `nil`                        |
+| `owncloudUsername`                  | User of the application                   | `user`                       |
+| `owncloudPassword`                  | Application password                      | Randomly generated           |
+| `owncloudEmail`                     | Admin email                               | `user@example.com`           |
+| `mariadb.mariadbRootPassword`       | MariaDB admin password                    | `nil`                        |
+| `serviceType`                       | Kubernetes Service type                   | `LoadBalancer`               |
+| `persistence.enabled`               | Enable persistence using PVC              | `true`                       |
+| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume       | `generic`                    |
+| `persistence.apache.accessMode`     | PVC Access Mode for Apache volume         | `ReadWriteOnce`              |
+| `persistence.apache.size`           | PVC Storage Request for Apache volume     | `1Gi`                        |
+| `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume     | `generic`                    |
+| `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume       | `ReadWriteOnce`              |
+| `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume   | `8Gi`                        |
+| `resources`                         | CPU/Memory resource requests/limits       | Memory: `512Mi`, CPU: `300m` |
 
 The above parameters map to the env variables defined in [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud). For more information please refer to the [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud) image documentation.
 

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -45,25 +45,25 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the ownCloud chart and their default values.
 
-|              Parameter              |                Description                |           Default            |
-|-------------------------------------|-------------------------------------------|------------------------------|
-| `image`                             | ownCloud image                            | `bitnami/owncloud:{VERSION}` |
-| `imagePullPolicy`                   | Image pull policy                         | `IfNotPresent`               |
-| `owncloudHost`                      | ownCloud host to create application URLs  | `nil`                        |
-| `owncloudLoadBalancerIP`            | `loadBalancerIP` for the owncloud Service | `nil`                        |
-| `owncloudUsername`                  | User of the application                   | `user`                       |
-| `owncloudPassword`                  | Application password                      | Randomly generated           |
-| `owncloudEmail`                     | Admin email                               | `user@example.com`           |
-| `mariadb.mariadbRootPassword`       | MariaDB admin password                    | `nil`                        |
-| `serviceType`                       | Kubernetes Service type                   | `LoadBalancer`               |
-| `persistence.enabled`               | Enable persistence using PVC              | `true`                       |
-| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume       | `generic`                    |
-| `persistence.apache.accessMode`     | PVC Access Mode for Apache volume         | `ReadWriteOnce`              |
-| `persistence.apache.size`           | PVC Storage Request for Apache volume     | `1Gi`                        |
-| `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume     | `generic`                    |
-| `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume       | `ReadWriteOnce`              |
-| `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume   | `8Gi`                        |
-| `resources`                         | CPU/Memory resource requests/limits       | Memory: `512Mi`, CPU: `300m` |
+|              Parameter              |                Description                |                   Default                   |
+|-------------------------------------|-------------------------------------------|---------------------------------------------|
+| `image`                             | ownCloud image                            | `bitnami/owncloud:{VERSION}`                |
+| `imagePullPolicy`                   | Image pull policy                         | `IfNotPresent`                              |
+| `owncloudHost`                      | ownCloud host to create application URLs  | `nil`                                       |
+| `owncloudLoadBalancerIP`            | `loadBalancerIP` for the owncloud Service | `nil`                                       |
+| `owncloudUsername`                  | User of the application                   | `user`                                      |
+| `owncloudPassword`                  | Application password                      | Randomly generated                          |
+| `owncloudEmail`                     | Admin email                               | `user@example.com`                          |
+| `mariadb.mariadbRootPassword`       | MariaDB admin password                    | `nil`                                       |
+| `serviceType`                       | Kubernetes Service type                   | `LoadBalancer`                              |
+| `persistence.enabled`               | Enable persistence using PVC              | `true`                                      |
+| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume       | `nil` (uses alpha storage class annotation) |
+| `persistence.apache.accessMode`     | PVC Access Mode for Apache volume         | `ReadWriteOnce`                             |
+| `persistence.apache.size`           | PVC Storage Request for Apache volume     | `1Gi`                                       |
+| `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume     | `nil` (uses alpha storage class annotation) |
+| `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume       | `ReadWriteOnce`                             |
+| `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume   | `8Gi`                                       |
+| `resources`                         | CPU/Memory resource requests/limits       | Memory: `512Mi`, CPU: `300m`                |
 
 The above parameters map to the env variables defined in [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud). For more information please refer to the [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud) image documentation.
 

--- a/stable/owncloud/requirements.lock
+++ b/stable/owncloud/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: http://storage.googleapis.com/kubernetes-charts
-  version: 0.5.2
-digest: sha256:400ac77ff2337dce024b0225bbfed9f509d77eb6ff6ee10000d59c5f6a367d51
-generated: 2016-10-20T17:55:13.834613554-07:00
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.5.6
+digest: sha256:1b3aad03b4383d1a24dfbfef6ba1beb45f7ace2baa399c66f5a4d56d0f7bc717
+generated: 2017-01-17T11:16:51.645003361+05:30

--- a/stable/owncloud/requirements.yaml
+++ b/stable/owncloud/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.2
+  version: 0.5.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/owncloud/templates/_helpers.tpl
+++ b/stable/owncloud/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -12,7 +12,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -20,7 +20,7 @@ Create a default fully qualified app name.
 We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "mariadb.fullname" -}}
-{{- printf "%s-%s" .Release.Name "mariadb" | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/owncloud/templates/apache-pvc.yaml
+++ b/stable/owncloud/templates/apache-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-apache
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- if .Values.persistence.apache.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.apache.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/owncloud/templates/owncloud-pvc.yaml
+++ b/stable/owncloud/templates/owncloud-pvc.yaml
@@ -4,7 +4,11 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-owncloud
   annotations:
-    volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.owncloud.storageClass | quote }}
+  {{- if .Values.persistence.owncloud.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.owncloud.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.owncloud.accessMode | quote }}

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami ownCloud image version
 ## ref: https://hub.docker.com/r/bitnami/owncloud/tags/
 ##
-image: bitnami/owncloud:9.1.3-r1
+image: bitnami/owncloud:9.1.3-r2
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -48,7 +48,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -63,11 +66,17 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 1Gi
   owncloud:
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass: generic
     accessMode: ReadWriteOnce
     size: 8Gi
 

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami ownCloud image version
 ## ref: https://hub.docker.com/r/bitnami/owncloud/tags/
 ##
-image: bitnami/owncloud:9.1.2-r0
+image: bitnami/owncloud:9.1.3-r1
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -4,10 +4,9 @@
 image: bitnami/owncloud:9.1.2-r0
 
 ## Specify a imagePullPolicy
-## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##
-# imagePullPolicy:
+imagePullPolicy: IfNotPresent
 
 ## ownCloud host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration


### PR DESCRIPTION
Changes:
 - set default `imagePullPolicy` to `IfNotPresent`, fixes #406
 - lock mariadb dependency to 0.5.x chart series
 - increase resource name truncation and trim - suffix
 - add alpha and beta storageclass annotation support
 - upgrade to `bitnami/owncloud:9.1.3-r1`