### PR TITLE
[incubator/zookeeper] - Zookeeper's pen cleanup

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.2.2
+version: 0.2.3
 description: Centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif
 sources:

--- a/incubator/zookeeper/templates/cm.yaml
+++ b/incubator/zookeeper/templates/cm.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ printf "cm-zk-%s" .Release.Name | trunc 24 }}"
-  annotations:
-    helm.sh/created: {{.Release.Time.Seconds | quote }}
   labels:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}

--- a/incubator/zookeeper/templates/pdb.yaml
+++ b/incubator/zookeeper/templates/pdb.yaml
@@ -2,8 +2,6 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ printf "pd-zk-%s" .Release.Name | trunc 24 }}"
-  annotations:
-    helm.sh/created: {{.Release.Time.Seconds | quote }}
   labels:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}

--- a/incubator/zookeeper/templates/ss.yaml
+++ b/incubator/zookeeper/templates/ss.yaml
@@ -2,8 +2,6 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: "{{ printf "zk-%s" .Release.Name  | trunc 24 }}"
-  annotations:
-    helm.sh/created: {{.Release.Time.Seconds | quote }}
   labels:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
@@ -33,7 +31,7 @@ spec:
                   "topologyKey": "kubernetes.io/hostname"
                 }]
               }
-            } 
+            }
         {{- else if eq .Values.AntiAffinity "soft"}}
         scheduler.alpha.kubernetes.io/affinity: >
             {
@@ -142,11 +140,7 @@ spec:
   - metadata:
       name: datadir
       annotations:
-        {{- if .Values.StorageClass}}
-        volume.beta.kubernetes.io/storage-class: {{.Values.StorageClass | quote}}
-        {{- else}}
-        volume.alpha.kubernetes.io/storage-class: "default"
-        {{- end}} 
+        volume.beta.kubernetes.io/storage-class: {{default "standard" .Values.StorageClass | quote}}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:


### PR DESCRIPTION
There are a few things that made it difficult to use this in conjunction with
the Kafka chart that I tried to cleanup

- The timestamp annotation on resources that can not have annotation updates
make upgrading this chart (or one which uses this as a dep) impossible as it
complains each time (Ex. pod disruption budget)

- Standardized the volume annotation to always be `volume.beta.kubernetes.io/storage-class`