### PR TITLE
Bump the GitLab-CE Chart version to the latest release 9.1

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,5 +1,5 @@
 name: gitlab-ce
-version: 0.1.7
+version: 0.1.8
 description: GitLab Community Edition
 keywords:
 - git

--- a/stable/gitlab-ce/values.yaml
+++ b/stable/gitlab-ce/values.yaml
@@ -1,7 +1,7 @@
 ## GitLab CE image
 ## ref: https://hub.docker.com/r/gitlab/gitlab-ce/tags/
 ##
-image: gitlab/gitlab-ce:9.0.0-ce.0
+image: gitlab/gitlab-ce:9.1.0-ce.0
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Version bump to the lastest verion

Corresponding EE chart update is here: https://github.com/kubernetes/charts/pull/960

Tested on GKE