### PR TITLE
[stable/kubernetes-dashboard] Allow UI to be reachable at its proxy path

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.6.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -11,8 +11,7 @@ metadata:
 spec:
   type: {{ .Values.serviceType }}
   ports:
-  - name: http
-    port: {{ .Values.httpPort }}
+  - port: {{ .Values.httpPort }}
     targetPort: http
 {{- if hasKey .Values "nodePort" }}
     nodePort: {{ .Values.nodePort }}


### PR DESCRIPTION
Assigning a name to the kubernetes-dashboard service port prevents kubernetes from detecting its endpoints. Removing the name from the service port fixes this issue.

I'm now able to access the dashboard at its cluster-service URL found in `kubectl cluster-info`.
This doesn't seem to cause any other issues, so was there a specific need for naming this service port?