### PR TITLE
[stable/gitlab] Add home and icon

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -8,9 +8,11 @@ keywords:
 - issue tracker
 - code review
 - wiki
+home: https://about.gitlab.com
 sources:
 - https://hub.docker.com/r/gitlab/gitlab-ce/
 - https://docs.gitlab.com/omnibus/
+icon: https://gitlab.com/uploads/group/avatar/6543/gitlab-logo-square.png
 maintainers:
 - name: Greg Taylor
   email: gtaylor@gc-taylor.com

--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,5 +1,5 @@
 name: gitlab-ce
-version: 0.1.4
+version: 0.1.5
 description: GitLab Community Edition
 keywords:
 - git


### PR DESCRIPTION
PR in the context of normalizing/improving metadata in the official charts. Refs https://github.com/kubernetes/charts/issues/124 and https://github.com/helm/monocular/issues/93

NOTE: I have not bumped the chartVersion attribute in order to avoid race conditions/conflicts with existing PRs. Maintainers should be able to change this value before the merge. Llet me know if you prefer that I update it instead.

cc/ @gtaylor 