### PR TITLE
[e2e] Increase the verify retry from 2 mins to 3 mins

### DIFF
--- a/test/verify-release.sh
+++ b/test/verify-release.sh
@@ -15,7 +15,7 @@ fi
 SUCCESS=0
 PODS_FOUND=0
 COUNT=0
-RETRY=12
+RETRY=18
 RETRY_DELAY=10
 while [ "$COUNT" -lt "$RETRY" ]; do
   POD_STATUS=`kubectl get pods --no-headers --namespace $NAMESPACE`


### PR DESCRIPTION
Some of the `statefulset` charts fail because they are started one after the other and might have configurations such as `initContainers` so 2 mins may not be enough for the workload to come up.  Increasing to 3 mins. 
https://github.com/kubernetes/charts/pull/1628