### PR TITLE
Added: option to specify nginx service annotations

### DIFF
--- a/stable/nginx-lego/templates/nginx-service.yaml
+++ b/stable/nginx-lego/templates/nginx-service.yaml
@@ -4,6 +4,12 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+  {{- if .Values.nginx.service }}
+  {{- range $key, $value := .Values.nginx.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.nginx.service.type | quote }}
   ports:

--- a/stable/nginx-lego/values.yaml
+++ b/stable/nginx-lego/values.yaml
@@ -12,6 +12,8 @@ nginx:
     pullPolicy: IfNotPresent
   service:
     type: LoadBalancer
+    # annotations:
+    #   key: value
   monitoring: false
   resources:
     limits:


### PR DESCRIPTION
In my setup I need to create internal ELB for nginx.
On AWS it may be configured via annotation "service.beta.kubernetes.io/aws-load-balancer-internal".

This PR adds option to specify annotations on nginx service.
Approach is the same as in `stable/traefik` chart.