### PR TITLE
[stable/spinnaker] update dependencies

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.1.1
+version: 0.1.2
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/stable/spinnaker/requirements.lock
+++ b/stable/spinnaker/requirements.lock
@@ -1,9 +1,15 @@
 dependencies:
-- name: redis
+- condition: ""
+  enabled: false
+  name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.4.2
-- name: minio
+  tags: null
+  version: 0.4.6
+- condition: ""
+  enabled: false
+  name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.0.1
-digest: sha256:c80d5e19cfba940133477743a3f5416a526b5942c7689f0589257be042ef0924
-generated: 2017-01-06T11:22:49.384880181-08:00
+  tags: null
+  version: 0.0.4
+digest: sha256:91011613b8280b041f555b6cc69a77074c7f1821288d4045cc72b9720df7b886
+generated: 2017-03-15T17:39:02.270304206Z

--- a/stable/spinnaker/requirements.yaml
+++ b/stable/spinnaker/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: redis
-  version: 0.4.2
+  version: 0.4.6
   repository: https://kubernetes-charts.storage.googleapis.com/
 - name: minio
-  version: 0.0.1
+  version: 0.0.4
   repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
Fixes an issue where Redis resources are truncated to 24 characters instead of
63.

Fixes https://github.com/kubernetes/helm/issues/2116