### PR TITLE
[incubator/kubernetes-vault] Initial submission of kubernetes-vault chart

### DIFF
--- a/incubator/kubernetes-vault/.helmignore
+++ b/incubator/kubernetes-vault/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/kubernetes-vault/Chart.yaml
+++ b/incubator/kubernetes-vault/Chart.yaml
@@ -1,11 +1,4 @@
-name: kubernetes-vault
 apiVersion: v1
-home: https://github.com/Boostport/kubernetes-vault
-description: The Kubernetes-Vault project allows pods to automatically receive a Vault token using Vaults AppRole auth backend.
+description: A Helm chart for Kubernetes
+name: kubernetes-vault
 version: 0.1.0
-appVersion: 0.4.7
-sources:
-  - https://github.com/Boostport/kubernetes-vault
-maintainers:
-  - name: bbriggs
-    email: bren.briggs@maxwellhealth.com

--- a/incubator/kubernetes-vault/Chart.yaml
+++ b/incubator/kubernetes-vault/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 home: https://github.com/Boostport/kubernetes-vault
 description: The Kubernetes-Vault project allows pods to automatically receive a Vault token using Vaults AppRole auth backend.
 version: 0.1.0
-appVersion: 0.4.7
+appVersion: 0.4.8
 sources:
   - https://github.com/Boostport/kubernetes-vault
 maintainers:

--- a/incubator/kubernetes-vault/Chart.yaml
+++ b/incubator/kubernetes-vault/Chart.yaml
@@ -1,0 +1,11 @@
+name: kubernetes-vault
+apiVersion: v1
+home: https://github.com/Boostport/kubernetes-vault
+description: The Kubernetes-Vault project allows pods to automatically receive a Vault token using Vaults AppRole auth backend.
+version: 0.1.0
+appVersion: 0.4.7
+sources:
+  - https://github.com/Boostport/kubernetes-vault
+maintainers:
+  - name: bbriggs
+    email: bren.briggs@maxwellhealth.com

--- a/incubator/kubernetes-vault/Chart.yaml
+++ b/incubator/kubernetes-vault/Chart.yaml
@@ -1,4 +1,12 @@
-apiVersion: v1
-description: A Helm chart for Kubernetes
 name: kubernetes-vault
+apiVersion: v1
+home: https://github.com/Boostport/kubernetes-vault
+description: The Kubernetes-Vault project allows pods to automatically receive a Vault token using Vaults AppRole auth backend.
 version: 0.1.0
+appVersion: 0.4.7
+sources:
+  - https://github.com/Boostport/kubernetes-vault
+maintainers:
+  - name: bbriggs
+    email: briggs.brenton@gmail.com
+

--- a/incubator/kubernetes-vault/README.md
+++ b/incubator/kubernetes-vault/README.md
@@ -23,18 +23,22 @@ $ helm install --name my-release incubator/kubernetes-vault --set vault.address=
 
 The following tables lists the configurable parameters of the consul chart and their default values.
 
