### PR TITLE
add option to include tolerations to daemonset

### DIFF
--- a/stable/sumokube/README.md
+++ b/stable/sumokube/README.md
@@ -54,6 +54,7 @@ The following tables lists the configurable parameters of the Sumokube chart and
 | `resources.limits.cpu`      | CPU resource limits                | 256m                                     |
 | `resources.requests.memory` | Memory resource requests           | 128Mi                                      |
 | `resources.limits.memory`   | Memory resource limits             | 256Mi                                      |
+| `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6)            | []    |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -61,6 +62,14 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```bash
 $ helm install --name my-release \
     --set sumologic.accessId=YOUR-ID-HERE,sumologic.accessKey=YOUR-KEY-HERE,sumologic.categoryName=my-source-category-name \
+    stable/sumokube
+```
+
+Example of adding daemonset tolerations to run on master nodes. Requires Helm >=2.5
+
+```bash
+$ helm install --name my-release \
+    --set sumologic.accessId=YOUR-ID-HERE,sumologic.accessKey=YOUR-KEY-HERE,sumologic.categoryName=my-source-category-name,daemonset.tolerations[0].effect=NoSchedule,daemonset.tolerations[0].key=node-role.kubernetes.io/master \
     stable/sumokube
 ```
 

--- a/stable/sumokube/templates/daemonset.yaml
+++ b/stable/sumokube/templates/daemonset.yaml
@@ -61,4 +61,6 @@ spec:
       - name: sumo-sources
         configMap:
           name: "{{ template "fullname" . }}-config-{{.Release.Time.Seconds }}"
+      tolerations:
+{{ toYaml .Values.daemonset.tolerations | indent 8 }}
 {{ end }}

--- a/stable/sumokube/values.yaml
+++ b/stable/sumokube/values.yaml
@@ -29,3 +29,7 @@ resources:
   limits:
     cpu: 256m
     memory: 256Mi
+
+daemonset:
+  tolerations: []
+


### PR DESCRIPTION
Occasionally pods need to run on the master nodes, and with Kubernetes 1.6.x there are taints on these nodes that prevent sumokube from running there and grabbing logs. This adds the option to add those tolerations to the daemonset.

I'm not sure on protocol for updating version number, so I left it alone.