### PR TITLE
[stable/ghost] Rename GHOST_PORT env var by GHOST_PORT_NUMBER

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 0.4.9
+version: 0.4.10
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:
 - ghost

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
               key: mariadb-root-password
         - name: GHOST_HOST
           value: {{ include "host" . | quote }}
-        - name: GHOST_PORT
+        - name: GHOST_PORT_NUMBER
           {{- if eq .Values.serviceType "ClusterIP" }}
           value: "2368"
           {{- else }}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Ghost image version
 ## ref: https://hub.docker.com/r/bitnami/ghost/tags/
 ##
-image: bitnami/ghost:0.11.8-r1
+image: bitnami/ghost:0.11.9-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -1,5 +1,6 @@
 ## Bitnami Ghost image version
 ## ref: https://hub.docker.com/r/bitnami/ghost/tags/
+##
 image: bitnami/ghost:0.11.9-r1
 
 ## Specify a imagePullPolicy


### PR DESCRIPTION
In order to avoid environment variable collision with ghost k8s service, we can rename GHOST_PORT environment variable by GHOST_PORT_NUMBER