### PR TITLE
[stable/aws-cluster-autoscaler] Update docker container to v0.5.4

### DIFF
--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: aws-cluster-autoscaler
-version: 0.2.1
+version: 0.2.2
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -48,7 +48,7 @@ Parameter | Description | Default
 `autoscalingGroups[].minSize` | minimum autoscaling group size | none
 `awsRegion` | AWS region | `us-east-1`
 `image.repository` | Image | `gcr.io/google_containers/cluster-autoscaler`
-`image.tag` | Image tag | `v0.4.0`
+`image.tag` | Image tag | `v0.5.4`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `extraArgs` | additional container arguments | `{}`
 `nodeSelector` | node labels for pod assignment | `{}`

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -7,7 +7,7 @@ awsRegion: us-east-1
 
 image:
   repository: gcr.io/google_containers/cluster-autoscaler
-  tag: v0.4.0
+  tag: v0.5.4
   pullPolicy: IfNotPresent
 
 extraArgs: {}


### PR DESCRIPTION
Since kubernetes `v1.6.*` has been out for awhile, we should probably bump this chart by default to give new users a better experience.  Aws-cluster-autoscaler has a [1-to-1 dependency](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases) on the version of kubernetes.  We should really encourage users to set their own image tag on this chart.  I added a note to https://github.com/kubernetes/charts/pull/684 to mention this as well.