### PR TITLE
Add capability for extra environmental variables

### DIFF
--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -64,6 +64,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- range $key, $value := .Values.controller.extraEnvs }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -65,6 +65,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- range $key, $value := .Values.controller.extraEnvs }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -49,6 +49,7 @@ controller:
     namespace: "" # defaults to .Release.Namespace
 
   extraArgs: {}
+  extraEnvs: {}
 
   ## DaemonSet or Deployment
   ##


### PR DESCRIPTION
It is useful to be able to inject extra environmental variables into the nginx-ingress chart.

When using logspout for centralised container logging, there is an environmental variable to disable logging of other containers. This environmental variable (LOGSPOUT) needs to be injected into the running container.

I have added extraEnvs to match the extra extraArgs option which already exists.