### PR TITLE
[stable/weave-cloud] sync with upstream

### DIFF
--- a/stable/weave-cloud/Chart.yaml
+++ b/stable/weave-cloud/Chart.yaml
@@ -1,8 +1,6 @@
 name: weave-cloud
-version: 0.1.0
+version: 0.1.1
 description: |
-    Weave Cloud Agents
-
     Weave Cloud is a add-on to Kubernetes which provides Continuous Delivery, along with hosted Prometheus Monitoring and a visual dashboard for exploring & debugging microservices
 home: https://weave.works
 maintainers:

--- a/stable/weave-cloud/templates/cortex.yaml
+++ b/stable/weave-cloud/templates/cortex.yaml
@@ -63,7 +63,7 @@ items:
                 - '-config.file=/etc/prometheus/prometheus.yml'
                 - '-web.listen-address=:8080'
                 - '-storage.local.engine=none'
-              image: 'prom/prometheus:v1.6.3'
+              image: 'prom/prometheus:v1.7.1'
               imagePullPolicy: IfNotPresent
               ports:
                 - containerPort: 8080
@@ -130,7 +130,7 @@ items:
           serviceAccountName: weave-cortex
           tolerations:
             - effect: NoSchedule
-              key: node-role.kubernetes.io/master
+              operator: Exists
       updateStrategy:
         type: RollingUpdate
   - apiVersion: v1
@@ -149,7 +149,7 @@ items:
         remote_write:
           - url: 'https://cloud.weave.works/api/prom/push'
             basic_auth:
-              password: '{{ .Values.ServiceToken }}'
+              password: '{{.Values.ServiceToken}}'
         scrape_configs:
           - job_name: kubernetes-service-endpoints
             kubernetes_sd_configs:

--- a/stable/weave-cloud/templates/flux.yaml
+++ b/stable/weave-cloud/templates/flux.yaml
@@ -60,7 +60,7 @@ items:
           containers:
             - name: agent
               args:
-                - '--token={{ .Values.ServiceToken }}'
-              image: 'quay.io/weaveworks/fluxd:0.2.0'
+                - '--token={{.Values.ServiceToken}}'
+              image: 'quay.io/weaveworks/fluxd:0.3.0'
               imagePullPolicy: IfNotPresent
           serviceAccountName: weave-flux

--- a/stable/weave-cloud/templates/scope.yaml
+++ b/stable/weave-cloud/templates/scope.yaml
@@ -63,8 +63,8 @@ items:
                 - '--probe.docker.bridge=docker0'
                 - '--probe.docker=true'
                 - '--probe.kubernetes=true'
-                - '--service-token={{ .Values.ServiceToken }}'
-              image: 'weaveworks/scope:1.4.0'
+                - '--service-token={{.Values.ServiceToken}}'
+              image: 'weaveworks/scope:1.6.2'
               imagePullPolicy: IfNotPresent
               securityContext:
                 privileged: true
@@ -73,12 +73,14 @@ items:
                   mountPath: /var/run/docker.sock
                 - name: scope-plugins
                   mountPath: /var/run/scope/plugins
+                - name: sys-kernel-debug
+                  mountPath: /sys/kernel/debug
           hostNetwork: true
           hostPID: true
           serviceAccountName: weave-scope
           tolerations:
             - effect: NoSchedule
-              key: node-role.kubernetes.io/master
+              operator: Exists
           volumes:
             - name: docker-socket
               hostPath:
@@ -86,5 +88,8 @@ items:
             - name: scope-plugins
               hostPath:
                 path: /var/run/scope/plugins
+            - name: sys-kernel-debug
+              hostPath:
+                path: /sys/kernel/debug
       updateStrategy:
         type: RollingUpdate


### PR DESCRIPTION
Latest releases:
- weaveworks/scope:1.6.2
- prom/prometheus:v1.7.1
- quay.io/weaveworks/fluxd:0.3.0

Minor changes:
- mount `/sys/kernel/debug` for access to eBPF
- broaden `NoSchedule` tolerations