### PR TITLE
Pass the release name through to sysdig pods

### DIFF
--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       name: {{ template "fullname" . }}
       labels:
         app: {{ template "fullname" . }}
+        release: "{{ .Release.Name }}"
     spec:
       volumes:
       - name: docker-sock


### PR DESCRIPTION
Passes down the release name to the pods for logging purposes (via logspout).