### PR TITLE
update pilot svc name to default for nicer UX

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Istio Helm chart for Kubernetes
 name: istio
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.1.6
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png

--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Istio Helm chart for Kubernetes
 name: istio
-version: 0.2.2
+version: 0.3.0
 appVersion: 0.1.6
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png

--- a/incubator/istio/README.md
+++ b/incubator/istio/README.md
@@ -109,11 +109,11 @@ $ helm install incubator/istio --name my-release -f values.yaml
 
 ## Custom ConfigMap
 
-When creating a new chart with this chart as a dependency, CustomConfigMap can be used to override the default config.xml provided. To use, set the value to true and provide the file `templates/configmap.yaml` for your use case. If you start by copying `configmap.yaml` from this chart and want to access values from this chart you must change all references from `.Values` to `.Values.istio`.
+When creating a new chart with this chart as a dependency, customConfigMap can be used to override the default config map provided. To use, set the value to true and provide the file `templates/configmap.yaml` for your use case. If you start by copying `configmap.yaml` from this chart and want to access values from this chart you must change all references from `.Values` to `.Values.istio`.
 
 ```
 pilot:
-  CustomConfigMap: true
+  customConfigMap: true
 ```
 
 ### Addons

--- a/incubator/istio/README.md
+++ b/incubator/istio/README.md
@@ -107,6 +107,15 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 $ helm install incubator/istio --name my-release -f values.yaml
 ```
 
+## Custom ConfigMap
+
+When creating a new chart with this chart as a dependency, CustomConfigMap can be used to override the default config.xml provided. To use, set the value to true and provide the file `templates/configmap.yaml` for your use case. If you start by copying `configmap.yaml` from this chart and want to access values from this chart you must change all references from `.Values` to `.Values.istio`.
+
+```
+pilot:
+  CustomConfigMap: true
+```
+
 ### Addons
 Istio ships with several preconfigured addons
 * Grafana

--- a/incubator/istio/templates/NOTES.txt
+++ b/incubator/istio/templates/NOTES.txt
@@ -47,4 +47,4 @@ Or deploy the BookInfo App!
 
 Using Istioctl
 
-  istioctl --configAPIService {{ $serviceName }}-{{ .Values.pilot.name }}:{{ .Values.pilot.service.externalHttpApiServer }} [command]
+  istioctl [command]

--- a/incubator/istio/templates/configmap.yaml
+++ b/incubator/istio/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
 {{ if .Values.auth.enabled }}
     authPolicy: MUTUAL_TLS
 {{ end }}
-    mixerAddress: {{ $serviceName }}-mixer:{{ .Values.mixer.service.externalTcpPort }}
-    discoveryAddress: {{ $serviceName }}-pilot:{{ .Values.pilot.service.externalHttpDiscovery }}
+    mixerAddress: {{ $serviceName }}-{{ .Values.mixer.deployment.name }}:{{ .Values.mixer.service.externalTcpPort }}
+    discoveryAddress: {{ .Values.pilot.name }}:{{ .Values.pilot.service.externalHttpDiscovery }}
     ingressService: istio-ingress
     zipkinAddress: {{ $serviceName }}-zipkin:{{ .Values.addons.zipkin.service.externalPort }}

--- a/incubator/istio/templates/configmap.yaml
+++ b/incubator/istio/templates/configmap.yaml
@@ -1,5 +1,5 @@
-{{- $serviceName := include "fullname" . -}}
 {{- if not .Values.pilot.CustomConfigMap }}
+{{- $serviceName := include "fullname" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/incubator/istio/templates/configmap.yaml
+++ b/incubator/istio/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- $serviceName := include "fullname" . -}}
+{{- if not .Values.pilot.CustomConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
     discoveryAddress: {{ .Values.pilot.name }}:{{ .Values.pilot.service.externalHttpDiscovery }}
     ingressService: istio-ingress
     zipkinAddress: {{ $serviceName }}-{{ .Values.addons.zipkin.deployment.name }}:{{ .Values.addons.zipkin.service.externalPort }}
+{{- end -}}

--- a/incubator/istio/templates/configmap.yaml
+++ b/incubator/istio/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.pilot.CustomConfigMap }}
+{{- if not .Values.pilot.customConfigMap }}
 {{- $serviceName := include "fullname" . -}}
 apiVersion: v1
 kind: ConfigMap

--- a/incubator/istio/templates/configmap.yaml
+++ b/incubator/istio/templates/configmap.yaml
@@ -13,4 +13,4 @@ data:
     mixerAddress: {{ $serviceName }}-{{ .Values.mixer.deployment.name }}:{{ .Values.mixer.service.externalTcpPort }}
     discoveryAddress: {{ .Values.pilot.name }}:{{ .Values.pilot.service.externalHttpDiscovery }}
     ingressService: istio-ingress
-    zipkinAddress: {{ $serviceName }}-zipkin:{{ .Values.addons.zipkin.service.externalPort }}
+    zipkinAddress: {{ $serviceName }}-{{ .Values.addons.zipkin.deployment.name }}:{{ .Values.addons.zipkin.service.externalPort }}

--- a/incubator/istio/templates/mixer-svc.yaml
+++ b/incubator/istio/templates/mixer-svc.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
     istio: {{ $serviceName }}-{{ .Values.mixer.deployment.name }}
+  annotations:
+    {{- range $key, $value := .Values.mixer.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.mixer.service.type }}
   ports:

--- a/incubator/istio/templates/pilot-svc.yaml
+++ b/incubator/istio/templates/pilot-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $serviceName }}-{{ .Values.pilot.name }}
+  name: {{ .Values.pilot.name }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
     istio: {{ $serviceName }}-{{ .Values.pilot.name }}

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -36,7 +36,7 @@ mixer:
 
 ## Pilot configuration
 pilot:
-  name: pilot
+  name: istio-pilot
 
   service:
     type: ClusterIP

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -38,6 +38,7 @@ mixer:
 ## Pilot configuration
 pilot:
   name: istio-pilot
+  CustomConfigMap: false
 
   service:
     type: ClusterIP

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -15,6 +15,7 @@ mixer:
 
   service:
     type: ClusterIP
+    annotations: {}
     externalTcpPort: 9091
     externalConfigApiPort: 9094
     externalPrometheusPort: 42422

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -38,7 +38,7 @@ mixer:
 ## Pilot configuration
 pilot:
   name: istio-pilot
-  CustomConfigMap: false
+  customConfigMap: false
 
   service:
     type: ClusterIP


### PR DESCRIPTION
This updates the chart to use the default svc name of isito-pilot for a nicer UX when using istioctl

Also updates service names in the configmap and allows the mixer svc to have annotations