### PR TITLE
[stable/grafana] Fixed storageClass annotation

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.2.2
+version: 0.2.3
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/dashboards-configmap.yaml
+++ b/stable/grafana/templates/dashboards-configmap.yaml
@@ -7,6 +7,6 @@ metadata:
     component: "{{ .Values.server.name }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "server.fullname" . }}-config
+  name: {{ template "server.fullname" . }}-dashs
 data:
-{{ toYaml .Values.serverConfigFile | indent 2 }}
+{{ toYaml .Values.serverDashboardFiles | indent 2 }}

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
-  {{- if .Values.server.persistentVolume.storageClass -}}
+  {{- if .Values.server.persistentVolume.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.server.persistentVolume.storageClass | quote }}
-  {{ else }}
+  {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
   {{- range $key, $value := .Values.server.persistentVolume.annotations }}

--- a/stable/grafana/templates/secret.yaml
+++ b/stable/grafana/templates/secret.yaml
@@ -9,9 +9,9 @@ metadata:
   name: {{ template "server.fullname" . }}
 type: Opaque
 data:
-  {{ if .Values.server.adminPassword }}
-  grafana-admin-password:  {{ .Values.server.adminPassword | b64enc | quote }}
-  {{ else }}
+  {{- if .Values.server.adminPassword }}
+  grafana-admin-password: {{ .Values.server.adminPassword | b64enc | quote }}
+  {{- else }}
   grafana-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
+  {{- end }}
   grafana-admin-user: {{ .Values.server.adminUser | b64enc | quote }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -325,4 +325,4 @@ serverConfigFile:
 ##
 ## and add it below.
 ##
-serverDashboardFiles:
+serverDashboardFiles: {}


### PR DESCRIPTION
Templating resulted in `annotations: volume.beta.kubernetes.io/storage-class: ...` on single line if `.Values.server.persistentVolume.storageClass` was defined.

Also adjusted other whitespacing, and separated dashboard configmap into own template.