### PR TITLE
Add dogstatsd chart

### DIFF
--- a/stable/dogstatsd/.helmignore
+++ b/stable/dogstatsd/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/dogstatsd/Chart.yaml
+++ b/stable/dogstatsd/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for StatsD
+name: statsd
+version: 0.1.0

--- a/stable/dogstatsd/Chart.yaml
+++ b/stable/dogstatsd/Chart.yaml
@@ -2,3 +2,11 @@ apiVersion: v1
 description: A Helm chart for DogStatsD
 name: dogstatsd
 version: 1.0
+keywords:
+  - statsd
+  - datadog
+maintainers:
+  - name: Yuvi Panda
+    email: yuvipanda@gmai.com
+sources:
+  - https://github.com/DataDog/docker-dd-agent#standalone-dogstatsd

--- a/stable/dogstatsd/Chart.yaml
+++ b/stable/dogstatsd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for StatsD
-name: statsd
-version: 0.1.0
+description: A Helm chart for DogStatsD
+name: dogstatsd
+version: 1.0

--- a/stable/dogstatsd/README.md
+++ b/stable/dogstatsd/README.md
@@ -1,0 +1,65 @@
+# Dogstatsd
+
+[Dogstatsd](http://docs.datadoghq.com/guides/dogstatsd/) is a statsd that can send data to [DataDog](https://datadoghq.com)
+
+## Introduction
+
+This chart sets up a single dogstatsd instance that your services can
+send arbitrary metrics to
+
+## Prerequisites
+
+- Kubernetes 1.2+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` in namespace `statsd`, retrieve your DataDog API key from your [Agent Installation Instructions](https://app.datadoghq.com/account/settings#agent/kubernetes) and run:
+
+```bash
+$ helm install --name my-release --namespace statsd \
+    --set datadog.apiKey=YOUR-KEY-HERE stable/datadog
+```
+
+You can then send statsd metrics to `dogstatsd.statsd` host on your kubernetes cluster,
+and they should show up on DataDog.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Datadog chart and their default values.
+
+|      Parameter              |          Description               |                         Default           |
+|-----------------------------|------------------------------------|-------------------------------------------|
+| `datadog.apiKey`            | Your Datadog API key               |  `Nil` You must provide your own key      |
+| `image.repository`          | The image repository to pull from  | `datadog/docker-dd-agent`  |
+| `image.tag`                 | The image tag to pull              | `11.0.5123-dogstatsd`               |
+| `resources.requests.cpu`    | CPU resource requests              | 128M                                      |
+| `resources.limits.cpu`      | CPU resource limits                | 512Mi                                     |
+| `resources.requests.memory` | Memory resource requests           | 100m                                      |
+| `resources.limits.memory`   | Memory resource limits             | 256m                                      |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set datadog.apiKey=YOUR-KEY-HERE \
+    stable/dogstatsd
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/dogstatsd
+```

--- a/stable/dogstatsd/templates/NOTES.txt
+++ b/stable/dogstatsd/templates/NOTES.txt
@@ -1,0 +1,4 @@
+This sets up a dogstatsd instance that sends
+statistics to DataDog.
+
+You can send data to this at `dogstatsd.{{ .Release.Namespace }}`.

--- a/stable/dogstatsd/templates/deployment.yaml
+++ b/stable/dogstatsd/templates/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: dogstatsd
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: dogstatsd
+    spec:
+      containers:
+      - name: dogstatsd-container
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        env:
+          - name: API_KEY
+            value: {{ .Values.datadog.apiKey | quote }}
+        ports:
+        - containerPort: 8125
+          name: statsd
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/stable/dogstatsd/templates/svc.yaml
+++ b/stable/dogstatsd/templates/svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dogstatsd
+spec:
+  selector:
+    name: dogstatsd
+  ports:
+    - protocol: UDP
+      port: 8125
+      targetPort: 8125

--- a/stable/dogstatsd/values.yaml
+++ b/stable/dogstatsd/values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: datadog/docker-dd-agent
+  tag: 11.0.5123-dogstatsd
+
+datadog:
+  apiKey: "Put your datadog API key here"
+
+resources:
+  limits:
+    cpu: 256m
+    memory: 512Mi
+  requests:
+    cpu: 128m
+    memory: 512Mi
+


### PR DESCRIPTION
Different from the `datadog` chart in the following ways:

1. Adds a deployment+service you can send statsd metrics to,
   rather than install an agent on each node
2. Much more lightweight if you're only using datadog as a statsd
   backend.

I considered integrating this into the datadog chart but that
seemed less clean