### PR TITLE
[stable/telegraf] Mount utmp for system input

### DIFF
--- a/stable/telegraf/templates/deployment.yaml
+++ b/stable/telegraf/templates/deployment.yaml
@@ -24,9 +24,14 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/telegraf
+        - name: utmp
+          mountPath: /var/run/utmp
       volumes:
       - name: config
         configMap:
           name: {{ template "fullname" . }}-s
+      - name: utpm
+        hostPath:
+          path: /var/run/utmp
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
The `system` input (enabled by default) requires access to `/var/run/utmp`, which needs to be mounted from the host.

If you don't have utmp mounted, the system input always fails with an error:

    Error in input [system]: open /var/run/utmp: no such file or directory

This change adds `/var/run/utmp` as a volume mount, and mounts it using `hostPath` in the Deployment.