### PR TITLE
[stable/spinnaker] Update to latest images & use /gate as gateHost for maximal compatibility

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.3.0
+version: 0.3.1
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
 version: 0.3.1
+appVersion: 1.1.0
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -8,5 +8,5 @@ sources:
 - https://github.com/viglesiasce/images
 icon: https://pbs.twimg.com/profile_images/669205226994319362/O7OjwPrh_400x400.png
 maintainers:
-- name: Vic Iglesias
+- name: viglesiasce
   email: viglesias@google.com

--- a/stable/spinnaker/templates/configmap/spinnaker-config.yaml
+++ b/stable/spinnaker/templates/configmap/spinnaker-config.yaml
@@ -171,7 +171,7 @@ data:
     'use strict';
 
     var feedbackUrl = 'http://localhost';
-    var gateHost = '{{ .Values.deck.protocol }}://{{ .Values.deck.host }}:{{ .Values.deck.port }}/gate';
+    var gateHost = '/gate';
     var bakeryDetailUrl = gateHost + '/bakery/logs/global/{{ "{{ " }}context.status.id{{ " }}" }}';
 
     window.spinnakerSettings = {

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -31,14 +31,14 @@ mail:
 
 # Images for each component
 images:
-  clouddriver: quay.io/spinnaker/clouddriver:v1.599.0
-  echo: quay.io/spinnaker/echo:v1.132.0
-  deck: quay.io/spinnaker/deck:v2.1095.0
-  igor: quay.io/spinnaker/igor:v1.65.0
-  orca: quay.io/spinnaker/orca:v1.395.2
-  gate: quay.io/spinnaker/gate:v3.28.0
-  front50: quay.io/spinnaker/front50:v1.90.0
-  rosco: quay.io/spinnaker/rosco:v0.93.0
+  clouddriver: gcr.io/spinnaker-marketplace/clouddriver:0.5.0-72
+  echo: gcr.io/spinnaker-marketplace/echo:0.4.0-72
+  deck: gcr.io/spinnaker-marketplace/deck:1.3.0-72
+  igor: gcr.io/spinnaker-marketplace/igor:0.4.0-72
+  orca: gcr.io/spinnaker-marketplace/orca:0.5.0-72
+  gate: gcr.io/spinnaker-marketplace/gate:0.5.0-72
+  front50: gcr.io/spinnaker-marketplace/front50:0.4.1-72
+  rosco: gcr.io/spinnaker-marketplace/rosco:0.4.0-72
 
 # Change this if youd like to expose Spinnaker outside the cluster
 deck:


### PR DESCRIPTION
When accessing Spinnaker via Deck the most accurate URL to use for the gateHost is just /gate so that it uses the URL that you are accessing Deck from.