### PR TITLE
[stable/drupal] Allow non-bitnami image Drupal data and Apache configuration volume paths

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.7.3
+version: 0.8.0
 appVersion: 8.3.3
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -69,6 +69,8 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | `persistence.drupal.hostPath`     | Host mount path for Drupal volume     | `nil` (will not mount to a host path)                     |
 | `persistence.drupal.size`         | PVC Storage Request for Drupal volume | `8Gi`                                                     |
 | `resources`                       | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                              |
+| `volumeMounts.drupal.mountPath`   | Drupal data volume mount path         | `/bitnami/drupal`                                         |
+| `volumeMounts.apache.mountPath`   | Apache data volume mount path         | `/bitnami/apache`                                         |
 
 The above parameters map to the env variables defined in [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal). For more information please refer to the [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal) image documentation.
 
@@ -110,8 +112,9 @@ helm install --name my-release -f values.yaml stable/drupal
 ```
 
 ## Persistence
+The configured image must store Drupal data and Apache configurations in separate paths of the container.
 
-The [Bitnami Drupal](https://github.com/bitnami/bitnami-docker-drupal) image stores the Drupal data and configurations at the `/bitnami/drupal` and `/bitnami/apache` paths of the container.
+The default [Bitnami Drupal](https://github.com/bitnami/bitnami-docker-drupal) image stores the Drupal data and Apache configurations at the `/bitnami/drupal` and `/bitnami/apache` paths of the container. If you wish to override the `image` value, and your image stores this data and configurations in different paths, you may specify these paths with `volumeMounts.drupal.mountPath` and `volumeMounts.apache.mountPath`.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -114,7 +114,7 @@ helm install --name my-release -f values.yaml stable/drupal
 ## Persistence
 The configured image must store Drupal data and Apache configurations in separate paths of the container.
 
-The default [Bitnami Drupal](https://github.com/bitnami/bitnami-docker-drupal) image stores the Drupal data and Apache configurations at the `/bitnami/drupal` and `/bitnami/apache` paths of the container. If you wish to override the `image` value, and your image stores this data and configurations in different paths, you may specify these paths with `volumeMounts.drupal.mountPath` and `volumeMounts.apache.mountPath`.
+The [Bitnami Drupal](https://github.com/bitnami/bitnami-docker-drupal) image stores the Drupal data and Apache configurations at the `/bitnami/drupal` and `/bitnami/apache` paths of the container. If you wish to override the `image` value, and your image stores this data and configurations in different paths, you may specify these paths with `volumeMounts.drupal.mountPath` and `volumeMounts.apache.mountPath`.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.

--- a/stable/drupal/templates/apache-pvc.yaml
+++ b/stable/drupal/templates/apache-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled -}}
+{{- if and .Values.persistence.enabled .Values.volumeMounts.apache.mountPath -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -57,8 +57,10 @@ spec:
         volumeMounts:
         - name: drupal-data
           mountPath: {{ .Values.volumeMounts.drupal.mountPath }}
+        {{- if .Values.volumeMounts.apache.mountPath }}
         - name: apache-data
           mountPath: {{ .Values.volumeMounts.apache.mountPath }}
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -71,10 +73,12 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+      {{- if .Values.volumeMounts.apache.mountPath }}
       - name: apache-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ template "fullname" . }}-apache
       {{- else }}
         emptyDir: {}
+      {{- end }}
       {{- end }}

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -56,9 +56,9 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: drupal-data
-          mountPath: /bitnami/drupal
+          mountPath: {{ .Values.volumeMounts.drupal.mountPath }}
         - name: apache-data
-          mountPath: /bitnami/apache
+          mountPath: {{ .Values.volumeMounts.apache.mountPath }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -120,3 +120,11 @@ resources:
   requests:
     memory: 512Mi
     cpu: 300m
+
+# Configure volume mounts. This is useful for images whose data mount paths are
+# different than the default.
+volumeMounts:
+  drupal:
+    mountPath: /bitnami/drupal
+  apache:
+    mountPath: /bitnami/apache

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -121,8 +121,10 @@ resources:
     memory: 512Mi
     cpu: 300m
 
-# Configure volume mounts. This is useful for images whose data mount paths are
-# different than the default.
+## Configure volume mounts. This is useful for images whose data mount paths are
+## different than the default.
+## Setting volumeMounts.apache.mountPath to "" prevents Apache config mount.
+##
 volumeMounts:
   drupal:
     mountPath: /bitnami/drupal


### PR DESCRIPTION
Follow up to #1231.

@prydonius As an aside, I'm unclear why we mount the Apache config directory? I'm sure I'm missing something obvious about this.