### PR TITLE
[stable/datadog] Support 1.6 tolerations

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.5.0
+version: 0.6.0
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -54,7 +54,7 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `resources.requests.memory` | Memory resource requests           | 100m                                      |
 | `resources.limits.memory`   | Memory resource limits             | 256m                                      |
 | `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
-| `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes 1.6) | `nil`              |
+| `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >1.6) | `nil`             |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -53,6 +53,7 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `resources.limits.cpu`      | CPU resource limits                | 512Mi                                     |
 | `resources.requests.memory` | Memory resource requests           | 100m                                      |
 | `resources.limits.memory`   | Memory resource limits             | 256m                                      |
+| `daemonset.tolerations`     | List of node taints to tolerate    | `nil`                                     |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -53,6 +53,7 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `resources.limits.cpu`      | CPU resource limits                | 512Mi                                     |
 | `resources.requests.memory` | Memory resource requests           | 100m                                      |
 | `resources.limits.memory`   | Memory resource limits             | 256m                                      |
+| `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
 | `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes 1.6) | `nil`              |
 
 

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -53,7 +53,7 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `resources.limits.cpu`      | CPU resource limits                | 512Mi                                     |
 | `resources.requests.memory` | Memory resource requests           | 100m                                      |
 | `resources.limits.memory`   | Memory resource limits             | 256m                                      |
-| `daemonset.tolerations`     | List of node taints to tolerate    | `nil`                                     |
+| `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes 1.6) | `nil`              |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -54,7 +54,7 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `resources.requests.memory` | Memory resource requests           | 100m                                      |
 | `resources.limits.memory`   | Memory resource limits             | 256m                                      |
 | `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
-| `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >1.6) | `nil`             |
+| `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -89,5 +89,9 @@ spec:
         - name: autoconf
           configMap:
             name: {{ template "autoconf.fullname" . }}
+      {{- if .Values.daemonset.tolerations }}
+      tolerations:
+{{ toYaml .Values.daemonset.tolerations | indent 8 }}
+      {{- end }}
 {{ end }}
 {{ end }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -12,6 +12,10 @@ spec:
       labels:
         app: {{ template "fullname" . }}
       name: {{ template "fullname" . }}
+      {{- if .Values.daemonset.podAnnotations }}
+      annotations:
+{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -17,7 +17,7 @@ daemonset:
   # podAnnotations:
   #   scheduler.alpha.kubernetes.io/tolerations: '[{"key": "example", "value": "foo"}]'
 
-  ## Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes 1.6)
+  ## Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >1.6)
   # tolerations: []
 
 # Apart from DaemonSet, deploy Datadog agent pods and related service for

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -13,6 +13,10 @@ image:
 daemonset:
   enabled: true
 
+  ## Annotations to add to the DaemonSet's Pods
+  # podAnnotations:
+  #   scheduler.alpha.kubernetes.io/tolerations: '[{"key": "example", "value": "foo"}]'
+
   ## Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes 1.6)
   # tolerations: []
 

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -13,6 +13,9 @@ image:
 daemonset:
   enabled: true
 
+  # Allow the DaemonSet to schedule on tainted nodes
+  # tolerations: []
+
 # Apart from DaemonSet, deploy Datadog agent pods and related service for
 # applications that want to send custom metrics. Provides DogStasD service.
 #

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -17,7 +17,7 @@ daemonset:
   # podAnnotations:
   #   scheduler.alpha.kubernetes.io/tolerations: '[{"key": "example", "value": "foo"}]'
 
-  ## Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >1.6)
+  ## Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >= 1.6)
   # tolerations: []
 
 # Apart from DaemonSet, deploy Datadog agent pods and related service for

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -13,7 +13,7 @@ image:
 daemonset:
   enabled: true
 
-  # Allow the DaemonSet to schedule on tainted nodes
+  ## Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes 1.6)
   # tolerations: []
 
 # Apart from DaemonSet, deploy Datadog agent pods and related service for


### PR DESCRIPTION
This allows the Datadog DaemonSet to run on tainted nodes, whether
that's a master provisioned by kubeadm (see #1100):

```yaml
tolerations:
  - effect: NoSchedule
    key: node-role.kubernetes.io/master
```

or any "dedicated" node:

```yaml
tolerations:
  - effect: NoSchedule
    operator: Exists
```