### PR TITLE
fix(influxdb): Allow for overriding the pvc name

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 0.4.0
+version: 0.4.1
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:
 - influxdb

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       volumes:
       - name: data
       {{- if .Values.persistence.enabled }}
-        {{- if .Values.persistence.useExisting }}
+        {{- if not (empty .Values.persistence.name) }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.name }}
         {{- else }}

--- a/stable/influxdb/templates/pvc.yaml
+++ b/stable/influxdb/templates/pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: "{{- if not (empty .Values.persistence.name) }}{{ .Values.persistence.name }}{{- else }}{{ template "fullname" . }}{{- end }}"
   labels:
-    app: {{ template "fullname" . }}
+    app: "{{- if not (empty .Values.persistence.name) }}{{ .Values.persistence.name }}{{- else }}{{ template "fullname" . }}{{- end }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"


### PR DESCRIPTION
* Bumps version to 0.4.1
* Allows a user to specify a name for the pvc. Otherwise one will be generated using the chart name and the release.