### PR TITLE
Spelling and Whitespace Corrections

### DIFF
--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -107,7 +107,7 @@ $ helm install --name my-release -f values.yaml stable/sumologic-fluentd
 
 By default, the fluentd position files will be written to an ephemeral
 `emptyDir`. Each time the pods die, new position files will be created, all of
-the logs in the cluster will be sent to sumologic again. To avoid unneccessary
+the logs in the cluster will be sent to sumologic again. To avoid unnecessary
 re-transmissions, pos directories can be maintained as a `hostPath`. Create a
 directory, on each of the nodes, and point `persistence.hostPath` at that
 directory.

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -17,12 +17,12 @@ sumologic:
   # numThreads: 1
 
   ## Set the _sourceName metadata field in SumoLogic. (Default "%{namespace}.%{pod}.%{container}")
-  # sourceName: 
+  # sourceName:
 
   ## Set the _sourceCategory metadata field in SumoLogic. (Default "%{namespace}/%{pod_name}")
-  # sourceCategory: 
+  # sourceCategory:
 
-  ## Set the prefix, for _sourceCategory metadata. (Defualt nil)
+  ## Set the prefix, for _sourceCategory metadata. (Default nil)
   # sourceCategoryPrefix:
 
   ## Used to replace - with another character. (default /)
@@ -36,9 +36,9 @@ sumologic:
   # kubernetesMeta: true
 
   ## Files matching this pattern will be ignored by the in_tail plugin, and will
-  ## not be sent to Kubernetes or Sumo Logic. This can be a comma seperated list.
+  ## not be sent to Kubernetes or Sumo Logic. This can be a comma separated list.
   ## ref: http://docs.fluentd.org/v0.12/articles/in_tail#excludepath
-  # excludePath: 
+  # excludePath:
 
   ## A ruby regex for namespaces. All matching namespaces will be excluded
   ## from Sumo Logic. The logs will still be sent to FluentD
@@ -53,7 +53,7 @@ sumologic:
   ## A ruby regex for containers. All matching containers will be excluded
   ## from Sumo Logic. The logs will still be sent to FluentD
   ## ref: http://rubular.com/
-  # excludeContainerRegex: 
+  # excludeContainerRegex:
 
   ## A ruby regex for hosts. All matching hosts will be excluded from Sumo
   ## Logic. The logs will still be sent to FluentD


### PR DESCRIPTION
Correct a couple of spelling mistakes and remove whitespace from the end
of the lines for the sumologic-fluentd chart.