### PR TITLE
Add a Chart for GitLab CI Runner

### DIFF
--- a/stable/gitlab-runner/.helmignore
+++ b/stable/gitlab-runner/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/gitlab-runner/Chart.yaml
+++ b/stable/gitlab-runner/Chart.yaml
@@ -1,0 +1,15 @@
+name: gitlab-runner
+version: 0.1.0
+description: GitLab Runner
+keywords:
+- git
+- ci
+- deploy
+sources:
+- https://hub.docker.com/r/gitlab/gitlab-runner/
+- https://docs.gitlab.com/runner/
+maintainers:
+- name: GitLab Inc.
+  email: support@gitlab.com
+- name: DJ Mountney
+  email: dj@gitlab.com

--- a/stable/gitlab-runner/Chart.yaml
+++ b/stable/gitlab-runner/Chart.yaml
@@ -1,6 +1,6 @@
 name: gitlab-runner
 version: 0.1.0
-description: GitLab Runner
+description: GitLab Runner is the open source project that is used to run your jobs and send the results back to GitLab.
 keywords:
 - git
 - ci
@@ -13,3 +13,4 @@ maintainers:
   email: support@gitlab.com
 - name: DJ Mountney
   email: dj@gitlab.com
+icon: https://gitlab.com/uploads/project/avatar/250833/runner_logo.png

