### PR TITLE
[stable/kube-lego]: add RBAC support

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.10
+version: 0.1.11
 keywords:
   - kube-lego
   - letsencrypt

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -53,7 +53,8 @@ Parameter | Description | Default
 `podAnnotations` | annotations to be added to pods | `{}`
 `replicaCount` | desired number of pods | `1`
 `resources` | kube-lego resource requests and limits (YAML) |`{}`
-`rbac.enabled` | Enable role and serviceaccount creation | `false`
+`rbac.create` | Create a role and serviceaccount | `false`
+`rbac.serviceAccountName` | serviceaccount name to use if `rbac.create` is false | `default`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -53,6 +53,7 @@ Parameter | Description | Default
 `podAnnotations` | annotations to be added to pods | `{}`
 `replicaCount` | desired number of pods | `1`
 `resources` | kube-lego resource requests and limits (YAML) |`{}`
+`rbac.enabled` | Enable role and serviceaccount creation | `false`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube-lego/templates/deployment.yaml
+++ b/stable/kube-lego/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
+{{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ template "fullname" . }}
+{{- end }}
       containers:
         - name: {{ template "name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kube-lego/templates/deployment.yaml
+++ b/stable/kube-lego/templates/deployment.yaml
@@ -19,9 +19,7 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
-{{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ template "fullname" . }}
-{{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ template "name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kube-lego/templates/role.yaml
+++ b/stable/kube-lego/templates/role.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  - "extensions"
+  resources:
+  - configmaps
+  - secrets
+  - services
+  - endpoints
+  - ingresses
+  - nodes
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - update
+  - delete
+- apiGroups:
+  - "extensions"
+  - ""
+  resources:
+  - ingresses
+  - ingresses/status
+  verbs:
+  - get
+  - update
+  - create
+  - list
+  - patch
+  - delete
+  - watch
+- apiGroups:
+  - "*"
+  - ""
+  resources:
+  - events
+  - certificates
+  - secrets
+  verbs:
+  - create
+  - list
+  - update
+  - get
+  - patch
+  - watch
+{{- end -}}

--- a/stable/kube-lego/templates/role.yaml
+++ b/stable/kube-lego/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/stable/kube-lego/templates/role.yaml
+++ b/stable/kube-lego/templates/role.yaml
@@ -11,33 +11,16 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - "extensions"
-  resources:
-  - configmaps
-  - secrets
-  - services
-  - endpoints
-  - ingresses
-  - nodes
-  - pods
-  verbs:
-  - list
-  - get
-  - watch
-- apiGroups:
-  - ""
   resources:
   - services
   verbs:
   - create
-  - update
+  - get
   - delete
 - apiGroups:
-  - "extensions"
-  - ""
+  - extensions
   resources:
   - ingresses
-  - ingresses/status
   verbs:
   - get
   - update
@@ -47,17 +30,11 @@ rules:
   - delete
   - watch
 - apiGroups:
-  - "*"
   - ""
   resources:
-  - events
-  - certificates
   - secrets
   verbs:
-  - create
-  - list
-  - update
   - get
-  - patch
-  - watch
+  - create
+  - update
 {{- end -}}

--- a/stable/kube-lego/templates/rolebinding.yaml
+++ b/stable/kube-lego/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/kube-lego/templates/rolebinding.yaml
+++ b/stable/kube-lego/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/kube-lego/templates/serviceaccount.yaml
+++ b/stable/kube-lego/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end -}}

--- a/stable/kube-lego/templates/serviceaccount.yaml
+++ b/stable/kube-lego/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -46,4 +46,5 @@ resources: {}
   #   memory: 8Mi
 
 rbac:
-  enabled: false
+  create: false
+  serviceAccountName: default

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -44,3 +44,6 @@ resources: {}
   # requests:
   #   cpu: 20m
   #   memory: 8Mi
+
+rbac:
+  enabled: false


### PR DESCRIPTION
Adds support in kube-lego for RBAC.
Permissions sourced from https://github.com/jetstack/kube-lego/issues/99 and adjusted slightly.

setting `rbac.enabled` to true will create a role, rolebinding and service account.