### PR TITLE
Improve datadog

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.7.0
+version: 0.8.0
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -38,3 +38,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "checksd.fullname" -}}
 {{- printf "%s-datadog-checksd" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified entrypoint name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "entrypoint.fullname" -}}
+{{- printf "%s-datadog-entrypoint" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       containers:
       - name: {{ .Chart.Name }}
+        command: ["/bin/bash", "/entrypoint.d/entrypoint.sh"]
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
@@ -69,6 +70,9 @@ spec:
           - name: confd
             mountPath: /conf.d
             readOnly: true
+          - name: entrypoint
+            mountPath: /entrypoint.d
+            readOnly: true
           - name: autoconf
             mountPath: /etc/dd-agent/conf.d/auto_conf
             readOnly: true
@@ -88,6 +92,9 @@ spec:
         - name: confd
           configMap:
             name: {{ template "confd.fullname" . }}
+        - name: entrypoint
+          configMap:
+            name: {{ template "entrypoint.fullname" . }}
         - name: checksd
           configMap:
             name: {{ template "checksd.fullname" . }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
         volumeMounts:
           - name: dockersocket
             mountPath: /var/run/docker.sock
+            readOnly: true
           - name: procdir
             mountPath: /host/proc
             readOnly: true

--- a/stable/datadog/templates/entrypoint-configmap.yaml
+++ b/stable/datadog/templates/entrypoint-configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "entrypoint.fullname" . }}
+  labels:
+    app: {{ template "entrypoint.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  entrypoint.sh: |
+    /bin/bash -eux
+    function collectEvents() {
+      if /opt/datadog-agent/embedded/bin/curl --unix-socket /var/run/docker.sock http://localhost/containers/json | grep -q kube-state-metrics; then
+        echo "true"
+      else
+        echo "false"
+      fi
+    }
+    export COLLECT_EVENTS=`collectEvents`
+    echo "collectEvents: $COLLECT_EVENTS"
+    if [[ "$COLLECT_EVENTS" == "true" ]]; then
+      echo "configuring the agent..."
+      cp /etc/dd-agent/conf.d/kubernetes_state.yaml.example /etc/dd-agent/conf.d/kubernetes_state.yaml
+      sed -i -e "s@# collect_events: false@ collect_events: true@" /etc/dd-agent/conf.d/kubernetes.yaml
+      sed -i -e "s@example.com@kube-state-metrics-kube-state-metrics@" /etc/dd-agent/conf.d/kubernetes_state.yaml
+    fi
+    /entrypoint.sh supervisord -n -c /etc/dd-agent/supervisor.conf 
+    while true; do
+      if [[ "$(collectEvents)" != "$COLLECT_EVENTS" ]]; then
+        service datadog-agent stop
+      fi
+      sleep 60
+    done


### PR DESCRIPTION
This is a little hack to make sure it deploys everywhere.
Do you think we should add a flag to activate it or not?
Or should it be the default?
Also I added hostNetwork, as I had issues to make datadog discover cadvisor and kubelet api by default.
Adding it, helped and solved all [my problems](https://github.com/DataDog/docker-dd-agent/issues/201).