### PR TITLE
Update the char limit of fullname to 63 for memcached chart

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 1.0.0
+version: 1.0.1
 description: Free & open source, high-performance, distributed memory object caching system.
 keywords:
 - memcached

--- a/stable/memcached/templates/_helpers.tpl
+++ b/stable/memcached/templates/_helpers.tpl
@@ -3,14 +3,14 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
Memcached was still using the old limit of 24 chars, updated that to 63 and added trimming of dash.