### PR TITLE
[stable/jenkins] Hide loadBalancerSourceRanges setting if ServiceType is not LoadBalancer

### DIFF
--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -20,4 +20,6 @@ spec:
   selector:
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
   type: {{.Values.Master.ServiceType}}
+  {{- if eq .Values.Master.ServiceType "LoadBalancer" }}
   loadBalancerSourceRanges: {{.Values.Master.LoadBalancerSourceRanges}}
+  {{- end }}


### PR DESCRIPTION
loadBalancerSourceRanges is an invalid setting for other service types.