### PR TITLE
Gogs chart

### DIFF
--- a/incubator/gogs/.helmignore
+++ b/incubator/gogs/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+description: "Gogs: Go Git Service"
+name: gogs
+version: 0.2.0
+home: https://gogs.io/
+icon: https://gogs.io/img/favicon.ico
+keywords:
+  - git

--- a/incubator/gogs/README.md
+++ b/incubator/gogs/README.md
@@ -1,0 +1,72 @@
+# Gogs Helm Chart
+
+[Gogs][] is a painless self-hosted Git service.
+
+## TL;DR;
+
+```console
+$ helm install incubator/gogs
+```
+
+## Introduction
+
+This chart bootstraps a [Gogs][] deployment on a [Kubernetes][] cluster using
+the [Helm][] package manager.
+
+## Prerequisites Details
+
+* PV support on underlying infrastructure (if persistence is required)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release incubator/gogs
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes nearly all the Kubernetes components associated with the
+chart and deletes the release.
+
+## Configuration
+
+The following tables lists some of the configurable parameters of the Gogs
+chart and their default values.
+
+| Parameter                        | Description                                                  | Default                                                    |
+| -----------------------          | ----------------------------------                           | ---------------------------------------------------------- |
+| `imageRepository`                | Gogs image                                                   | `gogs/gogs`                                                |
+| `imageTag`                       | Gogs image version                                           | `0.10.18`                                                  |
+| `imagePullPolicy`                | Gogs image pull policy                                       | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `postgresql.install`             | Weather or not to install PostgreSQL dependency              | `true`                                                     |
+| `postgresql.postgresHost`        | PostgreSQL host (if `postgresql.install == false`)           | `nil`                                                      |
+| `postgresql.postgresUser`        | PostgreSQL User to create                                    | `gogs`                                                     |
+| `postgresql.postgresPassword`    | PostgreSQL Password for the new user                         | `gogs`                                                     |
+| `postgresql.postgresDatabase`    | PostgreSQL Database to create                                | `gogs`                                                     |
+| `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true`                                                     |
+
+See [values.yaml](values.yaml) for a more complete list, and links to the Gogs documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml incubator/gogs
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+[Gogs]: https://github.com/gogits/gogs
+[Kubernetes]: https://kubernetes.io
+[Helm]: https://helm.sh

--- a/incubator/gogs/requirements.lock
+++ b/incubator/gogs/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- condition: ""
+  enabled: false
+  name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  tags: null
+  version: 0.6.0
+digest: sha256:a9c23d133496833af520073553aff46280d9cd53d09c87bd2c8202c812dbf10a
+generated: 2017-03-22T20:02:35.379453692-04:00

--- a/incubator/gogs/requirements.yaml
+++ b/incubator/gogs/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: postgresql
+    version: 0.6.0
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: postgresql.install

