### PR TITLE
[mongodb-replicaset] Add keyfile access control

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 1.0.0
+version: 1.1.0
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 icon: https://webassets.mongodb.com/_com_assets/cms/mongodb-logo-rgb-j6w271g1xn.jpg
 sources:

--- a/stable/mongodb-replicaset/init/Makefile
+++ b/stable/mongodb-replicaset/init/Makefile
@@ -14,7 +14,7 @@
 
 all: push
 
-TAG = 0.3
+TAG = 0.4
 PREFIX = gcr.io/google_containers/mongodb-install
 
 container:

--- a/stable/mongodb-replicaset/init/files/install.sh
+++ b/stable/mongodb-replicaset/init/files/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2016 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/stable/mongodb-replicaset/init/files/on-start.sh
+++ b/stable/mongodb-replicaset/init/files/on-start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2016 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,46 +14,85 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function join {
-    local IFS="$1"; shift; echo "$*";
-}
+replica_set=$REPLICA_SET
+script_name=${0##*/}
 
-HOSTNAME=$(hostname)
-
-# Read input from peer-finder
-while read -ra LINE; do
-    if [[ "${LINE}" == *"${HOSTNAME}"* ]]; then
-        MY_NAME=$LINE
-        continue
-    fi
-    PEERS=("${PEERS[@]}" $LINE)
-done
-
-# start a mongodb instance
-/usr/bin/mongod --config=/config/mongod.conf &> /work-dir/log.txt &
-until /usr/bin/mongo --eval 'printjson(db.serverStatus())'
-do
-  echo "Retrying..." >> /work-dir/log.txt
-  sleep 2
-done
-echo "Initialized." >> /work-dir/log.txt
-
-# try to find a master and add yourself to its replicaset.
-for f in "${PEERS[@]}"
-do
-  /usr/bin/mongo --host="${f}" --eval="printjson(rs.isMaster())" | grep "\"ismaster\" : true"
-  if [ $? -eq 0 ]; then
-    echo "${f}" MASTER >> /work-dir/log.txt
-    /usr/bin/mongo --host="${f}" --eval="printjson(rs.add('${MY_NAME}'))"
-    exit 0
-  fi
-done
-
-# else initiate a replicaset with yourself.
-/usr/bin/mongo --eval="printjson(rs.status())" | grep "no replset config has been received"
-if [ $? -eq 0 ]; then
-  /usr/bin/mongo --eval="printjson(rs.initiate({'_id': '${RS}', 'members': [{'_id': 0, 'host': '${MY_NAME}'}]}))"
+if [[ "$AUTH" == "true" ]]; then
+    admin_user="$ADMIN_USER"
+    admin_password="$ADMIN_PASSWORD"
+    admin_auth=(-u "$admin_user" -p "$admin_password")
 fi
 
-# Do a clean shutdown of mongod
-/usr/bin/mongo --eval "db.getSiblingDB('admin').shutdownServer({force: true})"
+function log() {
+    local msg="$1"
+    local timestamp=$(date --iso-8601=ns)
+    echo "[$timestamp] [$script_name] $msg" >> /work-dir/log.txt
+}
+
+function shutdown_mongo() {
+    log "Shutting down MongoDB..."
+    mongo admin "${admin_auth[@]}" --eval 'db.shutdownServer({force: true})'
+}
+
+my_hostname=$(hostname)
+log "Bootstrapping MongoDB replica set member: $my_hostname"
+
+log "Reading standard input..."
+while read -ra line; do
+    if [[ "${line}" == *"${my_hostname}"* ]]; then
+        service_name="$line"
+        continue
+    fi
+    peers=("${peers[@]}" "$line")
+done
+
+log "Peers: ${peers[@]}"
+
+log "Starting a MongoDB instance..."
+mongod --config /config/mongod.conf &> /work-dir/log.txt &
+
+log "Waiting for MongoDB to be ready..."
+until mongo --eval "db.adminCommand('ping')"; do
+    log "Retrying..."
+    sleep 2
+done
+
+log "Initialized."
+
+# try to find a master and add yourself to its replica set.
+for peer in "${peers[@]}"; do
+    mongo admin --host "$peer" "${admin_auth[@]}" --eval "rs.isMaster()" | grep '"ismaster" : true'
+    if [[ $? -eq 0 ]]; then
+        log "Found master: $peer"
+        log "Adding myself ($service_name) to replica set..."
+        mongo admin --host "$peer" "${admin_auth[@]}" --eval "rs.add('$service_name')"
+        log "Done."
+
+        shutdown_mongo
+        log "Good bye."
+        exit 0
+    fi
+done
+
+# else initiate a replica set with yourself.
+mongo --eval "rs.status()" | grep "no replset config has been received"
+if [[ $? -eq 0 ]]; then
+    log "Initiating a new replica set with myself ($service_name)..."
+    mongo --eval "rs.initiate({'_id': '$replica_set', 'members': [{'_id': 0, 'host': '$service_name'}]})"
+
+    mongo --eval "rs.status()"
+
+    if [[ "$AUTH" == "true" ]]; then
+        # sleep a little while just to be sure the initiation of the replica set has fully
+        # finished and we can create the user
+        sleep 3
+
+        log "Creating admin user..."
+        mongo admin --eval "db.createUser({user: '$admin_user', pwd: '$admin_password', roles: [{role: 'root', db: 'admin'}]})"
+    fi
+
+    log "Done."
+fi
+
+shutdown_mongo
+log "Good bye."

--- a/stable/mongodb-replicaset/templates/NOTES.txt
+++ b/stable/mongodb-replicaset/templates/NOTES.txt
@@ -1,13 +1,14 @@
 1. After the statefulset is created completely, one can check which instance is primary by running:
 
-    $ for ((i = 0; i < {{ .Values.replicas }}; ++i)); do kubectl exec --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-$i -- sh -c '/usr/bin/mongo --eval="printjson(rs.isMaster())"'; done
+    $ for ((i = 0; i < {{ .Values.replicas }}; ++i)); do kubectl exec --namespace {{ .Release.Namespace }} {{ template "fullname" . }}-$i -- sh -c 'mongo --eval="printjson(rs.isMaster())"'; done
 
 2. One can insert a key into the primary instance of the mongodb replica set by running the following:
     MASTER_POD_NAME must be replaced with the name of the master found from the previous step.
 
-    $ kubectl exec --namespace {{ .Release.Namespace }} MASTER_POD_NAME -- /usr/bin/mongo --eval="printjson(db.test.insert({key1: 'value1'}))"
+    $ kubectl exec --namespace {{ .Release.Namespace }} MASTER_POD_NAME -- mongo --eval="printjson(db.test.insert({key1: 'value1'}))"
 
 3. One can fetch the keys stored in the primary or any of the slave nodes in the following manner.
     POD_NAME must be replaced by the name of the pod being queried.
 
-    $ kubectl exec --namespace {{ .Release.Namespace }} POD_NAME -- /usr/bin/mongo --eval="rs.slaveOk(); db.test.find().forEach(printjson)"
+    $ kubectl exec --namespace {{ .Release.Namespace }} POD_NAME -- mongo --eval="rs.slaveOk(); db.test.find().forEach(printjson)"
+

--- a/stable/mongodb-replicaset/templates/_helpers.tpl
+++ b/stable/mongodb-replicaset/templates/_helpers.tpl
@@ -14,3 +14,25 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name for the admin secret.
+*/}}
+{{- define "adminSecret" -}}
+    {{- if .Values.auth.existingAdminSecret -}}
+        {{- .Values.auth.existingAdminSecret -}}
+    {{- else -}}
+        {{- template "fullname" . -}}-admin
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the key secret.
+*/}}
+{{- define "keySecret" -}}
+    {{- if .Values.auth.existingKeySecret -}}
+        {{- .Values.auth.existingKeySecret -}}
+    {{- else -}}
+        {{- template "fullname" . -}}-keyfile
+    {{- end -}}
+{{- end -}}

