### PR TITLE
Grafana nodeSelector support

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.2.4
+version: 0.2.5
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         component: "{{ .Values.server.name }}"
         release: "{{ .Release.Name }}"
     spec:
+      nodeSelector:
+{{ toYaml .Values.server.nodeSelector | indent 12 }}
       containers:
         - name: {{ template "name" . }}
           image: "{{ .Values.server.image }}"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -12,6 +12,8 @@ server:
   ##
   image: "grafana/grafana:latest"
 
+  nodeSelector: {}
+
   ingress:
     ## If true, Grafana Ingress will be created
     ##


### PR DESCRIPTION
Clusters that have different types of nodes in the cluster need
nodeSelector support to be usable so they land on the right kind
of node. This adds support to the Grafana chart.