### PR TITLE
[stable/jenkins] Add Agent.Privileged option

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.6.0
+version: 0.6.1
 appVersion: 2.46.1
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Agent.Enabled`         | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
 | `Agent.Image`           | Agent image name                                | `jenkinsci/jnlp-slave` |
 | `Agent.ImageTag`        | Agent image tag                                 | `2.62`                 |
+| `Agent.Privileged`      | Agent privileged container                      | `false`                |
 | `Agent.Cpu`             | Agent requested cpu                             | `200m`                 |
 | `Agent.Memory`          | Agent requested memory                          | `256Mi`                |
 

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -42,7 +42,11 @@ data:
                 <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
                   <name>jnlp</name>
                   <image>{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}</image>
+{{- if .Values.Agent.Privileged }}
+                  <privileged>true</privileged>
+{{- else }}
                   <privileged>false</privileged>
+{{- end }}
                   <alwaysPullImage>false</alwaysPullImage>
                   <workingDir>/home/jenkins</workingDir>
                   <command></command>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -57,6 +57,7 @@ Agent:
   Enabled: true
   Image: jenkinsci/jnlp-slave
   ImageTag: 2.62
+  Privileged: false
   Cpu: "200m"
   Memory: "256Mi"
 


### PR DESCRIPTION
This allows Jenkins slaves to execute as privileged containers. This is useful from some build systems that require such privileges, e.g. [Bazel](https://bazel.build/) needs privileges to create its sandboxed environments.