### PR TITLE
[stable/prestashop] Bump `bitnami/prestashop` image to version `1.6.1.9-r5`

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 0.4.1
+version: 0.4.2
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:
 - prestashop

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.4
-digest: sha256:7388428c9d365911ec0431462cd31a7feb89dd9b8488e387448f598017dea49d
-generated: 2016-12-08T15:17:52.50703327+05:30
+  version: 0.5.6
+digest: sha256:1b3aad03b4383d1a24dfbfef6ba1beb45f7ace2baa399c66f5a4d56d0f7bc717
+generated: 2017-01-25T16:48:57.093927912-08:00

--- a/stable/prestashop/requirements.yaml
+++ b/stable/prestashop/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.4
+  version: 0.5.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami PrestaShop image version
 ## ref: https://hub.docker.com/r/bitnami/prestashop/tags/
 ##
-image: bitnami/prestashop:1.6.1.9-r2
+image: bitnami/prestashop:1.6.1.9-r5
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Contains fix for https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5340