### PR TITLE
[stable/cluster-autoscaler] New chart

### DIFF
--- a/stable/cluster-autoscaler/.helmignore
+++ b/stable/cluster-autoscaler/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+description: Scales worker nodes within autoscaling groups.
+icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+name: cluster-autoscaler
+version: 0.1.0
+sources:
+  - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+  - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler
+maintainers:
+  - name: Michael Goodness
+    email: mgoodness@gmail.com
+engine: gotpl

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -92,8 +92,6 @@ Parameter | Description | Default
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `replicaCount` | desired number of pods | `1`
 `resources` | pod resource requests & limits | `{}`
-`scaleDown.delay` | time to wait between scaling operations | `10m` (10 minutes)
-`scaleDown.unneededTime` | How long a node should be unneeded before it is eligible for scale down | `10m` (10 minutes
 `service.annotations` | annotations to add to service | none
 `service.clusterIP` | IP address to assign to service | `""`
 `service.externalIPs` | service external IP addresses | `[]`
@@ -101,8 +99,6 @@ Parameter | Description | Default
 `service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `service.servicePort` | service port to expose | `8085`
 `service.type` | type of service to create | `ClusterIP`
-`skipNodes.withLocalStorage` | don't terminate nodes running pods that use local storage | `false`
-`skipNodes.withSystemPods` | don't terminate nodes running pods in the `kube-system` namespace | `true`
 `spotinst.account` | Spotinst Account ID (required if `cloudprovider=spotinst`) | `""`
 `spotinst.token` | Spotinst API token (required if `cloudprovider=spotinst`) | `""`
 `spotinst.image.repository` | Image (used if `cloudProvider=spotinst`) | `spotinst/kubernetes-cluster-autoscaler`

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -1,0 +1,143 @@
+# cluster-autoscaler
+
+[The cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) scales worker nodes within an AWS autoscaling group or Spotinst Elastigroup.
+
+## TL;DR:
+
+```console
+$ helm install stable/cluster-autoscaler -f values.yaml
+```
+Where `values.yaml` contains:
+
+```
+autoscalingGroups:
+  - name: your-scaling-group-name
+    maxSize: 10
+    minSize: 1
+```
+
+## Introduction
+
+This chart bootstraps an cluster-autoscaler deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.3+ with Beta APIs enabled
+
+## Installing the Chart
+
+In order for the chart to configure the cluster-autoscaler properly during the installation process, you must provide some minimal configuration which can't rely on defaults. This includes at least one element in the `autoscalingGroups` array and its three values: `name`, `minSize` and `maxSize`. These parameters cannot be passed to helm using the `--set` parameter at this time, so you must supply these using a `values.yaml` file such as:
+
+```
+autoscalingGroups:
+  - name: your-scaling-group-name
+    maxSize: 10
+    minSize: 1
+```
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install stable/cluster-autoscaler --name my-release -f values.yaml
+```
+
+The command deploys cluster-autoscaler on the Kubernetes cluster using the supplied configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Verifying Installation
+
+The chart will succeed even if the three required parameters are not supplied. To verify the cluster-autoscaler is configured properly find a pod that the deployment created and describe it. It must have a `--nodes` argument supplied to the `./cluster-autoscaler` app under `Command`. For example (all other values are omitted for brevity):
+
+```
+Containers:
+  cluster-autoscaler:
+    Command:
+      ./cluster-autoscaler
+      --cloud-provider=aws
+      --nodes=1:10:your-scaling-group-name
+      --scale-down-delay=10m
+      --skip-nodes-with-local-storage=false
+      --skip-nodes-with-system-pods=true
+      --v=4
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the cluster-autoscaler chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`autoscalingGroups[].name` | autoscaling group name | None. You *must* supply at least one.
+`autoscalingGroups[].maxSize` | maximum autoscaling group size | None. You *must* supply at least one.
+`autoscalingGroups[].minSize` | minimum autoscaling group size | None. You *must* supply at least one.
+`awsRegion` | AWS region (required if `cloudProvider=aws`) | `us-east-1`
+`cloudProvider` | `aws` or `spotinst` are currently supported | `aws`
+`image.repository` | Image (used if `cloudProvider=aws`) | `gcr.io/google_containers/cluster-autoscaler`
+`image.tag` | Image tag (used if `cloudProvider=aws`) | `v0.6.0`
+`image.pullPolicy` | Image pull policy (used if `cloudProvider=aws`) | `IfNotPresent`
+`extraArgs` | additional container arguments | `{}`
+`nodeSelector` | node labels for pod assignment | `{}`
+`podAnnotations` | annotations to add to each pod | `{}`
+`rbac.create` | If true, create & use RBAC resources | `false`
+`rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
+`replicaCount` | desired number of pods | `1`
+`resources` | pod resource requests & limits | `{}`
+`scaleDown.delay` | time to wait between scaling operations | `10m` (10 minutes)
+`scaleDown.unneededTime` | How long a node should be unneeded before it is eligible for scale down | `10m` (10 minutes
+`service.annotations` | annotations to add to service | none
+`service.clusterIP` | IP address to assign to service | `""`
+`service.externalIPs` | service external IP addresses | `[]`
+`service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
+`service.servicePort` | service port to expose | `8085`
+`service.type` | type of service to create | `ClusterIP`
+`skipNodes.withLocalStorage` | don't terminate nodes running pods that use local storage | `false`
+`skipNodes.withSystemPods` | don't terminate nodes running pods in the `kube-system` namespace | `true`
+`spotinst.account` | Spotinst Account ID (required if `cloudprovider=spotinst`) | `""`
+`spotinst.token` | Spotinst API token (required if `cloudprovider=spotinst`) | `""`
+`spotinst.image.repository` | Image (used if `cloudProvider=spotinst`) | `spotinst/kubernetes-cluster-autoscaler`
+`spotinst.image.tag` | Image tag (used if `cloudProvider=spotinst`) | `v0.6.0`
+`spotinst.image.pullPolicy` | Image pull policy (used if `cloudProvider=spotinst`) | `IfNotPresent`
+
+
+Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section.
+
+
+You can also specify any non-array parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install stable/cluster-autoscaler --name my-release \
+    --set awsRegion=us-west-1
+```
+
+## IAM Permissions
+The worker running the cluster autoscaler will need access to certain resources and actions:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:TerminateInstanceInAutoScalingGroup"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+Unfortunately AWS does not support ARNs for autoscaling groups yet so you must use "*" as the resource. More information [here](http://docs.aws.amazon.com/autoscaling/latest/userguide/IAM.html#UsingWithAutoScaling_Actions).

--- a/stable/cluster-autoscaler/templates/NOTES.txt
+++ b/stable/cluster-autoscaler/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that aws-cluster-autoscaler has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "name" . }},release={{ .Release.Name }}"

