### PR TITLE
Kibana chart

### DIFF
--- a/stable/kibana/.helmignore
+++ b/stable/kibana/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,0 +1,15 @@
+name: kibana
+version: 0.1.0
+description: Kibana lets you visualize your Elasticsearch data and navigate the Elastic Stack.
+engine: gotpl
+home: https://www.elastic.co/products/kibana
+keywords:
+- kibana
+- elasticsearch
+maintainers:
+- email: james@jagregory.com
+  name: James Gregory
+sources:
+- https://www.elastic.co/products/kibana
+- https://github.com/elastic/kibana-docker
+- https://hub.docker.com/_/kibana/

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -1,0 +1,35 @@
+# Kibana Helm Chart
+
+This chart deploys [Kibana](https://www.elastic.co/products/kibana), for viewing logs stored in Elasticsearch.
+
+
+## Installing the Chart
+
+```bash
+helm install stable/kibana
+```
+
+The command deploys Kibana with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+
+## Configuration
+
+The configurable parameters of the Kibana chart and the default values are listed in `values.yaml`.
+
+The [full image documentation](https://www.elastic.co/guide/en/kibana/current/_configuring_kibana_on_docker.html) contains more information about running Kibana in Docker.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install --set config.elasticsearch_url=http://elasticsearch.logs:9200 stable/kibana
+```
+
+The above command specifies the URL of Elasticsearch.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+helm install -f values.yaml stable/kibana
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -14,6 +14,8 @@ The command deploys Kibana with the default configuration. The [configuration](#
 
 ## Configuration
 
+To use Kibana, the `elasticsearch.url` setting will need to be changed; you can specify this using `--set "elasticsearch\.url"="http://..."`.
+
 The configurable parameters of the Kibana chart and the default values are listed in `values.yaml`.
 
 The [full image documentation](https://www.elastic.co/guide/en/kibana/current/_configuring_kibana_on_docker.html) contains more information about running Kibana in Docker.

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -21,7 +21,7 @@ The [full image documentation](https://www.elastic.co/guide/en/kibana/current/_c
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
-helm install --set config.elasticsearch_url=http://elasticsearch.logs:9200 stable/kibana
+helm install --set config.elasticsearch.url=http://elasticsearch.logs:9200 stable/kibana
 ```
 
 The above command specifies the URL of Elasticsearch.
@@ -31,5 +31,7 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 ```bash
 helm install -f values.yaml stable/kibana
 ```
+
+The `config` key in `values.yaml` will be serialized as the `kibana.yml` config file in the container.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/kibana/templates/NOTES.txt
+++ b/stable/kibana/templates/NOTES.txt
@@ -1,0 +1,18 @@
+Kibana can be accessed via port 80 on the following DNS name from within your cluster:
+
+- http://{{ template "fullname" . }}.{{ .Release.Namespace }}:80
+
+You can also connect to the container running Kibana. To open a shell session in the pod run the following:
+
+- kubectl exec -i -t --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{.items[0].metadata.name}') /bin/sh
+
+To tail the logs for the Kibana pod run the following:
+
+- kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{ .items[0].metadata.name }')
+
+{{- if eq .Values.service.type "LoadBalancer" }}
+
+To watch for the LoadBalancer IP or Hostname to populate run the following:
+
+- kubectl get svc -w --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }}
+{{- end }}

--- a/stable/kibana/templates/NOTES.txt
+++ b/stable/kibana/templates/NOTES.txt
@@ -16,3 +16,7 @@ To watch for the LoadBalancer IP or Hostname to populate run the following:
 
 - kubectl get svc -w --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }}
 {{- end }}
+
+To use this Chart, you should change the "elasticsearch.url" setting to the URL to your ElasticSearch cluster; the URL defaults to "http://elasticsearch.logs:9200", which is unlikely to be correct. Kibana will start without this setting, but won't function correctly until you've updated.
+
+- helm upgrade {{ .Release.Name }} stable/kibana --set "elasticsearch\.url"="http://my.elasticsearch.url:9200"

--- a/stable/kibana/templates/_helpers.tpl
+++ b/stable/kibana/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}

--- a/stable/kibana/templates/configmap.yaml
+++ b/stable/kibana/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  name: {{ template "fullname" . }}-config
+data:
+  kibana.yml: |
+{{ toYaml .Values.config | indent 4 }}

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        ports:
+        - containerPort: 5601
+          name: http
+        env:
+          - name: "ELASTICSEARCH_URL"
+            value: {{ .Values.config.elasticsearch_url | quote }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -23,12 +23,12 @@ spec:
           name: http
         livenessProbe:
           httpGet:
-            path: /status
+            path: /
             port: http
           initialDelaySeconds: 30
         readinessProbe:
           httpGet:
-            path: /status
+            path: /
             port: http
           initialDelaySeconds: 10
         volumeMounts:

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -21,6 +21,16 @@ spec:
         ports:
         - containerPort: 5601
           name: http
+        livenessProbe:
+          httpGet:
+            path: /status
+            port: http
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: http
+          initialDelaySeconds: 10
         volumeMounts:
         - name: config
           mountPath: /opt/kibana/config

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -21,8 +21,12 @@ spec:
         ports:
         - containerPort: 5601
           name: http
-        env:
-          - name: "ELASTICSEARCH_URL"
-            value: {{ .Values.config.elasticsearch_url | quote }}
+        volumeMounts:
+        - name: config
+          mountPath: /opt/kibana/config
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "fullname" . }}-config

