### PR TITLE
Get Grafana credentials from secret

### DIFF
--- a/stable/grafana/templates/job.yaml
+++ b/stable/grafana/templates/job.yaml
@@ -21,8 +21,19 @@ spec:
       containers:
       - name: {{ template "grafana.server.fullname" . }}-set-datasource
         image: "{{ .Values.server.setDatasource.image }}"
+        env:
+        - name: ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "server.fullname" . }}
+              key: grafana-admin-user
+        - name: ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "server.fullname" . }}
+              key: grafana-admin-password
         args:
-          - "http://{{ .Values.server.adminUser }}:{{ .Values.server.adminPassword }}@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/datasources"
+          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/datasources"
           - "-X"
           - POST
           - "-H"


### PR DESCRIPTION
The `stable/grafana` chart includes a Job that uses `curl` to set the default Grafana datasource. `curl` attempts to authenticate with `.Values.server.adminUser:.Values.server.adminPassword`, however, the chart creates a Secret with those credentials - and, by default, this is what Grafana uses.

This change updates the Job to pull the credentials from the Secret instead of the chart values.