### PR TITLE
Fix: (sentry) user.email not used in user-create job

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.0
+version: 0.1.1
 keywords:
   - debugging
   - logging

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
       - name: user-create-job
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        command: ["sentry","createuser","--no-input","--email","admin@sentry.local", "--superuser","--password","$(SENTRY_USER_PASSWORD)"]
+        command: ["sentry","createuser","--no-input","--email", "{{ .Values.user.email }}", "--superuser","--password","$(SENTRY_USER_PASSWORD)"]
         env:
         - name: SENTRY_SECRET_KEY
           valueFrom:


### PR DESCRIPTION
When user.email is set in values.yaml, the created username is still admin@sentry.local