### PR TITLE
Jenkins LTS 2.46.1

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.3.1
+version: 0.4.0
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:2.32.3
-RUN /usr/local/bin/install-plugins.sh kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.10 git:3.1.0 \
+FROM jenkinsci/jenkins:2.46.1-alpine
+RUN /usr/local/bin/install-plugins.sh kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.10 git:3.2.0 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch

--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jenkins:2.46.1-alpine
+FROM jenkinsci/jenkins:2.46.1
 RUN /usr/local/bin/install-plugins.sh kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.10 git:3.2.0 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -9,7 +9,7 @@ data:
     <?xml version='1.0' encoding='UTF-8'?>
     <hudson>
       <disabledAdministrativeMonitors/>
-      <version>2.32.3</version>
+      <version>2.46.1</version>
       <numExecutors>0</numExecutors>
       <mode>NORMAL</mode>
       <useSecurity>{{ .Values.Master.UseSecurity }}</useSecurity>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -6,7 +6,7 @@
 Master:
   Name: jenkins-master
   Image: "gcr.io/kubernetes-charts-ci/jenkins-master-k8s"
-  ImageTag: "v0.7.0"
+  ImageTag: "v0.8.0"
   ImagePullPolicy: "Always"
   Component: "jenkins-master"
   UseSecurity: true


### PR DESCRIPTION
- Latest LTS
- Latest Git Plugin
- Migrated base image to the official jenkins docker repo instaed of the official library as they are automaticly updated when released and the official docker libraray is just a clone of the official jenkins once