### PR TITLE
[nginx/stable] Add prometheus scrape annotations as defaults

### DIFF
--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -181,7 +181,10 @@ statsExporter:
     #   memory: 20Mi
 
   service:
-    annotations: {}
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9913"
+
     clusterIP: ""
 
     ## List of IP addresses at which the stats-exporter service is available


### PR DESCRIPTION
When stats exporter is enabled the user needs to add scrape annotations by hand.

This PR sets them by default so that when you enable the `statsExporter` you get the metrics in prometheus.