### PR TITLE
[stable/kube-ops-view] Add ingress support & enhance service template metadata

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-ops-view
-version: 0.2.0
+version: 0.3.0
 description: Kubernetes Operational View - read-only system dashboard for multiple K8s clusters
 keywords:
   - kubernetes

--- a/stable/kube-ops-view/templates/ingress.yaml
+++ b/stable/kube-ops-view/templates/ingress.yaml
@@ -1,20 +1,28 @@
----
-{{- if .Values.ingress }}
+{{- if .Values.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
   labels:
+    app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4}}
+{{- end }}
 spec:
   rules:
-  - http:
-       paths:
-       - path: {{ .Values.ingress.path }}
-         backend:
-           serviceName: {{ template "fullname" . }}
-           servicePort: {{ .Values.service.externalPort }}
-{{- if .Values.ingress.host }}
-    host: {{ template "fullname" . }}.{{ toYaml .Values.ingress.host }}
-{{- end }}
-{{- end }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "fullname" . }}
+              servicePort: {{ .Values.service.externalPort }}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end -}}
+{{- end -}}

--- a/stable/kube-ops-view/templates/ingress.yaml
+++ b/stable/kube-ops-view/templates/ingress.yaml
@@ -1,0 +1,20 @@
+---
+{{- if .Values.ingress }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  rules:
+  - http:
+       paths:
+       - path: {{ .Values.ingress.path }}
+         backend:
+           serviceName: {{ template "fullname" . }}
+           servicePort: {{ .Values.service.externalPort }}
+{{- if .Values.ingress.host }}
+    host: {{ template "fullname" . }}.{{ toYaml .Values.ingress.host }}
+{{- end }}
+{{- end }}

--- a/stable/kube-ops-view/templates/service.yaml
+++ b/stable/kube-ops-view/templates/service.yaml
@@ -2,8 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "fullname" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4}}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4}}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/kube-ops-view/values.yaml
+++ b/stable/kube-ops-view/values.yaml
@@ -5,6 +5,10 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 service:
+  # annotations:
+  #   service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+  # labels:
+  #   key: value
   type: ClusterIP
   externalPort: 80
   internalPort: 8080
@@ -15,4 +19,13 @@ resources:
   requests:
     cpu: 80m
     memory: 64Mi
-
+ingress:
+  enabled: false
+  # hostname: kube-ops-view.local
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  # tls:
+  ## Secrets must be manually created in the namespace
+  #   - secretName: kube-ops-view.local-tls
+  #     hosts:
+  #       - kube-ops-view.local


### PR DESCRIPTION
* Add optional ingress for kube-ops-view 
* Add optional metadata items (annotations + labels) to the service template

```release-note
Add optional ingress for kube-ops-view
```