### PR TITLE
prometheus: switch to Kubernetes 1.6 storage class specification

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 3.2.0
+version: 4.0.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -61,7 +61,7 @@ Parameter | Description | Default
 `alertmanager.persistentVolume.existingClaim` | alertmanager data Persistent Volume existing claim name | `""`
 `alertmanager.persistentVolume.mountPath` | alertmanager data Persistent Volume mount root path | `/data`
 `alertmanager.persistentVolume.size` | alertmanager data Persistent Volume size | `2Gi`
-`alertmanager.persistentVolume.storageClass` | alertmanager data Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default`
+`alertmanager.persistentVolume.storageClass` | alertmanager data Persistent Volume Storage Class | `unset
 `alertmanager.persistentVolume.subPath` | Subdirectory of alertmanager data Persistent Volume to mount | `""`
 `alertmanager.podAnnotations` | annotations to be added to alertmanager pods | `{}`
 `alertmanager.replicaCount` | desired number of alertmanager pods | `1`
@@ -131,7 +131,7 @@ Parameter | Description | Default
 `server.persistentVolume.existingClaim` | Prometheus server data Persistent Volume existing claim name | `""`
 `server.persistentVolume.mountPath` | Prometheus server data Persistent Volume mount root path | `/data`
 `server.persistentVolume.size` | Prometheus server data Persistent Volume size | `8Gi`
-`server.persistentVolume.storageClass` | Prometheus server data Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default`
+`server.persistentVolume.storageClass` | Prometheus server data Persistent Volume Storage Class |  unset
 `server.persistentVolume.subPath` | Subdirectory of Prometheus server data Persistent Volume to mount | `""`
 `server.podAnnotations` | annotations to be added to Prometheus server pods | `{}`
 `server.replicaCount` | desired number of Prometheus server pods | `1`

--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -3,13 +3,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-  {{- if .Values.alertmanager.persistentVolume.storageClass }}
-    volume.beta.kubernetes.io/storage-class: "{{ .Values.alertmanager.persistentVolume.storageClass }}"
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
   {{- if .Values.alertmanager.persistentVolume.annotations }}
+  annotations:
 {{ toYaml .Values.alertmanager.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
@@ -22,6 +17,13 @@ metadata:
 spec:
   accessModes:
 {{ toYaml .Values.alertmanager.persistentVolume.accessModes | indent 4 }}
+{{- if .Values.alertmanager.persistentVolume.storageClass }}
+{{- if (eq "-" .Values.alertmanager.persistentVolume.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.alertmanager.persistentVolume.storageClass }}"
+{{- end }}
+{{- end }}
   resources:
     requests:
       storage: "{{ .Values.alertmanager.persistentVolume.size }}"

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -3,13 +3,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  annotations:
-  {{- if .Values.server.persistentVolume.storageClass }}
-    volume.beta.kubernetes.io/storage-class: "{{ .Values.server.persistentVolume.storageClass }}"
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
   {{- if .Values.server.persistentVolume.annotations }}
+  annotations:
 {{ toYaml .Values.server.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
@@ -22,6 +17,13 @@ metadata:
 spec:
   accessModes:
 {{ toYaml .Values.server.persistentVolume.accessModes | indent 4 }}
+{{- if .Values.server.persistentVolume.storageClass }}
+{{- if (eq "-" .Values.server.persistentVolume.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
+{{- end }}
+{{- end }}
   resources:
     requests:
       storage: "{{ .Values.server.persistentVolume.size }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -84,10 +84,13 @@ alertmanager:
     size: 2Gi
 
     ## alertmanager data Persistent Volume Storage Class
-    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
     ##
-    storageClass: ""
+    # storageClass: "-"
 
     ## Subdirectory of alertmanager data Persistent Volume to mount
     ## Useful if the volume's root directory is not empty
@@ -360,10 +363,13 @@ server:
     size: 8Gi
 
     ## Prometheus server data Persistent Volume Storage Class
-    ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-    ## Default: volume.alpha.kubernetes.io/storage-class: default
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
     ##
-    storageClass: ""
+    # storageClass: "-"
 
     ## Subdirectory of Prometheus server data Persistent Volume to mount
     ## Useful if the volume's root directory is not empty


### PR DESCRIPTION
Ditching the alpha storage class annotation and using the 1.6 style specification instead brings the following benefits:

- a standard way to specify the default provisioner
- a mechanism to disble the dynamic provisioner

Unfortunately, go template makes the second one hacky.   See https://github.com/kubernetes/helm/issues/2600 for more details.   So instead of using an empty string to disable the dynamic provisioner, this PR uses "-".