### PR TITLE
redis-cache chart

### DIFF
--- a/incubator/redis-cache/.helmignore
+++ b/incubator/redis-cache/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/redis-cache/Chart.yaml
+++ b/incubator/redis-cache/Chart.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
+description: A Helm chart for pure in-memory redis cache, using statefulset and redis-sentinel-micro
 name: redis-cache
 version: 0.1.0
+icon: https://redis.io/images/redis-white.png
+sources:
+  - https://github.com/antirez/redis
+  - https://github.com/dhilipkumars/redis-sentinel-micro/tree/k8s
 maintainers:
   - name: dhilipkumars
     email: dhilip.kumar.s@huawei.com

--- a/incubator/redis-cache/Chart.yaml
+++ b/incubator/redis-cache/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: A Helm chart for pure in-memory redis cache, using statefulset and redis-sentinel-micro
+description: A pure in-memory redis cache, using statefulset and redis-sentinel-micro
 name: redis-cache
 version: 0.1.0
 icon: https://redis.io/images/redis-white.png

--- a/incubator/redis-cache/Chart.yaml
+++ b/incubator/redis-cache/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: redis-cache
+version: 0.1.0
+maintainers:
+  - name: dhilipkumars
+    email: dhilip.kumar.s@huawei.com

--- a/incubator/redis-cache/README.md
+++ b/incubator/redis-cache/README.md
@@ -1,24 +1,27 @@
 ## Redis-cache
 
