### PR TITLE
[stable/sumokube] Remove helm.sh/created annotations

### DIFF
--- a/stable/sumokube/Chart.yaml
+++ b/stable/sumokube/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumokube
-version: 0.1.0
+version: 0.1.1
 description: Sumologic Log Collector
 keywords:
 - monitoring

--- a/stable/sumokube/templates/config.yaml
+++ b/stable/sumokube/templates/config.yaml
@@ -9,7 +9,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
     "helm.sh/hook": pre-install,pre-upgrade
 data:
   sumo-sources.json: |-

--- a/stable/sumokube/templates/secrets.yaml
+++ b/stable/sumokube/templates/secrets.yaml
@@ -8,7 +8,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-    "helm.sh/created": {{.Release.Time.Seconds | quote }}
     "helm.sh/hook": pre-install,pre-upgrade
 type: Opaque
 data:


### PR DESCRIPTION
This is a split-off of PR #425 to just contain the chart 'stable/sumokube'.