### PR TITLE
Jenkins - move config to init-container allowing use of upstream containers

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.3.1
+version: 0.4.0
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -46,6 +46,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.Ingress.Annotations` | Ingress annotations       | `{}`                                                |
 | `Master.Ingress.TLS` | Ingress TLS configuration       | `[]`                                                |
 | `Master.InitScripts`       | List of Jenkins init scripts       | Not set                                                    |  
+| `Master.InstallPlugins`    | List of Jenkins plugins to install | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |
 
 ### Jenkins Agent
 

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -27,37 +27,37 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 ### Jenkins Master
 
 
-| Parameter                  | Description                        | Default                                                    |
-| -----------------------    | ---------------------------------- | ---------------------------------------------------------- |
-| `Master.Name`              | Jenkins master name                | `jenkins-master`                                           |
-| `Master.Image`             | Master image name                  | `jenkinsci/jenkins`           |
-| `Master.ImageTag`          | Master image tag                   | `2.46.1`                                                   |
-| `Master.ImagePullPolicy`   | Master image pull policy           | `Always`                                                   |
-| `Master.Component`         | k8s selector key                   | `jenkins-master`                                           |
-| `Master.Cpu`               | Master requested cpu               | `200m`                                                     |
-| `Master.Memory`            | Master requested memory            | `256Mi`                                                    |
-| `Master.ServiceType`       | k8s service type                   | `LoadBalancer`                                             |
-| `Master.ServicePort`       | k8s service port                   | `8080`                                                     |
-| `Master.NodePort`          | k8s node port                      | Not set                                                    |
-| `Master.ContainerPort`     | Master listening port              | `8080`                                                     |
-| `Master.SlaveListenerPort` | Listening port for agents          | `50000`                                                    |
-| `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses| `0.0.0.0/0`                                                |
-| `Master.CustomConfigMap`          | Use a custom ConfigMap             | `false`                                                    |
-| `Master.Ingress.Annotations` | Ingress annotations       | `{}`                                                |
-| `Master.Ingress.TLS` | Ingress TLS configuration       | `[]`                                                |
-| `Master.InitScripts`       | List of Jenkins init scripts       | Not set                                                    |  
-| `Master.InstallPlugins`    | List of Jenkins plugins to install | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |
-| `Master.ScriptApproval`       | List of groovy functions to approve       | Not set                                                    |  
+| Parameter                         | Description                         | Default                                                                      |
+| --------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------- |
+| `Master.Name`                     | Jenkins master name                 | `jenkins-master`                                                             |
+| `Master.Image`                    | Master image name                   | `jenkinsci/jenkins`                                                          |
+| `Master.ImageTag`                 | Master image tag                    | `2.46.1`                                                                     |
+| `Master.ImagePullPolicy`          | Master image pull policy            | `Always`                                                                     |
+| `Master.Component`                | k8s selector key                    | `jenkins-master`                                                             |
+| `Master.Cpu`                      | Master requested cpu                | `200m`                                                                       |
+| `Master.Memory`                   | Master requested memory             | `256Mi`                                                                      |
+| `Master.ServiceType`              | k8s service type                    | `LoadBalancer`                                                               |
+| `Master.ServicePort`              | k8s service port                    | `8080`                                                                       |
+| `Master.NodePort`                 | k8s node port                       | Not set                                                                      |
+| `Master.ContainerPort`            | Master listening port               | `8080`                                                                       |
+| `Master.SlaveListenerPort`        | Listening port for agents           | `50000`                                                                      |
+| `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses        | `0.0.0.0/0`                                                                  |
+| `Master.CustomConfigMap`          | Use a custom ConfigMap              | `false`                                                                      |
+| `Master.Ingress.Annotations`      | Ingress annotations                 | `{}`                                                                         |
+| `Master.Ingress.TLS`              | Ingress TLS configuration           | `[]`                                                                         |
+| `Master.InitScripts`              | List of Jenkins init scripts        | Not set                                                                      |
+| `Master.InstallPlugins`           | List of Jenkins plugins to install  | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |
+| `Master.ScriptApproval`           | List of groovy functions to approve | Not set                                                                      |
 
 ### Jenkins Agent
 
-| Parameter               | Description                        | Default                                                    |
-| ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
-| `Agent.Enabled`         | Generate jnlp-agent podTemplate for Kubernetes plugin.  | `true`                                |
-| `Agent.Image`           | Agent image name                   | `jenkinsci/jnlp-slave`                                     |
-| `Agent.ImageTag`        | Agent image tag                    | `2.62`                                                     |
-| `Agent.Cpu`             | Agent requested cpu                | `200m`                                                     |
-| `Agent.Memory`          | Agent requested memory             | `256Mi`                                                    |
+| Parameter               | Description                                     | Default                |
+| ----------------------- | ----------------------------------------------- | ---------------------- |
+| `Agent.Enabled`         | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
+| `Agent.Image`           | Agent image name                                | `jenkinsci/jnlp-slave` |
+| `Agent.ImageTag`        | Agent image tag                                 | `2.62`                 |
+| `Agent.Cpu`             | Agent requested cpu                             | `200m`                 |
+| `Agent.Memory`          | Agent requested memory                          | `256Mi`                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -79,14 +79,14 @@ It is possible to mount several volumes using `Persistence.volumes` and `Persist
 
 ### Persistence Values
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `Persistence.Enabled` | Enable the use of a Jenkins PVC | `true` |
-| `Persistence.ExistingClaim` | Provide the name of a PVC | `nil` |
-| `Persistence.AccessMode` | The PVC access mode | `ReadWriteOnce` |
-| `Persistence.Size` | The size of the PVC | `8Gi` |
-| `Persistence.volumes` | Additional volumes | `nil` |
-| `Persistence.mounts` | Additional mounts | `nil` |
+| Parameter                   | Description                     | Default         |
+| --------------------------- | ------------------------------- | --------------- |
+| `Persistence.Enabled`       | Enable the use of a Jenkins PVC | `true`          |
+| `Persistence.ExistingClaim` | Provide the name of a PVC       | `nil`           |
+| `Persistence.AccessMode`    | The PVC access mode             | `ReadWriteOnce` |
+| `Persistence.Size`          | The size of the PVC             | `8Gi`           |
+| `Persistence.volumes`       | Additional volumes              | `nil`           |
+| `Persistence.mounts`        | Additional mounts               | `nil`           |
 
 
 #### Existing PersistentVolumeClaim

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -30,8 +30,8 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | Parameter                  | Description                        | Default                                                    |
 | -----------------------    | ---------------------------------- | ---------------------------------------------------------- |
 | `Master.Name`              | Jenkins master name                | `jenkins-master`                                           |
