### PR TITLE
[stable/joomla] Bump `bitnami/joomla` image to version `3.6.5-r2`

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 0.4.1
+version: 0.4.2
 description: PHP content management system (CMS) for publishing web content
 keywords:
 - joomla

--- a/stable/joomla/requirements.lock
+++ b/stable/joomla/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.2
-digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
-generated: 2016-11-18T16:08:14.660962404-08:00
+  version: 0.5.6
+digest: sha256:1b3aad03b4383d1a24dfbfef6ba1beb45f7ace2baa399c66f5a4d56d0f7bc717
+generated: 2017-01-25T15:39:21.383456388-08:00

--- a/stable/joomla/requirements.yaml
+++ b/stable/joomla/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.2
+  version: 0.5.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Joomla! image version
 ## ref: https://hub.docker.com/r/bitnami/joomla/tags/
 ##
-image: bitnami/joomla:3.6.4-r0
+image: bitnami/joomla:3.6.5-r2
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Contains fix for https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5340