### PR TITLE
update Concourse CI ImageTag to release v3.2.1

### DIFF
--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -13,7 +13,7 @@ image: concourse/concourse
 ## Concourse image version.
 ## ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "2.6.0"
+imageTag: "3.2.1"
 
 ## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
 ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
3.2.1 is the newest numbered release on docker hub:
https://hub.docker.com/r/concourse/concourse/tags/