### PR TITLE
[stable/wordpress] Allow  helm chart to receive an existing database or create it by itself Open, HighAll Users

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.4.3
+version: 0.5.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -46,7 +46,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following tables lists the configurable parameters of the WordPress chart and their default values.
 
 | Parameter                            | Description                                | Default                                                    |
-| -------------------------------      | -------------------------------            | ---------------------------------------------------------- |
+| -------------------------------------| -------------------------------------------| ---------------------------------------------------------- |
 | `image`                              | WordPress image                            | `bitnami/wordpress:{VERSION}`                              |
 | `imagePullPolicy`                    | Image pull policy                          | `IfNotPresent`                                             |
 | `wordpressUsername`                  | User of the application                    | `user`                                                     |
@@ -55,6 +55,10 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `wordpressFirstName`                 | First name                                 | `FirstName`                                                |
 | `wordpressLastName`                  | Last name                                  | `LastName`                                                 |
 | `wordpressBlogName`                  | Blog name                                  | `User's Blog!`                                             |
+| `databaseName`                       | Database name to create                    | `nil`                                                      |
+| `databaseUser`                       | Database user to create                    | `nil`                                                      |
+| `databasePassword`                   | Password for the database                  | `nil`                                                      |
+| `allowEmptyPassword`                 | Allow DB blank passwords                   | `no`                                                      |
 | `smtpHost`                           | SMTP host                                  | `nil`                                                      |
 | `smtpPort`                           | SMTP port                                  | `nil`                                                      |
 | `smtpUser`                           | SMTP user                                  | `nil`                                                      |
@@ -65,7 +69,7 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `serviceType`                        | Kubernetes Service type                    | `LoadBalancer`                                             |
 | `ingress.enabled`                    | Enable ingress controller resource         | `false`                                                    |
 | `ingress.hostname`                   | URL to address your WordPress installation | `wordpress.local`                                          |
-| `ingress.tls`                        | Ingress TLS configuration                  | `[]`                                          |
+| `ingress.tls`                        | Ingress TLS configuration                  | `[]`                                                       |
 | `persistence.enabled`                | Enable persistence using PVC               | `true`                                                     |
 | `persistence.apache.storageClass`    | PVC Storage Class for Apache volume        | `nil` (uses alpha storage class annotation)                |
 | `persistence.apache.accessMode`      | PVC Access Mode for Apache volume          | `ReadWriteOnce`                                            |

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -45,7 +45,6 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the WordPress chart and their default values.
 
-<<<<<<< HEAD
 |              Parameter               |                Description                 |                    Default                     |
 |--------------------------------------|--------------------------------------------|------------------------------------------------|
 | `image`                              | WordPress image                            | `bitnami/wordpress:{VERSION}`                  |

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -45,39 +45,38 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the WordPress chart and their default values.
 