--- a/stable/mongodb-replicaset/templates/mongodb-admin-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-admin-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.auth.enabled) (not .Values.auth.existingAdminSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "adminSecret" . }}
+type: Opaque
+data:
+  user: {{ .Values.auth.adminUser | b64enc }}
+  password: {{ .Values.auth.adminPassword | b64enc }}
+{{- end -}}

--- a/stable/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.auth.enabled) (not .Values.auth.existingKeySecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "keySecret" . }}
+type: Opaque
+data:
+  key.txt: {{ .Values.auth.key | b64enc }}
+{{- end -}}
+

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -53,9 +53,33 @@ spec:
                         }
                     },
                     {
-                        "name": "RS",
+                        "name": "REPLICA_SET",
                         "value": "{{ .Values.replicaSet }}"
                     }
+                    {{- if .Values.auth.enabled }},
+                    {
+                        "name": "AUTH",
+                        "value": "true"
+                    },
+                    {
+                        "name": "ADMIN_USER",
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "name": "{{ template "adminSecret" . }}",
+                                "key": "user"
+                            }
+                        }
+                    },
+                    {
+                        "name": "ADMIN_PASSWORD",
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "name": "{{ template "adminSecret" . }}",
+                                "key": "password"
+                            }
+                        }
+                    }
+                    {{- end }}
                 ],
                 "volumeMounts": [
                     {
@@ -70,6 +94,13 @@ spec:
                         "name": "datadir",
                         "mountPath": "/data/db"
                     }
+                    {{- if .Values.auth.enabled }},
+                    {
+                        "name": "keydir",
+                        "mountPath": "/keydir",
+                        "readOnly": true
+                    }
+                    {{- end }}
                 ]
             }
         ]'
