### PR TITLE
[stable/fluent-bit] release 0.1.4 (Fluent Bit 0.11.15)

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluent-bit
-version: 0.1.3
-appVersion: 0.11.12
+version: 0.1.4
+appVersion: 0.11.15
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
   - logging

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -5,7 +5,7 @@ on_minikube: false
 image:
   fluent_bit:
     repository: fluent/fluent-bit
-    tag: 0.11.12
+    tag: 0.11.15
   pullPolicy: IfNotPresent
 
 backend:


### PR DESCRIPTION
Updates:

- Bump Chart to 0.1.4
- Use latest Fluent Bit 0.11.15

Signed-off-by: Eduardo Silva <eduardo@treasure-data.com>