### PR TITLE
Update ghost chart to work with non-root ghost container

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 0.4.13
+version: 0.4.14
 appVersion: 0.11.10
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -15,6 +15,13 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+      initContainers:
+      - name: volume-permissions
+        image: busybox
+        command: ['sh', '-c', 'chmod -R g+rwX /bitnami']
+        volumeMounts:
+        - mountPath: /bitnami
+          name: ghost-data
       containers:
       - name: {{ template "fullname" . }}
         image: "{{ .Values.image }}"

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       initContainers:
       - name: volume-permissions
-        image: "{{ .Values.initContainerImage }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        image: "{{ .Values.volumePermissions.image.name }}:{{ .Values.volumePermissions.image.tag }}"
+        imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
         command: ['sh', '-c', 'chmod -R g+rwX /bitnami']
         volumeMounts:
         - mountPath: /bitnami

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -17,7 +17,8 @@ spec:
     spec:
       initContainers:
       - name: volume-permissions
-        image: busybox
+        image: "{{ .Values.initContainerImage }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         command: ['sh', '-c', 'chmod -R g+rwX /bitnami']
         volumeMounts:
         - mountPath: /bitnami

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Ghost image version
 ## ref: https://hub.docker.com/r/bitnami/ghost/tags/
 ##
-image: bitnami/ghost:0.11.10-r1
+image: bitnami/ghost:0.11.10-r2
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -3,6 +3,10 @@
 ##
 image: bitnami/ghost:0.11.10-r2
 
+## Busybox image version
+##
+initContainerImage: busybox:1.27.1
+
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -3,9 +3,13 @@
 ##
 image: bitnami/ghost:0.11.10-r2
 
-## Busybox image version
+## Busybox image used to configure volume permissions
 ##
-initContainerImage: busybox:1.27.1
+volumePermissions:
+  image:
+    name: busybox
+    tag: 1.27.1
+#    pullPolicy:
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Since ghost 0.11.10-r2 version, it is being used a non-root approach to run the container so we need to set permission in the volume before initializing the ghost application.