### PR TITLE
Add PostgreSQL support to Redmine chart

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 0.5.3
+version: 1.0.0
 description: A flexible project management web application.
 keywords:
 - redmine

--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 0.4.3
+version: 0.5.3
 description: A flexible project management web application.
 keywords:
 - redmine

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -41,6 +41,14 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Using PostgreSQL instead of MariaDB
+
+This chart includes the option to use a PostgreSQL database for Redmine instead of MariaDB. To use this, MariaDB must be explicitly disabled and PostgreSQL enabled:
+
+```
+helm install --name my-release stable/redmine --set databaseType.mariadb=false,databaseType.postgresql=true
+```
+
 ## Configuration
 
 The following tables lists the configurable parameters of the Redmine chart and their default values.

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -58,8 +58,8 @@ The following tables lists the configurable parameters of the Redmine chart and 
 | `smtpUser`                      | SMTP user                       | `nil`                                                     |
 | `smtpPassword`                  | SMTP password                   | `nil`                                                     |
 | `smtpTls`                       | Use TLS encryption with SMTP    | `nil`                                                     |
-| `databaseType.postgresql`       | Select postgresql database      | `nil`                                                     |
-| `databaseType.mariadb`          | Select mariadb database         | `nil`                                                     |
+| `databaseType.postgresql`       | Select postgresql database      | `false`                                                   |
+| `databaseType.mariadb`          | Select mariadb database         | `true`                                                    |
 | `mariadb.mariadbRootPassword`   | MariaDB admin password          | `nil`                                                     |
 | `postgresql.postgresqlPassword` | PostgreSQL admin password       | `nil`                                                     |
 | `serviceType`                   | Kubernetes Service type         | `LoadBalancer`                                            |

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -12,7 +12,7 @@ $ helm install stable/redmine
 
 This chart bootstraps a [Redmine](https://github.com/bitnami/bitnami-docker-redmine) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the Redmine application.
+It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) and the [PostgreSQL chart](https://github.com/kubernetes/charts/tree/master/stable/postgresql) which are required for bootstrapping a MariaDB/PostgreSQL deployment for the database requirements of the Redmine application.
 
 ## Prerequisites
 
@@ -58,7 +58,10 @@ The following tables lists the configurable parameters of the Redmine chart and 
 | `smtpUser`                      | SMTP user                       | `nil`                                                     |
 | `smtpPassword`                  | SMTP password                   | `nil`                                                     |
 | `smtpTls`                       | Use TLS encryption with SMTP    | `nil`                                                     |
+| `databaseType.postgresql`       | Select postgresql database      | `nil`                                                     |
+| `databaseType.mariadb`          | Select mariadb database         | `nil`                                                     |
 | `mariadb.mariadbRootPassword`   | MariaDB admin password          | `nil`                                                     |
+| `postgresql.postgresqlPassword` | PostgreSQL admin password       | `nil`                                                     |
 | `serviceType`                   | Kubernetes Service type         | `LoadBalancer`                                            |
 | `persistence.enabled`           | Enable persistence using PVC    | `true`                                                    |
 | `persistence.existingClaim`     | The name of an existing PVC     | `nil`                                                     |
@@ -106,4 +109,3 @@ The following example includes two PVCs, one for redmine and another for Maria D
 ```bash
 $ helm install --name test --set persistence.existingClaim=PVC_REDMINE,mariadb.persistence.existingClaim=PVC_MARIADB  redmine
 ```
-

--- a/stable/redmine/requirements.lock
+++ b/stable/redmine/requirements.lock
@@ -1,9 +1,17 @@
 dependencies:
 - condition: ""
   enabled: false
+  import-values: null
   name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   tags: null
   version: 0.6.0
-digest: sha256:b4e89d834d107108f60c64c1c679a10798334ea7bb385a1a55080d802e2a9067
-generated: 2017-04-05T14:30:13.450057849-04:00
+- condition: ""
+  enabled: false
+  import-values: null
+  name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  tags: null
+  version: 0.6.0
+digest: sha256:38221d834fb6dc8d5f067bf2af4f5810e8224e3cfd6531ca24588d761bb37082
+generated: 2017-05-04T15:43:43.465748774+02:00

--- a/stable/redmine/requirements.yaml
+++ b/stable/redmine/requirements.yaml
@@ -2,3 +2,8 @@ dependencies:
 - name: mariadb
   version: 0.6.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: databaseType.mariadb
+- name: postgresql
+  version: 0.6.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: databaseType.postgresql

--- a/stable/redmine/templates/_helpers.tpl
+++ b/stable/redmine/templates/_helpers.tpl
@@ -23,3 +23,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/redmine/templates/deployment.yaml
+++ b/stable/redmine/templates/deployment.yaml
@@ -19,15 +19,23 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
-        - name: MARIADB_HOST
+        {{ if .Values.databaseType.postgresql }}
+        - name: REDMINE_DB_POSTGRES
+          value: {{ template "postgresql.fullname" . }}
+        - name: REDMINE_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "postgresql.fullname" . }}
+              key: postgres-password
+        {{ else }}
+        - name: REDMINE_DB_MYSQL
           value: {{ template "mariadb.fullname" . }}
