### PR TITLE
Add GoCD chart

### DIFF
--- a/stable/gocd/.helmignore
+++ b/stable/gocd/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+name: gocd
+description: GoCD is a continuous delivery server.
+icon: https://www.gocd.io/assets/images/go_logo-5b5ca9e1.svg
+version: 0.1.0
+keywords:
+  - gocd
+  - ci
+  - cd
+  - continuous delivery
+  - continuous integration
+  - testing
+home: https://www.gocd.io
+sources:
+  - https://github.com/gocd/gocd
+maintainers:
+  - name: Sean Knox
+    email: knoxville@gmail.com

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -1,0 +1,72 @@
+# GoCD Helm Chart
+
+[GoCD](https://www.gocd.io/) GoCD is a continuous delivery server.
+
+## TL;DR;
+
+```console
+$ helm install stable/gocd
+```
+
+## Introduction
+
+This chart bootstraps a [GoCD](https://www.gocd.io) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites Details
+
+* Kubernetes 1.5
+* PV support on underlying infrastructure (if persistence is required)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/gocd
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes nearly all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the GoCD chart and their default values.
+
+| Parameter               | Description                           | Default                                                    |
+| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `server.image.repository` | GoCD server image | `gocd/gocd-server` |
+| `server.image.tag` | GoCD server image version | `v17.3.0` |
+| `server.image.pullPolicy` | GoCD server image pull policy | `IfNotPresent` |
+| `server.resources.requests.cpu`    | GoCD server CPU resource requests              | none                                      |
+| `server.resources.limits.cpu`      | GoCD server CPU resource limits                | none                                     |
+| `server.resources.requests.memory` | GoCD server memory resource requests           | none                                      |
+| `server.resources.limits.memory`   | GoCD server memory resource limits             | none                                      |
+| `agent.image.repository` | GoCD agent image | `gocd/gocd-agent-ubuntu-16.04` |
+| `agent.image.tag` | GoCD agent image version | `v17.3.0` |
+| `agent.image.pullPolicy` | GoCD agent image pull policy | `IfNotPresent` |
+| `agent.replicaCount` | Number of GoCD agents to create | `1` |
+| `agent.resources.requests.cpu`    | GoCD agent CPU resource requests              | none                                      |
+| `agent.resources.limits.cpu`      | GoCD agent CPU resource limits                | none                                     |
+| `agent.resources.requests.memory` | GoCD agent memory resource requests           | none                                      |
+| `agent.resources.limits.memory`   | GoCD agent memory resource limits             | none                                      |
+| `service.name` | Name of GoCD service in Kubernetes | `gocd` |
+| `service.type` | Type of Kubernetes service for GoCD server | `ClusterIP` |
+| `service.externalPort` | GoCD server service port | `8080` |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/gocd
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -44,21 +44,22 @@ The following tables lists the configurable parameters of the GoCD chart and the
 | `server.image.repository` | GoCD server image | `gocd/gocd-server` |
 | `server.image.tag` | GoCD server image version | `v17.3.0` |
 | `server.image.pullPolicy` | GoCD server image pull policy | `IfNotPresent` |
-| `server.resources.requests.cpu`    | GoCD server CPU resource requests              | none                                      |
-| `server.resources.limits.cpu`      | GoCD server CPU resource limits                | none                                     |
-| `server.resources.requests.memory` | GoCD server memory resource requests           | none                                      |
-| `server.resources.limits.memory`   | GoCD server memory resource limits             | none                                      |
 | `agent.image.repository` | GoCD agent image | `gocd/gocd-agent-ubuntu-16.04` |
 | `agent.image.tag` | GoCD agent image version | `v17.3.0` |
 | `agent.image.pullPolicy` | GoCD agent image pull policy | `IfNotPresent` |
 | `agent.replicaCount` | Number of GoCD agents to create | `1` |
-| `agent.resources.requests.cpu`    | GoCD agent CPU resource requests              | none                                      |
-| `agent.resources.limits.cpu`      | GoCD agent CPU resource limits                | none                                     |
-| `agent.resources.requests.memory` | GoCD agent memory resource requests           | none                                      |
-| `agent.resources.limits.memory`   | GoCD agent memory resource limits             | none                                      |
 | `service.name` | Name of GoCD service in Kubernetes | `gocd` |
 | `service.type` | Type of Kubernetes service for GoCD server | `ClusterIP` |
 | `service.externalPort` | GoCD server service port | `8080` |
+| `persistence.enabled`                | Enable persistence using PVC             | `true` |
+| `persistence.godata.storageClass`    | PVC Storage Class for /godata volume      | `nil` (uses alpha storage class annotation)  |
+| `persistence.godata.accessMode`      | PVC Access Mode for /godata volume        | `ReadWriteOnce`|
+| `persistence.godata.size`            | PVC Storage Request for /godata volume    | `1Gi` |
+| `persistence.gohome.storageClass` | PVC Storage Class for /home/go volume   | `nil` (uses alpha storage class annotation)   |
+| `persistence.gohome.accessMode`   | PVC Access Mode for /home/go volume     | `ReadWriteOnce`   |
+| `persistence.gohome.size`         | PVC Storage Request for /home/go volume | `8Gi`  |
+| `agent.resources`                          | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`|
+| `server.resources`                          | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`|
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -50,14 +50,15 @@ The following tables lists the configurable parameters of the GoCD chart and the
 | `agent.replicaCount` | Number of GoCD agents to create | `1` |
 | `service.name` | Name of GoCD service in Kubernetes | `gocd` |
 | `service.type` | Type of Kubernetes service for GoCD server | `ClusterIP` |
-| `service.externalPort` | GoCD server service port | `8080` |
+| `service.http.externalPort` | GoCD server HTTP service port | `8080` |
+| `service.https.externalPort` | GoCD server HTTPS service port | `8081` |
 | `persistence.enabled`                | Enable persistence using PVC             | `true` |
-| `persistence.godata.storageClass`    | PVC Storage Class for /godata volume      | `nil` (uses alpha storage class annotation)  |
-| `persistence.godata.accessMode`      | PVC Access Mode for /godata volume        | `ReadWriteOnce`|
-| `persistence.godata.size`            | PVC Storage Request for /godata volume    | `1Gi` |
-| `persistence.gohome.storageClass` | PVC Storage Class for /home/go volume   | `nil` (uses alpha storage class annotation)   |
-| `persistence.gohome.accessMode`   | PVC Access Mode for /home/go volume     | `ReadWriteOnce`   |
-| `persistence.gohome.size`         | PVC Storage Request for /home/go volume | `8Gi`  |
+| `persistence.godata.storageClass`    | PVC Storage Class for GoCD server /godata volume      | `nil` (uses alpha storage class annotation)  |
+| `persistence.godata.accessMode`      | PVC Access Mode for GoCD server /godata volume        | `ReadWriteOnce`|
+| `persistence.godata.size`            | PVC Storage Request for GoCD server /godata volume    | `8Gi` |
+| `persistence.gohome.storageClass` | PVC Storage Class for GoCD server /home/go volume   | `nil` (uses alpha storage class annotation)   |
+| `persistence.gohome.accessMode`   | PVC Access Mode for GoCD server /home/go volume     | `ReadWriteOnce`   |
+| `persistence.gohome.size`         | PVC Storage Request for GoCD server /home/go volume | `8Gi`  |
 | `agent.resources`                          | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`|
 | `server.resources`                          | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`|
 

--- a/stable/gocd/templates/NOTES.txt
+++ b/stable/gocd/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "fullname" . }}-server" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:8153
+{{- end }}

