### PR TITLE
Add Stash chart

### DIFF
--- a/stable/stash/.helmignore
+++ b/stable/stash/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/stash/Chart.yaml
+++ b/stable/stash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: 'Stash by AppsCode - Backup your Kubernetes Volumes'
 name: stash
 version: 0.1.0
-appVersion: 0.3.0
+appVersion: 0.3.1
 home: https://github.com/appscode/stash
 icon: https://cdn.appscode.com/images/icon/stash.png
 sources:

--- a/stable/stash/Chart.yaml
+++ b/stable/stash/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+description: 'Stash by AppsCode - Backup your Kubernetes Volumes'
+name: stash
+version: 0.1.0
+appVersion: 0.3.0
+home: https://github.com/appscode/stash
+icon: https://cdn.appscode.com/images/icon/stash.png
+sources:
+  - https://github.com/appscode/stash
+maintainers:
+  - name: appscode
+    email: support@appscode.com

--- a/stable/stash/README.md
+++ b/stable/stash/README.md
@@ -42,7 +42,7 @@ The following tables lists the configurable parameters of the Stash chart and th
 | ------------------------ | ----------------------------------------------------------------- | ------------------ |
 | `replicaCount`           | Number of stash operator replicas to create (only 1 is supported) | `1`                |
 | `operator.image`         | operator container image                                          | `appscode/stash`   |
-| `operator.tag`           | operator container image tag                                      | `0.3.0`            |
+| `operator.tag`           | operator container image tag                                      | `0.3.1`            |
 | `operator.pullPolicy`    | operator container image pull policy                              | `IfNotPresent`     |
 | `pushgateway.image`      | Prometheus pushgateway container image                            | `prom/pushgateway` |
 | `pushgateway.tag`        | Prometheus pushgateway container image tag                        | `v0.4.0`           |

--- a/stable/stash/README.md
+++ b/stable/stash/README.md
@@ -1,0 +1,98 @@
+# Stash
+[Stash by AppsCode](https://github.com/appscode/stash) - Backup your Kubernetes Volumes
+## TL;DR;
+
+```bash
+$ helm install stable/stash
+```
+
+## Introduction
+
+This chart bootstraps a [Stash controller](https://github.com/appscode/stash) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.5+ 
+
+## Installing the Chart
+To install the chart with the release name `my-release`:
+```bash
+$ helm install stable/stash --name my-release
+```
+The command deploys Stash operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release`:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Stash chart and their default values.
+
+
+| Parameter                | Description                                                       | Default            |
+| ------------------------ | ----------------------------------------------------------------- | ------------------ |
+| `replicaCount`           | Number of stash operator replicas to create (only 1 is supported) | `1`                |
+| `operator.image`         | operator container image                                          | `appscode/stash`   |
+| `operator.tag`           | operator container image tag                                      | `0.3.0`            |
+| `operator.pullPolicy`    | operator container image pull policy                              | `IfNotPresent`     |
+| `pushgateway.image`      | Prometheus pushgateway container image                            | `prom/pushgateway` |
+| `pushgateway.tag`        | Prometheus pushgateway container image tag                        | `v0.4.0`           |
+| `pushgateway.pullPolicy` | Prometheus pushgateway container image pull policy                | `IfNotPresent`     |
+| `rbac.install`           | install required rbac service account, roles and rolebindings     | `false`            |
+| `rbac.apiVersion`        | rbac api version v1alpha1\|v1beta1                                | `v1beta1`          |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```bash
+$ helm install --name my-release --set image.tag=v0.2.1 stable/stash
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example:
+
+```bash
+$ helm install --name my-release --values values.yaml stable/stash
+```
+
+## RBAC
+By default the chart will not install the recommended RBAC roles and rolebindings.
+
+To determine if your cluster supports this running the following:
+
+```console
+$ kubectl api-versions | grep rbac
+```
+
+You also need to have the following parameter on the api server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)
+
+```
+--authorization-mode=RBAC
+```
+
+If the output contains "beta" or both "alpha" and "beta" you can may install with enabling the creating of rbac resources (see below).
+
+### Enable RBAC role/rolebinding creation
+
+To enable the creation of RBAC resources (On clusters with RBAC). Do the following:
+
+```console
+$ helm install --name my-release stable/stash --set rbac.install=true
+```
+
+### Changing RBAC manifest apiVersion
+
+By default the RBAC resources are generated with the "v1beta1" apiVersion. To use "v1alpha1" do the following:
+
+```console
+$ helm install --name my-release stable/stash --set rbac.install=true,rbac.apiVersion=v1alpha1
+```

--- a/stable/stash/README.md
+++ b/stable/stash/README.md
@@ -67,19 +67,19 @@ $ helm install --name my-release --values values.yaml stable/stash
 ## RBAC
 By default the chart will not install the recommended RBAC roles and rolebindings.
 
-To determine if your cluster supports this running the following:
-
-```console
-$ kubectl api-versions | grep rbac
-```
-
-You also need to have the following parameter on the api server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)
+You need to have the following parameter on the api server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)
 
 ```
 --authorization-mode=RBAC
 ```
 