-<<<<<<< HEAD
-| Parameter                            | Description                                | Default                                                    |
-| -------------------------------------| -------------------------------------------| ---------------------------------------------------------- |
-| `image`                              | WordPress image                            | `bitnami/wordpress:{VERSION}`                              |
-| `imagePullPolicy`                    | Image pull policy                          | `IfNotPresent`                                             |
-| `wordpressUsername`                  | User of the application                    | `user`                                                     |
-| `wordpressPassword`                  | Application password                       | _random 10 character long alphanumeric string_             |
-| `wordpressEmail`                     | Admin email                                | `user@example.com`                                         |
-| `wordpressFirstName`                 | First name                                 | `FirstName`                                                |
-| `wordpressLastName`                  | Last name                                  | `LastName`                                                 |
-| `wordpressBlogName`                  | Blog name                                  | `User's Blog!`                                             |
-| `databaseName`                       | Database name to create                    | `nil`                                                      |
-| `databaseUser`                       | Database user to create                    | `nil`                                                      |
-| `databasePassword`                   | Password for the database                  | `nil`                                                      |
-| `allowEmptyPassword`                 | Allow DB blank passwords                   | `no`                                                       |
-| `smtpHost`                           | SMTP host                                  | `nil`                                                      |
-| `smtpPort`                           | SMTP port                                  | `nil`                                                      |
-| `smtpUser`                           | SMTP user                                  | `nil`                                                      |
-| `smtpPassword`                       | SMTP password                              | `nil`                                                      |
-| `smtpUsername`                       | User name for SMTP emails                  | `nil`                                                      |
-| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]               | `nil`                                                      |
-| `mariadb.mariadbRootPassword`        | MariaDB admin password                     | `nil`                                                      |
-| `serviceType`                        | Kubernetes Service type                    | `LoadBalancer`                                             |
-| `ingress.enabled`                    | Enable ingress controller resource         | `false`                                                    |
-| `ingress.hostname`                   | URL to address your WordPress installation | `wordpress.local`                                          |
-| `ingress.tls`                        | Ingress TLS configuration                  | `[]`                                                       |
-| `persistence.enabled`                | Enable persistence using PVC               | `true`                                                     |
-| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume        | `nil` (uses alpha storage class annotation)                |
-| `persistence.apache.accessMode`      | PVC Access Mode for Apache volume          | `ReadWriteOnce`                                            |
-| `persistence.apache.size`            | PVC Storage Request for Apache volume      | `1Gi`                                                      |
-| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume     | `nil` (uses alpha storage class annotation)                |
-| `persistence.wordpress.accessMode`   | PVC Access Mode for WordPress volume       | `ReadWriteOnce`                                            |
-| `persistence.wordpress.size`         | PVC Storage Request for WordPress volume   | `8Gi`                                                      |
+|              Parameter               |                Description                 |                    Default                     |
+|--------------------------------------|--------------------------------------------|------------------------------------------------|
+| `image`                              | WordPress image                            | `bitnami/wordpress:{VERSION}`                  |
+| `imagePullPolicy`                    | Image pull policy                          | `IfNotPresent`                                 |
+| `wordpressUsername`                  | User of the application                    | `user`                                         |
+| `wordpressPassword`                  | Application password                       | _random 10 character long alphanumeric string_ |
+| `wordpressEmail`                     | Admin email                                | `user@example.com`                             |
+| `wordpressFirstName`                 | First name                                 | `FirstName`                                    |
+| `wordpressLastName`                  | Last name                                  | `LastName`                                     |
+| `wordpressBlogName`                  | Blog name                                  | `User's Blog!`                                 |
+| `allowEmptyPassword`                 | Allow DB blank passwords                   | `no`                                           |
+| `smtpHost`                           | SMTP host                                  | `nil`                                          |
+| `smtpPort`                           | SMTP port                                  | `nil`                                          |
+| `smtpUser`                           | SMTP user                                  | `nil`                                          |
+| `smtpPassword`                       | SMTP password                              | `nil`                                          |
+| `smtpUsername`                       | User name for SMTP emails                  | `nil`                                          |
+| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]               | `nil`                                          |
+| `mariadb.mariadbRootPassword`        | MariaDB admin password                     | `nil`                                          |
+| `mariadb.mariadbDatabase`            | Database name to create                    | `bitnami_wordpress`                            |
+| `mariadb.mariadbUser`                | Database user to create                    | `bn_wordpress`                                 |
+| `mariadb.mariadbPassword`            | Password for the database                  | _random 10 character long alphanumeric string_ |
+| `serviceType`                        | Kubernetes Service type                    | `LoadBalancer`                                 |
+| `ingress.enabled`                    | Enable ingress controller resource         | `false`                                        |
+| `ingress.hostname`                   | URL to address your WordPress installation | `wordpress.local`                              |
+| `ingress.tls`                        | Ingress TLS configuration                  | `[]`                                           |
+| `persistence.enabled`                | Enable persistence using PVC               | `true`                                         |
+| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume        | `nil` (uses alpha storage class annotation)    |
+| `persistence.apache.accessMode`      | PVC Access Mode for Apache volume          | `ReadWriteOnce`                                |
+| `persistence.apache.size`            | PVC Storage Request for Apache volume      | `1Gi`                                          |
+| `persistence.wordpress.storageClass` | PVC Storage Class for WordPress volume     | `nil` (uses alpha storage class annotation)    |
+| `persistence.wordpress.accessMode`   | PVC Access Mode for WordPress volume       | `ReadWriteOnce`                                |
+| `persistence.wordpress.size`         | PVC Storage Request for WordPress volume   | `8Gi`                                          |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -55,7 +55,7 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `wordpressFirstName`                 | First name                                 | `FirstName`                                    |
 | `wordpressLastName`                  | Last name                                  | `LastName`                                     |
 | `wordpressBlogName`                  | Blog name                                  | `User's Blog!`                                 |
