### PR TITLE
[stable/grafana] fix cmd for admin password

### DIFF
--- a/stable/grafana/templates/NOTES.txt
+++ b/stable/grafana/templates/NOTES.txt
@@ -1,6 +1,6 @@
 1. Get your '{{ .Values.server.adminUser }}' user password by running:
 
-   printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "server.fullname" . }} -o jsonpath="{.data.grafana-admin-password}" | base64 --decode);echo
+   kubectl get secret --namespace {{ .Release.Namespace }} {{ template "server.fullname" . }} -o jsonpath="{.data.grafana-admin-password}" | base64 --decode ; echo
 
 2. The Grafana server can be accessed via port {{ .Values.server.httpPort }} on the following DNS name from within your cluster:
 


### PR DESCRIPTION
Executing the old command got me:
```
error: error executing jsonpath "{.data.grafana-admin-password[*]}": string is not array or slice
```
This PR aims to fix the issue (and simplifies the command a bit)