### PR TITLE
[stable/jenkins] Remove old plugin locks before installing plugins

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.8.7
+version: 0.8.8
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based projects as well as arbitrary scripts.
 sources:

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -137,6 +137,7 @@ data:
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
 {{- if .Values.Master.InstallPlugins }}
     cp /var/jenkins_config/plugins.txt /var/jenkins_home;
+    rm /usr/share/jenkins/ref/plugins/*.lock
     /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
 {{- end }}
 {{- if .Values.Master.ScriptApproval }}


### PR DESCRIPTION
The init container will fail if the plugin .lock files exist when install_plugins is run:

```
Creating initial locks...
mkdir: cannot create directory ‘/usr/share/jenkins/ref/plugins/kubernetes.lock’: File exists
```

This just adds a rm *.lock before the plugin script is run.
Note: I still need to sign the CLA -- I will get that done tomorrow.