### PR TITLE
[stable/redmine] use a randomly generated password

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 0.3.11
+version: 0.4.0
 description: A flexible project management web application.
 keywords:
 - redmine

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -50,7 +50,7 @@ The following tables lists the configurable parameters of the Redmine chart and 
 | `image`                         | Redmine image                   | `bitnami/redmine:{VERSION}`                               |
 | `imagePullPolicy`               | Image pull policy               | `IfNotPresent`                                            |
 | `redmineUsername`               | User of the application         | `user`                                                    |
-| `redminePassword`               | Application password            | `bitnami`                                                 |
+| `redminePassword`               | Application password            | _random 10 character long alphanumeric string_            |
 | `redmineEmail`                  | Admin email                     | `user@example.com`                                        |
 | `redmineLanguage`               | Redmine default data language   | `en`                                                      |
 | `smtpHost`                      | SMTP host                       | `nil`                                                     |

--- a/stable/redmine/templates/NOTES.txt
+++ b/stable/redmine/templates/NOTES.txt
@@ -22,5 +22,5 @@
 
 2. Login with the following credentials
 
-  Username: {{ .Values.redmineUsername }}
-  Password: {{ .Values.redminePassword }}
+  echo Username: {{ .Values.redmineUsername }}
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.redmine-password}" | base64 --decode)

--- a/stable/redmine/templates/secrets.yaml
+++ b/stable/redmine/templates/secrets.yaml
@@ -9,5 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
+  {{ if .Values.redminePassword }}
   redmine-password: {{ default "" .Values.redminePassword | b64enc | quote }}
+  {{ else }}
+  redmine-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
   smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -14,9 +14,10 @@ imagePullPolicy: IfNotPresent
 redmineUsername: user
 
 ## Application password
-## ref: https://github.com/bitnami/bitnami-docker-redmine/#environment-variables
+## Defaults to a random 10-character alphanumeric string if not set
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
 ##
-redminePassword: bitnami
+# redminePassword:
 
 ## Admin email
 ## ref: https://github.com/bitnami/bitnami-docker-redmine/#environment-variables


### PR DESCRIPTION
Sets up Redmine to use a randomly generated password by default.

This also fixes a bug which wouldn't allow you to change the default password, because it was under 8 characters.