### PR TITLE
[stable/kube2iam] Support Helm release name = chart name

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.5.0
+version: 0.5.1
 description: Provide IAM credentials to pods based on annotations.
 keywords:
   - kube2iam

--- a/stable/kube2iam/templates/_helpers.tpl
+++ b/stable/kube2iam/templates/_helpers.tpl
@@ -12,5 +12,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Adopting the pattern described in https://github.com/kubernetes/helm/issues/1186#issuecomment-317856790 for naming resources when the Release name is the same as the Chart name.