-| `Master.Image`             | Master image name                  | `gcr.io/kubernetes-charts-ci/jenkins-master-k8s`           |
-| `Master.ImageTag`          | Master image tag                   | `v0.1.0`                                                   |
+| `Master.Image`             | Master image name                  | `jenkinsci/jenkins`           |
+| `Master.ImageTag`          | Master image tag                   | `2.46.1`                                                   |
 | `Master.ImagePullPolicy`   | Master image pull policy           | `Always`                                                   |
 | `Master.Component`         | k8s selector key                   | `jenkins-master`                                           |
 | `Master.Cpu`               | Master requested cpu               | `200m`                                                     |
@@ -53,7 +53,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | Parameter               | Description                        | Default                                                    |
 | ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
 | `Agent.Image`           | Agent image name                   | `jenkinsci/jnlp-slave`                                     |
-| `Agent.ImageTag`        | Agent image tag                    | `2.52`                                                     |
+| `Agent.ImageTag`        | Agent image tag                    | `2.62`                                                     |
 | `Agent.Cpu`             | Agent requested cpu                | `200m`                                                     |
 | `Agent.Memory`          | Agent requested memory             | `256Mi`                                                    |
 
@@ -108,6 +108,3 @@ jenkins:
   Master:
     CustomConfigMap: true
 ```
-
-# Todo
-* Enable Docker-in-Docker or Docker-on-Docker support on the Jenkins agents

--- a/stable/jenkins/master-image/Dockerfile
+++ b/stable/jenkins/master-image/Dockerfile
@@ -1,4 +1,0 @@
-FROM jenkins:2.32.3
-RUN /usr/local/bin/install-plugins.sh kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.10 git:3.1.0 \
-    && mkdir -p /usr/share/jenkins/ref/secrets/ \
-    && echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -90,7 +90,13 @@ data:
       <noUsageStatistics>true</noUsageStatistics>
     </hudson>
   apply_config.sh: |-
+    mkdir -p /usr/share/jenkins/ref/secrets/;
+    echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
+{{- if .Values.Master.InstallPlugins }}
+    cp -n /var/jenkins_config/plugins.txt /var/jenkins_home;
+    /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+{{- end }}
 {{- if .Values.Master.InitScripts }}
     mkdir -p /var/jenkins_home/init.groovy.d/;
     cp -n /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/
@@ -98,5 +104,11 @@ data:
 {{- range $key, $val := .Values.Master.InitScripts }}
   init{{ $key }}.groovy: |-
 {{ $val | indent 4}}
+{{- end }}
+  plugins.txt: |-
+{{- if .Values.Master.InstallPlugins }}
+{{- range $index, $val := .Values.Master.InstallPlugins }}
+{{ $val | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -36,6 +36,14 @@ spec:
                       {
                           "name": "jenkins-home",
                           "mountPath": "/var/jenkins_home"
+                      },
+                      {
+                          "name": "plugin-dir",
+                          "mountPath": "/usr/share/jenkins/ref/plugins/"
+                      },
+                      {
+                          "name": "secrets-dir",
+                          "mountPath": "/usr/share/jenkins/ref/secrets/"
                       }
                   ]
               }
@@ -86,6 +94,14 @@ spec:
               mountPath: /var/jenkins_config
               name: jenkins-config
               readOnly: true
+            -
+              mountPath: /usr/share/jenkins/ref/plugins/
+              name: plugin-dir
+              readOnly: false
+            -
+              mountPath: /usr/share/jenkins/ref/secrets/
+              name: secrets-dir
+              readOnly: false
       volumes:
 {{- if .Values.Persistence.volumes }}
 {{ toYaml .Values.Persistence.volumes | indent 6 }}
@@ -93,6 +109,10 @@ spec:
       - name: jenkins-config
         configMap:
           name: {{ template "fullname" . }}
+      - name: plugin-dir
+        emptyDir: {}
+      - name: secrets-dir
+        emptyDir: {}
       - name: jenkins-home
       {{- if .Values.Persistence.Enabled }}
         persistentVolumeClaim:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -5,8 +5,8 @@
 
 Master:
   Name: jenkins-master
-  Image: "gcr.io/kubernetes-charts-ci/jenkins-master-k8s"
-  ImageTag: "v0.7.0"
+  Image: "jenkins"
+  ImageTag: "2.46.1"
   ImagePullPolicy: "Always"
   Component: "jenkins-master"
   UseSecurity: true
@@ -27,6 +27,12 @@ Master:
   SlaveListenerPort: 50000
   LoadBalancerSourceRanges:
   - 0.0.0.0/0
+# List of plugins to be install during Jenkins master start
+  InstallPlugins:
+      - kubernetes:0.11 
+      - workflow-aggregator:2.5
+      - credentials-binding:1.11
+      - git:3.2.0
 # List of groovy init scripts to be executed during Jenkins master start
   InitScripts:
 #  - |
@@ -45,7 +51,7 @@ Master:
 
 Agent:
   Image: jenkinsci/jnlp-slave
-  ImageTag: 2.52
+  ImageTag: 2.62
   Cpu: "200m"
   Memory: "256Mi"
 

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -5,7 +5,7 @@
 
 Master:
   Name: jenkins-master
-  Image: "jenkins"
+  Image: "jenkinsci/jenkins"
   ImageTag: "2.46.1"
   ImagePullPolicy: "Always"
   Component: "jenkins-master"


### PR DESCRIPTION
This allows the use of upstream jenkins containers removing the dependency of having a chart specific container