### PR TITLE
Updated aws-cluster-autoscaler Instructions

### DIFF
--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -2,7 +2,7 @@
 
 [The cluster autoscaler on AWS](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws) scales worker nodes within an AWS autoscaling group.
 
-## TL;DR;
+## TL;DR:
 
 ```console
 $ helm install stable/aws-cluster-autoscaler -f values.yaml
@@ -25,7 +25,7 @@ This chart bootstraps an aws-cluster-autoscaler deployment on a [Kubernetes](htt
 
 ## Installing the Chart
 
-In order for the chart to configure the aws-cluster-autoscaler properly during the installation process, you must provide some minimal configuration which can't rely on defaults. This includes at least one element in the `autoscalingGroups` array and it's three values: `name`, `minSize` and `maxSize`. These parameters cannot be passed to helm using the `--set` parameter at this time, so you must supply these using a `values.yaml` file such as:
+In order for the chart to configure the aws-cluster-autoscaler properly during the installation process, you must provide some minimal configuration which can't rely on defaults. This includes at least one element in the `autoscalingGroups` array and its three values: `name`, `minSize` and `maxSize`. These parameters cannot be passed to helm using the `--set` parameter at this time, so you must supply these using a `values.yaml` file such as:
 
 ```
 autoscalingGroups:
@@ -34,21 +34,15 @@ autoscalingGroups:
     minSize: 1
 ```
 
-To install the chart with a `values.yaml` file in the working directory execute the following:
+To install the chart with the release name `my-release`:
 
 ```console
-$ helm install stable/aws-cluster-autoscaler -f values.yaml
+$ helm install stable/aws-cluster-autoscaler --name my-release -f values.yaml
 ```
 
-You can also set the Helm name, which adds a prefix to the Kubernetes service name by using the `--name` parameter. The following will create a Helm release named `example` and Kubernetes service named `example-aws-cluster-autoscaler`:
+The command deploys aws-cluster-autoscaler on the Kubernetes cluster using the supplied configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
-```console
-$ helm install stable/aws-cluster-autoscaler -f values.yaml --name example
-```
-
-The install command deploys aws-cluster-autoscaler on the Kubernetes cluster using the supplied configuration. The [configuration](#configuration) section lists all of the parameters that can be configured during installation.
-
-> **Tip**: After installing, you can list all installations using `helm list`.
+> **Tip**: List all releases using `helm list`
 
 ## Verifying Installation
 
@@ -108,7 +102,6 @@ Parameter | Description | Default
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section.
 
-> **Tip**: You can download all of the defaults here: [values.yaml](values.yaml)
 
 You can also specify any non-array parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -1,11 +1,19 @@
 # aws-cluster-autoscaler
 
-[The cluster autoscaler on AWS](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws) scales worker nodes within an autoscaling group.
+[The cluster autoscaler on AWS](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws) scales worker nodes within an AWS autoscaling group.
 
 ## TL;DR;
 
 ```console
-$ helm install stable/aws-cluster-autoscaler
+$ helm install stable/aws-cluster-autoscaler -f values.yaml
+```
+Where `values.yaml` contains:
+
+```
+autoscalingGroups:
+  - name: your-asg-name
+    maxSize: 10
+    minSize: 1
 ```
 
 ## Introduction
@@ -17,15 +25,47 @@ This chart bootstraps an aws-cluster-autoscaler deployment on a [Kubernetes](htt
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release`:
+In order for the chart to configure the aws-cluster-autoscaler properly during the installation process, you must provide some minimal configuration which can't rely on defaults. This includes at least one element in the `autoscalingGroups` array and it's three values: `name`, `minSize` and `maxSize`. These parameters cannot be passed to helm using the `--set` parameter at this time, so you must supply these using a `values.yaml` file such as:
 
-```console
-$ helm install stable/aws-cluster-autoscaler --name my-release
+```
+autoscalingGroups:
+  - name: your-asg-name
+    maxSize: 10
+    minSize: 1
 ```
 
-The command deploys aws-cluster-autoscaler on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+To install the chart with a `values.yaml` file in the working directory execute the following:
 
-> **Tip**: List all releases using `helm list`
+```console
+$ helm install stable/aws-cluster-autoscaler -f values.yaml
+```
+
+You can also set the Helm name, which adds a prefix to the Kubernetes service name by using the `--name` parameter. The following will create a Helm release named `example` and Kubernetes service named `example-aws-cluster-autoscaler`:
+
+```console
+$ helm install stable/aws-cluster-autoscaler -f values.yaml --name example
+```
+
+The install command deploys aws-cluster-autoscaler on the Kubernetes cluster using the supplied configuration. The [configuration](#configuration) section lists all of the parameters that can be configured during installation.
+
+> **Tip**: After installing, you can list all installations using `helm list`.
+
+## Verifying Installation
+
+The chart will succeed even if the three required parameters are not supplied. To verify the aws-cluster-autoscaler is configured properly find a pod that the deployment created and describe it. It must have a `--nodes` argument supplied to the `./cluster-autoscaler` app under `Command`. For example (all other values are omitted for brevity):
+
+```
+Containers:
+  aws-cluster-autoscaler:
+    Command:
+      ./cluster-autoscaler
+      --cloud-provider=aws
+      --nodes=1:10:your-asg-name
+      --scale-down-delay=10m
+      --skip-nodes-with-local-storage=false
+      --skip-nodes-with-system-pods=true
+      --v=4
+```
 
 ## Uninstalling the Chart
 
@@ -43,9 +83,9 @@ The following tables lists the configurable parameters of the aws-cluster-autosc
 
 Parameter | Description | Default
 --- | --- | ---
-`autoscalingGroups[].name` | autoscaling group name | none
-`autoscalingGroups[].maxSize` | maximum autoscaling group size | none
-`autoscalingGroups[].minSize` | minimum autoscaling group size | none
+`autoscalingGroups[].name` | autoscaling group name | None. You *must* supply at least one.
+`autoscalingGroups[].maxSize` | maximum autoscaling group size | None. You *must* supply at least one.
+`autoscalingGroups[].minSize` | minimum autoscaling group size | None. You *must* supply at least one.
 `awsRegion` | AWS region | `us-east-1`
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
 `image.tag` | Image tag | `v0.4.0`
@@ -66,23 +106,20 @@ Parameter | Description | Default
 `skipNodes.withLocalStorage` | don't terminate nodes running pods that use local storage | `false`
 `skipNodes.withSystemPods` | don't terminate nodes running pods in the `kube-system` namespace | `true`
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section.
+
+> **Tip**: You can download all of the defaults here: [values.yaml](values.yaml)
+
+You can also specify any non-array parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 $ helm install stable/aws-cluster-autoscaler --name my-release \
     --set awsRegion=us-west-1
 ```
 
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
-
-```console
-$ helm install stable/aws-cluster-autoscaler --name my-release -f values.yaml
-```
-
-> **Tip**: You can use the default [values.yaml](values.yaml)
-
 ## IAM Permissions
 The worker running the cluster autoscaler will need access to certain resources and actions:
+
 ```
 {
     "Version": "2012-10-17",


### PR DESCRIPTION
The aws-cluster-autoscaler instructions were revamped to describe the
required configuration parameters, how to supply them, and an example.

Also added instructions on how to verify the required parameters are
successfully configured.