### PR TITLE
[dask-distributed] Allow the service type to be changed to something else than LoadBalancer

### DIFF
--- a/stable/dask-distributed/Chart.yaml
+++ b/stable/dask-distributed/Chart.yaml
@@ -1,5 +1,5 @@
 name: dask-distributed
-version: 1.16.3
+version: 1.16.4
 description: Distributed computation in Python
 home: https://github.com/dask/distributed
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200

--- a/stable/dask-distributed/templates/dask-jupyter-service.yaml
+++ b/stable/dask-distributed/templates/dask-jupyter-service.yaml
@@ -16,4 +16,4 @@ spec:
     app: {{ template "name" . }}
     release: {{ .Release.Name | quote }}
     component: "{{ .Release.Name }}-{{ .Values.jupyter.component }}"
-  type: "LoadBalancer"
+  type: {{ .Values.jupyter.serviceType }}

--- a/stable/dask-distributed/templates/dask-scheduler-service.yaml
+++ b/stable/dask-distributed/templates/dask-scheduler-service.yaml
@@ -20,4 +20,4 @@ spec:
     app: {{ template "name" . }}
     release: {{ .Release.Name | quote }}
     component: "{{ .Release.Name }}-{{ .Values.scheduler.component }}"
-  type: "LoadBalancer"
+  type: {{ .Values.scheduler.serviceType }}

--- a/stable/dask-distributed/values.yaml
+++ b/stable/dask-distributed/values.yaml
@@ -11,6 +11,7 @@ scheduler:
   imageTag: "latest"
   replicas: 1
   component: "dask-scheduler"
+  serviceType: "LoadBalancer"
   servicePort: 8786
   containerPort: 8786
   resources: {}
@@ -47,6 +48,7 @@ jupyter:
   imageTag: "11be019e4079"
   replicas: 1
   component: "jupyter-notebook"
+  serviceType: "LoadBalancer"
   servicePort: 80
   containerPort: 8888
   password: 'sha1:aae8550c0a44:9507d45e087d5ee481a5ce9f4f16f37a0867318c'  # 'dask'


### PR DESCRIPTION
Not everybody wants the services to be exposed publicly.

I prefer ssh port-forwarding so I am going to use ClusterIP and this change will allow me do that.

The defaults were not changed.