### PR TITLE
Make the baggageclaim FS driver configurable.

### DIFF
--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -100,6 +100,7 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `concourse.resourceCheckingInterval` | Interval on which to check for new versions of resources | `1m` |
 | `concourse.oldResourceGracePeriod` | How long to cache the result of a get step after a newer version of the resource is found | `5m` |
 | `concourse.resourceCacheCleanupInterval` | The interval on which to check for and release old caches of resource versions | `30s` |
+| `concourse.baggageclaimDriver` | The filesystem driver used by baggageclaim | `naive` |
 | `concourse.externalURL` | URL used to reach any ATC from the outside world | `nil` |
 | `concourse.dockerRegistry` | An URL pointing to the Docker registry to use to fetch Docker images | `nil` |
 | `concourse.insecureDockerRegistry` | Docker registry(ies) (comma separated) to allow connecting to even if not secure | `nil` |
@@ -133,7 +134,7 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |
 | `persistence.worker.class` | Concourse Worker Persistent Volume Storage Class | `generic` |
 | `persistence.worker.accessMode` | Concourse Worker Persistent Volume Access Mode | `ReadWriteOnce` |
-| `persistence.worker.size` | Concourse Worker Persistent Volume Storage Size | `10Gi` |
+| `persistence.worker.size` | Concourse Worker Persistent Volume Storage Size | `20Gi` |
 | `postgresql.enabled` | Enable PostgreSQL as a chart dependency | `true` |
 | `postgresql.uri` | PostgreSQL connection URI | `nil` |
 | `postgresql.postgresUser` | PostgreSQL User to create | `concourse` |
@@ -229,7 +230,7 @@ persistence:
 
     ## Persistent Volume Storage Size.
     ##
-    size: "10Gi"
+    size: "20Gi"
 ```
 
 ### Ingress TLS

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -40,3 +40,7 @@
   Password: {{ .Values.concourse.password }}
 
 3. If this is your first time using Concourse, follow the tutorial at https://concourse.ci/hello-world.html
+{{- if contains "naive" .Values.concourse.baggageclaimDriver }}
+
+4. ***WARNING*** You are using the "naive" baggage claim driver, which is also the default value for this chart. This is the default for compatability reasons, but is very space inefficient, and should be changed to either "btrfs" or "overlay" depending on that filesystem's support in the Linux kernel your cluster is using. Please see https://github.com/concourse/concourse/issues/1230 for background.
+{{- end }}

--- a/stable/concourse/templates/configmap.yaml
+++ b/stable/concourse/templates/configmap.yaml
@@ -19,6 +19,7 @@ data:
   concourse-old-resource-grace-period: {{ .Values.concourse.oldResourceGracePeriod | quote }}
   concourse-resource-cache-cleanup-interval: {{ .Values.concourse.resourceCacheCleanupInterval | quote }}
   concourse-external-url: {{ default "" .Values.concourse.externalURL | quote }}
+  concourse-baggageclaim-driver: {{ .Values.concourse.baggageclaimDriver | quote }}
   garden-docker-registry: {{ default "" .Values.concourse.dockerRegistry | quote }}
   garden-insecure-docker-registry: {{ default "" .Values.concourse.insecureDockerRegistry | quote }}
   github-auth-organization: {{ default "" .Values.concourse.githubAuthOrganization | quote }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -75,6 +75,11 @@ spec:
               value: "/concourse-keys/worker_key"
             - name: CONCOURSE_WORK_DIR
               value: "/concourse-work-dir"
+            - name: CONCOURSE_BAGGAGECLAIM_DRIVER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.fullname" . }}
+                  key: concourse-baggageclaim-driver
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
           securityContext:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -13,7 +13,7 @@ image: concourse/concourse
 ## Concourse image version.
 ## ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "2.6.0"
+imageTag: "3.3.2"
 
 ## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
 ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -173,6 +173,13 @@ concourse:
   ## URL used to reach any ATC from the outside world.
   ##
   # externalURL:
+
+  ## The filesystem driver used by baggageclaim on workers, as of Concourse 3.1 can be values
+  ## "overlay", "btrfs", or "naive". "overlay" is more stable than "btrfs" but is not supported
+  ## on some Linux kernels, while "naive" is most supported but least space efficient. For background see
+  ## https://github.com/concourse/concourse/issues/1230.
+  ##
+  baggageclaimDriver: naive
 
   ## An URL pointing to the Docker registry to use to fetch Docker images.
   ## If unset, this will default to the Docker default
@@ -344,7 +351,7 @@ persistence:
 
     ## Persistent Volume Storage Size.
     ##
-    size: 10Gi
+    size: 20Gi
 
 ## Configuration values for the postgresql dependency.
 ## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md


### PR DESCRIPTION
Default to btrfs to retain backwards compatibility with Concourse versions before 3.1.

Also set the default persistent volume size to 20Gi, 10Gi will easily run out of space.

Helps address kernel compatiblity issues with FS drivers, see https://github.com/concourse/concourse/issues/1230.

Fixes #1479.