### PR TITLE
Upgrade Fluent bit 0.11.9

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,16 +1,20 @@
 name: fluent-bit
-version: 0.1.0
-appVersion: 0.11.8
+version: 0.1.1
+appVersion: 0.11.9
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
-- fluent
-- bit
+  - logging
+  - monitoring
+  - fluent
+  - fluentd
 sources:
-- http://fluentbit.io
+  - http://fluentbit.io
 icon: http://fluentbit.io/assets/img/logo1-default.png
 home: http://fluentbit.io
 maintainers:
-- name: edsiper
-  email: eduardo@treasure-data.com
-- name: kfox1111
-  email: Kevin.Fox@pnnl.gov
+  - name: kfox1111
+    email: Kevin.Fox@pnnl.gov
+  - name: Eduardo Silva
+    email: eduardo@treasure-data.com
+  - name: Eduardo Silva
+    email: edsiper@gmail.com

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluent-bit
 version: 0.1.1
-appVersion: 0.11.9
+appVersion: 0.11.10
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
   - logging
@@ -14,7 +14,5 @@ home: http://fluentbit.io
 maintainers:
   - name: kfox1111
     email: Kevin.Fox@pnnl.gov
-  - name: Eduardo Silva
+  - name: edsiper
     email: eduardo@treasure-data.com
-  - name: Eduardo Silva
-    email: edsiper@gmail.com

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -1,12 +1,13 @@
-# fluent-bit Chart
+# Fluent-Bit Chart
 
 [Fluent Bit](http://fluentbit.io/) is an open source and multi-platform Log Forwarder.
 
 ## Chart Details
+
 This chart will do the following:
 
-* Install a configmap for fluent bit
-* Install a daemonset that provisions the fluent bit [per-host architecture]
+* Install a configmap for Fluent Bit
+* Install a daemonset that provisions Fluent Bit [per-host architecture]
 
 ## Installing the Chart
 
@@ -14,6 +15,12 @@ To install the chart with the release name `my-release`:
 
 ```bash
 $ helm install --name my-release stable/fluent-bit
+```
+
+When installing this chart on [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/), it's required to specify that so the DaemonSet will be able to mount the log files properly, make sure to append the _--set on\_minikube=true_ option at the end of the _helm_ command, e.g:
+
+```bash
+$ helm install --name my-release stable/fluent-bit --set on_minikube=true
 ```
 
 ## Configuration

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -5,7 +5,7 @@ on_minikube: false
 image:
   fluent_bit:
     repository: fluent/fluent-bit
-    tag: 0.11.9
+    tag: 0.11.10
   pullPolicy: IfNotPresent
 
 backend:

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -5,7 +5,7 @@ on_minikube: false
 image:
   fluent_bit:
     repository: fluent/fluent-bit
-    tag: 0.11.8
+    tag: 0.11.9
   pullPolicy: IfNotPresent
 
 backend:


### PR DESCRIPTION
This patch do the following changes:
    
- Use the new Fluent Bit v0.11.9
- Bump chart version to AppVersion 0.1.1
- Update description keywords
    
For more details about Fluent Bit v0.11.9 changes, please visit the following release notes:
    
http://fluentbit.io/announcements/v0.11.9/