--- a/stable/gocd/templates/_helpers.tpl
+++ b/stable/gocd/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/gocd/templates/agent-deployment.yaml
+++ b/stable/gocd/templates/agent-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: "{{ template "fullname" . }}-agent"
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.agent.replicaCount }}
   template:
     metadata:
       labels:

--- a/stable/gocd/templates/agent-deployment.yaml
+++ b/stable/gocd/templates/agent-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
         imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
         env:
-        - name: GO_SERVER
-          value: {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+        - name: GO_SERVER_URL
+          value: "https://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.https.externalPort }}/go"
         resources:
 {{ toYaml .Values.agent.resources | indent 12 }}

--- a/stable/gocd/templates/agent-deployment.yaml
+++ b/stable/gocd/templates/agent-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-agent
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: "{{ template "fullname" . }}-agent"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+        component: "{{ template "fullname" . }}-agent"
+    spec:
+      securityContext:
+        runAsUser: 0
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+        imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+        env:
+        - name: GO_SERVER
+          value: {{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+        resources:
+{{ toYaml .Values.agent.resources | indent 12 }}

--- a/stable/gocd/templates/agent-policy.yaml
+++ b/stable/gocd/templates/agent-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  minAvailable: {{ .Values.agent.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      component: "{{ template "fullname" . }}-agent"

--- a/stable/gocd/templates/godata-pvc.yaml
+++ b/stable/gocd/templates/godata-pvc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}-godata
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end -}}

--- a/stable/gocd/templates/gohome-pvc.yaml
+++ b/stable/gocd/templates/gohome-pvc.yaml
@@ -2,22 +2,22 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}-godata
+  name: {{ template "fullname" . }}-gohome
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-  {{- if .Values.persistence.godata.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.godata.storageClass | quote }}
+  {{- if .Values.persistence.gohome.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.gohome.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.godata.accessMode | quote }}
+    - {{ .Values.persistence.gohome.accessMode | quote }}
   resources:
     requests:
-      storage: {{ .Values.persistence.godata.size | quote }}
+      storage: {{ .Values.persistence.gohome.size | quote }}
 {{- end -}}

--- a/stable/gocd/templates/server-deployment.yaml
+++ b/stable/gocd/templates/server-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-server
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: "{{ template "fullname" . }}-server"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+        component: "{{ template "fullname" . }}-server"
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+        imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+        ports:
+        - containerPort: 8153
+        resources:
+{{ toYaml .Values.server.resources | indent 12 }}

--- a/stable/gocd/templates/server-deployment.yaml
+++ b/stable/gocd/templates/server-deployment.yaml
@@ -27,3 +27,14 @@ spec:
         - containerPort: 8153
         resources:
 {{ toYaml .Values.server.resources | indent 12 }}
+        volumeMounts:
+        - name: godata
+          mountPath: /godata
+      volumes:
+      - name: godata
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-godata
+      {{- else }}
+        emptyDir: {}
+      {{- end }}

--- a/stable/gocd/templates/server-deployment.yaml
+++ b/stable/gocd/templates/server-deployment.yaml
@@ -24,7 +24,10 @@ spec:
         image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
         imagePullPolicy: {{ .Values.server.image.pullPolicy }}
         ports:
-        - containerPort: 8153
+        - name: http
+          containerPort: 8153
+        - name: https
+          containerPort: 8154
         resources:
 {{ toYaml .Values.server.resources | indent 12 }}
         volumeMounts:

--- a/stable/gocd/templates/server-deployment.yaml
+++ b/stable/gocd/templates/server-deployment.yaml
@@ -30,11 +30,20 @@ spec:
         volumeMounts:
         - name: godata
           mountPath: /godata
+        - name: gohome
+          mountPath: /home/go
       volumes:
       - name: godata
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ template "fullname" . }}-godata
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      - name: gohome
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-gohome
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/gocd/templates/server-deployment.yaml
+++ b/stable/gocd/templates/server-deployment.yaml
@@ -32,7 +32,7 @@ spec:
 {{ toYaml .Values.server.resources | indent 12 }}
         volumeMounts:
         - name: godata
