### PR TITLE
[stable/openvpn] add kubevpn simple CLI

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to install an openvpn server inside a kubernetes cluster.  Certificate generation is also part of the deployment, and this chart will generate client keys as needed.
 name: openvpn
-version: 1.1.0
+version: 1.2.0
 maintainers:
   - name: John Felten
     email: john.felten@gmail.com

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -21,19 +21,23 @@ POD_NAME=`kubectl get pods -l type=openvpn | awk END'{ print $1 }'` \
 && kubectl log $POD_NAME --follow
 ```
 
-When ready generate a client key as follows:
+When ready, get the kubevpn CLI:
 
 ```bash
-POD_NAME=`kubectl get pods --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` \
-&& SERVICE_NAME=`kubectl get svc --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` \
-&& SERVICE_IP=`kubectl get svc $SERVICE_NAME --namespace {{ .Release.Namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}'` \
-&& KEY_NAME=kubeVPN \
-&& kubectl exec --namespace {{ .Release.Namespace }} -it $POD_NAME /etc/openvpn/setup/newClientCert.sh $KEY_NAME $SERVICE_IP \
-&& kubectl exec --namespace {{ .Release.Namespace }} -it $POD_NAME cat /etc/openvpn/certs/pki/$KEY_NAME.ovpn > $KEY_NAME.ovpn
+POD_NAME=`kubectl get pods --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` && \
+kubectl exec --namespace {{ .Release.Namespace }} -it $POD_NAME cat /etc/openvpn/setup/kubevpn.sh | tr -d '\r' > ./kubevpn && chmod +x ./kubevpn
 
 ```
 
-Be sure to change KEY_NAME if generating additional keys.  Import the .ovpn file into your favorite openvpn tool like tunnelblick and verify connectivity.
+And generate a client key as follows:
+
+```bash
+KEY_NAME=kubeVPN && \
+./kubevpn $KEY_NAME
+
+```
+
+Be sure to change KEY_NAME to your client name to generate additional keys.  Import the .ovpn file into your favorite openvpn tool like tunnelblick and verify connectivity.
 
 ## Configuration
 

--- a/stable/openvpn/templates/NOTES.txt
+++ b/stable/openvpn/templates/NOTES.txt
@@ -12,11 +12,10 @@ Check service status via: kubectl get svc
 Once the external IP is available and all the server certificates are generated, get the super simple kubepvn CLI:
 
 POD_NAME=`kubectl get pods --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` && \
-kubectl exec --namespace {{ .Release.Namespace }} -it $POD_NAME cat /etc/openvpn/setup/kubevpn.sh | tr -d '\r' > ./kubevpn && chmod +x ./kubevpn
+kubectl exec --namespace {{ .Release.Namespace }} -it $POD_NAME cat /etc/openvpn/setup/kubevpn | tr -d '\r' > ./kubevpn && chmod +x ./kubevpn
 
 And generate a client key (at KEY_NAME) as follows:
 
-KEY_NAME=kubeVPN && \
-./kubevpn $KEY_NAME
+KEY_NAME=kubeVPN && ./kubevpn $KEY_NAME
 
 Copy the resulting $KEY_NAME.ovpn file to your open vpn client (ex: in tunnelblick, just double click on the file).  Do this for each user that needs to connect to the VPN.  Change KEY_NAME for each additional user.

--- a/stable/openvpn/templates/NOTES.txt
+++ b/stable/openvpn/templates/NOTES.txt
@@ -9,13 +9,14 @@ LoadBalancer ingress creation can take some time as well.
 
 Check service status via: kubectl get svc
 
-Once the external IP is available and all the server certificates are generated create client key .ovpn files by pasting the following into a shell:
+Once the external IP is available and all the server certificates are generated, get the super simple kubepvn CLI:
 
-POD_NAME=`kubectl get pods --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` \
-&& SERVICE_NAME=`kubectl get svc --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` \
-&& SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} $SERVICE_NAME -o jsonpath='{.status.loadBalancer.ingress[0].ip}') \
-&& KEY_NAME=kubeVPN \
-&& kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME /etc/openvpn/setup/newClientCert.sh $KEY_NAME $SERVICE_IP \
-&& kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME cat /etc/openvpn/certs/pki/$KEY_NAME.ovpn > $KEY_NAME.ovpn
+POD_NAME=`kubectl get pods --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` && \
+kubectl exec --namespace {{ .Release.Namespace }} -it $POD_NAME cat /etc/openvpn/setup/kubevpn.sh | tr -d '\r' > ./kubevpn && chmod +x ./kubevpn
+
+And generate a client key (at KEY_NAME) as follows:
+
+KEY_NAME=kubeVPN && \
+./kubevpn $KEY_NAME
 
 Copy the resulting $KEY_NAME.ovpn file to your open vpn client (ex: in tunnelblick, just double click on the file).  Do this for each user that needs to connect to the VPN.  Change KEY_NAME for each additional user.

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -18,8 +18,7 @@ data:
       ./easyrsa build-server-full server nopass
       ./easyrsa gen-dh 
     fi
-    
-    
+
   newClientCert.sh: |-
       #!/bin/bash
       EASY_RSA_LOC="/etc/openvpn/certs"
@@ -48,7 +47,7 @@ data:
       </connection>
       EOF
       cat pki/$1.ovpn
-      
+
   configure.sh: |-
       #!/bin/sh
       /etc/openvpn/setup/setup-certs.sh
@@ -74,6 +73,7 @@ data:
       sed 's|NETWORK|'"${NETWORK}"'|' -i /etc/openvpn/openvpn.conf
       
       openvpn --config /etc/openvpn/openvpn.conf
+
   openvpn.conf: |-
       server {{ .Values.openvpn.OVPN_NETWORK }} {{ .Values.openvpn.OVPN_SUBNET }}
       verb 3
@@ -102,3 +102,18 @@ data:
 
       push "dhcp-option DOMAIN OVPN_K8S_SEARCH"
       push "dhcp-option DNS OVPN_K8S_DNS"
+
+  kubevpn.sh: |+
+      #!/bin/bash
+      if [ -z "$1" ]
+        then echo -n "Enter KEY_NAME: "
+        read -e KEY_NAME
+      else
+        KEY_NAME=$1
+      fi
+
+      POD_NAME=`kubectl get pods --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` \
+      && SERVICE_NAME=`kubectl get svc --namespace {{ .Release.Namespace }} -l type=openvpn | awk END'{ print $1 }'` \
+      && SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} $SERVICE_NAME -o jsonpath='{.status.loadBalancer.ingress[0].hostname}') \
+      && kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME /etc/openvpn/setup/newClientCert.sh $KEY_NAME $SERVICE_IP \
+      && kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME cat /etc/openvpn/certs/pki/$KEY_NAME.ovpn > $KEY_NAME.ovpn

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -103,7 +103,7 @@ data:
       push "dhcp-option DOMAIN OVPN_K8S_SEARCH"
       push "dhcp-option DNS OVPN_K8S_DNS"
 
-  kubevpn.sh: |+
+  kubevpn: |+
       #!/bin/bash
       if [ -z "$1" ]
         then echo -n "Enter KEY_NAME: "


### PR DESCRIPTION
The pod now generates the kubevpn CLI so you don't overflow your terminal with so many lines. 
Copy once from the pod, use anywhere (if you want it... with the correct kubectl context, of course)