### PR TITLE
[stable/fluent-bit] Added nodeselector and tolerations support

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.1.6
+version: 0.1.7
 appVersion: 0.11.17
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -33,6 +33,14 @@ spec:
           readOnly: true
 {{ end }}
       terminationGracePeriodSeconds: 10
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
       volumes:
       - name: varlog
         hostPath:

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -25,3 +25,17 @@ resources:
   requests:
     cpu: 100m
     memory: 100Mi
+
+## Node tolerations for fluent-bit scheduling to nodes with taints
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations: []
+#- key: "key"
+#  operator: "Equal|Exists"
+#  value: "value"
+#  effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+## Node labels for fluent-bit pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}


### PR DESCRIPTION
This commit adds support for `nodeSelector` and `tolerations` to the
`stable/fluent-bit` chart.