### PR TITLE
WIP: [stable/traefik] Keep basic auth user/passwd data in secret

### DIFF
--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -7,3 +7,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "fullname" -}}
 {{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "dashboardUsers" -}}
+{{- range $key, $value := .Values.dashboard.auth.basic -}}{{- printf "%s:%s\n" $key $value -}}{{- end -}}
+{{- end -}}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -63,6 +63,7 @@ data:
       {{- if .Values.dashboard.auth }}
       {{- if .Values.dashboard.auth.basic }}
       [web.auth.basic]
+        usersFile = "/dashboard/users"
         users = [{{ range $key, $value := .Values.dashboard.auth.basic }}"{{ $key }}:{{ $value }}",{{ end }}]
       {{- end}}
       {{- end}}

--- a/stable/traefik/templates/dashboard-users-secret.yaml
+++ b/stable/traefik/templates/dashboard-users-secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.dashboard.enabled }}
+{{- if .Values.dashboard.auth }}
+{{- if .Values.dashboard.auth.basic }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-dashboard-users
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  users: {{ include "dashboardUsers" . | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: config
+        {{- if .Values.dashboard.enabled }}
+        {{- if .Values.dashboard.auth }}
+        {{- if .Values.dashboard.auth.basic }}
+        - mountPath: /dashboard
+          name: dashboard-users
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.ssl.enabled }}
         - mountPath: /ssl
           name: ssl
@@ -70,6 +78,15 @@ spec:
       - name: config
         configMap:
           name: {{ template "fullname" . }}
+      {{- if .Values.dashboard.enabled }}
+      {{- if .Values.dashboard.auth }}
+      {{- if .Values.dashboard.auth.basic }}
+      - name: dashboard-users
+        secret:
+          secretName: {{ template "fullname" . }}-dashboard-users
+      {{- end }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.ssl.enabled }}
       - name: ssl
         secret:


### PR DESCRIPTION
@c-knowles you will be interested in this, I think. It's the follow-up to #414 

This depends on https://github.com/containous/traefik/pull/1189 being merged and included in a future Traefik release.

@c-knowles if you want to test drive, the Docker image `krancour/traefik:usersfile` is built from my fork of Traefik.