### PR TITLE
Enabled NodePort for zipkin, grafana and prometheus.

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Istio Helm chart for Kubernetes
 name: istio
-version: 0.1.6-chart1
+version: 0.1.6-chart2
 appVersion: 0.1.6
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -148,7 +148,7 @@ addons:
     enabled: true
 
     service:
-      type: ClusterIP
+      type: NodePort
       externalPort: 9411
     
     deployment:
@@ -172,7 +172,7 @@ addons:
     enabled: true
     
     service:
-      type: ClusterIP
+      type: NodePort
       externalPort: 9090
       annotations:
         prometheus.io/scrape: 'true'
@@ -198,7 +198,7 @@ addons:
     enabled: true
     
     service:
-      type: ClusterIP
+      type: NodePort
       externalPort: 3000
     
     deployment:


### PR DESCRIPTION
Fixed https://github.com/kubernetes/charts/issues/1369

/cc @lachie83 