### PR TITLE
Add nginx-ingress chart

### DIFF
--- a/stable/nginx-ingress/.helmignore
+++ b/stable/nginx-ingress/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A helm chart for the official nginx ingress controller
+name: nginx-ingress
+version: 0.1.0

--- a/stable/nginx-ingress/requirements.yaml
+++ b/stable/nginx-ingress/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: default-backend
+  version: 0.1.0
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/nginx-ingress/templates/_helpers.tpl
+++ b/stable/nginx-ingress/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified redis name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "defaultBackend.fullname" -}}
+{{- printf "%s-%s" .Release.Name "default-backend" | trunc 24 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/nginx-ingress/templates/configmap.yaml
+++ b/stable/nginx-ingress/templates/configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  body-size: {{ .Values.config.bodySize | quote }}
+  error-log-level: {{ .Values.config.errorLogLevel | quote }}
+  gzip-types: {{ .Values.config.gzipTypes | quote }}
+  hts-include-subdomains: {{ .Values.config.htsIncludeSubdomains | quote }}
+  hts-max-age: {{ .Values.config.htsMaxAge | quote }}
+  keep-alive: {{ .Values.config.keepAlive | quote }}
+  max-worker-connections: {{ .Values.config.maxWorkerConnections | quote }}
+  proxy-connect-timeout: {{ .Values.config.proxyConnectTimeout | quote }}
+  proxy-read-timeout: {{ .Values.config.proxyReadTimeout | quote }}
+  proxy-real-ip-cidr: {{ .Values.config.proxyRealIpCidr | quote }}
+  proxy-send-timeout: {{ .Values.config.proxySendTimeout | quote }}
+  server-name-hash-bucket-size: {{ .Values.config.serverNameHashBucketSize | quote }}
+  server-name-hash-max-size: {{ .Values.config.serverNameHashMaxSize | quote }}
+  ssl-buffer-size: {{ .Values.config.sslBufferSize | quote }}
+  ssl-ciphers: {{ .Values.config.sslCiphers | quote }}
+  ssl-protocols: {{ .Values.config.sslProtocols | quote }}
+  ssl-session-cache: {{ .Values.config.sslSessionCache | quote }}
+  ssl-session-cache-size: {{ .Values.config.sslSessionCacheSize | quote }}
+  ssl-session-tickets: {{ .Values.config.sslSessionTickets | quote }}
+  ssl-session-timeout: {{ .Values.config.sslSessionTimeout | quote }}
+  use-gzip: {{ .Values.config.useGzip | quote }}
+  use-hts: {{ .Values.config.useHts | quote }}
+  worker-processes: {{ .Values.config.workerProcesses | quote }}

--- a/stable/nginx-ingress/templates/deployment.yaml
+++ b/stable/nginx-ingress/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: extensions/v1beta1
+kind: {{ .Values.kind }}
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        name: {{ .Chart.Name }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        # use downward API
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - containerPort: 80
+        - containerPort: 443
+{{- range $key, $value := .Values.tcp }}
+        - containerPort: {{ $key }}
+          protocol: TCP
+{{- end }}
+{{- range $key, $value := .Values.udp }}
+        - containerPort: {{ $key }}
+          protocol: UDP
+{{- end }}
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/{{ template "defaultBackend.fullname" . }}
+        - --nginx-configmap=$(POD_NAMESPACE)/{{ template "fullname" . }}
+        - --tcp-services-configmap=$(POD_NAMESPACE)/{{ template "fullname" . }}-tcp
+        - --udp-services-configmap=$(POD_NAMESPACE)/{{ template "fullname" . }}-udp

--- a/stable/nginx-ingress/templates/service.yaml
+++ b/stable/nginx-ingress/templates/service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.service.type }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- if .Values.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{- range $ip := .Values.loadBalancerSourceRanges }}
+  - {{ $ip }}
+{{- end }}
+{{- end }}
+  ports:
+  - port: 80
+    targetPort: 80
+    name: http
+  - port: 443
+    targetPort: 443
+    name: https
+{{- range $key, $value := .Values.tcp }}
+  - port: {{ $key }}
+    targetPort: {{ $key }}
+    name: '{{ $key }}-tcp'
+{{- end }}
+{{- range $key, $value := .Values.udp }}
+  - port: {{ $key }}
+    targetPort: {{ $key }}
+    name: '{{ $key }}-udp'
+    protocol: 'UDP'
+{{- end }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/stable/nginx-ingress/templates/tcp-configmap.yaml
+++ b/stable/nginx-ingress/templates/tcp-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-tcp
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- if .Values.tcp }}
+{{ toYaml .Values.tcp | indent 2 }}
+{{- end }}

--- a/stable/nginx-ingress/templates/udp-configmap.yaml
+++ b/stable/nginx-ingress/templates/udp-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-udp
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- if .Values.udp }}
+{{ toYaml .Values.udp | indent 2 }}
+{{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -1,0 +1,54 @@
+# Default values for nginx-ingress.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+kind: DaemonSet
+
+image:
+  repository: gcr.io/google_containers/nginx-ingress-controller
+  tag: 0.8.3
+  pullPolicy: IfNotPresent
+
+service:
+  type: LoadBalancer
+#  loadBalancerIP: ''
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# Enter a list of TCP backend services here to loadbalance
+# see: https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tcp
+tcp:
+#  8080: "default/example-tcp-svc:9000"
+
+loadBalancerSourceRanges:
+# - 1.2.3.4/32
+
+config:
+  bodySize: 1m
+  errorLogLevel: info
+  gzipTypes: application/atom+xml application/javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/svg+xml image/x-icon text/css text/plain text/x-component
+  htsIncludeSubdomains: "true"
+  htsMaxAge: "15724800"
+  keepAlive: "75"
+  maxWorkerConnections: "16384"
+  proxyConnectTimeout: "30"
+  proxyReadTimeout: "30"
+  proxyRealIpCidr: 0.0.0.0/0
+  proxySendTimeout: "30"
+  serverNameHashBucketSize: "64"
+  serverNameHashMaxSize: "512"
+  sslBufferSize: 4k
+  sslCiphers: ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA
+  sslProtocols: TLSv1 TLSv1.1 TLSv1.2
+  sslSessionCache: "true"
+  sslSessionCacheSize: 10m
+  sslSessionTickets: "true"
+  sslSessionTimeout: 10m
+  useGzip: "true"
+  useHts: "true"
+  workerProcesses: "8"


### PR DESCRIPTION
This PR adds a chart for nginx-ingress.

It requires this be merged first: https://github.com/kubernetes/charts/pull/541 (and then requirements.lock updating)