### PR TITLE
[stable/mysql] Accept custom mysql config files

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.2.7
+version: 0.2.8
 description: Fast, reliable, scalable, and easy to use open-source relational database system.
 keywords:
 - mysql

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -92,7 +92,7 @@ you can change the values.yaml to disable persistence and use an emptyDir instea
 
 ## Custom MySQL configuration files
 
-The [MySQL](https://hub.docker.com/_/mysql/) image accepts custom configuration files at the path `/etc/mysql/conf.d`. If you want to use a customized MySQL configuration, you can create your alternative configuration files by passing the file contents on the `configurationFiles` attribute. Note that according with the MySQL documentation only files ending with `.cfn` are loaded.
+The [MySQL](https://hub.docker.com/_/mysql/) image accepts custom configuration files at the path `/etc/mysql/conf.d`. If you want to use a customized MySQL configuration, you can create your alternative configuration files by passing the file contents on the `configurationFiles` attribute. Note that according to the MySQL documentation only files ending with `.cfn` are loaded.
 
 ```yaml
 configurationFiles:

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -57,6 +57,7 @@ The following tables lists the configurable parameters of the MySQL chart and th
 | `persistence.storageClass` | Type of persistent volume claim    | nil  (uses alpha storage class annotation)                 |
 | `persistence.accessMode`   | ReadWriteOnce or ReadOnly          | ReadWriteOnce                                              |
 | `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                              |
+| `configurationFiles`       | List of mysql configuration files  | `nil`
 
 Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).
 
@@ -86,3 +87,18 @@ By default a PersistentVolumeClaim is created and mounted into that directory. I
 you can change the values.yaml to disable persistence and use an emptyDir instead.
 
 > *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+## Custom MySQL configuration files
+
+The [MySQL](https://hub.docker.com/_/mysql/) image accepts custom configuration files at the path `/etc/mysql/conf.d`. If you want to use a customized MySQL configuration, you can create your alternative configuration files by passing the file contents on the `configurationFiles` attribute. Note that according with the MySQL documentation only files ending with `.cfn` are loaded.
+
+```yaml
+configurationFiles:
+  mysql.cnf: |-
+    [mysqld]
+    skip-host-cache
+    skip-name-resolve
+    sql-mode=STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+  mysql_custom.cnf: |-
+    [mysqld]
+```

--- a/stable/mysql/templates/configmap.yaml
+++ b/stable/mysql/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.configurationFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+data:
+{{- range $key, $val := .Values.configurationFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -86,7 +86,16 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/mysql
+        {{- if .Values.configurationFiles }}
+        - name: configurations
+          mountPath: /etc/mysql/conf.d
+        {{- end }}
       volumes:
+      {{- if .Values.configurationFiles }}
+      - name: configurations
+        configMap:
+          name: {{ template "fullname" . }}
+      {{- end }}
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -45,3 +45,9 @@ resources:
   requests:
     memory: 256Mi
     cpu: 100m
+
+# Custom mysql configuration files used to override default mysql settings
+configurationFiles:
+#  mysql.cnf: |-
+#    [mysqld]
+#    skip-name-resolve


### PR DESCRIPTION
The official MySQL image allows passing custom MySQL config files but the helm chart was not exposing this as a first class feature.