### PR TITLE
Use ServicePort so tests continue to pass

### DIFF
--- a/stable/jenkins/templates/test-config.yaml
+++ b/stable/jenkins/templates/test-config.yaml
@@ -5,5 +5,5 @@ metadata:
 data:
   run.sh: |-
     @test "Testing Jenkins UI is accessible" {
-      curl --retry 12 --retry-delay 10 {{ .Release.Name }}-jenkins:8080/login
+      curl --retry 12 --retry-delay 10 {{ .Release.Name }}-jenkins:{{ .Values.Master.ServicePort }}/login
     }


### PR DESCRIPTION
Currently 'helm test' will fail if ServicePort is updated.  Have the test also use the variable.