### PR TITLE
[stable/orangehrm] Bump `bitnami/orangehrm` image to version `3.3.3-r8`

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: orangehrm
-version: 0.4.0
+version: 0.4.1
 description: OrangeHRM is a free HR management system that offers a wealth of modules to suit the needs of your business.
 keywords:
 - orangehrm

--- a/stable/orangehrm/values.yaml
+++ b/stable/orangehrm/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami OrangeHRM image version
 ## ref: https://hub.docker.com/r/bitnami/orangehrm/tags/
 ##
-image: bitnami/orangehrm:3.3.3-r5
+image: bitnami/orangehrm:3.3.3-r8
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Contains fix for https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5340