### PR TITLE
[stable/traefik]Added loadBalancerIP too the traefik service template

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.7.3
+version: 1.8
 appVersion: 1.3.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.7.2
+version: 1.7.3
 appVersion: 1.3.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.8.0
+version: 1.9.0
 appVersion: 1.3.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -88,6 +88,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
 | `imageTag`                      | The version of the official Traefik image to use                     | `1.3.1`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
+| `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
 | `replicas`                      | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |
@@ -119,7 +120,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `accessLogs.enabled`            | Whether to enable Traefik's access logs                              | `false`                                   |
 | `accessLogs.filePath`           | The path to the log file. Logs to stdout if omitted                  | None                                      |
 | `accessLogs.format`             | What format the log entries should be in. Either `common` or `json`  | `common`                                  |
-| `gcp.staticIP`            | An available IP you have reserved on Google Cloud Platform           | None                                      |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -88,6 +88,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
 | `imageTag`                      | The version of the official Traefik image to use                     | `1.3.1`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
+| `googleStaticIP`                | An available IP you have reserved on Google Cloud Platform           | None                                      |
 | `replicas`                      | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -88,7 +88,6 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
 | `imageTag`                      | The version of the official Traefik image to use                     | `1.3.1`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
-| `googleStaticIP`                | An available IP you have reserved on Google Cloud Platform           | None                                      |
 | `replicas`                      | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |
@@ -120,6 +119,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `accessLogs.enabled`            | Whether to enable Traefik's access logs                              | `false`                                   |
 | `accessLogs.filePath`           | The path to the log file. Logs to stdout if omitted                  | None                                      |
 | `accessLogs.format`             | What format the log entries should be in. Either `common` or `json`  | `common`                                  |
+| `gcp.staticIP`            | An available IP you have reserved on Google Cloud Platform           | None                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -20,8 +20,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.serviceType }}
-  {{- if .Values.googleStaticIP }}
-  loadBalancerIP: {{ .Values.googleStaticIP }}
+  {{- if .Values.gcp.staticIP }}
+  loadBalancerIP: {{ .Values.gcp.staticIP }}
   {{- end }}
   selector:
     app: {{ template "fullname" . }}

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -20,8 +20,8 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.serviceType }}
-  {{- if .Values.gcp.staticIP }}
-  loadBalancerIP: {{ .Values.gcp.staticIP }}
+  {{- if .Values.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}
   selector:
     app: {{ template "fullname" . }}

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -20,6 +20,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.serviceType }}
+  {{- if .Values.googleStaticIP }}
+  loadBalancerIP: {{ .Values.googleStaticIP }}
+  {{- end }}
   selector:
     app: {{ template "fullname" . }}
   ports:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,7 +2,6 @@
 image: traefik
 imageTag: 1.3.4
 serviceType: LoadBalancer
-googleStaticIP:
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi
@@ -62,3 +61,5 @@ accessLogs:
 #  labelSelector:
 rbac:
   enabled: false
+gcp:
+  staticIP:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,6 +2,7 @@
 image: traefik
 imageTag: 1.3.4
 serviceType: LoadBalancer
+loadBalancerIP:
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi
@@ -61,5 +62,3 @@ accessLogs:
 #  labelSelector:
 rbac:
   enabled: false
-gcp:
-  staticIP:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,6 +2,7 @@
 image: traefik
 imageTag: 1.3.4
 serviceType: LoadBalancer
+googleStaticIP:
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi


### PR DESCRIPTION
This can be set through a value called googleStaticIP, which is None by default. This was needed to make it possible to set up your loadbalancer with helm and assigning an already reserverd static ip in GCP. Im not sure if this works on other clouds, therefor have I called it googleStaticIP. Updated README with proper values