### PR TITLE
Existing PVC support for stable/drupal

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.5.3
+version: 0.6.0
 description: One of the most versatile open source content management systems.
 keywords:
 - drupal

--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,6 @@
 name: drupal
 version: 0.6.0
+appVersion: 8.3.2
 description: One of the most versatile open source content management systems.
 keywords:
 - drupal
@@ -14,6 +15,6 @@ icon: https://bitnami.com/assets/stacks/drupal/img/drupal-stack-220x234.png
 sources:
 - https://github.com/bitnami/bitnami-docker-drupal
 maintainers:
-- name: Bitnami
+- name: bitnami-bot
   email: containers@bitnami.com
 engine: gotpl

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -59,12 +59,12 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                     |
 | `serviceType`                     | Kubernetes Service type               | `LoadBalancer`                                            |
 | `persistence.enabled`             | Enable persistence using PVC          | `true`                                                    |
-| `persistence.ExistingClaim`       | An Existing PVC name                  | `nil`                                                     |
 | `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `nil` (uses alpha storage class annotation)               |
 | `persistence.apache.accessMode`   | PVC Access Mode for Apache volume     | `ReadWriteOnce`                                           |
 | `persistence.apache.size`         | PVC Storage Request for Apache volume | `1Gi`                                                     |
 | `persistence.drupal.storageClass` | PVC Storage Class for Drupal volume   | `nil` (uses alpha storage class annotation)               |
 | `persistence.drupal.accessMode`   | PVC Access Mode for Drupal volume     | `ReadWriteOnce`                                           |
+| `persistence.drupal.ExistingClaim`| An Existing PVC name                  | `nil`                                                     |
 | `persistence.drupal.size`         | PVC Storage Request for Drupal volume | `8Gi`                                                     |
 | `resources`                       | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                              |
 
@@ -101,5 +101,5 @@ See the [Configuration](#configuration) section to configure the PVC or to disab
 1. Create the PersistentVolumeClaim
 1. Install the chart
 ```bash
-$ helm install --name my-release --set persistence.ExistingClaim=PVC_NAME stable/drupal
+$ helm install --name my-release --set persistence.drupal.ExistingClaim=PVC_NAME stable/drupal
 ```

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -59,6 +59,7 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                     |
 | `serviceType`                     | Kubernetes Service type               | `LoadBalancer`                                            |
 | `persistence.enabled`             | Enable persistence using PVC          | `true`                                                    |
+| `persistence.ExistingClaim`       | An Existing PVC name                  | `nil`                                                     |
 | `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `nil` (uses alpha storage class annotation)               |
 | `persistence.apache.accessMode`   | PVC Access Mode for Apache volume     | `ReadWriteOnce`                                           |
 | `persistence.apache.size`         | PVC Storage Request for Apache volume | `1Gi`                                                     |
