### PR TITLE
RBAC support for heapster

### DIFF
--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -43,6 +43,7 @@ The default configuration values for this chart are listed in `values.yaml`.
 | `resources.requests`                  | Server resource requests            | requests: {cpu: 100m, memory: 128Mi}              |
 | `command`                             | Commands for heapster pod           | "/heapster --source=kubernetes.summary_api:''     |
 | `resizer.enabled`                     | If enabled, scale resources         | true                                              |
+| `rbac.enabled`                        | Bind system:heapster role           | false                                              |
 
 The table below is only applicable if `resizer.enabled` is `true`. More information on resizer can be found [here](https://github.com/kubernetes/contrib/blob/master/addon-resizer/README.md).
 

--- a/stable/heapster/templates/deployment.yaml
+++ b/stable/heapster/templates/deployment.yaml
@@ -11,6 +11,9 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+{{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ template "fullname" . }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/heapster/templates/rolebinding.yaml
+++ b/stable/heapster/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:heapster
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/heapster/templates/serviceaccount.yaml
+++ b/stable/heapster/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end -}}

--- a/stable/heapster/values.yaml
+++ b/stable/heapster/values.yaml
@@ -59,3 +59,6 @@ resizer:
   - "--extra-memory=6Mi"
   - "--threshold=5"
   - "--poll-period=300000"
+
+## For RBAC support:
+rbac.enabled: false


### PR DESCRIPTION
If `rbac.enabled` is set to `true` - bind default ClusterRole `system:heapster`.