### PR TITLE
Add Gluster Chart for helm deployment.

### DIFF
--- a/incubator/gluster/.helmignore
+++ b/incubator/gluster/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/gluster/Chart.yaml
+++ b/incubator/gluster/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: gluster
+home: https://www.gluster.org
+version: 1.0.0
+description: GlusterFS is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks.
+icon: https://www.gluster.org/images/antmascot.png?1458134976
+sources:
+  - https://github.com/gluster
+  - https://github.com/gluster
+maintainers:
+  - name: Humble Chirammal
+email: hchiramm@redhat.com

--- a/incubator/gluster/README.md
+++ b/incubator/gluster/README.md
@@ -1,0 +1,17 @@
+Gluster
+=====
+
+[Gluster](https://www.gluster.org) GlusterFS is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks. GlusterFS is free and open source software. 
+ 
+
+Introduction
+------------
+
+This chart bootstraps Gluster deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Prerequisites
+-------------
+
+-	Kubernetes 1.4+ with Beta APIs enabled for default standalone mode.
+
+

--- a/incubator/gluster/templates/NOTES.txt
+++ b/incubator/gluster/templates/NOTES.txt
@@ -1,0 +1,14 @@
+Gluster service can be accessed via:
+
+1. export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+
+2. kubectl port-forward $POD_NAME 24007 --namespace {{ .Release.Namespace }}
+
+Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/
+
+Your gluster server is listening on $POD_NAME:24007. 
+
+Gluster server can be accessed via port {{ .Values.servicePort }} on an external IP address. Get the service external IP address by:
+kubectl get svc --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }}
+
+Note that Public IP and access it's 24007 to connect glusterd service running in this.

--- a/incubator/gluster/templates/_helpers.tpl
+++ b/incubator/gluster/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/gluster/templates/deployment.yaml
+++ b/incubator/gluster/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.service.internalPort }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.service.internalPort }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/incubator/gluster/templates/service.yaml
+++ b/incubator/gluster/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/incubator/gluster/values.yaml
+++ b/incubator/gluster/values.yaml
@@ -1,0 +1,22 @@
+# Default values for gluster.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+# ref # https://hub.docker.com/r/gluster/gluster-centos
+
+image: gluster-centos
+pullPolicy: IfNotPresent
+replicaCount: 1
+repository: hub.docker.com/gluster
+resources: 
+  limits: 
+    cpu: 100m
+    memory: 1Gi
+  requests: 
+    cpu: 100m
+    memory: 1Gi
+service: 
+  externalPort: 24007
+  internalPort: 24007
+  name: glusterfs
+tag: latest
+


### PR DESCRIPTION
GlusterFS ( www.gluster.org)  is a scalable network filesystem. Using common off-the-shelf hardware, you can create large, distributed storage solutions for media streaming, data analysis, and other data- and bandwidth-intensive tasks. GlusterFS is free and open source software and completely user space filesystem. This chart enable to run gluster containers in a kube setup.

Signed-off-by: hchiramm <hchiramm@redhat.com>