### PR TITLE
Jenkins add script approval

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,7 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.3.1
+version: 0.4.0
+appVersion: 2.32.3
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -46,6 +46,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.Ingress.Annotations` | Ingress annotations       | `{}`                                                |
 | `Master.Ingress.TLS` | Ingress TLS configuration       | `[]`                                                |
 | `Master.InitScripts`       | List of Jenkins init scripts       | Not set                                                    |  
+| `Master.ScriptApproval`       | List of groovy functions to approve       | Not set                                                    |  
 
 ### Jenkins Agent
 

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -89,8 +89,28 @@ data:
       <globalNodeProperties/>
       <noUsageStatistics>true</noUsageStatistics>
     </hudson>
+{{- if .Values.Master.ScriptApproval }}
+  scriptapproval.xml: |-
+    <?xml version='1.0' encoding='UTF-8'?>
+    <scriptApproval plugin="script-security@1.27">
+      <approvedScriptHashes/>
+      <approvedSignatures>
+{{- range $key, $val := .Values.Master.ScriptApproval }}
+        <string>{{ $val }}</string>
+{{- end }}
+      </approvedSignatures>
+      <aclApprovedSignatures/>
+      <approvedClasspathEntries/>
+      <pendingScripts/>
+      <pendingSignatures/>
+      <pendingClasspathEntries/>
+    </scriptApproval>
+{{- end }}
   apply_config.sh: |-
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
+{{- if .Values.Master.ScriptApproval }}
+    cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+{{- end }}
 {{- if .Values.Master.InitScripts }}
     mkdir -p /var/jenkins_home/init.groovy.d/;
     cp -n /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -27,6 +27,10 @@ Master:
   SlaveListenerPort: 50000
   LoadBalancerSourceRanges:
   - 0.0.0.0/0
+# Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
+  # ScriptApproval:
+  #   - "method groovy.json.JsonSlurperClassic parseText java.lang.String"
+  #   - "new groovy.json.JsonSlurperClassic"
 # List of groovy init scripts to be executed during Jenkins master start
   InitScripts:
 #  - |


### PR DESCRIPTION
This enables users to specify a list of groovy functions to approve in the script-security plugin.