### PR TITLE
Include namespace in port-forward suggestion

### DIFF
--- a/incubator/artifactory/templates/NOTES.txt
+++ b/incubator/artifactory/templates/NOTES.txt
@@ -13,7 +13,7 @@ Get the Artifactory URL to visit by running these commands in the same shell:
 {{- else if contains "ClusterIP"  .Values.ServiceType }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:{{ .Values.httpPort }}
-  kubectl port-forward $POD_NAME {{ .Values.httpPort }}:{{ .Values.httpPort }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.httpPort }}:{{ .Values.httpPort }}
 
 {{- end }}
 


### PR DESCRIPTION
The commands suggested in the NOTES.txt did not include the namespace.