### PR TITLE
[stable/selenium] Fix chromeDebug/firefoxDebug not to produce bad metadata.name

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.1.0
+version: 0.1.1
 description: Chart for selenium grid
 keywords:
   - qa

--- a/stable/selenium/templates/_helpers.tpl
+++ b/stable/selenium/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Create a default fully qualified app name, for chromeDebug.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "chromeDebug.fullname" -}}
-{{- printf "%s-selenium-chromeDebug" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-selenium-chrome-debug" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -52,6 +52,6 @@ Create a default fully qualified app name, for firefoxDebug.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "firefoxDebug.fullname" -}}
-{{- printf "%s-selenium-firefoxDebug" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-selenium-firefox-debug" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 


### PR DESCRIPTION
I've tested this by running `helm package . && helm install selenium-0.1.1.tgz --set chromeDebug.enabled=true --set firefoxDebug.enabled=true --name selenium-grid` and verifying all the pods to be running.

Fix #1238