### PR TITLE
Add ALLOW_EMPTY_PASSWORD env var support to Redis image

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.6.0
+version: 0.6.1
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:
 - redis

--- a/stable/redis/templates/NOTES.txt
+++ b/stable/redis/templates/NOTES.txt
@@ -3,14 +3,14 @@ Redis can be accessed via port 6379 on the following DNS name from within your c
 
 To get your password run:
 
-    REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.redis-password}" | base64 --decode)
+    $ echo REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run {{ template "fullname" . }}-client --rm --tty -i --env REDIS_PASSWORD=$REDIS_PASSWORD --image {{ .Values.image }} -- bash
+    $ kubectl run {{ template "fullname" . }}-client --rm --tty -i --env REDIS_PASSWORD=$REDIS_PASSWORD --image {{ .Values.image }} -- bash
 
 2. Connect using the Redis CLI:
 
-  redis-cli -h {{ template "fullname" . }} -a $REDIS_PASSWORD
+    $ redis-cli -h {{ template "fullname" . }} -a $REDIS_PASSWORD

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: redis-password
+        - name: ALLOW_EMPTY_PASSWORD
+          value: "yes"
         ports:
         - name: redis
           containerPort: 6379

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Redis image version
 ## ref: https://hub.docker.com/r/bitnami/redis/tags/
 ##
-image: bitnami/redis:3.2.9-r0
+image: bitnami/redis:3.2.9-r2
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Since bitnami/redis:3.2.9-r2 image, Redis image accepts the ALLOW_EMPTY_PASSWORD environment variable. 
If this env var is set to "yes", Redis could be configured without a password, otherwise, a password must be specified.