--- a/incubator/gogs/templates/NOTES.txt
+++ b/incubator/gogs/templates/NOTES.txt
@@ -1,0 +1,23 @@
+1. Get the Gogs URL by running:
+
+{{- if contains "NodePort" .Values.serviceType }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/
+
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP/
+{{- else if contains "ClusterIP"  .Values.serviceType }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}
+
+2. Register a user.  The first user registered will be the administrator.

--- a/incubator/gogs/templates/_helpers.tpl
+++ b/incubator/gogs/templates/_helpers.tpl
@@ -3,16 +3,16 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -25,11 +25,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{/*
 Create a default fully qualified postgresql name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "postgresql.fullname" -}}
 {{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/incubator/gogs/templates/_helpers.tpl
+++ b/incubator/gogs/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified server name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "gogs.fullname" -}}
+{{- printf "%s-%s" .Release.Name "gogs" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified postgresql name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Determine database user based on use of postgresql dependency.
+*/}}
+{{- define "database.host" -}}
+{{- if .Values.postgresql.install -}}
+{{- template "postgresql.fullname" . -}}
+{{- else -}}
+{{- .Values.service.gogs.databaseHost | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine database user based on use of postgresql dependency.
+*/}}
+{{- define "database.user" -}}
+{{- if .Values.postgresql.install -}}
+{{- .Values.postgresql.postgresUser | quote -}}
+{{- else -}}
+{{- .Values.service.gogs.databaseUser | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine database password based on use of postgresql dependency.
+*/}}
+{{- define "database.password" -}}
+{{- if .Values.postgresql.install -}}
+{{- .Values.postgresql.postgresPassword | quote -}}
+{{- else -}}
+{{- .Values.service.gogs.databasePassword | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Determine database name based on use of postgresql dependency.
+*/}}
+{{- define "database.name" -}}
+{{- if .Values.postgresql.install -}}
+{{- .Values.postgresql.postgresDatabase | quote -}}
+{{- else -}}
+{{- .Values.service.gogs.databaseName | quote -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/gogs/templates/configmap-tcp.yaml
+++ b/incubator/gogs/templates/configmap-tcp.yaml
@@ -1,0 +1,13 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "fullname" . }}-tcp
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ default "gogs" .Values.service.nameOverride }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: tcp-{{ template "gogs.fullname" . }}-ssh
+data:
+  2222: default/{{ template "fullname" . }}:ssh
+

--- a/incubator/gogs/templates/configmap.yaml
+++ b/incubator/gogs/templates/configmap.yaml
@@ -1,4 +1,3 @@
----
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/incubator/gogs/templates/configmap.yaml
+++ b/incubator/gogs/templates/configmap.yaml
@@ -72,16 +72,3 @@ data:
     SHOW_FOOTER_VERSION = {{ .Values.service.gogs.otherShowFooterVersion }}
     SHOW_FOOTER_TEMPLATE_LOAD_TIME = {{ .Values.service.gogs.otherShowFooterTemplateLoadTime }}
 
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  labels:
-    app: {{ template "fullname" . }}-tcp
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    component: {{ default "gogs" .Values.service.nameOverride }}
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-  name: tcp-{{ template "gogs.fullname" . }}-ssh
-data:
-  2222: default/{{ template "fullname" . }}:ssh