-If the output contains "beta" or both "alpha" and "beta" you can may install with enabling the creating of rbac resources (see below).
+To determine if your cluster supports RBAC, run the the following command:
+
+```console
+$ kubectl api-versions | grep rbac
+```
+
+If the output contains "alpha" and/or "beta", you can may install the chart with RBAC enabled (see below).
 
 ### Enable RBAC role/rolebinding creation
 

--- a/stable/stash/templates/NOTES.txt
+++ b/stable/stash/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that Stash has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get deployments -l "release={{ .Release.Name }}, app={{ template "name" . }}"

--- a/stable/stash/templates/_helpers.tpl
+++ b/stable/stash/templates/_helpers.tpl
@@ -3,14 +3,14 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 45 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/stash/templates/_helpers.tpl
+++ b/stable/stash/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 45 -}}
+{{- end -}}

--- a/stable/stash/templates/cluster-role-binding.yaml
+++ b/stable/stash/templates/cluster-role-binding.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.rbac.install }}
+{{- $serviceName := include "fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "name" . }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ $serviceName }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $serviceName }}
+{{ end }}

--- a/stable/stash/templates/cluster-role.yaml
+++ b/stable/stash/templates/cluster-role.yaml
@@ -49,22 +49,4 @@ rules:
   resources:
   - pods
   verbs: ["list", delete"]
----
-apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
-kind: ClusterRoleBinding
-metadata:
-  name: {{ $serviceName }}
-  labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    app: "{{ template "name" . }}"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-subjects:
-- kind: ServiceAccount
-  name: {{ $serviceName }}
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ $serviceName }}
 {{ end }}

--- a/stable/stash/templates/deployment.yaml
+++ b/stable/stash/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
       - args:
         - run
         - --v=3
-        image: '{{.Values.operator.image}}:{{.Values.operator.tag}}'
-        imagePullPolicy: '{{.Values.operator.pullPolicy}}'
+        image: '{{ .Values.operator.image }}:{{ .Values.operator.tag }}'
+        imagePullPolicy: '{{ .Values.operator.pullPolicy }}'
         name: operator
         ports:
         - containerPort: 56790
@@ -33,8 +33,8 @@ spec:
       - args:
         - -web.listen-address=:56789
         - -persistence.file=/var/pv/pushgateway.dat
-        image: '{{.Values.pushgateway.image}}:{{.Values.pushgateway.tag}}'
-        imagePullPolicy: '{{.Values.pushgateway.pullPolicy}}'
+        image: '{{ .Values.pushgateway.image }}:{{ .Values.pushgateway.tag }}'
+        imagePullPolicy: '{{ .Values.pushgateway.pullPolicy }}'
         name: pushgateway
         ports:
         - containerPort: 56789

--- a/stable/stash/templates/deployment.yaml
+++ b/stable/stash/templates/deployment.yaml
@@ -8,13 +8,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 spec:
-  replicas: {{.Values.replicaCount}}
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         app: "{{ template "name" . }}"
-        heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
     spec:
 {{- if .Values.rbac.install }}

--- a/stable/stash/templates/deployment.yaml
+++ b/stable/stash/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "name" . }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  replicas: {{.Values.replicaCount}}
+  template:
+    metadata:
+      labels:
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        app: "{{ template "name" . }}"
+        heritage: "{{ .Release.Service }}"
+        release: "{{ .Release.Name }}"
+    spec:
+{{- if .Values.rbac.install }}
+      serviceAccountName: {{ template "fullname" . }}
+{{- end }}
+      containers:
+      - args:
+        - run
+        - --v=3
+        image: '{{.Values.operator.image}}:{{.Values.operator.tag}}'
+        imagePullPolicy: '{{.Values.operator.pullPolicy}}'
+        name: operator
+        ports:
+        - containerPort: 56790
+          name: http
+          protocol: TCP
+        terminationMessagePolicy: File
+      - args:
+        - -web.listen-address=:56789
+        - -persistence.file=/var/pv/pushgateway.dat
+        image: '{{.Values.pushgateway.image}}:{{.Values.pushgateway.tag}}'
+        imagePullPolicy: '{{.Values.pushgateway.pullPolicy}}'
+        name: pushgateway
+        ports:
+        - containerPort: 56789
+          name: pushgateway
+          protocol: TCP
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/pv
+          name: data-volume
+        - mountPath: /tmp
+          name: stash-scratchdir
+      volumes:
+        - emptyDir: {}
+          name: data-volume
+        - emptyDir: {}
+          name: stash-scratchdir

