### PR TITLE
telegraf: allow overriding protocol

### DIFF
--- a/stable/telegraf/templates/service.yaml
+++ b/stable/telegraf/templates/service.yaml
@@ -1,3 +1,4 @@
+{{ $statsd_protocol := .Values.single.service.statsd.protocol }}
 {{- if .Values.single.enabled -}}
 {{- if .Values.single.service.enabled -}}
 apiVersion: v1
@@ -19,6 +20,9 @@ spec:
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "statsd"
+    {{- if $statsd_protocol }}
+    protocol: {{ $statsd_protocol }}
+    {{- end }}
     {{- end }}
     {{- if eq $key "tcp-listener" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}

--- a/stable/telegraf/values.yaml
+++ b/stable/telegraf/values.yaml
@@ -69,7 +69,7 @@ daemonset:
 ##        insecure_skip_verify: false
 ##        data_format: "influx"
 ##      kafka:
-##        brokers: 
+##        brokers:
 ##          - "localhost:9092"
 ##        topic: "telegraf"
 ##        routing_tag: "host"
@@ -82,7 +82,7 @@ daemonset:
 ##        insecure_skip_verify: false
 ##        data_format: "influx"
 ##      mqtt:
-##        servers: 
+##        servers:
 ##          - "localhost:1883"
 ##        topic_prefix: "telegraf"
 ##        username: "telegraf"
@@ -93,7 +93,7 @@ daemonset:
 ##        insecure_skip_verify: false
 ##        data_format: "influx"
 ##      nats:
-##        servers: 
+##        servers:
 ##          - "nats://localhost:4222"
 ##        username: ""
 ##        password: ""
@@ -113,8 +113,8 @@ daemonset:
         totalcpu: true
         collect_cpu_time: false
       disk:
-        ignore_fs: 
-          - "tmpfs" 
+        ignore_fs:
+          - "tmpfs"
           - "devtmpfs"
       diskio:
       docker:
@@ -129,7 +129,7 @@ daemonset:
         url: "http://$HOSTNAME:10255"
         bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
         insecure_skip_verify: true
-        
+
 ## Configure the telegraf single instance here.
 ## Resource limits and outputs can be set seperately
 single:
@@ -150,11 +150,13 @@ single:
   service:
     enabled: true
     type: ClusterIP
-    
+##    statsd:
+##      protocol: "UDP"
+
   ## Exposed telegraf configuration
   ## For full list of possible values see `/docs/all-config-values.yaml` and `/docs/all-config-values.toml`
   ## ref: https://docs.influxdata.com/telegraf/v1.1/administration/configuration/
-  
+
   config:
 ##    global_tags:
 ##      dc: "us-east-1"
@@ -203,7 +205,7 @@ single:
 ##        insecure_skip_verify: false
 ##        data_format: "influx"
 ##      kafka:
-##        brokers: 
+##        brokers:
 ##          - "localhost:9092"
 ##        topic: "telegraf"
 ##        routing_tag: "host"
@@ -216,7 +218,7 @@ single:
 ##        insecure_skip_verify: false
 ##        data_format: "influx"
 ##      mqtt:
-##        servers: 
+##        servers:
 ##          - "localhost:1883"
 ##        topic_prefix: "telegraf"
 ##        username: "telegraf"
@@ -227,7 +229,7 @@ single:
 ##        insecure_skip_verify: false
 ##        data_format: "influx"
 ##      nats:
-##        servers: 
+##        servers:
 ##          - "nats://localhost:4222"
 ##        username: ""
 ##        password: ""
@@ -247,14 +249,14 @@ single:
         totalcpu: true
       system:
 ##      aerospike:
-##        servers: 
+##        servers:
 ##          - "localhost:3000"
 ##      apache:
-##        urls: 
+##        urls:
 ##          - "http://localhost/server-status?auto"
 ##      cassandra:
 ##        context: "/jolokia/read"
-##        servers: 
+##        servers:
 ##          - "myuser:mypassword@10.10.10.1:8778"
 ##          - "10.10.10.2:8778"
 ##          - ":8778"
@@ -276,8 +278,8 @@ single:
 ##        namespace: "AWS/ELB"
 ##        ratelimit: 10
 ##        metrics:
-##         names: 
-##          - "Latency" 
+##         names:
+##          - "Latency"
 ##          - "RequestCount"
 ##         dimensions:
 ##           name: "LoadBalancerName"
@@ -290,30 +292,30 @@ single:
 ##        password: ""
 ##        datacentre: ""
 ##      couchbase:
-##        servers: 
+##        servers:
 ##          - "http://localhost:8091"
 ##      couchdb:
-##        hosts: 
+##        hosts:
 ##          - "http://localhost:8086/_stats"
 ##      disque:
-##        servers: 
+##        servers:
 ##          - "localhost"
 ##      dns_query:
-##        servers: 
+##        servers:
 ##          - "8.8.8.8"
-##        domains: 
+##        domains:
 ##          - "."
 ##        record_type: "A"
 ##        port: 53
 ##        timeout: 2
 ##      dovecot:
-##        servers: 
+##        servers:
 ##          - "localhost:24242"
 ##        type: "global"
 ##        filters:
 ##          - ""
 ##      elasticsearch:
-##        servers: 
+##        servers:
 ##          - "http://localhost:9200"
 ##        http_timeout: "5s"
 ##        local: true
@@ -335,7 +337,7 @@ single:
 ##        ssl_key: "/etc/telegraf/key.pem"
 ##        insecure_skip_verify: false
 ##      haproxy:
-##        servers: 
+##        servers:
 ##          - "http://myhaproxy.com:1936/haproxy?stats"
       influxdb:
         urls:
@@ -354,13 +356,13 @@ single:
 ##        days_old: 0
 ##        campaign_id: ""
 ##      memcached:
-##        servers: 
+##        servers:
 ##          - "localhost:11211"
 ##        unix_sockets:
 ##          - "/var/run/memcached.sock"
 ##      mesos:
 ##        timeout: 100
-##        masters: 
+##        masters:
 ##          - "localhost:5050"
 ##        master_collections:
 ##          - "resources"
@@ -373,7 +375,7 @@ single:
 ##          - "evqueue"
 ##          - "registrar"
 ##        slaves:
-##          - 
+##          -
 ##        slave_collections:
 ##          - "resources"
 ##          - "agent"
@@ -382,11 +384,11 @@ single:
 ##          - "tasks"
 ##          - "messages"
 ##      mongodb:
-##        servers: 
+##        servers:
 ##          - "mongodb://user:password@127.0.0.1:27017"
 ##        gather_perdb_stats: false
 ##      mysql:
-##        servers: 
+##        servers:
 ##          - "tcp(127.0.0.1:3306)?tls=false"
 ##        perf_events_statements_digest_text_limit : 120
 ##        perf_events_statements_limit: 250
@@ -412,16 +414,16 @@ single:
 ##        expect: "ssh"
 ##        read_timeout: "1s"
 ##      nginx:
-##        urls: 
+##        urls:
 ##          - "http://nginx.nginx-ingress/nginx_status"
 ##      nsq:
-##        endpoints: 
+##        endpoints:
 ##          - "http://localhost:4151"
 ##      phpfpm:
-##        urls: 
+##        urls:
 ##          - "http://localhost/status"
 ##      ping:
-##        urls: 
+##        urls:
 ##          - "www.google.com"
 ##        count: 1
 ##        ping_interval: 1.0
@@ -429,13 +431,13 @@ single:
 ##        interface: ""
 ##      postgresql:
 ##        address: "postgres://user:password@localhost?sslmode=disable"
-##        ignored_databases: 
+##        ignored_databases:
 ##          - "postgres"
-##        databases: 
+##        databases:
 ##          - "app_production"
 ##          - "testing"
       prometheus:
-        urls: 
+        urls:
           - "https://kubernetes.default:443/metrics"
         name_prefix: "prom_"
         bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
@@ -452,31 +454,31 @@ single:
 ##       ssl_cert: "/etc/telegraf/cert.pem"
 ##       ssl_key: "/etc/telegraf/key.pem"
 ##       insecure_skip_verify: false
-##       nodes: 
+##       nodes:
 ##         - "rabbit@node1"
 ##         - "rabbit@node2"
 ##     raindrops:
-##       urls: 
+##       urls:
 ##         - "http://localhost:8080/_raindrops"
 ##     redis:
-##       servers: 
+##       servers:
 ##         - "tcp://localhost:6379"
 ##     rethinkdb:
-##       servers: 
+##       servers:
 ##         - "127.0.0.1:28015"
 ##     riak:
-##       servers: 
+##       servers:
 ##         - "http://localhost:8098"
 ##     sqlserver:
 ##       servers:
 ##         - "Server=192.168.1.10;Port=1433;User Id=<user>;Password=<pw>;app name=telegraf;log=1;"
 ##     twemproxy:
 ##       addr: "localhost:22222"
-##        pools: 
+##        pools:
 ##          - "redis_pool"
 ##          - "mc_pool"
 ##      zookeeper:
-##        servers: 
+##        servers:
 ##          - "localhost:2181"
 ##      http_listener:
 ##        service_address: ":8186"
@@ -486,7 +488,7 @@ single:
 ##        max_line_size: 0
       statsd:
         service_address: ":8125"
-        percentiles: 
+        percentiles:
           - 50
           - 95
           - 99


### PR DESCRIPTION
Allows users to change the protocol for Telegraf's StatsD from TCP to
UDP.