### PR TITLE
Don't add create-at annotation to zookeeper pdb

### DIFF
--- a/incubator/zookeeper/templates/pdb.yaml
+++ b/incubator/zookeeper/templates/pdb.yaml
@@ -2,8 +2,6 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ printf "zk-pdb-%s" .Release.Name | trunc 24 }}"
-  annotations:
-    helm.sh/created: {{.Release.Time.Seconds | quote }}
   labels:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}


### PR DESCRIPTION
Currently a PodDisruptionBudget is an immutable object in kubernetes.
Adding a created annotation time means that if a chart is upgraded then
it will try to update this annotation and then the whole upgrade process
will fail with:

    Error: UPGRADE FAILED: PodDisruptionBudget.policy "zk-pdb-NAME" is
    invalid: spec: Forbidden: updates to poddisruptionbudget spec are
    forbidden.

This is particularly annoying when zookeeper is used as a dependency as
we are not actually trying to update the PodDisruptionBudget details,
however this causes the whole upgrade process to fail.

Signed-off-by: Jamie Lennox <jlennox@au1.ibm.com>