### PR TITLE
Fix istio pilot service type to use correct value

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Istio Helm chart for Kubernetes
 name: istio
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.1.6
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png

--- a/incubator/istio/templates/pilot-svc.yaml
+++ b/incubator/istio/templates/pilot-svc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "labels.standard" . | indent 4 }}
     istio: {{ $serviceName }}-{{ .Values.pilot.name }}
 spec:
-  type: {{ .Values.mixer.service.type }}
+  type: {{ .Values.pilot.service.type }}
   ports:
   - port: {{ .Values.pilot.service.externalHttpDiscovery }}
     name: http-discovery


### PR DESCRIPTION
Currently Pilot service in Istio chart uses mixed service type and it seems incorrect, because in values.yaml there is pilot service type defined as well.