### PR TITLE
testlink: fix probes to properly query pod health

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,6 @@
 name: testlink
-version: 0.4.9
+version: 0.4.10
+appVersion: 1.9.16
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png
 keywords:
@@ -11,6 +12,6 @@ home: http://www.testlink.org/
 sources:
 - https://github.com/bitnami/bitnami-docker-testlink
 maintainers:
-- name: Bitnami
+- name: bitnami-bot
   email: containers@bitnami.com
 engine: gotpl

--- a/stable/testlink/templates/deployment.yaml
+++ b/stable/testlink/templates/deployment.yaml
@@ -61,16 +61,14 @@ spec:
           containerPort: 443
         livenessProbe:
           httpGet:
-            path: /
+            path: /login.php
             port: http
           initialDelaySeconds: 120
-          timeoutSeconds: 5
         readinessProbe:
           httpGet:
-            path: /
+            path: /login.php
             port: http
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
+          initialDelaySeconds: 30
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:


### PR DESCRIPTION
The bitnami images render  a loading page while the application is being initialized (at container startup). The health probes consider this as the pod being healthy/ready, which is not really true. The pod should indicate readiness only when the target application has been initialized and ready to accept queries. 

This PR changes the http endpoint of the health checks to query the state of the application. Consequently the initial delay has been bumped because we want to give enough time for the application to initialize and start.