### PR TITLE
[stable/nginx] adding serviceAccount to controller for better rbac support

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.9.0-beta.7
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -54,7 +54,7 @@ Parameter | Description | Default
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
 `controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)
 `controller.scope.namespace` | namespace to watch for ingress | `""` (use the release namespace)
-`controller.serviceAccount` | Service account to run under | `default`
+`controller.serviceAccountName` | Service account to run under | `default`
 `controller.extraArgs` | Additional controller container arguments | `{}`
 `controller.kind` | install as Deployment or DaemonSet | `Deployment`
 `controller.nodeSelector` | node labels for pod assignment | `{}`

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -54,6 +54,7 @@ Parameter | Description | Default
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
 `controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)
 `controller.scope.namespace` | namespace to watch for ingress | `""` (use the release namespace)
+`controller.serviceAccount` | Service account to run under | `default`
 `controller.extraArgs` | Additional controller container arguments | `{}`
 `controller.kind` | install as Deployment or DaemonSet | `Deployment`
 `controller.nodeSelector` | node labels for pod assignment | `{}`

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -22,7 +22,9 @@ spec:
         release: {{ .Release.Name }}
     spec:
       hostNetwork: {{ .Values.controller.hostNetwork }}
-      serviceAccount: {{- if .Values.controller.serviceAccount }} {{ .Values.controller.serviceAccount }}{{- else }} default{{- end }}
+    {{- if .Values.controller.serviceAccountName }}
+      serviceAccountName: {{ .Values.controller.serviceAccountName }}
+    {{- end }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -22,6 +22,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       hostNetwork: {{ .Values.controller.hostNetwork }}
+      serviceAccount: {{- if .Values.controller.serviceAccount }} {{ .Values.controller.serviceAccount }}{{- else }} default{{- end }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       hostNetwork: {{ .Values.controller.hostNetwork }}
+      serviceAccount: {{- if .Values.controller.serviceAccount }} {{ .Values.controller.serviceAccount }}{{- else }} default{{- end }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -23,7 +23,9 @@ spec:
         release: {{ .Release.Name }}
     spec:
       hostNetwork: {{ .Values.controller.hostNetwork }}
-      serviceAccount: {{- if .Values.controller.serviceAccount }} {{ .Values.controller.serviceAccount }}{{- else }} default{{- end }}
+    {{- if .Values.controller.serviceAccountName }}
+      serviceAccountName: {{ .Values.controller.serviceAccountName }}
+    {{- end }}
       containers:
         - name: {{ template "name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -46,10 +46,10 @@ controller:
   ##
   nodeSelector: {}
 
-  ## Run the controller under a specified service account
+  ## Run the controller via this service account
   ## Ref: https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx
   ## 
-  serviceAccount: ""  
+  serviceAccountName: ""  
 
   ## Annotations to be added to controller pods
   ##

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -46,6 +46,11 @@ controller:
   ##
   nodeSelector: {}
 
+  ## Run the controller under a specified service account
+  ## Ref: https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx
+  ## 
+  serviceAccount: ""  
+
   ## Annotations to be added to controller pods
   ##
   podAnnotations: {}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -48,8 +48,8 @@ controller:
 
   ## Run the controller via this service account
   ## Ref: https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx
-  ## 
-  serviceAccountName: ""  
+  ##
+  serviceAccountName: ""
 
   ## Annotations to be added to controller pods
   ##


### PR DESCRIPTION
We would like to start using this chart with the 0.9 version of the nginx-ingress which allows namespace-specific controllers. In order for that to be useful, we need to run the nginx deployment under a namespace-specific serviceaccount that cluster administrators have bound to a "least privileges" cluster role, as defined [here](https://github.com/kubernetes/ingress/blob/master/examples/rbac/nginx/nginx-ingress-controller-rbac.yml#L12).