### PR TITLE
[stable/sentry] Pass environment variables with email return address and TLS config values

### DIFF
--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -55,6 +55,10 @@ spec:
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
           value: {{ default "" .Values.email.port | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
         - name: SENTRY_EMAIL_USER
           value: {{ default "" .Values.email.user | quote }}
         - name: SENTRY_EMAIL_PASSWORD

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -58,6 +58,10 @@ spec:
           value: {{ default "" .Values.smtpHost | quote }}
         - name: SENTRY_EMAIL_PORT
           value: {{ default "" .Values.smtpPort | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
         - name: SENTRY_EMAIL_USER
           value: {{ default "" .Values.smtpUser | quote }}
         - name: SENTRY_EMAIL_PASSWORD

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -57,6 +57,10 @@ spec:
           value: {{ default "" .Values.smtpHost | quote }}
         - name: SENTRY_EMAIL_PORT
           value: {{ default "" .Values.smtpPort | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
         - name: SENTRY_EMAIL_USER
           value: {{ default "" .Values.smtpUser | quote }}
         - name: SENTRY_EMAIL_PASSWORD

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -54,6 +54,10 @@ spec:
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
           value: {{ default "" .Values.email.port | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
         - name: SENTRY_EMAIL_USER
           value: {{ default "" .Values.email.user | quote }}
         - name: SENTRY_EMAIL_PASSWORD

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -55,6 +55,10 @@ spec:
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
           value: {{ default "" .Values.email.port | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
         - name: SENTRY_EMAIL_USER
           value: {{ default "" .Values.email.user | quote }}
         - name: SENTRY_EMAIL_PASSWORD


### PR DESCRIPTION
The [configuration docs in the readme](https://github.com/kubernetes/charts/blob/master/stable/sentry/README.md#configuration) specify `email.from_address` and `email.use_tls` values, but they were not being passed to the Sentry container. I added environment variables for each.

Fixes #1328