### PR TITLE
[stable/datadog] Add home and icon

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -5,6 +5,8 @@ keywords:
 - monitoring
 - alerting
 - metric
+home: https://www.datadoghq.com
+icon: https://datadog-live.imgix.net/img/dd_logo_70x75.png
 sources:
 - https://app.datadoghq.com/account/settings#agent/kubernetes
 - https://github.com/DataDog/docker-dd-agent

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.2.0
+version: 0.2.1
 description: DataDog Agent
 keywords:
 - monitoring


### PR DESCRIPTION
PR in the context of normalizing/improving metadata in the official charts. Refs https://github.com/kubernetes/charts/issues/124 and https://github.com/helm/monocular/issues/93

NOTE: I have not bumped the chartVersion attribute in order to avoid race conditions/conflicts with existing PRs. Maintainers should be able to change this value before the merge. Llet me know if you prefer that I update it instead.

cc/ @gtaylor 