### PR TITLE
[stable/wordpress] Bump `bitnami/wordpress` image to version `4.7.1-r2`

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.4.0
+version: 0.4.1
 description: Web publishing platform for building blogs and websites.
 keywords:
 - wordpress

--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.4.1
+version: 0.4.2
 description: Web publishing platform for building blogs and websites.
 keywords:
 - wordpress

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-image: bitnami/wordpress:4.7-r0
+image: bitnami/wordpress:4.7.1-r2
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-image: bitnami/wordpress:4.7.1-r2
+image: bitnami/wordpress:4.7.2-r0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Contains fix for https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5340