### PR TITLE
Expose /metrics endpoint for prometheus

### DIFF
--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
         {{- end }}
         args:
         - --configfile=/config/traefik.toml
+        {{- if .Values.metrics }}
+        - --web.metrics.prometheus
+        - --web.metrics.prometheus.buckets={{- default "0.1,0.3,1.2,5" .Values.metrics.prometheus.buckets }}
+        {{- end}}
       volumes:
       - name: config
         configMap:

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         {{- end }}
         args:
         - --configfile=/config/traefik.toml
-        {{- if .Values.metrics }}
+        {{- if .Values.metrics.enabled }}
         - --web.metrics.prometheus
         - --web.metrics.prometheus.buckets={{- default "0.1,0.3,1.2,5" .Values.metrics.prometheus.buckets }}
         {{- end}}

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -30,3 +30,5 @@ spec:
     {{- if not .Values.ssl.enabled }}
     targetPort: 80
     {{- end }}
+  - port: 8080
+    name: metrics

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -61,3 +61,8 @@ accessLogs:
 #  labelSelector:
 rbac:
   enabled: false
+# Enable the /metrics endpoint, for now only supports prometheus
+# set to true to enable metric collection by prometheus
+metrics:
+  enabled: false
+  prometheus.buckets: 0.1,0.3,1.2,5


### PR DESCRIPTION
* Expose the traefik `/metrics` endpoint for collectors like prometheus via the command line arg `--web.metrics.prometheus`
* The prometheus buckets are also made configurable, again via a command line flag `--web.metrics.prometheus.buckets`

Tested on kubespray kubernetes cluster on AWS. 