--- a/stable/cluster-autoscaler/templates/_helpers.tpl
+++ b/stable/cluster-autoscaler/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default (printf "%s-%s" .Values.cloudProvider .Chart.Name) .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default (printf "%s-%s" .Values.cloudProvider .Chart.Name) .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/cluster-autoscaler/templates/_helpers.tpl
+++ b/stable/cluster-autoscaler/templates/_helpers.tpl
@@ -11,6 +11,10 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
-{{- $name := default (printf "%s-%s" .Values.cloudProvider .Chart.Name) .Chart.Name .Values.nameOverride -}}
+{{- $name := default (printf "%s-%s" .Values.cloudProvider .Chart.Name) .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+      - endpoints
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    resourceNames:
+      - cluster-autoscaler
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+      - services
+      - replicationcontrollers
+      - persistentvolumeclaims
+      - persistentvolumes
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - extensions
+    resources:
+      - replicasets
+      - daemonsets
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - watch
+      - list
+{{- end -}}

--- a/stable/cluster-autoscaler/templates/clusterrolebinding.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -39,8 +39,6 @@ spec:
             - --scale-down-unneeded-time={{ .Values.scaleDown.unneededTime }}
             - --skip-nodes-with-local-storage={{ .Values.skipNodes.withLocalStorage }}
             - --skip-nodes-with-system-pods={{ .Values.skipNodes.withSystemPods }}
-            - --stderrthreshold=info
-            - --v=4
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
             - --scale-down-unneeded-time={{ .Values.scaleDown.unneededTime }}
             - --skip-nodes-with-local-storage={{ .Values.skipNodes.withLocalStorage }}
             - --skip-nodes-with-system-pods={{ .Values.skipNodes.withSystemPods }}
+            - --stderrthreshold=info
             - --v=4
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "name" . }}
+        {{- if eq .Values.cloudProvider "spotinst" }}
+          image: "{{ .Values.spotinst.image.repository }}:{{ .Values.spotinst.image.tag }}"
+          imagePullPolicy: "{{ .Values.spotinst.image.pullPolicy }}"
+        {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        {{- end }}
+          command:
+            - ./cluster-autoscaler
+            - --cloud-provider={{ .Values.cloudProvider }}
+            - --namespace={{ .Release.Namespace }}
+          {{- range .Values.autoscalingGroups }}
+            - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
+          {{- end }}
+            - --scale-down-delay={{ .Values.scaleDown.delay }}
+            - --scale-down-unneeded-time={{ .Values.scaleDown.unneededTime }}
+            - --skip-nodes-with-local-storage={{ .Values.skipNodes.withLocalStorage }}
+            - --skip-nodes-with-system-pods={{ .Values.skipNodes.withSystemPods }}
+            - --v=4
+          {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
+          env:
+          {{- if eq .Values.cloudProvider "aws" }}
+            - name: AWS_REGION
+              value: "{{ .Values.awsRegion }}"
+          {{- else if eq .Values.cloudProvider "spotinst" }}
+            - name: SPOTINST_TOKEN
+              value: "{{ .Values.spotinst.token }}"
+            - name: SPOTINST_ACCOUNT
+              value: "{{ .Values.spotinst.account }}"
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health-check
+              port: 8085
+          ports:
+            - containerPort: 8085
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              readOnly: true
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs/ca-certificates.crt

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -35,10 +35,6 @@ spec:
           {{- range .Values.autoscalingGroups }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
           {{- end }}
-            - --scale-down-delay={{ .Values.scaleDown.delay }}
-            - --scale-down-unneeded-time={{ .Values.scaleDown.unneededTime }}
-            - --skip-nodes-with-local-storage={{ .Values.skipNodes.withLocalStorage }}
-            - --skip-nodes-with-system-pods={{ .Values.skipNodes.withSystemPods }}
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}

--- a/stable/cluster-autoscaler/templates/role.yaml
+++ b/stable/cluster-autoscaler/templates/role.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - cluster-autoscaler-status
+    verbs:
+      - delete
+      - get
+      - update
+{{- end -}}

--- a/stable/cluster-autoscaler/templates/rolebinding.yaml
+++ b/stable/cluster-autoscaler/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/cluster-autoscaler/templates/service.yaml
+++ b/stable/cluster-autoscaler/templates/service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+spec:
+  clusterIP: "{{ .Values.service.clusterIP }}"
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - port: {{ .Values.service.servicePort }}
+      protocol: TCP
+      targetPort: 8085
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+  type: "{{ .Values.service.type }}"

--- a/stable/cluster-autoscaler/templates/serviceaccount.yaml
+++ b/stable/cluster-autoscaler/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end -}}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -15,6 +15,10 @@ image:
   pullPolicy: IfNotPresent
 
 extraArgs: {}
