### PR TITLE
stable/nginx-ingress: add optional controller.defaultSSLCertificate configuration value.

### DIFF
--- a/stable/nginx-ingress/templates/NOTES.txt
+++ b/stable/nginx-ingress/templates/NOTES.txt
@@ -46,6 +46,7 @@ An example Ingress that makes use of the controller:
                 servicePort: 80
               path: /
     # This section is only required if TLS is to be enabled for the Ingress
+    # secretName can be omitted if you have specified controller.defaultSSLCertificate
     tls:
         - hosts:
             - www.example.com

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -33,6 +33,9 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- if .Values.controller.defaultSSLCertificate }}
+            - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
+          {{- end }}
           {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "controller.publishServicePath" . }}
           {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -20,6 +20,11 @@ controller:
   ##
   defaultBackendService: ""
 
+  ## Optionally specify the secret name for default SSL certificate
+  ## Must be <namespace>/<secret_name>
+  ##
+  defaultSSLCertificate: ""
+
   ## Allows customization of the external service
   ## the ingress will be bound to via DNS
   publishService:


### PR DESCRIPTION
Useful if you want to use one certificate cluster-wide and do not want individual namespace admins having direct access to the ssl certificate secret.

I signed CNCF CLA on 19 July 2017.