### PR TITLE
[stable/minio] Set maxSurge: 0, maxUnavailable: 1 for RollingUpdate d…

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Distributed object storage server built for cloud applications and devops.
 name: minio
-version: 0.0.4
+version: 0.0.5
 keywords:
 - storage
 - object-storage

--- a/stable/minio/templates/minio_deployment.yaml
+++ b/stable/minio/templates/minio_deployment.yaml
@@ -12,6 +12,11 @@ spec:
   selector:
     matchLabels:
       app: {{ template "fullname" . }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       name: {{ template "fullname" . }}


### PR DESCRIPTION
…eployment strategy

This fixes an issue with `ReadWriteOnly` `PersistentVolume`s when the minio server Pod is deleted and recreated. This change causes the deployment to wait until the deleted pod is completely terminated before starting a replacement to avoid errors with the PV already being in-use.

This is similar behavior as setting the strategy to `Recreate`, however I went this route because it would work better for users that end up running multiple standalone minio servers on shared/distributed backend storage.

Fixes: #763