### PR TITLE
[Feature] Influxdb - Create Database post-install

### DIFF
--- a/stable/influxdb/templates/post-install-create-db.yaml
+++ b/stable/influxdb/templates/post-install-create-db.yaml
@@ -38,6 +38,6 @@ spec:
           - |-
              curl -X POST http://{{ template "fullname" . }}:{{ .Values.config.http.bind_address }}/query \
              --data-urlencode \
-             "q=CREATE DATABASE ${INFLUXDB_DATABASE} WITH DURATION ${INFLUXDB_DURATION} REPLICATION ${INFLUXDB_REPLICATION} SHARD DURATION ${INFLUXDB_SHARD_DURATION} NAME ${INFLUXDB_SHARD_GROUP_NAME}"
+             "q=CREATE DATABASE \"${INFLUXDB_DATABASE}\" WITH DURATION ${INFLUXDB_DURATION} REPLICATION ${INFLUXDB_REPLICATION} SHARD DURATION ${INFLUXDB_SHARD_DURATION} NAME \"${INFLUXDB_SHARD_GROUP_NAME}\""
       restartPolicy: {{ .Values.createDatabase.restartPolicy }}
 {{- end -}}

--- a/stable/influxdb/templates/post-install-create-db.yaml
+++ b/stable/influxdb/templates/post-install-create-db.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.createDatabase.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  name: {{ template "fullname" . }}-create-db
+  annotations:
+    "helm.sh/hook": post-install
+spec:
+  activeDeadlineSeconds: {{ default 300 .Values.createDatabase.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}-create-db
+        image: "{{ .Values.createDatabase.image }}"
+        env:
+          - name: INFLUXDB_DATABASE
+            value: {{ default "influxdb" .Values.createDatabase.database.database | quote }}
+          - name: INFLUXDB_DURATION
+            value: {{ default "3d" .Values.createDatabase.database.duration | quote }}
+          - name: INFLUXDB_REPLICATION
+            value: {{ default 1 .Values.createDatabase.database.replication | quote }}
+          - name: INFLUXDB_SHARD_DURATION
+            value: {{ default "1h" .Values.createDatabase.database.duration | quote }}
+          - name: INFLUXDB_SHARD_GROUP_NAME
+            value: {{ default "influxdb" .Values.createDatabase.database.shardGroupName | quote }}
+        args:
+          - "/bin/sh"
+          - "-c"
+          - |-
+             curl -X POST http://{{ template "fullname" . }}:{{ .Values.config.http.bind_address }}/query \
+             --data-urlencode \
+             "q=CREATE DATABASE ${INFLUXDB_DATABASE} WITH DURATION ${INFLUXDB_DURATION} REPLICATION ${INFLUXDB_REPLICATION} SHARD DURATION ${INFLUXDB_SHARD_DURATION} NAME ${INFLUXDB_SHARD_GROUP_NAME}"
+      restartPolicy: {{ .Values.createDatabase.restartPolicy }}
+{{- end -}}

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -61,6 +61,48 @@ setDefaultUser:
     ## Default: "WITH ALL PRIVILEGES"
     # privileges: "WITH ALL PRIVILEGES"
 
+## Create database through Kubernetes job
+## Defaults indicated below
+##
+createDatabase:
+  enabled: false
+
+  ## Image of the container used for job
+  ## Default: appropriate/curl:latest
+  ##
+  #image: appropriate/curl:latest
+
+  ## Deadline for job so it does not retry forever.
+  ## Default: activeDeadline: 300
+  ##
+  #activeDeadline: 300
+
+  ## Restart policy for job
+  ## Default: OnFailure
+  #restartPolicy: OnFailure
+
+  #database:
+
+    ## The user name
+    ## Default: "influxdb"
+    #database: ""
+
+    ## The duration
+    ## Default: "3d"
+    #duration: ""
+
+    ## The replication factor
+    ## Default: "1"
+    #replication: ""
+
+    ## The shard duration
+    ## Default: "1h"
+    #shardDuration: ""
+
+    ## The shard group name
+    ## Default: "influxdb"
+    #shardGroupName: ""
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources:


### PR DESCRIPTION
Added post-install script to create database on deploy (copied from post-install create user script).

Some of the influxdb interfaces automatically create databases when metrics are written to them, the HTTP interface doesn't, so automation of database creation is desirable.

This is my first contribution to this project so please let me know if anything needs changing.