### PR TITLE
[stable/grafana] New existingClaim configuration parameter

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.3.2
+version: 0.3.3
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -38,6 +38,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.persistentVolume.size`        | Size of persistent volume claim     | 1Gi RW                                            |
 | `server.persistentVolume.storageClass`| Type of persistent volume claim     | `nil` (uses alpha storage class annotation)       |
 | `server.persistentVolume.accessMode`  | ReadWriteOnce or ReadOnly           | [ReadWriteOnce]                                   |
+| `server.persistentVolume.existingClaim` | Grafana data Persistent Volume existing claim name | `""` |
 | `server.resources`                    | Server resource requests and limits | requests: {cpu: 100m, memory: 100Mi}              |
 | `server.serviceType`                  | ClusterIP, NodePort, or LoadBalancer| ClusterIP                                         |
 | `server.setDatasource.enabled`        | Creates grafana datasource with job | false                                             |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         - name: storage-volume
       {{- if .Values.server.persistentVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "grafana.server.fullname" . }}
+            claimName: {{ if .Values.server.persistentVolume.existingClaim }}{{ .Values.server.persistentVolume.existingClaim }}{{- else }}{{ template "grafana.server.fullname" . }}{{- end }}
       {{- else }}
           emptyDir: {}
       {{- end -}}

--- a/stable/grafana/templates/pvc.yaml
+++ b/stable/grafana/templates/pvc.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.server.persistentVolume.enabled -}}
+{{- if not .Values.server.persistentVolume.existingClaim -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -26,4 +27,5 @@ spec:
   resources:
     requests:
       storage: {{ .Values.server.persistentVolume.size | quote }}
+{{- end -}}
 {{- end -}}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -70,6 +70,11 @@ server:
     ##
     # annotations:
 
+    ## Grafana data Persistent Volume existing claim name
+    ## Requires server.persistentVolume.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    existingClaim: ""
+
     ## Grafana data Persistent Volume size
     ## Default: 1Gi
     ##


### PR DESCRIPTION
- Added `server.persistentVolume.existingClaim` to README.
- Honour the value in `deployment.yaml`.
- Don't define PersistentVolumeClaim if `existingClaim` is set.
- Default value in `values.yaml` is set to `""`.