### PR TITLE
[stable/kube2iam] feature: allow setting of no-value arguments (flags)

### DIFF
--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -42,6 +42,7 @@ The following tables lists the configurable parameters of the kube2iam chart and
 Parameter | Description | Default
 --- | --- | ---
 `extraArgs` | Additional container arguments | `{}`
+`extraFlags` | Additional container arguments (flags without values)| `[]`
 `host.ip` | IP address of host | `$(HOST_IP)`
 `host.iptables` | Add iptables rule | `false`
 `host.interface` | Host interface for proxying AWS metadata | `docker0`
@@ -59,7 +60,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install stable/kube2iam --name my-release \
-  --set=extraArgs.base-role-arn=arn:aws:iam::0123456789:role/,extraArgs.default-role=kube2iam-default,host.iptables=true,host.interface=cbr0
+  --set=extraArgs.base-role-arn=arn:aws:iam::0123456789:role/,extraArgs.default-role=kube2iam-default,host.iptables=true,host.interface=cbr0,extraFlags.0=auto-discover-base-arn
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -36,6 +36,9 @@ spec:
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
+          {{- range .Values.extraFlags }}
+            - --{{ . }}
+          {{- end }}
           {{- if .Values.verbose }}
             - --verbose
           {{- end }}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -4,6 +4,10 @@ extraArgs: {}
 #   api-server: ...
 #   api-token: ...
 
+extraFlags: []
+  # - auto-discover-base-arn
+  # - auto-discover-default-role
+
 host:
   ip: $(HOST_IP)
   iptables: false


### PR DESCRIPTION
A bunch of options are available, but with no values needs - they are just flags.
This PR adds support for specifying these.