### PR TITLE
[stable/redis] namespace the template helpers with chart name ({{ define "fullname" }} --> {{ define "redis.fullname" }}

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.8.1
+version: 0.8.2
 appVersion: 3.2.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/NOTES.txt
+++ b/stable/redis/templates/NOTES.txt
@@ -1,18 +1,18 @@
 Redis can be accessed via port 6379 on the following DNS name from within your cluster:
-{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{ template "redis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 {{- if .Values.usePassword }}
 To get your password run:
 
-    REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.redis-password}" | base64 --decode)
+    REDIS_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "redis.fullname" . }} -o jsonpath="{.data.redis-password}" | base64 --decode)
 {{- end }}
 
 To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run {{ template "fullname" . }}-client --rm --tty -i{{ if .Values.usePassword }} --env REDIS_PASSWORD=$REDIS_PASSWORD{{ end }} --image {{ .Values.image }} -- bash
+   kubectl run {{ template "redis.fullname" . }}-client --rm --tty -i{{ if .Values.usePassword }} --env REDIS_PASSWORD=$REDIS_PASSWORD{{ end }} --image {{ .Values.image }} -- bash
 
 2. Connect using the Redis CLI:
 
-  redis-cli -h {{ template "fullname" . }}{{ if .Values.usePassword }} -a $REDIS_PASSWORD{{ end }}
+  redis-cli -h {{ template "redis.fullname" . }}{{ if .Values.usePassword }} -a $REDIS_PASSWORD{{ end }}

--- a/stable/redis/templates/_helpers.tpl
+++ b/stable/redis/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "redis.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "redis.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "redis.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "redis.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "redis.fullname" . }}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:
@@ -22,7 +22,7 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       containers:
-      - name: {{ template "fullname" . }}
+      - name: {{ template "redis.fullname" . }}
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
@@ -30,7 +30,7 @@ spec:
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "redis.fullname" . }}
               key: redis-password
         {{- else }}
         - name: ALLOW_EMPTY_PASSWORD
@@ -64,12 +64,12 @@ spec:
         imagePullPolicy: {{ .Values.metrics.imagePullPolicy | quote }}
         env:
         - name: REDIS_ALIAS
-          value: {{ template "fullname" . }}
+          value: {{ template "redis.fullname" . }}
         {{- if .Values.usePassword }}
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "redis.fullname" . }}
               key: redis-password
         {{- end }}
         ports:
@@ -82,7 +82,7 @@ spec:
       - name: redis-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim | default (include "fullname" .) }}
+          claimName: {{ .Values.persistence.existingClaim | default (include "redis.fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{- end -}}

--- a/stable/redis/templates/pvc.yaml
+++ b/stable/redis/templates/pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "redis.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "redis.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/redis/templates/secrets.yaml
+++ b/stable/redis/templates/secrets.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "redis.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "redis.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/redis/templates/svc.yaml
+++ b/stable/redis/templates/svc.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "redis.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "redis.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -17,4 +17,4 @@ spec:
     port: 6379
     targetPort: redis
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "redis.fullname" . }}


### PR DESCRIPTION
Per https://docs.helm.sh/chart_best_practices/#names-of-defined-templates