### PR TITLE
Correct Mistake in MariaDB CLI Command

### DIFF
--- a/stable/mariadb/templates/NOTES.txt
+++ b/stable/mariadb/templates/NOTES.txt
@@ -8,4 +8,4 @@ To connect to your database:
     kubectl run {{ template "fullname" . }}-client --rm --tty -i --image bitnami/mariadb --command -- bash
 
 2. Connect using the mysql cli, then provide your password:
-    $ mysql -h {{ template "fullname" . }} {{- if .Values.mariadbRootPassword }} -p {{ .Values.mariadbRootPassword }}{{- end -}}
+    $ mysql -h {{ template "fullname" . }} {{- if .Values.mariadbRootPassword }} -p{{ .Values.mariadbRootPassword }}{{- end -}}


### PR DESCRIPTION
There cannot be a space between `-p` and the password. This PR removes the space to correct the command used to connect to the MariaDB database.