### PR TITLE
Fix influxdb deployment

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 0.4.1
+version: 0.4.2
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:
 - influxdb

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -23,23 +23,23 @@ spec:
         ports:
         - name: api
           containerPort: {{ .Values.config.http.bind_address }}
-        {{- if .Values.config.admin.enabled -}}
+        {{ if .Values.config.admin.enabled -}}
         - name: admin
           containerPort: {{ .Values.config.admin.bind_address }}
         {{- end }}
-        {{- if .Values.config.graphite.enabled -}}
+        {{ if .Values.config.graphite.enabled -}}
         - name: graphite
           containerPort: {{ .Values.config.graphite.bind_address }}
         {{- end }}
-        {{- if .Values.config.collectd.enabled -}}
+        {{ if .Values.config.collectd.enabled -}}
         - name: collectd
           containerPort: {{ .Values.config.collectd.bind_address }}
         {{- end }}
-        {{- if .Values.config.udp.enabled -}}
+        {{ if .Values.config.udp.enabled -}}
         - name: udp
           containerPort: {{ .Values.config.udp.bind_address }}
         {{- end }}
-        {{- if .Values.config.opentsdb.enabled -}}
+        {{ if .Values.config.opentsdb.enabled -}}
         - name: opentsdb
           containerPort: {{ .Values.config.opentsdb.bind_address }}
         {{- end }}


### PR DESCRIPTION
Previously, setting `config.graphite.enabled` (or other such
parameters) to `true` resulted in a yaml syntax error because the
content within the `{{- if` block would be appended to the previous
line due to the hyphen.