### PR TITLE
[stable/prometheus] Allow explicit NodePort value for prometheus

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.3.0
+version: 4.4.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -165,6 +165,7 @@ Parameter | Description | Default
 `server.service.externalIPs` | Prometheus server service external IP addresses | `[]`
 `server.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `server.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`server.service.nodePort` | Port to be used as the service NodePort (ignored if `server.service.type` is not `NodePort`) | `0`
 `server.service.servicePort` | Prometheus server service port | `80`
 `server.service.type` | type of Prometheus server service to create | `ClusterIP`
 `server.terminationGracePeriodSeconds` | Prometheus server Pod termination grace period | `300`

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -37,6 +37,9 @@ spec:
       port: {{ .Values.server.service.servicePort }}
       protocol: TCP
       targetPort: 9090
+    {{- if .Values.server.service.nodePort }}
+      nodePort: {{ .Values.server.service.nodePort }}
+    {{- end }}
   selector:
     app: {{ template "prometheus.name" . }}
     component: "{{ .Values.server.name }}"


### PR DESCRIPTION
Currently, if one wants prometheus running as a NodePort service one is stuck with whatever port is dynamically assigned when the service starts. This PR allows the explicit specification of the NodePort port with the `server.service.nodePort` value.