### PR TITLE
[stable/grafana] Remove path from ingress specification to allow other paths (e.g., /l…

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.4.0
+version: 0.4.1
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/ingress.yaml
+++ b/stable/grafana/templates/ingress.yaml
@@ -21,8 +21,7 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: /
-            backend:
+          - backend:
               serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
               servicePort: {{ $servicePort }}
   {{- end -}}


### PR DESCRIPTION
…ogin) to work.

This is the same pattern as prometheus
https://github.com/kubernetes/charts/blob/master/stable/prometheus/templates/server-ingress.yaml