### PR TITLE
Fixing stable/concourse

### DIFF
--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -14,27 +14,20 @@ spec:
     metadata:
       labels:
         app: {{ template "worker.fullname" . }}
-      annotations:
-        scheduler.alpha.kubernetes.io/affinity: >
-          {
-            "podAntiAffinity": {
-              "preferredDuringSchedulingIgnoredDuringExecution": [
-                {
-                  "weight": 100,
-                  "labelSelector": {
-                    "matchExpressions": [{
-                      "key": "app",
-                      "operator": "In",
-                      "values": ["{{ template "worker.fullname" . }}"]
-                    }]
-                  },
-                  "topologyKey": "kubernetes.io/hostname"
-                }
-              ]
-            }
-          }
     spec:
       terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "worker.fullname" . }}
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: {{ template "worker.fullname" . }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"


### PR DESCRIPTION
On the version of kubernetes and mininkube I'm using (I believe latest stable of each) I'm getting an error installing concourse like:

`Error: release concourse failed: StatefulSet.apps "concourse-worker" is invalid: spec.template.annotations.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey: Required value: can not be empty
`

This might fix it as I was able to install concourse locally after making this change.

Please check this fix.
I used this as a guide https://github.com/yanns/charts/commit/dd70527c778be75d59fddf88754b029ffa23256a