### PR TITLE
Add release name to `helm test`

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -72,7 +72,7 @@ for directory in ${CHANGED_FOLDERS}; do
     kubectl get svc --namespace ${NAMESPACE}
     kubectl get deployments --namespace ${NAMESPACE}
     kubectl get endpoints --namespace ${NAMESPACE}
-    helm test
+    helm test ${RELEASE_NAME}
     if [ -n $VERIFICATION_PAUSE ]; then
       cat install_output
       sleep $VERIFICATION_PAUSE


### PR DESCRIPTION
Should resolve failures like [this](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/charts/1744/pull-charts-e2e/2615/)