@@ -84,25 +115,61 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           command:
-            - /usr/bin/mongod
+            - mongod
             - --config=/config/mongod.conf
+          {{- if .Values.auth.enabled }}
+          env:
+            - name: AUTH
+              value: "true"
+            - name: ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "adminSecret" . }}"
+                  key: user
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "adminSecret" . }}"
+                  key: password
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - mongo
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
           readinessProbe:
             exec:
               command:
-                - sh
-                - -c
-                - "/usr/bin/mongo --eval 'printjson(db.serverStatus())'"
+                - mongo
+                - --eval
+                - "db.adminCommand('ping')"
             initialDelaySeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 1
           volumeMounts:
             - name: datadir
               mountPath: /data/db
             - name: config
               mountPath: /config
+            - name: workdir
+              mountPath: /work-dir
+          {{- if .Values.auth.enabled }}
+            - name: keydir
+              mountPath: /keydir
+              readOnly: true
+          {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ template "fullname" . }}
+        {{- if .Values.auth.enabled }}
+        - name: keydir
+          secret:
+            defaultMode: 0400
+            secretName: {{ template "keySecret" . }}
+        {{- end }}
         - name: workdir
           emptyDir: {}
 {{- if .Values.persistentVolume.enabled }}

--- a/stable/mongodb-replicaset/test.sh
+++ b/stable/mongodb-replicaset/test.sh
@@ -17,9 +17,9 @@
 NS="${RELEASE_NAMESPACE:-default}"
 POD_NAME="${RELEASE_NAME:-mongo}-mongodb-replicaset"
 
-for i in `seq 0 2`; do
+for i in $(seq 0 2); do
     pod="${POD_NAME}-$i"
-    kubectl exec --namespace $NS $pod -- sh -c '/usr/bin/mongo --eval="printjson(rs.isMaster())"' | grep '"ismaster" : true'
+    kubectl exec --namespace $NS $pod -- sh -c 'mongo --eval="printjson(rs.isMaster())"' | grep '"ismaster" : true'
 
     if [ $? -eq 0 ]; then
         echo "Found master: $pod"
@@ -28,15 +28,15 @@ for i in `seq 0 2`; do
     fi
 done
 
-kubectl exec --namespace $NS $MASTER -- /usr/bin/mongo --eval='printjson(db.test.insert({"status": "success"}))'
+kubectl exec --namespace $NS $MASTER -- mongo --eval='printjson(db.test.insert({"status": "success"}))'
 
 # TODO: find maximum duration to wait for slaves to be up-to-date with master.
 sleep 2
 
-for i in `seq 0 2`; do
+for i in $(seq 0 2); do
     pod="${POD_NAME}-$i"
     if [[ $pod != $MASTER ]]; then
         echo "Reading from slave: $pod"
-        kubectl exec --namespace $NS $pod -- /usr/bin/mongo --eval='rs.slaveOk(); db.test.find().forEach(printjson)'
+        kubectl exec --namespace $NS $pod -- mongo --eval='rs.slaveOk(); db.test.find().forEach(printjson)'
     fi
 done

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -2,10 +2,18 @@ replicaSet: rs0
 replicas: 3
 port: 27017
 
+auth:
+  enabled: false
+  # adminUser:
+  # adminPassword:
+  # key:
+  # existingKeySecret:
+  # existingAdminSecret:
+
 # Specs for the Docker image for the init container that establishes the replica set
 installImage:
   name: gcr.io/google_containers/mongodb-install
-  tag: 0.3
+  tag: 0.4
   pullPolicy: IfNotPresent
 
 # Specs for the MongoDB image
@@ -18,12 +26,12 @@ image:
 podAnnotations: {}
 
 resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 512Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 512Mi
+# limits:
+#   cpu: 100m
+#   memory: 512Mi
+# requests:
+#   cpu: 100m
+#   memory: 512Mi
 
 persistentVolume:
   enabled: true
@@ -47,3 +55,6 @@ configmap:
     port: 27017
   replication:
     replSetName: rs0
+# security:
+#   authorization: enabled
+#   keyFile: /keydir/key.txt


### PR DESCRIPTION
Note that `gcr.io/google_containers/mongodb-install:0.4` must be built and pushed for these changes to work.