### PR TITLE
[stable/grafana] Fixed grafana PVC template that generates invalid manifest

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.2.1
+version: 0.2.2
 description: A Helm chart for Kubernetes
 home: https://grafana.net
 sources:

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
-  {{- if .Values.server.persistentVolume.storageClass -}}
+  {{- if .Values.server.persistentVolume.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass | quote }}
   {{ else }}
     volume.alpha.kubernetes.io/storage-class: default


### PR DESCRIPTION
Without this fix and when setting a value for `annotations:volume.beta.kubernetes.io/storage-class`, the generated template looks like the following and errors when trying to deploy:

```
# Source: grafana/templates/pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:volume.beta.kubernetes.io/storage-class: gluster-heketi

  labels:
```

```
$ sudo helm install --name rgrafana --set server.persistentVolume.storageClass=gluster-heketi stable/grafana
Fetched stable/grafana to grafana-0.2.0.tgz
Error: release rgrafana failed: error validating "": error validating data: found invalid field annotations:volume.beta.kubernetes.io/storage-class for v1.ObjectMeta
```

Also, I grepped the project for other instances of this issue and the grafana chart is the only one.