### PR TITLE
[stable/traefik] Bump Traefik version to 1.3.5

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.11.0
-appVersion: 1.3.4
+version: 1.11.1
+appVersion: 1.3.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -86,7 +86,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | Parameter                       | Description                                                          | Default                                   |
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
-| `imageTag`                      | The version of the official Traefik image to use                     | `1.3.1`                                  |
+| `imageTag`                      | The version of the official Traefik image to use                     | `1.3.5`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
 | `loadBalancerSourceRanges`      | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Traefik
 image: traefik
-imageTag: 1.3.4
+imageTag: 1.3.5
 serviceType: LoadBalancer
 loadBalancerIP:
 #loadBalancerSourceRanges: []


### PR DESCRIPTION
See https://github.com/containous/traefik/releases