### PR TITLE
Adds a generic CoreDNS chart

### DIFF
--- a/stable/coredns/.helmignore
+++ b/stable/coredns/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,0 +1,14 @@
+name: coredns
+version: 0.1.0
+description: CoreDNS is a DNS server that chains middleware and provides Kubernetes DNS Services
+keywords:
+- coredns
+- dns
+- kubedns
+home: https://coredns.io
+icon: https://coredns.io/img/coredns-logo.png
+sources:
+- https://github.com/coredns/coredns
+maintainers:
+- name: Acaleph
+  email: hello@acale.ph

--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -6,9 +6,11 @@ keywords:
 - dns
 - kubedns
 home: https://coredns.io
-icon: https://coredns.io/img/coredns-logo.png
+icon: https://raw.githubusercontent.com/coredns/logo/master/Icon/CoreDNS_Colour_Icon.svg
 sources:
 - https://github.com/coredns/coredns
 maintainers:
 - name: Acaleph
   email: hello@acale.ph
+- name: Shashidhara TD
+  email: shashidhara.huawei@gmail.com

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -1,0 +1,84 @@
+CoreDNS
+=======
+
+CoreDNS is a DNS server that chains middleware and provides Kubernetes DNS Services
+
+TL;DR;
+------
+
+```console
+$ helm install --name coredns stable/coredns
+```
+
+Introduction
+------------
+
+This chart bootstraps a [CoreDNS](https://github.com/coredns/coredns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+This chart will provide DNS Services to a Kubernetes cluster and is a drop-in replacement for Kube/SkyDNS.
+
+Prerequisites
+-------------
+
+-	Kubernetes 1.4+ with Beta APIs enabled
+
+Installing the Chart
+--------------------
+
+Since there is typically only a single DNS Server per kubernetes cluster, this Chart does not make use of the release name. For convenience the chart can be installed as follows:
+
+```console
+$ helm install --name coredns stable/coredns
+```
+
+The command deploys CoreDNS on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+Uninstalling the Chart
+----------------------
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete coredns
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+Configuration
+-------------
+
+The following tables lists the configurable parameters of the CoreDNS chart and their default values.
+
+| Parameter          | Description                         | Default                      |
+|--------------------|-------------------------------------|------------------------------|
+| `image.repository` | CoreDNS image                       | `coredns/coredns`            |
+| `image.tag`        | CoreDNS tag                         | `006`                        |
+| `image.pullPolicy` | Image pull policy                   | `IfNotPresent`               |
+| `clusterCidr`      | The CIDR for the Kubernetes Cluster | `10.3.0.0/24`                |
+| `clusterDomain`    | The Domain for the Cluster DNS      | `cluster.local`              |
+| `clusterIP`        | The IP for the DNS Server           | `10.3.0.10`                  |
+| `metrics.enabled`  | Enable Prometheus Metrics           | `true`                       |
+| `metrics.port`     | Prometheus Pot                      | `9153`                       |
+| `resources`        | CPU/Memory resource requests/limits | Memory: `128Mi`, CPU: `100m` |
+
+The above parameters map to the env variables defined in [coredns/coredns](http://github.com/coredns/coredns). For more information please refer to the [coredns/coredns](http://github.com/coredns/coredns) image documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name coredns \
+  --set metrics.enabled=false \
+    stable/coredns
+```
+
+The above command disables the Prometheus metrics.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name coredns -f values.yaml stable/coredns
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -1,21 +1,35 @@
 CoreDNS
 =======
 
-CoreDNS is a DNS server that chains middleware and provides Kubernetes DNS Services
+CoreDNS is a DNS server that chains middleware and provides DNS Services
 
 TL;DR;
 ------
 
 ```console
-$ helm install --name coredns stable/coredns
+$ helm install --name coredns --namespace=kube-system stable/coredns
 ```
 
 Introduction
 ------------
 
-This chart bootstraps a [CoreDNS](https://github.com/coredns/coredns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [CoreDNS](https://github.com/coredns/coredns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. This chart will provide DNS Services and can be deployed in multiple configuration to support various scenarios listed below:
 
-This chart will provide DNS Services to a Kubernetes cluster and is a drop-in replacement for Kube/SkyDNS.
+ - CoreDNS as a cluster dns service and a drop-in replacement for Kube/SkyDNS. This is the default mode and CoreDNS is deployed as cluster-service in kube-system namespace. This mode is chosen by setting `isClusterService` to true.
+ - CoreDNS as an external dns service. In this mode CoreDNS is deployed as any kubernetes app in user specified namespace. The CoreDNS service can be exposed outside the cluster by using using either the NodePort or LoadBalancer type of service. This mode is chosen by setting `isClusterService` to false.
+ - CoreDNS as an external dns provider for kubernetes federation. This is a sub case of 'external dns service' which uses etcd middleware for CoreDNS backend. This deployment mode as a dependency on `etcd-operator` chart, which needs to be pre-installed. To use this deployment mode use below configuration file to override default values.
+```
+isClusterService: false
+   serviceType: "NodePort"
+   middleware:
+     kubernetes:
+       enabled: false
+     etcd:
+       enabled: true
+       zones:
+       - "<example.io>"
+       endpoint: "http://<etcd-cluster>:2379"
+```
 
 Prerequisites
 -------------
@@ -25,13 +39,13 @@ Prerequisites
 Installing the Chart
 --------------------
 
-Since there is typically only a single DNS Server per kubernetes cluster, this Chart does not make use of the release name. For convenience the chart can be installed as follows:
+The chart can be installed as follows:
 
 ```console
-$ helm install --name coredns stable/coredns
+$ helm install --name coredns --namespace=kube-system stable/coredns
 ```
 
-The command deploys CoreDNS on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys CoreDNS on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists various ways to override default configuration during deployment.
 
 > **Tip**: List all releases using `helm list`
 
@@ -49,31 +63,15 @@ The command removes all the Kubernetes components associated with the chart and 
 Configuration
 -------------
 
-The following tables lists the configurable parameters of the CoreDNS chart and their default values.
-
-| Parameter          | Description                         | Default                      |
-|--------------------|-------------------------------------|------------------------------|
-| `image.repository` | CoreDNS image                       | `coredns/coredns`            |
-| `image.tag`        | CoreDNS tag                         | `006`                        |
-| `image.pullPolicy` | Image pull policy                   | `IfNotPresent`               |
-| `clusterCidr`      | The CIDR for the Kubernetes Cluster | `10.3.0.0/24`                |
-| `clusterDomain`    | The Domain for the Cluster DNS      | `cluster.local`              |
-| `clusterIP`        | The IP for the DNS Server           | `10.3.0.10`                  |
-| `metrics.enabled`  | Enable Prometheus Metrics           | `true`                       |
-| `metrics.port`     | Prometheus Pot                      | `9153`                       |
-| `resources`        | CPU/Memory resource requests/limits | Memory: `128Mi`, CPU: `100m` |
-
-The above parameters map to the env variables defined in [coredns/coredns](http://github.com/coredns/coredns). For more information please refer to the [coredns/coredns](http://github.com/coredns/coredns) image documentation.
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+See `values.yaml` for configuration notes. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 $ helm install --name coredns \
-  --set metrics.enabled=false \
+  --set middleware.prometheus.enabled=false \
     stable/coredns
 ```
 
-The above command disables the Prometheus metrics.
+The above command disables the Prometheus middleware.
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 

--- a/stable/coredns/templates/NOTES.txt
+++ b/stable/coredns/templates/NOTES.txt
@@ -14,8 +14,8 @@ It can be accessed using the below endpoint
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     echo $SERVICE_IP
 {{- else if contains "ClusterIP"  .Values.serviceType }}
-    echo "{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
-    echo "from within the cluster"
+    "{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    from within the cluster
 {{- end }}
 {{- end }}
 

--- a/stable/coredns/templates/NOTES.txt
+++ b/stable/coredns/templates/NOTES.txt
@@ -1,0 +1,11 @@
+CoreDNS is now running in the cluster.
+
+It can be tested with the following:
+
+1. Launch a Pod with DNS tools:
+
+kubectl run -it --rm --restart=Never --image=infoblox/dnstools:latest dnstools
+
+2. Query the DNS server:
+
+/ # host kubernetes

--- a/stable/coredns/templates/NOTES.txt
+++ b/stable/coredns/templates/NOTES.txt
@@ -1,4 +1,23 @@
+{{- if .Values.isClusterService }}
+CoreDNS is now running in the cluster as a cluster-service.
+{{- else }}
 CoreDNS is now running in the cluster.
+It can be accessed using the below endpoint
+{{- if contains "NodePort" .Values.serviceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo $SERVICE_IP
+{{- else if contains "ClusterIP"  .Values.serviceType }}
+    echo "{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    echo "from within the cluster"
+{{- end }}
+{{- end }}
 
 It can be tested with the following:
 

--- a/stable/coredns/templates/_helpers.tpl
+++ b/stable/coredns/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -1,20 +1,44 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: coredns
-  namespace: kube-system
+  name: {{ template "fullname" . }}
 data:
-  Corefile: |
+  Corefile: |-
     .:53 {
-        errors
-        log stdout
-        health
-{{- if .Values.metrics.enabled }}
-        prometheus localhost:{{ .Values.metrics.port }}
-{{- end }}
-        kubernetes {{ .Values.clusterDomain }} {
-          cidrs {{ .Values.clusterCidr }}
+      {{- range $key, $middleware := .Values.middleware }}
+      {{- if $middleware.enabled }}
+      {{- if eq "kubernetes" $key }}
+        kubernetes {{ $middleware.clusterDomain }} {
+          cidrs {{ $middleware.clusterCidr }}
         }
+      {{- end }}
+      {{- if eq "etcd" $key }}
+        etcd {{ range $middleware.zones }}{{ . }} {{ end }}{
+          {{ if $middleware.path }}path {{ $middleware.path }}{{ end }}
+          endpoint {{ $middleware.endpoint }}
+        }
+      {{- end }}
+      {{- if eq "loadbalance" $key }}
+        loadbalance {{ default "round_robin" $middleware.policy }}
+      {{- end }}
+      {{- if eq "log" $key }}
+        log {{ default "stdout" $middleware.file }}
+      {{- end }}
+      {{- if eq "errors" $key }}
+        errors {{ default "stderr" $middleware.file }}
+      {{- end }}
+      {{- if eq "health" $key }}
+        health
+      {{- end }}
+      {{- if eq "prometheus" $key }}
+        prometheus localhost:{{ $middleware.port }}
+      {{- end }}
+      {{- if eq "proxy" $key }}
         proxy . /etc/resolv.conf
+      {{- end }}
+      {{- if eq "cache" $key }}
         cache 30
+      {{- end }}
+      {{- end }}
+      {{- end }}
     }

--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        log stdout
+        health
+{{- if .Values.metrics.enabled }}
+        prometheus localhost:{{ .Values.metrics.port }}
+{{- end }}
+        kubernetes {{ .Values.clusterDomain }} {
+          cidrs {{ .Values.clusterCidr }}
+        }
+        proxy . /etc/resolv.conf
+        cache 30
+    }

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -1,29 +1,44 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: coredns
-  namespace: kube-system
+  name: {{ template "fullname" . }}
   labels:
-    k8s-app: coredns
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- else }}
+    app: {{ template "fullname" . }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      k8s-app: coredns
+      {{- if .Values.isClusterService }}
+      k8s-app: {{ .Chart.Name | quote }}
+      {{- else }}
+      app: {{ template "fullname" . }}
+      {{- end }}
   template:
     metadata:
       labels:
-        k8s-app: coredns
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+        {{- if .Values.isClusterService }}
+        k8s-app: {{ .Chart.Name | quote }}
+        {{- else }}
+        app: {{ template "fullname" . }}
+        {{- end }}
+        release: {{ .Release.Name | quote }}
       annotations:
+        {{- if .Values.isClusterService }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        {{- end }}
     spec:
       containers:
-      - name: coredns
+      - name: "coredns"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "-conf", "/etc/coredns/Corefile" ]
@@ -48,11 +63,10 @@ spec:
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 5
-      dnsPolicy: Default
       volumes:
         - name: config-volume
           configMap:
-            name: coredns
+            name: {{ template "fullname" . }}
             items:
             - key: Corefile
               path: Corefile

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: coredns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      k8s-app: coredns
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      containers:
+      - name: coredns
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: coredns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  annotations:
+{{- if .Values.metrics.enabled }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.metrics.port }}
+{{- end }}
+spec:
+  selector:
+    k8s-app: coredns
+
+  clusterIP: {{ .Values.clusterIP }}
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -1,23 +1,33 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-dns
-  namespace: kube-system
+  name: {{ template "fullname" . }}
   labels:
-    k8s-app: coredns
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- else }}
+    app: {{ template "fullname" . }}
+    {{- end }}
   annotations:
