### PR TITLE
Fixed port mentioned in the cli notes

### DIFF
--- a/stable/redis/templates/NOTES.txt
+++ b/stable/redis/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Redis can be accessed via port 3306 on the following DNS name from within your cluster:
+Redis can be accessed via port 6379 on the following DNS name from within your cluster:
 {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To get your password run:


### PR DESCRIPTION
In redis chart the NOTES.txt mentions the mysql port 3306 instead of the redis port 6379.
Small typo fix.