### PR TITLE
adding serviceAccount to controller for better rbac support

### DIFF
--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -53,6 +53,7 @@ Parameter | Description | Default
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
 `controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)
 `controller.scope.namespace` | namespace to watch for ingress | `""` (use the release namespace)
+`controller.serviceAccount` | Service account to run under | `default`
 `controller.extraArgs` | Additional controller container arguments | `{}`
 `controller.kind` | install as Deployment or DaemonSet | `Deployment`
 `controller.nodeSelector` | node labels for pod assignment | `{}`

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
     spec:
+      serviceAccount: {{- if .Values.controller.serviceAccount }} {{ .Values.controller.serviceAccount }}{{- else }} default{{- end }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
     spec:
+      serviceAccount: {{- if .Values.controller.serviceAccount }} {{ .Values.controller.serviceAccount }}{{- else }} default{{- end }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -32,6 +32,11 @@ controller:
   ##
   nodeSelector: {}
 
+  ## Run the controller under a specified service account
+  ## Ref: https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx
+  ## 
+  serviceAccount: ""  
+
   ## Annotations to be added to controller pods
   ##
   podAnnotations: {}


### PR DESCRIPTION
We would like to start using this chart with the 0.9 version of the nginx-ingress which allows namespace-specific controllers. In order for that to be useful, we need to run the nginx deployment under a namespace-specific serviceaccount that cluster administrators have bound to a "least privileges" cluster role, as defined [here](https://github.com/kubernetes/ingress/blob/master/examples/rbac/nginx/nginx-ingress-controller-rbac.yml#L12).