### PR TITLE
Removed default Persistence.StorageClass: generic

### DIFF
--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -32,6 +32,9 @@ Agent:
 
 Persistence:
   Enabled: true
-  StorageClass: generic
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass:
   AccessMode: ReadWriteOnce
   Size: 8Gi


### PR DESCRIPTION
This is related to the changes done on the following commit:

https://github.com/kubernetes/charts/commit/a7fc595aa796664d5b6feb80a20f5c5ec25edb94

With the existing default generic StorageClass, we get errors when
testing though minikube ( didn't test on AWS or other cloud solutions )