### PR TITLE
added override to use the right persistent volume

### DIFF
--- a/incubator/kafka/templates/kafka-ss.yaml
+++ b/incubator/kafka/templates/kafka-ss.yaml
@@ -112,7 +112,7 @@ spec:
         command:
         - sh
         - -c
-        - "./bin/kafka-server-start.sh config/server.properties --override zookeeper.connect={{ printf "%s-zookeeper-%s" .Release.Name .Values.zookeeper.Name | trunc 63 }}:2181/ --override broker.id=${HOSTNAME##*-}"
+        - "./bin/kafka-server-start.sh config/server.properties --override zookeeper.connect={{ printf "%s-zookeeper-%s" .Release.Name .Values.zookeeper.Name | trunc 63 }}:2181/ --override log.dirs={{ printf "%s" .Values.DataDirectory | trunc 63 }} --override broker.id=${HOSTNAME##*-}"
         volumeMounts:
         - name: datadir
           mountPath: "{{ .Values.DataDirectory }}"

--- a/incubator/kafka/templates/kafka-ss.yaml
+++ b/incubator/kafka/templates/kafka-ss.yaml
@@ -112,7 +112,7 @@ spec:
         command:
         - sh
         - -c
-        - "./bin/kafka-server-start.sh config/server.properties --override zookeeper.connect={{ printf "%s-zookeeper-%s" .Release.Name .Values.zookeeper.Name | trunc 63 }}:2181/ --override log.dirs={{ printf "%s" .Values.DataDirectory | trunc 63 }} --override broker.id=${HOSTNAME##*-}"
+        - "./bin/kafka-server-start.sh config/server.properties --override zookeeper.connect={{ printf "%s-zookeeper-%s" .Release.Name .Values.zookeeper.Name | trunc 63 }}:2181/ --override log.dirs={{ printf "%s/logs" .Values.DataDirectory | trunc 63 }} --override broker.id=${HOSTNAME##*-}"
         volumeMounts:
         - name: datadir
           mountPath: "{{ .Values.DataDirectory }}"


### PR DESCRIPTION
The kafka command line use the log.dirs from the server.properties which put the logs (data) into /tmp/kafka-logs by default.
As we want to use the persistent volume mounted in the container (defined in the value file to /opt/kafka/data), I added an override on the command line.