### PR TITLE
(bugfix): Istio - create istioRelease value to work around Helm bug

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Istio Helm chart for Kubernetes
 name: istio
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.5
 home: https://istio.io/
 sources:

--- a/incubator/istio/templates/addons-grafana-deployment.yaml
+++ b/incubator/istio/templates/addons-grafana-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image:  "{{ .Values.addons.grafana.deployment.image }}:{{ .Chart.AppVersion }}"
+        image:  "{{ .Values.addons.grafana.deployment.image }}:{{ .Values.istioRelease }}"
         imagePullPolicy: {{ .Values.addons.grafana.deployment.imagePullPolicy }}
         ports:
           - containerPort: {{ .Values.addons.grafana.service.externalPort }}

--- a/incubator/istio/templates/ca-deployment.yaml
+++ b/incubator/istio/templates/ca-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: {{ template "fullname" . }}-ca-service-account
       containers:
       - name: istio-ca
-        image: "{{ .Values.ca.deployment.image }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.ca.deployment.image }}:{{ .Values.istioRelease }}"
         imagePullPolicy: {{ .Values.ca.deployment.imagePullPolicy }}
         env:
         - name: NAMESPACE

--- a/incubator/istio/templates/egress-deployment.yaml
+++ b/incubator/istio/templates/egress-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: proxy
-        image: "{{ .Values.egress.deployment.image }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.egress.deployment.image }}:{{ .Values.istioRelease }}"
         imagePullPolicy: {{ .Values.egress.deployment.imagePullPolicy }}
         args: ["proxy", "egress", "-v", "2"]
         env:

--- a/incubator/istio/templates/ingress-deployment.yaml
+++ b/incubator/istio/templates/ingress-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: {{ template "fullname" . }}-ingress-service-account
       containers:
       - name: istio-ingress
-        image: "{{ .Values.ingress.deployment.image }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.ingress.deployment.image }}:{{ .Values.istioRelease }}"
         args: ["proxy", "ingress", "-v", "2"]
         imagePullPolicy: {{ .Values.ingress.deployment.imagePullPolicy }}
         ports:

--- a/incubator/istio/templates/manager-deployment.yaml
+++ b/incubator/istio/templates/manager-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: {{ template "fullname" . }}-manager-service-account
       containers:
       - name: discovery
-        image: "{{ .Values.manager.deployment.discovery.image }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.manager.deployment.discovery.image }}:{{ .Values.istioRelease }}"
         imagePullPolicy: {{ .Values.manager.deployment.discovery.imagePullPolicy }}
         args: ["discovery", "-v", "2"]
         ports:
@@ -30,7 +30,7 @@ spec:
         resources:
 {{ toYaml .Values.manager.deployment.discovery.resources | indent 10 }}
       - name: apiserver
-        image: "{{ .Values.manager.deployment.apiserver.image }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.manager.deployment.apiserver.image }}:{{ .Values.istioRelease }}"
         imagePullPolicy: {{ .Values.manager.deployment.apiserver.imagePullPolicy }}
         args: ["apiserver", "-v", "2"]
         ports:

--- a/incubator/istio/templates/mixer-deployment.yaml
+++ b/incubator/istio/templates/mixer-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: {{ template "fullname" . }}-mixer
-        image: "{{ .Values.mixer.deployment.image }}:{{ .Chart.AppVersion }}"
+        image: "{{ .Values.mixer.deployment.image }}:{{ .Values.istioRelease }}"
         imagePullPolicy: {{ .Values.mixer.deployment.imagePullPolicy }}
         ports:
         - containerPort: {{ .Values.mixer.service.externalTcpPort }}

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -3,6 +3,8 @@ rbac:
   install: true
   apiVersion: v1beta1
 
+istioRelease: 0.1.5
+
 ## Enable Istio auth feature 
 ## This deploys a CA in the namespace and enables mTLS between the services
 auth:


### PR DESCRIPTION
Add istioRelease to values as {{ .Chart.AppVersion }} not be expanded when installing from remote helm repo.

https://github.com/kubernetes/helm/issues/2514