### PR TITLE
[stable/prometheus] Add alertmanager extra args

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 2.0.3
+version: 2.0.4
 description: A Prometheus Helm chart for Kubernetes. Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 sources:

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -44,6 +44,7 @@ The following tables lists the configurable parameters of the Prometheus chart a
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
+| `alertmanager.extraArgs` | Additional Alertmanager container arguments | `[]` |
 | `alertmanager.httpPort` | Alertmanager Service port | `80` |
 | `alertmanager.httpPortName` | Alertmanager service port name | `http` |
 | `alertmanager.image` | Alertmanager Docker image | `prom/alertmanager:${VERSION}` |

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -44,7 +44,7 @@ The following tables lists the configurable parameters of the Prometheus chart a
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `alertmanager.extraArgs` | Additional Alertmanager container arguments | `[]` |
+| `alertmanager.extraArgs` | Additional Alertmanager container arguments | `{}` |
 | `alertmanager.httpPort` | Alertmanager Service port | `80` |
 | `alertmanager.httpPortName` | Alertmanager service port name | `http` |
 | `alertmanager.image` | Alertmanager Docker image | `prom/alertmanager:${VERSION}` |
@@ -72,7 +72,7 @@ The following tables lists the configurable parameters of the Prometheus chart a
 | `kubeStateMetrics.resources` | Kube-state-metrics resource requests and limits (YAML) | `requests: {cpu: 10m, memory:16Mi}` |
 | `kubeStateMetrics.serviceType` | Kube-state-metrics service type | `ClusterIP` |
 | `server.annotations` | Server Pod annotations | `[]` |
-| `server.extraArgs` | Additional Server container arguments | `[]` |
+| `server.extraArgs` | Additional Server container arguments | `{}` |
 | `server.httpPort` | Server service port | `80` |
 | `server.httpPortName` | Server service port name | `http` |
 | `server.image` | Server Docker image | ` prom/prometheus:${VERSION}` |

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -24,6 +24,9 @@ spec:
           args:
             - --config.file=/etc/config/alertmanager.yml
             - --storage.path={{ default "/data" .Values.alertmanager.storagePath }}
+          {{- range $key, $value := .Values.alertmanager.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
           ports:
             - containerPort: 9093
           readinessProbe:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -1,7 +1,7 @@
 alertmanager:
   ## Additional Alertmanager container arguments
   ##
-  # extraArgs:
+  extraArgs: {}
 
   ## Alertmanager service port
   ##
@@ -161,7 +161,7 @@ server:
 
   ## Additional Server container arguments
   ##
-  # extraArgs:
+  extraArgs: {}
 
   ## Server service port
   ##

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -1,4 +1,8 @@
 alertmanager:
+  ## Additional Alertmanager container arguments
+  ##
+  # extraArgs:
+
   ## Alertmanager service port
   ##
   httpPort: 80


### PR DESCRIPTION
Add support for extra command line arguments for alertmanager deployment.

One use case for this is allow the user to specify the `web.external-url` command line flag, useful when exposing the alertmanager via Ingress or some other method.