### PR TITLE
Don't run Zookeeper as a shell subprocess

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.2.1
+version: 0.2.2
 description: Centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif
 sources:

--- a/incubator/zookeeper/templates/ss.yaml
+++ b/incubator/zookeeper/templates/ss.yaml
@@ -119,7 +119,7 @@ spec:
         command:
         - sh
         - -c
-        - zkGenConfig.sh && zkServer.sh start-foreground
+        - zkGenConfig.sh && exec zkServer.sh start-foreground
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
It improves signal handling, as with this change it is
java process which receives container signals such as SIGTERM