### PR TITLE
[datadog] Add kube-state-metrics autoconf by default

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.7.0
+version: 0.7.1
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -79,14 +79,13 @@ datadog:
   ## Each key will become a file in /conf.d/auto_conf
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
   ##
-  # autoconf:
-  #   redisdb.yaml: |-
-  #     docker_images:
-  #       - redis
-  #     init_config:
-  #     instances:
-  #       - host: "%%host%%"
-  #         port: "%%port%%"
+  autoconf:
+    kubernetes_state.yaml: |-
+      docker_images:
+        - kube-state-metrics
+      init_config:
+      instances:
+        - kube_state_url: http://%%host%%:%%port%%/metrics
 
   ## Provide additonal service definitions
   ## Each key will become a file in /conf.d


### PR DESCRIPTION
Now that the chart runs kube-state-metrics by default we should include an auto config template for it as well.

Might help with #1466 as well.