### PR TITLE
[stable/jenkins] Add serviceAccountName to deployment when RBAC enabled

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.8.2
+version: 0.8.3
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -61,6 +61,7 @@ spec:
       {{- end }}
       securityContext:
         runAsUser: 0
+      serviceAccountName: {{ if .Values.rbac.install }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ template "fullname" . }}
           image: "{{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}"

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -119,6 +119,7 @@ NetworkPolicy:
 ## Install Default RBAC roles and bindings
 rbac:
   install: false
+  serviceAccount: default
   # RBAC api version (currently either v1beta1 or v1alpha1)
   apiVersion: v1beta1
   # Cluster role reference


### PR DESCRIPTION
When you set `rbac.install: true` for Jenkins it currently creates a service account but then doesn't actually assign the service account to the Jenkins deployment. The causes RBAC DENY errors and breaks the jenkins kubernetes plugin.

This branch adds the `serviceAccountName` to the deployment so that everything works as expected without needing manual edits to the deployment.

I tested a fresh installation with the update and everything is working as expected.

I assumed that the chart version number needs to be bumped, but let me know if I should remove that. I bumped it from 0.8.1 to 0.8.2.

I'm not sure about upgrading, I am not able to get an upgrade working because helm doesn't seem to detect that adding a serviceAccountName requires an update to the deployment. When I do `helm upgrade --dry-run --debug` I see the `serviceAccountName` in the YAML output, but then when I actually run it the default service account is still on the deployment.  Is this a bug in helm itself? In the tiller logs it just says `Looks like there are no changes for Deployment "jenkins-jenkins"`.