### PR TITLE
[incubator/zookeeper] Remove helm.sh/created annotations

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.1.1
+version: 0.1.2
 description: Zookeeper Helm chart for Kubernetes.
 sources:
   - https://github.com/apache/zookeeper

--- a/incubator/zookeeper/templates/zookeeper-petset.yaml
+++ b/incubator/zookeeper/templates/zookeeper-petset.yaml
@@ -8,7 +8,6 @@ metadata:
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Component}}"
   annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   ports:
@@ -29,8 +28,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Component}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 24 }}"
   replicas: {{default 3 .Values.Replicas}}


### PR DESCRIPTION
This is a split-off of PR #425 to just contain the chart 'incubator/zookeeper'.