### PR TITLE
[memcached] Separate replicaCount from PDB minAvailable

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 1.2.0
+version: 1.2.1
 description: Free & open source, high-performance, distributed memory object caching system.
 keywords:
 - memcached

--- a/stable/memcached/templates/pdb.yaml
+++ b/stable/memcached/templates/pdb.yaml
@@ -9,5 +9,5 @@ spec:
       chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
-  minAvailable: {{ .Values.pdbCount }}
+  minAvailable: {{ .Values.pdbMinAvailable }}
   

--- a/stable/memcached/templates/pdb.yaml
+++ b/stable/memcached/templates/pdb.yaml
@@ -9,5 +9,5 @@ spec:
       chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
-  minAvailable: {{ .Values.replicaCount }}
+  minAvailable: {{ .Values.pdbCount }}
   

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -14,7 +14,7 @@ image: memcached:1.4.36-alpine
 replicaCount: 3
 
 ##Pod disruption budget minAvailable count
-pdbCount: 3
+pdbMinAvailable: 3
 
 ## Select AnitAffinity as either hard or soft, default is hard
 AntiAffinity: "hard"

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -13,6 +13,9 @@ image: memcached:1.4.36-alpine
 ##Replica count 
 replicaCount: 3
 
+##Pod disruption budget minAvailable count
+pdbCount: 3
+
 ## Select AnitAffinity as either hard or soft, default is hard
 AntiAffinity: "hard"
   


### PR DESCRIPTION
The current chart generates and error when scaling with`helm upgrade --set replicaCount=N` because the PodDisruptionbudget cannot be updated.

```
helm upgrade cache --set replicaCount=2 stable/memcached/
Error: UPGRADE FAILED: PodDisruptionBudget.policy "cache-memcached" is invalid: spec: Forbidden: updates to poddisruptionbudget spec are forbidden.
```

This patch separates `replicaCount` from PDB `minAvailable` field and adds a new value `pdbCount` so that the counts can be set independently. 