### PR TITLE
[stable/kapacitor] Fixes broken Persistent Volume support

### DIFF
--- a/stable/kapacitor/Chart.yaml
+++ b/stable/kapacitor/Chart.yaml
@@ -1,5 +1,5 @@
 name: kapacitor
-version: 0.2.1
+version: 0.2.2
 description: InfluxDB's native data processing engine. It can process both stream and batch data from InfluxDB.
 keywords:
 - kapacitor

--- a/stable/kapacitor/templates/deployment.yaml
+++ b/stable/kapacitor/templates/deployment.yaml
@@ -34,10 +34,10 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
         - name: data
-        {{ if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
-          {{ else }}
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "fullname" . }}
+        {{- else }}
           emptyDir: {}
-          {{ end }}
+        {{- end }}
 {{- end }}

--- a/stable/kapacitor/templates/pvc.yaml
+++ b/stable/kapacitor/templates/pvc.yaml
@@ -2,12 +2,12 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: {{ template "fullname" . }}
   labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     app: {{ template "fullname" . }}
-    name: {{ template "fullname" . }}
   annotations:
   {{- if .Values.persistence.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}

--- a/test/verify-release.sh
+++ b/test/verify-release.sh
@@ -38,7 +38,7 @@ while [ "$COUNT" -lt "$RETRY" ]; do
   fi
 done
 
-if [ "$PODS_FOUND" -eq 1 ];then
+if [ "$PODS_FOUND" -eq 0 ];then
   echo "WARN: No pods launched by this chart's default settings"
   exit 0
 else


### PR DESCRIPTION
There are a couple of errors in the Kapacitor Persistent Volume config, which only manifest when you enable persistence in the config.

  * The Deployment is incorrectly indented, resulting in invalid YAML
  * The PVC itself has metadata keys in the wrong place, resulting in a failure to install