-| `allowEmptyPassword`                 | Allow DB blank passwords                   | `no`                                           |
+| `allowEmptyPassword`                 | Allow DB blank passwords                   | `yes`                                          |
 | `smtpHost`                           | SMTP host                                  | `nil`                                          |
 | `smtpPort`                           | SMTP port                                  | `nil`                                          |
 | `smtpUser`                           | SMTP user                                  | `nil`                                          |

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -55,10 +55,10 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `wordpressFirstName`                 | First name                                 | `FirstName`                                                |
 | `wordpressLastName`                  | Last name                                  | `LastName`                                                 |
 | `wordpressBlogName`                  | Blog name                                  | `User's Blog!`                                             |
-| `databaseName`                       | Database name to create                    | `nil`                                                      |
-| `databaseUser`                       | Database user to create                    | `nil`                                                      |
-| `databasePassword`                   | Password for the database                  | `nil`                                                      |
-| `allowEmptyPassword`                 | Allow DB blank passwords                   | `no`                                                      |
+| `databaseName`                       | Database name to create                    | `bitnami_wordpress`                                        |
+| `databaseUser`                       | Database user to create                    | `bn_wordpress`                                             |
+| `databasePassword`                   | Password for the database                  | _random 10 character long alphanumeric string_             |
+| `allowEmptyPassword`                 | Allow DB blank passwords                   | `no`                                                       |
 | `smtpHost`                           | SMTP host                                  | `nil`                                                      |
 | `smtpPort`                           | SMTP port                                  | `nil`                                                      |
 | `smtpUser`                           | SMTP user                                  | `nil`                                                      |

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -45,6 +45,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the WordPress chart and their default values.
 
+<<<<<<< HEAD
 |              Parameter               |                Description                 |                    Default                     |
 |--------------------------------------|--------------------------------------------|------------------------------------------------|
 | `image`                              | WordPress image                            | `bitnami/wordpress:{VERSION}`                  |

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -45,6 +45,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the WordPress chart and their default values.
 
+<<<<<<< HEAD
 | Parameter                            | Description                                | Default                                                    |
 | -------------------------------------| -------------------------------------------| ---------------------------------------------------------- |
 | `image`                              | WordPress image                            | `bitnami/wordpress:{VERSION}`                              |

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -55,9 +55,9 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `wordpressFirstName`                 | First name                                 | `FirstName`                                                |
 | `wordpressLastName`                  | Last name                                  | `LastName`                                                 |
 | `wordpressBlogName`                  | Blog name                                  | `User's Blog!`                                             |
-| `databaseName`                       | Database name to create                    | `bitnami_wordpress`                                        |
-| `databaseUser`                       | Database user to create                    | `bn_wordpress`                                             |
-| `databasePassword`                   | Password for the database                  | _random 10 character long alphanumeric string_             |
+| `databaseName`                       | Database name to create                    | `nil`                                                      |
+| `databaseUser`                       | Database user to create                    | `nil`                                                      |
+| `databasePassword`                   | Password for the database                  | `nil`                                                      |
 | `allowEmptyPassword`                 | Allow DB blank passwords                   | `no`                                                       |
 | `smtpHost`                           | SMTP host                                  | `nil`                                                      |
 | `smtpPort`                           | SMTP port                                  | `nil`                                                      |

--- a/stable/wordpress/requirements.lock
+++ b/stable/wordpress/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.9
-digest: sha256:2c911bb44ebae5d8e3d9d69cfb49ce9704cf6cd02bc3583b29fc945e9f213d6a
-generated: 2017-02-14T19:54:59.173151824-05:00
+  version: 0.5.10
+digest: sha256:6a6567b76c5ff5d87c65bb1fe9b330d260bd0b1db0f72760dc5a7e5d166b8635
+generated: 2017-03-09T12:25:44.190563274+01:00

--- a/stable/wordpress/requirements.yaml
+++ b/stable/wordpress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.9
+  version: 0.5.10
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
@@ -17,7 +17,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
-          value: {{ default "no" .Values.allowEmptyPassword  | quote }}
+          value: {{ default "no" .Values.allowEmptyPassword | quote }}
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -35,9 +35,9 @@ spec:
         - name: WORDPRESS_DATABASE_NAME
           value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
         - name: MYSQL_CLIENT_CREATE_DATABASE_USER
