### PR TITLE
stable/coredns: Add a configuration to choose serviceProtocol

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 0.1.0
+version: 0.2.0
 description: CoreDNS is a DNS server that chains middleware and provides Kubernetes DNS Services
 keywords:
 - coredns

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -80,3 +80,14 @@ $ helm install --name coredns -f values.yaml stable/coredns
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+
+Caveats
+-------
+
+CoreDNS service, by default is deployed to listen on both "TCP" and "UDP".
+Some cloud environments like "GCE" or "Azure container service" cannot
+create external loadbalancers with both "TCP" and "UDP" protocols. So
+When deploying CoreDNS with `serviceType="LoadBalancer"` on such cloud
+environments, it is preferred to use either "TCP" or "UDP" by setting
+`serviceProtocol` parameter.

--- a/stable/coredns/templates/NOTES.txt
+++ b/stable/coredns/templates/NOTES.txt
@@ -9,7 +9,12 @@ It can be accessed using the below endpoint
   echo "$NODE_IP:$NODE_PORT"
 {{- else if contains "LoadBalancer" .Values.serviceType }}
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+        You can watch the status by running 'kubectl get svc -w {{ template "fullname" . }}'
+
+{{- if contains "UDPNTCP" .Values.serviceProtocol }}
+  NOTE: Some cloud environments cannot create external loadbalancers with both "TCP" and "UDP" protocols.
+        So in case of error, use either "UDP" or "TCP" protocol by setting `serviceProtocol` parameter.
+{{- end }}
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     echo $SERVICE_IP

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -48,12 +48,16 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
+        {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "UDP") }}
         - containerPort: 53
           name: dns
           protocol: UDP
+        {{- end }}
+        {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "TCP") }}
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -29,10 +29,14 @@ spec:
   clusterIP: {{ .Values.middleware.kubernetes.clusterIP }}
   {{- end }}
   ports:
+  {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "UDP") }}
   - name: dns
     port: 53
     protocol: UDP
+  {{- end }}
+  {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "TCP") }}
   - name: dns-tcp
     port: 53
     protocol: TCP
+  {{- end }}
   type: {{ default "ClusterIP" .Values.serviceType }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -23,6 +23,10 @@ isClusterService: true
 # serviceType specifies type of service to be created for this chart.
 serviceType: "ClusterIP"
 
+# serviceProtocol specifies the protocol on which to expose the CoreDNS service.
+# Can be one of three options: "UDPNTCP" (default), "UDP" or "TCP"
+serviceProtocol: "UDPNTCP"
+
 # middleware configuration of CoreDNS refer to https://github.com/coredns/coredns/tree/master/middleware
 # for all specific details. set enabled to true/false to enable/disable a middleware.
 middleware:


### PR DESCRIPTION
This is to fix the issue  #924 
It is found that when serviceType is "LoadBalancer", on some cloud environments CoreDNS fails to deploy.
CoreDNS listens on both "UDP" and "TCP", but due to limitations some cloud environment does not support external loadbalancers with both "UDP" & "TCP" protocols. 
To fix the issue, this pr adds a configurable parameter `serviceProtocol` to choose protocol for the service and the values could be one of "UDP", "TCP" or "UDPNTCP" (default). By default the service listens on both "UDP" and "TCP"