### PR TITLE
[stable/traefik] Allow static IP address

### DIFF
--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -30,3 +30,6 @@ spec:
     {{- if not .Values.ssl.enabled }}
     targetPort: 80
     {{- end }}
+  {{- if .Values.loadBalancerIP}}
+  loadBalancerIP: {{ .Values.loadBalancerIP }}
+  {{- end }}

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -30,7 +30,8 @@ spec:
     {{- if not .Values.ssl.enabled }}
     targetPort: 80
     {{- end }}
-  {{- if and (.Values.loadBalancerIP) (ne .Values.loadBalancerIP "nil") (ne .Values.loadBalancerIP "dynamic") }}
+  {{- if (.Values.loadBalancerIP) }}
+  {{- if and (ne .Values.loadBalancerIP "nil") (ne .Values.loadBalancerIP "dynamic") }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}
-  
+  {{- end }}

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -30,6 +30,7 @@ spec:
     {{- if not .Values.ssl.enabled }}
     targetPort: 80
     {{- end }}
-  {{- if .Values.loadBalancerIP }}
+  {{- if and (.Values.loadBalancerIP) (ne .Values.loadBalancerIP "nil") (ne .Values.loadBalancerIP "dynamic") }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}
+  

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -30,6 +30,6 @@ spec:
     {{- if not .Values.ssl.enabled }}
     targetPort: 80
     {{- end }}
-  {{- if .Values.loadBalancerIP}}
+  {{- if .Values.loadBalancerIP }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,7 +2,7 @@
 image: traefik
 imageTag: v1.2.1
 serviceType: LoadBalancer
-# Static IP Address
+# Static IP Address pass --set loadBalancerIP=false from command line if running mulitiple 
 # loadBalancerIP: xx.xx.xx.xx
 replicas: 1
 cpuRequest: 100m

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,7 +2,7 @@
 image: traefik
 imageTag: v1.2.1
 serviceType: LoadBalancer
-loadBalancerIP: dynamic
+loadBalancerIP:
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,6 +2,8 @@
 image: traefik
 imageTag: v1.2.1
 serviceType: LoadBalancer
+# Static IP Address
+# loadBalancerIP: xx.xx.xx.xx
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,8 +2,7 @@
 image: traefik
 imageTag: v1.2.1
 serviceType: LoadBalancer
-# Static IP Address pass --set loadBalancerIP=false from command line if running mulitiple 
-# loadBalancerIP: xx.xx.xx.xx
+loadBalancerIP: dynamic
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi


### PR DESCRIPTION
If cloud provider supports, will assign the static IP address to the raefik service https://kubernetes.io/docs/api-reference/v1.6/#servicespec-v1-core

Confirmed on GCP. 