### PR TITLE
bump kube-lego to v0.1.4

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.9
+version: 0.1.10
 keywords:
   - kube-lego
   - letsencrypt

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -20,7 +20,7 @@ config:
 ##
 image:
   repository: jetstack/kube-lego
-  tag: 0.1.3
+  tag: 0.1.4
   pullPolicy: IfNotPresent
 
 ## Node labels for pod assignment


### PR DESCRIPTION
Related to https://github.com/jetstack/kube-lego/blob/master/CHANGELOG.md#014---2017-05-12
There's no breaking from v.0.1.3