### PR TITLE
[stable/jenkins] - Workflow plugin pin

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.7.1
+version: 0.7.2
 appVersion: 2.46.3
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -38,6 +38,7 @@ Master:
   InstallPlugins:
       - kubernetes:0.11 
       - workflow-aggregator:2.5
+      - workflow-job:2.11
       - credentials-binding:1.11
       - git:3.2.0
 # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval


### PR DESCRIPTION
The latest release of https://plugins.jenkins.io/workflow-job, 2.12, requires an upgrade to the Jenkins 2.60.x line.  Instead of taking the chart off the LTS line of Jenkins, I opted for pinning the explicit version to enable easy installation and lower risk.