### PR TITLE
Add weave-cortex chart

### DIFF
--- a/stable/weave-cortex/.helmignore
+++ b/stable/weave-cortex/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/weave-cortex/Chart.yaml
+++ b/stable/weave-cortex/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes that installs the components for running weave cortex locally without the need for weave cloud.
+name: weave-cortex
+version: 0.1.0

--- a/stable/weave-cortex/README.md
+++ b/stable/weave-cortex/README.md
@@ -1,0 +1,308 @@
+#Cortex
+This is a chart to install cortex into a kubernetes cluster locally, without the dependency on the weave-cloud. 
+
+Below is the list of properties that can be configured through the values.yaml,
+or  through --set <oroperty>=<value>  when installing the helm chart.
+
+When using this deployment you may want to set the ip address of your clusters DNS service.
+If you are getting errors with nginx finding services, then this is likely the cause.
+You can use the following command to get your clusters kube-dns ip address.
+```
+kubectl get service kube-dns --namespace kube-system -o jsonpath={.spec.clusterIP}
+```
+
+Then on helm install you may set the ``nginx.http.resolverAddress`` the the ip of your DNS.
+
+If you would like to use an s3 bucket from amazon, then you may also update the S3 URI,
+and disable the fakeS3 service.
+
+Set ``fakeS3.enabled=false``, and set ``global.s3URI=<your S3 bucket>``
+
+### global
+|Property|Default Value|
+|---|---|
+|global.s3URI|"s3://abc:123@s3.default.svc.cluster.local:4569"|
+|global.dynamoDBURI|"dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000"|
+|global.consulURI|"consul.default.svc.cluster.local:8500"|
+|global.memcachedURI|"memcached.default.svc.cluster.local"|
+|global.memcachedTimeout|"100ms"|
+|global.memcachedService|"memcached"|
+|global.configDbURI|"postgres://postgres@configs-db.default.svc.cluster.local/configs?sslmode=disable"|
+|global.configs|"http://configs.default.svc.cluster.local:80"|
+|global.alertmanagerURI|"http://alertmanager.default.svc.cluster.local/api/prom/alertmanager/"|
+### alertmanager
+|Property|Default Value|
+|---|---|
+|alertmanager.image.repository|"quay.io/weaveworks/cortex-alertmanager"|
+|alertmanager.image.tag|"master-0a92a540"|
+|alertmanager.image.imagePullPolicy|"IfNotPresent"|
+|alertmanager.listenPort|80|
+|alertmanager.servicePort|80|
+|alertmanager.configURL|"http://configs.default.svc.cluster.local:80"|
+|alertmanager.externalURI|"/api/prom/alertmanager"|
+|alertmanager.loglevel|"debug"|
+### postgressConfigDB
+|Property|Default Value|
+|---|---|
+|postgressConfigDB.servicePort|5432|
+|postgressConfigDB.listenPort|5432|
+|postgressConfigDB.image.repository|"postgres"|
+|postgressConfigDB.image.tag|9.6|
+|postgressConfigDB.image.pullPolicy|"IfNotPresent"|
+### cortexConfigs
+|Property|Default Value|
+|---|---|
+|cortexConfigs.listenPort|80|
+|cortexConfigs.servicePort|80|
+|cortexConfigs.migrationsURI|"/migrations"|
+|cortexConfigs.image.repository|"quay.io/weaveworks/cortex-configs"|
+|cortexConfigs.image.tag|"master-eb4b2116"|
+|cortexConfigs.image.pullPolicy|"IfNotPresent"|
+### consul
+|Property|Default Value|
+|---|---|
+|consul.serverNoScrapePort|8300|
+|consul.serfNoScrapePort|8301|
+|consul.clientNoScrapePort|8400|
+|consul.httpNoScrapePort|8500|
+|consul.serviceHttpPort|8500|
+|consul.image.repository|"consul"|
+|consul.image.tag|"0.7.1"|
+|consul.image.pullPolicy|"IfNotPresent"|
+### distributor
+|Property|Default Value|
+|---|---|
+|distributor.logLevel|"debug"|
+|distributor.listenPort|80|
+|distributor.servicePort|80|
+|distributor.consulHostName|"consul.default.svc.cluster.local"|
+|distributor.replicationFactor|1|
+|distributor.image.repository|"quay.io/weaveworks/cortex-distributor"|
+|distributor.image.tag|"master-eb4b2116"|
+|distributor.image.pullPolicy|"IfNotPresent"|
+### dynamodb
+|Property|Default Value|
+|---|---|
+|dynamodb.listenPort|8000|
+|dynamodb.servicePort|8000|
+|dynamodb.image.repository|"deangiberson/aws-dynamodb-local"|
+|dynamodb.image.tag|"latest"|
+|dynamodb.image.pullPolicy|"IfNotPresent"|
+### ingester
+|Property|Default Value|
+|---|---|
+|ingester.replicas|1|
+|ingester.minReadySeconds|60|
+|ingester.joinAfter|"30s"|
+|ingester.claimOnRollout|false|
+|ingester.terminationGracePeriodSeconds|2400|
+|ingester.listenPort|80|
+|ingester.servicePort|80|
+|ingester.strategy.rollingUpdateMaxSurge|0|
+|ingester.strategy.rollingUpdateMinAvailable|1|
+|ingester.image.repository|"quay.io/weaveworks/cortex-ingester"|
+|ingester.image.tag|"master-747f3493"|
+|ingester.image.pullPolicy|"IfNotPresent"|
+### memcached
+|Property|Default Value|
+|---|---|
+|memcached.replicas|1|
+|memcached.maxMemMB|64|
+|memcached.listenPort|11211|
+|memcached.servicePort|11211|
+|memcached.image.repository|"memcached"|
+|memcached.image.tag|"1.4.25"|
+|memcached.image.pullPolicy|"IfNotPresent"|
+### nginx
+|Property|Default Value|
+|---|---|
+|nginx.replicas|1|
+|nginx.listenPort|80|
+|nginx.servicePort|80|
+|nginx.serviceType|"NodePort"|
+|nginx.nodePort|30080|
+|nginx.image.repository|"nginx"|
+|nginx.image.tag|"latest"|
+|nginx.image.pullPolicy|"IfNotPresent"|
+|nginx.config.workerProcesses|5|
+|nginx.config.errorLog|"/dev/stderr"|
+|nginx.config.pid|"nginx.pid"|
+|nginx.config.workerRLimitNoFile|8192|
+|nginx.config.workerConnections|4096|
+|nginx.config.http.sendfile|true|
+|nginx.config.http.tcpNoPush|true|
+|nginx.config.http.resolverAddress|"10.0.0.10"|
+|nginx.config.server.listenPort|80|
+|nginx.config.server.pushPassthroughURI|"http://distributor.default.svc.cluster.local"|
+|nginx.config.server.queryPassthroughURI|"http://querier.default.svc.cluster.local"|
+### querier
+|Property|Default Value|
+|---|---|
+|querier.replicas|1|
+|querier.listenPort|80|
+|querier.servicePort|80|
+|querier.image.repository|"quay.io/weaveworks/cortex-querier"|
+|querier.image.tag|"master-eb4b2116"|
+|querier.image.pullPolicy|"IfNotPresent"|
+### ruler
+|Property|Default Value|
+|---|---|
+|ruler.replicas|1|
+|ruler.logLevel|"debug"|
+|ruler.listenPort|80|
+|ruler.servicePort|80|
+|ruler.image.repository|"quay.io/weaveworks/cortex-ruler"|
+|ruler.image.tag|"master-eb4b2116"|
+|ruler.image.pullPolicy|"IfNotPresent"|
+### fakeS3
+|Property|Default Value|
+|---|---|
+|fakeS3.enabled|true|
+|fakeS3.replicas|1|
+|fakeS3.listenPort|4569|
+|fakeS3.servicePort|4569|
+|fakeS3.image.repository|"lphoward/fake-s3"|
+|fakeS3.image.tag|"latest"|
+|fakeS3.image.pullPolicy|"IfNotPresent"|
+### tableManager
+|Property|Default Value|
+|---|---|
+|tableManager.replicas|1|
+|tableManager.listenPort|80|
+|tableManager.servicePort|80|
+|tableManager.image.repository|"quay.io/weaveworks/cortex-table-manager"|
+|tableManager.image.tag|"master-d18915fb"|
+|tableManager.image.pullPolicy|"IfNotPresent"|
+### retrieval
+|Property|Default Value|
+|---|---|
+|retrieval.replicas|1|
+|retrieval.listenPort|80|
+|retrieval.servicePort|80|
+|retrieval.image.repository|"prom/prometheus"|
+|retrieval.image.tag|"v1.4.1"|
+|retrieval.image.pullPolicy|"IfNotPresent"|
+
+Retrieval is a configured prometheus instance with the following config.
+The config can be changed by overriding the  ```retrieval.configFiles``` in the values.yaml
+
+```
+prometheus.yml: |-
+      global:
+        scrape_interval: 30s # By default, scrape targets every 15 seconds.
+
+      remote_write:
+        url: http://nginx.default.svc.cluster.local:80/api/prom/push
+
+      scrape_configs:
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+          - role: pod
+
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # You can specify the following annotations (on pods):
+        #   prometheus.io.scrape: false - don't scrape this pod
+        #   prometheus.io.scheme: https - use https for scraping
+        #   prometheus.io.port - scrape this port
+        #   prometheus.io.path - scrape this path
+        relabel_configs:
+
+        # Always use HTTPS for the api server
+        - source_labels: [__meta_kubernetes_service_label_component]
+          regex: apiserver
+          action: replace
+          target_label: __scheme__
+          replacement: https
+
+        # Drop anything annotated with prometheus.io.scrape=false
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: drop
+          regex: false
+
+        # Drop any endpoint who's pod port name ends with -noscrape
+        - source_labels: [__meta_kubernetes_pod_container_port_name]
+          action: drop
+          regex: .*-noscrape
+
+        # Allow pods to override the scrape scheme with prometheus.io.scheme=https
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+          action: replace
+          target_label: __scheme__
+          regex: ^(https?)$
+          replacement: $1
+
+        # Allow service to override the scrape path with prometheus.io.path=/other_metrics_path
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: ^(.+)$
+          replacement: $1
+
+        # Allow services to override the scrape port with prometheus.io.port=1234
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          target_label: __address__
+          regex: (.+?)(\:\d+)?;(\d+)
+          replacement: $1:$3
+
+        # Drop pods without a name label
+        - source_labels: [__meta_kubernetes_pod_label_name]
+          action: drop
+          regex: ^$
+
+        # Rename jobs to be <namespace>/<name, from pod name label>
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_name]
+          action: replace
+          separator: /
+          target_label: job
+          replacement: $1
+
+        # Rename instances to be the pod name
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: instance
+
+        # Include node name as a extra field
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: node
+
+      # This scrape config gather all nodes
+      - job_name: 'kubernetes-nodes'
+        kubernetes_sd_configs:
+          - role: node
+
+        # couldn't get prometheus to validate the kublet cert for scraping, so don't bother for now
+        tls_config:
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        relabel_configs:
+        - target_label: __scheme__
+          replacement: https
+        - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+          target_label: instance
+
+      # This scrape config just pulls in the default/kubernetes service
+      - job_name: 'kubernetes-service'
+        kubernetes_sd_configs:
+          - role: endpoints
+
+        tls_config:
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_service_label_component]
+          regex: apiserver
+          action: keep
+
+        - target_label: __scheme__
+          replacement: https
+
+        - source_labels: []
+          target_label: job
+          replacement: default/kubernetes
+```

