### PR TITLE
[stable/orangehrm] workaround session timeouts due to clientIP changes

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: orangehrm
-version: 0.4.3
+version: 0.4.4
 description: OrangeHRM is a free HR management system that offers a wealth of modules to suit the needs of your business.
 keywords:
 - orangehrm

--- a/stable/orangehrm/README.md
+++ b/stable/orangehrm/README.md
@@ -16,7 +16,7 @@ It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/chart
 
 ## Prerequisites
 
-- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.5+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -1,6 +1,9 @@
 dependencies:
-- name: mariadb
+- condition: ""
+  enabled: false
+  name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.5.9
-digest: sha256:2c911bb44ebae5d8e3d9d69cfb49ce9704cf6cd02bc3583b29fc945e9f213d6a
-generated: 2017-02-14T19:54:56.502484019-05:00
+  tags: null
+  version: 0.5.10
+digest: sha256:a294108cdfa55885a7244fac40760c0a2405c24933ed326de2437cd8e5063c88
+generated: 2017-03-15T19:19:19.917864165+05:30

--- a/stable/orangehrm/requirements.yaml
+++ b/stable/orangehrm/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mariadb
-  version: 0.5.9
+  version: 0.5.10
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/orangehrm/templates/svc.yaml
+++ b/stable/orangehrm/templates/svc.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    service.beta.kubernetes.io/external-traffic: OnlyLocal
 spec:
   type: {{ .Values.serviceType }}
   ports:


### PR DESCRIPTION
changes:
 - fixes session timeouts dues to client ip changes
 - mariadb chart dependency updated to `0.5.10`
