### PR TITLE
[stable/traefik] RBAC support for Traefik

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.3.0
+version: 1.4.0
 appVersion: 1.2.1
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -18,6 +18,7 @@ resources _cluster-wide_.
 ## Prerequisites
 
 - Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.6+ if you want to enable RBAC
 - You are deploying the chart to a cluster with a cloud provider capable of provisioning an
 external load balancer (e.g. AWS or GKE)
 - You control DNS for the domain(s) you intend to route through Traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -95,6 +95,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |
 | `cpuLimit`                      | CPU limit per Traefik pod                                            | `200m`                                    |
 | `memoryLimit`                   | Memory limit per Traefik pod                                         | `30Mi`                                    |
+| `rbac.enabled`                  | Whether to enable RBAC with a specific cluster role and binding for Traefik | `false`                            |
 | `ssl.enabled`                   | Whether to enable HTTPS                                              | `false`                                   |
 | `ssl.enforced`                  | Whether to redirect HTTP requests to HTTPS                           | `false`                                   |
 | `ssl.defaultCert`               | Base64 encoded default certficate                                    | A self-signed certificate                 |

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -20,6 +20,11 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ template "fullname" . }}
+      {{- else }}
+      serviceAccountName: default
+      {{- end }}
       terminationGracePeriodSeconds: 60
       containers:
       - image: {{ .Values.image }}:{{ .Values.imageTag }}

--- a/stable/traefik/templates/rbac.yaml
+++ b/stable/traefik/templates/rbac.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.rbac.enabled }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -47,3 +47,5 @@ gzip:
 #  namespaces:
 #  - default
 #  labelSelector:
+rbac:
+  enabled: false


### PR DESCRIPTION
For https://github.com/kubernetes/charts/issues/948.

When switching RBAC from true to false, the `serviceAccountName` stays
as the Traefik specific one so set it to `default`. Not sure if this is
a Helm issue or further upstream.