### PR TITLE
[stable/datadog] Add config maps, env vars, and ports

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.2.1
+version: 0.3.0
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -43,6 +43,12 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `image.repository`          | The image repository to pull from  | `datadog/docker-dd-agent`                 |
 | `image.tag`                 | The image tag to pull              | `latest`                                  |
 | `imagePullPolicy`           | Image pull policy                  | `IfNotPresent`                            |
+| `datadog.env` | Additional Datadog environment variables | `nil` |
+| `datadog.apmEnabled` | Enable tracing from the host | `nil` |
+| `datadog.autoconf` | Additional Datadog service discovery configurations | `nil` |
+| `datadog.checksd` | Additional Datadog service checks | `nil` |
+| `datadog.confd` | Additional Datadog service configurations | `nil` |
+| `imagePullPolicy`           | Image pull policy                  | `IfNotPresent`                            |
 | `resources.requests.cpu`    | CPU resource requests              | 128M                                      |
 | `resources.limits.cpu`      | CPU resource limits                | 512Mi                                     |
 | `resources.requests.memory` | Memory resource requests           | 100m                                      |
@@ -64,3 +70,40 @@ $ helm install --name my-release -f values.yaml stable/datadog
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Image tags
+
+Datadog offers a multitude of [tags](https://hub.docker.com/r/datadog/docker-dd-agent/tags/), including alpine based agents and JMX.
+
+### confd and checksd
+
+The Datadog entrypoint will copy files found in `/conf.d` and `/check.d` to
+`/etc/dd-agent/conf.d` and `/etc/dd-agent/check.d` respectively. The keys for
+`datadog.confd`, `datadog.autoconf`, and `datadog.checksd` should mirror the content found in their 
+respective ConfigMaps, ie
+
+```yaml
+datadog:
+  autoconf: 
+    redisdb.yaml: |-
+      docker_images:
+        - redis
+        - bitnami/redis
+      init_config:
+      instances:
+        - host: "%%host%%"
+          port: "%%port%%"
+    jmx.yaml: |-
+      docker_images:
+        - openjdk
+      instance_config:
+      instances:
+        - host: "%%host%%"
+          port: "%%port_0%%"
+  confd:
+    redisdb.yaml: |-
+      init_config:
+      instances:
+        - host: "outside-k8s.example.com"
+          port: 6379
+```

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -23,3 +23,7 @@ Then run:
     helm upgrade {{ .Release.Name }} \
         --set datadog.apiKey=YOUR-KEY-HERE stable/datadog
 {{- end }}
+
+{{- if .Values.datadog.apmEnabled }}
+The datadog agent is listening on ports 7777 and 8126.
+{{- end }}

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -3,14 +3,39 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified confd name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "confd.fullname" -}}
+{{- printf "%s-datadog-confd" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified autoconf name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "autoconf.fullname" -}}
+{{- printf "%s-datadog-autoconf" .Release.Name | trunc 22 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified checksd name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "checksd.fullname" -}}
+{{- printf "%s-datadog-checksd" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -28,7 +28,7 @@ Create a default fully qualified autoconf name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "autoconf.fullname" -}}
-{{- printf "%s-datadog-autoconf" .Release.Name | trunc 22 | trimSuffix "-" -}}
+{{- printf "%s-datadog-autoconf" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/datadog/templates/autoconf-configmap.yaml
+++ b/stable/datadog/templates/autoconf-configmap.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/datadog/templates/autoconf-configmap.yaml
+++ b/stable/datadog/templates/autoconf-configmap.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "autoconf.fullname" . }}
+  labels:
+    app: {{ template "autoconf.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- if .Values.datadog.autoconf }}
+{{ toYaml .Values.datadog.autoconf | indent 2 }}
+{{- end -}}

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "checksd.fullname" . }}
+  labels:
+    app: {{ template "checksd.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- if .Values.datadog.checksd }}
+{{ toYaml .Values.datadog.checksd | indent 2 }}
+{{- end -}}

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "confd.fullname" . }}
+  labels:
+    app: {{ template "confd.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- if .Values.datadog.confd }}
+{{ toYaml .Values.datadog.confd | indent 2 }}
+{{- end -}}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -22,6 +22,14 @@ spec:
         - containerPort: 8125
           name: dogstatsdport
           protocol: UDP
+        {{- if .Values.datadog.apmEnabled }}
+        - containerPort: 8126
+          name: traceport
+          protocol: TCP
+        - containerPort: 7777
+          name: legacytraceport
+          protocol: TCP
+        {{- end }}
         env:
           - name: API_KEY
             valueFrom:
@@ -36,8 +44,13 @@ spec:
             value: {{ default "" .Values.datadog.nonLocalTraffic | quote }}
           - name: TAGS
             value: {{ default "" .Values.datadog.tags | quote }}
+          - name: DD_APM_ENABLED
+            value: {{ default "" .Values.datadog.apmEnabled | quote }}
           - name: KUBERNETES
             value: "yes"
+{{- if .Values.datadog.env }}
+{{ toYaml .Values.datadog.env | indent 10 }}
+{{- end }}
         volumeMounts:
           - name: dockersocket
             mountPath: /var/run/docker.sock
@@ -46,6 +59,15 @@ spec:
             readOnly: true
           - name: cgroups
             mountPath: /host/sys/fs/cgroup
+            readOnly: true
+          - name: confd
+            mountPath: /conf.d
+            readOnly: true
+          - name: autoconf
+            mountPath: /etc/dd-agent/conf.d/auto_conf
+            readOnly: true
+          - name: checksd
+            mountPath: /checks.d
             readOnly: true
       volumes:
         - hostPath:
@@ -57,4 +79,13 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - name: confd
+          configMap:
+            name: {{ template "confd.fullname" . }}
+        - name: checksd
+          configMap:
+            name: {{ template "checksd.fullname" . }}
+        - name: autoconf
+          configMap:
+            name: {{ template "autoconf.fullname" . }}
 {{ end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -25,6 +25,49 @@ datadog:
   ##
   # tags:
 
+  ## Un-comment this to enable APM and tracing, on ports 7777 and 8126
+  ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
+  ##
+  # apmEnabled: true
+
+  ## The dd-agent supports many environment variables
+  ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
+  ##
+  # env:
+  #   - name: 
+  #     value: 
+
+  ## Provide additonal service definitions
+  ## Each key will become a file in /conf.d/auto_conf
+  ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
+  ## 
+  # autoconf:
+  #   redisdb.yaml: |-
+  #     docker_images:
+  #       - redis
+  #     init_config:
+  #     instances:
+  #       - host: "%%host%%"
+  #         port: "%%port%%"
+
+  ## Provide additonal service definitions
+  ## Each key will become a file in /conf.d
+  ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
+  ## 
+  # confd:
+  #   redisdb.yaml: |-
+  #     init_config:
+  #     instances:
+  #       - host: "name"
+  #         port: "6379"
+
+  ## Provide additonal service checks
+  ## Each key will become a file in /checks.d
+  ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
+  ## 
+  # checksd:
+  #   service.py: |-
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
* Optionally open up APM tracing ports
* Provide configmap hooks for custom autoconf, checks.d, and conf.d
* Open up environment variables