### PR TITLE
Initial version of NATS

### DIFF
--- a/incubator/nats/.helmignore
+++ b/incubator/nats/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/nats/Chart.yaml
+++ b/incubator/nats/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: NATS high performance messaging system for cloud native applications, IoT messaging, and microservices architectures
+name: nats
+version: 0.1.0

--- a/incubator/nats/README.md
+++ b/incubator/nats/README.md
@@ -1,0 +1,83 @@
+# NATS
+
+[NATS](https://nats.io/) is a simple, high performance open source messaging system for cloud native applications, IoT messaging, and microservices architectures.
+
+## TL;DR;
+
+```console
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm install incubator/nats
+```
+
+## Introduction
+
+This chart bootstraps a [NATS](https://nats.io/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.5+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm install --name my-release incubator/nats
+```
+
+The command deploys NATS on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the NATS chart and their default values.
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+Parameter                   | Description                              | Default            |
+--------------------------- | ---------------------------------------- | -------------------
+`replicaCount`              | Number of StatefulSet replicas           | `3`                |
+`image.repository`          | Path to Docker image repository          | `gabrtv/nats`      |
+`image.tag`                 | Docker image tag                         | `0.9.6`            |
+`image.pullPolicy`          | Pull policy for Docker image             | `IfNotPresent`     |
+`service.client.type`       | Kubernetes service type (client)         | `ClusterIP`        |
+`service.client.port`       | Kubernetes service port (client)         | `4222`             |
+`service.client.name`       | Kubernetes service name (client)         | `nats`             |
+`service.cluster.type`      | Kubernetes service type (cluster)        | `None`             |
+`service.cluster.port`      | Kubernetes service port (cluster)        | `6222`             |
+`service.cluster.name`      | Kubernetes service name (cluster)        | `nats-cluster`     |
+`service.management.type`   | Kubernetes service type (management)     | `ClusterIP`        |
+`service.management.port`   | Kubernetes service port (management)     | `8222`             |
+`service.management.name`   | Kubernetes service name (management)     | `nats-mgmt`        |
+`ingress.enabled`           | Enable ingress for web management        | `false`            |
+`ingress.hosts[N]`          | Ingress hostnames for web management     | `nats.example.com` |
+`ingress.annotations`       | Ingress annotations (used for ACME)      | empty              |
+`ingress.tls`               | Ingress TLS configuration                | empty              |
+`resources.limits.cpu`      | CPU resource limits                      | `100m`             |
+`resources.requests.cpu`    | CPU resource requests                    | `100m`             |
+`resources.limits.memory`   | Memory resource limits                   | `128Mi`            |
+`resources.requests.memory` | Memory resource requests                 | `128Mi`            |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install stable/nats --name my-release --set ingress.enabled=true,ingress.hosts[0]=nats.gabrtv.io
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install incubator/nats --name my-release -f values.yaml
+```

--- a/incubator/nats/templates/NOTES.txt
+++ b/incubator/nats/templates/NOTES.txt
@@ -1,0 +1,8 @@
+
+Wait for NATS to bootstrap {{ .Values.replicaCount }} pods with:
+kubectl get po -n {{ .Release.Namespace }} -w
+
+Once NATS is running, access the NATS client port via the internal Kubernetes service: 
+{{ template "fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.client.port }}
+
+{{ if eq .Values.ingress.enabled true }}Optionally, explore the NATS management dashboard at: {{- range $index, $host := .Values.ingress.hosts }} http://{{ $host }} {{- end }}{{ end }}

--- a/incubator/nats/templates/_helpers.tpl
+++ b/incubator/nats/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/nats/templates/ingress.yaml
+++ b/incubator/nats/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.management.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}-mgmt
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/incubator/nats/templates/service-client.yaml
+++ b/incubator/nats/templates/service-client.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.client.type }}
+  ports:
+  - port: {{ .Values.service.client.port }}
+    targetPort: {{ .Values.service.client.port }}
+    protocol: TCP
+    name: {{ .Values.service.client.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/incubator/nats/templates/service-cluster.yaml
+++ b/incubator/nats/templates/service-cluster.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-cluster
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  clusterIP: {{ .Values.service.cluster.type }}
+  ports:
+  - port: {{ .Values.service.cluster.port }}
+    targetPort: {{ .Values.service.cluster.port }}
+    protocol: TCP
+    name: {{ .Values.service.cluster.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/incubator/nats/templates/service-mgmt.yaml
+++ b/incubator/nats/templates/service-mgmt.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-mgmt
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.management.type }}
+  ports:
+  - port: {{ .Values.service.management.port }}
+    targetPort: {{ .Values.service.management.port }}
+    protocol: TCP
+    name: {{ .Values.service.management.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/incubator/nats/templates/statefulset.yaml
+++ b/incubator/nats/templates/statefulset.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  serviceName: {{ template "fullname" . }}-cluster
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - "/bin/sh"
+        - "-ec"
+        - |
+          /gnatsd -c gnatsd.conf -D \
+          -cluster nats://${HOSTNAME}.{{ template "fullname" . }}-cluster.{{.Release.Namespace}}.svc.cluster.local:6222 \
+          -routes nats://{{ template "fullname" . }}-0.{{ template "fullname" . }}-cluster.{{.Release.Namespace}}.svc.cluster.local:6222
+        ports:
+        - containerPort: {{ .Values.service.client.port }}
+          name: {{ .Values.service.client.name }}
+        - containerPort: {{ .Values.service.cluster.port }}
+          name: {{ .Values.service.cluster.name }}
+        - containerPort: {{ .Values.service.management.port }}
+          name: {{ .Values.service.management.name }}          
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.service.client.port }}
+          initialDelaySeconds: 3
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.service.client.port }}
+          initialDelaySeconds: 5
+          periodSeconds: 20
+        resources:
+{{ toYaml .Values.resources | indent 10 }}

--- a/incubator/nats/values.yaml
+++ b/incubator/nats/values.yaml
@@ -1,0 +1,42 @@
+# Default values for nats.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 3
+image:
+  repository: gabrtv/nats
+  tag: 0.9.6
+  pullPolicy: IfNotPresent
+service:
+  client:
+    type: ClusterIP
+    port: 4222
+    name: nats
+  cluster:
+    type: None
+    port: 6222
+    name: nats-cluster
+  management:
+    type: ClusterIP
+    port: 8222
+    name: nats-mgmt
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - nats.example.com
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+


### PR DESCRIPTION
This PR adds a NATS chart that uses StatefulSet to provide clustering support.  Besides general testing, I see at least two things that must to be improved before this chart can graduate to stable:

1. **Use a blessed NATS Docker image** - Due to the `StatefulSet` patterns for registering nodes in quorum-based systems, we need shell interpolation support in the Docker image.  Unfortunately, the current NATS Docker image is built `FROM scratch` without a shell.  I will discuss adding shell interpolation support with the NATS folks, so I can remove my personal image as the default.
2. **Add Authorization support** - NATS supports [authorization](http://nats.io/documentation/server/gnatsd-authorization/) for the client and cluster ports. Writing a configuration file via a template appears to be the best approach.  This should be added ASAP.

That said, this chart works well for me as-is, so PR'ing it now.