--- a/stable/weave-cortex/templates/_helpers.tpl
+++ b/stable/weave-cortex/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cortex.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cortex.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/weave-cortex/templates/alertmanager-dep.yaml
+++ b/stable/weave-cortex/templates/alertmanager-dep.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: alertmanager
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: alertmanager
+        app: {{ template "cortex.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: alertmanager
+        image: {{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}
+        imagePullPolicy: {{ .Values.alertmanager.image.imagePullPolicy }}
+        args:
+        - -log.level={{ .Values.alertmanager.loglevel }}
+        - -server.http-listen-port={{ .Values.alertmanager.listenPort }}
+        - -alertmanager.configs.url={{ .Values.alertmanager.configURL }}
+        - -alertmanager.web.external-url={{ .Values.alertmanager.externalURI }}
+        ports:
+        - containerPort: {{ .Values.alertmanager.listenPort }}

--- a/stable/weave-cortex/templates/alertmanager-svc.yaml
+++ b/stable/weave-cortex/templates/alertmanager-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.alertmanager.servicePort }}
+      targetPort: {{ .Values.alertmanager.listenPort }}
+  selector:
+    name: alertmanager
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/configs-db-dep.yaml
+++ b/stable/weave-cortex/templates/configs-db-dep.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: configs-db
+  namespace: default
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: configs-db
+        release: {{ .Release.Name }}
+      annotations:
+        prometheus.io.scrape: "false"
+    spec:
+      containers:
+      - name: configs-db
+        image: {{ .Values.postgressConfigDB.image.repository }}:{{ .Values.postgressConfigDB.image.tag }}
+        imagePullPolicy: {{ .Values.postgressConfigDB.image.pullPolicy }}
+        env:
+          - name: POSTGRES_DB
+            value: configs
+        ports:
+        - containerPort: {{ .Values.postgressConfigDB.listenPort }}

--- a/stable/weave-cortex/templates/configs-db-svc.yaml
+++ b/stable/weave-cortex/templates/configs-db-svc.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: configs-db
+  namespace: default
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.postgressConfigDB.servicePort }}
+      targetPort: {{ .Values.postgressConfigDB.listenPort }}
+  selector:
+    name: configs-db
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/configs-dep.yaml
+++ b/stable/weave-cortex/templates/configs-dep.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: configs
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: configs
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: configs
+        image: {{ .Values.cortexConfigs.image.repository }}:{{ .Values.cortexConfigs.image.tag }}
+        imagePullPolicy: {{ .Values.cortexConfigs.image.pullPolicy }}
+        args:
+        - -server.http-listen-port={{ .Values.cortexConfigs.listenPort }}
+        - -database.uri={{ .Values.global.configDbURI }}
+        - -database.migrations={{ .Values.cortexConfigs.migrationsURI }}
+        ports:
+        - containerPort: {{ .Values.cortexConfigs.listenPort }}