+  # scale-down-delay: 10m
+  # scale-down-unneeded-time: 10m
+  # skip-nodes-with-local-storage: false
+  # skip-nodes-with-system-pods: true
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -41,10 +45,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 300Mi
 
-scaleDown:
-  delay: 10m
-  unneededTime: 10m
-
 service:
   annotations: {}
   clusterIP: ""
@@ -58,10 +58,6 @@ service:
   loadBalancerSourceRanges: []
   servicePort: 8085
   type: ClusterIP
-
-skipNodes:
-  withLocalStorage: false
-  withSystemPods: true
 
 spotinst:
   account: ""

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -1,0 +1,73 @@
+autoscalingGroups: []
+  # - name: asg1
+  #   maxSize: 1
+  #   minSize: 1
+
+# Required if cloudProvider=aws
+awsRegion: us-east-1
+
+# Currently only `aws` & `spotinst` are supported
+cloudProvider: aws
+
+image:
+  repository: gcr.io/google_containers/cluster-autoscaler
+  tag: v0.6.0
+  pullPolicy: IfNotPresent
+
+extraArgs: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+podAnnotations: {}
+replicaCount: 1
+
+rbac:
+  ## If true, create & use RBAC resources
+  ##
+  create: false
+
+  ## Ignored if rbac.create is true
+  ##
+  serviceAccountName: default
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
+
+scaleDown:
+  delay: 10m
+  unneededTime: 10m
+
+service:
+  annotations: {}
+  clusterIP: ""
+
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  servicePort: 8085
+  type: ClusterIP
+
+skipNodes:
+  withLocalStorage: false
+  withSystemPods: true
+
+spotinst:
+  account: ""
+  token: ""
+
+  image:
+    repository: spotinst/kubernetes-cluster-autoscaler
+    tag: 0.6.0
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
This is the first stab at a unified `cluster-autoscaler` chart. If accepted, it would initially replace the [aws-cluster-autoscaler](https://github.com/kubernetes/charts/tree/master/stable/aws-cluster-autoscaler) and add support for the `spotinst` provider. It's my hope that it would also be extended to replace the [acs-engine-autoscaler](https://github.com/kubernetes/charts/tree/master/stable/acs-engine-autoscaler).