### PR TITLE
[stable/external-dns] Add RBAC

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others) for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.1.0
-appVersion: 0.4.2
+version: 0.1.1
+appVersion: 0.4.3
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
   - https://github.com/kubernetes-incubator/external-dns

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -8,10 +8,6 @@ This chart will do the following:
 
 Currently this uses the [Zalando] hosted container, if this is a concern follow the steps in the [external-dns] documentation to compile the binary and make a container. Where the chart pulls the image from is fully configurable.
 
-## Notes
-
-You probably want to make sure the nodes have IAM permissions to modify the R53 entries. More on this later.
-
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:
@@ -31,7 +27,7 @@ The following tables lists the configurable parameters of the external-dns chart
 | `extraArgs`            | Optional object of extra args, as `name`: `value` pairs. Where the name is the command line arg to external-dns.           | `{}`                                                         |
 | `image.name`           | Container image name (Including repository name if not `hub.docker.com`).                                                  | `registry.opensource.zalan.do/teapot/external-dns`           |
 | `image.pullPolicy`     | Container pull policy.                                                                                                     | `IfNotPresent`                                               |
-| `image.tag`            | Container image tag.                                                                                                       | `v0.4.2`                                                     |
+| `image.tag`            | Container image tag.                                                                                                       | `v0.4.3`                                                     |
 | `podAnnotations`       | Additional annotations to apply to the pod.                                                                                | `{}`                                                       |
 | `policy`               | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only ).                        | `upsert-only`                                                |
 | `provider`             | The DNS provider where the DNS records will be created (options: aws, google, azure, cloudflare, digitalocean, inmemory ). | `aws`                                                        |
@@ -50,6 +46,35 @@ $ helm install --name my-release -f values.yaml stable/external-dns
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## IAM Permissions
+
+```json
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Effect": "Allow",
+     "Action": [
+       "route53:ChangeResourceRecordSets"
+     ],
+     "Resource": [
+       "arn:aws:route53:::hostedzone/*"
+     ]
+   },
+   {
+     "Effect": "Allow",
+     "Action": [
+       "route53:ListHostedZones",
+       "route53:ListResourceRecordSets"
+     ],
+     "Resource": [
+       "*"
+     ]
+   }
+ ]
+}
+```
 
 [external-dns]: https://github.com/kubernetes-incubator/external-dns
 [Zalando]: https://zalando.github.io/

--- a/stable/external-dns/templates/_helpers.tpl
+++ b/stable/external-dns/templates/_helpers.tpl
@@ -12,7 +12,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "external-dns.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/* Generate basic labels */}}

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "external-dns.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - ingresses
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/stable/external-dns/templates/clusterrolebinding.yaml
+++ b/stable/external-dns/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "external-dns.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "external-dns.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "external-dns.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   template:
     metadata:
-      labels: {{ include "external-dns.labels" . | indent 8 }}
     {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8}}
     {{- end }}
+      labels: {{ include "external-dns.labels" . | indent 8 }}
     spec:
       containers:
         - name: {{ template "name" . }}
@@ -29,8 +29,18 @@ spec:
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 7979
+          ports:
+            - containerPort: 7979
         {{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "external-dns.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -18,11 +18,14 @@ spec:
           image: "{{.Values.image.name}}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
-            - --provider={{ .Values.provider }}
-            - --policy={{ .Values.policy }}
+          {{- if .Values.debug }}
+            - --debug
+          {{- end }}
           {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}
           {{- end }}
+            - --policy={{ .Values.policy }}
+            - --provider={{ .Values.provider }}
           {{- range .Values.sources }}
             - --source={{ . }}
           {{- end }}

--- a/stable/external-dns/templates/service.yaml
+++ b/stable/external-dns/templates/service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "external-dns.fullname" . }}
+spec:
+  clusterIP: "{{ .Values.service.clusterIP }}"
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - port: {{ .Values.service.servicePort }}
+      protocol: TCP
+      targetPort: 7979
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+  type: "{{ .Values.service.type }}"

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -1,7 +1,7 @@
 ## Details about the image to be pulled.
 image:
   name: registry.opensource.zalan.do/teapot/external-dns
-  tag: v0.4.2
+  tag: v0.4.3
   pullPolicy: IfNotPresent
 
 ## This controls which types of resource external-dns should 'watch' for new
@@ -15,6 +15,11 @@ provider: aws
 
 ## Limit possible target zones by domain suffixes (optional)
 domainFilters: []
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
 
 ## Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only )
 policy: upsert-only
@@ -41,3 +46,17 @@ rbac:
   ## Ignored if rbac.create is true
   ##
   serviceAccountName: default
+
+service:
+  annotations: {}
+  clusterIP: ""
+
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  servicePort: 7979
+  type: ClusterIP

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -28,6 +28,8 @@ policy: upsert-only
 ##
 podAnnotations: {}
 
+debug: false
+
 extraArgs: {}
 
 ## CPU and Memory limit and request for external-dns


### PR DESCRIPTION
Also:
* bumped the image version
* documented IAM requirements
* added livenessProbe
* added nodeSelector
* added a Service (for metrics)

RBAC comes from [here](https://github.com/kubernetes-incubator/external-dns/issues/233).

CC: @rk295 @sstarcher @linki @SamClinckspoor 