-          mountPath: /godata
+          mountPath: /var/lib/go-server
         - name: gohome
           mountPath: /home/go
       volumes:

--- a/stable/gocd/templates/server-svc.yaml
+++ b/stable/gocd/templates/server-svc.yaml
@@ -10,9 +10,12 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - name: {{ .Values.service.name }}
-    port: {{ .Values.service.externalPort }}
+  - name: http
+    port: {{ .Values.service.http.externalPort }}
     targetPort: 8153
+  - name: https
+    port: {{ .Values.service.https.externalPort }}
+    targetPort: 8154
   selector:
     app: {{ template "fullname" . }}
     component: "{{ template "fullname" . }}-server"

--- a/stable/gocd/templates/service.yaml
+++ b/stable/gocd/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: {{ .Values.service.name }}
+    port: {{ .Values.service.externalPort }}
+    targetPort: 8153
+  selector:
+    app: {{ template "fullname" . }}
+    component: "{{ template "fullname" . }}-server"

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -32,3 +32,12 @@ service:
   name: gocd
   type: ClusterIP
   externalPort: 8080
+
+persistence:
+  enabled: true
+  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  ## Default: volume.alpha.kubernetes.io/storage-class: default
+  ##
+  # storageClass:
+  accessMode: ReadWriteOnce
+  size: 8Gi

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -1,0 +1,34 @@
+# Default values for gocd.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+server:
+  image:
+    repository: gocd/gocd-server
+    tag: "v17.3.0"
+    pullPolicy: IfNotPresent
+  # See minimum server requirements: https://docs.gocd.io/current/installation/system_requirements.html
+  # resources:
+  #   limits:
+  #     cpu: 200m
+  #     memory: 1024Mi
+  #   requests:
+  #     cpu: 200m
+  #     memory: 1024Mi
+agent:
+  replicaCount: 1
+  image:
+    repository: gocd/gocd-agent-ubuntu-16.04
+    tag: "v17.3.0"
+    pullPolicy: IfNotPresent
+  # resources:
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+
+service:
+  name: gocd
+  type: ClusterIP
+  externalPort: 8080

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -33,11 +33,22 @@ service:
   type: ClusterIP
   externalPort: 8080
 
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
 persistence:
   enabled: true
