### PR TITLE
[stable/heapster] Add heapster to chart repository

### DIFF
--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+description: A helm chart to deploy Heapster to Kubernetes
+name: heapster
+version: 0.1.0
+sources:
+  - https://github.com/kubernetes/heapster
+  - https://github.com/kubernetes/contrib/tree/master/addon-resizer
+keywords:
+  - metrics
+  - cadvisor
+  - monitoring
+maintainers:
+- name: Jose Aguirre
+  email: jose.g.aguirre@intel.com
+engine: gotpl

--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: A helm chart to deploy Heapster to Kubernetes
+description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
 version: 0.1.0
 sources:

--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -1,12 +1,11 @@
 # Heapster
 
-##  Container Cluster Monitoring and Performance Analysis
+[Heapster](https://github.com/kubernetes/heapster) enables Container Cluster Monitoring and Performance Analysis. It collects and interprets various signals like compute resource usage, lifecycle events, etc, and exports cluster metrics via REST endpoints.
 
-[Heapster](https://github.com/kubernetes/heapster) collects and interprets various signals like compute resource usage, lifecycle events, etc, and exports cluster metrics via REST endpoints. 
 ## QuickStart
 
 ```bash
-$ helm install stable/heapster 
+$ helm install stable/heapster
 ```
 
 ## Installing the Chart
@@ -29,8 +28,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The default configuration values for this chart are listed in `values.yaml`. 
-
+The default configuration values for this chart are listed in `values.yaml`.
 
 | Parameter                             | Description                         | Default                                           |
 |---------------------------------------|-------------------------------------|---------------------------------------------------|
@@ -46,7 +44,7 @@ The default configuration values for this chart are listed in `values.yaml`.
 | `command`                             | Commands for heapster pod           | "/heapster --source=kubernetes.summary_api:''     |
 | `resizer.enabled`                     | If enabled, scale resources         | true                                              |
 
-Below table only applicable if `resizer.enabled` is `true`. More information on resizer can be found [here](https://github.com/kubernetes/contrib/blob/master/addon-resizer/README.md).
+The table below is only applicable if `resizer.enabled` is `true`. More information on resizer can be found [here](https://github.com/kubernetes/contrib/blob/master/addon-resizer/README.md).
 
 | Parameter                             | Description                         | Default                                           |
 |---------------------------------------|-------------------------------------|---------------------------------------------------|

--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -1,0 +1,58 @@
+# Heapster
+
+##  Container Cluster Monitoring and Performance Analysis
+
+[Heapster](https://github.com/kubernetes/heapster) collects and interprets various signals like compute resource usage, lifecycle events, etc, and exports cluster metrics via REST endpoints. 
+## QuickStart
+
+```bash
+$ helm install stable/heapster 
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/heapster
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The default configuration values for this chart are listed in `values.yaml`. 
+
+
+| Parameter                             | Description                         | Default                                           |
+|---------------------------------------|-------------------------------------|---------------------------------------------------|
+| `image.repository`                    | Repository for container image      | gcr.io/google_containers/heapster                 |
+| `image.tag`                           | Container image tag                 | v1.3.0-beta.0                                     |
+| `image.pullPolicy`                    | Image pull policy                   | IfNotPresent                                      |
+| `service.name`                        | Service port name                   | api                                               |
+| `service.type`                        | Type for the service                | ClusterIP                                         |
+| `service.externalPort`                | Service external port               | 8082                                              |
+| `service.internalPort`                | Service internal port               | 8082                                              |
+| `resources.limits`                    | Server resource  limits             | requests: {cpu: 100m, memory: 128Mi}              |
+| `resources.requests`                  | Server resource requests            | requests: {cpu: 100m, memory: 128Mi}              |
+| `command`                             | Commands for heapster pod           | "/heapster --source=kubernetes.summary_api:''     |
+| `resizer.enabled`                     | If enabled, scale resources         | true                                              |
+
+Below table only applicable if `resizer.enabled` is `true`. More information on resizer can be found [here](https://github.com/kubernetes/contrib/blob/master/addon-resizer/README.md).
+
+| Parameter                             | Description                         | Default                                           |
+|---------------------------------------|-------------------------------------|---------------------------------------------------|
+| `resizer.image.repository`            | Repository for container image      | gcr.io/google_containers/heapster                 |
+| `resizer.image.tag`                   | Container image tag                 | v1.3.0-beta.0                                     |
+| `resizer.image.pullPolicy`            | Image pull policy                   | IfNotPresent                                      |
+| `resizer.resources.limits`            | Server resource  limits             | requests: {cpu: 50m, memory: 90Mi}                |
+| `resizer.resources.requests`          | Server resource requests            | requests: {cpu: 50m, memory: 90Mi}                |
+| `resizer.flags`                       | Flags for pod nanny command         | Defaults set in values.yaml                       |

--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -35,7 +35,7 @@ The default configuration values for this chart are listed in `values.yaml`.
 | Parameter                             | Description                         | Default                                           |
 |---------------------------------------|-------------------------------------|---------------------------------------------------|
 | `image.repository`                    | Repository for container image      | gcr.io/google_containers/heapster                 |
-| `image.tag`                           | Container image tag                 | v1.3.0-beta.0                                     |
+| `image.tag`                           | Container image tag                 | v1.3.0                                            |
 | `image.pullPolicy`                    | Image pull policy                   | IfNotPresent                                      |
 | `service.name`                        | Service port name                   | api                                               |
 | `service.type`                        | Type for the service                | ClusterIP                                         |
@@ -51,7 +51,7 @@ Below table only applicable if `resizer.enabled` is `true`. More information on 
 | Parameter                             | Description                         | Default                                           |
 |---------------------------------------|-------------------------------------|---------------------------------------------------|
 | `resizer.image.repository`            | Repository for container image      | gcr.io/google_containers/heapster                 |
-| `resizer.image.tag`                   | Container image tag                 | v1.3.0-beta.0                                     |
+| `resizer.image.tag`                   | Container image tag                 | v1.3.0                                            |
 | `resizer.image.pullPolicy`            | Image pull policy                   | IfNotPresent                                      |
 | `resizer.resources.limits`            | Server resource  limits             | requests: {cpu: 50m, memory: 90Mi}                |
 | `resizer.resources.requests`          | Server resource requests            | requests: {cpu: 50m, memory: 90Mi}                |

--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -48,8 +48,8 @@ The table below is only applicable if `resizer.enabled` is `true`. More informat
 
 | Parameter                             | Description                         | Default                                           |
 |---------------------------------------|-------------------------------------|---------------------------------------------------|
-| `resizer.image.repository`            | Repository for container image      | gcr.io/google_containers/heapster                 |
-| `resizer.image.tag`                   | Container image tag                 | v1.3.0                                            |
+| `resizer.image.repository`            | Repository for container image      | gcr.io/google_containers/addon-resizer            |
+| `resizer.image.tag`                   | Container image tag                 | 1.7                                               |
 | `resizer.image.pullPolicy`            | Image pull policy                   | IfNotPresent                                      |
 | `resizer.resources.limits`            | Server resource  limits             | requests: {cpu: 50m, memory: 90Mi}                |
 | `resizer.resources.requests`          | Server resource requests            | requests: {cpu: 50m, memory: 90Mi}                |

--- a/stable/heapster/templates/NOTES.txt
+++ b/stable/heapster/templates/NOTES.txt
@@ -1,14 +1,14 @@
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "service.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "service.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "service.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "service.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.externalPort }}
 {{- end }}

--- a/stable/heapster/templates/NOTES.txt
+++ b/stable/heapster/templates/NOTES.txt
@@ -1,11 +1,11 @@
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }}-service)
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}-service'
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}

--- a/stable/heapster/templates/NOTES.txt
+++ b/stable/heapster/templates/NOTES.txt
@@ -1,0 +1,14 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }}-service)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}-service'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.externalPort }}
+{{- end }}

--- a/stable/heapster/templates/_helpers.tpl
+++ b/stable/heapster/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/heapster/templates/_helpers.tpl
+++ b/stable/heapster/templates/_helpers.tpl
@@ -14,3 +14,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a service name that defaults to app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "service.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- .Values.service.nameOverride | default (printf "%s-%s" .Release.Name $name) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/heapster/templates/deployment.yaml
+++ b/stable/heapster/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.service.internalPort }}
+          initialDelaySeconds: 180
+          timeoutSeconds: 5
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+        command:
+          {{- range .Values.command }}
+          - {{ . | quote }}
+          {{- end }}
+{{ if .Values.resizer.enabled }}
+      - name: {{ .Chart.Name }}-nanny
+        {{ with .Values.resizer }}
+        image: "{{ .image.repository }}:{{ .image.tag }}"
+        imagePullPolicy: {{ .image.pullPolicy }}
+        resources:
+{{ toYaml .resources | indent 12 }}
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        {{- end }}
+        command:
+          - "/pod_nanny"
+          - "--deployment={{ template "fullname" . }}"
+          - "--container={{ .Chart.Name }}"
+          {{- range .Values.resizer.flags }}
+          - {{ . | quote }}
+          {{- end }}
+{{- end -}}

--- a/stable/heapster/templates/service.yaml
+++ b/stable/heapster/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-service
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "fullname" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/stable/heapster/templates/service.yaml
+++ b/stable/heapster/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "service.fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "fullname" . }}
@@ -13,6 +13,5 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
   selector:
     app: {{ template "fullname" . }}

--- a/stable/heapster/templates/service.yaml
+++ b/stable/heapster/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-service
+  name: {{ template "fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "fullname" . }}

--- a/stable/heapster/values.yaml
+++ b/stable/heapster/values.yaml
@@ -3,7 +3,7 @@
 replicaCount: 1
 image:
   repository: gcr.io/google_containers/heapster
-  tag: v1.3.0-beta.0
+  tag: v1.3.0
   pullPolicy: IfNotPresent
 service:
   name: api

--- a/stable/heapster/values.yaml
+++ b/stable/heapster/values.yaml
@@ -6,10 +6,12 @@ image:
   tag: v1.3.0
   pullPolicy: IfNotPresent
 service:
-  name: api
   type: ClusterIP
   externalPort: 8082
   internalPort: 8082
+  ## This allows an overide of the heapster service name
+  ## Default: {{ template "fullname" . }}
+  # nameOverride:
 resources:
   limits:
     cpu: 100m

--- a/stable/heapster/values.yaml
+++ b/stable/heapster/values.yaml
@@ -1,0 +1,59 @@
+## Default values for heapster.
+##
+replicaCount: 1
+image:
+  repository: gcr.io/google_containers/heapster
+  tag: v1.3.0-beta.0
+  pullPolicy: IfNotPresent
+service:
+  name: api
+  type: ClusterIP
+  externalPort: 8082
+  internalPort: 8082
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+## Heapster command and arguments
+## Default source=kubernetes.summary_api:''
+## ref: https://github.com/kubernetes/heapster/blob/master/docs/source-configuration.md
+##
+## By default sink not set
+## ref: https://github.com/kubernetes/heapster/blob/master/docs/sink-configuration.md
+##
+command:
+- "/heapster"
+- "--source=kubernetes.summary_api:''"
+
+## Resizer scales resources linearly with the number of nodes in the cluster
+## Resizer is enabled by default
+##
+resizer:
+  enabled: true
+  image:
+    repository: gcr.io/google_containers/addon-resizer
+    tag: 1.7
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 50m
+      memory: 90Mi
+    requests:
+      cpu: 50m
+      memory: 90Mi
+
+  ## Flags used for /pod_nanny command
+  ## container and deployment flags already determined chart name
+  ## ref: https://github.com/kubernetes/contrib/blob/master/addon-resizer/README.md
+  ##
+  flags:
+  - "--cpu=150m"
+  - "--extra-cpu=10m"
+  - "--memory=200Mi"
+  - "--extra-memory=6Mi"
+  - "--threshold=5"
+  - "--poll-period=300000"


### PR DESCRIPTION
My use case for this chart would be to test custom sinks and sources without needing to modify cluster add-ons.  This is my first stab at this chart so I just thought I would share.  