### PR TITLE
[stable/jenkins] Update slaves, support pipeline

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.3.1
+version: 0.5.0
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.5.0
+version: 0.4.0
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
 FROM jenkinsci/jenkins:2.46.1
-RUN /usr/local/bin/install-plugins.sh kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.10 git:3.2.0 \
+RUN /usr/local/bin/install-plugins.sh kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch

--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:2.32.3
-RUN /usr/local/bin/install-plugins.sh kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.10 git:3.1.0 \
+FROM jenkinsci/jenkins:2.46.1
+RUN /usr/local/bin/install-plugins.sh kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.10 git:3.2.0 \
     && mkdir -p /usr/share/jenkins/ref/secrets/ \
     && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -9,7 +9,7 @@ data:
     <?xml version='1.0' encoding='UTF-8'?>
     <hudson>
       <disabledAdministrativeMonitors/>
-      <version>2.32.3</version>
+      <version>2.46.1</version>
       <numExecutors>0</numExecutors>
       <mode>NORMAL</mode>
       <useSecurity>{{ .Values.Master.UseSecurity }}</useSecurity>
@@ -36,7 +36,12 @@ data:
               <idleMinutes>0</idleMinutes>
               <label></label>
               <nodeSelector></nodeSelector>
-              <volumes/>
+              <volumes>
+                <org.csanchez.jenkins.plugins.kubernetes.PodVolumes_-HostPathVolume>
+                  <mountPath>/var/run/docker.sock</mountPath>
+                  <hostPath>/var/run/docker.sock</hostPath>
+                </org.csanchez.jenkins.plugins.kubernetes.PodVolumes_-HostPathVolume>
+              </volumes>
               <containers>
                 <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
                   <name>jnlp</name>

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -38,6 +38,22 @@ spec:
                           "mountPath": "/var/jenkins_home"
                       }
                   ]
+              },
+              {
+                  "name": "copy-script-approval",
+                  "image": "{{.Values.Master.Image}}:{{.Values.Master.ImageTag}}",
+                  "imagePullPolicy": "{{.Values.Master.ImagePullPolicy}}",
+                  "command": ["cp", "-n", "/var/jenkins_script-approval/scriptapproval.xml", "/var/jenkins_home/scriptApproval.xml"],
+                  "volumeMounts": [
+                      {
+                          "name": "jenkins-script-approval",
+                          "mountPath": "/var/jenkins_script-approval"
+                      },
+                      {
+                          "name": "jenkins-home",
+                          "mountPath": "/var/jenkins_home"
+                      }
+                  ]
               }
           ]'
     spec:
@@ -86,6 +102,10 @@ spec:
               mountPath: /var/jenkins_config
               name: jenkins-config
               readOnly: true
+            -
+              mountPath: /var/jenkins_script-approval
+              name: jenkins-script-approval
+              readOnly: true              
       volumes:
 {{- if .Values.Persistence.volumes }}
 {{ toYaml .Values.Persistence.volumes | indent 6 }}
@@ -93,6 +113,9 @@ spec:
       - name: jenkins-config
         configMap:
           name: {{ template "fullname" . }}
+      - name: jenkins-script-approval
+        configMap:
+          name: {{ template "fullname" . }}-script-approval          
       - name: jenkins-home
       {{- if .Values.Persistence.Enabled }}
         persistentVolumeClaim:

--- a/stable/jenkins/templates/script-approval.yaml
+++ b/stable/jenkins/templates/script-approval.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-script-approval
+data: 
+  scriptapproval.xml: |-
+    <?xml version='1.0' encoding='UTF-8'?>
+    <scriptApproval plugin="script-security@1.23">
+      <approvedScriptHashes/>
+      <approvedSignatures>
+        <string>method groovy.json.JsonSlurperClassic parseText java.lang.String</string>
+        <string>new groovy.json.JsonSlurperClassic</string>
+        <string>staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Map java.util.Map</string>
+      </approvedSignatures>
+      <aclApprovedSignatures/>
+      <approvedClasspathEntries/>
+      <pendingScripts/>
+      <pendingSignatures/>
+      <pendingClasspathEntries/>
+    </scriptApproval>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -5,15 +5,15 @@
 
 Master:
   Name: jenkins-master
