### PR TITLE
[stable/traefik] Upgrade Traefik to 1.3.1

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.4.0
-appVersion: 1.2.1
+version: 1.5.0
+appVersion: 1.3.1
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Traefik
 image: traefik
-imageTag: v1.2.1
+imageTag: v1.3.1
 serviceType: LoadBalancer
 replicas: 1
 cpuRequest: 100m


### PR DESCRIPTION
@krancour @kachkaev As requested in https://github.com/kubernetes/charts/pull/1225.