--- a/stable/weave-cortex/templates/configs-svc.yaml
+++ b/stable/weave-cortex/templates/configs-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: configs
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.cortexConfigs.servicePort }}
+      targetPort: {{ .Values.cortexConfigs.listenPort }}
+  selector:
+    name: configs
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/consul-dep.yaml
+++ b/stable/weave-cortex/templates/consul-dep.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: consul
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: consul
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: consul
+        image: {{ .Values.consul.image.repository }}:{{ .Values.consul.image.tag }}
+        imagePullPolicy: {{ .Values.consul.image.pullPolicy }}
+        args:
+        - agent
+        - -ui
+        - -server
+        - -client=0.0.0.0
+        - -bootstrap
+        env:
+        - name: CHECKPOINT_DISABLE
+          value: "1"
+        ports:
+        - name: server-noscrape
+          containerPort: {{ .Values.consul.serverNoScrapePort }}
+        - name: serf-noscrape
+          containerPort: {{ .Values.consul.serfNoScrapePort }}
+        - name: client-noscrape
+          containerPort: {{ .Values.consul.clientNoScrapePort }}
+        - name: http-noscrape
+          containerPort: {{ .Values.consul.httpNoScrapePort }}

--- a/stable/weave-cortex/templates/consul-svc.yaml
+++ b/stable/weave-cortex/templates/consul-svc.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: consul
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+  - name: http
+    port: {{ .Values.consul.serviceHttpPort }}
+    targetPort: {{ .Values.consul.httpNoScrapePort }}
+  selector:
+    name: consul
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/distributor-dep.yaml
+++ b/stable/weave-cortex/templates/distributor-dep.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: distributor
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: distributor
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: distributor
+        image: {{ .Values.distributor.image.repository }}:{{ .Values.distributor.image.tag }}
+        imagePullPolicy: {{ .Values.distributor.image.pullPolicy }}
+        args:
+        - -log.level={{ .Values.distributor.logLevel }}
+        - -server.http-listen-port={{ .Values.distributor.listenPort }}
+        - -consul.hostname={{ .Values.distributor.consulHostName }}:{{ .Values.consul.serviceHttpPort }}
+        - -distributor.replication-factor={{ .Values.distributor.replicationFactor }}
+        ports:
+        - containerPort: {{ .Values.distributor.listenPort }}

