### PR TITLE
[stable/redis] Add missing if statement for redis password for metrics sidecar

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.8.0
+version: 0.8.1
 appVersion: 3.2.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -65,11 +65,13 @@ spec:
         env:
         - name: REDIS_ALIAS
           value: {{ template "fullname" . }}
+        {{- if .Values.usePassword }}
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: redis-password
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 9121


### PR DESCRIPTION
Add check to see if `usePassword=true` for redis for the metrics sidecar. The metrics sidecar is currently failing if redis isn't using a password because the secret key cannot be found.