--- a/incubator/gogs/templates/configmap.yaml
+++ b/incubator/gogs/templates/configmap.yaml
@@ -1,0 +1,88 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "fullname" . }}-config
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ default "gogs" .Values.service.nameOverride }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "gogs.fullname" . }}-config
+data:
+  app.ini: |-
+    APP_NAME = {{ .Values.service.gogs.appName }}
+    RUN_MODE = {{ .Values.service.gogs.runMode }}
+
+    [repository.upload]
+    ENABLED = {{ .Values.service.gogs.repositoryUploadEnabled }}
+    ALLOWED_TYPES = {{ .Values.service.gogs.repositoryUploadAllowedTypes }}
+    MAX_FILE_SIZE = {{ .Values.service.gogs.repositoryUploadMaxFileSize }}
+    MAX_FILES = {{ .Values.service.gogs.repositoryUploadMaxFiles }}
+
+    [server]
+    PROTOCOL = http
+    DOMAIN = {{ .Values.service.gogs.serverDomain }}
+    ROOT_URL = {{ .Values.service.gogs.serverRootUrl }}
+    LANDING_PAGE = {{ .Values.service.gogs.serverLandingPage }}
+
+    [service]
+    ENABLE_CAPTCHA = {{ .Values.service.gogs.serviceEnableCaptcha }}
+    ACTIVE_CODE_LIVE_MINUTES = 180
+    RESET_PASSWD_CODE_LIVE_MINUTES = 180
+    REGISTER_EMAIL_CONFIRM = {{ .Values.service.gogs.serviceRegisterEmailConfirm }}
+    DISABLE_REGISTRATION = {{ .Values.service.gogs.serviceDisableRegistration }}
+    REQUIRE_SIGNIN_VIEW = {{ .Values.service.gogs.serviceRequireSignInView }}
+    ENABLE_NOTIFY_MAIL = {{ .Values.service.gogs.serviceEnableNotifyMail }}
+    ENABLE_REVERSE_PROXY_AUTHENTICATION = false
+    ENABLE_REVERSE_PROXY_AUTO_REGISTRATION = false
+
+    [database]
+    DB_TYPE = {{ .Values.service.gogs.databaseType | quote }}
+    HOST = {{ template "database.host" . }}
+    NAME = {{ template "database.name" . }}
+    USER = {{ template "database.user" . }}
+    PASSWD = {{ template "database.password" . }}
+
+    [security]
+    INSTALL_LOCK = true
+    SECRET_KEY = {{ default "" .Values.service.gogs.securitySecretKey | b64enc | quote }}
+
+    [ui]
+    EXPLORE_PAGING_NUM = {{ .Values.service.gogs.uiExplorePagingNum }}
+    ISSUE_PAGING_NUM = {{ .Values.service.gogs.uiIssuePagingNum }}
+    FEED_MAX_COMMIT_NUM = {{ .Values.service.gogs.uiFeedMaxCommitNum }}
+
+    [cache]
+    ADAPTER = {{ .Values.service.gogs.cacheAdapter }}
+    INTERVAL = {{ .Values.service.gogs.cacheInterval }}
+    HOST = {{ .Values.service.gogs.cacheHost }}
+
+    [webhook]
+    QUEUE_LENGTH = {{ .Values.service.gogs.webhookQueueLength }}
+    DELIVER_TIMEOUT = {{ .Values.service.gogs.webhookDeliverTimeout }}
+    SKIP_TLS_VERIFY = {{ .Values.service.gogs.webhookSkipTlsVerify }}
+    PAGING_NUM = {{ .Values.service.gogs.webhookPagingNum }}
+
+    [log]
+    MODE = {{ .Values.service.gogs.logMode }}
+    LEVEL = {{ .Values.service.gogs.logLevel }}
+
+    [other]
+    SHOW_FOOTER_BRANDING = {{ .Values.service.gogs.otherShowFooterBranding }}
+    SHOW_FOOTER_VERSION = {{ .Values.service.gogs.otherShowFooterVersion }}
+    SHOW_FOOTER_TEMPLATE_LOAD_TIME = {{ .Values.service.gogs.otherShowFooterTemplateLoadTime }}
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "fullname" . }}-tcp
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ default "gogs" .Values.service.nameOverride }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: tcp-{{ template "gogs.fullname" . }}-ssh
+data:
+  2222: default/{{ template "fullname" . }}:ssh

--- a/incubator/gogs/templates/deployment.yaml
+++ b/incubator/gogs/templates/deployment.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/incubator/gogs/templates/deployment.yaml
+++ b/incubator/gogs/templates/deployment.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - containerPort: 3000
+            - containerPort: 2222
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+          env:
+            # https://github.com/gogits/gogs/tree/master/docker#container-options
+            - name: SOCAT_LINK
+              value: "false"
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /data/gogs/conf/app.ini
+              subPath: app.ini
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "fullname" . }}-config
+        - name: data
+      {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "fullname" . }}
+      {{- else }}
+          emptyDir: {}
+      {{- end -}}

