### PR TITLE
[stable/chronograf] Auth secrets

### DIFF
--- a/stable/chronograf/README.md
+++ b/stable/chronograf/README.md
@@ -43,8 +43,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The configurable parameters of the Chronograf chart and 
-their descriptions can be seen in `values.yaml`. The [full image documentation](https://quay.io/influxdb/chronograf) contains more information about running Chronograf in docker.
+The configurable parameters of the Chronograf chart and their descriptions can be seen in `values.yaml`. The [full image documentation](https://quay.io/influxdb/chronograf) contains more information about running Chronograf in docker.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -69,3 +68,7 @@ $ helm install --name my-release -f values.yaml stable/chronograf
 The [Chronograf](https://quay.io/influxdb/chronograf) image stores data in the `/var/lib/chronograf` directory in the container.
 
 The chart optionally mounts a [Persistent Volume](kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning.
+
+## Authentication
+
+To enable Github authentication, follow the [Chronograf auth instructions](https://github.com/influxdata/chronograf/blob/master/docs/auth.md) and set the secrets in your `values.yaml` under `auth`, then set `enabled: true`.

--- a/stable/chronograf/templates/deployment.yaml
+++ b/stable/chronograf/templates/deployment.yaml
@@ -34,6 +34,24 @@ spec:
           mountPath: /var/lib/chronograf
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.auth.enabled }}
+        env:
+          - name: GH_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}-secrets
+                key: github_client_id
+          - name: GH_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}-secrets
+                key: github_client_secret
+          - name: TOKEN_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}-secrets
+                key: token_secret
+{{- end }}
       volumes:
         - name: data
         {{- if .Values.persistence.enabled }}

--- a/stable/chronograf/templates/secrets.yaml
+++ b/stable/chronograf/templates/secrets.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.auth.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "fullname" . }}-secrets
+type: Opaque
+data:
+  {{- if .Values.auth.github.client_id }}
+  github_client_id: {{ .Values.auth.github.client_id | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.auth.github.client_secret }}
+  github_client_secret: {{ .Values.auth.github.client_secret | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.auth.token_secret }}
+  token_secret: {{ .Values.auth.token_secret | b64enc | quote }}
+  {{- end }}
+{{- end -}}

--- a/stable/chronograf/values.yaml
+++ b/stable/chronograf/values.yaml
@@ -39,3 +39,10 @@ ingress:
   hostname: chronograf.foobar.com
   annotations:
     kubernetes.io/ingress.class: "nginx"
+
+auth:
+  enabled: false
+  github:
+    client_id: your_client_id
+    client_secret: your_secret
+  token_secret: a_random_token


### PR DESCRIPTION
Auth in Chronograf is enabled by [setting three environment variables](https://github.com/influxdata/chronograf/blob/master/docs/auth.md). These variables are sensitive, so they're stored in a Secret.

I've left auth disabled by default, but setting `enabled: true` supplying the secrets will enable it.