### PR TITLE
mariadb: adds prometheus metrics sidecar container

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 0.6.3
+version: 0.7.0
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:
 - mariadb

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -45,21 +45,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MariaDB chart and their default values.
 
-| Parameter                   | Description                                | Default                                                    |
-| -----------------------     | ----------------------------------         | ---------------------------------------------------------- |
-| `image`                     | MariaDB image                              | `bitnami/mariadb:{VERSION}`                                |
-| `imagePullPolicy`           | Image pull policy.                         | `IfNotPresent`                                             |
-| `mariadbRootPassword`       | Password for the `root` user.              | `nil`                                                      |
-| `mariadbUser`               | Username of new user to create.            | `nil`                                                      |
-| `mariadbPassword`           | Password for the new user.                 | `nil`                                                      |
-| `mariadbDatabase`           | Name for new database to create.           | `nil`                                                      |
-| `persistence.enabled`       | Use a PVC to persist data                  | `true`                                                     |
-| `persistence.existingClaim` | Use an existing PVC                        | `nil`                                                      |
-| `persistence.storageClass`  | Storage class of backing PVC               | `nil` (uses alpha storage class annotation)                |
-| `persistence.accessMode`    | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                            |
-| `persistence.size`          | Size of data volume                        | `8Gi`                                                      |
-| `resources`                 | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `250m`                               |
-| `config`                    | Multi-line string for my.cnf configuration | `nil`                                                      |
+|          Parameter          |                Description                 |                   Default                   |
+|-----------------------------|--------------------------------------------|---------------------------------------------|
+| `image`                     | MariaDB image                              | `bitnami/mariadb:{VERSION}`                 |
+| `imagePullPolicy`           | Image pull policy.                         | `IfNotPresent`                              |
+| `mariadbRootPassword`       | Password for the `root` user.              | `nil`                                       |
+| `mariadbUser`               | Username of new user to create.            | `nil`                                       |
+| `mariadbPassword`           | Password for the new user.                 | `nil`                                       |
+| `mariadbDatabase`           | Name for new database to create.           | `nil`                                       |
+| `persistence.enabled`       | Use a PVC to persist data                  | `true`                                      |
+| `persistence.existingClaim` | Use an existing PVC                        | `nil`                                       |
+| `persistence.storageClass`  | Storage class of backing PVC               | `nil` (uses alpha storage class annotation) |
+| `persistence.accessMode`    | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                             |
+| `persistence.size`          | Size of data volume                        | `8Gi`                                       |
+| `resources`                 | CPU/Memory resource requests/limits        | Memory: `256Mi`, CPU: `250m`                |
+| `config`                    | Multi-line string for my.cnf configuration | `nil`                                       |
+| `metrics.enabled`           | Start a side-car prometheus exporter       | `false`                                     |
+| `metrics.image`             | Exporter image                             | `prom/mysqld-exporter`                      |
+| `metrics.imageTag`          | Exporter image                             | `v0.10.0`                                   |
+| `metrics.imagePullPolicy`   | Exporter image pull policy                 | `IfNotPresent`                              |
+| `metrics.resources`         | Exporter resource requests/limit           | `nil`                                       |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 
@@ -117,3 +122,7 @@ The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/pers
 ```bash
 $ helm install --set persistence.existingClaim=PVC_NAME postgresql
 ```
+
+## Metrics
+
+The chart can optionally start a metrics exporter endpoint on port `9104` for [prometheus](https://prometheus.io). The data exposed by the endpoint is intended to be consumed by a prometheus chart deployed within the cluster and as such the endpoint is not exposed outside the cluster.

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -73,6 +73,19 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.metrics.enabled }}
+      - name: metrics
+        image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
+        imagePullPolicy: {{ .Values.metrics.imagePullPolicy | quote }}
+        env:
+        - name: DATA_SOURCE_NAME
+          value: "root:{{ .Values.mariadbRootPassword }}@(localhost:3306)/"
+        ports:
+        - name: metrics
+          containerPort: 9104
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: data
           mountPath: /bitnami/mariadb

--- a/stable/mariadb/templates/svc.yaml
+++ b/stable/mariadb/templates/svc.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.metrics.enabled }}
+  annotations:
+{{ toYaml .Values.metrics.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.serviceType }}
   ports:

--- a/stable/mariadb/templates/svc.yaml
+++ b/stable/mariadb/templates/svc.yaml
@@ -17,5 +17,10 @@ spec:
   - name: mysql
     port: 3306
     targetPort: mysql
+{{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: 9104
+    targetPort: metrics
+{{- end }}
   selector:
     app: {{ template "fullname" . }}

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -54,6 +54,16 @@ persistence:
   # [mysqld]
   # innodb_buffer_pool_size=2G
 
+metrics:
+  enabled: false
+  image: prom/mysqld-exporter
+  imageTag: v0.10.0
+  imagePullPolicy: IfNotPresent
+  resources: {}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9104"
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
Adds `prom/mysqld-exporter` sidecar container to expose
a metrics endpoint for prometheus. The exporter should be
enabled using `metrics.enable=true` while deploying the
chart.

Bumps the chart version to `0.7.0`