### PR TITLE
Allow sysdig to run on master nodes

### DIFF
--- a/stable/sysdig/README.md
+++ b/stable/sysdig/README.md
@@ -44,6 +44,7 @@ The following tables lists the configurable parameters of the Sysdig chart and t
 | `image.repository`          | The image repository to pull from  | `sysdig/agent`                            |
 | `image.tag`                 | The image tag to pull              | `latest`                                  |
 | `image.pullPolicy`          | The Image pull policy              | `Always`                                  |
+| `tolerations`               | The tolerations for scheduling     | `node-role.kubernetes.io/master:NoSchedule`                       |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -36,6 +36,8 @@ spec:
           path: /usr
       hostNetwork: true
       hostPID: true
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/sysdig/values.yaml
+++ b/stable/sysdig/values.yaml
@@ -19,3 +19,8 @@ resources:
   limits:
     cpu: 500m
     memory: 768Mi
+
+# Allow sysdig to run on Kubernetes 1.6 masters.
+tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master


### PR DESCRIPTION
Kubernetes 1.6 switched to a taint on the master node, we need to
add a toleration so this can schedule.