-          value: {{ default "bn_wordpress" .Values.databaseUser| quote }}
+          value: {{ default "bn_wordpress" .Values.databaseUser | quote }}
         - name: WORDPRESS_DATABASE_USER
-          value: {{ default "bn_wordpress" .Values.databaseUser| quote }}
+          value: {{ default "bn_wordpress" .Values.databaseUser | quote }}
         - name: MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -21,22 +21,33 @@ spec:
         env:
         - name: ALLOW_EMPTY_PASSWORD
           value: {{ default "no" .Values.allowEmptyPassword  | quote }}
+        - name: MARIADB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mariadb.fullname" . }}
+              key: mariadb-root-password
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}
         - name: MARIADB_PORT
           value: "3306"
         - name: MYSQL_CLIENT_CREATE_DATABASE_NAME
-          value: {{ default "" .Values.databaseName | quote }}
+          value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
         - name: WORDPRESS_DATABASE_NAME
-          value: {{ default "" .Values.databaseName | quote }}
+          value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
         - name: MYSQL_CLIENT_CREATE_DATABASE_USER
-          value: {{ default "" .Values.databaseUser| quote }}
+          value: {{ default "bn_wordpress" .Values.databaseUser| quote }}
         - name: WORDPRESS_DATABASE_USER
-          value: {{ default "" .Values.databaseUser| quote }}
+          value: {{ default "bn_wordpress" .Values.databaseUser| quote }}
         - name: MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