-  Image: "gcr.io/kubernetes-charts-ci/jenkins-master-k8s"
-  ImageTag: "v0.7.0"
+  Image: "dtzar/jenkins-master-k8s"
+  ImageTag: "latest"
   ImagePullPolicy: "Always"
   Component: "jenkins-master"
   UseSecurity: true
   AdminUser: admin
 # AdminPassword: <defaults to random>
   Cpu: "200m"
-  Memory: "256Mi"
+  Memory: "512Mi"
 # Set min/max heap here if needed with:
 # JavaOpts: "-Xms512m -Xmx512m"
   ServicePort: 8080
@@ -25,8 +25,8 @@ Master:
 # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
   SlaveListenerPort: 50000
-  LoadBalancerSourceRanges:
-  - 0.0.0.0/0
+  #LoadBalancerSourceRanges:
+  #- 0.0.0.0/0
 # List of groovy init scripts to be executed during Jenkins master start
   InitScripts:
 #  - |
@@ -44,10 +44,10 @@ Master:
       #     - jenkins.cluster.local
 
 Agent:
-  Image: jenkinsci/jnlp-slave
-  ImageTag: 2.52
+  Image: dtzar/jnlp-slave-helm
+  ImageTag: latest
   Cpu: "200m"
-  Memory: "256Mi"
+  Memory: "512Mi"
 
 Persistence:
   Enabled: true

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -6,14 +6,14 @@
 Master:
   Name: jenkins-master
   Image: "dtzar/jenkins-master-k8s"
-  ImageTag: "latest"
+  ImageTag: "2.46.1"
   ImagePullPolicy: "Always"
   Component: "jenkins-master"
   UseSecurity: true
   AdminUser: admin
 # AdminPassword: <defaults to random>
   Cpu: "200m"
-  Memory: "512Mi"
+  Memory: "256Mi"
 # Set min/max heap here if needed with:
 # JavaOpts: "-Xms512m -Xmx512m"
   ServicePort: 8080
@@ -25,8 +25,8 @@ Master:
 # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
   SlaveListenerPort: 50000
-  #LoadBalancerSourceRanges:
-  #- 0.0.0.0/0
+  LoadBalancerSourceRanges:
+  - 0.0.0.0/0
 # List of groovy init scripts to be executed during Jenkins master start
   InitScripts:
 #  - |
@@ -44,10 +44,10 @@ Master:
       #     - jenkins.cluster.local
 
 Agent:
-  Image: dtzar/jnlp-slave-helm
-  ImageTag: latest
+  Image: jenkinsci/jnlp-slave
+  ImageTag: 2.62
   Cpu: "200m"
-  Memory: "512Mi"
+  Memory: "256Mi"
 
 Persistence:
   Enabled: true


### PR DESCRIPTION
This is a major update to include the native ability for: 
- Jenkins slave image update on K8s to do docker-in-docker builds via binding to the docker daemon on the K8s node.  Also kubectl and helm binaries included.
- Jenkins master also approves the required scripts in order to run pipelines from git repositories
Thanks to @lachie83 for the existing work he already did via [his fork here](https://github.com/lachie83/charts/tree/master/stable/jenkins).

I included the Jenkins version update changes from @jwhitcraft with PR https://github.com/kubernetes/charts/pull/733.
I added a link to the master image in my DockerHub for now to be able for anyone to test, but happy to revert to the existing gcr repo once it is updated.
For the Jenkins slave docker image I'm open to keeping the repo pointed to where it is at now, but of course open to other suggestions on the permanent home.
For both I realize that we should not use latest tag, but it was easiest until I get feedback on permanent home for the images.