### PR TITLE
[stable/prometheus] Fix RBAC permissions (required by kubeadm 1.6)

### DIFF
--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         component: "{{ .Values.alertmanager.name }}"
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.kubeStateMetrics.serviceAccountName }}
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         component: "{{ .Values.kubeStateMetrics.name }}"
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.kubeStateMetrics.serviceAccountName }}
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.kubeStateMetrics.name }}
           image: "{{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}"

--- a/stable/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/prometheus/templates/node-exporter-daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         component: "{{ .Values.nodeExporter.name }}"
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.kubeStateMetrics.serviceAccountName }}
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.nodeExporter.name }}
           image: "{{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag }}"

--- a/stable/prometheus/templates/rbac-setup.yml
+++ b/stable/prometheus/templates/rbac-setup.yml
@@ -1,0 +1,35 @@
+# https://github.com/prometheus/prometheus/pull/2641/files
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: default

--- a/stable/prometheus/templates/rbac-setup.yml
+++ b/stable/prometheus/templates/rbac-setup.yml
@@ -18,7 +18,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: prometheus
+  name: {{ .Values.kubeStateMetrics.serviceAccountName }}
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         component: "{{ .Values.server.name }}"
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ .Values.kubeStateMetrics.serviceAccountName }}
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.name }}
           image: "{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -179,6 +179,8 @@ kubeStateMetrics:
     #   cpu: 10m
     #   memory: 16Mi
 
+  serviceAccountName: prometheus
+
   service:
     annotations:
       prometheus.io/scrape: "true"
@@ -510,6 +512,14 @@ serverFiles:
         relabel_configs:
           - action: labelmap
             regex: __meta_kubernetes_node_label_(.+)
+          - target_label: __address__
+            replacement: kubernetes.default.svc:443
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/${1}/proxy/metrics
+
+      # https://github.com/prometheus/prometheus/pull/2641/files
 
       # Scrape config for service endpoints.
       #

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -179,7 +179,7 @@ kubeStateMetrics:
     #   cpu: 10m
     #   memory: 16Mi
 
-  serviceAccountName: prometheus
+  serviceAccountName: {{ .Values.kubeStateMetrics.serviceAccountName }}
 
   service:
     annotations:


### PR DESCRIPTION
I believe this fixes https://github.com/kubernetes/charts/issues/1075.

I might be over eager here, not sure if alertmanager and node exporter need the service account but Prometheus definitely does.

Tested on a pristine Kubeadm v1.6.4.