### PR TITLE
Gitlab EE  9.1  Version bump

### DIFF
--- a/stable/gitlab-ee/Chart.yaml
+++ b/stable/gitlab-ee/Chart.yaml
@@ -1,5 +1,5 @@
 name: gitlab-ee
-version: 0.1.6
+version: 0.1.7
 description: GitLab Enterprise Edition
 keywords:
 - git

--- a/stable/gitlab-ee/templates/data-pvc.yaml
+++ b/stable/gitlab-ee/templates/data-pvc.yaml
@@ -4,8 +4,8 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-data
   annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.gitlabData.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.gitlabData.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}

--- a/stable/gitlab-ee/templates/etc-pvc.yaml
+++ b/stable/gitlab-ee/templates/etc-pvc.yaml
@@ -4,8 +4,8 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-etc
   annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- if .Values.persistence.gitlabEtc.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.gitlabEtc.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
   {{- end }}

--- a/stable/gitlab-ee/values.yaml
+++ b/stable/gitlab-ee/values.yaml
@@ -1,7 +1,7 @@
 ## GitLab EE image
 ## ref: https://hub.docker.com/r/gitlab/gitlab-ee/tags/
 ##
-image: gitlab/gitlab-ee:9.0.0-ee.0
+image: gitlab/gitlab-ee:9.1.0-ee.0
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Corresponding PR for the CE version bump is here: https://github.com/kubernetes/charts/pull/959

This PR brings in the previous changes from https://github.com/kubernetes/charts/pull/898 into the EE chart, and bumps the version to the new EE image.

Tested on GKE