--- a/stable/weave-cortex/templates/distributor-svc.yaml
+++ b/stable/weave-cortex/templates/distributor-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: distributor
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.distributor.servicePort }}
+      targetPort: {{ .Values.distributor.listenPort }}
+  selector:
+    name: distributor
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/dynamodb-dep.yaml
+++ b/stable/weave-cortex/templates/dynamodb-dep.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: dynamodb
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: dynamodb
+        release: {{ .Release.Name }}
+      annotations:
+        prometheus.io.scrape: "false"
+    spec:
+      containers:
+      - name: dynamodb
+        image: {{ .Values.dynamodb.image.repository }}:{{ .Values.dynamodb.image.tag }}
+        imagePullPolicy: {{ .Values.dynamodb.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.dynamodb.listenPort }}

--- a/stable/weave-cortex/templates/dynamodb-svc.yaml
+++ b/stable/weave-cortex/templates/dynamodb-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamodb
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.dynamodb.servicePort }}
+      targetPort: {{ .Values.dynamodb.listenPort }}
+  selector:
+    name: dynamodb
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/ingester-dep.yaml
+++ b/stable/weave-cortex/templates/ingester-dep.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ingester
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+
+  # Ingesters are not ready for at least 1 min
+  # after creation.  This has to be in sync with
+  # the ring timeout value, as this will stop a
+  # stampede of new ingesters if we should loose
+  # some.
+  minReadySeconds: {{ .Values.ingester.minReadySeconds }}
+
+  # Having maxSurge 0 and maxUnavailable 1 means
+  # the deployment will update one ingester at a time
+  # as it will have to stop one (making one unavailable)
+  # before it can start one (surge of zero)
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.ingester.strategy.rollingUpdateMaxSurge }}
+      maxUnavailable: {{ .Values.ingester.strategy.rollingUpdateMinAvailable }}
+
+  template:
+    metadata:
+      labels:
+        name: ingester
+        release: {{ .Release.Name }}
+    spec:
+      # Give ingesters 40 minutes grace to flush chunks and exit cleanly.
+      # Service is available during this time, as long as we don't stop
+      # too many ingesters at once.
+      terminationGracePeriodSeconds: {{ .Values.ingester.terminationGracePeriodSeconds }}
+
+      containers:
+      - name: ingester
+        image: {{ .Values.ingester.image.repository }}:{{ .Values.ingester.image.tag }}
+        imagePullPolicy: {{ .Values.ingester.image.pullPolicy }}
+        args:
+        - -ingester.join-after={{ .Values.ingester.joinAfter }}
+        - -ingester.claim-on-rollout={{ .Values.ingester.claimOnRollout }}
+        - -consul.hostname={{ .Values.global.consulURI }}
+        - -s3.url={{ .Values.global.s3URI }}:{{ .Values.fakeS3.servicePort }}
+        - -dynamodb.original-table-name=cortex
+        - -dynamodb.url={{ .Values.global.dynamoDBURI }}
+        - -dynamodb.periodic-table.prefix=cortex_weekly_
+        - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.daily-buckets-from=2017-01-10
+        - -dynamodb.base64-buckets-from=2017-01-17
+        - -dynamodb.v4-schema-from=2017-02-05
+        - -dynamodb.v5-schema-from=2017-02-22
+        - -dynamodb.v7-schema-from=2017-03-19
+        - -dynamodb.chunk-table.from=2017-04-17
+        - -memcached.hostname={{ .Values.global.memcachedURI }}
+        - -memcached.timeout={{ .Values.global.memcachedTimeout }}
+        - -memcached.service={{ .Values.global.memcachedService }}
+        ports:
+        - containerPort: {{ .Values.ingester.listenPort }}
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: {{ .Values.ingester.listenPort }}
+          initialDelaySeconds: 15
+          timeoutSeconds: 1

