### PR TITLE
Copy all xml files from the ConfigMap for jenkins

### DIFF
--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -29,7 +29,7 @@ spec:
                   "name": "copy-default-config",
                   "image": "{{.Values.Master.Image}}:{{.Values.Master.ImageTag}}",
                   "imagePullPolicy": "{{.Values.Master.ImagePullPolicy}}",
-                  "command": ["cp", "-n", "/var/jenkins_config/config.xml", "/var/jenkins_home"],
+                  "command": ["cp", "-n", "/var/jenkins_config/*.xml", "/var/jenkins_home"],
                   "volumeMounts": [
                       {
                           "name": "jenkins-config",

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -29,7 +29,7 @@ spec:
                   "name": "copy-default-config",
                   "image": "{{.Values.Master.Image}}:{{.Values.Master.ImageTag}}",
                   "imagePullPolicy": "{{.Values.Master.ImagePullPolicy}}",
-                  "command": ["cp", "-n", "/var/jenkins_config/*.xml", "/var/jenkins_home"],
+                  "command": ["sh", "-c", "cp -n /var/jenkins_config/*.xml /var/jenkins_home"],
                   "volumeMounts": [
                       {
                           "name": "jenkins-config",


### PR DESCRIPTION
This will allow pre-configuring of credentials.xml and any other site wide configuration files that may be needed in addition to config.xml. https://wiki.jenkins-ci.org/display/JENKINS/Administering+Jenkins