### PR TITLE
[incubator-kafka] Fix zookeeper address

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.
 name: kafka
-version: 0.1.3
+version: 0.1.4
 keywords:
   - kafka
   - zookeeper

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
             command:
               - bin/kafka-topics.sh
               - --zookeeper
-              - "{{ template "name" . }}-zookeeper:2181"
+              - "{{ .Release.Name }}-zookeeper:2181"
               - --list
           initialDelaySeconds: 30
           timeoutSeconds: 5
@@ -34,7 +34,7 @@ spec:
             command:
               - bin/kafka-topics.sh
               - --zookeeper
-              - "{{ template "name" . }}-zookeeper:2181"
+              - "{{ .Release.Name }}-zookeeper:2181"
               - --list
           initialDelaySeconds: 30
           timeoutSeconds: 5
@@ -51,7 +51,7 @@ spec:
         command:
         - sh
         - -c
-        - "./bin/kafka-server-start.sh config/server.properties --override zookeeper.connect={{ template "name" . }}-zookeeper:2181/ --override broker.id=${HOSTNAME##*-}"
+        - "./bin/kafka-server-start.sh config/server.properties --override zookeeper.connect={{ .Release.Name }}-zookeeper:2181/ --override broker.id=${HOSTNAME##*-}"
         volumeMounts:
         - name: datadir
           mountPath: "{{ .Values.DataDirectory }}"


### PR DESCRIPTION
Currently, if I deploy kafka named `eventbus` (`helm install --name eventbus incubator/kafka`), kafka service tries to access zookeeper at `kafka-zookepeer` instead of `eventbus-zookeeper` which prevents kafka from starting.