### PR TITLE
Allow pods to send metrics to datadog

### DIFF
--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -12,6 +12,7 @@ spec:
         app: {{ template "fullname" . }}
       name: {{ template "fullname" . }}
     spec:
+      hostNetwork: true
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -20,6 +21,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
         ports:
         - containerPort: 8125
+          hostPort: 8125
           name: dogstatsdport
           protocol: UDP
         {{- if .Values.datadog.apmEnabled }}


### PR DESCRIPTION
[Not sure this is a great idea, but I wanted to see what people think about the idea.  I don't want to have to run lots and lots of dogstatsd containers!]

By using host networking and a nodeport, clusters running CNI can
use the downward API to send metrics to a single dogstatsd rather
than one per pod.

An example:

 - name: DATADOG_HOST
   valueFrom:
     fieldRef:
       fieldPath: spec.nodeName

Then just send metrics to $DATADOG_HOST:8125.