### PR TITLE
[stable/influxdb] Ensure value replacement won't cause invalid YAML

### DIFF
--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
         - name: api
-          containerPort: {{ .Values.config.http.bind_address -}}
+          containerPort: {{ .Values.config.http.bind_address }}
         {{- if .Values.config.admin.enabled -}}
         - name: admin
           containerPort: {{ .Values.config.admin.bind_address }}


### PR DESCRIPTION
I think this bug as it currently stands makes it impossible to enable admin.