### PR TITLE
[stable/drupal] Make liveness and readiness probes configurable

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.7.3
+version: 0.8.0
 appVersion: 8.3.3
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.8.0
+version: 0.9.0
 appVersion: 8.3.3
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -43,15 +43,9 @@ spec:
         - name: https
           containerPort: 443
         livenessProbe:
-          httpGet:
-            path: /user/login
-            port: http
-          initialDelaySeconds: 120
+{{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
-          httpGet:
-            path: /user/login
-            port: http
-          initialDelaySeconds: 30
+{{ toYaml .Values.readinessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -120,3 +120,21 @@ resources:
   requests:
     memory: 512Mi
     cpu: 300m
+
+## Configure liveness and readiness probes.
+## Drupal core exposes /user/login to unauthenticated requests, making it a good
+## default liveness and readiness path. However, that may not always be the
+## case. For example, if the image value is overridden to an image containing a
+## module that alters that route, or an image that does not auto-install Drupal.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+#
+livenessProbe:
+  httpGet:
+    path: /user/login
+    port: http
+  initialDelaySeconds: 120
+readinessProbe:
+  httpGet:
+    path: /user/login
+    port: http
+  initialDelaySeconds: 30


### PR DESCRIPTION
Reasoning for this PR is explained in the values file comments:

> Drupal core exposes /user/login to unauthenticated requests, making it a good
> default liveness and readiness path. However, that may not always be the
> case. For example, if the image value is overridden to an image containing a
> module that alters that route, or an image that does not auto-install Drupal.