### PR TITLE
Enable using image with preinstalled plugins

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -48,6 +48,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.Ingress.TLS`              | Ingress TLS configuration           | `[]`                                                                         |
 | `Master.InitScripts`              | List of Jenkins init scripts        | Not set                                                                      |
 | `Master.InstallPlugins`           | List of Jenkins plugins to install  | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |
+| `Master.PreinstalledPluginsDirectory` | Directory of pre-installed plugins | Not set                                                                   |
 | `Master.ScriptApproval`           | List of groovy functions to approve | Not set                                                                      |
 
 ### Jenkins Agent
@@ -123,3 +124,21 @@ jenkins:
   Master:
     CustomConfigMap: true
 ```
+
+## Preinstalling Plugins
+
+Plugins are constantly being updated.  Sometimes this causes issues, especially if versions are not explicitly added to
+the plugins list in values.yaml.  One way to address this is starting from a base image that has plugins pre-installed.
+This should be pretty straight-forward, but since we mount the plugins directory as a volume, any pre-installed plugins
+are simply ignored.  To address this, install the plugins to a separate directory
+(e.g. `/usr/share/jenkins/ref/preinstalled_plugins`).  Below is an example Dockerfile:
+
+```
+FROM jenkinsci/jenkins:2.66
+
+RUN mkdir -p /usr/share/jenkins/ref/preinstalled_plugins
+ADD plugins.txt /usr/share/jenkins/ref/preinstalled_plugins/plugins.txt
+RUN REF=/usr/share/jenkins/ref/preinstalled_plugins /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/preinstalled_plugins/plugins.txt
+```
+
+The plugins will be copied as part of the init-containers hook.

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -116,6 +116,9 @@ data:
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
+{{- if .Values.Master.PreinstalledPluginsDirectory }}
+    cp -r {{ .Values.Master.PreinstalledPluginsDirectory }}/* /usr/share/jenkins/ref/plugins/;
+{{- end }}
 {{- if .Values.Master.InstallPlugins }}
     cp /var/jenkins_config/plugins.txt /var/jenkins_home;
     /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -30,17 +30,19 @@ Master:
 # Optionally configure a JMX port
 # requires additional JavaOpts, ie
 # JavaOpts: >
-#   -Dcom.sun.management.jmxremote.port=4000 
-#   -Dcom.sun.management.jmxremote.authenticate=false 
-#   -Dcom.sun.management.jmxremote.ssl=false 
+#   -Dcom.sun.management.jmxremote.port=4000
+#   -Dcom.sun.management.jmxremote.authenticate=false
+#   -Dcom.sun.management.jmxremote.ssl=false
 # JMXPort: 4000
 # List of plugins to be install during Jenkins master start
   InstallPlugins:
-      - kubernetes:0.11 
+      - kubernetes:0.11
       - workflow-aggregator:2.5
       - workflow-job:2.11
       - credentials-binding:1.11
       - git:3.2.0
+# If using a custom master image, copy the plugins from the below directory
+  # PreinstalledPluginsDirectory: /usr/share/jenkins/ref/preinstalled_plugins
 # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   # ScriptApproval:
   #   - "method groovy.json.JsonSlurperClassic parseText java.lang.String"


### PR DESCRIPTION
Previously using a master image with pre-installed plugins doesn't
work because the plugin directory is mounted as a kubernetes
volume.  Therefore, this gets around this issue by copying from
another (configurable) location.  This makes jenkins deployments
far more reliable as all of the plugins are baked into the image
as opposed to pulled/installed at deploy time.

See the additions to the README for usage.