### PR TITLE
Use correct value keys to determine which storageClass to use

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,5 +1,5 @@
 name: gitlab-ce
-version: 0.1.6
+version: 0.1.7
 description: GitLab Community Edition
 keywords:
 - git

--- a/stable/gitlab-ce/templates/data-pvc.yaml
+++ b/stable/gitlab-ce/templates/data-pvc.yaml
@@ -4,8 +4,8 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-data
   annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.gitlabData.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.gitlabData.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}

--- a/stable/gitlab-ce/templates/etc-pvc.yaml
+++ b/stable/gitlab-ce/templates/etc-pvc.yaml
@@ -4,8 +4,8 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-etc
   annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.gitlabEtc.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.gitlabEtc.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}


### PR DESCRIPTION
The keys in the Postgres and Redis PVC templates had been updated, but those in the data/etc PVC ones were assuming an old version of values.yaml.