### PR TITLE
[stable/prometheus] Fixing warnings in kubectl get events missing path

### DIFF
--- a/stable/prometheus/templates/alertmanager-ingress.yaml
+++ b/stable/prometheus/templates/alertmanager-ingress.yaml
@@ -21,7 +21,8 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - backend:
+          - path: /
+            backend:
               serviceName: {{ printf "%s-%s" $releaseName "alerts" | trunc 63 }}
               servicePort: {{ $servicePort }}
   {{- end -}}

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -21,7 +21,8 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - backend:
+          - path: /
+            backend:
               serviceName: {{ printf "%s-%s" $releaseName "server" | trunc 63 }}
               servicePort: {{ $servicePort }}
   {{- end -}}


### PR DESCRIPTION
From kubectl get event: `deploy-prom-server   Ingress             Warning   MAPPING   {nginx-ingress-controller }   Ingress rule 'default/deploy-prom-server' contains no path definition. Assuming /`