-        - name: MARIADB_PORT
-          value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: REDMINE_DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mariadb.fullname" . }}
               key: mariadb-root-password
+        {{ end }}
         - name: REDMINE_USERNAME
           value: {{ default "" .Values.redmineUsername | quote }}
         - name: REDMINE_PASSWORD

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Redmine image version
 ## ref: https://hub.docker.com/r/bitnami/redmine/tags/
 ##
-image: bitnami/redmine:3.3.3-r1
+image: bitnami/redmine:3.3.3-r2
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -38,6 +38,13 @@ redmineLanguage: en
 # smtpPassword:
 # smtpTls:
 
+## Database configuration. Please note that only one of the following databases should be selected.
+## ref: https://github.com/bitnami/bitnami-docker-redmine#run-the-application-using-postgresql-database
+##
+databaseType:
+  mariadb: true
+  postgresql: false
+
 ##
 ## MariaDB chart configuration
 ##
@@ -55,7 +62,33 @@ mariadb:
     ## A manually manage Persistent Volume Claim
     ## Requires mariadb.persistence.enable: true
     ## If defined, PVC must be created manually before volume will be bound
-    # existingClaim: 
+    # existingClaim:
+
+    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ##
+    # storageClass:
+    accessMode: ReadWriteOnce
+    size: 8Gi
+
+##
+## PostgreSQL chart configuration
+##
+postgresql:
+  ## PostgreSQL admin password
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
+  ##
+  # postgresqlPassword:
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## A manually manage Persistent Volume Claim
+    ## Requires postgresql.persistence.enable: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
 
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default
@@ -77,7 +110,7 @@ persistence:
   ## A manually manage Persistent Volume Claim
   ## Requires persistence.enable: true
   ## If defined, PVC must be created manually before volume will be bound
-  # existingClaim: 
+  # existingClaim:
 
   ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
   ## Default: volume.alpha.kubernetes.io/storage-class: default


### PR DESCRIPTION
Since bitnami/redmine:3.3.3-r2 it is possible to configure either a MariaDB/MySQL database or a PostgreSQL database for the Redmine application.

Regarding this change, some environment variables from the bitnami/redmine docker image has been renamed as follows:

`MARIADB_HOST` -> `REDMINE_DB_MYSQL` or `REDMINE_DB_POSTGRES`
`MARIADB_PORT` -> `REDMINE_DB_PORT_NUMBER`
`MARIADB_USER` -> `REDMINE_DB_USERNAME`
`MARIADB_PASSWORD` -> `REDMINE_DB_PASSWORD`