--- a/stable/gitlab-runner/README.md
+++ b/stable/gitlab-runner/README.md
@@ -1,0 +1,59 @@
+# GitLab Runner
+
+[GitLab Runner](https://docs.gitlab.com/runner) is the open source project that is used to run your jobs and send the results back to GitLab. It is used in conjunction with [GitLab CI](https://about.gitlab.com/gitlab-ci/), the open-source continuous integration service included with GitLab that coordinates the jobs.
+
+## Introduction
+
+This chart deploys a GitLab Runner instance configured to run using the [Kubernetes executor](https://docs.gitlab.com/runner/install/kubernetes.html)
+
+For each new job it recieves from [GitLab CI](https://about.gitlab.com/gitlab-ci/), it will provision a new pod within the specified namespace to run it.
+
+## Prerequisites
+
+- _At least_ 2 vCPUs available on your cluster
+- Kubernetes 1.4+ with Beta APIs enabled
+- Your GitLab Server's API is reachable from the cluster
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` run:
+
+```bash
+$ helm install --name my-release \
+    --set gitlabUrl=http://gitlab.your-domain.com/,runnerRegistrationToken=your-token \
+    stable/gitlab-runner
+```
+
+Note that you _must_ pass in gitlabUrl and runnerRegistrationToken, or you'll end up with a non-functioning release.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Refer to [values.yaml](values.yaml) for the full run-down on defaults. These are a mixture of Kubernetes and GitLab Runner-related directives.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set gitlabUrl=http://gitlab.your-domain.com/,runnerRegistrationToken=your-token,concurrent=4 \
+    stable/gitlab-runner
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/gitlab-runner
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/gitlab-runner/templates/NOTES.txt
+++ b/stable/gitlab-runner/templates/NOTES.txt
@@ -1,5 +1,5 @@
-{{- if default "" .Values.gitlabUrl }}
-{{- if default "" .Values.runnerRegistrationToken }}
+{{- if .Values.gitlabUrl }}
+{{- if .Values.runnerRegistrationToken }}
 Your GitLab Runner should now be registered against the GitLab instance reachable at: {{ .Values.gitlabUrl }}
 {{- else -}}
 ##############################################################################

--- a/stable/gitlab-runner/templates/NOTES.txt
+++ b/stable/gitlab-runner/templates/NOTES.txt
@@ -1,0 +1,27 @@
+{{- if default "" .Values.gitlabUrl }}
+{{- if default "" .Values.runnerRegistrationToken }}
+Your GitLab Runner should now be registered against the GitLab instance reachable at: {{ .Values.gitlabUrl }}
+{{- else -}}
+##############################################################################
+## WARNING: You did not specify an runnerRegistrationToken in your 'helm install' call. ##
+##############################################################################
+
+This deployment will be incomplete until you provide the Registration Token for your
+GitLab instance:
+
+    helm upgrade {{ .Release.Name }} \
+        --set gitlabUrl=http://gitlab.your-domain.com,runnerRegistrationToken=your-registration-token \
+        stable/gitlab-runner
+{{- end -}}
+{{- else -}}
+##############################################################################
+## WARNING: You did not specify an gitlabUrl in your 'helm install' call. ##
+##############################################################################
+
+This deployment will be incomplete until you provide the URL that your
+GitLab instance is reachable at:
+
+    helm upgrade {{ .Release.Name }} \
+        --set gitlabUrl=http://gitlab.your-domain.com,runnerRegistrationToken=your-registration-token \
+        stable/gitlab-runner
+{{- end -}}

--- a/stable/gitlab-runner/templates/_helpers.tpl
+++ b/stable/gitlab-runner/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/gitlab-runner/templates/configmap.yaml
+++ b/stable/gitlab-runner/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  entrypoint: |
+    #!/bin/bash
+
+    set -xe
+
+    cp /scripts/config.toml /etc/gitlab-runner/
+
+    # Register the runner
+    /entrypoint register --non-interactive \
+      --url $GITLAB_URL \
+      --executor kubernetes
+
+    # Start the runner
+    /entrypoint run --user=gitlab-runner \
+      --working-directory=/home/gitlab-runner
+  config.toml: |
+    concurrent = {{ .Values.concurrent }}
+    check_interval = {{ .Values.checkInterval }}

--- a/stable/gitlab-runner/templates/deployment.yaml
+++ b/stable/gitlab-runner/templates/deployment.yaml
@@ -32,10 +32,10 @@ spec:
           value: {{ .Values.runners.image | quote }}
         {{ if .Values.runners.privileged }}
         - name: KUBERNETES_PRIVILEGED
-          value: true
+          value: "true"
         {{ end }}
         - name: KUBERNETES_NAMESPACE
-          value: {{ default "" .Values.runners.namespace | quote }}
+          value: {{ default .Release.Namespace .Values.runners.namespace | quote }}
         - name: KUBERNETES_CPU_LIMIT
           value: {{ default "" .Values.runners.builds.cpuLimit | quote }}
         - name: KUBERNETES_MEMORY_LIMIT

--- a/stable/gitlab-runner/templates/deployment.yaml
+++ b/stable/gitlab-runner/templates/deployment.yaml
@@ -1,0 +1,89 @@
+{{- if and (default "" .Values.gitlabUrl) (default "" .Values.runnerRegistrationToken) }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}
+        image: {{ .Values.image }}
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        command: ["/bin/bash", "/scripts/entrypoint"]
+        env:
+        - name: GITLAB_URL
+          value: {{ default "" .Values.gitlabUrl | quote }}
+        - name: REGISTRATION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: runner-registration-token
+        - name: KUBERNETES_IMAGE
+          value: {{ .Values.runners.image | quote }}
+        {{ if .Values.runners.privileged }}
+        - name: KUBERNETES_PRIVILEGED
+          value: true
+        {{ end }}
+        - name: KUBERNETES_NAMESPACE
+          value: {{ default "" .Values.runners.namespace | quote }}
+        - name: KUBERNETES_CPU_LIMIT
+          value: {{ default "" .Values.runners.builds.cpuLimit | quote }}
+        - name: KUBERNETES_MEMORY_LIMIT
+          value: {{ default "" .Values.runners.builds.memoryLimit | quote }}
+        - name: KUBERNETES_CPU_REQUEST
+          value: {{ default "" .Values.runners.builds.cpuRequests | quote }}
+        - name: KUBERNETES_MEMORY_REQUEST
+          value: {{ default "" .Values.runners.builds.memoryRequests| quote }}
+        - name: KUBERNETES_SERVICE_CPU_LIMIT
+          value: {{ default "" .Values.runners.services.cpuLimit | quote }}
+        - name: KUBERNETES_SERVICE_MEMORY_LIMIT
+          value: {{ default "" .Values.runners.services.memoryLimit | quote }}
+        - name: KUBERNETES_SERVICE_CPU_REQUEST
+          value: {{ default "" .Values.runners.services.cpuRequests | quote }}
+        - name: KUBERNETES_SERVICE_MEMORY_REQUEST
+          value: {{ default "" .Values.runners.services.memoryRequests | quote }}
+        - name: KUBERNETES_HELPERS_CPU_LIMIT
+          value: {{ default "" .Values.runners.helpers.cpuLimit | quote }}
+        - name: KUBERNETES_HELPERS_MEMORY_LIMIT
+          value: {{ default "" .Values.runners.helpers.memoryLimit | quote }}
+        - name: KUBERNETES_HELPERS_CPU_REQUEST
+          value: {{ default "" .Values.runners.helpers.cpuRequests | quote }}
+        - name: KUBERNETES_HELPERS_MEMORY_REQUEST
+          value: {{ default "" .Values.runners.helpers.memoryRequests| quote }}
+        livenessProbe:
+          exec:
+            command: ["/usr/bin/pgrep","gitlab-ci-multi"]
+          initialDelaySeconds: 60
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/pgrep","gitlab-ci-multi"]
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      volumes:
+      - name: scripts
+        configMap:
+          name: {{ template "fullname" . }}
+{{ else }}
+{{ end }}

--- a/stable/gitlab-runner/templates/secrets.yaml
+++ b/stable/gitlab-runner/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  runner-registration-token: {{ default "" .Values.runnerRegistrationToken | b64enc | quote }}

--- a/stable/gitlab-runner/values.yaml
+++ b/stable/gitlab-runner/values.yaml
@@ -38,6 +38,9 @@ runners:
   image: ubuntu:16.04
 
   ## Run all containers with the privileged flag enabled
+  ## This will allow the docker:dind image to run if you need to run Docker
+  ## commands. Please read the docs before turning this on:
+  ## ref: https://docs.gitlab.com/runner/executors/kubernetes.html#using-docker-dind
   ##
   privileged: false
 

--- a/stable/gitlab-runner/values.yaml
+++ b/stable/gitlab-runner/values.yaml
@@ -1,7 +1,7 @@
 ## GitLab Runner Image
 ## ref: https://hub.docker.com/r/gitlab/gitlab-runner/tags/
 ##
-image: gitlab/gitlab-runner:alpine-v1.10.4
+image: gitlab/gitlab-runner:alpine-v9.0.0
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'

--- a/stable/gitlab-runner/values.yaml
+++ b/stable/gitlab-runner/values.yaml
@@ -1,0 +1,81 @@
+## GitLab Runner Image
+## ref: https://hub.docker.com/r/gitlab/gitlab-runner/tags/
+##
+image: gitlab/gitlab-runner:alpine-v1.10.4
+
+## Specify a imagePullPolicy
+## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
+
+## The GitLab Server URL (with protocol) that want to register the runner against
+## ref: https://docs.gitlab.com/runner/commands/README.html#gitlab-runner-register
+##
+# gitlabURL: http://gitlab.your-domain.com/
+
+## The Registration Token for adding new Runners to the GitLab Server. This must
+## be retreived from your GitLab Instance.
+## ref: https://docs.gitlab.com/ce/ci/runners/README.html#creating-and-registering-a-runner
+##
+# runnerRegistrationToken: ""
+
+## Configure the maximum number of concurrent jobs
+## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section
+##
+concurrent: 10
+
+## Defines in seconds how often to check GitLab for a new builds
+## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section
+##
+checkInterval: 30
+
+## Configuration for the Pods that that the runner launches for each new job
+##
+runners:
+  ## Default container image to use for builds when none is specified
+  ##
+  image: ubuntu:16.04
+
+  ## Run all containers with the privileged flag enabled
+  ##
+  privileged: false
+
+  ## Namespace to run Kubernetes jobs in (defaults to 'default')
+  ##
+  # namespace:
+
+  ## Build Container specific configuration
+  ##
+  builds:
+    # cpuLimit: 200m
+    # memoryLimit: 256Mi
+    cpuRequests: 100m
+    memoryRequests: 128Mi
+
+  ## Service Container specific configuration
+  ##
+  services:
+    # cpuLimit: 200m
+    # memoryLimit: 256Mi
+    cpuRequests: 100m
+    memoryRequests: 128Mi
+
+  ## Helper Container specific configuration
+  ##
+  helpers:
+    # cpuLimit: 200m
+    # memoryLimit: 256Mi
+    cpuRequests: 100m
+    memoryRequests: 128Mi
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  # limits:
+  #   memory: 256Mi
+  #   cpu: 200m
+  requests:
+    memory: 128Mi
+    cpu: 100m

--- a/stable/gitlab-runner/values.yaml
+++ b/stable/gitlab-runner/values.yaml
@@ -12,7 +12,7 @@ image: gitlab/gitlab-runner:alpine-v1.10.4
 ## The GitLab Server URL (with protocol) that want to register the runner against
 ## ref: https://docs.gitlab.com/runner/commands/README.html#gitlab-runner-register
 ##
-# gitlabURL: http://gitlab.your-domain.com/
+# gitlabUrl: http://gitlab.your-domain.com/
 
 ## The Registration Token for adding new Runners to the GitLab Server. This must
 ## be retreived from your GitLab Instance.


### PR DESCRIPTION
In order for this Chart to properly work, you need to specify the GitLab URL that you want to register the runner to. And the registration token, taken from the GitLab instance. (Either from the Shared Runners page for Admins, or any Project's CI/CD Pipelines settings)