### PR TITLE
[stable/linkerd] Add icon

### DIFF
--- a/stable/linkerd/Chart.yaml
+++ b/stable/linkerd/Chart.yaml
@@ -3,6 +3,7 @@ description: Service mesh for cloud native apps
 name: linkerd
 version: 0.1.0
 home: https://linkerd.io/
+icon: https://pbs.twimg.com/profile_images/690258997237014528/KNgQd9GL_400x400.png
 sources:
 - https://github.com/BuoyantIO/linkerd
 maintainers:

--- a/stable/linkerd/Chart.yaml
+++ b/stable/linkerd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Service mesh for cloud native apps
 name: linkerd
-version: 0.1.0
+version: 0.1.1
 home: https://linkerd.io/
 icon: https://pbs.twimg.com/profile_images/690258997237014528/KNgQd9GL_400x400.png
 sources:


### PR DESCRIPTION
PR in the context of normalizing/improving metadata in the official charts. Refs https://github.com/kubernetes/charts/issues/124 and https://github.com/helm/monocular/issues/93

I was not able to find any icon that could suit non-dark background so I decided to use their official Twitter account icon.

NOTE: I have not bumped the chartVersion attribute in order to avoid race conditions/conflicts with existing PRs. Maintainers should be able to change this value before the merge. Llet me know if you prefer that I update it instead.

cc/ @viglesiasce 
