### PR TITLE
[stable/grafana] Improve curl invocation

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.3.6
+version: 0.3.7
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/job.yaml
+++ b/stable/grafana/templates/job.yaml
@@ -34,8 +34,8 @@ spec:
               key: grafana-admin-password
         args:
           - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/datasources"
-          - "-X"
-          - POST
+          - "--max-time"
+          - "10"
           - "-H"
           - "Content-Type: application/json;charset=UTF-8"
           - "--data-binary"


### PR DESCRIPTION
- Remove `-X POST` since it is redundant with `--data-binary` (curl
  warns about this when invoked with `-v`)
- Use `--max-time 10` to timeout/retry faster (When the Job is
  created at nearly the same time as the Deployment, it has a
  tendency to block for a long time on the first run before failing
  and retrying)