### PR TITLE
Support custom domains in the cockroachdb chart's init container

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.2.3
+version: 0.2.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -46,6 +46,7 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | `Memory`                | Container requested memory         | `512Mi`                                                    |
 | `Storage`               | Persistent volume size             | `1Gi`                                                      |
 | `StorageClass`          | Persistent volume class            | `anything`                                                 |
+| `ClusterDomain`         | Cluster's default DNS domain       | `cluster.local`                                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/templates/cockroachdb-petset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-petset.yaml
@@ -125,7 +125,8 @@ spec:
                 "imagePullPolicy": "{{.Values.ImagePullPolicy}}",
                 "args": [
                   "-on-start=/on-start.sh",
-                  "-service={{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
+                  "-service={{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}",
+                  "-domain={{.Values.ClusterDomain}}"
                 ],
                 "env": [
                   {

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -5,10 +5,10 @@
 
 Name: "cockroachdb"
 Image: "cockroachdb/cockroach"
-ImageTag: "v1.0"
+ImageTag: "v1.0.1"
 ImagePullPolicy: "Always"
 BootstrapImage: "cockroachdb/cockroach-k8s-init"
-BootstrapImageTag: "0.1"
+BootstrapImageTag: "0.2"
 Replicas: 3
 MinAvailable: "67%"
 Component: "cockroachdb"
@@ -20,3 +20,4 @@ Resources:
     memory: "512Mi"
 Storage: "1Gi"
 StorageClass: "anything"
+ClusterDomain: "cluster.local"


### PR DESCRIPTION
This switches from using v0.1 of the peer-finder image to a version that
includes https://github.com/kubernetes/contrib/pull/2013

While I'm here, switch the version of cockroachdb from 1.0 to 1.0.1