### PR TITLE
update magento README

### DIFF
--- a/stable/magento/README.md
+++ b/stable/magento/README.md
@@ -80,10 +80,10 @@ A YAML file that specifies the values for the above parameters can be provided w
 $ helm inspect values stable/magento > values.yaml
 $ vi values.yaml
 $ helm install --name my-release -f values.yaml stable/magento
+```
 
 ### Installing on GKE
 
-```
 > **Note**:
 >
 > For Magento to function correctly, you should specify the `magentoHost` parameter to specify the FQDN (recommended) or the public IP address of the Magento service.

--- a/stable/magento/templates/NOTES.txt
+++ b/stable/magento/templates/NOTES.txt
@@ -25,8 +25,14 @@ host. To configure Magento with the URL of your service:
 
 2. Complete your Magento deployment by running:
 
+  {{- if contains "LoadBalancer" .Values.serviceType }}
   helm upgrade {{ .Release.Name }} \
     --set magentoHost=$APP_HOST,magentoPassword=$APP_PASSWORD,mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD stable/magento
+
+  {{- else if contains "NodePort" .Values.serviceType }}
+  helm upgrade {{ .Release.Name }} --set magentoHost=$APP_HOST:$APP_PORT
+
+  {{- end }}
 
 {{- else -}}
 1. Get the Magento URL by running:


### PR DESCRIPTION
- add minikube installation instructions
- add metal installation instructions
- add some missing configuration variables
- remove problematic html install --set instructions
- fix NOTES.TXT for serviceType of NodePort, assuming minikube