### PR TITLE
kube-lego: Make LEGO_EMAIL a required field

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.8
+version: 0.1.9
 keywords:
   - kube-lego
   - letsencrypt

--- a/stable/kube-lego/templates/deployment.yaml
+++ b/stable/kube-lego/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+          # {{ required "config.LEGO_EMAIL is a required field" .Values.config.LEGO_EMAIL }}
           {{- range $key, $value := .Values.config }}
             - name: "{{ $key }}"
               value: "{{ $value }}"

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -4,7 +4,7 @@
 config:
   ## Email address to use for registration with Let's Encrypt
   ##
-  LEGO_EMAIL: my@email.tld
+  # LEGO_EMAIL: my@email.tld
 
   ## Let's Encrypt API endpoint
   ## Production: https://acme-v01.api.letsencrypt.org/directory


### PR DESCRIPTION
We've had users complaining that the default email address is not working for them when using kube-lego.

Given this field is required for the user to fill in, this PR makes `config.LEGO_EMAIL` a required field.

I'm unsure if this is the best way to implement this change in a backward compatible manner (via a comment in the deployment manifest) - alternatively, something like the below should work:

```
            - name: LEGO_EMAIL
              value: "{{ required "config.LEGO_EMAIL is a required field" .Values.config.LEGO_EMAIL }}"
          {{- range $key, $value := .Values.config }}
          {{- if not (eq $key "LEGO_EMAIL")) }}
            - name: "{{ $key }}"
              value: "{{ $value }}"
          {{- end }}
          {{- end }}
```