### PR TITLE
Allow datadog to run on masters with a taint of NoSchedule

### DIFF
--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -53,7 +53,7 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `resources.limits.cpu`      | CPU resource limits                | 512Mi                                     |
 | `resources.requests.memory` | Memory resource requests           | 100m                                      |
 | `resources.limits.memory`   | Memory resource limits             | 256m                                      |
-
+| `tolerations`               | The tolerations for scheduling     | Setup to match the taint for `node.alpha.kubernetes.io/role=master:NoSchedule`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -79,12 +79,12 @@ Datadog offers a multitude of [tags](https://hub.docker.com/r/datadog/docker-dd-
 
 The Datadog entrypoint will copy files found in `/conf.d` and `/check.d` to
 `/etc/dd-agent/conf.d` and `/etc/dd-agent/check.d` respectively. The keys for
-`datadog.confd`, `datadog.autoconf`, and `datadog.checksd` should mirror the content found in their 
+`datadog.confd`, `datadog.autoconf`, and `datadog.checksd` should mirror the content found in their
 respective ConfigMaps, ie
 
 ```yaml
 datadog:
-  autoconf: 
+  autoconf:
     redisdb.yaml: |-
       docker_images:
         - redis

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -12,6 +12,10 @@ spec:
         app: {{ template "fullname" . }}
       name: {{ template "fullname" . }}
     spec:
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -39,13 +39,13 @@ datadog:
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
   ##
   # env:
-  #   - name: 
-  #     value: 
+  #   - name:
+  #     value:
 
   ## Provide additonal service definitions
   ## Each key will become a file in /conf.d/auto_conf
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
-  ## 
+  ##
   # autoconf:
   #   redisdb.yaml: |-
   #     docker_images:
@@ -58,7 +58,7 @@ datadog:
   ## Provide additonal service definitions
   ## Each key will become a file in /conf.d
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
-  ## 
+  ##
   # confd:
   #   redisdb.yaml: |-
   #     init_config:
@@ -69,7 +69,7 @@ datadog:
   ## Provide additonal service checks
   ## Each key will become a file in /checks.d
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
-  ## 
+  ##
   # checksd:
   #   service.py: |-
 
@@ -80,3 +80,10 @@ resources:
   limits:
     cpu: 256m
     memory: 512Mi
+
+# Allow datadog to run on Kubernetes 1.6 masters.
+tolerations:
+  - effect: NoSchedule
+    operator: Equal
+    key: node.alpha.kubernetes.io/role
+    value: master


### PR DESCRIPTION
Basically datadog is one daemonset that I want to run on all of my nodes, regardless of the taints really. At the moment we use `kube-aws` and by default it sets up the masters with a NoSchedule taint. I have added this as a default tolerant but it can be modified by the values file.