### PR TITLE
[stable/testlink] Bump `bitnami/testlink` image to version `1.9.16-r1`

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 0.4.2
+version: 0.4.3
 description: Web-based test management system that facilitates software quality assurance.
 keywords:
 - testlink

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.2
-digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
-generated: 2016-11-18T16:08:16.150784632-08:00
+  version: 0.5.6
+digest: sha256:1b3aad03b4383d1a24dfbfef6ba1beb45f7ace2baa399c66f5a4d56d0f7bc717
+generated: 2017-01-25T17:06:30.276245527-08:00

--- a/stable/testlink/requirements.yaml
+++ b/stable/testlink/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.2
+  version: 0.5.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/testlink/values.yaml
+++ b/stable/testlink/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami TestLink image version
 ## ref: https://hub.docker.com/r/bitnami/testlink/tags/
 ##
-image: bitnami/testlink:1.9.15-r1
+image: bitnami/testlink:1.9.16-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Contains fix for https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5340