-          value: {{ default "" .Values.databasePassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: wordpress-db-password
         - name: WORDPRESS_DATABASE_PASSWORD
-          value: {{ default "" .Values.databasePassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: wordpress-db-password
         - name: WORDPRESS_USERNAME
           value: {{ default "" .Values.wordpressUsername | quote }}
         - name: WORDPRESS_PASSWORD

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -31,17 +31,23 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MYSQL_CLIENT_CREATE_DATABASE_NAME
-          value: {{ default "" .Values.databaseName | quote }}
+          value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
         - name: WORDPRESS_DATABASE_NAME
-          value: {{ default "" .Values.databaseName | quote }}
+          value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
         - name: MYSQL_CLIENT_CREATE_DATABASE_USER
-          value: {{ default "" .Values.databaseUser| quote }}
+          value: {{ default "bn_wordpress" .Values.databaseUser| quote }}
         - name: WORDPRESS_DATABASE_USER
-          value: {{ default "" .Values.databaseUser| quote }}
+          value: {{ default "bn_wordpress" .Values.databaseUser| quote }}
         - name: MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
-          value: {{ default "" .Values.databasePassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: wordpress-db-password
         - name: WORDPRESS_DATABASE_PASSWORD
-          value: {{ default "" .Values.databasePassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: wordpress-db-password
         - name: WORDPRESS_USERNAME
           value: {{ default "" .Values.wordpressUsername | quote }}
         - name: WORDPRESS_PASSWORD

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -31,23 +31,17 @@ spec:
         - name: MARIADB_PORT
           value: "3306"
         - name: MYSQL_CLIENT_CREATE_DATABASE_NAME
-          value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
+          value: {{ default "" .Values.databaseName | quote }}
         - name: WORDPRESS_DATABASE_NAME
-          value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
+          value: {{ default "" .Values.databaseName | quote }}
         - name: MYSQL_CLIENT_CREATE_DATABASE_USER
-          value: {{ default "bn_wordpress" .Values.databaseUser| quote }}
+          value: {{ default "" .Values.databaseUser| quote }}
         - name: WORDPRESS_DATABASE_USER
-          value: {{ default "bn_wordpress" .Values.databaseUser| quote }}
+          value: {{ default "" .Values.databaseUser| quote }}
         - name: MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: wordpress-db-password
+          value: {{ default "" .Values.databasePassword | quote }}
         - name: WORDPRESS_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: wordpress-db-password
+          value: {{ default "" .Values.databasePassword | quote }}
         - name: WORDPRESS_USERNAME
           value: {{ default "" .Values.wordpressUsername | quote }}
         - name: WORDPRESS_PASSWORD

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -19,15 +19,24 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: {{ default "no" .Values.allowEmptyPassword  | quote }}
         - name: MARIADB_HOST
           value: {{ template "mariadb.fullname" . }}
         - name: MARIADB_PORT
           value: "3306"
-        - name: MARIADB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.fullname" . }}
-              key: mariadb-root-password
+        - name: MYSQL_CLIENT_CREATE_DATABASE_NAME
+          value: {{ default "" .Values.databaseName | quote }}
+        - name: WORDPRESS_DATABASE_NAME
+          value: {{ default "" .Values.databaseName | quote }}
+        - name: MYSQL_CLIENT_CREATE_DATABASE_USER
+          value: {{ default "" .Values.databaseUser| quote }}
+        - name: WORDPRESS_DATABASE_USER
+          value: {{ default "" .Values.databaseUser| quote }}
+        - name: MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
+          value: {{ default "" .Values.databasePassword | quote }}
+        - name: WORDPRESS_DATABASE_PASSWORD
+          value: {{ default "" .Values.databasePassword | quote }}
         - name: WORDPRESS_USERNAME
           value: {{ default "" .Values.wordpressUsername | quote }}
         - name: WORDPRESS_PASSWORD

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -20,7 +20,11 @@ spec:
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
-          value: {{ default "no" .Values.allowEmptyPassword | quote }}
+        {{- if .Values.allowEmptyPassword }}
+          value: "yes"
+        {{- else }}
+          value: "no"
+        {{- end }}
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -30,24 +34,15 @@ spec:
           value: {{ template "mariadb.fullname" . }}
         - name: MARIADB_PORT
           value: "3306"
-        - name: MYSQL_CLIENT_CREATE_DATABASE_NAME
-          value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
         - name: WORDPRESS_DATABASE_NAME
-          value: {{ default "bitnami_wordpress" .Values.databaseName | quote }}
-        - name: MYSQL_CLIENT_CREATE_DATABASE_USER
-          value: {{ default "bn_wordpress" .Values.databaseUser | quote }}
+          value: {{ default "" .Values.mariadb.mariadbDatabase | quote }}
         - name: WORDPRESS_DATABASE_USER
-          value: {{ default "bn_wordpress" .Values.databaseUser | quote }}
-        - name: MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: wordpress-db-password
+          value: {{ default "" .Values.mariadb.mariadbUser | quote }}
         - name: WORDPRESS_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: wordpress-db-password
+              name: {{ template "mariadb.fullname" . }}
+              key: mariadb-password
         - name: WORDPRESS_USERNAME
           value: {{ default "" .Values.wordpressUsername | quote }}
         - name: WORDPRESS_PASSWORD

--- a/stable/wordpress/templates/secrets.yaml
+++ b/stable/wordpress/templates/secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.wordpressPassword }}
-  wordpress-password: {{ default "" .Values.wordpressPassword | b64enc | quote }}
+  wordpress-password: {{ default "" .wordpressPassword | b64enc | quote }}
   {{ else }}
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}

--- a/stable/wordpress/templates/secrets.yaml
+++ b/stable/wordpress/templates/secrets.yaml
@@ -14,9 +14,4 @@ data:
   {{ else }}
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
-  {{ if .Values.databasePassword }}
-  wordpress-db-password: {{ default "" .Values.databasePassword | b64enc | quote }}
-  {{ else }}
-  wordpress-db-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
   smtp-password: {{ default ""  .Values.smtpPassword | b64enc | quote }}

--- a/stable/wordpress/templates/secrets.yaml
+++ b/stable/wordpress/templates/secrets.yaml
@@ -10,8 +10,13 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.wordpressPassword }}
-  wordpress-password: {{ default "" .Values.wordpressPassword | b64enc | quote }}
+  wordpress-password: {{ default "" .wordpressPassword | b64enc | quote }}
   {{ else }}
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
-  smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
+  {{ if .Values.databasePassword }}
+  wordpress-db-password: {{ default "" .Values.databasePassword | b64enc | quote }}
+  {{ else }}
+  wordpress-db-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  smtp-password: {{ default ""  .Values.smtpPassword | b64enc | quote }}

--- a/stable/wordpress/templates/secrets.yaml
+++ b/stable/wordpress/templates/secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.wordpressPassword }}
-  wordpress-password: {{ default "" .wordpressPassword | b64enc | quote }}
+  wordpress-password: {{ default "" .Values.wordpressPassword | b64enc | quote }}
   {{ else }}
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}

