### PR TITLE
Bumping up CI version to use helm 2.4.2

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -46,7 +46,7 @@ fi
 
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.4.1-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.4.2-linux-amd64.tar.gz
 INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 pushd /opt
   wget -q ${HELM_URL}/${HELM_TARBALL}

--- a/test/helm-test-e2e.sh
+++ b/test/helm-test-e2e.sh
@@ -7,7 +7,7 @@ set -o xtrace
 
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.2.3-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.4.2-linux-amd64.tar.gz
 
 wget -q ${HELM_URL}/${HELM_TARBALL}
 tar xzfv ${HELM_TARBALL}


### PR DESCRIPTION
We should keep the PULL and HEAD e2e testing in sync in helm version.