### PR TITLE
[stable/testlink] add icon

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,6 +1,7 @@
 name: testlink
 version: 0.4.3
 description: Web-based test management system that facilitates software quality assurance.
+icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png
 keywords:
 - testlink
 - testing

--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 0.4.3
+version: 0.4.4
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png
 keywords:


### PR DESCRIPTION
PR in the context of normalizing/improving metadata in the official charts. Refs #124 and helm/monocular#93

NOTE: I have not bumped the chartVersion attribute in order to avoid race conditions/conflicts with existing PRs. Maintainers should be able to change this value before the merge. Llet me know if you prefer that I update it instead.