### PR TITLE
Jenkins - add ability to toggle jnlp-agent podTemplate generation

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.3.1
+version: 0.4.1
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -51,6 +51,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 
 | Parameter               | Description                        | Default                                                    |
 | ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
+| `Agent.Enabled`         | Generate jnlp-agent podTemplate for Kubernetes plugin.  | `true`                                |
 | `Agent.Image`           | Agent image name                   | `jenkinsci/jnlp-slave`                                     |
 | `Agent.ImageTag`        | Agent image tag                    | `2.52`                                                     |
 | `Agent.Cpu`             | Agent requested cpu                | `200m`                                                     |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -29,6 +29,7 @@ data:
         <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@0.11">
           <name>kubernetes</name>
           <templates>
+{{- if .Values.Agent.Enabled }}
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
               <inheritFrom></inheritFrom>
               <name>default</name>
@@ -59,6 +60,7 @@ data:
               <imagePullSecrets/>
               <nodeProperties/>
             </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+{{- end -}}
           </templates>
           <serverUrl>https://kubernetes.default</serverUrl>
           <skipTlsVerify>false</skipTlsVerify>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -44,6 +44,7 @@ Master:
       #     - jenkins.cluster.local
 
 Agent:
+  Enabled: true
   Image: jenkinsci/jnlp-slave
   ImageTag: 2.52
   Cpu: "200m"


### PR DESCRIPTION
Given that this configuration can be generated by a Jenkins pipeline file, so users may want to disable the default podTemplate creation. This does not change default behavior.