### PR TITLE
[stable/kube-state-metrics] Update documented image version

### DIFF
--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -15,7 +15,7 @@ $ helm install stable/kube-state-metrics
 | Parameter          | Description                         | Default                                      |
 |--------------------|-------------------------------------|----------------------------------------------|
 | `image.repository` | The image repository to pull from   | gcr.io/google_containers/kube-state-metrics  |
-| `image.tag`        | The image tag to pull from          | v0.4.1                                       |
+| `image.tag`        | The image tag to pull from          | v1.0.0                                       |
 | `image.pullPolicy` | Image pull policy                   | IfNotPresent                                 |
 | `service.port`     | The port of the container           | 8080                                         |
 | `prometheusScrape` | Whether or not enable prom scrape   | True                                         |


### PR DESCRIPTION
As of #1700, this chart installs kube-state-metrics v1.0.0; update its README
to match that.