### PR TITLE
[stable/openvpn] Mitigate SWEET32 OpenVPN vulnerability by using more secure cipher.

### DIFF
--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -32,6 +32,7 @@ data:
       nobind
       dev tun
       redirect-gateway def1
+      cipher AES-256-CBC
       <key>
       `cat ${EASY_RSA_LOC}/pki/private/$1.key`
       </key>
@@ -87,6 +88,8 @@ data:
       keepalive 10 60
       persist-key
       persist-tun
+
+      cipher AES-256-CBC
 
       proto {{ .Values.openvpn.OVPN_PROTO }}
       port  {{ .Values.service.internalPort }}


### PR DESCRIPTION
In order to migitgate SWEET32 vulnerability in OpenVPN, configure the server and the clients to use AES-256-CBC cipher instead of the default BF-CBC cipher.

For more info see https://community.openvpn.net/openvpn/wiki/SWEET32