### PR TITLE
Update all dependent charts to mariadb 0.5.8

### DIFF
--- a/stable/drupal/requirements.lock
+++ b/stable/drupal/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T16:44:04.845592445-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T17:43:38.669390159-05:00

--- a/stable/drupal/requirements.yaml
+++ b/stable/drupal/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/ghost/requirements.lock
+++ b/stable/ghost/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T16:07:02.693815624-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:15:59.006325509-05:00

--- a/stable/ghost/requirements.yaml
+++ b/stable/ghost/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/jasperreports/requirements.lock
+++ b/stable/jasperreports/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T16:07:02.693815624-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:16:48.577104279-05:00

--- a/stable/jasperreports/requirements.yaml
+++ b/stable/jasperreports/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/joomla/requirements.lock
+++ b/stable/joomla/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T16:07:02.693815624-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:17:17.374241232-05:00

--- a/stable/joomla/requirements.yaml
+++ b/stable/joomla/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/magento/requirements.lock
+++ b/stable/magento/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T16:07:02.693815624-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:20:29.718173001-05:00

--- a/stable/magento/requirements.yaml
+++ b/stable/magento/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T16:07:02.693815624-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:28:15.477818969-05:00

--- a/stable/mediawiki/requirements.yaml
+++ b/stable/mediawiki/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/opencart/requirements.lock
+++ b/stable/opencart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T18:02:06.574333356-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:28:29.013418222-05:00

--- a/stable/opencart/requirements.yaml
+++ b/stable/opencart/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/owncloud/requirements.lock
+++ b/stable/owncloud/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T18:09:43.854355049-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:28:37.707601037-05:00

--- a/stable/owncloud/requirements.yaml
+++ b/stable/owncloud/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/phabricator/requirements.lock
+++ b/stable/phabricator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T18:15:33.428097822-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:28:48.295235108-05:00

--- a/stable/phabricator/requirements.yaml
+++ b/stable/phabricator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/phpbb/requirements.lock
+++ b/stable/phpbb/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T18:20:03.117235483-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:28:56.594274765-05:00

--- a/stable/phpbb/requirements.yaml
+++ b/stable/phpbb/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T18:24:45.763614473-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:29:12.33172216-05:00

--- a/stable/prestashop/requirements.yaml
+++ b/stable/prestashop/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T18:43:49.386029334-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:30:22.658021445-05:00

--- a/stable/redmine/requirements.yaml
+++ b/stable/redmine/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/testlink/requirements.lock
+++ b/stable/testlink/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T16:26:59.945259986-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:30:43.11164597-05:00

--- a/stable/testlink/requirements.yaml
+++ b/stable/testlink/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.7
-digest: sha256:409eefb841b53ef1aa91d0607d87e6c475297df40101180c787260d766657d95
-generated: 2017-01-27T16:07:02.693815624-08:00
+  version: 0.5.8
+digest: sha256:0d0793c22b46ed7d285611d44761bb34c9f72e486a09035bb3bb511e81022d94
+generated: 2017-02-11T18:30:47.598056429-05:00

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.7
+  version: 0.5.8
   repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
The MariaDB dependency for stable/drupal should be updated from 0.5.7 to 0.5.8. See #427 