### PR TITLE
[incubator/elasticsearch] Configure data anti-affinity policy.

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.1.6
+version: 0.1.7
 description: Flexible and powerful open source, distributed real-time search and analytics engine.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -72,6 +72,7 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `data.storage`                       | Data persistent volume size             | `30Gi`                              |
 | `data.storageClass`                  | Data persistent volume Class            | `nil`                               |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds) | `3600`                              |
+| `data.antiAffinity`                  | Data anti-affinity policy               | `soft`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/elasticsearch/templates/elasticsearch-client-deployment.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-client-deployment.yaml
@@ -32,6 +32,29 @@ spec:
         ]'
     spec:
       serviceAccountName: {{ template "fullname" . }}
+      {{- if eq .Values.client.antiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.client.name }}"
+      {{- else if eq .Values.client.antiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.client.name }}"
+      {{- end }}
       containers:
       - name: elasticsearch
         env:

--- a/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
@@ -34,6 +34,29 @@ spec:
         ]'
     spec:
       serviceAccountName: {{ template "fullname" . }}
+      {{- if eq .Values.data.antiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.data.name }}"
+      {{- else if eq .Values.data.antiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.data.name }}"
+      {{- end }}
       containers:
       - name: elasticsearch
         env:

--- a/incubator/elasticsearch/templates/elasticsearch-master-deployment.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-master-deployment.yaml
@@ -32,6 +32,29 @@ spec:
         ]'
     spec:
       serviceAccountName: {{ template "fullname" . }}
+      {{- if eq .Values.master.antiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.master.name }}"
+      {{- else if eq .Values.master.antiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.master.name }}"
+      {{- end }}
       containers:
       - name: elasticsearch
         env:

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -12,6 +12,7 @@ client:
   replicas: 2
   serviceType: ClusterIP
   heapSize: "128m"
+  antiAffinity: "soft"
   resources:
     limits:
       cpu: "1"
@@ -24,6 +25,7 @@ master:
   name: master
   replicas: 2
   heapSize: "128m"
+  antiAffinity: "soft"
   resources:
     limits:
       cpu: "1"

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -39,6 +39,7 @@ data:
   storage: "30Gi"
   # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600
+  antiAffinity: "soft"
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
So that elasticsearch data nodes can be configured to be scheduled to different hosts to avoid downtime during a rolling node restart. The default `soft` policy uses `preferredDuringSchedulingIgnoredDuringExecution` and makes a best-effort attempt to schedule pods on different hosts; the `hard` policy uses `requiredDuringSchedulingIgnoredDuringExecution` and will refuse to schedule pods on the same host.