### PR TITLE
Consul - removed default StorageClass notation

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 0.2.0
+version: 0.2.1
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 icon: https://www.consul.io/assets/images/logo_large-475cebb0.png
 sources:

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -36,7 +36,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | `Cpu`                   | container requested cpu               | `100m`                                                     |
 | `Memory`                | container requested memory            | `512Mi`                                                    |
 | `Storage`               | Persistent volume size                | `1Gi`                                                      |
-| `StorageClass`          | Persistent volume storage class       | `default`                                                  |
+| `StorageClass`          | Persistent volume storage class       | `nil`                                                  |
 | `HttpPort`              | Consul http listening port            | `8500`                                                     |
 | `RpcPort`               | Consul rpc listening port             | `8400`                                                     |
 | `SerflanPort`           | Container serf lan listening port     | `8301`                                                     |

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -23,8 +23,8 @@ Memory: "256Mi"
 ## Persistent volume size
 Storage: "1Gi"
 
-## StorageClass name for use with Persistent Volume Claim (PVC)
-StorageClass: default
+## StorageClass name for use with Persistent Volume Claim (PVC) using beta notations
+# StorageClass:
 
 ## Enable Consul Web UI
 ##


### PR DESCRIPTION
Defaults to using alpha rather than beta notations like all other charts in order to get through CI