### PR TITLE
[stable/odoo] Rename POSTGRESQL_PORT env var to POSTGRESQL_PORT_NUMBER

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,5 +1,5 @@
 name: odoo
-version: 0.5.1
+version: 0.5.2
 description: A suite of web based open source business apps.
 keywords:
 - odoo

--- a/stable/odoo/templates/deployment.yaml
+++ b/stable/odoo/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         env:
         - name: POSTGRESQL_HOST
           value: {{ template "postgresql.fullname" . }}
-        - name: POSTGRESQL_PORT
+        - name: POSTGRESQL_PORT_NUMBER
           value: "5432"
         - name: POSTGRESQL_PASSWORD
           valueFrom:

--- a/stable/odoo/values.yaml
+++ b/stable/odoo/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Odoo image version
 ## ref: https://hub.docker.com/r/bitnami/odoo/tags/
 ##
-image: bitnami/odoo:10.0.20170515-r1
+image: bitnami/odoo:10.0.20170515-r2
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
In order to avoid environment variable collision with postgresql k8s service, we can rename POSTGRESQL_PORT environment variable by POSTGRESQl_PORT_NUMBER