### PR TITLE
Add Eventrouter Chart

### DIFF
--- a/incubator/eventrouter/.helmignore
+++ b/incubator/eventrouter/.helmignore
@@ -1,0 +1,5 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+.git

--- a/incubator/eventrouter/.helmignore
+++ b/incubator/eventrouter/.helmignore
@@ -2,4 +2,20 @@
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.
 .DS_Store
-.git
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/eventrouter/Chart.yaml
+++ b/incubator/eventrouter/Chart.yaml
@@ -1,0 +1,13 @@
+name: eventrouter
+description: A simple introspective kubernetes service that forwards events to a specified sink.
+version: 0.1.0
+keywords:
+  - kubernetes
+  - eventrouter
+  - introspection
+home: "https://github.com/heptio/eventrouter"
+sources:
+  - "https://gcr.io/heptio-images/eventrouter"
+maintainers:
+  - name: Ross Kukulinski
+    email: ross@kukulinski.com

--- a/incubator/eventrouter/README.md
+++ b/incubator/eventrouter/README.md
@@ -1,0 +1,47 @@
+# Eventrouter: A simple event router for Kubernetes
+
+Built by the [Heptio](https://www.heptio.com/) team.
+
+This Chart installs a Kubernetes [Eventrouter](https://github.com/heptio/eventrouter)]. The event router serves as an active watcher of _event_ resource in the kubernetes system, which takes those events and _pushes_ them to a user specified _sink_.  This is useful for a number of different purposes, but most notably long term behavioral analysis of your workloads running on your kubernetes cluster. 
+
+This chart installs the Eventrouter according to the following
+pattern:
+
+- A `ConfigMap` is used to store the _sink_ the router will send events to.
+  ([templates/configmap.yaml](templates/configmap.yaml))
+- A `Deployment` is used to create a Replica Set of EventRouter pods.
+  ([templates/deployment.yaml](templates/deployment.yaml))
+
+The [values.yaml](values.yaml) exposes the available configuration options in the
+chart.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release incubator/eventrouter
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes nearly all the Kubernetes components associated with the
+chart and deletes the release.
+
+## Configuration
+
+The following tables lists some of the configurable parameters of the Eventrouter
+chart and their default values.
+
+| Parameter                        | Description                                                  | Default                                                    |
+| -----------------------          | ----------------------------------                           | ---------------------------------------------------------- |
+| `image`                          | Eventrouter image                                            | `gcr.io/heptio-images/eventrouter`                         |
+| `imageTag`                       | Eventrouter image version                                    | `v0.1`                                                     |
+| `sink`                           | Sink Eventrouter will use                                    | `stdout`                                                   |
+| `namespace`                      | Namespace to install release into                            | `kube-system`

--- a/incubator/eventrouter/templates/NOTES.txt
+++ b/incubator/eventrouter/templates/NOTES.txt
@@ -1,0 +1,12 @@
+
+#################################################################################
+######                   Eventrouter is now starting                        #####
+#################################################################################
+
+If you selected a sink that prints to the console (e.g. `stdout` which is the 
+default sink), then you can see the events being printed out:
+
+    export POD_NAME=$(kubectl get pods --namespace {{ .Values.namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+    kubectl -n {{ .Values.namespace }} logs -f ${POD_NAME}
+
+For more information, please refer to the Eventrouter GitHub repo: https://github.com/heptio/eventrouter

--- a/incubator/eventrouter/templates/_helpers.tpl
+++ b/incubator/eventrouter/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{define "name"}}{{default "eventrouter" .Values.nameOverride | trunc 63 | trimSuffix "-" }}{{end}}
+
+{{/*
+Create a default fully qualified app name.
+
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{define "fullname"}}
+{{- $name := default "eventrouter" .Values.nameOverride -}}
+{{printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{end}}

--- a/incubator/eventrouter/templates/configmap.yaml
+++ b/incubator/eventrouter/templates/configmap.yaml
@@ -1,0 +1,28 @@
+# Copyright 2017 Heptio Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{template "fullname" .}}
+  namespace: {{default "kube-system" .Values.namespace | quote}}
+  labels:
+    release: {{ .Release.Name | quote }}
+    app: {{template "fullname" .}}
+    heritage: {{.Release.Service | quote }}
+data:
+  config.json: |- 
+    {
+      "sink": {{default "glog" .Values.sink | quote}}
+    }

--- a/incubator/eventrouter/templates/configmap.yaml
+++ b/incubator/eventrouter/templates/configmap.yaml
@@ -15,14 +15,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{template "fullname" .}}
-  namespace: {{default "kube-system" .Values.namespace | quote}}
+  name: {{ template "fullname" . }}
   labels:
     release: {{ .Release.Name | quote }}
-    app: {{template "fullname" .}}
-    heritage: {{.Release.Service | quote }}
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
 data:
   config.json: |- 
     {
-      "sink": {{default "glog" .Values.sink | quote}}
+      "sink": {{ default "glog" .Values.sink | quote }}
     }

--- a/incubator/eventrouter/templates/deployment.yaml
+++ b/incubator/eventrouter/templates/deployment.yaml
@@ -1,0 +1,46 @@
+# Copyright 2017 Heptio Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{template "fullname" .}}
+  namespace: {{default "kube-system" .Values.namespace | quote}}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+spec:
+  # TODO - Set to 2 when ConfigMap locking is merged ~1.7
+  # https://github.com/kubernetes/kubernetes/pull/42666
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{template "fullname" .}}
+        release: {{.Release.Name | quote }}
+        component: eventrouter
+        tier: control-plane-addons
+    spec:
+      containers:
+        - name: kube-eventrouter
+          image: "{{default "gcr.io/heptio-images/eventrouter" .Values.image}}:{{default "latest" .Values.imageTag}}"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/eventrouter
+      volumes: 
+        - name: config-volume
+          configMap:
+            name: {{template "fullname" .}}

--- a/incubator/eventrouter/templates/deployment.yaml
+++ b/incubator/eventrouter/templates/deployment.yaml
@@ -15,12 +15,12 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{template "fullname" .}}
-  namespace: {{default "kube-system" .Values.namespace | quote}}
+  name: {{ template "fullname" . }}
   labels:
-    heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
 spec:
   # TODO - Set to 2 when ConfigMap locking is merged ~1.7
   # https://github.com/kubernetes/kubernetes/pull/42666
@@ -28,19 +28,21 @@ spec:
   template:
     metadata:
       labels:
-        app: {{template "fullname" .}}
-        release: {{.Release.Name | quote }}
+        release: {{ .Release.Name | quote }}
+        app: {{ template "name" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        heritage: {{ .Release.Service | quote }}
         component: eventrouter
         tier: control-plane-addons
     spec:
       containers:
         - name: kube-eventrouter
-          image: "{{default "gcr.io/heptio-images/eventrouter" .Values.image}}:{{default "latest" .Values.imageTag}}"
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: IfNotPresent
           volumeMounts:
-          - name: config-volume
-            mountPath: /etc/eventrouter
+            - name: config-volume
+              mountPath: /etc/eventrouter
       volumes: 
         - name: config-volume
           configMap:
-            name: {{template "fullname" .}}
+            name: {{ template "fullname" . }}

--- a/incubator/eventrouter/values.yaml
+++ b/incubator/eventrouter/values.yaml
@@ -1,0 +1,8 @@
+# Default values for eventrouter.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+
+namespace: "kube-system"
+image: "gcr.io/heptio-images/eventrouter"
+imageTag: "v0.1"
+sink: "stdout"


### PR DESCRIPTION
This Pull Request adds an incubator chart for [Eventrouter](https://github.com/heptio/eventrouter).

The Eventrouter serves as an active watcher of _event_ resource in the kubernetes system, which takes those events and _pushes_ them to a user specified _sink_.  This is useful for a number of different purposes, but most notably long term behavioral analysis of your workloads running on your kubernetes cluster.