-{{- if .Values.metrics.enabled }}
+    {{- if .Values.middleware.prometheus.enabled }}
     prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.metrics.port }}
-{{- end }}
+    prometheus.io/port: {{ .Values.middleware.prometheus.port | quote }}
+    {{- end }}
 spec:
   selector:
-    k8s-app: coredns
-
-  clusterIP: {{ .Values.clusterIP }}
+  {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+  {{- else }}
+    app: {{ template "fullname" . }}
+  {{- end }}
+  {{- if .Values.isClusterService }}
+  clusterIP: {{ .Values.middleware.kubernetes.clusterIP }}
+  {{- end }}
   ports:
   - name: dns
     port: 53
@@ -25,3 +35,4 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
+  type: {{ default "ClusterIP" .Values.serviceType }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -1,0 +1,23 @@
+# Default values for coredns.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+clusterCidr: 10.3.0.0/24
+clusterDomain: cluster.local
+clusterIP: 10.3.0.10
+
+replicaCount: 1
+image:
+  repository: coredns/coredns
+  tag: "006"
+  pullPolicy: IfNotPresent
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+metrics:
+  enabled: true
+  port: 9153

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -2,15 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-clusterCidr: 10.3.0.0/24
-clusterDomain: cluster.local
-clusterIP: 10.3.0.10
-
 replicaCount: 1
+
 image:
   repository: coredns/coredns
   tag: "006"
   pullPolicy: IfNotPresent
+
 resources:
   limits:
     cpu: 100m
@@ -18,6 +16,42 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
-metrics:
-  enabled: true
-  port: 9153
+
+# isClusterService specifies whether chart should be deployed as cluster-service or normal k8s app.
+isClusterService: true
+
+# serviceType specifies type of service to be created for this chart.
+serviceType: "ClusterIP"
+
+# middleware configuration of CoreDNS refer to https://github.com/coredns/coredns/tree/master/middleware
+# for all specific details. set enabled to true/false to enable/disable a middleware.
+middleware:
+  kubernetes:
+    enabled: true
+    clusterCidr: "10.3.0.0/24"
+    clusterDomain: "cluster.local"
+    clusterIP:
+  prometheus:
+    enabled: true
+    port: "9153"
+  errors:
+    enabled: true
+    file: "stderr"
+  log:
+    enabled: false
+    file: "stdout"
+  health:
+    enabled: true
+  proxy:
+    enabled: true
+  cache:
+    enabled: true
+  loadbalance:
+    enabled: true
+    policy: "round_robin"
+  etcd:
+    enabled: false
+    zones:
+      - "k8s.io"
+    path: "/skydns"
+    endpoint: "http://localhost:2379"


### PR DESCRIPTION
This pr builds upon the initial pr for CoreDNS chart #758 done by @hunter,
I have included the commit in that pr and extended the chart to be deployable for multiple scenarios.

The original pr was handling only the scenario of replacing kube-dns by CoreDNS
I have extended now to deploy CoreDNS as a normal k8s app offering DNS service, which can be used from within cluster as well as outside the cluster like external dns service.

Request all members cc'ed below for a review.
cc @hunter @johnbelamaric @miekg 

@hunter, if you agree we can push this pr instead of the original one as this one already includes your commit. we can iterate over this pr and push for merge asap.
