### PR TITLE
[stable/redis]: add args parameter for custom command-line arguments

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.8.2
+version: 0.9.0
 appVersion: 3.2.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -49,6 +49,7 @@ The following tables lists the configurable parameters of the Redis chart and th
 | `imagePullPolicy`          | Image pull policy                     | `IfNotPresent`                                            |
 | `usePassword`              | Use password                          | `true`                                         |
 | `redisPassword`            | Redis password                        | Randomly generated                                        |
+| `args`                     | Redis command-line args               | []                                                        |
 | `persistence.enabled`      | Use a PVC to persist data             | `true`                                                    |
 | `persistence.existingClaim`| Use an existing PVC to persist data   | `nil`                                                     |
 | `persistence.storageClass` | Storage class of backing PVC          | `generic`                                                 |

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -25,8 +25,10 @@ spec:
       - name: {{ template "redis.fullname" . }}
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        {{- if .Values.args }}
         args:
 {{ toYaml .Values.args | indent 10 }}
+        {{- end }}
         env:
         {{- if .Values.usePassword }}
         - name: REDIS_PASSWORD

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       - name: {{ template "redis.fullname" . }}
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        args:
+{{ toYaml .Values.args | indent 10 }}
         env:
         {{- if .Values.usePassword }}
         - name: REDIS_PASSWORD

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -17,6 +17,15 @@ usePassword: true
 ##
 # redisPassword:
 
+## Redis command arguments
+##
+## Can be used to specify command line arguments, for example:
+##
+## args:
+##  - "redis-server"
+##  - "--maxmemory-policy volatile-ttl"
+args:
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
This PR adds an `args` parameter to the stable/redis chart for specifying arbitrary command-line arguments. For example, this will allow you to [configure Redis as an LRU cache](https://github.com/kubernetes/charts/issues/529) with the following:

```
args:
  - "redis-server"
  - "--maxmemory-policy volatile-ttl"
```
