### PR TITLE
[stable/grafana] update README - admin password generated

### DIFF
--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 5.4.6-1
+version: 5.4.6-2
 appVersion: 5.4.6
 description: Universal Repository Manager supporting all major packaging formats, build tools and CI servers.
 keywords:

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -64,7 +64,7 @@ The following tables lists the configurable parameters of the artifactory chart 
 | `database.env.type`          | Database type                     | `postgresql`                                             |
 | `database.env.name`          | Database name                     | `artifactory`                                            |
 | `database.env.user`          | Database username                 | `artifactory`                                            |
-| `database.env.pass`          | Database password                 | `artXifactory1973`                                       |
+| `database.env.pass`          | Database password                 | `Randomly generated`                                     |
 | `database.image.repository`          | Database container image                     | `docker.bintray.io/postgres`             |
 | `database.image.version`          | Database container image tag                     | `9.5.2`                                 |
 | `database.image.pullPolicy`         | Container pull policy             | `IfNotPresent`                                           |

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.4.3
+version: 0.4.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -33,7 +33,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-------------------------------------------|-------------------------------------|---------------------------------------------------|
 | `server.image`                            | Container image to run              | grafana/grafana:latest                            |
 | `server.adminUser`                        | Admin user username                 | admin                                             |
-| `server.adminPassword`                    | Admin user password                 | admin                                             |
+| `server.adminPassword`                    | Admin user password                 | Randomly generated                                |
 | `server.persistentVolume.enabled`         | Create a volume to store data       | true                                              |
 | `server.persistentVolume.size`            | Size of persistent volume claim     | 1Gi RW                                            |
 | `server.persistentVolume.storageClass`    | Type of persistent volume claim     | `nil` (uses alpha storage class annotation)       |


### PR DESCRIPTION
Just a small update to the README, so users won't try `admin` as the password.

The grafana admin password is randomly generated by default.
see ( `stable/grafana/templates/secret.yaml` ):
```
  grafana-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
```

Same goes for `stable/artifactory` - database password.
