### PR TITLE
Fix etcd-operator

### DIFF
--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -58,7 +58,7 @@ The following tables lists the configurable parameters of the etcd-operator char
 | `resources.requests.memory`                       | Memory request per etcd-operator pod                                 | `128Mi`                                        |
 | `cluster.enabled`                                 | Whether to enable provisioning of and etcd-cluster                   | `true`                                         |
 | `cluster.name`                                    | etcd cluster name                                                    | `etcd-cluster`                                 |
-| `cluster.version`                                 | etcd cluster version                                                 | `v3.1.0-rc.0`                               |
+| `cluster.version`                                 | etcd cluster version                                                 | `3.1.2`                               |
 | `cluster.size`                                    | etcd cluster size                                                    | `3`                                            |
 | `cluster.backup.enabled`                          | Whether to create PV for cluster backups                             | `true`                                         |
 | `cluster.backup.provisioner`                      | Which PV provisioner to use                                          | `kubernetes.io/gce-pd` (kubernetes.io/aws-ebs) |

--- a/stable/etcd-operator/templates/deployment.yaml
+++ b/stable/etcd-operator/templates/deployment.yaml
@@ -30,5 +30,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/stable/etcd-operator/templates/etcd-cluster.yaml
+++ b/stable/etcd-operator/templates/etcd-cluster.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.cluster.enabled -}}
-apiVersion: "coreos.com/v1"
-kind: "EtcdCluster"
+apiVersion: "etcd.coreos.com/v1beta1"
+kind: "Cluster"
 metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -18,7 +18,7 @@ cluster:
   enabled: false
   name: etcd-cluster
   size: 3
-  version: v3.1.0-rc.0
+  version: 3.1.2
   backup:
     enabled: false
     ## Cloud specific PV provisioner


### PR DESCRIPTION
It seems `stable/etcd-operator` is broken after some recent updates to etcd-operaor image.
I have tried fixing these inconsistencies by referring to https://github.com/coreos/etcd-operator/tree/master/example
