### PR TITLE
[stable/acs-engine-autoscaler] upgrade to 2.0.0

### DIFF
--- a/stable/acs-engine-autoscaler/Chart.yaml
+++ b/stable/acs-engine-autoscaler/Chart.yaml
@@ -2,9 +2,11 @@ apiVersion: v1
 description: Scales worker nodes within agent pools
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: acs-engine-autoscaler
-version: 0.1.0
+version: 1.0.0
 sources:
   - https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
 maintainers:
   - name: Rita Zhang
     email: ritazh@microsoft.com
+  - name: William Buchwalter
+    email: wibuch@microsoft.com

--- a/stable/acs-engine-autoscaler/README.md
+++ b/stable/acs-engine-autoscaler/README.md
@@ -17,6 +17,7 @@ acsenginecluster:
   azuresptenantid:
   kubeconfigprivatekey:
   clientprivatekey:
+  caprivatekey:
 ```
 
 ## Introduction
@@ -38,6 +39,7 @@ acsenginecluster:
   azuresptenantid:
   kubeconfigprivatekey:
   clientprivatekey:
+  caprivatekey:
 ```
 
 To install the chart with the release name `my-release`:
@@ -107,11 +109,13 @@ Parameter | Description | Default
 `azuresptenantid`| An Azure service principal tenant id | None. You *must* supply one.
 `kubeconfigprivatekey`| The key passed to the `kubeConfigPrivateKey` parameter in your `azuredeploy.parameters.json` generated with `acs-engine` | None. You *must* supply one.
 `clientprivatekey`| The key passed to the `clientPrivateKey` parameter in your `azuredeploy.parameters.json` generated with `acs-engine` | None. You *must* supply one.
-`acsdeployment`| [OPTIONAL] The name of the deployment used to deploy the kubernetes cluster initially. If not provided, it is defaulted to `azuredeploy` | None.
-`sleeptime`| [OPTIONAL] The number of seconds to sleep between scaling loops. If not provided, a default of 60 seconds is used. | 60
+`caprivatekey`| The key passed to the `caPrivateKey` parameter in your `azuredeploy.parameters.json` generated with `acs-engine` | None. You *must* supply one.
+`acsdeployment`| [OPTIONAL] The name of the deployment used to deploy the kubernetes cluster initially. | `azuredeploy`.
+`sleeptime`| [OPTIONAL] The number of seconds to sleep between scaling loops. | 60
 `ignorepools`| [OPTIONAL] A list of comma seperated pool names the autoscaler should ignore. | None.
-`spareagents`| [OPTIONAL] Number of agents per pool that should always remain up. If not provided, a default of 1 agent is used. | 1
-
+`spareagents`| [OPTIONAL] Number of agents per pool that should always remain up. | 1
+`idlethreshold`| [OPTIONAL] Maximum duration (in seconds) an agent can stay idle before being deleted. | 1800 (30 minutes)
+`overprovision`| [OPTIONAL] Number of extra agents to create when scaling out. | 0
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section.
 
 

--- a/stable/acs-engine-autoscaler/templates/deployment.yaml
+++ b/stable/acs-engine-autoscaler/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: client-private-key
+        - name: CA_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: ca-private-key
         command:
             - python
             - main.py
@@ -53,15 +58,23 @@ spec:
             {{- end }}
             {{- if .Values.acsenginecluster.sleeptime }}
             - --sleep
-            - {{ .Values.acsenginecluster.sleeptime }}
+            - {{ .Values.acsenginecluster.sleeptime | quote }}
             {{- end }}
             {{- if .Values.acsenginecluster.ignorepools }}
-            - --ignore-pools
+            - --ignore-pools 
             - {{ .Values.acsenginecluster.ignorepools }}
             {{- end }}
             {{- if .Values.acsenginecluster.spareagents }}
-            - --spare-agents
-            - {{ .Values.acsenginecluster.spareagents }}
+            - --spare-agents 
+            - {{ .Values.acsenginecluster.spareagents | quote }}
+            {{- end }}
+            {{- if .Values.acsenginecluster.idlethreshold }}
+            - --idle-threshold 
+            - {{ .Values.acsenginecluster.idlethreshold | quote }}
+            {{- end }}
+            {{- if .Values.acsenginecluster.overprovision }}
+            - --over-provision 
+            - {{ .Values.acsenginecluster.overprovision | quote }}
             {{- end }}
             - -vvv
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/acs-engine-autoscaler/templates/secrets.yaml
+++ b/stable/acs-engine-autoscaler/templates/secrets.yaml
@@ -11,3 +11,4 @@ data:
   azure-sp-tenant-id: {{ default "MISSING" .Values.acsenginecluster.azuresptenantid | b64enc | quote }}
   kubeconfig-private-key: {{ default "MISSING" .Values.acsenginecluster.kubeconfigprivatekey | b64enc | quote }}
   client-private-key: {{ default "MISSING" .Values.acsenginecluster.clientprivatekey | b64enc | quote }}
+  ca-private-key: {{ default "MISSING" .Values.acsenginecluster.caprivatekey | b64enc | quote }}

--- a/stable/acs-engine-autoscaler/values.yaml
+++ b/stable/acs-engine-autoscaler/values.yaml
@@ -5,8 +5,8 @@ replicaCount: 1
 ## Image for kubernetes-acs-engine-autoscaler
 ## Will update the image and tag later
 image:
-  repository: ritazh/kubernetes-acs-engine-autoscaler
-  tag: 0.3.1
+  repository: wbuchwalter/kubernetes-acs-engine-autoscaler
+  tag: 2.0.0
   pullPolicy: IfNotPresent
 acsenginecluster:
   resourcegroup:
@@ -15,6 +15,7 @@ acsenginecluster:
   azuresptenantid:
   kubeconfigprivatekey:
   clientprivatekey:
+  caprivatekey:
   ## Optional parameter for deployment name if not using default
   #acsdeployment:
   ## Optional parameter for sleep time between scaling loops (default: 60)
@@ -23,4 +24,7 @@ acsenginecluster:
   #ignorepools:
   ## Optional parameter denominating number of nodes to spare in a pool after scaling
   #spareagents:
-
+  ## Optional parameter denominating the maximum duration (in seconds) an agent can stay idle before being deleted
+  #idlethreshold:
+  ## Optional parameter denominating the number of extra agents to create when scaling out
+  #overprovision:


### PR DESCRIPTION
Includes changes from https://github.com/kubernetes/charts/pull/1307, and add the new `caprivatekey` value.