### PR TITLE
feat(stable/etcd-operator): add support for supplying additional command args

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.3.2
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/templates/deployment.yaml
+++ b/stable/etcd-operator/templates/deployment.yaml
@@ -27,7 +27,11 @@ spec:
         command:
         - "/bin/sh"
         - "-c"
-        - "/usr/local/bin/etcd-operator --pv-provisioner={{ .Values.cluster.backup.provisioner }}"
+        - "/usr/local/bin/etcd-operator"
+        - "--pv-provisioner={{ .Values.cluster.backup.provisioner }}"
+{{- range $key, $value := .Values.commandArgs }}
+        - "--{{ $key }}={{ $value }}"
+{{- end }}
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -13,6 +13,12 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+
+## etcd-operator specific values
+## additional command arguments go here; will be translated to `--key=value` form
+commandArgs:
+  # analytics: true
+
 ## etcd-cluster specific values
 cluster:
   enabled: false


### PR DESCRIPTION
Adds support for supplying additional arguments to the `etcd-operator` command, i.e. for specifying different flags, backup methods, etc.