### PR TITLE
[stable/traefik] Give traefik access to secrets, as in its official repo

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.7.0
+version: 1.7.1
 appVersion: 1.3.1
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/rbac.yaml
+++ b/stable/traefik/templates/rbac.yaml
@@ -15,6 +15,7 @@ rules:
       - pods
       - services
       - endpoints
+      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
See https://github.com/containous/traefik/commit/ca5bbab20a661b3b3810aeba84f2169322c88fd4

Traefik pod may end up in an error loop otherwise.