### PR TITLE
Bump Helm version in repo-sync

### DIFF
--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -15,7 +15,7 @@
 
 # Setup Helm
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.1.3-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.4.2-linux-amd64.tar.gz
 STABLE_REPO_URL=https://kubernetes-charts.storage.googleapis.com/
 INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 wget -q ${HELM_URL}/${HELM_TARBALL}


### PR DESCRIPTION
Looks like we were using a different version to package charts that we did in tests. Discovered this after I noticed appVersion wasn't being exposed in the index.yaml we generate.

cc @kubernetes/charts-maintainers @foxish 