### PR TITLE
Missing chart in helm install statement

### DIFF
--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -65,5 +65,5 @@ $ helm install stable/kube2iam --name my-release \
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml stable/kube2iam
+$ helm install stable/kube2iam --name my-release -f values.yaml
 ```

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -58,10 +58,10 @@ The following tables lists the configurable parameters of the kube2iam chart and
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release \
-  --set=extraArgs.base-role-arn=arn:aws:iam::0123456789:role/, \
+$ helm install stable/kube2iam --name my-release \
+  --set="extraArgs.base-role-arn=arn:aws:iam::0123456789:role/, \
     extraArgs.default-role=kube2iam-default, \
-    host.iptables=true,host.interface=cbr0
+    host.iptables=true,host.interface=cbr0"
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -58,10 +58,8 @@ The following tables lists the configurable parameters of the kube2iam chart and
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install stable/kube2iam --name my-release \
-  --set="extraArgs.base-role-arn=arn:aws:iam::0123456789:role/, \
-    extraArgs.default-role=kube2iam-default, \
-    host.iptables=true,host.interface=cbr0"
+$ helm install --name my-release \
+  --set=extraArgs.base-role-arn=arn:aws:iam::0123456789:role/,extraArgs.default-role=kube2iam-default,host.iptables=true,host.interface=cbr0
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -58,7 +58,7 @@ The following tables lists the configurable parameters of the kube2iam chart and
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install --name my-release \
+$ helm install stable/kube2iam --name my-release \
   --set=extraArgs.base-role-arn=arn:aws:iam::0123456789:role/,extraArgs.default-role=kube2iam-default,host.iptables=true,host.interface=cbr0
 ```
 


### PR DESCRIPTION
Usage: (v2.1.3)
  helm install [CHART] [flags]

* Include chart in install statement
* Fix set flag to use strings as required