--- a/stable/kibana/templates/ingress.yaml
+++ b/stable/kibana/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "fullname" . }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.hostname }}
+    secretName: {{ template "fullname" . }}-tls
+{{- end }}
+  rules:
+  - host: {{ .Values.ingress.hostname }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: 80
+{{- end -}}

--- a/stable/kibana/templates/service.yaml
+++ b/stable/kibana/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  type: {{ default "ClusterIP" .Values.service.type }}
+  ports:
+  - port: 80
+    targetPort: 5601
+  selector:
+    app: {{ template "fullname" . }}
+{{- end -}}

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -15,5 +15,90 @@ service:
   annotations:
     # zalando.org/dnsname: kibana.your.cluster
 
+## See: https://github.com/elastic/kibana/blob/master/config/kibana.yml
+## Please note these config settings may vary depending on which Kibana image
+## you choose to use. These settings are based on 4.6.4.
 config:
-  elasticsearch_url: http://elasticsearch.logs:9200
+  # Kibana is served by a back end server. This controls which port to use.
+  # server.port: 5601
+
+  # The host to bind the server to.
+  # server.host: "0.0.0.0"
+
+  # If you are running kibana behind a proxy, and want to mount it at a path,
+  # specify that path here. The basePath can't end in a slash.
+  # server.basePath: ""
+
+  # The maximum payload size in bytes on incoming server requests.
+  # server.maxPayloadBytes: 1048576
+
+  # The Elasticsearch instance to use for all your queries.
+  elasticsearch.url: "http://elasticsearch.logs:9200"
+
+  # preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+  # then the host you use to connect to *this* Kibana instance will be sent.
+  # elasticsearch.preserveHost: true
+
+  # Kibana uses an index in Elasticsearch to store saved searches, visualizations
+  # and dashboards. It will create a new index if it doesn't already exist.
+  # kibana.index: ".kibana"
+
+  # The default application to load.
+  # kibana.defaultAppId: "discover"
+
+  # If your Elasticsearch is protected with basic auth, these are the user credentials
+  # used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
+  # users will still need to authenticate with Elasticsearch (which is proxied through
+  # the Kibana server)
+  # elasticsearch.username: "user"
+  # elasticsearch.password: "pass"
+
+  # SSL for outgoing requests from the Kibana Server to the browser (PEM formatted)
+  # server.ssl.cert: /path/to/your/server.crt
+  # server.ssl.key: /path/to/your/server.key
+
+  # Optional setting to validate that your Elasticsearch backend uses the same key files (PEM formatted)
+  # elasticsearch.ssl.cert: /path/to/your/client.crt
+  # elasticsearch.ssl.key: /path/to/your/client.key
+
+  # If you need to provide a CA certificate for your Elasticsearch instance, put
+  # the path of the pem file here.
+  # elasticsearch.ssl.ca: /path/to/your/CA.pem
+
+  # Set to false to have a complete disregard for the validity of the SSL
+  # certificate.
+  # elasticsearch.ssl.verify: true
+
+  # Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
+  # request_timeout setting
+  # elasticsearch.pingTimeout: 1500
+
+  # Time in milliseconds to wait for responses from the back end or elasticsearch.
+  # This must be > 0
+  # elasticsearch.requestTimeout: 30000
+
+  # Header names and values that are sent to Elasticsearch. Any custom headers cannot be overwritten
+  # by client-side headers.
+  # elasticsearch.customHeaders: {}
+
+  # Time in milliseconds for Elasticsearch to wait for responses from shards.
+  # Set to 0 to disable.
+  # elasticsearch.shardTimeout: 0
+
+  # Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
+  # elasticsearch.startupTimeout: 5000
+
+  # Set the path to where you would like the process id file to be created.
+  # pid.file: /var/run/kibana.pid
+
+  # If you would like to send the log output to a file you can set the path below.
+  # logging.dest: stdout
+
+  # Set this to true to suppress all logging output.
+  # logging.silent: false
+
+  # Set this to true to suppress all logging output except for error messages.
+  # logging.quiet: false
+
+  # Set this to true to log all events, including system usage information and all requests.
+  # logging.verbose: false

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -15,6 +15,19 @@ service:
   annotations:
     # zalando.org/dnsname: kibana.your.cluster
 
+ingress:
+  enabled: false
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: 'true'
+    # zalando.org/dnsname: kibana.your.cluster
+
+  hostname: kibana.your.cluster
+  # tls:
+  #   - secretName: kibana-server-tls
+  #     hosts:
+  #       - kibana.your.cluster
+
 ## See: https://github.com/elastic/kibana/blob/master/config/kibana.yml
 ## Please note these config settings may vary depending on which Kibana image
 ## you choose to use. These settings are based on 4.6.4.

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -1,0 +1,19 @@
+image:
+  repo: "kibana"
+  tag: "5.2.0"
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 100m
+  requests:
+    cpu: 100m
+
+service:
+  enabled: true
+  type: ClusterIP
+  annotations:
+    # zalando.org/dnsname: kibana.your.cluster
+
+config:
+  elasticsearch_url: http://elasticsearch.logs:9200


### PR DESCRIPTION
Installing this chart creates a Deployment of Kibana, configured with a ConfigMap. I believe this satisfies the contributors guidelines, but it's my first chart so please let me know if there's anything missing/weird.

The chart defaults to Kibana 5.2, which is the latest version at the time of writing; however, this is unfortunately incompatible with the out-of-date incubator/elasticsearch. I figured it better to keep Kibana latest and allow downgrades, than pin Kibana based on an incubator chart.