### PR TITLE
Support different service types for Postgresql

### DIFF
--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -43,29 +43,30 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the PostgresSQL chart and their default values.
 
-| Parameter                  | Description                                | Default                                                    |
-| -----------------------    | ----------------------------------         | ---------------------------------------------------------- |
-| `image`                    | `postgres` image repository                | `postgres`                                                 |
-| `imageTag`                 | `postgres` image tag                       | `9.6.2`                                                    |
-| `imagePullPolicy`          | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `postgresUser`             | Username of new user to create.            | `postgres`                                                 |
-| `postgresPassword`         | Password for the new user.                 | random 10 characters                                       |
-| `postgresDatabase`         | Name for new database to create.           | `postgres`                                                 |
-| `postgresInitdbArgs`       | Initdb Arguments                           | `nil`                                                      |
-| `persistence.enabled`      | Use a PVC to persist data                  | `true`                                                     |
-| `persistence.existingClaim`| Provide an existing PersistentVolumeClaim  | `nil`                                                      |
-| `persistence.storageClass` | Storage class of backing PVC               | `nil` (uses alpha storage class annotation)                |
-| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                            |
-| `persistence.size`         | Size of data volume                        | `8Gi`                                                      |
-| `persistence.subPath`      | Subdirectory of the volume to mount at     | `postgresql-db`                                            |
-| `resources`                | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `100m`                               |
-| `metrics.enabled`          | Start a side-car prometheus exporter       | `false`                                                    |
-| `metrics.image`            | Exporter image                             | `wrouesnel/postgres_exporter`                              |
-| `metrics.imageTag`         | Exporter image                             | `v0.1.1`                                                   |
-| `metrics.imagePullPolicy`  | Exporter image pull policy                 | `IfNotPresent`                                             |
-| `metrics.resources`        | Exporter resource requests/limit           | Memory: `256Mi`, CPU: `100m`                               |
-| `service.externalIPs`      | External IPs to listen on                  | `[]`                                                       |
-| `service.port`             | TCP port                                   | `5432`                                                     |
+| Parameter                  | Description                                     | Default                                                    |
+| -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
+| `image`                    | `postgres` image repository                     | `postgres`                                                 |
+| `imageTag`                 | `postgres` image tag                            | `9.6.2`                                                    |
+| `imagePullPolicy`          | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `postgresUser`             | Username of new user to create.                 | `postgres`                                                 |
+| `postgresPassword`         | Password for the new user.                      | random 10 characters                                       |
+| `postgresDatabase`         | Name for new database to create.                | `postgres`                                                 |
+| `postgresInitdbArgs`       | Initdb Arguments                                | `nil`                                                      |
+| `persistence.enabled`      | Use a PVC to persist data                       | `true`                                                     |
+| `persistence.existingClaim`| Provide an existing PersistentVolumeClaim       | `nil`                                                      |
+| `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
+| `persistence.size`         | Size of data volume                             | `8Gi`                                                      |
+| `persistence.subPath`      | Subdirectory of the volume to mount at          | `postgresql-db`                                            |
+| `resources`                | CPU/Memory resource requests/limits             | Memory: `256Mi`, CPU: `100m`                               |
+| `metrics.enabled`          | Start a side-car prometheus exporter            | `false`                                                    |
+| `metrics.image`            | Exporter image                                  | `wrouesnel/postgres_exporter`                              |
+| `metrics.imageTag`         | Exporter image                                  | `v0.1.1`                                                   |
+| `metrics.imagePullPolicy`  | Exporter image pull policy                      | `IfNotPresent`                                             |
+| `metrics.resources`        | Exporter resource requests/limit                | Memory: `256Mi`, CPU: `100m`                               |
+| `service.externalIPs`      | External IPs to listen on                       | `[]`                                                       |
+| `service.port`             | TCP port                                        | `5432`                                                     |
+| `service.type`             | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                          |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -11,3 +11,18 @@ To connect to your database run the following command (using the env variable fr
    --env "PGPASSWORD=$PGPASSWORD" \
    --command -- psql -U {{ default "postgres" .Values.postgresUser }} \
    -h {{ template "fullname" . }} {{ default "postgres" .Values.postgresDatabase }}
+
+To connect to your database directly from outside the K8s cluster:
+   {{- if contains "NodePort" .Values.service.type }}
+     PGHOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+     PGPORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "ClusterIP" .Values.service.type }}
+     PGHOST=127.0.0.1
+     PGPORT={{ default "5432" .Values.service.port }}
+
+     # Execute the following commands to route the connection:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ default "5432" .Values.service.port }}:{{ default "5432" .Values.service.port }}
+
+   {{- end }}

--- a/stable/postgresql/templates/svc.yaml
+++ b/stable/postgresql/templates/svc.yaml
@@ -13,6 +13,7 @@ metadata:
     prometheus.io/port: "9187"
 {{- end }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
   - name: postgresql
     port: {{ .Values.service.port }}

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -62,5 +62,6 @@ resources:
     cpu: 100m
 
 service:
+  type: ClusterIP
   port: 5432
   externalIPs: []


### PR DESCRIPTION
Want to be able to specify the service type (e.g. `NodePort` for use with Minikube) for different setups.

Output of startup for `service.type=ClusterIP` (default is now:
```bash
NOTES:
PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
calico-lion-postgresql.default.svc.cluster.local

To get your user password run:

    PGPASSWORD=$(kubectl get secret --namespace default calico-lion-postgresql -o jsonpath="{.data.postgres-password}" | base64 --decode; echo)

To connect to your database run the following command (using the env variable from above):

   kubectl run calico-lion-postgresql-client --rm --tty -i --image postgres \
   --env "PGPASSWORD=$PGPASSWORD" \
   --command -- psql -U postgres \
   -h calico-lion-postgresql postgres

To connect to your database directly from outside the K8s cluster:
     PGHOST=127.0.0.1
     PGPORT=5432

     # Execute the following commands to route the connection:
     export POD_NAME=$(kubectl get pods --namespace default -l "app=calico-lion-postgresql" -o jsonpath="{.items[0].metadata.name}")
     kubectl port-forward $POD_NAME 5432:5432
```

And for `service.type=NodePort`:
```bash
NOTES:
PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
plinking-dachshund-postgresql.default.svc.cluster.local

To get your user password run:

    PGPASSWORD=$(kubectl get secret --namespace default plinking-dachshund-postgresql -o jsonpath="{.data.postgres-password}" | base64 --decode; echo)

To connect to your database run the following command (using the env variable from above):

   kubectl run plinking-dachshund-postgresql-client --rm --tty -i --image postgres \
   --env "PGPASSWORD=$PGPASSWORD" \
   --command -- psql -U postgres \
   -h plinking-dachshund-postgresql postgres

To connect to your database directly from outside the K8s cluster:
     PGHOST=$(kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}')
     PGPORT=$(kubectl get svc --namespace default plinking-dachshund-postgresql -o jsonpath='{.spec.ports[0].nodePort}')
```