### PR TITLE
[stable/jenkins] Upgrade jenkins to 2.46.2

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.6.0
-appVersion: 2.46.1
+version: 0.6.1
+appVersion: 2.46.2
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:
   - https://github.com/jenkinsci/jenkins

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -6,7 +6,7 @@
 Master:
   Name: jenkins-master
   Image: "jenkinsci/jenkins"
-  ImageTag: "2.46.1"
+  ImageTag: "2.46.2"
   ImagePullPolicy: "Always"
   Component: "jenkins-master"
   UseSecurity: true


### PR DESCRIPTION
Jenkins started showing a warning that the version 2.46.1 is vulnerable (https://jenkins.io/security/advisory/2017-04-26/) and that we should update to 2.46.2 which addresses those security issues.
Don't know whether I should bump the chart version to `0.6.1` or `0.7.0`. 