@@ -93,3 +94,12 @@ The [Bitnami Drupal](https://github.com/bitnami/bitnami-docker-drupal) image sto
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+### Existing PersistentVolumeClaim
+
+1. Create the PersistentVolume
+1. Create the PersistentVolumeClaim
+1. Install the chart
+```bash
+$ helm install --name my-release --set persistence.ExistingClaim=PVC_NAME stable/drupal
+```

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -64,7 +64,7 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | `persistence.apache.size`         | PVC Storage Request for Apache volume | `1Gi`                                                     |
 | `persistence.drupal.storageClass` | PVC Storage Class for Drupal volume   | `nil` (uses alpha storage class annotation)               |
 | `persistence.drupal.accessMode`   | PVC Access Mode for Drupal volume     | `ReadWriteOnce`                                           |
-| `persistence.drupal.ExistingClaim`| An Existing PVC name                  | `nil`                                                     |
+| `persistence.drupal.existingClaim`| An Existing PVC name                  | `nil`                                                     |
 | `persistence.drupal.size`         | PVC Storage Request for Drupal volume | `8Gi`                                                     |
 | `resources`                       | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                              |
 
@@ -101,5 +101,5 @@ See the [Configuration](#configuration) section to configure the PVC or to disab
 1. Create the PersistentVolumeClaim
 1. Install the chart
 ```bash
-$ helm install --name my-release --set persistence.drupal.ExistingClaim=PVC_NAME stable/drupal
+$ helm install --name my-release --set persistence.drupal.existingClaim=PVC_NAME stable/drupal
 ```

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       - name: drupal-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}-drupal
+          claimName: {{ .Values.persistence.ExistingClaim | default (include "fullname" .) "-drupal" }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       - name: drupal-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.ExistingClaim | default (printf "%s-drupal" (include "fullname" .)) }}
+          claimName: {{ .Values.persistence.drupal.ExistingClaim | default (printf "%s-drupal" (include "fullname" .)) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       - name: drupal-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.ExistingClaim | default (include "fullname" .) "-drupal" }}
+          claimName: {{ .Values.persistence.ExistingClaim | default (printf "%s-drupal" (include "fullname" .)) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       - name: drupal-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.drupal.ExistingClaim | default (printf "%s-drupal" (include "fullname" .)) }}
+          claimName: {{ .Values.persistence.drupal.existingClaim | default (printf "%s-drupal" (include "fullname" .)) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/drupal/templates/drupal-pvc.yaml
+++ b/stable/drupal/templates/drupal-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.ExistingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/drupal/templates/drupal-pvc.yaml
+++ b/stable/drupal/templates/drupal-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.ExistingClaim) -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.drupal.ExistingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/drupal/templates/drupal-pvc.yaml
+++ b/stable/drupal/templates/drupal-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.drupal.ExistingClaim) -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.drupal.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -78,6 +78,11 @@ ingress:
 ##
 persistence:
   enabled: true
+  ## A manually managed Persistent Volume Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  ##
+  # ExistingClaim:
   apache:
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -78,11 +78,6 @@ ingress:
 ##
 persistence:
   enabled: true
-  ## A manually managed Persistent Volume Claim
-  ## Requires persistence.enabled: true
-  ## If defined, PVC must be created manually before volume will be bound
-  ##
-  # ExistingClaim:
   apache:
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default
@@ -97,6 +92,12 @@ persistence:
     # storageClass:
     accessMode: ReadWriteOnce
     size: 8Gi
+
+    ## A manually managed Persistent Volume Claim
+    ## Requires persistence.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    ##
+    # ExistingClaim:
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -97,7 +97,7 @@ persistence:
     ## Requires persistence.enabled: true
     ## If defined, PVC must be created manually before volume will be bound
     ##
-    # ExistingClaim:
+    # existingClaim:
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
## Context

@prydonius This is what we talked about in relation to #1057 (this is an independent PR, but which the other would rely on if we go the PV/PVC route for local k8s app dev best practices) - just adding existing PVC support to an example stable chart (in this case Drupal. If this works out we can open PRs for the other applicable stable charts missing this feature).

## Testing
I have not yet tested this locally, because I'm having trouble getting a PVC to bind to a PV in minikube for some reason. If it's helpful, Here are YAML files for the PV and PVC I'm attempting to bind in Minikube.

### existing-pv.yaml
<details>

```yaml
kind: PersistentVolume
apiVersion: v1
metadata:
  name: existing-drupal-pv
  labels:
    environment: local
  annotations:
    volume.alpha.kubernetes.io/storage-class: default
spec:
  capacity:
    storage: "8Gi"
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Recycle
  hostPath:
    path: "/PATH/TO/EXISTING/DIR/ON/HOST/MACHINE"
```
</details>

### existing-pvc.yaml
<details>

```yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: existing-drupal-pvc
  labels:
    environment: local
  annotations:
    volume.alpha.kubernetes.io/storage-class: default
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: "8Gi"
  selector:
    matchLabels:
      environment: local
```
</details>


I'm hoping someone more knowledgable about PV/PVC binding may be able to help with this part. If so, I'll be happy to add testing feedback. (note that I have read the [PersistentVolume Selector section](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector) and [Labels and Selectors docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/), and have found very few other discussions about this online, mostly old ones like [this](http://stackoverflow.com/questions/34282704/can-a-pvc-be-bound-to-a-specific-pv/34323691#34323691)).
