### PR TITLE
Adding support for sleep time, ignored pools, and spare agents

### DIFF
--- a/stable/acs-engine-autoscaler/README.md
+++ b/stable/acs-engine-autoscaler/README.md
@@ -108,6 +108,9 @@ Parameter | Description | Default
 `kubeconfigprivatekey`| The key passed to the `kubeConfigPrivateKey` parameter in your `azuredeploy.parameters.json` generated with `acs-engine` | None. You *must* supply one.
 `clientprivatekey`| The key passed to the `clientPrivateKey` parameter in your `azuredeploy.parameters.json` generated with `acs-engine` | None. You *must* supply one.
 `acsdeployment`| [OPTIONAL] The name of the deployment used to deploy the kubernetes cluster initially. If not provided, it is defaulted to `azuredeploy` | None.
+`sleeptime`| [OPTIONAL] The number of seconds to sleep between scaling loops. If not provided, a default of 60 seconds is used. | 60
+`ignorepools`| [OPTIONAL] A list of comma seperated pool names the autoscaler should ignore. | None.
+`spareagents`| [OPTIONAL] Number of agents per pool that should always remain up. If not provided, a default of 1 agent is used. | 1
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section.
 

--- a/stable/acs-engine-autoscaler/templates/deployment.yaml
+++ b/stable/acs-engine-autoscaler/templates/deployment.yaml
@@ -3,13 +3,13 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
-  labels: 
+  labels:
 {{ include "labels.standard" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
-      labels: 
+      labels:
 {{ include "labels.standard" . | indent 8 }}
         openai/do-not-drain: "true"
     spec:
@@ -31,7 +31,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ template "fullname" . }}
-              key: azure-sp-tenant-id    
+              key: azure-sp-tenant-id
         - name: KUBECONFIG_PRIVATE_KEY
           valueFrom:
             secretKeyRef:
@@ -41,16 +41,28 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ template "fullname" . }}
-              key: client-private-key   
+              key: client-private-key
         command:
             - python
             - main.py
-            - --resource-group 
+            - --resource-group
             - {{ .Values.acsenginecluster.resourcegroup }}
-            {{- if .Values.acsenginecluster.acsdeployment}}
-            - --acs-deployment 
+            {{- if .Values.acsenginecluster.acsdeployment }}
+            - --acs-deployment
             - {{ .Values.acsenginecluster.acsdeployment }}
-            {{- end}}
+            {{ end }}
+            {{- if .Values.acsenginecluster.sleeptime }}
+            - --sleep
+            - {{ .Values.acsenginecluster.sleeptime }}
+            {{ end }}
+            {{- if .Values.acsenginecluster.ignorepools }}
+            - --ignore-pools
+            - {{ .Values.acsenginecluster.ignorepools }}
+            {{ end }}
+            {{- if .Values.acsenginecluster.spareagents }}
+            - --spare-agents
+            - {{ .Values.acsenginecluster.spareagents }}
+            {{ end }}
             - -vvv
         imagePullPolicy: {{ .Values.image.pullPolicy }}
       restartPolicy: Always

--- a/stable/acs-engine-autoscaler/values.yaml
+++ b/stable/acs-engine-autoscaler/values.yaml
@@ -9,12 +9,18 @@ image:
   tag: 0.3.1
   pullPolicy: IfNotPresent
 acsenginecluster:
-  resourcegroup: 
-  azurespappid: 
-  azurespsecret: 
-  azuresptenantid: 
-  kubeconfigprivatekey: 
-  clientprivatekey: 
+  resourcegroup:
+  azurespappid:
+  azurespsecret:
+  azuresptenantid:
+  kubeconfigprivatekey:
+  clientprivatekey:
   ## Optional parameter for deployment name if not using default
-  #acsdeployment: 
+  #acsdeployment:
+  ## Optional parameter for sleep time between scaling loops (default: 60)
+  #sleeptime:
+  ## Optional parameter for pools to ignore scaling on
+  #ignorepools:
+  ## Optional parameter denominating number of nodes to spare in a pool after scaling
+  #spareagents:
 


### PR DESCRIPTION
Please forgive my overbearing editor for the whitespace changes. :|

I found some extra features of acs-engine-autoscaler that may be helpful, so I modified the chart's `command` field to include them. @ritazh can you do a once over on this? :)