### PR TITLE
[stable/dokuwiki] Bump dokuwiki version to `20160626a-r7`

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: dokuwiki
-version: 0.1.1
+version: 0.1.2
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating documentation. It is targeted at developer teams, workgroups, and small companies. All data is stored in plain text files, so no database is required.
 keywords:
 - dokuwiki

--- a/stable/dokuwiki/values.yaml
+++ b/stable/dokuwiki/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami DokuWiki image version
 ## ref: https://hub.docker.com/r/bitnami/dokuwiki/tags/
 ##
-image: bitnami/dokuwiki:20160626a-r3
+image: bitnami/dokuwiki:20160626a-r7
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Contains fix for https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5340