### PR TITLE
[stable/kapacitor] Add envVars for kapacitor configuration

### DIFF
--- a/stable/kapacitor/Chart.yaml
+++ b/stable/kapacitor/Chart.yaml
@@ -1,5 +1,5 @@
 name: kapacitor
-version: 0.2.3
+version: 0.3.0
 description: InfluxDB's native data processing engine. It can process both stream and batch data from InfluxDB.
 keywords:
 - kapacitor

--- a/stable/kapacitor/Chart.yaml
+++ b/stable/kapacitor/Chart.yaml
@@ -1,5 +1,5 @@
 name: kapacitor
-version: 0.2.2
+version: 0.2.3
 description: InfluxDB's native data processing engine. It can process both stream and batch data from InfluxDB.
 keywords:
 - kapacitor

--- a/stable/kapacitor/README.md
+++ b/stable/kapacitor/README.md
@@ -43,6 +43,25 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
+The following table lists the configurable parameters of the Kapacitor chart and their default values.
+
+| Parameter               | Description                           | Default                                                    |
+| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `image.repository` | Kapacitor image | `kapacitor` |
+| `image.tag` | Kapacitor image version | `1.2` |
+| `image.pullPolicy` | Kapacitor image pull policy |  `IfNotPresent` |
+| `service.type` | Kapacitor web service type  | `ClusterIP` |
+| `persistence.enabled` | Enable Kapacitor persistence using Persistent Volume Claims | `false` |
+| `persistence.storageClass` | Kapacitor Persistent Volume Storage Class | `default` |
+| `persistence.accessMode` | Kapacitor Persistent Volume Access Mode | `ReadWriteOnce` |
+| `persistence.size` | Kapacitor Persistent Volume Storage Size | `8Gi` |
+| `resources.request.memory` | Kapacitor memory request | `256Mi` |
+| `resources.request.cpu` | Kapacitor cpu request | `0.1` |
+| `resources.limits.memory` | Kapacitor memory limit | `2Gi` |
+| `resources.limits.cpu` | Kapacitor cpu limit | `2` |
+| `envVars` | Environment variables to set initial Kapacitor configuration | `{}` |
+| `influxURL` | InfluxDB url used to interact with Kapacitor (also can be set with ```envVars.KAPACITOR_INFLUXDB_0_URLS_0```) | `http://influxdb-influxdb.tick:8086` |
+
 The configurable parameters of the Kapacitor chart and the default values are listed in `values.yaml`.
 
 The [full image documentation](https://hub.docker.com/_/kapacitor/) contains more information about running Kapacitor in docker.

--- a/stable/kapacitor/README.md
+++ b/stable/kapacitor/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the Kapacitor chart and
 | `resources.request.cpu` | Kapacitor cpu request | `0.1` |
 | `resources.limits.memory` | Kapacitor memory limit | `2Gi` |
 | `resources.limits.cpu` | Kapacitor cpu limit | `2` |
-| `envVars` | Environment variables to set initial Kapacitor configuration | `{}` |
+| `envVars` | Environment variables to set initial Kapacitor configuration (https://hub.docker.com/_/kapacitor/) | `{}` |
 | `influxURL` | InfluxDB url used to interact with Kapacitor (also can be set with ```envVars.KAPACITOR_INFLUXDB_0_URLS_0```) | `http://influxdb-influxdb.tick:8086` |
 
 The configurable parameters of the Kapacitor chart and the default values are listed in `values.yaml`.

--- a/stable/kapacitor/templates/deployment.yaml
+++ b/stable/kapacitor/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
           value: {{ template "fullname" . }}.{{ .Release.Namespace }}
         - name: KAPACITOR_INFLUXDB_0_URLS_0
           value: {{ .Values.influxURL }}
+        {{- range $key, $val := .Values.envVars }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+        {{- end}}
         ports:
         - containerPort: 9092
         volumeMounts:

--- a/stable/kapacitor/values.yaml
+++ b/stable/kapacitor/values.yaml
@@ -36,7 +36,7 @@ resources:
     cpu: 2
 
 ## Set the environment variables for kapacitor (or anything else you want to use)
-## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/
+## ref: https://hub.docker.com/_/kapacitor/
 ##
 # Examples below
 #

--- a/stable/kapacitor/values.yaml
+++ b/stable/kapacitor/values.yaml
@@ -12,7 +12,7 @@ image:
 service:
   type: ClusterIP
 
-## Persist data to a persitent volume
+## Persist data to a persistent volume
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
@@ -34,6 +34,15 @@ resources:
   limits:
     memory: 2Gi
     cpu: 2
+
+## Set the environment variables for kapacitor (or anything else you want to use)
+## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/
+##
+# Example Below
+#
+# envVars:
+#   KAPACITOR_SLACK_ENABLED: true
+#   KAPACITOR_SLACK_URL: "http://slack.com/xxxxx/xxxxx/xxxx/xxxxxxx"
     
 ## Set the URL of InfluxDB instance to create subscription on
 ## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/

--- a/stable/kapacitor/values.yaml
+++ b/stable/kapacitor/values.yaml
@@ -38,11 +38,15 @@ resources:
 ## Set the environment variables for kapacitor (or anything else you want to use)
 ## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/
 ##
-# Example Below
+# Examples below
 #
 # envVars:
 #   KAPACITOR_SLACK_ENABLED: true
 #   KAPACITOR_SLACK_URL: "http://slack.com/xxxxx/xxxxx/xxxx/xxxxxxx"
+#
+# or, at your terminal, with
+#
+# helm install --name kapacitor-rls --set influxURL=http://influxurl.com,envVars.KAPACITOR_SLACK_ENABLED=true,envVars.KAPACITOR_SLACK_URL="http://slack.com/xxxxx/xxxxx/xxxx/xxxxxxx" stable/kapacitor
     
 ## Set the URL of InfluxDB instance to create subscription on
 ## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/


### PR DESCRIPTION
Kapacitor can use environment variables to set it's configuration using a var of the form ```KAPACITOR_*``` (the chart itself already uses it to set the  influx url and the kapacitor hostname).

I propose to extend kapacitor chart with env vars, you can configure the chart from the ```values.yaml``` file or use ```--set``` as in
```bash
# E.g. enabling slack and setting its url
helm install --name kapacitor-rls \
  --set influxURL=http://influx-url:8086,envVars.KAPACITOR_SLACK_ENABLED=true,envVars.KAPACITOR_SLACK_URL=https://xxxxx/yyy/zzz/aaaa \
  stable/kapacitor
```