### PR TITLE
[stable/kube-ops-view] Add RBAC support

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-ops-view
-version: 0.3.0
+version: 0.3.1
 description: Kubernetes Operational View - read-only system dashboard for multiple K8s clusters
 keywords:
   - kubernetes

--- a/stable/kube-ops-view/templates/clusterrole.yaml
+++ b/stable/kube-ops-view/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "pods"]
+  verbs: ["list"]
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  resourceNames: ["heapster"]
+  verbs: ["get"]
+{{- end -}}

--- a/stable/kube-ops-view/templates/clusterrolebinding.yaml
+++ b/stable/kube-ops-view/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/kube-ops-view/templates/deployment.yaml
+++ b/stable/kube-ops-view/templates/deployment.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kube-ops-view/templates/serviceaccount.yaml
+++ b/stable/kube-ops-view/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end -}}

--- a/stable/kube-ops-view/values.yaml
+++ b/stable/kube-ops-view/values.yaml
@@ -29,3 +29,8 @@ ingress:
   #   - secretName: kube-ops-view.local-tls
   #     hosts:
   #       - kube-ops-view.local
+rbac:
+  # If true, create & use RBAC resources
+  create: false
+  # Ignored if rbac.create is true
+  serviceAccountName: default


### PR DESCRIPTION
This PR adds RBAC support to stable/kube-ops-view.
ClusterRole sourced from https://github.com/hjacobs/kube-ops-view/blob/b1150b797fd259de04ae1225c4eee95bf141cc7b/deploy/auth.yaml.