### PR TITLE
[stable/traefik] Fix a typo in RBAC (secret -> secrets)

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.7.1
+version: 1.7.2
 appVersion: 1.3.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/rbac.yaml
+++ b/stable/traefik/templates/rbac.yaml
@@ -15,7 +15,7 @@ rules:
       - pods
       - services
       - endpoints
-      - secret
+      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
This PR follows https://github.com/kubernetes/charts/pull/1485 and fixes a tiny typo we missed.