### PR TITLE
[stable/traefik] Allow setting targetPort on https

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
 # Lock step with the Traefik version, appended with -a, -b, etc. to denote versions of the chart
-version: 1.2.1-a
+version: 1.2.1-b
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -27,3 +27,6 @@ spec:
     name: http
   - port: 443
     name: https
+    {{- if not .Values.ssl.enabled }}
+    targetPort: 80
+    {{- end }}


### PR DESCRIPTION
This would allow you to forward to the port 80 traefik pod when your using aws elb to do ssl termination, eliminating the need for SSL certificates being served by traefik.