### PR TITLE
fix README: link to the used docker container

### DIFF
--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -3,7 +3,7 @@
 This image is using Fabric8's great [kubernetes discovery
 plugin](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) for
 elasticsearch and their
-[image](https://hub.docker.com/r/fabric8/elasticsearch-k8s/) as parent.
+[image](https://hub.docker.com/r/jetstack/elasticsearch-pet/) as parent.
 
 ## Prerequisites Details
 


### PR DESCRIPTION
Update the doc to point to the docker image used in https://github.com/kubernetes/charts/blob/master/incubator/elasticsearch/values.yaml#L6