### PR TITLE
[sumologic-fluentd] make rbac service account name configurable

### DIFF
--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -85,6 +85,7 @@ The following tables lists the configurable parameters of the sumologic-fluentd 
 | `resources.limits.cpu` | CPU resource limits | 256m |
 | `resources.requests.memory` | Memory resource requests | 128Mi |
 | `resources.limits.memory` | Memory resource limits | 256Mi |
+| `rbac.serviceAccountName` | RBAC service account name | {{ fullname }} |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -14,7 +14,11 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+    {{- if .Values.rbac.serviceAccountName }}
+      serviceAccountName: {{ .Values.rbac.serviceAccountName }}
+    {{- else }}
       serviceAccountName: {{ template "fullname" . }}
+    {{- end }}
       containers:
         - name: {{ template "fullname" . }}
           image: "{{.Values.image.name}}:{{.Values.image.tag}}"

--- a/stable/sumologic-fluentd/templates/serviceaccount.yaml
+++ b/stable/sumologic-fluentd/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.rbac.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,4 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -17,10 +17,10 @@ sumologic:
   # numThreads: 1
 
   ## Set the _sourceName metadata field in SumoLogic. (Default "%{namespace}.%{pod}.%{container}")
-  # sourceName: 
+  # sourceName:
 
   ## Set the _sourceCategory metadata field in SumoLogic. (Default "%{namespace}/%{pod_name}")
-  # sourceCategory: 
+  # sourceCategory:
 
   ## Set the prefix, for _sourceCategory metadata. (Defualt nil)
   # sourceCategoryPrefix:
@@ -38,7 +38,7 @@ sumologic:
   ## Files matching this pattern will be ignored by the in_tail plugin, and will
   ## not be sent to Kubernetes or Sumo Logic. This can be a comma seperated list.
   ## ref: http://docs.fluentd.org/v0.12/articles/in_tail#excludepath
-  # excludePath: 
+  # excludePath:
 
   ## A ruby regex for namespaces. All matching namespaces will be excluded
   ## from Sumo Logic. The logs will still be sent to FluentD
@@ -53,7 +53,7 @@ sumologic:
   ## A ruby regex for containers. All matching containers will be excluded
   ## from Sumo Logic. The logs will still be sent to FluentD
   ## ref: http://rubular.com/
-  # excludeContainerRegex: 
+  # excludeContainerRegex:
 
   ## A ruby regex for hosts. All matching hosts will be excluded from Sumo
   ## Logic. The logs will still be sent to FluentD
@@ -78,3 +78,5 @@ resources:
   limits:
     cpu: 256m
     memory: 256Mi
+
+rbac: {}


### PR DESCRIPTION
This is to make user configuration simpler, so we can create our own service account and reuse that same service account configuration across clusters should we choose to do so.
@flah00 @frankreno
