### PR TITLE
Prometheus nodeSelector support

### DIFF
--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -17,6 +17,8 @@ spec:
         component: "{{ .Values.alertmanager.name }}"
         release: "{{ .Release.Name }}"
     spec:
+      nodeSelector:
+{{ toYaml .Values.alertmanager.nodeSelector | indent 12 }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image }}"

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -17,6 +17,8 @@ spec:
         component: "{{ .Values.kubeStateMetrics.name }}"
         release: "{{ .Release.Name }}"
     spec:
+      nodeSelector:
+{{ toYaml .Values.kubeStateMetrics.nodeSelector | indent 12 }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.kubeStateMetrics.name }}
           image: "{{ .Values.kubeStateMetrics.image }}"

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -21,6 +21,8 @@ spec:
         component: "{{ .Values.server.name }}"
         release: "{{ .Release.Name }}"
     spec:
+      nodeSelector:
+{{ toYaml .Values.server.nodeSelector | indent 12 }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.name }}
           image: "{{ .Values.configmapReload.image }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -3,6 +3,10 @@ alertmanager:
   ##
   extraArgs: {}
 
+  ## Node Selector
+  ##
+  nodeSelector: {}
+
   ## Alertmanager service port
   ##
   httpPort: 80
@@ -121,6 +125,10 @@ configmapReload:
 # imagePullPolicy:
 
 kubeStateMetrics:
+  ## Node Selector
+  ##
+  nodeSelector: {}
+
   ## Kube-state-metrics service port
   ##
   httpPort: 80
@@ -162,6 +170,10 @@ server:
   ## Additional Server container arguments
   ##
   extraArgs: {}
+
+  ## Node Selector
+  ##
+  nodeSelector: {}
 
   ## Server service port
   ##


### PR DESCRIPTION
Clusters that have different types of nodes in the cluster need
nodeSelector support to be usable so they land on the right kind
of node. This adds support to the Prometheus chart.