### PR TITLE
Traefik: Allow configuration of source IP ranges in load balancer.

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.9.0
+version: 1.10.0
 appVersion: 1.3.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -88,8 +88,8 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
 | `imageTag`                      | The version of the official Traefik image to use                     | `1.3.1`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
-| `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
-| `loadBalancerSourceRanges`      | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |
+| `loadBalancer.IP`               | An available static IP you have reserved on your cloud platform      | None                                      |
+| `loadBalancer.sourceRanges`     | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |
 | `replicas`                      | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -88,8 +88,8 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
 | `imageTag`                      | The version of the official Traefik image to use                     | `1.3.1`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
-| `loadBalancer.IP`               | An available static IP you have reserved on your cloud platform      | None                                      |
-| `loadBalancer.sourceRanges`     | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |
+| `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
+| `loadBalancerSourceRanges`      | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |
 | `replicas`                      | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -89,6 +89,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `imageTag`                      | The version of the official Traefik image to use                     | `1.3.1`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
+| `loadBalancerSourceRanges`      | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |
 | `replicas`                      | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |
 | `memoryRequest`                 | Initial share of memory requested per Traefik pod                    | `20Mi`                                    |

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -20,12 +20,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.serviceType }}
-  {{- if .Values.loadBalancer.IP }}
-  loadBalancerIP: {{ .Values.loadBalancer.IP }}
+  {{- if .Values.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.loadBalancer.sourceRanges }}
+  {{- if .Values.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-    {{- range $cidr := .Values.loadBalancer.sourceRanges }}
+    {{- range $cidr := .Values.loadBalancerSourceRanges }}
     - {{ $cidr }}
     {{- end }}
   {{- end }}

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -23,6 +23,12 @@ spec:
   {{- if .Values.loadBalancerIP }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range $cidr := .Values.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+    {{- end }}
+  {{- end }}
   selector:
     app: {{ template "fullname" . }}
   ports:

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -20,12 +20,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.serviceType }}
-  {{- if .Values.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.loadBalancerIP }}
+  {{- if .Values.loadBalancer.IP }}
+  loadBalancerIP: {{ .Values.loadBalancer.IP }}
   {{- end }}
-  {{- if .Values.loadBalancerSourceRanges }}
+  {{- if .Values.loadBalancer.sourceRanges }}
   loadBalancerSourceRanges:
-    {{- range $cidr := .Values.loadBalancerSourceRanges }}
+    {{- range $cidr := .Values.loadBalancer.sourceRanges }}
     - {{ $cidr }}
     {{- end }}
   {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,8 +2,9 @@
 image: traefik
 imageTag: 1.3.4
 serviceType: LoadBalancer
-loadBalancerIP:
-#loadBalancerSourceRanges: []
+loadBalancer:
+  IP:
+  #sourceRanges: []
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -3,6 +3,7 @@ image: traefik
 imageTag: 1.3.4
 serviceType: LoadBalancer
 loadBalancerIP:
+#loadBalancerSourceRanges: []
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -2,9 +2,8 @@
 image: traefik
 imageTag: 1.3.4
 serviceType: LoadBalancer
-loadBalancer:
-  IP:
-  #sourceRanges: []
+loadBalancerIP:
+#loadBalancerSourceRanges: []
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi


### PR DESCRIPTION
This PR will allow to configure traefik's service to restrict its access to a list of source IP ranges, if it uses the service type `LoadBalancer` and if it is supported.

Please, let me know if this satisfies all requirements and style. If not, I'll change the PR.

Thanks.