### PR TITLE
[stable/kube2iam] Allow user-managed RBAC

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.3.2
+version: 0.4.0
 description: Provide IAM credentials to pods based on annotations.
 keywords:
   - kube2iam

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -50,10 +50,12 @@ Parameter | Description | Default
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to be added to pods | `{}`
+`rbac.create` | If true, create & use RBAC resources | `false`
+`rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `resources` | pod resource requests & limits | `{}`
 `verbose` | Enable verbose output | `false`
-`rbac.enabled` | Enable role and serviceaccount creation | `false`
 `updateStrategy` | The strategy for daemon set updates, e.g. `RollingUpdate` (requires Kubernetes 1.6+) | not set
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube2iam/templates/clusterrole.yaml
+++ b/stable/kube2iam/templates/clusterrole.yaml
@@ -12,6 +12,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - namespaces
       - pods
     verbs:
       - list

--- a/stable/kube2iam/templates/clusterrole.yaml
+++ b/stable/kube2iam/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -9,11 +9,11 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "fullname" . }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - watch
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - watch
 {{- end -}}

--- a/stable/kube2iam/templates/clusterrolebinding.yaml
+++ b/stable/kube2iam/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -18,11 +18,6 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
-{{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ template "fullname" . }}
-{{- else }}
-      serviceAccountName: default
-{{- end }}
       containers:
         - name: kube2iam
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -51,12 +46,13 @@ spec:
         {{- if .Values.host.iptables }}
           securityContext:
             privileged: true
-          {{- end }}
+        {{- end }}
       hostNetwork: true
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
   {{- if .Values.updateStrategy }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}

--- a/stable/kube2iam/templates/serviceaccount.yaml
+++ b/stable/kube2iam/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -23,6 +23,15 @@ nodeSelector: {}
 ##
 podAnnotations: {}
 
+rbac:
+  ## If true, create & use RBAC resources
+  ##
+  create: false
+
+  ## Ignored if rbac.create is true
+  ##
+  serviceAccountName: default
+
 resources: {}
   # limits:
   #   cpu: 4m
@@ -31,7 +40,5 @@ resources: {}
   #   cpu: 4m
   #   memory: 16Mi
 
-verbose: false
 
-rbac:
-  enabled: false
+verbose: false


### PR DESCRIPTION
**Breaking change**

This renames `rbac.enabled` to `rbac.create`, indicating whether or not Helm should create & manage RBAC resources. Users may alternatively create & manage their own RBAC configuration, then specify the ServiceAccount to use (`rbac.serviceAccountName`).