### PR TITLE
magento: bump `initialDelaySeconds` of the magento deployment to 420s

### DIFF
--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -1,5 +1,5 @@
 name: magento
-version: 0.4.10
+version: 0.4.11
 appVersion: 2.1.7
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/templates/deployment.yaml
+++ b/stable/magento/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             httpHeaders:
             - name: Host
               value: {{ include "host" . | quote }}
-          initialDelaySeconds: 300
+          initialDelaySeconds: 420
           timeoutSeconds: 5
           failureThreshold: 6
         readinessProbe:


### PR DESCRIPTION
We've noticed deployment instances where the 300s initial delay was not
sufficient