### PR TITLE
[stable/concourse] update description and add icon

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,7 @@
 name: concourse
 version: 0.1.0
-description: Concourse Helm chart for Kubernetes.
+description: Concourse is a simple and scalable CI system.
+icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:
   - ci
   - concourse

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.1.0
+version: 0.1.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:


### PR DESCRIPTION
PR in the context of normalizing/improving metadata in the official charts. Refs #124 and helm/monocular#93

NOTE: I have not bumped the chartVersion attribute in order to avoid race conditions/conflicts with existing PRs. Maintainers should be able to change this value before the merge. Llet me know if you prefer that I update it instead.