### PR TITLE
Jenkins - removed extra space from hardcoded password templating

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.5.0
+version: 0.5.1
 appVersion: 2.46.1
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:

--- a/stable/jenkins/templates/secret.yaml
+++ b/stable/jenkins/templates/secret.yaml
@@ -11,7 +11,7 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.Master.AdminPassword }}
-  jenkins-admin-password:  {{ .Values.Master.AdminPassword | b64enc | quote }}
+  jenkins-admin-password: {{ .Values.Master.AdminPassword | b64enc | quote }}
   {{ else }}
   jenkins-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}


### PR DESCRIPTION
This caused the secret to be updated if you use a generated password in the values.yaml to perform an upgrade. It's just basic cleanup.