--- a/stable/weave-cortex/templates/ingester-svc.yaml
+++ b/stable/weave-cortex/templates/ingester-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingester
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.ingester.servicePort }}
+      targetPort: {{ .Values.ingester.listenPort }}
+  selector:
+    name: ingester
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/memcached-dep.yaml
+++ b/stable/weave-cortex/templates/memcached-dep.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: memcached
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.memcached.replicas }}
+  template:
+    metadata:
+      labels:
+        name: memcached
+        release: {{ .Release.Name }}
+      annotations:
+        prometheus.io.scrape: "false"
+    spec:
+      containers:
+      - name: memcached
+        image: {{ .Values.memcached.image.repository }}:{{ .Values.memcached.image.tag }}
+        imagePullPolicy: {{ .Values.memcached.image.pullPolicy }}
+        args:
+        - -m {{ .Values.memcached.maxMemMB }} # Maximum memory to use, in megabytes. 64MB is default.
+        - -p {{ .Values.memcached.listenPort }} # Default port, but being explicit is nice.
+        ports:
+        - name: clients
+          containerPort: {{ .Values.memcached.listenPort }}

--- a/stable/weave-cortex/templates/memcached-svc.yaml
+++ b/stable/weave-cortex/templates/memcached-svc.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: memcached
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  # The memcache client uses DNS to get a list of memcached servers and then
+  # uses a consistent hash of the key to determine which server to pick.
+  clusterIP: None
+  ports:
+    - name: memcached
+      port: {{ .Values.memcached.listenPort }}
+    - name: prom
+      port: 9150
+  selector:
+    name: memcached
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/nginx-config.yaml
+++ b/stable/weave-cortex/templates/nginx-config.yaml
@@ -1,0 +1,44 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-{{ .Release.Name }}
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  nginx.conf: |-
+    worker_processes  {{ .Values.nginx.config.workerProcesses }};  ## Default: 1
+    error_log  {{ .Values.nginx.config.errorLog }};
+    pid        {{ .Values.nginx.config.pid }};
+    worker_rlimit_nofile {{ .Values.nginx.config.workerRLimitNoFile }};
+
+    events {
+      worker_connections  {{ .Values.nginx.config.workerConnections }};  ## Default: 1024
+    }
+
+    http {
+      default_type application/octet-stream;
+      log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+        '"$request" $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log   /dev/stderr  main;
+      sendfile     on;
+      tcp_nopush   on;
+      resolver {{ .Values.nginx.config.http.resolverAddress }};
+
+      server { # simple reverse-proxy
+        listen {{ .Values.nginx.config.server.listenPort }};
+        proxy_set_header X-Scope-OrgID 0;
+
+        # pass requests for dynamic content to rails/turbogears/zope, et al
+        location = /api/prom/push {
+          proxy_pass      {{ .Values.nginx.config.server.pushPassthroughURI }}$request_uri;
+        }
+
+        location ~ /api/prom/.* {
+          proxy_pass      {{ .Values.nginx.config.server.queryPassthroughURI }}$request_uri;
+        }
+      }
+    }

--- a/stable/weave-cortex/templates/nginx-dep.yaml
+++ b/stable/weave-cortex/templates/nginx-dep.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.nginx.replicas }}
+  template:
+    metadata:
+      labels:
+        name: nginx
+        release: {{ .Release.Name }}
+      annotations:
+        prometheus.io.scrape: "false"
+    spec:
+      containers:
+      - name: nginx
+        image: {{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: {{ .Values.nginx.listenPort }}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/nginx
+      volumes:
+        - name: config-volume
+          configMap:
+            name: nginx-{{ .Release.Name }}

--- a/stable/weave-cortex/templates/nginx-svc.yaml
+++ b/stable/weave-cortex/templates/nginx-svc.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: {{ .Values.nginx.listenPort }}
+    targetPort: {{ .Values.nginx.servicePort }}
+{{- if eq .Values.nginx.serviceType "NodePort" }}
+    nodePort: {{ .Values.nginx.nodePort }}
+{{- end }}
+  selector:
+    name: nginx
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/querier-dep.yaml
+++ b/stable/weave-cortex/templates/querier-dep.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: querier
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.querier.replicas }}
+  template:
+    metadata:
+      labels:
+        name: querier
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: querier
+        image: {{ .Values.querier.image.repository }}:{{ .Values.querier.image.tag }}
+        imagePullPolicy: {{ .Values.querier.image.pullPolicy }}
+        args:
+        - -server.http-listen-port={{ .Values.querier.listenPort }}
+        - -consul.hostname={{ .Values.global.consulURI }}
+        - -s3.url={{ .Values.global.s3URI }}
+        - -dynamodb.original-table-name=cortex
+        - -dynamodb.url={{ .Values.global.dynamoDBURI }}
+        - -dynamodb.periodic-table.prefix=cortex_weekly_
+        - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.daily-buckets-from=2017-01-10
+        - -dynamodb.base64-buckets-from=2017-01-17
+        - -dynamodb.v4-schema-from=2017-02-05
+        - -dynamodb.v5-schema-from=2017-02-22
+        - -dynamodb.v7-schema-from=2017-03-19
+        - -dynamodb.chunk-table.from=2017-04-17
+        - -memcached.hostname={{ .Values.global.memcachedURI }}
+        - -memcached.timeout={{ .Values.global.memcachedTimeout }}
+        - -memcached.service={{ .Values.global.memcachedService }}
+        - -distributor.replication-factor={{ .Values.distributor.replicationFactor }}
+        ports:
+        - containerPort: {{ .Values.querier.listenPort }}

