### PR TITLE
[stable/kube2iam] No default resources

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.2.0
+version: 0.2.2-1
 description: Provide IAM credentials to pods based on annotations.
 keywords:
   - kube2iam

--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.2.2-1
+version: 0.2.1
 description: Provide IAM credentials to pods based on annotations.
 keywords:
   - kube2iam

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -50,7 +50,7 @@ Parameter | Description | Default
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to be added to pods | `{}`
-`resources` | pod resource requests & limits | `limits: {cpu: 4m, memory: 16Mi}, requests: {cpu: 4m, memory: 16Mi}`
+`resources` | pod resource requests & limits | `{}`
 `verbose` | Enable verbose output | `false`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -23,12 +23,12 @@ nodeSelector: {}
 ##
 podAnnotations: {}
 
-resources:
-  limits:
-    cpu: 4m
-    memory: 16Mi
-  requests:
-    cpu: 4m
-    memory: 16Mi
+resources: {}
+  # limits:
+  #   cpu: 4m
+  #   memory: 16Mi
+  # requests:
+  #   cpu: 4m
+  #   memory: 16Mi
 
 verbose: false

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -16,6 +16,7 @@ image:
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
 nodeSelector: {}
 
 ## Annotations to be added to pods


### PR DESCRIPTION
Proposing we don't set default resource requests and limits. Can be difficult for an end-user to override, especially when it comes to [QoS classes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md).

Also adjusted semver to reference upstream versioning.