### PR TITLE
[stable/cockroachdb] Remove helm.sh/created annotations

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.2.0
+version: 0.2.1
 description: CockroachDB Helm chart for Kubernetes.
 sources:
   - https://github.com/cockroachdb/cockroach

--- a/stable/cockroachdb/templates/cockroachdb-petset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-petset.yaml
@@ -9,8 +9,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Component}}"
-  annotations:
-    helm.sh/created: {{.Release.Time.Seconds | quote }}
 spec:
   ports:
   # The main port, served by gRPC, serves Postgres-flavor SQL, internode
@@ -39,7 +37,6 @@ metadata:
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Component}}"
   annotations:
-    helm.sh/created: {{.Release.Time.Seconds | quote }}
     # This is needed to make the peer-finder work properly and to help avoid
     # edge cases where instance 0 comes up after losing its data and needs to
     # decide whether it should create a new cluster or try to join an existing
@@ -82,8 +79,6 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
-  annotations:
-    helm.sh/created: {{.Release.Time.Seconds | quote }}
 spec:
   serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
   replicas: {{default 3 .Values.Replicas}}
@@ -95,7 +90,6 @@ spec:
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"
         component: "{{.Release.Name}}-{{.Values.Component}}"
       annotations:
-        helm.sh/created: {{.Release.Time.Seconds | quote }}
         scheduler.alpha.kubernetes.io/affinity: >
             {
               "podAntiAffinity": {


### PR DESCRIPTION
This is a split-off of PR #425 to just contain the chart 'stable/cockroachdb'.