### PR TITLE
[stable/nginx-ingress] Release 0.3.2

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.3.1
+version: 0.3.2
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
 keywords:


### PR DESCRIPTION
(#770 didn't bump the version number; this releases a version of the chart that includes that fix.)