### PR TITLE
[stable/datadog] Adds support for activating detailed process and container monitoring

### DIFF
--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -48,6 +48,8 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `datadog.autoconf`          | Additional Datadog service discovery configurations | `nil`                    |
 | `datadog.checksd`           | Additional Datadog service checks  | `nil`                                     |
 | `datadog.confd`             | Additional Datadog service configurations | `nil`                              |
+| `datadog.volumes`           | Additional volumes for the daemonset or deployment | `nil`                     |
+| `datadog.volumeMounts`      | Additional volumeMounts for the daemonset or deployment | `nil`                |
 | `resources.requests.cpu`    | CPU resource requests              | `100m`                                    |
 | `resources.limits.cpu`      | CPU resource limits                | `256m`                                    |
 | `resources.requests.memory` | Memory resource requests           | `128Mi`                                   |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -74,6 +74,9 @@ spec:
           - name: checksd
             mountPath: /checks.d
             readOnly: true
+{{- if .Values.datadog.volumeMounts }}
+{{ toYaml .Values.datadog.volumeMounts | indent 10 }}
+{{- end }}
       volumes:
         - hostPath:
             path: /var/run/docker.sock
@@ -93,6 +96,9 @@ spec:
         - name: autoconf
           configMap:
             name: {{ template "autoconf.fullname" . }}
+{{- if .Values.datadog.volumes }}
+{{ toYaml .Values.datadog.volumes | indent 8 }}
+{{- end }}
       {{- if .Values.daemonset.tolerations }}
       tolerations:
 {{ toYaml .Values.daemonset.tolerations | indent 8 }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
           - name: checksd
             mountPath: /checks.d
             readOnly: true
+{{- if .Values.datadog.volumeMounts }}
+{{ toYaml .Values.datadog.volumeMounts | indent 10 }}
+{{- end }}
       volumes:
         - hostPath:
             path: /var/run/docker.sock
@@ -91,5 +94,8 @@ spec:
         - name: autoconf
           configMap:
             name: {{ template "autoconf.fullname" . }}
+{{- if .Values.datadog.volumes }}
+{{ toYaml .Values.datadog.volumes | indent 8 }}
+{{- end }}
 {{ end }}
 {{ end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -79,6 +79,20 @@ datadog:
   #   - name:
   #     value:
 
+  ## The dd-agent supports detailed process and container monitoring and
+  ## requires control over the volume and volumeMounts for the daemonset
+  ## or deployment.
+  ## ref: https://docs.datadoghq.com/guides/process/
+  ##
+  # volume:
+  #  - hostPath:
+  #      path: /etc/passwd
+  #    name: passwd
+  # volumeMount:
+  #   - name: passwd
+  #     mountPath: /etc/passwd
+  #     readOnly: true
+
   ## Provide additonal service definitions
   ## Each key will become a file in /conf.d/auto_conf
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files


### PR DESCRIPTION
The Datadog agent supports detailed monitoring for processes and containers and based on [their documentation][0], activating it requires setting a `volume` and a `volumeMount`. This PR adds support to include those elements to either the `daemonset` or `deployment` manifests.

[0]: https://docs.datadoghq.com/guides/process/