### PR TITLE
[stable/aws-cluster-autoscaler] Add deprecation field to deprecated charts

### DIFF
--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
+deprecated: true
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: aws-cluster-autoscaler
-version: 0.3.0
+version: 0.3.1
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -1,5 +1,7 @@
 # aws-cluster-autoscaler
 
+**This chart has been deprecated as of version 0.3.1 and will not be updated. Please use the cluster-autoscaler chart instead.**
+
 [The cluster autoscaler on AWS](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws) scales worker nodes within an AWS autoscaling group.
 
 ## TL;DR:

--- a/stable/aws-cluster-autoscaler/templates/NOTES.txt
+++ b/stable/aws-cluster-autoscaler/templates/NOTES.txt
@@ -1,3 +1,8 @@
+################################################################################
+#### This chart has been deprecated as of version 0.3.1 and will not be updated.
+#### Please use the cluster-autoscaler chart instead.
+################################################################################
+
 To verify that aws-cluster-autoscaler has started, run:
 
   kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "name" . }},release={{ .Release.Name }}"

--- a/stable/nginx-lego/Chart.yaml
+++ b/stable/nginx-lego/Chart.yaml
@@ -1,5 +1,6 @@
 name: nginx-lego
-version: 0.2.1
+version: 0.2.2
+deprecated: true
 description: Chart for nginx-ingress-controller and kube-lego
 keywords:
 - kube-lego

--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,5 +1,6 @@
 name: telegraf
-version: 0.2.1
+version: 0.2.2
+deprecated: true
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:
 - telegraf


### PR DESCRIPTION
This PR primarily marks `aws-cluster-autoscaler` as deprecated in favor of the combined `cluster-autoscaler` chart.

However, it also adds the `deprecated` field to `stable/nginx-lego` and `stable/telegraf`. Both of these were deprecated months ago, so I don't see a problem combining them here.