### PR TITLE
[mongodb-replicaset] Updated doc with correct helm install command

### DIFF
--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -75,7 +75,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml incubator/mongodb-replicaset
+$ helm install --name my-release -f values.yaml stable/mongodb-replicaset
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
[mongodb-replicaset] Updated doc with correct helm install command, as it was pointing to incubator, while chart has been moved to stable.
