### PR TITLE
[incubator/patroni] Bump etcd chart version

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: "Highly available elephant herd: HA PostgreSQL cluster."
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.0-p5
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/requirements.yaml
+++ b/incubator/patroni/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: etcd
-  version: 0.2.0
+  version: 0.2.1
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/


### PR DESCRIPTION
The new version of the etcd chart allows `storageClass` to be explicitly set.