### PR TITLE
Add explicit image tag to CockroachDB chart

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.2.2
+version: 0.2.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -35,17 +35,17 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
 | `Name`                  | Chart name                         | `cockroachdb`                                              |
 | `Image`                 | Container image name               | `cockroachdb/cockroach`                                    |
-| `ImageTag`              | Container image tag                | `latest`                                                    |
+| `ImageTag`              | Container image tag                | `v1.0`                                                     |
 | `ImagePullPolicy`       | Container pull policy              | `Always`                                                   |
 | `Replicas`              | k8s statefulset replicas           | `3`                                                        |
-| `MinAvailable`          | k8s PodDisruptionBudget parameter  | `67%`                                                        |
+| `MinAvailable`          | k8s PodDisruptionBudget parameter  | `67%`                                                      |
 | `Component`             | k8s selector key                   | `cockroachdb`                                              |
-| `GrpcPort`              | CockroachDB primary serving port   | `26257`                                                     |
+| `GrpcPort`              | CockroachDB primary serving port   | `26257`                                                    |
 | `HttpPort`              | CockroachDB HTTP port              | `8080`                                                     |
 | `Cpu`                   | Container requested cpu            | `100m`                                                     |
 | `Memory`                | Container requested memory         | `512Mi`                                                    |
 | `Storage`               | Persistent volume size             | `1Gi`                                                      |
-| `StorageClass`          | Persistent volume class            | `anything`                                                      |
+| `StorageClass`          | Persistent volume class            | `anything`                                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -74,7 +74,7 @@ was created with your installed chart):
 $ kubectl run -it --rm cockroach-client \
     --image=cockroachdb/cockroach \
     --restart=Never \
-    --command -- ./cockroach sql --host my-release-cockroachdb-public
+    --command -- ./cockroach sql --insecure --host my-release-cockroachdb-public
 Waiting for pod default/cockroach-client to be running, status is Pending,
 pod ready: false
 If you don't see a command prompt, try pressing enter.

--- a/stable/cockroachdb/templates/NOTES.txt
+++ b/stable/cockroachdb/templates/NOTES.txt
@@ -10,7 +10,7 @@ For example, you can open up a SQL shell to the cluster by running:
     kubectl run -it --rm cockroach-client \
         --image=cockroachdb/cockroach \
         --restart=Never \
-        --command -- ./cockroach sql --host {{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-public.{{ .Release.Namespace }}
+        --command -- ./cockroach sql --insecure --host {{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-public.{{ .Release.Namespace }}
 
 From there, you can interact with the SQL shell as you would any other SQL shell,
 confident that any data you write will be safe and available even if parts of

--- a/stable/cockroachdb/templates/cockroachdb-petset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-petset.yaml
@@ -161,16 +161,6 @@ spec:
         env:
         - name: STATEFULSET_NAME
           value: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
-        livenessProbe:
-          httpGet:
-            path: /_admin/v1/health
-            port: http
-          initialDelaySeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /_admin/v1/health
-            port: http
-          initialDelaySeconds: 10
         volumeMounts:
         - name: datadir
           mountPath: /cockroach/cockroach-data

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -5,7 +5,7 @@
 
 Name: "cockroachdb"
 Image: "cockroachdb/cockroach"
-ImageTag: "latest" # Keep at latest until 1.0, then switch to a specific version
+ImageTag: "v1.0"
 ImagePullPolicy: "Always"
 BootstrapImage: "cockroachdb/cockroach-k8s-init"
 BootstrapImageTag: "0.1"


### PR DESCRIPTION
Also remove liveness/readingess probes while I'm here. This ensures the cluster can properly recover even if all the nodes are brought down at once. More detailed explanation at:
https://github.com/kubernetes/test-infra/issues/1740#issuecomment-279555187