### PR TITLE
[stable/heapster] add rbac for heapster

### DIFF
--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
-version: 0.1.1
+version: 0.1.2
 sources:
   - https://github.com/kubernetes/heapster
   - https://github.com/kubernetes/contrib/tree/master/addon-resizer

--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -30,19 +30,21 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The default configuration values for this chart are listed in `values.yaml`.
 
-| Parameter                             | Description                         | Default                                           |
-|---------------------------------------|-------------------------------------|---------------------------------------------------|
-| `image.repository`                    | Repository for container image      | gcr.io/google_containers/heapster                 |
-| `image.tag`                           | Container image tag                 | v1.3.0                                            |
-| `image.pullPolicy`                    | Image pull policy                   | IfNotPresent                                      |
-| `service.name`                        | Service port name                   | api                                               |
-| `service.type`                        | Type for the service                | ClusterIP                                         |
-| `service.externalPort`                | Service external port               | 8082                                              |
-| `service.internalPort`                | Service internal port               | 8082                                              |
-| `resources.limits`                    | Server resource  limits             | requests: {cpu: 100m, memory: 128Mi}              |
-| `resources.requests`                  | Server resource requests            | requests: {cpu: 100m, memory: 128Mi}              |
-| `command`                             | Commands for heapster pod           | "/heapster --source=kubernetes.summary_api:''     |
-| `resizer.enabled`                     | If enabled, scale resources         | true                                              |
+| Parameter                             | Description                                                  | Default                                           |
+|---------------------------------------|-------------------------------------                         |---------------------------------------------------|
+| `image.repository`                    | Repository for container image                               | gcr.io/google_containers/heapster                 |
+| `image.tag`                           | Container image tag                                          | v1.3.0                                            |
+| `image.pullPolicy`                    | Image pull policy                                            | IfNotPresent                                      |
+| `service.name`                        | Service port name                                            | api                                               |
+| `service.type`                        | Type for the service                                         | ClusterIP                                         |
+| `service.externalPort`                | Service external port                                        | 8082                                              |
+| `service.internalPort`                | Service internal port                                        | 8082                                              |
+| `resources.limits`                    | Server resource  limits                                      | requests: {cpu: 100m, memory: 128Mi}              |
+| `resources.requests`                  | Server resource requests                                     | requests: {cpu: 100m, memory: 128Mi}              |
+| `command`                             | Commands for heapster pod                                    | "/heapster --source=kubernetes.summary_api:''     |
+| `rbac.create`                         | Bind system:heapster role                                    | false                                             |
+| `rbac.serviceAccountName`             | existing ServiceAccount to use (ignored if rbac.create=true) | default                                           |
+| `resizer.enabled`                     | If enabled, scale resources                                  | true                                              |
 
 The table below is only applicable if `resizer.enabled` is `true`. More information on resizer can be found [here](https://github.com/kubernetes/contrib/blob/master/addon-resizer/README.md).
 

--- a/stable/heapster/templates/deployment.yaml
+++ b/stable/heapster/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       containers:

--- a/stable/heapster/templates/heapster-crb.yaml
+++ b/stable/heapster/templates/heapster-crb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:heapster
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/heapster/templates/pod-nanny-role.yaml
+++ b/stable/heapster/templates/pod-nanny-role.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.rbac.create -}}
+{{- if .Values.resizer.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "fullname" . }}-pod-nanny
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+{{- end -}}
+{{- end -}}

--- a/stable/heapster/templates/pod-nanny-rolebinding.yaml
+++ b/stable/heapster/templates/pod-nanny-rolebinding.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.resizer.enabled -}}
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "fullname" . }}-pod-nanny
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "fullname" . }}-pod-nanny
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/stable/heapster/templates/serviceaccount.yaml
+++ b/stable/heapster/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end -}}

--- a/stable/heapster/values.yaml
+++ b/stable/heapster/values.yaml
@@ -73,3 +73,11 @@ resizer:
   - "--extra-memory=6Mi"
   - "--threshold=5"
   - "--poll-period=300000"
+
+## For RBAC support:
+rbac:
+  create: false
+
+  ## Ignored if rbac.create is true
+  ##
+  serviceAccountName: default


### PR DESCRIPTION
picking up #1337 i added rbac for heapster
This adds an additional role for the pod nanny. 
I also renamed rbac.enabled to rbac.create as that is the flag most of the other charts tend to use