### PR TITLE
Add prometheus support to gitlab-ce

### DIFF
--- a/stable/gitlab-ce/templates/clusterrole.yaml
+++ b/stable/gitlab-ce/templates/clusterrole.yaml
@@ -1,0 +1,18 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "nodes"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"

--- a/stable/gitlab-ce/templates/clusterrolebinding.yaml
+++ b/stable/gitlab-ce/templates/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+  apiGroup: ""

--- a/stable/gitlab-ce/templates/deployment.yaml
+++ b/stable/gitlab-ce/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+      serviceAccountName: {{ template "fullname" . }}
       containers:
       - name: {{ template "fullname" . }}
         image: {{ .Values.image }}
@@ -72,6 +73,8 @@ spec:
           containerPort: 80
         - name: https
           containerPort: 443
+        - name: prometheus
+          containerPort: 9090
         livenessProbe:
           httpGet:
             path: /help

--- a/stable/gitlab-ce/templates/serviceaccount.yaml
+++ b/stable/gitlab-ce/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"

--- a/stable/gitlab-ce/templates/svc.yaml
+++ b/stable/gitlab-ce/templates/svc.yaml
@@ -19,5 +19,8 @@ spec:
   - name: https
     port: {{ .Values.httpsPort | int }}
     targetPort: https
+  - name: prometheus
+    port: {{ .Values.prometheusPort | int }}
+    targetPort: prometheus
   selector:
     app: {{ template "fullname" . }}

--- a/stable/gitlab-ce/values.yaml
+++ b/stable/gitlab-ce/values.yaml
@@ -29,6 +29,7 @@ serviceType: LoadBalancer
 sshPort: 22
 httpPort: 80
 httpsPort: 443
+prometheusPort: 9090
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
The integrated prometheus in Gitlab does currently not work with an RBAC enabled cluster and is also not considered in the charts service template. 

This fixes #1191 