### PR TITLE
[stable/traefik] Bump Traefik version to 1.3.1

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.4.0
-appVersion: 1.2.1
+version: 1.5.0
+appVersion: 1.3.1
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -89,7 +89,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | Parameter                       | Description                                                          | Default                                   |
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
-| `imageTag`                      | The version of the official Traefik image to use                     | `v1.2.1`                                  |
+| `imageTag`                      | The version of the official Traefik image to use                     | `1.3.1`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `replicas`                      | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Traefik
 image: traefik
-imageTag: v1.2.1
+imageTag: 1.3.1
 serviceType: LoadBalancer
 replicas: 1
 cpuRequest: 100m


### PR DESCRIPTION
Follows https://github.com/kubernetes/charts/pull/1225#issuecomment-311856345