### PR TITLE
[stable/kube-lego] Removed hyperkube values

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.3
+version: 0.1.4
 keywords:
   - kube-lego
   - letsencrypt

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -43,9 +43,6 @@ The following tables lists the configurable parameters of the Prometheus chart a
 
 Parameter | Description | Default
 --------- | ----------- | -------
-`global.hyperkube.image` | hyperkube container image repository (used when deleting kube-lego service) | `quay.io/coreos/hyperkube`
-`global.hyperkube.tag` | hyperkube container image tag (used when deleting kube-lego service) | `v1.5.2_coreos.1`
-`global.hyperkube.pullPolicy` | hyperkube container image pull policy (used when deleting kube-lego service) | `IfNotPresent`
 `config.LEGO_EMAIL` | email address to use for registration with Let's Encrypt | none
 `config.LEGO_URL` | Let's Encrypt API endpoint | `https://acme-staging.api.letsencrypt.org/directory` (staging)
 `config.LEGO_PORT` | kube-lego port | `8080`

--- a/stable/kube-lego/templates/deployment.yaml
+++ b/stable/kube-lego/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: {{ template "name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           env:
             - name: LEGO_NAMESPACE
               valueFrom:
@@ -29,7 +29,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           {{- range $key, $value := .Values.config }}
-            - name: {{ $key }}
+            - name: "{{ $key }}"
               value: "{{ $value }}"
           {{- end }}
           ports:

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -1,11 +1,3 @@
-global:
-  ## hyperkube image to use when deleting kube-lego service
-  ##
-  hyperkube:
-    repository: quay.io/coreos/hyperkube
-    tag: v1.5.2_coreos.1
-    pullPolicy: IfNotPresent
-
 ## kube-lego configuration
 ## Ref: https://github.com/jetstack/kube-lego
 ##


### PR DESCRIPTION
I had removed the post-install cleanup jobs that used hyperkube, but not the `global.hyperkube` values. Also scrubbed the README.