### PR TITLE
Add persistence.existingClaim and persistence.subPath options to mysql chart

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.2.6
+version: 0.2.7
 description: Fast, reliable, scalable, and easy to use open-source relational database system.
 keywords:
 - mysql

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -56,6 +56,8 @@ The following tables lists the configurable parameters of the MySQL chart and th
 | `persistence.size`         | Size of persistent volume claim    | 8Gi RW                                                     |
 | `persistence.storageClass` | Type of persistent volume claim    | nil  (uses alpha storage class annotation)                 |
 | `persistence.accessMode`   | ReadWriteOnce or ReadOnly          | ReadWriteOnce                                              |
+| `persistence.existingClaim`| Name of existing persistent volume | `nil`
+| `persistence.subPath`      | Subdirectory of the volume to mount | `nil`
 | `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                              |
 
 Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
                   "volumeMounts": [
                       {
                           "name": "data",
+                          {{- if .Values.persistence.subPath }}
+                          "subPath": "{{ .Values.persistence.subPath }}",
+                          {{- end }}
                           "mountPath": "/var/lib/mysql"
                       }
                   ],
@@ -74,11 +77,14 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/mysql
+          {{- if .Values.persistence.subPath }}
+          subPath: {{ .Values.persistence.subPath }}
+          {{- end }}
       volumes:
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
+          claimName: {{ .Values.persistence.existingClaim | default (include "fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{- end -}}

--- a/stable/mysql/templates/pvc.yaml
+++ b/stable/mysql/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Add two new options to the `stable/mysql` chart:
* `persistence.exisitngClaim` - in case someone wants to use existing volume claim
* `persistence.subPath` - use subdirectory in the volume claim