### PR TITLE
[incubator/mongodb-replicaset] Improve persistence configuration

### DIFF
--- a/incubator/mongodb-replicaset/README.md
+++ b/incubator/mongodb-replicaset/README.md
@@ -49,6 +49,7 @@ The following tables lists the configurable parameters of the mongodb chart and 
 | `Memory`                | container requested memory         | `512Mi`                                                    |
 | `PeerPort`              | Container listening port           | `27017`                                                    |
 | `Storage`               | Persistent volume size             | `10Gi`                                                     |
+| `StorageClass`          | Persistent volume storage class    | If not specified, `default` is used as value for `volume.alpha.kubernetes.io/storage-class`. Otherwise, `volume.beta.kubernetes.io/storage-class` is used with the specified value |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/mongodb-replicaset/templates/mongodb-petset.yaml
+++ b/incubator/mongodb-replicaset/templates/mongodb-petset.yaml
@@ -158,7 +158,11 @@ spec:
   - metadata:
       name: datadir
       annotations:
-        volume.alpha.kubernetes.io/storage-class: {{.Values.StorageClass}}
+      {{- if .Values.StorageClass | quote }}
+        volume.beta.kubernetes.io/storage-class: {{ .Values.StorageClass | quote }}
+      {{- else }}
+        volume.alpha.kubernetes.io/storage-class: default
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/incubator/mongodb-replicaset/values.yaml
+++ b/incubator/mongodb-replicaset/values.yaml
@@ -17,5 +17,5 @@ ImagePullPolicy: "Always"
 Cpu: "100m"
 Memory: "512Mi"
 Storage: "10Gi"
-StorageClass: generic
+#StorageClass: ""
 


### PR DESCRIPTION
Allows using the new annotation 'volume.beta.kubernetes.io/storage-class'.