### PR TITLE
Bump Gitlab-EE version to 9.4.1

### DIFF
--- a/stable/gitlab-ee/Chart.yaml
+++ b/stable/gitlab-ee/Chart.yaml
@@ -1,5 +1,5 @@
 name: gitlab-ee
-version: 0.1.7
+version: 0.1.8
 description: GitLab Enterprise Edition
 keywords:
 - git

--- a/stable/gitlab-ee/values.yaml
+++ b/stable/gitlab-ee/values.yaml
@@ -1,7 +1,7 @@
 ## GitLab EE image
 ## ref: https://hub.docker.com/r/gitlab/gitlab-ee/tags/
 ##
-image: gitlab/gitlab-ee:9.1.0-ee.0
+image: gitlab/gitlab-ee:9.4.1-ee.0
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
I'm aware there's currently an issue open ( https://github.com/kubernetes/charts/issues/1138 ) relating to the ownership of Gitlab charts going forward given Gitlab now publishing official charts being maintained by them. 

However the current version used by the published chart is now one unpatched for a [serious security vulnerability](https://about.gitlab.com/2017/07/19/gitlab-9-dot-3-dot-8-released/) as well as numerous other improvements.

Matching CE version bump PR: https://github.com/kubernetes/charts/pull/1562

Tested on GKE.