### PR TITLE
Update etcd-operator to 0.2.1, and don't abide to cluster.enabled on install

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,11 +1,13 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.1.1
+version: 0.2.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png
 sources:
   - https://github.com/coreos/etcd-operator
 maintainers:
+  - name: Chance Zibolski
+    email: chance.zibolski@coreos.com
   - name: Lachlan Evenson
     email: lachlan@deis.com

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -27,6 +27,9 @@ To install the chart with the release name `my-release`:
 $ helm install stable/etcd-operator --name my-release
 ```
 
+__Note__: If you set `cluster.enabled` on install, it will have no effect.
+Before you create create an etcd cluster, the TPR must be installed by the operator, so this option is ignored during helm installs, but can be used in upgrades.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:
@@ -50,27 +53,27 @@ The following tables lists the configurable parameters of the etcd-operator char
 | ------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------- |
 | `replicaCount`                                    | Number of etcd-operator replicas to create (only 1 is supported)     | `1`                                            |
 | `image.repository`                                | etcd-operator container image                                        | `quay.io/coreos/etcd-operator`                 |
-| `image.tag`                                       | etcd-operator container image tag                                    | `latest`                                       |
+| `image.tag`                                       | etcd-operator container image tag                                    | `v0.2.1`                                       |
 | `image.pullPolicy`                                | etcd-operator container image pull policy                            | `IfNotPresent`                                 |
 | `resources.limits.cpu`                            | CPU limit per etcd-operator pod                                      | `100m`                                         |
 | `resources.limits.memory`                         | Memory limit per etcd-operator pod                                   | `128Mi`                                        |
 | `resources.requests.cpu`                          | CPU request per etcd-operator pod                                    | `100m`                                         |
 | `resources.requests.memory`                       | Memory request per etcd-operator pod                                 | `128Mi`                                        |
-| `cluster.enabled`                                 | Whether to enable provisioning of and etcd-cluster                   | `true`                                         |
+| `cluster.enabled`                                 | Whether to enable provisioning of and etcd-cluster                   | `false`                                        |
 | `cluster.name`                                    | etcd cluster name                                                    | `etcd-cluster`                                 |
-| `cluster.version`                                 | etcd cluster version                                                 | `v3.1.0-rc.0`                               |
+| `cluster.version`                                 | etcd cluster version                                                 | `v3.1.2`                                       |
 | `cluster.size`                                    | etcd cluster size                                                    | `3`                                            |
-| `cluster.backup.enabled`                          | Whether to create PV for cluster backups                             | `true`                                         |
+| `cluster.backup.enabled`                          | Whether to create PV for cluster backups                             | `false`                                        |
 | `cluster.backup.provisioner`                      | Which PV provisioner to use                                          | `kubernetes.io/gce-pd` (kubernetes.io/aws-ebs) |
 | `cluster.backup.config.snapshotIntervalInSecond`  | etcd snapshot interval in seconds                                    | `30`                                           |
 | `cluster.backup.config.maxSnapshot`               | maximum number of snapshots to keep                                  | `5`                                            |
-| `cluster.backup.config.volumeSizeInMB`            | size of backup PV                                                    | `512MB`                                        |
-| `cluster.backup.config.storageType`              | Type to storage to provision                                          | `PersistentVolume`                             |
+| `cluster.backup.config.storageType`               | Type to storage to provision                                         | `PersistentVolume`                             |
+| `cluster.backup.config.pv.volumeSizeInMB`         | size of backup PV                                                    | `512MB`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```bash
-$ helm install --name my-release --set cluster.version=v3.1.0-alpha.1  stable/etcd-operator
+$ helm install --name my-release --set image.tag=v0.2.1 stable/etcd-operator
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -1,10 +1,10 @@
 # CoreOS etcd-operator
 
