### PR TITLE
Concourse 3.3.0 and GitLab Auth configuration for main team

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.2.0
+version: 0.3.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -111,6 +111,12 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `concourse.githubAuthAuthUrl` | Override default endpoint AuthURL for Github Enterprise | `nil` |
 | `concourse.githubAuthTokenUrl` | Override default endpoint TokenURL for Github Enterprise | `nil` |
 | `concourse.githubAuthApiUrl` | Override default API endpoint URL for Github Enterprise | `nil` |
+| `concourse.gitlabAuthClientId` | Application client ID for enabling GitLab OAuth | `nil` |
+| `concourse.gitlabAuthClientSecret` | Application client secret for enabling GitLab OAuth | `nil` |
+| `concourse.gitlabAuthGroup` | GitLab groups (comma separated) whose members will have access | `nil` |
+| `concourse.gitlabAuthAuthUrl` | Endpoint AuthURL for GitLab server | `nil` |
+| `concourse.gitlabAuthTokenUrl` | Endpoint TokenURL for GitLab server | `nil` |
+| `concourse.gitlabAuthApiUrl` | API endpoint URL for GitLab server | `nil` |
 | `concourse.genericOauthDisplayName` | Name for this auth method on the web UI | `nil` |
 | `concourse.genericOauthClientId` | Application client ID for enabling generic OAuth | `nil` |
 | `concourse.genericOauthClientSecret` | Application client secret for enabling generic OAuth | `nil` |

--- a/stable/concourse/templates/configmap.yaml
+++ b/stable/concourse/templates/configmap.yaml
@@ -27,6 +27,10 @@ data:
   github-auth-auth-url: {{ default "" .Values.concourse.githubAuthAuthUrl | quote }}
   github-auth-token-url: {{ default "" .Values.concourse.githubAuthTokenUrl | quote }}
   github-auth-api-url: {{ default "" .Values.concourse.githubAuthApiUrl | quote }}
+  gitlab-auth-group: {{ default "" .Values.concourse.gitlabAuthGroup | quote }}
+  gitlab-auth-auth-url: {{ default "" .Values.concourse.gitlabAuthAuthUrl | quote }}
+  gitlab-auth-token-url: {{ default "" .Values.concourse.gitlabAuthTokenUrl | quote }}
+  gitlab-auth-api-url: {{ default "" .Values.concourse.gitlabAuthApiUrl | quote }}
   generic-oauth-display-name: {{ default "" .Values.concourse.genericOauthDisplayName | quote }}
   generic-oauth-auth-url: {{ default "" .Values.concourse.genericOauthAuthUrl | quote }}
   generic-oauth-auth-url-param: {{ default "" .Values.concourse.genericOauthAuthUrlParam | quote }}

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -23,5 +23,7 @@ data:
   worker-key-pub: {{ .Values.concourse.workerKeyPub | b64enc | quote }}
   github-auth-client-id: {{ default "" .Values.concourse.githubAuthClientId | b64enc | quote }}
   github-auth-client-secret: {{ default "" .Values.concourse.githubAuthClientSecret | b64enc | quote }}
+  gitlab-auth-client-id: {{ default "" .Values.concourse.gitlabAuthClientId | b64enc | quote }}
+  gitlab-auth-client-secret: {{ default "" .Values.concourse.gitlabAuthClientSecret | b64enc | quote }}
   generic-oauth-client-id: {{ default "" .Values.concourse.genericOauthClientId | b64enc | quote }}
   generic-oauth-client-secret: {{ default "" .Values.concourse.genericOauthClientSecret | b64enc | quote }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -155,6 +155,38 @@ spec:
                 configMapKeyRef:
                   name: {{ template "concourse.fullname" . }}
                   key: github-auth-api-url
+            - name: CONCOURSE_GITLAB_AUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.fullname" . }}
+                  key: gitlab-auth-client-id
+            - name: CONCOURSE_GITLAB_AUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.fullname" . }}
+                  key: gitlab-auth-client-secret
+            {{- if .Values.concourse.gitlabAuthGroup }}
+            - name: CONCOURSE_GITLAB_AUTH_GROUP
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.fullname" . }}
+                  key: gitlab-auth-group
+            {{- end }}
+            - name: CONCOURSE_GITLAB_AUTH_AUTH_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.fullname" . }}
+                  key: gitlab-auth-auth-url
+            - name: CONCOURSE_GITLAB_AUTH_TOKEN_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.fullname" . }}
+                  key: gitlab-auth-token-url
+            - name: CONCOURSE_GITLAB_AUTH_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.fullname" . }}
+                  key: gitlab-auth-api-url
             - name: CONCOURSE_GENERIC_OAUTH_DISPLAY_NAME
               valueFrom:
                 configMapKeyRef:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -215,6 +215,30 @@ concourse:
   ##
   # githubAuthApiUrl:
 
+  ## Application client ID for enabling GitLab OAuth.
+  ##
+  # gitlabAuthClientId:
+
+  ## Application client secret for enabling GitLab OAuth.
+  ##
+  # gitlabAuthClientSecret:
+
+  ## GitLab Group (comma separated) whose members will have access.
+  ##
+  # gitlabAuthGroup:
+
+  ## Endpoint AuthURL for Gitlab server.
+  ##
+  # gitlabAuthAuthUrl:
+
+  ## Endpoint TokenURL for Gitlab server.
+  ##
+  # gitlabAuthTokenUrl:
+
+  ## API endpoint URL for Github server.
+  ##
+  # gitlabAuthApiUrl:
+
   ## Name for this auth method on the web UI.
   ##
   # genericOauthDisplayName:


### PR DESCRIPTION
[Concourse 3.3.0](http://concourse.ci/downloads.html#v330) introduced GitLab OAuth provider support (similar to GitHub auth provider). 

This PR contains the config changes to provide the ability to set GitLab auth configuration for the Concourse main team

Updated README.md and values.yml with placeholders

Deployed and tested helm chart on GKE k8s 1.6.4 using Concourse 3.3.0 and GitLab CE 8.17.4.

See related:
- http://concourse.ci/downloads.html#v330
- https://github.com/concourse/atc/pull/172