### PR TITLE
Add optional deployment and service for DataDog

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.4.0
+version: 0.5.0
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -75,16 +75,19 @@ $ helm install --name my-release -f values.yaml stable/datadog
 
 Datadog offers a multitude of [tags](https://hub.docker.com/r/datadog/docker-dd-agent/tags/), including alpine based agents and JMX.
 
+### DaemonSet and Deployment
+By default installs Datadog agent inside a DaemonSet. You may also use Datadog agent inside a Deployment, if you want to collect Kubernetes API events or send custom metrics to DogStatsD endpoint.
+
 ### confd and checksd
 
 The Datadog entrypoint will copy files found in `/conf.d` and `/check.d` to
 `/etc/dd-agent/conf.d` and `/etc/dd-agent/check.d` respectively. The keys for
-`datadog.confd`, `datadog.autoconf`, and `datadog.checksd` should mirror the content found in their 
+`datadog.confd`, `datadog.autoconf`, and `datadog.checksd` should mirror the content found in their
 respective ConfigMaps, ie
 
 ```yaml
 datadog:
-  autoconf: 
+  autoconf:
     redisdb.yaml: |-
       docker_images:
         - redis

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.daemonset.enabled }}
 {{- if .Values.datadog.apiKey }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -88,4 +89,5 @@ spec:
         - name: autoconf
           configMap:
             name: {{ template "autoconf.fullname" . }}
+{{ end }}
 {{ end }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -28,9 +28,6 @@ spec:
         - containerPort: 8126
           name: traceport
           protocol: TCP
-        - containerPort: 7777
-          name: legacytraceport
-          protocol: TCP
         {{- end }}
         env:
           - name: API_KEY

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -1,25 +1,37 @@
+{{- if .Values.deployment.enabled }}
 {{- if .Values.datadog.apiKey }}
-{{- if .Values.datadog.collectEvents }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-events
+  name: {{ template "fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
-  replicas: 1
+  replicas: {{ .Values.deployment.replicas }}
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}-events
-      name: {{ template "fullname" . }}-events
+        app: {{ template "fullname" . }}
+      name: {{ template "fullname" . }}
     spec:
       containers:
-      - name: {{ .Chart.Name }}-events
+      - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+        ports:
+        - containerPort: 8125
+          name: dogstatsdport
+          protocol: UDP
+        {{- if .Values.datadog.apmEnabled }}
+        - containerPort: 8126
+          name: traceport
+          protocol: TCP
+        - containerPort: 7777
+          name: legacytraceport
+          protocol: TCP
+        {{- end }}
         env:
           - name: API_KEY
             valueFrom:
@@ -34,10 +46,17 @@ spec:
             value: {{ default "" .Values.datadog.nonLocalTraffic | quote }}
           - name: TAGS
             value: {{ default "" .Values.datadog.tags | quote }}
+          - name: DD_APM_ENABLED
+            value: {{ default "" .Values.datadog.apmEnabled | quote }}
           - name: KUBERNETES
             value: "yes"
+          {{- if .Values.datadog.collectEvents }}
           - name: KUBERNETES_COLLECT_EVENTS
             value: "yes"
+          {{- end }}
+{{- if .Values.datadog.env }}
+{{ toYaml .Values.datadog.env | indent 10 }}
+{{- end }}
         volumeMounts:
           - name: dockersocket
             mountPath: /var/run/docker.sock
@@ -46,6 +65,15 @@ spec:
             readOnly: true
           - name: cgroups
             mountPath: /host/sys/fs/cgroup
+            readOnly: true
+          - name: confd
+            mountPath: /conf.d
+            readOnly: true
+          - name: autoconf
+            mountPath: /etc/dd-agent/conf.d/auto_conf
+            readOnly: true
+          - name: checksd
+            mountPath: /checks.d
             readOnly: true
       volumes:
         - hostPath:
@@ -57,5 +85,14 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        - name: confd
+          configMap:
+            name: {{ template "confd.fullname" . }}
+        - name: checksd
+          configMap:
+            name: {{ template "checksd.fullname" . }}
+        - name: autoconf
+          configMap:
+            name: {{ template "autoconf.fullname" . }}
 {{ end }}
 {{ end }}

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.deployment.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  type: {{ .Values.serviceType }}
+  selector:
+    app: {{ template "fullname" . }}
+  ports:
+  - port: 8125
+    name: dogstatsdport
+    protocol: UDP
+  {{- if .Values.datadog.apmEnabled }}
+  - port: 8126
+    name: traceport
+    protocol: TCP
+  {{- end }}
+{{ end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -4,6 +4,23 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+# NB! Normally you need to keep Datadog DaemonSet enabled!
+# The exceptional case could be a situation when you need to run
+# single DataDog pod per every namespace, but you do not need to
+# re-create a DaemonSet for every non-default namespace install.
+# Note, that StatsD and DogStatsD work over UDP, so you may not
+# get guaranteed delivery of the metrics in Datadog-per-namespace setup!
+daemonset:
+  enabled: true
+
+# Apart from DaemonSet, deploy Datadog agent pods and related service for
+# applications that want to send custom metrics. Provides DogStasD service.
+#
+# HINT: If you want to use datadog.collectEvents, keep deployment.replicas set to 1.
+deployment:
+  enabled: false
+  replicas: 1
+
 datadog:
   ## You'll need to set this to your Datadog API key before the agent will run.
   ## ref: https://app.datadoghq.com/account/settings#agent/kubernetes
@@ -39,13 +56,13 @@ datadog:
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
   ##
   # env:
-  #   - name: 
-  #     value: 
+  #   - name:
+  #     value:
 
   ## Provide additonal service definitions
   ## Each key will become a file in /conf.d/auto_conf
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
-  ## 
+  ##
   # autoconf:
   #   redisdb.yaml: |-
   #     docker_images:
@@ -58,7 +75,7 @@ datadog:
   ## Provide additonal service definitions
   ## Each key will become a file in /conf.d
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
-  ## 
+  ##
   # confd:
   #   redisdb.yaml: |-
   #     init_config:
@@ -69,7 +86,7 @@ datadog:
   ## Provide additonal service checks
   ## Each key will become a file in /checks.d
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
-  ## 
+  ##
   # checksd:
   #   service.py: |-
 


### PR DESCRIPTION
Hi all! :wave: 

## Why do we need it?
* Serve applications that want to send custom metrics with an accessible DogStasD service endpoint.
* Make DaemonSet optional (enabled by default though), so we could put a Datadog deployment into every namespace w/o overhead of re-adding a new DaemonSet (mostly for single-pod deployments). 
* This could also serve, if you have a single Datadog agent pod in every namespace, and you run custom python checks against your services (e.g. HTTP smokes) from this pod and you do not really need a DaemonSet for it, especially if you need a single pod deployment to save resources and avoid duplication of metrics/events (not only K8s ones, think about your custom ones also).   

## GIF
*That's my first chart contribution* :wink:
 
![](https://media.giphy.com/media/CovFciJgWyxUs/giphy.gif)