### PR TITLE
Add namerd chart

### DIFF
--- a/stable/namerd/.helmignore
+++ b/stable/namerd/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/namerd/Chart.yaml
+++ b/stable/namerd/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+description: Service that manages routing for multiple linkerd instances
+name: namerd
+version: 0.1.0
+home: https://linkerd.io/in-depth/namerd/
+icon: https://pbs.twimg.com/profile_images/690258997237014528/KNgQd9GL_400x400.png
+sources:
+- https://github.com/BuoyantIO/namerd
+maintainers:
+- name: Sean Knox
+  email: knoxville@gmail.com

--- a/stable/namerd/Chart.yaml
+++ b/stable/namerd/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 home: https://linkerd.io/in-depth/namerd/
 icon: https://pbs.twimg.com/profile_images/690258997237014528/KNgQd9GL_400x400.png
 sources:
-- https://github.com/BuoyantIO/namerd
+- https://github.com/linkerd/linkerd
 maintainers:
 - name: Sean Knox
   email: knoxville@gmail.com

--- a/stable/namerd/README.md
+++ b/stable/namerd/README.md
@@ -5,7 +5,7 @@
 ## Chart Details
 This chart will do the following:
 
-* Install a deployment that provisions namerd with a default configuration.
+* Install a deployment that provisions namerd with a default configuration and three replicas for HA.
 
 ## Installing the Chart
 

