### PR TITLE
[stable/prometheus] Add extra service labels (#886)

### DIFF
--- a/stable/prometheus/templates/alertmanager-service.yaml
+++ b/stable/prometheus/templates/alertmanager-service.yaml
@@ -12,6 +12,9 @@ metadata:
     component: "{{ .Values.alertmanager.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.alertmanager.service.labels }}
+{{ toYaml .Values.alertmanager.service.labels | indent 4}}
+{{- end }}
   name: {{ template "alertmanager.fullname" . }}
 spec:
 {{- if .Values.alertmanager.service.clusterIP }}

--- a/stable/prometheus/templates/kube-state-metrics-svc.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-svc.yaml
@@ -12,6 +12,9 @@ metadata:
     component: "{{ .Values.kubeStateMetrics.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.kubeStateMetrics.service.labels }}
+{{ toYaml .Values.kubeStateMetrics.service.labels | indent 4}}
+{{- end }}
   name: {{ template "kubeStateMetrics.fullname" . }}
 spec:
 {{- if .Values.kubeStateMetrics.service.clusterIP }}

--- a/stable/prometheus/templates/node-exporter-service.yaml
+++ b/stable/prometheus/templates/node-exporter-service.yaml
@@ -12,6 +12,9 @@ metadata:
     component: "{{ .Values.nodeExporter.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.nodeExporter.service.labels }}
+{{ toYaml .Values.nodeExporter.service.labels | indent 4}}
+{{- end }}
   name: {{ template "nodeExporter.fullname" . }}
 spec:
 {{- if .Values.nodeExporter.service.clusterIP }}

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -11,6 +11,9 @@ metadata:
     component: "{{ .Values.server.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.server.service.labels }}
+{{ toYaml .Values.server.service.labels | indent 4}}
+{{- end }}
   name: {{ template "server.fullname" . }}
 spec:
 {{- if .Values.server.service.clusterIP }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -108,6 +108,7 @@ alertmanager:
 
   service:
     annotations: {}
+    labels: {}
     clusterIP: ""
 
     ## List of IP addresses at which the alertmanager service is available
@@ -181,6 +182,7 @@ kubeStateMetrics:
   service:
     annotations:
       prometheus.io/scrape: "true"
+    labels: {}
 
     clusterIP: None
 
@@ -237,6 +239,7 @@ nodeExporter:
   service:
     annotations:
       prometheus.io/scrape: "true"
+    labels: {}
 
     clusterIP: None
 
@@ -361,6 +364,7 @@ server:
 
   service:
     annotations: {}
+    labels: {}
     clusterIP: ""
 
     ## List of IP addresses at which the Prometheus server service is available


### PR DESCRIPTION
I have added the ability to set extra service labels to:
- alertmanager
- node-exporter
- server
- kube-state-metrics