### PR TITLE
[incubator/patroni] Fixed default persistentVolume.mountPath

### DIFF
--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -56,7 +56,7 @@ spec:
         - name: USE_WALE
           value: ""
         - name: PGROOT
-          value: /home/postgres/pgdata/pgroot
+          value: "{{ .Values.persistentVolume.mountPath }}/pgroot"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -37,7 +37,7 @@ persistentVolume:
   size: 1G
   storageClass: ""
   subPath: ""
-  mountPath: "/home/postgres/data"
+  mountPath: "/home/postgres/pgdata"
   annotations: {}
 
   accessModes:


### PR DESCRIPTION
In the file templates/statefulset-patroni.yaml environment variable PGROOT=/home/postgres/**pgdata**/pgroot, but in values.yaml persistentVolume.mountPath = /home/postgres/**data**. Therefore, by default, the postgres cluster files written to an internal container file system, not in persistentVolume.