### PR TITLE
[stable/mysql] Use different probe commands depending on the presence of root password

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.2.6
+version: 0.2.7
 description: Fast, reliable, scalable, and easy to use open-source relational database system.
 keywords:
 - mysql

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -60,15 +60,27 @@ spec:
         livenessProbe:
           exec:
             command:
+            {{- if .Values.mysqlAllowEmptyPassword }}
             - mysqladmin
             - ping
+            {{- else }}
+            - sh
+            - -c
+            - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+            {{- end }}
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
           exec:
             command:
+            {{- if .Values.mysqlAllowEmptyPassword }}
             - mysqladmin
             - ping
+            {{- else }}
+            - sh
+            - -c
+            - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+            {{- end }}
           initialDelaySeconds: 5
           timeoutSeconds: 1
         volumeMounts:


### PR DESCRIPTION
the mysql running process will emit `Access denied for user 'root'@'localhost' (using password: NO)` every time a client tries to connect without providing the right credentials.

Each time the liveness and readiness probes execute the `mysqladmin ping` command, without providing the right credentials, that error shows up making the container logs excessively noisy.