--- a/stable/weave-cortex/templates/querier-svc.yaml
+++ b/stable/weave-cortex/templates/querier-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: querier
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.querier.servicePort }}
+      targetPort: {{ .Values.querier.listenPort }}
+  selector:
+    name: querier
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/retrieval-config.yaml
+++ b/stable/weave-cortex/templates/retrieval-config.yaml
@@ -1,0 +1,12 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: retrieval-{{ .Release.Name }}
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{ toYaml .Values.retrieval.configFiles | indent 2 }}

--- a/stable/weave-cortex/templates/retrieval-dep.yaml
+++ b/stable/weave-cortex/templates/retrieval-dep.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: retrieval
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.retrieval.replicas }}
+  template:
+    metadata:
+      labels:
+        name: retrieval
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: retrieval
+        image: {{ .Values.retrieval.image.repository }}:{{ .Values.retrieval.image.tag }}
+        imagePullPolicy: {{ .Values.retrieval.image.pullPolicy }}
+        args:
+        - -config.file=/etc/prometheus/prometheus.yml
+        - -web.listen-address=:{{- .Values.retrieval.listenPort }}
+        ports:
+        - containerPort: {{ .Values.retrieval.listenPort }}
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/prometheus
+      volumes:
+        - name: config-volume
+          configMap:
+            name: retrieval-{{ .Release.Name }}

--- a/stable/weave-cortex/templates/retrieval-svc.yaml
+++ b/stable/weave-cortex/templates/retrieval-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: retrieval
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.retrieval.servicePort }}
+      targetPort: {{ .Values.retrieval.listenPort }}
+  selector:
+    name: retrieval
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/ruler-dep.yaml
+++ b/stable/weave-cortex/templates/ruler-dep.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ruler
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.ruler.replicas }}
+  template:
+    metadata:
+      labels:
+        name: ruler
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: ruler
+        image: {{ .Values.ruler.image.repository }}:{{ .Values.ruler.image.tag }}
+        imagePullPolicy: {{ .Values.ruler.image.pullPolicy}}
+        args:
+        - -log.level={{ .Values.ruler.logLevel }}
+        - -server.http-listen-port={{ .Values.ruler.listenPort }}
+        - -ruler.configs.url={{ .Values.global.configs }}
+        - -ruler.alertmanager-url={{ .Values.global.alertmanagerURI }}
+        - -consul.hostname={{ .Values.global.consulURI }}
+        - -s3.url={{ .Values.global.s3URI -}}/s3
+        - -dynamodb.original-table-name=cortex
+        - -dynamodb.url={{ .Values.global.dynamoDBURI }}
+        - -dynamodb.periodic-table.prefix=cortex_weekly_
+        - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.daily-buckets-from=2017-01-10
+        - -dynamodb.base64-buckets-from=2017-01-17
+        - -dynamodb.v4-schema-from=2017-02-05
+        - -dynamodb.v5-schema-from=2017-02-22
+        - -dynamodb.v7-schema-from=2017-03-19
+        - -dynamodb.chunk-table.from=2017-04-17
+        - -memcached.hostname={{ .Values.global.memcachedURI }}
+        - -memcached.timeout={{ .Values.global.memcachedTimeout }}
+        - -memcached.service={{ .Values.global.memcachedService }}
+        - -distributor.replication-factor={{ .Values.distributor.replicationFactor }}
+        ports:
+        - containerPort: {{ .Values.ruler.listenPort }}