-[etcd-operator](https://coreos.com/blog/introducing-the-etcd-operator.html) Simplify etcd cluster 
+[etcd-operator](https://coreos.com/blog/introducing-the-etcd-operator.html) Simplify etcd cluster
 configuration and management.
 
 __DISCLAIMER:__ While this chart has been well-tested, the etcd-operator is still currently in alpha.
-Current project status is available [here](https://github.com/coreos/etcd-operator) 
+Current project status is available [here](https://github.com/coreos/etcd-operator)
 
 ## Introduction
 
@@ -59,7 +59,7 @@ The following tables lists the configurable parameters of the etcd-operator char
 | `resources.limits.memory`                         | Memory limit per etcd-operator pod                                   | `128Mi`                                        |
 | `resources.requests.cpu`                          | CPU request per etcd-operator pod                                    | `100m`                                         |
 | `resources.requests.memory`                       | Memory request per etcd-operator pod                                 | `128Mi`                                        |
-| `cluster.enabled`                                 | Whether to enable provisioning of and etcd-cluster                   | `false`                                        |
+| `cluster.enabled`                                 | Whether to enable provisioning of an etcd-cluster                    | `false`                                        |
 | `cluster.name`                                    | etcd cluster name                                                    | `etcd-cluster`                                 |
 | `cluster.version`                                 | etcd cluster version                                                 | `v3.1.2`                                       |
 | `cluster.size`                                    | etcd cluster size                                                    | `3`                                            |
@@ -67,7 +67,7 @@ The following tables lists the configurable parameters of the etcd-operator char
 | `cluster.backup.provisioner`                      | Which PV provisioner to use                                          | `kubernetes.io/gce-pd` (kubernetes.io/aws-ebs) |
 | `cluster.backup.config.snapshotIntervalInSecond`  | etcd snapshot interval in seconds                                    | `30`                                           |
 | `cluster.backup.config.maxSnapshot`               | maximum number of snapshots to keep                                  | `5`                                            |
-| `cluster.backup.config.storageType`               | Type to storage to provision                                         | `PersistentVolume`                             |
+| `cluster.backup.config.storageType`               | Type of storage to provision                                         | `PersistentVolume`                             |
 | `cluster.backup.config.pv.volumeSizeInMB`         | size of backup PV                                                    | `512MB`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/stable/etcd-operator/templates/NOTES.txt
+++ b/stable/etcd-operator/templates/NOTES.txt
@@ -1,19 +1,28 @@
-{{- if .Values.cluster.enabled -}}
+{{- $clusterEnabled := (and (not .Release.IsInstall) .Values.cluster.enabled) -}}
+{{- if and .Release.IsInstall .Values.cluster.enabled -}}
+Not enabling cluster, the ThirdPartResource must be installed before you can create a Cluster. Continuing rest of normal deployment.
+
+{{ end -}}
+
+{{- if $clusterEnabled -}}
 1. Watch etcd cluster start
   kubectl get pods -l etcd_cluster={{ .Values.cluster.name }} --namespace {{ .Release.Namespace }} -w
 2. Confirm etcd cluster is healthy
-  $ kubectl run --rm -i --tty etcd-test --image quay.io/coreos/etcd --restart=Never -- /bin/sh
-  / # ETCDCTL_API=3 etcdctl --endpoints http://{{ .Values.cluster.name }}-0000:2379 put foo bar
-  / # ETCDCTL_API=3 etcdctl --endpoints http://{{ .Values.cluster.name }}-0000:2379 member list
+  $ kubectl run --rm -i --tty --env="ETCDCTL_API=3" --env="ETCDCTL_ENDPOINTS=http://{{ .Values.cluster.name }}-0000:2379" etcd-test --image quay.io/coreos/etcd --restart=Never -- /bin/sh -c 'watch -n1 "etcdctl  member list"'
+
+3. Interact with the cluster!
+  $ kubectl run --rm -i --tty --env ETCDCTL_API=3 etcd-test --image quay.io/coreos/etcd --restart=Never -- /bin/sh
+  / # etcdctl --endpoints http://{{ .Values.cluster.name }}-0000:2379 put foo bar
+  / # etcdctl --endpoints http://{{ .Values.cluster.name }}-0000:2379 get foo
   OK
   (ctrl-D to exit)
-3. Optional
+4. Optional
   Check the etcd-operator logs
   export POD=$(kubectl get pods -l app={{ template "fullname" . }} --namespace {{ .Release.Namespace }} --output name)
   kubectl logs $POD --namespace={{ .Release.Namespace }}
 
 {{- else -}}
-1. etcd-operator deployed. 
+1. etcd-operator deployed.
   If you would like to deploy an etcd-cluster set cluster.enabled to true in values.yaml
   Check the etcd-operator logs
     export POD=$(kubectl get pods -l app={{ template "fullname" . }} --namespace {{ .Release.Namespace }} --output name)

--- a/stable/etcd-operator/templates/cluster.yaml
+++ b/stable/etcd-operator/templates/cluster.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.cluster.enabled -}}
-apiVersion: "coreos.com/v1"
-kind: "EtcdCluster"
+{{- if and .Values.cluster.enabled (not .Release.IsInstall) -}}
+apiVersion: "etcd.coreos.com/v1beta1"
+kind: "Cluster"
 metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/etcd-operator/templates/deployment.yaml
+++ b/stable/etcd-operator/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: 
+        command:
         - "/bin/sh"
         - "-c"
         - "/usr/local/bin/etcd-operator --pv-provisioner={{ .Values.cluster.backup.provisioner }}"
@@ -30,5 +30,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: quay.io/coreos/etcd-operator
-  tag: latest
+  tag: v0.2.1
   pullPolicy: IfNotPresent
 resources:
   limits:
@@ -18,7 +18,7 @@ cluster:
   enabled: false
   name: etcd-cluster
   size: 3
-  version: v3.1.0-rc.0
+  version: v3.1.2
   backup:
     enabled: false
     ## Cloud specific PV provisioner
@@ -28,5 +28,6 @@ cluster:
       ## short snapshot interval for testing, do not use this in production!
       snapshotIntervalInSecond: 30
       maxSnapshot: 5
-      volumeSizeInMB: 512
       storageType: PersistentVolume
+      pv:
+        volumeSizeInMB: 512


### PR DESCRIPTION
Fixes #728. The issue is that the TPR will not exist until after the
etcd-operator runs, causing validation to fail when the etcd.coreos.com/v1beta1
API version doesn't exist. Since it must be run-post install, ignore the
setting when the Release is an install.