### PR TITLE
[stable/mariadb] Update Chart.yaml metadata

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -6,10 +6,12 @@ keywords:
 - mysql
 - database
 - sql
+- prometheus
 home: https://mariadb.org
 icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
 sources:
 - https://github.com/bitnami/bitnami-docker-mariadb
+- https://github.com/prometheus/mysqld_exporter
 maintainers:
 - name: Bitnami
   email: containers@bitnami.com


### PR DESCRIPTION
Now that mariadb chart has support for prometheus metrics, it's probably useful to publish that info in chart metadata.