### PR TITLE
[incubator/mongodb-replicaset] Improve persistence configuration

### DIFF
--- a/incubator/mongodb-replicaset/templates/_helpers.tpl
+++ b/incubator/mongodb-replicaset/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/mongodb-replicaset/templates/mongodb-persistentvolumeclaim.yaml
+++ b/incubator/mongodb-replicaset/templates/mongodb-persistentvolumeclaim.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.persistentVolume.enabled -}}
+{{- if not .Values.persistentVolume.existingClaim -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+  {{- if .Values.persistentVolume.storageClass | quote }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistentVolume.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+  {{- range $key, $value := .Values.persistentVolume.annotations }}
+    {{ $key }}: {{ $value }}
+  {{- end }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "fullname" . }}
+spec:
+  accessModes:
+{{- range .Values.persistentVolume.accessModes }}
+  - {{ . | quote }}
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistentVolume.size | quote }}
+{{- end -}}
+{{- end -}}

--- a/incubator/mongodb-replicaset/templates/mongodb-petset.yaml
+++ b/incubator/mongodb-replicaset/templates/mongodb-petset.yaml
@@ -145,7 +145,7 @@ spec:
           timeoutSeconds: 5
         volumeMounts:
         - name: datadir
-          mountPath: /data/db
+          mountPath: {{ .Values.persistentVolume.mountPath }}
         - name: config
           mountPath: /config
       volumes:
@@ -154,13 +154,10 @@ spec:
           name: "{{.Release.Name}}-mongo-config"
       - name: workdir
         emptyDir: {}
-  volumeClaimTemplates:
-  - metadata:
-      name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: {{.Values.StorageClass}}
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: {{.Values.Storage}}
+      - name: datadir
+      {{- if .Values.persistentVolume.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "fullname" . }}{{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}

--- a/incubator/mongodb-replicaset/values.yaml
+++ b/incubator/mongodb-replicaset/values.yaml
@@ -16,6 +16,40 @@ InstallImageTag: "0.3"
 ImagePullPolicy: "Always"
 Cpu: "100m"
 Memory: "512Mi"
-Storage: "10Gi"
-StorageClass: generic
+
+persistentVolume:
+    ## If true, create/use a Persistent Volume Claim
+    ## If false, use emptyDir
+    ##
+    enabled: true
+
+    ## Persistent Volume access modes
+    ## Must match those of existing PV or dynamic provisioner
+    ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    accessModes:
+      - ReadWriteOnce
+
+    ## Persistent Volume Claim annotations
+    ##
+    annotations: {}
+
+    ## Persistent Volume existing claim name
+    ## Requires persistentVolume.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    existingClaim: ""
+
+    ## Persistent Volume mount root path
+    ##
+    mountPath: /data/db
+
+    ## Persistent Volume size
+    ##
+    size: 10Gi
+
+    ## Persistent Volume Storage Class
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    storageClass: ""
 


### PR DESCRIPTION
This improves configurability of persistence options and allows the new annotation
'volume.beta.kubernetes.io/storage-class' to be used.