### PR TITLE
[stable/mediawiki] Bump `bitnami/mediawiki` image to version `1.28.0-r4`

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 0.4.2
+version: 0.4.3
 description: Extremely powerful, scalable software and a feature-rich wiki implementation that uses PHP to process and display data stored in a database.
 keywords:
 - mediawiki

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.2
-digest: sha256:ae046856c4ffb4d8eafbf3c0f7281dd28b28f32323115e045336674cfe1ccc56
-generated: 2016-11-18T16:08:14.967212355-08:00
+  version: 0.5.6
+digest: sha256:1b3aad03b4383d1a24dfbfef6ba1beb45f7ace2baa399c66f5a4d56d0f7bc717
+generated: 2017-01-25T15:49:36.742067612-08:00

--- a/stable/mediawiki/requirements.yaml
+++ b/stable/mediawiki/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.2
+  version: 0.5.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami MediaWiki image version
 ## ref: https://hub.docker.com/r/bitnami/mediawiki/tags/
 ##
-image: bitnami/mediawiki:1.28.0-r0
+image: bitnami/mediawiki:1.28.0-r4
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Contains fix for https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5340