--- a/stable/namerd/README.md
+++ b/stable/namerd/README.md
@@ -1,0 +1,30 @@
+# namerd Chart
+
+[namerd](https://linkerd.io/in-depth/namerd/) is a service that manages routing for multiple [linkerd](https://github.com/kubernetes/charts/tree/master/stable/linkerd) instances.
+
+## Chart Details
+This chart will do the following:
+
+* Install a deployment that provisions namerd with a default configuration.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/namerd
+```
+
+## Configuration
+
+Configurable values are documented in the `values.yaml`.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/namerd
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/namerd/templates/NOTES.txt
+++ b/stable/namerd/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
+{{- end }}

--- a/stable/namerd/templates/_helpers.tpl
+++ b/stable/namerd/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/namerd/templates/config.yaml
+++ b/stable/namerd/templates/config.yaml
@@ -10,8 +10,8 @@ metadata:
 data:
   config.yaml: |-
     admin:
-      ip: 127.0.0.1
-      port: 9991
+      ip: 0.0.0.0
+      port: {{ .Values.service.adminPort }}
     storage:
       kind: io.l5d.k8s
       experimental: true

--- a/stable/namerd/templates/config.yaml
+++ b/stable/namerd/templates/config.yaml
@@ -17,7 +17,6 @@ data:
       experimental: true
     namers:
       - kind: io.l5d.k8s
-        experimental: true
         host: 127.0.0.1
         port: 8001
     interfaces:

--- a/stable/namerd/templates/config.yaml
+++ b/stable/namerd/templates/config.yaml
@@ -8,10 +8,6 @@ metadata:
     release: "{{ .Release.Name }}"
   name: {{ template "fullname" . }}-config
 data:
-{{ if .Values.config }}
-  config.yaml: |-
-{{ toYaml .Values.config| indent 4 }}
-{{ else }}
   config.yaml: |-
     admin:
       ip: 127.0.0.1
@@ -31,4 +27,3 @@ data:
       - kind: io.l5d.httpController
         ip: 0.0.0.0
         port: 4180
-{{ end}}

--- a/stable/namerd/templates/config.yaml
+++ b/stable/namerd/templates/config.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "fullname" . }}-config
+data:
+{{ if .Values.config }}
+  config.yaml: |-
+{{ toYaml .Values.config| indent 4 }}
+{{ else }}
+  config.yaml: |-
+    admin:
+      ip: 127.0.0.1
+      port: 9991
+    storage:
+      kind: io.l5d.k8s
+      experimental: true
+    namers:
+      - kind: io.l5d.k8s
+        experimental: true
+        host: 127.0.0.1
+        port: 8001
+    interfaces:
+      - kind: io.l5d.thriftNameInterpreter
+        ip: 0.0.0.0
+        port: 4100
+      - kind: io.l5d.httpController
+        ip: 0.0.0.0
+        port: 4180
+{{ end}}

--- a/stable/namerd/templates/config.yaml
+++ b/stable/namerd/templates/config.yaml
@@ -22,7 +22,7 @@ data:
     interfaces:
       - kind: io.l5d.thriftNameInterpreter
         ip: 0.0.0.0
-        port: 4100
+        port: {{ .Values.service.syncPort }}
       - kind: io.l5d.httpController
         ip: 0.0.0.0
-        port: 4180
+        port: {{ .Values.service.apiPort }}

--- a/stable/namerd/templates/deployment.yaml
+++ b/stable/namerd/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:

--- a/stable/namerd/templates/deployment.yaml
+++ b/stable/namerd/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         image: "{{ .Values.namerd.image.repository }}"
         imagePullPolicy: {{ default "" .Values.namerd.image.pullPolicy | quote }}
         args:
-        - /io.buoyant/namerd/config/config.yml
+        - /io.buoyant/namerd/config/config.yaml
         ports:
         - name: sync
           containerPort: 4100

--- a/stable/namerd/templates/deployment.yaml
+++ b/stable/namerd/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
         - /io.buoyant/namerd/config/config.yaml
         ports:
         - name: sync
-          containerPort: 4100
+          containerPort: {{ .Values.service.syncPort }}
         - name: api
-          containerPort: 4180
+          containerPort: {{ .Values.service.apiPort }}
         volumeMounts:
         - name: "{{ template "fullname" . }}-config"
           mountPath: "/io.buoyant/namerd/config"

--- a/stable/namerd/templates/deployment.yaml
+++ b/stable/namerd/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      volumes:
+      - name: {{ template "fullname" . }}-config
+        configMap:
+          name: "{{ template "fullname" . }}-config"
+      containers:
+      - name: {{ template "fullname" . }}
+        image: "{{ .Values.namerd.image.repository }}"
+        imagePullPolicy: {{ default "" .Values.namerd.image.pullPolicy | quote }}
+        args:
+        - /io.buoyant/namerd/config/config.yml
+        ports:
+        - name: sync
+          containerPort: 4100
+        - name: api
+          containerPort: 4180
+        volumeMounts:
+        - name: "{{ template "fullname" . }}-config"
+          mountPath: "/io.buoyant/namerd/config"
+          readOnly: true
+        resources:
+{{ toYaml .Values.namerd.resources | indent 12 }}
+      - name: kubectl
+        image: "{{ .Values.kubectl.image.repository }}"
+        imagePullPolicy: {{ default "" .Values.kubectl.image.pullPolicy | quote }}
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+        resources:
+{{ toYaml .Values.kubectl.resources | indent 12 }}

--- a/stable/namerd/templates/service.yaml
+++ b/stable/namerd/templates/service.yaml
@@ -11,5 +11,7 @@ spec:
     port: {{ .Values.service.syncPort }}
   - name: api
     port: {{ .Values.service.apiPort }}
+  - name: admin
+    port: {{ .Values.service.adminPort }}
   selector:
     app: {{ template "fullname" . }}

--- a/stable/namerd/templates/service.yaml
+++ b/stable/namerd/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: sync
+    port: 4100
+  - name: api
+    port: 4180
+  selector:
+    app: {{ template "fullname" . }}

--- a/stable/namerd/templates/service.yaml
+++ b/stable/namerd/templates/service.yaml
@@ -8,8 +8,8 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - name: sync
-    port: 4100
+    port: {{ .Values.service.syncPort }}
   - name: api
-    port: 4180
+    port: {{ .Values.service.apiPort }}
   selector:
     app: {{ template "fullname" . }}

--- a/stable/namerd/templates/tpr.yaml
+++ b/stable/namerd/templates/tpr.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: d-tab.l5d.io
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+description: stores dtabs used by Buoyant's `namerd` service
+versions:
+  - name: v1alpha1 # Do not change this value as it hardcoded in Namerd and doesn't work with other value.

--- a/stable/namerd/values.yaml
+++ b/stable/namerd/values.yaml
@@ -1,0 +1,30 @@
+# Default values for namerd.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+namerd:
+  image:
+    repository: buoyantio/namerd:0.9.1
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 0
+      memory: 512Mi
+kubectl:
+  image:
+    repository: buoyantio/kubectl:v1.4.0
+    pullPolicy: IfNotPresent
+  resources:
+    # limits:
+    #   cpu: 10m
+    #   memory: 32Mi
+    requests:
+      cpu: 0
+      memory: 32Mi
+service:
+  type: ClusterIP
+
+config:

--- a/stable/namerd/values.yaml
+++ b/stable/namerd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for namerd.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 1
+replicaCount: 3
 namerd:
   image:
     repository: buoyantio/namerd:0.9.1

--- a/stable/namerd/values.yaml
+++ b/stable/namerd/values.yaml
@@ -26,3 +26,5 @@ kubectl:
       memory: 32Mi
 service:
   type: ClusterIP
+  syncPort: 4100
+  apiPort: 4180

--- a/stable/namerd/values.yaml
+++ b/stable/namerd/values.yaml
@@ -28,3 +28,4 @@ service:
   type: ClusterIP
   syncPort: 4100
   apiPort: 4180
+  adminPort: 9991

--- a/stable/namerd/values.yaml
+++ b/stable/namerd/values.yaml
@@ -26,5 +26,3 @@ kubectl:
       memory: 32Mi
 service:
   type: ClusterIP
-
-config:


### PR DESCRIPTION
[namerd](https://linkerd.io/in-depth/namerd/) is a service that manages routing for multiple [linkerd](https://github.com/kubernetes/charts/tree/master/stable/linkerd) instances. It's also a dependency of BuoyantIO's new TCP load balancer for the linkerd service mesh, [linkerd-tcp](https://github.com/linkerd/linkerd-tcp) (as an aside, I see linkerd-tcp being incredibly valuable in porting legacy applications to Kubernetes).

Chart is modeled after the example from [namerd docs](https://linkerd.io/config/0.9.1/namerd/index.html#kubernetes) and the existing [linkerd chart](https://github.com/kubernetes/charts/tree/master/stable/linkerd). @olix0r can you give some 👀 and make sure this seems sane at baseline?