### PR TITLE
[stable/chaoskube] Update description

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,10 +1,10 @@
 name: chaoskube
-version: 0.3.1
-description: chaoskube periodically kills random pods in your Kubernetes cluster.
+version: 0.3.1-1
+description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube
 sources:
 - https://github.com/linki/chaoskube
 maintainers:
 - name: Martin Linkhorst
-  email: linki+helm.sh@posteo.de
+  email: linki+kubernetes.io@posteo.de
 engine: gotpl

--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 name: chaoskube
 version: 0.3.1
-description: A Helm chart for chaoskube
+description: chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube
 sources:
 - https://github.com/linki/chaoskube


### PR DESCRIPTION
PR in the context of normalizing/improving metadata in official charts.

Refs #124 and helm/monocular#93

NOTE: I have not bumped the chartVersion attribute in order to avoid race conditions/conflicts with existing PRs. Maintainers should be able to change this value before merging (let me know if you prefer that I update it instead)