### PR TITLE
[stable/nginx-ingress] update version to 0.9.0-beta.11

### DIFF
--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -5,7 +5,7 @@ controller:
   name: controller
   image:
     repository: gcr.io/google_containers/nginx-ingress-controller
-    tag: "0.9.0-beta.7"
+    tag: "0.9.0-beta.11"
     pullPolicy: IfNotPresent
 
   config: {}


### PR DESCRIPTION
This update contains a fix for NGINX [CVE-2017-7529](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7529)
