### PR TITLE
allow the grafana service annotations to be customised

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.3.7
+version: 0.4.0
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -43,3 +43,4 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.resources`                     | Server resource requests and limits | requests: {cpu: 100m, memory: 100Mi}              |
 | `server.serviceType`                   | ClusterIP, NodePort, or LoadBalancer| ClusterIP                                         |
 | `server.setDatasource.enabled`         | Creates grafana datasource with job | false                                             |
+| `server.service.annotations`           | Service annotations                 | null                                              |

--- a/stable/grafana/templates/svc.yaml
+++ b/stable/grafana/templates/svc.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.server.service.annotations }}
+  annotations:
+{{ toYaml .Values.server.service.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -111,6 +111,11 @@ server:
   ##
   serviceType: ClusterIP
 
+  ## Grafana service annotations
+  ##
+  service:
+    annotations: {}
+
   ## Load balancer IP address
   ## Is not required, but allows for static address with
   ## serviceType LoadBalancer.


### PR DESCRIPTION
In a similar way to the prometheus chart, allow the service annotations to be specified.  This lets us use an internal aws load balancer, for example, by specifying: service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0