### PR TITLE
[stable/jenkins] Fix ingress host http path (GKE)

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.8.1
+version: 0.8.2
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -12,7 +12,7 @@ spec:
   - host: {{ .Values.Master.HostName | quote }}
     http:
       paths:
-      - path: /
+      - path: /*
         backend:
           serviceName: {{ template "fullname" . }}
           servicePort: {{ .Values.Master.ServicePort }}


### PR DESCRIPTION
Apart from manually redefining the health check in order to hit the `/login` endpoint.
This is also needed to properly route to the right `backend service` (tested in GKE).