### PR TITLE
Remove duplicate home tag in spark Chart

### DIFF
--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,4 @@
 name: spark
-home: http://spark.apache.org/
 version: 0.1.3
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark
-version: 0.1.3
+version: 0.1.4
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png


### PR DESCRIPTION
Spark chart contained duplicate home tag.

This caused Kubernetic to crash https://github.com/harbur/kubernetic-issues/issues/18

Not sure how if this should up the version number or not since it's clearly altering the hash of the release tarball.
