### PR TITLE
Add ability to configure image to mysql chart

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.2.5
+version: 0.2.6
 description: Fast, reliable, scalable, and easy to use open-source relational database system.
 keywords:
 - mysql

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}
-        image: "mysql:{{ .Values.imageTag }}"
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -1,6 +1,7 @@
 ## mysql image version
 ## ref: https://hub.docker.com/r/library/mysql/tags/
 ##
+image: "mysql"
 imageTag: "5.7.14"
 
 ## Specify password for root user


### PR DESCRIPTION
Simple PR to bring mysql chart in line with helm standards by making image configurable.