### PR TITLE
[stable/postgresql] Add external ip and port variables

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.6.0
+version: 0.7.0
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -63,6 +63,8 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 | `metrics.imageTag`         | Exporter image                             | `v0.1.1`                                                   |
 | `metrics.imagePullPolicy`  | Exporter image pull policy                 | `IfNotPresent`                                             |
 | `metrics.resources`        | Exporter resource requests/limit           | Memory: `256Mi`, CPU: `100m`                               |
+| `service.externalIPs`      | External IPs to listen on                  | `[]`                                                       |
+| `service.port`             | TCP port                                   | `5432`                                                     |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 

--- a/stable/postgresql/templates/svc.yaml
+++ b/stable/postgresql/templates/svc.yaml
@@ -15,7 +15,11 @@ metadata:
 spec:
   ports:
   - name: postgresql
-    port: 5432
+    port: {{ .Values.service.port }}
     targetPort: postgresql
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
   selector:
     app: {{ template "fullname" . }}

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -55,3 +55,7 @@ resources:
   requests:
     memory: 256Mi
     cpu: 100m
+
+service:
+  port: 5432
+  externalIPs: []


### PR DESCRIPTION
This lets one expose the service on external ip and a custom port number