### PR TITLE
[stable magento] fix random password generator to include a number

### DIFF
--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -1,5 +1,5 @@
 name: magento
-version: 0.4.11
+version: 0.4.12
 appVersion: 2.1.7
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/templates/_helpers.tpl
+++ b/stable/magento/templates/_helpers.tpl
@@ -16,6 +16,22 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a random alphanumeric password string.
+We append a random number to the string to avoid password validation errors
+*/}}
+{{- define "randomPassword" -}}
+{{- randAlphaNum 9 -}}{{- randNumeric 1 -}}
+{{- end -}}
+
+{{/*
+Get the user defined password or use a random string
+*/}}
+{{- define "password" -}}
+{{- $password := index .Values (printf "%sPassword" .Chart.Name) -}}
+{{- default (include "randomPassword" .) $password -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/magento/templates/secrets.yaml
+++ b/stable/magento/templates/secrets.yaml
@@ -9,8 +9,4 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  {{ if .Values.magentoPassword }}
-  magento-password: {{ default "" .Values.magentoPassword | b64enc | quote }}
-  {{ else }}
-  magento-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
+  magento-password: "{{ b64enc (include "password" .) }}"


### PR DESCRIPTION
Magento deployment fails of the password does not contain a number. When a
random password is generated, `randAlphaNum` does not gaurantee that the string
will contain a number.

This commit adds a helper function named `password` that returns the
user defined password if it exists or else generates a random password
with a random number appended to it.