### PR TITLE
[stable/concourse] promote pod affinity from annotation to spec

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.3.2
+version: 0.3.3
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,6 @@
 name: concourse
-version: 0.3.3
+version: 0.4.0
+appVersion: 3.3.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [Concourse](https://concourse.ci/) deployment on a [Kube
 
 ## Prerequisites Details
 
-* Kubernetes 1.5 (for `StatefulSets` support)
+* Kubernetes 1.6 (for `pod affinity` support)
 * PV support on underlying infrastructure (if persistence is required)
 
 ## Installing the Chart

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -14,25 +14,6 @@ spec:
     metadata:
       labels:
         app: {{ template "worker.fullname" . }}
-      annotations:
-        scheduler.alpha.kubernetes.io/affinity: >
-          {
-            "podAntiAffinity": {
-              "preferredDuringSchedulingIgnoredDuringExecution": [
-                {
-                  "weight": 100,
-                  "labelSelector": {
-                    "matchExpressions": [{
-                      "key": "app",
-                      "operator": "In",
-                      "values": ["{{ template "worker.fullname" . }}"]
-                    }]
-                  },
-                  "topologyKey": "kubernetes.io/hostname"
-                }
-              ]
-            }
-          }
     spec:
       terminationGracePeriodSeconds: 60
       containers:
@@ -90,6 +71,16 @@ spec:
               readOnly: true
             - name: concourse-work-dir
               mountPath: /concourse-work-dir
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: {{ template "worker.fullname" . }}
+                  release: {{ .Release.Name | quote }}
       volumes:
         - name: concourse-keys
           secret:

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+
 spec:
   serviceName: {{ template "worker.fullname" . }}
   replicas: {{ .Values.worker.replicas }}
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: {{ template "worker.fullname" . }}
+      annotations:
+        {{- range $key, $value := .Values.worker.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 60
       containers:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -313,7 +313,7 @@ web:
     ##
     enabled: false
 
-    ## Annotations.
+    ## Annotations to be added to the web ingress.
     ##
     # annotations:
     #   kubernetes.io/ingress.class: nginx
@@ -356,6 +356,11 @@ worker:
     requests:
       cpu: "100m"
       memory: "512Mi"
+
+  ## Annotations to be added to the worker pods.
+  ##
+  # annotations:
+  #   iam.amazonaws.com/role: arn:aws:iam::123456789012:role/concourse
 
 ## Persistent Volume Storage configuration.
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes


### PR DESCRIPTION
This updates @pfeodrippe's pull request to address
@unguiculus's comments. It moves the affinity into the
kubernetes 1.7 compatible affinity. It follows the pattern
used to fix cockroachdb in #1326.

Closes #1462, #1525, #1306