### PR TITLE
Allow consul's gossip encryption to be turned off

### DIFF
--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -35,6 +35,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | `Cpu`                   | container requested cpu               | `100m`                                                     |
 | `DatacenterName`        | Consul Datacenter Name                | `dc1` (The consul default)                                 |
 | `DisableHostNodeId`     | Disable Node Id creation (uses random)| `false`                                                    |
+| `EncryptGossip`         | Whether or not gossip is encrypted    | `true`                                                     |
 | `Memory`                | container requested memory            | `512Mi`                                                    |
 | `Storage`               | Persistent volume size                | `1Gi`                                                      |
 | `StorageClass`          | Persistent volume storage class       | `nil`                                                      |

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -156,10 +156,12 @@ spec:
           - |
             IP=$(hostname -i)
 
+            {{- if .Values.EncryptGossip }}
             if [ -e /etc/consul/secrets/gossip-key ]; then
               echo "{\"encrypt\": \"$(base64 /etc/consul/secrets/gossip-key)\"}" > /etc/consul/encrypt.json
               GOSSIP_KEY="-config-file /etc/consul/encrypt.json"
             fi
+            {{- end }}
 
             for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
                 while true; do
@@ -190,7 +192,9 @@ spec:
               -bind=0.0.0.0 \
               -advertise=${IP} \
               ${PEERS} \
+            {{- if .Values.EncryptGossip }}
               ${GOSSIP_KEY} \
+            {{- end }}
               -client=0.0.0.0 \
               -dns-port=${DNSPORT}
       volumes:

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -32,6 +32,9 @@ DisableHostNodeId: false
 ## default 'dc1'
 # DatacenterName: dc1
 
+## Encrypt Gossip traffic
+EncryptGossip: true
+
 ## StorageClass name for use with Persistent Volume Claim (PVC) using beta notations
 # StorageClass:
 


### PR DESCRIPTION

Add value for turning consul's encryption off(enabled by default). This helps if joining a wan that doesn't already have encryption.

https://www.consul.io/docs/agent/encryption.html