### PR TITLE
[stable/jenkins] Remove helm.sh/created annotations

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.1.7
+version: 0.1.8
 description: A Jenkins Helm chart for Kubernetes.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -7,8 +7,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Master.Name}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   replicas: 1
   strategy:

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -7,8 +7,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   ports:
     - port: {{.Values.Master.ServicePort}}


### PR DESCRIPTION
This is a split-off of PR #425 to just contain the chart 'stable/jenkins'.