### PR TITLE
[stable/jenkins] add jmx option

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.6.2
+version: 0.7.0
 appVersion: 2.46.2
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -42,6 +42,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.ContainerPort`            | Master listening port               | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents           | `50000`                                                                      |
 | `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses        | `0.0.0.0/0`                                                                  |
+| `Master.JMXPort`                  | Open a port, for JMX stats          | Not set                                                                      |
 | `Master.CustomConfigMap`          | Use a custom ConfigMap              | `false`                                                                      |
 | `Master.Ingress.Annotations`      | Ingress annotations                 | `{}`                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration           | `[]`                                                                         |

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       labels:
+        app: {{ template "fullname" . }}
         heritage: {{.Release.Service | quote }}
         release: {{.Release.Name | quote }}
         chart: "{{.Chart.Name}}-{{.Chart.Version}}"

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -78,6 +78,10 @@ spec:
               name: http
             - containerPort: {{.Values.Master.SlaveListenerPort}}
               name: slavelistener
+            {{- if .Values.Master.JMXPort }}
+            - containerPort: {{ .Values.Master.JMXPort }}
+              name: jmx
+            {{- end }}
           resources:
             requests:
               cpu: "{{.Values.Master.Cpu}}"

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{template "fullname" . }}
   labels:
+    app: {{ template "fullname" . }}
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -27,6 +27,13 @@ Master:
   SlaveListenerPort: 50000
   LoadBalancerSourceRanges:
   - 0.0.0.0/0
+# Optionally configure a JMX port
+# requires additional JavaOpts, ie
+# JavaOpts: >
+#   -Dcom.sun.management.jmxremote.port=4000 
+#   -Dcom.sun.management.jmxremote.authenticate=false 
+#   -Dcom.sun.management.jmxremote.ssl=false 
+# JMXPort: 4000
 # List of plugins to be install during Jenkins master start
   InstallPlugins:
       - kubernetes:0.11 


### PR DESCRIPTION
Add `Master.JMXPort` option, which opens a port on the pod, for JMX. 