### PR TITLE
[stable/spark] Remove helm.sh/created annotations

### DIFF
--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,6 +1,6 @@
 name: spark
 home: http://spark.apache.org/
-version: 0.1.1
+version: 0.1.2
 description: A Apache Spark Helm chart for Kubernetes. Apache Spark is a fast and general-purpose cluster computing system
 sources:
   - https://github.com/kubernetes/kubernetes/tree/master/examples/spark

--- a/stable/spark/templates/spark-master-deployment.yaml
+++ b/stable/spark/templates/spark-master-deployment.yaml
@@ -7,8 +7,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   ports:
     - port: {{.Values.Master.ServicePort}}
@@ -25,8 +23,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   ports:
     - port: {{.Values.WebUi.ServicePort}}
@@ -44,8 +40,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Master.Component}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   replicas: {{default 1 .Values.Master.Replicas}}
   strategy:

--- a/stable/spark/templates/spark-worker-deployment.yaml
+++ b/stable/spark/templates/spark-worker-deployment.yaml
@@ -7,8 +7,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Worker.Component}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   replicas: {{default 1 .Values.Worker.Replicas}}
   strategy:

--- a/stable/spark/templates/spark-zeppelin-deployment.yaml
+++ b/stable/spark/templates/spark-zeppelin-deployment.yaml
@@ -7,8 +7,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Zeppelin.Component}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   ports:
     - port: {{.Values.Zeppelin.ServicePort}}
@@ -26,8 +24,6 @@ metadata:
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
     component: "{{.Release.Name}}-{{.Values.Zeppelin.Component}}"
-  annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   replicas: {{default 1 .Values.Zeppelin.Replicas}}
   strategy:


### PR DESCRIPTION
This is a split-off of PR #425 to just contain the chart 'stable/spark'.