### PR TITLE
[stable/drupal] Private image registry support with imagePullSecrets

### DIFF
--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -89,7 +89,11 @@ $ helm install --name my-release -f values.yaml stable/drupal
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-## Private image registry
+## Image
+
+The `image` parameter allows specifying which image will be pulled for the chart.
+
+### Private registry
 
 If you configure the `image` value to one in a private registry, you will need to [specify an image pull secret](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
 

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -48,6 +48,7 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | Parameter                         | Description                           | Default                                                   |
 | --------------------------------- | ------------------------------------- | --------------------------------------------------------- |
 | `image`                           | Drupal image                          | `bitnami/drupal:{VERSION}`                                |
+| `imagePullSecrets`                | Specify image pull secrets            | `nil` (does not add image pull secrets to deployed pods)  |
 | `imagePullPolicy`                 | Image pull policy                     | `IfNotPresent`                                            |
 | `drupalUsername`                  | User of the application               | `user`                                                    |
 | `drupalPassword`                  | Application password                  | _random 10 character long alphanumeric string_            |
@@ -87,6 +88,21 @@ $ helm install --name my-release -f values.yaml stable/drupal
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Private image registry
+
+If you configure the `image` value to one in a private registry, you will need to [specify an image pull secret](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
+
+1. Manually create image pull secret(s) in the namespace. See [this YAML example reference](https://kubernetes.io/docs/concepts/containers/images/#creating-a-secret-with-a-docker-config). Consult your image registry's documentation about getting the appropriate secret.
+1. Note that the `imagePullSecrets` configuration value cannot currently be passed to helm using the `--set` parameter, so you must supply these using a `values.yaml` file, such as:
+```yaml
+imagePullSecrets:
+  - name: SECRET_NAME
+```
+1. Install the chart
+```console
+helm install --name my-release -f values.yaml stable/drupal
+```
 
 ## Persistence
 

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
           mountPath: /bitnami/drupal
         - name: apache-data
           mountPath: /bitnami/apache
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       volumes:
       - name: drupal-data
       {{- if .Values.persistence.enabled }}

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -3,6 +3,13 @@
 ##
 image: bitnami/drupal:8.3.2-r0
 
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+##
+# imagePullSecrets:
+#   - name: myRegistryKeySecretName
+
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##


### PR DESCRIPTION
- I hope the README explains the value of this PR (without it, you can specify the `image` config value, but only if it's in a public registry).
- If this is accepted, I'll make PRs with `imagePullPolicy` support in the other applicable stable charts.
- Note my README comment about needing to set `imagePullPolicy` in a `values.yaml` file is has the same root cause as the aws-cluster-autoscaler chart README `autoscalingGroups` value note (see these two issues: https://github.com/kubernetes/helm/issues/1987 and https://github.com/kubernetes/charts/issues/668).