### PR TITLE
[stable/traefik] Fix invalid template variables

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
 # Lock step with the Traefik version, appended with -a, -b, etc. to denote versions of the chart
-version: 1.1.2-f
+version: 1.1.2-g
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/templates/acme-pvc.yaml
+++ b/stable/traefik/templates/acme-pvc.yaml
@@ -9,8 +9,8 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.acme.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.acme.persistence.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}


### PR DESCRIPTION
Currently the chart fails while rendering templates if ACME option is enabled.  This fixes the issue/typos.