### PR TITLE
[stable/consul] Allow configuration of consul datacenter name

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.7.5
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 icon: https://raw.githubusercontent.com/hashicorp/consul/bce3809dfca37b883828c3715b84143dd71c0f85/website/source/assets/images/favicons/android-chrome-512x512.png

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -33,10 +33,11 @@ The following tables lists the configurable parameters of the consul chart and t
 | `Replicas`              | k8s statefulset replicas              | `3`                                                        |
 | `Component`             | k8s selector key                      | `consul`                                                   |
 | `Cpu`                   | container requested cpu               | `100m`                                                     |
-| `DisableHostNodeId`     | Disable Node Id creation (uses random)| `false`                                                   |
+| `DatacenterName`        | Consul Datacenter Name                | `dc1` (The consul default)                                 |
+| `DisableHostNodeId`     | Disable Node Id creation (uses random)| `false`                                                    |
 | `Memory`                | container requested memory            | `512Mi`                                                    |
 | `Storage`               | Persistent volume size                | `1Gi`                                                      |
-| `StorageClass`          | Persistent volume storage class       | `nil`                                                  |
+| `StorageClass`          | Persistent volume storage class       | `nil`                                                      |
 | `HttpPort`              | Consul http listening port            | `8500`                                                     |
 | `RpcPort`               | Consul rpc listening port             | `8400`                                                     |
 | `SerflanPort`           | Container serf lan listening port     | `8301`                                                     |
@@ -46,7 +47,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | `ServerPort`            | Container server listening port       | `8300`                                                     |
 | `ConsulDnsPort`         | Container dns listening port          | `8600`                                                     |
 | `ui.enabled`            | Enable Consul Web UI                  | `false`                                                    |
-| `uiService.enabled`      | Create dedicated Consul Web UI svc    | `false`                                                    |
+| `uiService.enabled`     | Create dedicated Consul Web UI svc    | `false`                                                    |
 | `uiService.type`        | Dedicate Consul Web UI svc type       | `NodePort`                                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -173,6 +173,9 @@ spec:
             {{- if .Values.DisableHostNodeId }}
               -disable-host-node-id \
             {{- end }}
+            {{- if .Values.DatacenterName }}
+              -datacenter {{ .Values.DatacenterName }} \
+            {{- end }}
               -data-dir=/var/lib/consul \
               -server \
               -bootstrap-expect=${INITIAL_CLUSTER_SIZE} \

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -28,6 +28,10 @@ Storage: "1Gi"
 ## host id.
 DisableHostNodeId: false
 
+## Datacenter name for consul. If not supplied, will use the consul
+## default 'dc1'
+# DatacenterName: dc1
+
 ## StorageClass name for use with Persistent Volume Claim (PVC) using beta notations
 # StorageClass:
 


### PR DESCRIPTION
Hi,

Simple PR here. Updating consul chart to allow for setting the consul datacenter name. This is useful when [running consul across Multiple Datacenters](https://www.consul.io/docs/guides/datacenters.html).

If no parameter is supplied for `DatacenterName`, it simply does not pass a parameter to consul and you get the standard "dc1" name.

Testing:

![unnamed-2](https://cloud.githubusercontent.com/assets/6900888/26749540/f1bd6dbc-47d2-11e7-8815-69f9f5e06ff2.png)
![unnamed](https://cloud.githubusercontent.com/assets/6900888/26749541/f1cbec8e-47d2-11e7-844e-ff6e2d7d51f4.png)
