### PR TITLE
[stable/chaoskube] bump version to v0.5.0

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,5 +1,5 @@
 name: chaoskube
-version: 0.4.0
+version: 0.5.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube
 sources:

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -45,6 +45,7 @@ $ helm install stable/chaoskube --set dryRun=false
 | `replicas`                | number of replicas to run                           | 1                                 |
 | `interval`                | interval between pod terminations                   | 10m                               |
 | `labels`                  | label selector to filter pods by                    | "" (matches everything)           |
+| `annotations`             | annotation selector to filter pods by               | "" (matches everything)           |
 | `namespaces`              | namespace selector to filter pods by                | "" (all namespaces)               |
 | `dryRun`                  | don't kill pods, only log what would have been done | true                              |
 | `resources.cpu`           | cpu resource requests and limits                    | 10m                               |

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - --in-cluster
         - --interval={{ .Values.interval }}
         - --labels={{ .Values.labels }}
+        - --annotations={{ .Values.annotations }}
         - --namespaces={{ .Values.namespaces }}
         {{- if not .Values.dryRun}}
         - --no-dry-run

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -5,7 +5,7 @@ name: chaoskube
 image: quay.io/linki/chaoskube
 
 # docker image tag
-imageTag: v0.4.0
+imageTag: v0.5.0
 
 # number of replicas to run
 replicas: 1
@@ -15,6 +15,9 @@ interval: 10m
 
 # label selector to filter pods by, e.g. app=foo,stage!=prod
 labels:
+
+# annotation selector to filter pods by, e.g. chaos.alpha.kubernetes.io/enabled=true
+annotations:
 
 # namespace selector to filter pods by, e.g. '!kube-system,!production' (use quotes)
 namespaces:


### PR DESCRIPTION
Updates chaoskube to v0.5.0 which supports filtering pods by annotations.