### PR TITLE
Add helm test to CI

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -72,6 +72,7 @@ for directory in ${CHANGED_FOLDERS}; do
     kubectl get svc --namespace ${NAMESPACE}
     kubectl get deployments --namespace ${NAMESPACE}
     kubectl get endpoints --namespace ${NAMESPACE}
+    helm test
     if [ -n $VERIFICATION_PAUSE ]; then
       cat install_output
       sleep $VERIFICATION_PAUSE


### PR DESCRIPTION
Should be merged after #1701 as I believe in the 2.4.x series running Helm test when there was no tests caused a failure.