### PR TITLE
[stable/etcd-operator] Update Icon and added home

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
 version: 0.1.0
+home: https://github.com/coreos/etcd-operator
+icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png
 sources:
   - https://github.com/coreos/etcd-operator
 maintainers:
   - name: Lachlan Evenson
     email: lachlan@deis.com
-icon: https://github.com/coreos/etcd/blob/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png
 sources:


### PR DESCRIPTION
PR in the context of normalizing/improving metadata in the official charts. Refs https://github.com/kubernetes/charts/issues/124 and https://github.com/helm/monocular/issues/93

NOTE: I have not bumped the chartVersion attribute in order to avoid race conditions/conflicts with existing PRs. Maintainers should be able to change this value before the merge. Llet me know if you prefer that I update it instead.

cc/ @lachie83 