### PR TITLE
Fix Cassandra chart for time consuming bootstraps

### DIFF
--- a/incubator/cassandra/templates/cassandra-statefulset.yaml
+++ b/incubator/cassandra/templates/cassandra-statefulset.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: status.podIP
         livenessProbe:
           exec:
-            command: [ "/bin/sh", "-c", "nodetool status | grep -E \"^UN\\s+${POD_IP}\"" ]
+            command: [ "/bin/sh", "-c", "nodetool status" ]
           initialDelaySeconds: 90
           periodSeconds: 30
         readinessProbe:


### PR DESCRIPTION
When adding new nodes that require a longer bootstrap process due to having to stream data kubernetes will kill the pod because the livenessProbe from nodetool status will be UJ for a while so to mitigate that we can just run nodetool status to see if we get a response from cassandra for livenessProbe so kubernetes wont kill the pod and let the bootstrap continue but wont add the next statefulset until readinessProbe is successful where we check for UN.