### PR TITLE
[stable/minecraft]  Chart is broken fix resources tag

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,5 +1,5 @@
 name: minecraft
-version: 0.1.2
+version: 0.1.3
 description: Minecraft server
 keywords:
 - game

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -19,7 +19,9 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: Always
         resources:
-          {{ include "toYaml" .Values.resources | indent 10 }}
+          requests:
+            memory: {{ .Values.resources.requests.memory }}
+            cpu: {{ .Values.resources.requests.cpu }}
         env:
         - name: EULA
           value: {{ .Values.minecraftServer.eula | quote }}

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -19,9 +19,7 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: Always
         resources:
-          requests:
-            memory: {{ .Values.resources.requests.memory }}
-            cpu: {{ .Values.resources.requests.cpu }}
+{{ toYaml .Values.resources | indent 10 }}
         env:
         - name: EULA
           value: {{ .Values.minecraftServer.eula | quote }}


### PR DESCRIPTION
As is the resources tag generates incorrectly spaced yaml in the deployment definition.  Removing the toYaml tag is less error prone