### PR TITLE
Replace user by user@example.com in Ghost

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 0.4.14
+version: 0.4.15
 appVersion: 0.11.10
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -52,14 +52,14 @@ The following tables lists the configurable parameters of the Ghost chart and th
 | `ghostHost`                       | Ghost host to create application URLs                 | `nil`                                                     |
 | `ghostPort`                       | Ghost port to create application URLs along with host | `80`                                                      |
 | `ghostLoadBalancerIP`             | `loadBalancerIP` for the Ghost Service                | `nil`                                                     |
-| `ghostUsername`                   | User of the application                               | `user`                                                    |
+| `ghostUsername`                   | User of the application                               | `user@example.com`                                        |
 | `ghostPassword`                   | Application password                                  | Randomly generated                                        |
 | `ghostEmail`                      | Admin email                                           | `user@example.com`                                        |
 | `ghostBlogTitle`                  | Ghost Blog name                                       | `User's Blog`                                             |
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                                | `nil`                                                     |
 | `serviceType`                     | Kubernetes Service type                               | `LoadBalancer`                                            |
 | `persistence.enabled`             | Enable persistence using PVC                          | `true`                                                    |
-| `persistence.storageClass`        | PVC Storage Class for Ghost volume                    | `nil` (uses alpha storage annotation) |
+| `persistence.storageClass`        | PVC Storage Class for Ghost volume                    | `nil` (uses alpha storage annotation)                     |
 | `persistence.accessMode`          | PVC Access Mode for Ghost volume                      | `ReadWriteOnce`                                           |
 | `persistence.size`                | PVC Storage Request for Ghost volume                  | `8Gi`                                                     |
 | `resources`                       | CPU/Memory resource requests/limits                   | Memory: `512Mi`, CPU: `300m`                              |

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -35,7 +35,7 @@ ghostPort: 80
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-ghost#configuration
 ##
-ghostUsername: user
+ghostUsername: user@example.com
 
 ## Application password
 ## Defaults to a random 10-character alphanumeric string if not set


### PR DESCRIPTION
Ghost is using the email instead of the user, in these cases, we should change the value of the current variable `user` to the email `user@example.com`.

@prydonius @sameersbn 