### PR TITLE
Fixes node id clash on single node deployments.

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 0.2.2
+version: 0.2.3
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 icon: https://www.consul.io/assets/images/logo_large-475cebb0.png
 sources:

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -34,7 +34,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | `Replicas`              | k8s statefulset replicas              | `3`                                                        |
 | `Component`             | k8s selector key                      | `consul`                                                   |
 | `Cpu`                   | container requested cpu               | `100m`                                                     |
-| `DisableHostNodeId`     | Disable Node Id create (uses random)  | `false`                                                   |
+| `DisableHostNodeId`     | Disable Node Id creation (uses random)| `false`                                                   |
 | `Memory`                | container requested memory            | `512Mi`                                                    |
 | `Storage`               | Persistent volume size                | `1Gi`                                                      |
 | `StorageClass`          | Persistent volume storage class       | `nil`                                                  |

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -34,6 +34,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | `Replicas`              | k8s statefulset replicas              | `3`                                                        |
 | `Component`             | k8s selector key                      | `consul`                                                   |
 | `Cpu`                   | container requested cpu               | `100m`                                                     |
+| `DisableHostNodeId`     | Disable Node Id create (uses random)  | `false`                                                   |
 | `Memory`                | container requested memory            | `512Mi`                                                    |
 | `Storage`               | Persistent volume size                | `1Gi`                                                      |
 | `StorageClass`          | Persistent volume storage class       | `nil`                                                  |

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -170,6 +170,9 @@ spec:
             {{- if .Values.uiService.enabled }}
               -ui \
             {{- end }}
+            {{- if .Values.DisableHostNodeId }}
+              -disable-host-node-id \
+            {{- end }}
               -data-dir=/var/lib/consul \
               -server \
               -bootstrap-expect=${INITIAL_CLUSTER_SIZE} \

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -23,6 +23,11 @@ Memory: "256Mi"
 ## Persistent volume size
 Storage: "1Gi"
 
+## Needed for 0.8.0 and later IF all consul containers are spun up
+## on the same machine. Without this they all generate the same
+## host id.
+DisableHostNodeId: false
+
 ## StorageClass name for use with Persistent Volume Claim (PVC) using beta notations
 # StorageClass:
 


### PR DESCRIPTION
I raised #1067 a little while ago. This new option enables use of consul `>=0.8.0` in single node (eg: minikube) deployments. 