-This chart will allow as to use redis as a pure in-memory cache, this uses a special utility to perform master-slave promotion which overcomes this [promblem](https://redis.io/topics/replication#safety-of-replication-when-master-has-persistence-turned-off), K8s could restart the master soon enough that it is detected and agreed among the redis-sentinels. 
+This chart will allow us to use redis as a pure in-memory cache, this uses a special utility to perform master-slave promotion which overcomes this [problem](https://redis.io/topics/replication#safety-of-replication-when-master-has-persistence-turned-off), K8s could restart the master way before it is detected and agreed among the redis-sentinels.  
+
+###Prerequisites
+* Kubernetes 1.6+
 
 Install Redis-cache chart as an in-memory cache. 
-* Uses 7MB [redis:3-alpine](https://hub.docker.com/r/library/redis/tags/3-alpine/) image which is extreemly light weight
+* Uses 7MB [redis:3-alpine](https://hub.docker.com/r/library/redis/tags/3-alpine/) image which is extremely light weight
 * Uses [redis-sentinel-k8s](https://github.com/dhilipkumars/redis-sentinel-micro/tree/k8s) for automatic slave promotion if master fails, feel free to fork.
-* Super fast caching as no persistance involved
+* Super fast caching as no persistence involved
 * Has Pod Disruption Budget
 * Uses Statefulset
 * Has Anti-Affinity Configured
 
-Quick Benchmark comparision between redis with and without persistence enabled, as you can notice the writes are atleast 3 times slower.
+Quick Benchmark comparison between redis with and without persistence enabled, as you can notice the writes are at least 3 times slower.
 
-Redis persistance enabled
+Redis persistence enabled
 ```
 $ k exec -i -t ${REPLICA-NAME} -c redis -- redis-benchmark -q -h ${REPLICA-NAME}.${POD-NAME}.${NAMESPACE} -p 6379 -t set,get -n 100000 -d 100 -r 1000000
 SET: 22026.43 requests per second
 GET: 76161.46 requests per second
 ```
-Redis without persistance
+Redis without persistence
 ```
 $ k exec -i -t ${REPLICA-NAME} -c redis -- redis-benchmark -q -h ${REPLICA-NAME}.${POD-NAME}.${NAMESPACE} -p 6379 -t set,get -n 100000 -d 100 -r 1000000
 SET: 60060.06 requests per second
@@ -81,7 +84,7 @@ $kubectl exec -i -t rd-dev-0 -c redis -- redis-cli -h rd-dev-0.rd-dev.default -p
 OK
 ```
 
-Check if that is replicated in anyof the slave0
+Check if that is replicated in any of the slaves
 ```
 $kubectl exec -i -t rd-dev-0 -c redis -- redis-cli -h rd-dev-2.rd-dev.default -p 6379 get foo
 "bar"

--- a/incubator/redis-cache/README.md
+++ b/incubator/redis-cache/README.md
@@ -27,7 +27,7 @@ GET: 89285.71 requests per second
 
 Here is a sample demo of master slave promotion.
 
-Insall this chart
+Install this chart
 ```
 $helm install -n dev incubator/redis-cache/ 
 NAME:   dev

--- a/incubator/redis-cache/README.md
+++ b/incubator/redis-cache/README.md
@@ -1,0 +1,116 @@
+## Redis-cache
+
+This chart will allow as to use redis as a pure in-memory cache, this uses a special utility to perform master-slave promotion which overcomes this [promblem](https://redis.io/topics/replication#safety-of-replication-when-master-has-persistence-turned-off), K8s could restart the master soon enough that it is detected and agreed among the redis-sentinels. 
+
+Install Redis-cache chart as an in-memory cache. 
+* Uses 7MB [redis:3-alpine](https://hub.docker.com/r/library/redis/tags/3-alpine/) image which is extreemly light weight
+* Uses [redis-sentinel-k8s](https://github.com/dhilipkumars/redis-sentinel-micro/tree/k8s) for automatic slave promotion if master fails, feel free to fork.
+* Super fast caching as no persistance involved
+* Has Pod Disruption Budget
+* Uses Statefulset
+* Has Anti-Affinity Configured
+
+Quick Benchmark comparision between redis with and without persistence enabled, as you can notice the writes are atleast 3 times slower.
+
+Redis persistance enabled
+```
+$ k exec -i -t ${REPLICA-NAME} -c redis -- redis-benchmark -q -h ${REPLICA-NAME}.${POD-NAME}.${NAMESPACE} -p 6379 -t set,get -n 100000 -d 100 -r 1000000
+SET: 22026.43 requests per second
+GET: 76161.46 requests per second
+```
+Redis without persistance
+```
+$ k exec -i -t ${REPLICA-NAME} -c redis -- redis-benchmark -q -h ${REPLICA-NAME}.${POD-NAME}.${NAMESPACE} -p 6379 -t set,get -n 100000 -d 100 -r 1000000
+SET: 60060.06 requests per second
+GET: 89285.71 requests per second
+```
+
+Here is a sample demo of master slave promotion.
+
+Insall this chart
+```
+$helm install -n dev incubator/redis-cache/ 
+NAME:   dev
+LAST DEPLOYED: Wed Apr 12 23:25:56 2017
+NAMESPACE: default
+STATUS: DEPLOYED
+
+RESOURCES:
+==> v1/Service
+NAME    CLUSTER-IP  EXTERNAL-IP  PORT(S)   AGE
+rd-dev  None        <none>       6379/TCP  0s
+
+==> policy/v1beta1/PodDisruptionBudget
+NAME    MIN-AVAILABLE  ALLOWED-DISRUPTIONS  AGE
+rd-dev  2              0                    0s
+
+==> apps/v1beta1/StatefulSet
+NAME    DESIRED  CURRENT  AGE
+rd-dev  3        0        0s
+
+
+NOTES:
+1. To Find which replica is the master
+  kubectl exec -i -t rd-dev-0 -c redis -- redis-cli -h rd-dev-0.rd-dev.default -p 6379 info replication
+```
+
+Wait until the PODs are created and check which replica is the master (by default it creates 3 replicas with 1 master and 2 slaves)
+```
+$kubectl get pods
+NAME                  READY     STATUS    RESTARTS   AGE
+rd-dev-0              2/2       Running   0          57s
+rd-dev-1              2/2       Running   0          41s
+rd-dev-2              2/2       Running   0          29s
+
+$kubectl exec -i -t rd-dev-0 -c redis -- redis-cli -h rd-dev-0.rd-dev.default -p 6379 info replication
+# Replication
+role:master
+connected_slaves:2
+slave0:ip=10.244.2.18,port=6379,state=online,offset=29,lag=0
+slave1:ip=10.244.1.16,port=6379,state=online,offset=29,lag=0
+master_repl_offset:29
+repl_backlog_active:1
+repl_backlog_size:1048576
+repl_backlog_first_byte_offset:2
+repl_backlog_histlen:28
+```
+
+Set a Key
+```
+$kubectl exec -i -t rd-dev-0 -c redis -- redis-cli -h rd-dev-0.rd-dev.default -p 6379 set foo bar
+OK
+```
+
+Check if that is replicated in anyof the slave0
+```
+$kubectl exec -i -t rd-dev-0 -c redis -- redis-cli -h rd-dev-2.rd-dev.default -p 6379 get foo
+"bar"
+```
+
+Kill the master
+```
+$kubeclt delete po/rd-dev-0
+pod "rd-dev-0" deleted
+```
+
+Wait until the kubernetes restarts rd-dev-0, once this is up you can check sentinel-micro's logs to find out which of the slave is now elected as the new master.
+```
+$kubectl logs rd-dev-0 sentinel-micro
+I0412 18:07:08.633263       1 redis_sentinel_k8s.go:368] Available endpoints are [rd-dev-2.rd-dev.default.svc.cluster.local rd-dev-1.rd-dev.default.svc.cluster.local]
+I0412 18:07:08.633392       1 redis_sentinel_k8s.go:194] Processing rd-dev-2.rd-dev.default.svc.cluster.local
+I0412 18:07:08.633446       1 redis_sentinel_k8s.go:194] Processing rd-dev-1.rd-dev.default.svc.cluster.local
+R=&{ slave -1 7 937 rd-dev-0.rd-dev.default 6379 100 false <nil>}
+R=&{ slave -1 7 937 rd-dev-0.rd-dev.default 6379 100 false <nil>}
+I0412 18:07:08.645222       1 redis_sentinel_k8s.go:382] OldMaster=<nil> NewMaster=&{rd-dev-1.rd-dev.default:6379 slave -1 7 937 rd-dev-0.rd-dev.default 6379 100 false 0xc42000e300}
+I0412 18:07:08.646876       1 redis_sentinel_k8s.go:398] New Master is rd-dev-1.rd-dev.default:6379, All the slaves are re-configured to replicate from this
+I0412 18:07:08.647040       1 redis_sentinel_k8s.go:421] Redis-Sentinal-micro Finished
+```
+
+As you can see `rd-dev-1` is the new master while `rd-dev-0` and `rd-dev-2` are its slaves
+Lets check if our original key `foo` is retained across master restarts
+```
+$kubectl exec -i -t rd-dev-0 -c redis -- redis-cli -h rd-dev-0.rd-dev.default -p 6379 get foo
+"bar"
+```
+
+#### Note: Care should be taken when you scale down the number of replicas of this statefulset.  Please make sure that current redis-master is not among _to be scaled down_ replicas. 

--- a/incubator/redis-cache/templates/NOTES.txt
+++ b/incubator/redis-cache/templates/NOTES.txt
@@ -9,5 +9,5 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
-  kubectl exec -i -t {{ printf "rd-%s" .Release.Name  | trunc 20 }}-0 -c redis -- redis-cli -h {{ printf "rd-%s" .Release.Name  | trunc 20 }}-0.{{ printf "rd-%s" .Release.Name  | trunc 20 }}.{{ .Release.Namespace }} -p 6379 info replication
+  kubectl exec -i -t {{ template "fullname" . }}-0 -c redis -- redis-cli -h {{ template "fullname" . }}-0.{{ template "fullname" . }}.{{ .Release.Namespace }} -p 6379 info replication
 {{- end }}

--- a/incubator/redis-cache/templates/NOTES.txt
+++ b/incubator/redis-cache/templates/NOTES.txt
@@ -1,0 +1,13 @@
+1. To Find which replica is the master 
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  kubectl exec -i -t {{ printf "rd-%s" .Release.Name  | trunc 20 }}-0 -c redis -- redis-cli -h {{ printf "rd-%s" .Release.Name  | trunc 20 }}-0.{{ printf "rd-%s" .Release.Name  | trunc 20 }}.{{ .Release.Namespace }} -p 6379 info replication
+{{- end }}

--- a/incubator/redis-cache/templates/NOTES.txt
+++ b/incubator/redis-cache/templates/NOTES.txt
@@ -1,13 +1,2 @@
 1. To Find which replica is the master 
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/login
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
-{{- else if contains "ClusterIP"  .Values.service.type }}
   kubectl exec -i -t {{ template "fullname" . }}-0 -c redis -- redis-cli -h {{ template "fullname" . }}-0.{{ template "fullname" . }}.{{ .Release.Namespace }} -p 6379 info replication
-{{- end }}

--- a/incubator/redis-cache/templates/_helpers.tpl
+++ b/incubator/redis-cache/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/redis-cache/templates/pdb.yaml
+++ b/incubator/redis-cache/templates/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ printf "rd-%s" .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ printf "rd-%s" .Release.Name  | trunc 20  }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/incubator/redis-cache/templates/pdb.yaml
+++ b/incubator/redis-cache/templates/pdb.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "name" . }}
       chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"

--- a/incubator/redis-cache/templates/pdb.yaml
+++ b/incubator/redis-cache/templates/pdb.yaml
@@ -1,9 +1,12 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ printf "rd-%s" .Release.Name }}
+  name: {{ template "fullname" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ printf "rd-%s" .Release.Name  | trunc 20  }}
+      app: {{ template "fullname" . }}
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      release: "{{ .Release.Name }}"
+      heritage: "{{ .Release.Service }}"
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/incubator/redis-cache/templates/service.yaml
+++ b/incubator/redis-cache/templates/service.yaml
@@ -3,14 +3,16 @@ kind: Service
 metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-  name: {{ printf "rd-%s" .Release.Name | trunc 20 }}
+  name: {{ template "fullname" . }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    app: {{ printf "rd-%s" .Release.Name  | trunc 20 }}
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   ports:
-  - port: {{ .Values.service.Port }}
+  - port: {{ .Values.service.port }}
     name: {{ .Values.service.name }}
   clusterIP: None
   selector:
-    app: {{ printf "rd-%s" .Release.Name  | trunc 20}}
+    app: {{ template "fullname" . }}

--- a/incubator/redis-cache/templates/service.yaml
+++ b/incubator/redis-cache/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  name: {{ printf "rd-%s" .Release.Name | trunc 20 }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ printf "rd-%s" .Release.Name  | trunc 20 }}
+spec:
+  ports:
+  - port: {{ .Values.service.Port }}
+    name: {{ .Values.service.name }}
+  clusterIP: None
+  selector:
+    app: {{ printf "rd-%s" .Release.Name  | trunc 20}}

--- a/incubator/redis-cache/templates/service.yaml
+++ b/incubator/redis-cache/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -15,4 +15,4 @@ spec:
     name: {{ .Values.service.name }}
   clusterIP: None
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}

--- a/incubator/redis-cache/templates/ss.yaml
+++ b/incubator/redis-cache/templates/ss.yaml
@@ -23,7 +23,10 @@ spec:
            {
              "name":"sentinel-micro",
              "image":"{{ .Values.microSentinel.image }}:{{ .Values.microSentinel.tag }}",
-                         "args" : ["-service","{{ template "fullname" . }}"],
+             "imagePullPolicy": "{{ .Values.microSentinel.pullPolicy }}",
+             "args" : ["-service","{{ template "fullname" . }}"],
+             "resources":
+{{ toJson .Values.microSentinel.resources | indent 17 }},
              "env": [
                {
                   "name": "POD_NAMESPACE",
@@ -66,6 +69,7 @@ spec:
       containers:
       - name: redis
         image: {{ .Values.redis.image }}:{{ .Values.redis.tag }}
+        imagePullPolicy: {{ .Values.redis.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.port }}
           name: {{ .Values.service.name }}
@@ -73,6 +77,9 @@ spec:
 {{ toYaml .Values.redis.resources | indent 12 }}
       - name: make-slave
         image: {{ .Values.makeSlave.image }}:{{ .Values.makeSlave.tag }}
+        imagePullPolicy: {{ .Values.makeSlave.pullPolicy }}
+        resources:
+{{ toYaml .Values.makeSlave.resources | indent 12 }}
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/incubator/redis-cache/templates/ss.yaml
+++ b/incubator/redis-cache/templates/ss.yaml
@@ -22,7 +22,7 @@ spec:
         pod.beta.kubernetes.io/init-containers: '[
            {
              "name":"sentinel-micro",
-             "image":"{{ .Values.image.microSentinel }}:{{ .Values.tag.microSentinel }}",
+             "image":"{{ .Values.microSentinel.image }}:{{ .Values.microSentinel.tag }}",
                          "args" : ["-service","{{ template "fullname" . }}"],
              "env": [
                {
@@ -65,14 +65,14 @@ spec:
            }
       containers:
       - name: redis
-        image: {{ .Values.image.redis }}:{{ .Values.tag.redis }}
+        image: {{ .Values.redis.image }}:{{ .Values.redis.tag }}
         ports:
         - containerPort: {{ .Values.service.port }}
           name: {{ .Values.service.name }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.redis.resources | indent 12 }}
       - name: make-slave
-        image: {{ .Values.image.makeSlave }}:{{ .Values.tag.makeSlave }}
+        image: {{ .Values.makeSlave.image }}:{{ .Values.makeSlave.tag }}
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/incubator/redis-cache/templates/ss.yaml
+++ b/incubator/redis-cache/templates/ss.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: "{{ printf "rd-%s" .Release.Name  | trunc 20 }}"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  serviceName: "{{ printf "rd-%s" .Release.Name  | trunc 20 }}"
+  replicas: {{default 3 .Values.replicaCount}}
+  template:
+    metadata:
+      labels:
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+        app: "{{ printf "rd-%s" .Release.Name  | trunc 20  }}"
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+        pod.beta.kubernetes.io/init-containers: '[
+           {
+             "name":"sentinel-micro",
+             "image":"dhilipkumars/redis-sentinel-k8s",
+                         "args" : ["-service","{{ printf "rd-%s" .Release.Name  | trunc 20  }}"],
+             "env": [
+               {
+                  "name": "POD_NAMESPACE",
+                  "valueFrom": {
+                     "fieldRef" : {
+                        "apiVersion" : "v1",
+                        "fieldPath" : "metadata.namespace"
+                     }
+                  }
+               }
+
+             ],
+            "volumeMounts": [
+               {
+                  "name": "config",
+                  "mountPath": "/config"
+               }
+            ]
+           }
+        ]'
+    spec:
+      terminationGracePeriodSeconds: 5
+      affinity:
+           {
+              podAntiAffinity: {
+                 preferredDuringSchedulingIgnoredDuringExecution: [{
+                      weight: 5,
+                      podAffinityTerm: {
+                        labelSelector: {
+                           matchExpressions: [{
+                               "key": "app",
+                               "operator": "In",
+                                "values": ["{{ printf "rd-%s" .Release.Name  | trunc 20 }}"]
+                            }]
+                        },
+                        topologyKey: "kubernetes.io/hostname"
+                      }
+                  }]
+               }
+           }
+      containers:
+      - name: redis
+        image: redis:3.0-alpine
+        ports:
+        - containerPort: {{ .Values.service.Port }}
+          name: {{ .Values.service.Name }}
+      - name: make-slave
+        image: dhilipkumars/mk-redis-slave
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: "v1"
+                fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        emptyDir: {}

--- a/incubator/redis-cache/templates/ss.yaml
+++ b/incubator/redis-cache/templates/ss.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: "{{ template "fullname" . }}"
   labels:
-     app: {{ template "fullname" . }}
+     app: {{ template "name" . }}
      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
      release: "{{ .Release.Name }}"
      heritage: "{{ .Release.Service }}"
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "name" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
@@ -22,11 +22,11 @@ spec:
         pod.beta.kubernetes.io/init-containers: '[
            {
              "name":"sentinel-micro",
-             "image":"{{ .Values.microSentinel.image }}:{{ .Values.microSentinel.tag }}",
-             "imagePullPolicy": "{{ .Values.microSentinel.pullPolicy }}",
+             "image":"{{ .Values.microSentinel.image.repository }}:{{ .Values.microSentinel.image.tag }}",
+             "imagePullPolicy": "{{ .Values.microSentinel.image.pullPolicy }}",
              "args" : ["-service","{{ template "fullname" . }}"],
              "resources":
-{{ toJson .Values.microSentinel.resources | indent 17 }},
+{{ toJson .Values.microSentinel.resources | indent 16 }},
              "env": [
                {
                   "name": "POD_NAMESPACE",
@@ -49,35 +49,29 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       affinity:
-           {
-              podAntiAffinity: {
-                 preferredDuringSchedulingIgnoredDuringExecution: [{
-                      weight: 5,
-                      podAffinityTerm: {
-                        labelSelector: {
-                           matchExpressions: [{
-                               "key": "app",
-                               "operator": "In",
-                                "values": ["{{ template "fullname" . }}"]
-                            }]
-                        },
-                        topologyKey: "kubernetes.io/hostname"
-                      }
-                  }]
-               }
-           }
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 5
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  -  "{{ template "name" . }}"
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - name: redis
-        image: {{ .Values.redis.image }}:{{ .Values.redis.tag }}
-        imagePullPolicy: {{ .Values.redis.pullPolicy }}
+        image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
+        imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.port }}
           name: {{ .Values.service.name }}
         resources:
 {{ toYaml .Values.redis.resources | indent 12 }}
       - name: make-slave
-        image: {{ .Values.makeSlave.image }}:{{ .Values.makeSlave.tag }}
-        imagePullPolicy: {{ .Values.makeSlave.pullPolicy }}
+        image: {{ .Values.makeSlave.image.repository }}:{{ .Values.makeSlave.image.tag }}
+        imagePullPolicy: {{ .Values.makeSlave.image.pullPolicy }}
         resources:
 {{ toYaml .Values.makeSlave.resources | indent 12 }}
         env:

--- a/incubator/redis-cache/templates/ss.yaml
+++ b/incubator/redis-cache/templates/ss.yaml
@@ -1,24 +1,29 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: "{{ printf "rd-%s" .Release.Name  | trunc 20 }}"
+  name: "{{ template "fullname" . }}"
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+     app: {{ template "fullname" . }}
+     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+     release: "{{ .Release.Name }}"
+     heritage: "{{ .Release.Service }}"
 spec:
-  serviceName: "{{ printf "rd-%s" .Release.Name  | trunc 20 }}"
-  replicas: {{default 3 .Values.replicaCount}}
+  serviceName: "{{ template "fullname" . }}"
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-        app: "{{ printf "rd-%s" .Release.Name  | trunc 20  }}"
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
       annotations:
         pod.alpha.kubernetes.io/initialized: "true"
         pod.beta.kubernetes.io/init-containers: '[
            {
              "name":"sentinel-micro",
-             "image":"dhilipkumars/redis-sentinel-k8s",
-                         "args" : ["-service","{{ printf "rd-%s" .Release.Name  | trunc 20  }}"],
+             "image":"{{ .Values.image.microSentinel }}:{{ .Values.tag.microSentinel }}",
+                         "args" : ["-service","{{ template "fullname" . }}"],
              "env": [
                {
                   "name": "POD_NAMESPACE",
@@ -29,7 +34,6 @@ spec:
                      }
                   }
                }
-
              ],
             "volumeMounts": [
                {
@@ -51,7 +55,7 @@ spec:
                            matchExpressions: [{
                                "key": "app",
                                "operator": "In",
-                                "values": ["{{ printf "rd-%s" .Release.Name  | trunc 20 }}"]
+                                "values": ["{{ template "fullname" . }}"]
                             }]
                         },
                         topologyKey: "kubernetes.io/hostname"
@@ -61,12 +65,17 @@ spec:
            }
       containers:
       - name: redis
-        image: redis:3.0-alpine
+        image: {{ .Values.image.redis }}:{{ .Values.tag.redis }}
         ports:
-        - containerPort: {{ .Values.service.Port }}
-          name: {{ .Values.service.Name }}
+        - containerPort: {{ .Values.service.port }}
+          name: {{ .Values.service.name }}
+        resources:
+          requests:
+            memory: {{ .Values.resources.requests.memory }}
+          limits:
+            memory: {{ .Values.resources.limits.memory }}
       - name: make-slave
-        image: dhilipkumars/mk-redis-slave
+        image: {{ .Values.image.makeSlave }}:{{ .Values.tag.makeSlave }}
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/incubator/redis-cache/templates/ss.yaml
+++ b/incubator/redis-cache/templates/ss.yaml
@@ -70,10 +70,7 @@ spec:
         - containerPort: {{ .Values.service.port }}
           name: {{ .Values.service.name }}
         resources:
-          requests:
-            memory: {{ .Values.resources.requests.memory }}
-          limits:
-            memory: {{ .Values.resources.limits.memory }}
+{{ toYaml .Values.resources | indent 12 }}
       - name: make-slave
         image: {{ .Values.image.makeSlave }}:{{ .Values.tag.makeSlave }}
         env:

--- a/incubator/redis-cache/values.yaml
+++ b/incubator/redis-cache/values.yaml
@@ -4,25 +4,28 @@
 
 ##Statefulset related configurations ss.yaml
 replicaCount: 3
-image:
-  redis: redis
-  redisTag: 3.0-alpine
-  microSentinel: dhilipkumars/redis-sentinel-k8s
-  makeSlave: dhilipkumars/mk-redis-slave
-tag:
-  redis: 3.0-alpine
-  microSentinel: latest
-  makeSlave: latest
-resources:
-  limits:
-    memory: 128Mi
-  requests:
-    memory: 128Mi
+redis:
+  image: redis
+  tag: 3.0-alpine
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 128Mi
+microSentinel:
+  image: dhilipkumars/redis-sentinel-k8s
+  tag: latest
+makeSlave:
+  image: dhilipkumars/mk-redis-slave
+  tag: latest
+
 # Service related configurations
 service:
   name: rd-port
   port: 6379
   type: ClusterIP
 # Pod Disruption budget related configurations
+
 podDisruptionBudget:
   minAvailable: 2
+  

--- a/incubator/redis-cache/values.yaml
+++ b/incubator/redis-cache/values.yaml
@@ -17,7 +17,7 @@ redis:
 microSentinel:
   image:
     repository: dhilipkumars/redis-sentinel-k8s
-    tag: latest
+    tag: 0.1.0
     pullPolicy: IfNotPresent
   resources: {}
     # limits:
@@ -29,7 +29,7 @@ microSentinel:
 makeSlave:
   image:
     repository: dhilipkumars/mk-redis-slave
-    tag: latest
+    tag: 0.1.0
     pullPolicy: IfNotPresent
   resources: {}
     # limits:

--- a/incubator/redis-cache/values.yaml
+++ b/incubator/redis-cache/values.yaml
@@ -7,6 +7,7 @@ replicaCount: 3
 redis:
   image: redis
   tag: 3.0-alpine
+  pullPolicy: IfNotPresent
   resources:
     limits:
       memory: 128Mi
@@ -15,17 +16,31 @@ redis:
 microSentinel:
   image: dhilipkumars/redis-sentinel-k8s
   tag: latest
+  pullPolicy: IfNotPresent
+  resources: {}
+    # limits:
+    #   cpu: 10m
+    #   memory: 20Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 20Mi
 makeSlave:
   image: dhilipkumars/mk-redis-slave
   tag: latest
+  pullPolicy: IfNotPresent
+  resources: {}
+    # limits:
+    #   cpu: 10m
+    #   memory: 20Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 20Mi
 
-# Service related configurations
+# Service related configurations common for templates/service.yaml and templates/ss.yaml (redis container)
 service:
   name: rd-port
   port: 6379
-  type: ClusterIP
-# Pod Disruption budget related configurations
 
+  # Pod Disruption budget related configurations
 podDisruptionBudget:
   minAvailable: 2
-  

--- a/incubator/redis-cache/values.yaml
+++ b/incubator/redis-cache/values.yaml
@@ -1,0 +1,22 @@
+# Default values for redis-cache.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 3
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+service:
+  name: rd-port
+  Port: 6379
+  type: ClusterIP
+podDisruptionBudget:
+  minAvailable: 2
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+

--- a/incubator/redis-cache/values.yaml
+++ b/incubator/redis-cache/values.yaml
@@ -5,18 +5,20 @@
 ##Statefulset related configurations ss.yaml
 replicaCount: 3
 redis:
-  image: redis
-  tag: 3.0-alpine
-  pullPolicy: IfNotPresent
+  image:
+    repository: redis
+    tag: 3.0-alpine
+    pullPolicy: IfNotPresent
   resources:
     limits:
       memory: 128Mi
     requests:
       memory: 128Mi
 microSentinel:
-  image: dhilipkumars/redis-sentinel-k8s
-  tag: latest
-  pullPolicy: IfNotPresent
+  image:
+    repository: dhilipkumars/redis-sentinel-k8s
+    tag: latest
+    pullPolicy: IfNotPresent
   resources: {}
     # limits:
     #   cpu: 10m
@@ -25,9 +27,10 @@ microSentinel:
     #   cpu: 10m
     #   memory: 20Mi
 makeSlave:
-  image: dhilipkumars/mk-redis-slave
-  tag: latest
-  pullPolicy: IfNotPresent
+  image:
+    repository: dhilipkumars/mk-redis-slave
+    tag: latest
+    pullPolicy: IfNotPresent
   resources: {}
     # limits:
     #   cpu: 10m

--- a/incubator/redis-cache/values.yaml
+++ b/incubator/redis-cache/values.yaml
@@ -3,20 +3,22 @@
 # Declare variables to be passed into your templates.
 replicaCount: 3
 image:
-  repository: nginx
-  tag: stable
-  pullPolicy: IfNotPresent
+  redis: redis
+  redisTag: 3.0-alpine
+  microSentinel: dhilipkumars/redis-sentinel-k8s
+  makeSlave: dhilipkumars/mk-redis-slave
+tag:
+  redis: 3.0-alpine
+  microSentinel: latest
+  makeSlave: latest
 service:
   name: rd-port
-  Port: 6379
+  port: 6379
   type: ClusterIP
 podDisruptionBudget:
   minAvailable: 2
 resources:
   limits:
-    cpu: 100m
     memory: 128Mi
   requests:
-    cpu: 100m
     memory: 128Mi
-

--- a/incubator/redis-cache/values.yaml
+++ b/incubator/redis-cache/values.yaml
@@ -1,6 +1,8 @@
 # Default values for redis-cache.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+##Statefulset related configurations ss.yaml
 replicaCount: 3
 image:
   redis: redis
@@ -11,14 +13,16 @@ tag:
   redis: 3.0-alpine
   microSentinel: latest
   makeSlave: latest
-service:
-  name: rd-port
-  port: 6379
-  type: ClusterIP
-podDisruptionBudget:
-  minAvailable: 2
 resources:
   limits:
     memory: 128Mi
   requests:
     memory: 128Mi
+# Service related configurations
+service:
+  name: rd-port
+  port: 6379
+  type: ClusterIP
+# Pod Disruption budget related configurations
+podDisruptionBudget:
+  minAvailable: 2


### PR DESCRIPTION
A version of redis chart which can make redis a pure in-memory cache.   This was originally contributed to 'contrib' repo and was recommended to Charts. 

CC: @erictune 

https://github.com/kubernetes/contrib/pull/2301
