### PR TITLE
parse: bump `initialDelaySeconds` for dashboard deployment to 240s

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,5 +1,5 @@
 name: parse
-version: 0.2.0
+version: 0.2.1
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:
 - parse

--- a/stable/parse/templates/dashboard-deployment.yaml
+++ b/stable/parse/templates/dashboard-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           httpGet:
             path: /
             port: dashboard-http
-          initialDelaySeconds: 120
+          initialDelaySeconds: 240
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Since the dashboard deployment depends on the launch of the mongodb and
parse containers, the deployment of the dashboard container could take a
while.