### PR TITLE
Included the missing metadata.name

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.7
+version: 0.1.8
 keywords:
   - kube-lego
   - letsencrypt

--- a/stable/kube-lego/templates/NOTES.txt
+++ b/stable/kube-lego/templates/NOTES.txt
@@ -5,6 +5,7 @@ EXAMPLE INGRESS YAML:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  name: example
   namespace: foo
   annotations:
     kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Included the missing metadata.name which was causing an error  `resource name may not be empty` while trying to run the example yaml.