--- a/stable/wordpress/templates/secrets.yaml
+++ b/stable/wordpress/templates/secrets.yaml
@@ -10,8 +10,13 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.wordpressPassword }}
-  wordpress-password: {{ default "" .Values.wordpressPassword | b64enc | quote }}
+  wordpress-password: {{ default "" .wordpressPassword | b64enc | quote }}
   {{ else }}
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
-  smtp-password: {{ default ""  .Values.smtpPassword | b64enc | quote }}
+  {{ if .Values.databasePassword }}
+  wordpress-db-password: {{ default "" .Values.databasePassword | b64enc | quote }}
+  {{ else }}
+  wordpress-db-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -39,6 +39,21 @@ wordpressLastName: LastName
 ##
 wordpressBlogName: User's Blog!
 
+## Database name to create 
+## databaseName: 
+
+## Database user to create
+## databaseUser: 
+
+## Database password for the new user
+## databasePassword: 
+
+## Set the environment variable to `yes` to allow the container to be started with blank passwords
+## Defaults to no
+## allowEmptyPassword: 
+
+
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
 ##

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -39,27 +39,9 @@ wordpressLastName: LastName
 ##
 wordpressBlogName: User's Blog!
 
-## Database name to create
-## Sets WORDPRESS_DATABASE_NAME and MYSQL_CLIENT_CREATE_DATABASE_NAME
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-databaseName: bitnami_wordpress
-
-## Database user to create
-## Sets WORDPRESS_DATABASE_USER and MYSQL_CLIENT_CREATE_DATABASE_USER 
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-databaseUser: bn_wordpress
-
-## Database password for the new user
-## Sets WORDPRESS_DATABASE_PASSWORD  and  MYSQL_CLIENT_CREATE_DATABASE_PASSWORD 
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-## databasePassword: 
-
 ## Set to `yes` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-## Defaults to no
-## allowEmptyPassword: 
-
-
+allowEmptyPassword: yes
 
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
@@ -79,6 +61,21 @@ mariadb:
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##
   # mariadbRootPassword:
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_wordpress
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_wordpress
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -42,12 +42,12 @@ wordpressBlogName: User's Blog!
 ## Database name to create
 ## Sets WORDPRESS_DATABASE_NAME and MYSQL_CLIENT_CREATE_DATABASE_NAME
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-## databaseName: 
+databaseName: bitnami_wordpress
 
 ## Database user to create
 ## Sets WORDPRESS_DATABASE_USER and MYSQL_CLIENT_CREATE_DATABASE_USER 
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-## databaseUser: 
+databaseUser: bn_wordpress
 
 ## Database password for the new user
 ## Sets WORDPRESS_DATABASE_PASSWORD  and  MYSQL_CLIENT_CREATE_DATABASE_PASSWORD 

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -39,16 +39,23 @@ wordpressLastName: LastName
 ##
 wordpressBlogName: User's Blog!
 
-## Database name to create 
+## Database name to create
+## Sets WORDPRESS_DATABASE_NAME and MYSQL_CLIENT_CREATE_DATABASE_NAME
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ## databaseName: 
 
 ## Database user to create
+## Sets WORDPRESS_DATABASE_USER and MYSQL_CLIENT_CREATE_DATABASE_USER 
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ## databaseUser: 
 
 ## Database password for the new user
+## Sets WORDPRESS_DATABASE_PASSWORD  and  MYSQL_CLIENT_CREATE_DATABASE_PASSWORD 
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ## databasePassword: 
 
-## Set the environment variable to `yes` to allow the container to be started with blank passwords
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ## Defaults to no
 ## allowEmptyPassword: 
 


### PR DESCRIPTION
Summary of changes:

    WordPress module does not longer expect the MARIADB_USER input
    WordPress module does not longer expect the MARIADB_PASSWORD input
    WordPress module now expects the WORDPRESS_DATABASE_NAME input
    WordPress module now expects the WORDPRESS_DATABASE_USER input
    WordPress module now expects the WORDPRESS_DATABASE_PASSWORD input

Now, we can also create the database from the application side.
The ENV vars are:

    MYSQL_CLIENT_CREATE_DATABASE_NAME
    MYSQL_CLIENT_CREATE_DATABASE_USER
    MYSQL_CLIENT_CREATE_DATABASE_PASSWORD

Also, we have added an additional security measure regarding passwordless logins. 

`"allowEmptyPassword": {"default": "no", "type": "choice", "validValues": ["yes", "no"], "description": "Allow to set an empty password"}`

In case the container does not have the related ENV var enabled. The ENV var is:

   ` ALLOW_EMPTY_PASSWORD`