--- a/stable/weave-cortex/templates/ruler-svc.yaml
+++ b/stable/weave-cortex/templates/ruler-svc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruler
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.ruler.servicePort }}
+      targetPort: {{ .Values.ruler.listenPort}}
+  selector:
+    name: ruler
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/templates/s3-dep.yaml
+++ b/stable/weave-cortex/templates/s3-dep.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.fakeS3.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: s3
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.ruler.replicas }}
+  template:
+    metadata:
+      labels:
+        name: s3
+        release: {{ .Release.Name }}
+      annotations:
+        prometheus.io.scrape: "false"
+    spec:
+      containers:
+      - name: s3
+        image: {{ .Values.fakeS3.image.repository }}:{{ .Values.fakeS3.image.tag }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: {{ .Values.fakeS3.listenPort }}
+{{- end -}}

--- a/stable/weave-cortex/templates/s3-svc.yaml
+++ b/stable/weave-cortex/templates/s3-svc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.fakeS3.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: s3
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.fakeS3.servicePort }}
+      targetPort: {{ .Values.fakeS3.listenPort }}
+  selector:
+    name: s3
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/stable/weave-cortex/templates/table-manager-dep.yaml
+++ b/stable/weave-cortex/templates/table-manager-dep.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: table-manager
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.tableManager.replicas }}
+  template:
+    metadata:
+      labels:
+        name: table-manager
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: table-manager
+        image: {{ .Values.tableManager.image.repository }}:{{ .Values.tableManager.image.tag }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - -server.http-listen-port={{ .Values.tableManager.listenPort }}
+        - -dynamodb.original-table-name=cortex
+        - -dynamodb.url={{ .Values.global.dynamoDBURI }}
+        - -dynamodb.periodic-table.prefix=cortex_weekly_
+        - -dynamodb.periodic-table.start=2017-01-06
+        - -dynamodb.chunk-table.from=2017-04-17
+        ports:
+        - containerPort: {{ .Values.tableManager.listenPort }}

--- a/stable/weave-cortex/templates/table-manager-svc.yaml
+++ b/stable/weave-cortex/templates/table-manager-svc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: table-manager
+  labels:
+    app: {{ template "cortex.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.tableManager.servicePort }}
+  selector:
+    name: table-manager
+    release: {{ .Release.Name }}

--- a/stable/weave-cortex/values.yaml
+++ b/stable/weave-cortex/values.yaml
@@ -1,0 +1,301 @@
+global:
+  s3URI: s3://abc:123@s3.default.svc.cluster.local:4569
+  dynamoDBURI: dynamodb://user:pass@dynamodb.default.svc.cluster.local:8000
+  consulURI: consul.default.svc.cluster.local:8500
+  memcachedURI: memcached.default.svc.cluster.local
+  memcachedTimeout: 100ms
+  memcachedService: memcached
+  configDbURI: postgres://postgres@configs-db.default.svc.cluster.local/configs?sslmode=disable
+  configs: http://configs.default.svc.cluster.local:80
+  alertmanagerURI: http://alertmanager.default.svc.cluster.local/api/prom/alertmanager/
+
+alertmanager:
+  image:
+    repository: quay.io/weaveworks/cortex-alertmanager
+    tag: master-0a92a540
+    imagePullPolicy: IfNotPresent
+
+  listenPort: 80
+  servicePort: 80
+  configURL: http://configs.default.svc.cluster.local:80
+  externalURI: /api/prom/alertmanager
+  loglevel: debug
+
+postgressConfigDB:
+  servicePort: 5432
+  listenPort: 5432
+  image:
+    repository: postgres
+    tag: 9.6
+    pullPolicy: IfNotPresent
+
+cortexConfigs:
+  listenPort: 80
+  servicePort: 80
+  migrationsURI: /migrations
+  image:
+    repository: quay.io/weaveworks/cortex-configs
+    tag: master-eb4b2116
+    pullPolicy: IfNotPresent
+
+consul:
+  serverNoScrapePort: 8300
+  serfNoScrapePort: 8301
+  clientNoScrapePort: 8400
+  httpNoScrapePort: 8500
+  serviceHttpPort: 8500
+
+  image:
+    repository: consul
+    tag: 0.7.1
+    pullPolicy: IfNotPresent
+
+distributor:
+  logLevel: debug
+  listenPort: 80
+  servicePort: 80
+  consulHostName: consul.default.svc.cluster.local
+  replicationFactor: 1
+  image:
+    repository: quay.io/weaveworks/cortex-distributor
+    tag: master-eb4b2116
+    pullPolicy: IfNotPresent
+
+dynamodb:
+  listenPort: 8000
+  servicePort: 8000
+  image:
+    repository: deangiberson/aws-dynamodb-local
+    tag: latest
+    pullPolicy: IfNotPresent
+
+ingester:
+  replicas: 1
+  minReadySeconds: 60
+  joinAfter: 30s
+  claimOnRollout: false
+  terminationGracePeriodSeconds: 2400
+  listenPort: 80
+  servicePort: 80
+
+  strategy:
+    rollingUpdateMaxSurge: 0
+    rollingUpdateMinAvailable: 1
+
+  image:
+    repository: quay.io/weaveworks/cortex-ingester
+    tag: master-747f3493
+    pullPolicy: IfNotPresent
+
+memcached:
+  replicas: 1
+  maxMemMB: 64
+  listenPort: 11211
+  servicePort: 11211
+
+  image:
+    repository: memcached
+    tag: 1.4.25
+    pullPolicy: IfNotPresent
+
+nginx:
+  replicas: 1
+  listenPort: 80
+  servicePort: 80
+  serviceType: NodePort
+  nodePort: 30080
+
+  image:
+    repository: nginx
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  config:
+    workerProcesses: 5
+    errorLog: /dev/stderr
+    pid: nginx.pid
+    workerRLimitNoFile: 8192
+    workerConnections: 4096
+
+    http:
+      sendfile: on
+      tcpNoPush: on
+      resolverAddress: 10.0.0.10
+
+    server:
+      listenPort: 80
+      pushPassthroughURI: http://distributor.default.svc.cluster.local
+      queryPassthroughURI: http://querier.default.svc.cluster.local
+
+querier:
+  replicas: 1
+  listenPort: 80
+  servicePort: 80
+
+  image:
+    repository: quay.io/weaveworks/cortex-querier
+    tag: master-eb4b2116
+    pullPolicy: IfNotPresent
+
+ruler:
+  replicas: 1
+  logLevel: debug
+  listenPort: 80
+  servicePort: 80
+
+  image:
+    repository: quay.io/weaveworks/cortex-ruler
+    tag: master-eb4b2116
+    pullPolicy: IfNotPresent
+
+
+fakeS3:
+  enabled: true
+  replicas: 1
+  listenPort: 4569
+  servicePort: 4569
+
+  image:
+    repository: lphoward/fake-s3
+    tag: latest
+    pullPolicy: IfNotPresent
+
+
+tableManager:
+  replicas: 1
+  listenPort: 80
+  servicePort: 80
+  image:
+    repository: quay.io/weaveworks/cortex-table-manager
+    tag: master-d18915fb
+    pullPolicy: IfNotPresent
+
+
+retrieval:
+  replicas: 1
+  listenPort: 80
+  servicePort: 80
+  image:
+    repository: prom/prometheus
+    tag: v1.4.1
+    pullPolicy: IfNotPresent
+
+  configFiles:
+    prometheus.yml: |-
+      global:
+        scrape_interval: 30s # By default, scrape targets every 15 seconds.
+
+      remote_write:
+        url: http://nginx.default.svc.cluster.local:80/api/prom/push
+
+      scrape_configs:
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+          - role: pod
+
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # You can specify the following annotations (on pods):
+        #   prometheus.io.scrape: false - don't scrape this pod
+        #   prometheus.io.scheme: https - use https for scraping
+        #   prometheus.io.port - scrape this port
+        #   prometheus.io.path - scrape this path
+        relabel_configs:
+
+        # Always use HTTPS for the api server
+        - source_labels: [__meta_kubernetes_service_label_component]
+          regex: apiserver
+          action: replace
+          target_label: __scheme__
+          replacement: https
+
+        # Drop anything annotated with prometheus.io.scrape=false
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: drop
+          regex: false
+
+        # Drop any endpoint who's pod port name ends with -noscrape
+        - source_labels: [__meta_kubernetes_pod_container_port_name]
+          action: drop
+          regex: .*-noscrape
+
+        # Allow pods to override the scrape scheme with prometheus.io.scheme=https
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+          action: replace
+          target_label: __scheme__
+          regex: ^(https?)$
+          replacement: $1
+
+        # Allow service to override the scrape path with prometheus.io.path=/other_metrics_path
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: ^(.+)$
+          replacement: $1
+
+        # Allow services to override the scrape port with prometheus.io.port=1234
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          target_label: __address__
+          regex: (.+?)(\:\d+)?;(\d+)
+          replacement: $1:$3
+
+        # Drop pods without a name label
+        - source_labels: [__meta_kubernetes_pod_label_name]
+          action: drop
+          regex: ^$
+
+        # Rename jobs to be <namespace>/<name, from pod name label>
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_name]
+          action: replace
+          separator: /
+          target_label: job
+          replacement: $1
+
+        # Rename instances to be the pod name
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: instance
+
+        # Include node name as a extra field
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: node
+
+      # This scrape config gather all nodes
+      - job_name: 'kubernetes-nodes'
+        kubernetes_sd_configs:
+          - role: node
+
+        # couldn't get prometheus to validate the kublet cert for scraping, so don't bother for now
+        tls_config:
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        relabel_configs:
+        - target_label: __scheme__
+          replacement: https
+        - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+          target_label: instance
+
+      # This scrape config just pulls in the default/kubernetes service
+      - job_name: 'kubernetes-service'
+        kubernetes_sd_configs:
+          - role: endpoints
+
+        tls_config:
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_service_label_component]
+          regex: apiserver
+          action: keep
+
+        - target_label: __scheme__
+          replacement: https
+
+        - source_labels: []
+          target_label: job
+          replacement: default/kubernetes


### PR DESCRIPTION
This is the helm chart for weave cortex. 
Traditionally weave cortex is installed using the weave cloud backing. 
This chart is a local install that does not require the weave cloud backing, and can be used independently in a local cluster. 