### PR TITLE
[stable/orangehrm] disable 'generic' storageClass for MariaDB dep

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: orangehrm
-version: 0.4.3
+version: 0.4.4
 description: OrangeHRM is a free HR management system that offers a wealth of modules to suit the needs of your business.
 keywords:
 - orangehrm

--- a/stable/orangehrm/README.md
+++ b/stable/orangehrm/README.md
@@ -67,7 +67,7 @@ The following tables lists the configurable parameters of the OrangeHRM chart an
 | `persistence.orangehrm.size`         | PVC Storage Request for OrangeHRM volume | `8Gi`                                          |
 | `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                          |
 | `mariadb.persistence.enabled`        | Enable MariaDB persistence using PVC     | `true`                                         |
-| `mariadb.persistence.storageClass`   | PVC Storage Class for MariaDB volume     | `generic`                                      |
+| `mariadb.persistence.storageClass`   | PVC Storage Class for MariaDB volume     | `nil` (uses alpha storage class annotation)    |
 | `mariadb.persistence.accessMode`     | PVC Access Mode for MariaDB volume       | `ReadWriteOnce`                                |
 | `mariadb.persistence.size`           | PVC Storage Request for MariaDB volume   | `8Gi`                                          |
 

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -1,6 +1,9 @@
 dependencies:
-- name: mariadb
+- condition: ""
+  enabled: false
+  name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.9
-digest: sha256:2c911bb44ebae5d8e3d9d69cfb49ce9704cf6cd02bc3583b29fc945e9f213d6a
-generated: 2017-02-14T19:54:56.502484019-05:00
+  tags: null
+  version: 0.5.10
+digest: sha256:a294108cdfa55885a7244fac40760c0a2405c24933ed326de2437cd8e5063c88
+generated: 2017-03-14T15:42:50.73945905Z

--- a/stable/orangehrm/requirements.yaml
+++ b/stable/orangehrm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.9
+  version: 0.5.10
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/orangehrm/templates/NOTES.txt
+++ b/stable/orangehrm/templates/NOTES.txt
@@ -26,4 +26,4 @@
 2. Login with the following credentials
 
   echo Username: {{ .Values.orangehrmUsername }}
-  echo Password: $(printf $(printf '\%o' `kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.orangehrm-password[*]}"`))
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.orangehrm-password}" | base64 --decode)

--- a/stable/orangehrm/values.yaml
+++ b/stable/orangehrm/values.yaml
@@ -41,7 +41,10 @@ mariadb:
   ##
   persistence:
     enabled: true
-    storageClass: generic
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
     accessMode: ReadWriteOnce
     size: 8Gi
 
@@ -59,14 +62,14 @@ persistence:
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default
     ##
-    # storageClass: generic
+    # storageClass:
     accessMode: ReadWriteOnce
     size: 1Gi
   orangehrm:
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default
     ##
-    # storageClass: generic
+    # storageClass:
     accessMode: ReadWriteOnce
     size: 8Gi
 


### PR DESCRIPTION
The dependent MariaDB chart was configured to use a storageClass called
'generic' which doesn't exist prevented the alpha storage class
annotation from being used, and breaking the chart if a storage class
named generic doesn't exist on the cluster.

This fixes the chart to correctly leave the storageClass unset unless
provided by the user.