--- a/incubator/gogs/templates/ingress.yaml
+++ b/incubator/gogs/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.service.ingress.enabled -}}
+{{- $releaseName := .Release.Name -}}
+{{- $serviceName := default "gogs" .Values.service.nameOverride -}}
+{{- $httpPort := .Values.service.httpPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "gogs.fullname" . }}
+  labels:
+    app: {{ template "gogs.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- range $key, $value := .Values.service.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range .Values.service.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ printf "%s-%s" $releaseName $serviceName | trunc 63 | trimSuffix "-" }}
+              servicePort: {{ $httpPort }}
+    {{- end -}}
+{{- end -}}

--- a/incubator/gogs/templates/pvc.yaml
+++ b/incubator/gogs/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/incubator/gogs/templates/secrets.yaml
+++ b/incubator/gogs/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "gogs.fullname" . }}
+  labels:
+    app: {{ template "gogs.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  postgresql-user: {{ .Values.postgresql.postgresUser | b64enc | quote }}

--- a/incubator/gogs/templates/service.yaml
+++ b/incubator/gogs/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: {{ .Values.serviceType }}
+  ports:
+  - port: {{ .Values.service.httpPort | int }}
+    targetPort: 3000
+    name: {{ default "gogs" .Values.service.nameOverride }}-http
+  - port: {{ .Values.service.sshPort | int }}
+    targetPort: 2222
+    name: {{ default "gogs" .Values.service.nameOverride }}-ssh
+  selector:
+    app: {{ template "fullname" . }}

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -1,0 +1,270 @@
+---
+## Override the name of the Chart.
+##
+# nameOverride:
+
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer
+##
+serviceType: NodePort
+
+replicaCount: 1
+
+image: gogs/gogs
+imageTag: 0.10.18
+imagePullPolicy: IfNotPresent
+
+service:
+  ## Override the components name (defaults to service).
+  ##
+  # nameOverride:
+
+  ## HTTP listen port.
+  ## ref: https://gogs.io/docs/advanced/configuration_cheat_sheet
+  ##
+  httpPort: 80
+
+  ## SSH listen port.
+  ## ref: https://gogs.io/docs/advanced/configuration_cheat_sheet
+  ##
+  sshPort: 22
+
+  ## Gogs configuration values
+  ## ref: https://gogs.io/docs/advanced/configuration_cheat_sheet
+  ##
+  gogs:
+
+    ## Application name, can be your company or team name.
+    ##
+    appName: 'Gogs'
+
+    ## Either "dev", "prod" or "test".
+    ##
+    runMode: 'prod'
+
+    ## Force every new repository to be private.
+    ##
+    forcePrivate: false
+
+    ## Indicates whether or not to disable Git clone through HTTP/HTTPS. When
+    ## disabled, users can only perform Git operations via SSH.
+    ##
+    disableHttpGit: false
+
+    ## Indicates whether or not to enable repository file upload feature.
+    ##
+    repositoryUploadEnabled: true
+
+    ## File types that are allowed to be uploaded, e.g. image/jpeg|image/png.
+    ## Leave empty means allow any file typ
+    ##
+    repositoryUploadAllowedTypes:
+
+    ## Maximum size of each file in MB.
+    ##
+    repositoryUploadMaxFileSize: 3
+
+    ## Maximum number of files per upload.
+    ##
+    repositoryUploadMaxFiles: 5
+
+    ## Enable this to use captcha validation for registration.
+    ##
+    serviceEnableCaptcha: true
+
+    ## Users need to confirm e-mail for registration
+    ##
+    serviceRegisterEmailConfirm: false
+
+    ## Weather or not to allow users to register.
+    ##
+    serviceDisableRegistration: false
+
+    ## Weather or not sign in is required to view anything.
+    ##
+    serviceRequireSignInView: false
+
+    ## Mail notification
+    ##
+    serviceEnableNotifyMail: false
+
+    ## Either "memory", "redis", or "memcache", default is "memory"
+    ##
+    cacheAdapter: memory
+
+    ## For "memory" only, GC interval in seconds, default is 60
+    ##
+    cacheInterval: 60
+
+    ## For "redis" and "memcache", connection host address
+    ## redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
+    ## memcache: `127.0.0.1:11211`
+    ##
+    cacheHost:
+
+    ## Enable this to use captcha validation for registration.
+    ##
+    serverDomain: gogs.example.com
+
+    ## Full public URL of Gogs server.
+    ##
+    serverRootUrl: http://gogs.example.com/
+
+    ## Landing page for non-logged users, can be "home" or "explore"
+    ##
+    serverLandingPage: home
+
+    ## Either "mysql", "postgres" or "sqlite3", you can connect to TiDB with
+    ## MySQL protocol.  Default is to use the postgresql configuration included
+    ## with this chart.
+    ##
+    databaseType: postgres
+
+    ## Database host.  Unused unless `postgresql.install` is false.
+    ##
+    databaseHost:
+
+    ## Database user.  Unused unless `postgresql.install` is false.
+    ##
+    databaseUser:
+
+    ## Database password.  Unused unless `postgresql.install` is false.
+    ##
+    databasePassword:
+
+    ## Database password.  Unused unless `postgresql.install` is false.
+    ##
+    databaseName:
+
+    ## Hook task queue length, increase if webhook shooting starts hanging
+    ##
+    webhookQueueLength: 1000
+
+    ## Deliver timeout in seconds
+    ##
+    webhookDeliverTimeout: 5
+
+    ## Allow insecure certification
+    ##
+    webhookSkipTlsVerify: true
+
+    ## Number of history information in each page
+    ##
+    webhookPagingNum: 10
+
+    ## Can be "console" and "file", default is "console"
+    ## Use comma to separate multiple modes, e.g. "console, file"
+    ##
+    logMode: console
+
+    ## Either "Trace", "Info", "Warn", "Error", "Fatal", default is "Trace"
+    ##
+    logLevel: Trace
+
+    ## Undocumented, but you can take a guess.
+    ##
+    otherShowFooterBranding: false
+
+    ## Show version information about Gogs and Go in the footer
+    ##
+    otherShowFooterVersion: true
+
+    ## Show time of template execution in the footer
+    ##
+    otherShowFooterTemplateLoadTime: true
+
+    ## Change this value for your installation.
+    ##
+    securitySecretKey: "changeme"
+
+    ## Number of repositories that are showed in one explore page
+    ##
+    uiExplorePagingNum: 20
+
+    ## Number of issues that are showed in one page
+    ##
+    uiIssuePagingNum: 10
+
+    ## Number of maximum commits showed in one activity feed.
+    ## NOTE: This value is also used in how many commits a webhook will send.
+    ##
+    uiFeedMaxCommitNum: 5
+
+  ## Ingress configuration.
+  ## ref: https://kubernetes.io/docs/user-guide/ingress/
+  ##
+  ingress:
+    ## Enable Ingress.
+    ##
+    enabled: false
+
+    ## Annotations.
+    ##
+    # annotations:
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: 'true'
+
+    ## Hostnames.
+    ## Must be provided if Ingress is enabled.
+    ##
+    # hosts:
+    #   - gogs.domain.com
+
+    ## TLS configuration.
+    ## Secrets must be manually created in the namespace.
+    ##
+    # tls:
+    #   - secretName: gogs-tls
+    #     hosts:
+    #       - gogs.domain.com
+
+
+## Persistent Volume Storage configuration.
+## ref: https://kubernetes.io/docs/user-guide/persistent-volumes
+##
+persistence:
+  ## Enable persistence using Persistent Volume Claims.
+  ##
+  enabled: true
+
+  ## Persistent Volume Storage Class.
+  ##
+  # storageClass:
+
+  ## Persistent Volume Access Mode.
+  ##
+  accessMode: ReadWriteOnce
+
+  ## Persistent Volume Storage Size.
+  ##
+  size: 1Gi
+
+## Configuration values for the postgresql dependency.
+## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
+##
+postgresql:
+
+  ### Install PostgreSQL dependency
+  ##
+  install: true
+
+  ### PostgreSQL User to create.
+  ##
+  postgresUser: gogs
+
+  ## PostgreSQL Password for the new user.
+  ## If not set, a random 10 characters password will be used.
+  ##
+  postgresPassword: gogs
+
+  ## PostgreSQL Database to create.
+  ##
+  postgresDatabase: gogs
+
+  ## Persistent Volume Storage configuration.
+  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes
+  ##
+  persistence:
+    ## Enable PostgreSQL persistence using Persistent Volume Claims.
+    ##
+    enabled: true

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -1,4 +1,3 @@
----
 ## Override the name of the Chart.
 ##
 # nameOverride:


### PR DESCRIPTION
This adds a chart for Gogs (https://github.com/gogits/gogs).  It is currently functional for a development install (e.g., minikube).