-| Parameter               | Description                           | Default                                                    |
-| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
-| `image`                 | Container image name                  | `boostport/kubernetes-vault`                               |
-| `imageTag`              | Container image tag                   | `v0.7.5`                                                   |
-| `imagePullPolicy`       | Container pull policy                 | `Always`                                                   |
-| `replicaCount`          | k8s pod replicas                      | `3`                                                        |
-| `app`                   | k8s selector key                      | `kubernetes-vault`                                         |
-| `service.dummyPort`     | Dummy port to register pod with API. Not actually used. | `80`                                     |
-| `vault.address`         | URL of Vault server                   | `http://vault:8200`                                        |
-| `vault.token`           | Token generated from AppRole backend  | `change-this-value`                                        |
-| `vault.vaultCertBackend` | Name of CA backend used in Vault     | `intermediate-ca`                                          |
-| `vault.vaultCertRole`   | Name of cert role used in Vault       | `kubernetes-vault`                                         |
+| Parameter                   | Description                                             | Default                                                    |
+| --------------------------  | ----------------------------------                      | ---------------------------------------------------------- |
+| `image`                     | Container image name                                    | `boostport/kubernetes-vault`                               |
+| `imageTag`                  | Container image tag                                     | `v0.7.5`                                                   |
+| `imagePullPolicy`           | Container pull policy                                   | `Always`                                                   |
+| `replicaCount`              | k8s pod replicas                                        | `3`                                                        |
+| `app`                       | k8s selector key                                        | `kubernetes-vault`                                         |
+| `service.dummyPort`         | Dummy port to register pod with API. Not actually used. | `80`                                                       |
+| `vault.address`             | URL of Vault server                                     | `http://vault:8200`                                        |
+| `vault.token`               | Token generated from AppRole backend                    | `change-this-value`                                        |
+| `vault.vaultCertBackend`    | Name of CA backend used in Vault                        | `intermediate-ca`                                          |
+| `vault.vaultCertRole`       | Name of cert role used in Vault                         | `kubernetes-vault`                                         |
+| `resources.limits.cpu`      | CPU limit                                               | `100m`                                                     |
+| `resources.limits.memory`   | Memory limit                                            | `128Mi`                                                    |
+| `resources.requests.cpu`    | CPU resource request                                    | `100m`                                                     |
+| `resources.requests.memory` | Memory resource request                                 | `128Mi`                                                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/kubernetes-vault/README.md
+++ b/incubator/kubernetes-vault/README.md
@@ -1,0 +1,45 @@
+# Kubernetes-vault Helm Chart
+
+## Prerequisites Details
+* Working Vault cluster configured per instructions found [here](https://github.com/Boostport/kubernetes-vault/blob/master/quick-start.md#22-set-up-the-root-certificate-authority)
+* Vault server API is available from Kubernetes pods
+* A Vault token created for the AppRole backend
+* Kubernetes 1.5
+
+## Chart Details
+This chart will do the following:
+
+* Allows pods to automatically receive a Vault token using Vault's [AppRole auth backend](https://www.vaultproject.io/docs/auth/approle.html).
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release incubator/kubernetes-vault --set vault.address=$your_vault_server --set vault.token=$your_vault_token
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the consul chart and their default values.
+
+| Parameter               | Description                           | Default                                                    |
+| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `image`                 | Container image name                  | `boostport/kubernetes-vault`                               |
+| `imageTag`              | Container image tag                   | `v0.7.5`                                                   |
+| `imagePullPolicy`       | Container pull policy                 | `Always`                                                   |
+| `replicaCount`          | k8s pod replicas                      | `3`                                                        |
+| `app`                   | k8s selector key                      | `kubernetes-vault`                                         |
+| `service.dummyPort`     | Dummy port to register pod with API. Not actually used. | `80`                                     |
+| `vault.address`         | URL of Vault server                   | `http://vault:8200`                                        |
+| `vault.token`           | Token generated from AppRole backend  | `change-this-value`                                        |
+| `vault.vaultCertBackend` | Name of CA backend used in Vault     | `intermediate-ca`                                          |
+| `vault.vaultCertRole`   | Name of cert role used in Vault       | `kubernetes-vault`                                         |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml incubator/kubernetes-vault
+```

--- a/incubator/kubernetes-vault/README.md
+++ b/incubator/kubernetes-vault/README.md
@@ -26,7 +26,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | Parameter                   | Description                                             | Default                                                    |
 | --------------------------  | ----------------------------------                      | ---------------------------------------------------------- |
 | `image`                     | Container image name                                    | `boostport/kubernetes-vault`                               |
-| `imageTag`                  | Container image tag                                     | `v0.7.5`                                                   |
+| `imageTag`                  | Container image tag                                     | `0.4.8`                                                    |
 | `imagePullPolicy`           | Container pull policy                                   | `Always`                                                   |
 | `replicaCount`              | k8s pod replicas                                        | `3`                                                        |
 | `app`                       | k8s selector key                                        | `kubernetes-vault`                                         |

--- a/incubator/kubernetes-vault/templates/NOTES.txt
+++ b/incubator/kubernetes-vault/templates/NOTES.txt
@@ -1,0 +1,15 @@
+This deployment will be incomplete unless you followed the prerequisites for setting up Vault:
+https://github.com/Boostport/kubernetes-vault/blob/master/quick-start.md#22-set-up-the-root-certificate-authority
+
+If you deployed this chart without a providing a Vault token, you can upgrade as follows:
+helm upgrade {{ .Release.Name }} \
+        --set vault.token=aaaa-bbbb-cccc incubator/kubernetes-vault
+
+View logs to ensure that kubernetes-vault is working with the following command to list your pods:
+kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" .}}"
+
+And then view logs:
+kubectl logs $podName
+
+If kubernetes-vault successfully contacted Vault and received a token, you will see Consul
+debug messages.

--- a/incubator/kubernetes-vault/templates/_helpers.tpl
+++ b/incubator/kubernetes-vault/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/kubernetes-vault/templates/configMap.yaml
+++ b/incubator/kubernetes-vault/templates/configMap.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "name" . }}
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 data:
   kubernetes-vault.yml: |
     # Dummy comment: https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/yaml_techniques.md#strings-in-yaml

--- a/incubator/kubernetes-vault/templates/configMap.yaml
+++ b/incubator/kubernetes-vault/templates/configMap.yaml
@@ -12,7 +12,7 @@ data:
     kubernetes:
       watchNamespace: ${KUBERNETES_NAMESPACE}
       serviceNamespace: ${KUBERNETES_NAMESPACE}
-      service: {{ template "name" . }}
+      service: {{ template "fullname" . }}
 
     prometheus:
       tls:

--- a/incubator/kubernetes-vault/templates/configMap.yaml
+++ b/incubator/kubernetes-vault/templates/configMap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "name" . }}
+data:
+  kubernetes-vault.yml: |
+    # Dummy comment: https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/yaml_techniques.md#strings-in-yaml
+    vault:
+      addr: {{ .Values.vault.address }}
+      token: {{ .Values.vault.token }}
+
+    kubernetes:
+      watchNamespace: ${KUBERNETES_NAMESPACE}
+      serviceNamespace: ${KUBERNETES_NAMESPACE}
+      service: {{ template "name" . }}
+
+    prometheus:
+      tls:
+        vaultCertBackend: {{ .Values.vault.vaultCertBackend }}
+        vaultCertRole: {{ .Values.vault.vaultCertRole }}

--- a/incubator/kubernetes-vault/templates/deployment.yaml
+++ b/incubator/kubernetes-vault/templates/deployment.yaml
@@ -1,32 +1,39 @@
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ .Values.app }}
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
-      labels: 
-        app: {{ template "fullname" . }}
-        release: release: {{ .Release.Name }}
-          spec:
-      containers:
-      - name: kubernetes-vault
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        env:
-        - name: KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        volumeMounts:
-        - name: config-volume
-          mountPath: /kubernetes-vault
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
       volumes:
         - name: config-volume
           configMap:
             name: {{ template "fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+          - name: config-volume
+            mountPath: /kubernetes-vault
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/incubator/kubernetes-vault/templates/deployment.yaml
+++ b/incubator/kubernetes-vault/templates/deployment.yaml
@@ -8,6 +8,9 @@ spec:
   template:
     metadata:
       labels:
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app: {{ .Values.app }}
     spec:
       containers:

--- a/incubator/kubernetes-vault/templates/deployment.yaml
+++ b/incubator/kubernetes-vault/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ .Values.app }}
     spec:
       containers:
       - name: kubernetes-vault

--- a/incubator/kubernetes-vault/templates/deployment.yaml
+++ b/incubator/kubernetes-vault/templates/deployment.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubernetes-vault
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: kubernetes-vault
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        env:
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config-volume
+          mountPath: /kubernetes-vault
+      volumes:
+        - name: config-volume
+          configMap:
+            name: kubernetes-vault

--- a/incubator/kubernetes-vault/templates/deployment.yaml
+++ b/incubator/kubernetes-vault/templates/deployment.yaml
@@ -2,20 +2,22 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: kubernetes-vault
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ .Values.app }}
+    release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
-      labels:
-        heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}
-        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app: {{ .Values.app }}
-    spec:
+      labels: 
+        app: {{ template "fullname" . }}
+        release: release: {{ .Release.Name }}
+          spec:
       containers:
       - name: kubernetes-vault
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: KUBERNETES_NAMESPACE
           valueFrom:
@@ -27,4 +29,4 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: kubernetes-vault
+            name: {{ template "fullname" . }}

--- a/incubator/kubernetes-vault/templates/service.yaml
+++ b/incubator/kubernetes-vault/templates/service.yaml
@@ -4,7 +4,8 @@ metadata:
   name: "{{ template "fullname" . }}"
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    component: "{{ template "fullname" . }}"
+    app: {{ template "fullname" . }}
+    release: {{ .Release.Name }}
 spec:
   clusterIP: None
   ports:
@@ -12,3 +13,5 @@ spec:
       port: {{ .Values.service.dummyPort }}
   selector:
     run: {{ template "fullname" . }}
+    app: {{ template "fullname" . }}
+    release: {{ .Release.Name }}

--- a/incubator/kubernetes-vault/templates/service.yaml
+++ b/incubator/kubernetes-vault/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "fullname" . }}"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    component: "{{ template "fullname" . }}"
+spec:
+  clusterIP: None
+  ports:
+    - name: port
+      port: {{ .Values.service.dummyPort }}
+  selector:
+    run: {{ template "fullname" . }}

--- a/incubator/kubernetes-vault/templates/service.yaml
+++ b/incubator/kubernetes-vault/templates/service.yaml
@@ -1,17 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "fullname" . }}"
+  name: {{ template "fullname" . }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   clusterIP: None
   ports:
-    - name: port
+    - name: port 
       port: {{ .Values.service.dummyPort }}
   selector:
     run: {{ template "fullname" . }}
-    app: {{ template "fullname" . }}
+    app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/incubator/kubernetes-vault/values.yaml
+++ b/incubator/kubernetes-vault/values.yaml
@@ -6,11 +6,12 @@ replicaCount: 3
 image: boostport/kubernetes-vault
 imageTag: v0.4.7
 imagePullPolicy: always
+app: kubernetes-vault
 service:
   dummyPort: 80
 vault:
   address: http://vault:8200
-  token: your-vault-token
+  token: change-this-value
   vaultCertBackend: intermediate-ca
   vaultCertRole: kubernetes-vault
 resources:

--- a/incubator/kubernetes-vault/values.yaml
+++ b/incubator/kubernetes-vault/values.yaml
@@ -1,0 +1,23 @@
+# Default values for kubernetes-vault.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 3
+image: boostport/kubernetes-vault
+imageTag: v0.4.7
+imagePullPolicy: always
+service:
+  dummyPort: 80
+vault:
+  address: http://vault:8200
+  token: your-vault-token
+  vaultCertBackend: intermediate-ca
+  vaultCertRole: kubernetes-vault
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+

--- a/incubator/kubernetes-vault/values.yaml
+++ b/incubator/kubernetes-vault/values.yaml
@@ -3,9 +3,10 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 3
-image: boostport/kubernetes-vault
-imageTag: 0.4.8
-imagePullPolicy: always
+image:
+  repository: boostport/kubernetes-vault
+  tag: 0.4.8
+  pullPolicy: always
 app: kubernetes-vault
 service:
   dummyPort: 80

--- a/incubator/kubernetes-vault/values.yaml
+++ b/incubator/kubernetes-vault/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 3
 image:
   repository: boostport/kubernetes-vault
   tag: 0.4.8
-  pullPolicy: always
+  pullPolicy: Always
 app: kubernetes-vault
 service:
   dummyPort: 80

--- a/incubator/kubernetes-vault/values.yaml
+++ b/incubator/kubernetes-vault/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 3
 image:
   repository: boostport/kubernetes-vault
-  tag: 0.4.8
+  tag: v0.4.8
   pullPolicy: Always
 app: kubernetes-vault
 service:

--- a/incubator/kubernetes-vault/values.yaml
+++ b/incubator/kubernetes-vault/values.yaml
@@ -4,7 +4,7 @@
 
 replicaCount: 3
 image: boostport/kubernetes-vault
-imageTag: v0.4.7
+imageTag: 0.4.8
 imagePullPolicy: always
 app: kubernetes-vault
 service:


### PR DESCRIPTION
_edit: This is not to be confused with Vault. Kubernetes-vault is a tool for managing distribution of Vault tokens to k8s pods._

This packages the deployment found in [boostport/kubernetes-vault](https://github.com/Boostport/kubernetes-vault) into a helm chart.

Also, this is my first attempt at submitting any charts or changes here (or in the Kubernetes community at large), so any feedback, help, or advice is greatly appreciated.

I did my best to follow the requirements laid out in the style guides and used the Consul chart as a model for most of this. One thing I was unable to do or figure out the best approach for was with requiring users to supply the Vault URL and AppRole token, breaking the simple "this runs with defaults" guideline. I'd particularly welcome any guidance there.