### PR TITLE
stable/nginx-ingress: Add flag to terminate SSL at load balancer

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.3.2
+version: 0.4.2
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
 keywords:

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -64,7 +64,8 @@ Parameter | Description | Default
 `controller.service.externalIPs` | controller service external IP addresses | `[]`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`controller.service.loadBalancerTerminateSSL` | terminates SSL at load balancer (forwards 443 to 80) | false
+`controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
+`controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
 `controller.service.nodePorts.http` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
 `controller.service.nodePorts.https` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -64,6 +64,7 @@ Parameter | Description | Default
 `controller.service.externalIPs` | controller service external IP addresses | `[]`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`controller.service.loadBalancerTerminateSSL` | terminates SSL at load balancer (forwards 443 to 80) | false
 `controller.service.type` | type of controller service to create | `LoadBalancer`
 `controller.service.nodePorts.http` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
 `controller.service.nodePorts.https` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -29,18 +29,14 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      targetPort: 80
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
       {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
       {{- end }}
     - name: https
       port: 443
       protocol: TCP
-      {{- if .Values.controller.service.loadBalancerTerminateSSL }}
-      targetPort: 80
-      {{- else }}
-      targetPort: 443
-      {{- end }}
+      targetPort: {{ .Values.controller.service.targetPorts.https }}
       {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
       {{- end }}

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -36,7 +36,11 @@ spec:
     - name: https
       port: 443
       protocol: TCP
+      {{- if .Values.controller.service.loadBalancerTerminateSSL }}
+      targetPort: 80
+      {{- else }}
       targetPort: 443
+      {{- end }}
       {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
       {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -71,7 +71,7 @@ controller:
     #   https: 32443
     nodePorts:
       http: ""
-      https: "" 
+      https: ""
 
   stats:
     enabled: false

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -57,6 +57,12 @@ controller:
 
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
+
+    ## Used to terminate SSL at the load balancer. Changes the 'https'
+    ## port on the controller service to point to the 'http' port on the
+    ## controller deployment/daemonset
+    loadBalancerTerminateSSL: false
+    
     type: LoadBalancer
 
     # type: NodePort
@@ -65,7 +71,7 @@ controller:
     #   https: 32443
     nodePorts:
       http: ""
-      https: ""
+      https: "" 
 
   stats:
     enabled: false

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -58,11 +58,10 @@ controller:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
 
-    ## Used to terminate SSL at the load balancer. Changes the 'https'
-    ## port on the controller service to point to the 'http' port on the
-    ## controller deployment/daemonset
-    loadBalancerTerminateSSL: false
-    
+    targetPorts:
+      http: 80
+      https: 443
+
     type: LoadBalancer
 
     # type: NodePort


### PR DESCRIPTION
Added a flag that allows SSL to terminate at the load balancer. Helpful for users who want to access services served by the ingress controller via HTTPS, but don't want to setup TLS on all of the ingress resources. 

The use-case is explained in the "SSL offloading" section of this doc: https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md#server-side-https-enforcement-through-redirect