### PR TITLE
[stable/kube2iam] Update strategy

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.4.0
+version: 0.5.0
 description: Provide IAM credentials to pods based on annotations.
 keywords:
   - kube2iam

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -53,8 +53,8 @@ Parameter | Description | Default
 `rbac.create` | If true, create & use RBAC resources | `false`
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `resources` | pod resource requests & limits | `{}`
+`updateStrategy` | Strategy for DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
 `verbose` | Enable verbose output | `false`
-`updateStrategy` | The strategy for daemon set updates, e.g. `RollingUpdate` (requires Kubernetes 1.6+) | not set
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
-  {{- if .Values.updateStrategy }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (gt .Capabilities.KubeVersion.Minor "5") }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
-  {{- end }}
+{{- end }}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -40,5 +40,9 @@ resources: {}
   #   cpu: 4m
   #   memory: 16Mi
 
+## Strategy for DaemonSet updates (requires Kubernetes 1.6+)
+## Ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+##
+updateStrategy: OnDelete
 
 verbose: false


### PR DESCRIPTION
This PR uses Helm's `.Capabilities` object to set the DaemonSet's UpdateStrategy if the cluster version is >= 1.6. The default strategy is `OnDelete`, which provides backwards compatibility.