### PR TITLE
[stable/grafana] Define GF_INSTALL_PLUGINS

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.2.5
+version: 0.2.6
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.2.6
+version: 0.3.0
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/configmap.yaml
+++ b/stable/grafana/templates/configmap.yaml
@@ -9,4 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
   name: {{ template "server.fullname" . }}-config
 data:
+  {{- if .Values.server.installPlugins }}
+  grafana-install-plugins: {{ .Values.server.installPlugins | quote }}
+  {{- end }}
 {{ toYaml .Values.serverConfigFile | indent 2 }}

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -38,6 +38,13 @@ spec:
                 secretKeyRef:
                   name: {{ template "server.fullname" . }}
                   key: grafana-admin-password
+            {{- if .Values.server.installPlugins }}
+            - name: GF_INSTALL_PLUGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "server.fullname" . }}-config
+                  key: grafana-install-plugins
+            {{- end }}
           ports:
             - containerPort: 3000
           readinessProbe:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -132,6 +132,12 @@ server:
   ##
   # terminationGracePeriodSeconds: 300
 
+  ## Pass the plugins you want installed as a comma seperated list.
+  ## This will pass each plugin name to `grafana-cli plugins install ${plugin}`.
+  ## Ref: https://github.com/grafana/grafana-docker#installing-plugins-for-grafana-3
+  ##
+  # installPlugins:
+
   # Set datasource in beginning
   setDatasource:
     ## If true, an initial Grafana Datasource will be set


### PR DESCRIPTION
This is intended to work with the official Grafana image.

When this environment variable is defined, the bootstrap script `run.sh` installs the given list of plugins before launching the Grafana server.