### PR TITLE
Bump Gitlab-CE version to 9.4.1

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,5 +1,5 @@
 name: gitlab-ce
-version: 0.1.8
+version: 0.1.9
 description: GitLab Community Edition
 keywords:
 - git

--- a/stable/gitlab-ce/values.yaml
+++ b/stable/gitlab-ce/values.yaml
@@ -1,7 +1,7 @@
 ## GitLab CE image
 ## ref: https://hub.docker.com/r/gitlab/gitlab-ce/tags/
 ##
-image: gitlab/gitlab-ce:9.1.0-ce.0
+image: gitlab/gitlab-ce:9.4.1-ce.0
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
I'm aware there's currently an issue open ( https://github.com/kubernetes/charts/issues/1138 ) relating to the ownership of Gitlab charts going forward given Gitlab now publishing official charts being maintained by them. 

However the current version used by the published chart is now one unpatched for a [serious security vulnerability](https://about.gitlab.com/2017/07/19/gitlab-9-dot-3-dot-8-released/) as well as numerous other improvements.

Matching EE version bump PR: https://github.com/kubernetes/charts/pull/1563

Tested on GKE.