### PR TITLE
Updated istio charts use image pull policy as IfNotPresent.

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Istio Helm chart for Kubernetes
 name: istio
-version: 0.1.6-chart2
+version: 0.1.6-chart3
 appVersion: 0.1.6
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -23,7 +23,7 @@ mixer:
   deployment:
     name: mixer
     image: docker.io/istio/mixer
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     replicas: 1
     annotations:
       alpha.istio.io/sidecar: ignore
@@ -53,7 +53,7 @@ pilot:
     discovery:
       name: discovery
       image: docker.io/istio/pilot
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       resources:
         limits:
           cpu: 100m
@@ -65,7 +65,7 @@ pilot:
     apiserver:
       name: apiserver
       image: docker.io/istio/pilot
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       resources:
         limits:
           cpu: 100m
@@ -87,7 +87,7 @@ ingress:
     annotations:
       alpha.istio.io/sidecar: ignore
     image: docker.io/istio/proxy_debug
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     replicas: 1
     resources:
       limits:
@@ -109,7 +109,7 @@ egress:
     annotations:
       alpha.istio.io/sidecar: ignore
     image: docker.io/istio/proxy_debug
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     replicas: 1
     resources:
       limits:
@@ -206,7 +206,7 @@ addons:
       annotations:
         alpha.istio.io/sidecar: ignore
       image: docker.io/istio/grafana
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       replicas: 1
       resources:
         limits:
@@ -230,7 +230,7 @@ addons:
         alpha.istio.io/sidecar: ignore
       image: gcr.io/istio-testing/servicegraph
       imageTag: latest
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       replicas: 1
       resources:
         limits:


### PR DESCRIPTION
Fixed https://github.com/kubernetes/charts/issues/1368