-  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-  ## Default: volume.alpha.kubernetes.io/storage-class: default
-  ##
-  # storageClass:
-  accessMode: ReadWriteOnce
-  size: 8Gi
+  godata:
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
+    accessMode: ReadWriteOnce
+    size: 8Gi
+  gohome:
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
+    accessMode: ReadWriteOnce
+    size: 8Gi

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -33,9 +33,11 @@ agent:
   #     memory: 128Mi
 
 service:
-  name: gocd
   type: ClusterIP
-  externalPort: 8080
+  http:
+    externalPort: 8080
+  https:
+    externalPort: 8081
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 server:
   image:
-    repository: gocd/gocd-server
-    tag: "v17.3.0"
+    repository: quay.io/knoxville/gocd-server
+    tag: "v2"
     pullPolicy: IfNotPresent
   # See minimum server requirements: https://docs.gocd.io/current/installation/system_requirements.html
   # resources:
@@ -21,8 +21,8 @@ agent:
   ##
   minAvailable: 1
   image:
-    repository: gocd/gocd-agent-ubuntu-16.04
-    tag: "v17.3.0"
+    repository: quay.io/knoxville/gocd-agent
+    tag: "v3"
     pullPolicy: IfNotPresent
   # resources:
   #   limits:

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -15,7 +15,11 @@ server:
   #     cpu: 200m
   #     memory: 1024Mi
 agent:
-  replicaCount: 1
+  replicaCount: 2
+  ## Minimun number of workers available after an eviction
+  ## ref: https://kubernetes.io/docs/admin/disruptions/
+  ##
+  minAvailable: 1
   image:
     repository: gocd/gocd-agent-ubuntu-16.04
     tag: "v17.3.0"


### PR DESCRIPTION
This adds a chart for [GoCD](https://www.gocd.io/), a CI/CD server from Thoughtworks.

I've built GoCD server and agent images that work a bit better than the official ones (namely, the official images don't log to STDOUT). 