### PR TITLE
[stable/wordpress] Use subPath mounts to comply with docker image

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.6.0
+version: 0.6.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -91,8 +91,15 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 1
         volumeMounts:
-        - name: wordpress-data
-          mountPath: /bitnami
+        - mountPath: /bitnami/apache
+          name: wordpress-data
+          subPath: apache
+        - mountPath: /bitnami/wordpress
+          name: wordpress-data
+          subPath: wordpress
+        - mountPath: /bitnami/php
+          name: wordpress-data
+          subPath: php 
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       volumes:


### PR DESCRIPTION
Since the bitnami docker image explicitly defines volumes in subpaths (https://github.com/bitnami/bitnami-docker-wordpress/blob/master/4/Dockerfile#L40), no data is actually persisted when mounting the parent folder (found out the hard way).