--- a/stable/stash/templates/rbac.yaml
+++ b/stable/stash/templates/rbac.yaml
@@ -1,0 +1,70 @@
+{{ if .Values.rbac.install }}
+{{- $serviceName := include "fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+kind: ClusterRole
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "name" . }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - thirdpartyresources
+  verbs: ["get", "create"]
+- apiGroups:
+  - stash.appscode.com
+  resources:
+  - restics
+  verbs: ["*"]
+- apiGroups:
+  - extensions
+  resources:
+  - deployments
+  - replicasets
+  - daemonsets
+  verbs: ["list", "watch", "update"]
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs: ["list", "watch", "update"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - replicationcontrollers
+  verbs: ["list", "watch", "update"]
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get"]
+- apiGroups: [""]
+  resources:
+  - events
+  verbs: ["create"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", delete"]
+---
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "name" . }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ $serviceName }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $serviceName }}
+{{ end }}

--- a/stable/stash/templates/service-account.yaml
+++ b/stable/stash/templates/service-account.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.rbac.install }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "name" . }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{ end }}

--- a/stable/stash/templates/service.yaml
+++ b/stable/stash/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: "{{ template "name" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+  - name: pushgateway
+    port: 56789
+    protocol: TCP
+    targetPort: pushgateway
+  - name: http
+    port: 56790
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: "{{ template "name" . }}"
+    release: "{{ .Release.Name }}"

--- a/stable/stash/values.yaml
+++ b/stable/stash/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 operator:
   image: appscode/stash
   pullPolicy: IfNotPresent
-  tag: 0.3.0
+  tag: 0.3.1
 pushgateway:
   image: prom/pushgateway
   pullPolicy: IfNotPresent

--- a/stable/stash/values.yaml
+++ b/stable/stash/values.yaml
@@ -1,0 +1,16 @@
+# Default values for stash.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+operator:
+  image: appscode/stash
+  pullPolicy: IfNotPresent
+  tag: 0.3.0
+pushgateway:
+  image: prom/pushgateway
+  pullPolicy: IfNotPresent
+  tag: v0.4.0
+## Install Default RBAC roles and bindings
+rbac:
+  install: false
+  apiVersion: v1beta1


### PR DESCRIPTION
[Stash](https://github.com/appscode/stash) is a Kubernetes operator for [restic](https://github.com/restic/restic). Using Stash, you can backup Kubernetes volumes mounted in following types of workloads:
- Deployment
- DaemonSet
- ReplicaSet
- ReplicationController
- StatefulSet

Backed up files can be stored in various cloud storage provider, including S3, GCS, Azure, OpenStack Swift etc.