### PR TITLE
[stable/kubernetes-dashboard] Add RBAC support

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.1.1
+version: 0.2.0
 appVersion: 1.6.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -49,6 +49,9 @@ The following tables lists the configurable parameters of the kubernetes-dashboa
 | `ingress.enabled`     | Enable ingress controller resource | `false`                                                                  |
 | `ingress.hosts`       | Dashboard Hostnames                | `nil`                                                                    |
 | `ingress.tls`         | Ingress TLS configuration          | `[]`                                                                     |
+| `rbac.create`         | Create & use RBAC resources        | `false`                                                                  |
+| `rbac.serviceAccountName` |  ServiceAccount kubernetes-dashboard will use (ignored if rbac.create=true) | `default`        |
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         kubernetes.io/cluster-service: "true"
     spec:
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 10 }}
       containers:

--- a/stable/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/stable/kubernetes-dashboard/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/kubernetes-dashboard/templates/serviceaccount.yaml
+++ b/stable/kubernetes-dashboard/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end -}}

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -45,3 +45,12 @@ ingress:
   #   - secretName: kubernetes-dashboard-tls
   #     hosts:
   #       - kubernetes-dashboard.domain.com
+
+rbac:
+  ## If true, create & use RBAC resources
+  #
+  create: false
+
+  ## Ignored if rbac.create is true
+  #
+  serviceAccountName: default


### PR DESCRIPTION
Adds support in kubernetes-dashboard for RBAC.
Permissions sourced from https://github.com/kubernetes/dashboard/blob/master/src/deploy/kubernetes-dashboard.yaml and adjusted slightly.

setting rbac.enabled to true will create a rolebinding and service account.