### PR TITLE
[stable/magento] Bump `bitnami/magento` image to version `2.1.3-r1`

### DIFF
--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -1,5 +1,5 @@
 name: magento
-version: 0.4.1
+version: 0.4.2
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:
 - magento

--- a/stable/magento/values.yaml
+++ b/stable/magento/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Magento image version
 ## ref: https://hub.docker.com/r/bitnami/magento/tags/
 ##
-image: bitnami/magento:2.1.2-r6
+image: bitnami/magento:2.1.3-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Contains fix for https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5340