### PR TITLE
[stable/kube-state-metrics] Add RBAC support

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.0.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -12,10 +12,12 @@ $ helm install stable/kube-state-metrics
 
 ## Configuration
 
-| Parameter          | Description                         | Default                                      |
-|--------------------|-------------------------------------|----------------------------------------------|
-| `image.repository` | The image repository to pull from   | gcr.io/google_containers/kube-state-metrics  |
-| `image.tag`        | The image tag to pull from          | v1.0.0                                       |
-| `image.pullPolicy` | Image pull policy                   | IfNotPresent                                 |
-| `service.port`     | The port of the container           | 8080                                         |
-| `prometheusScrape` | Whether or not enable prom scrape   | True                                         |
+| Parameter                 | Description                                             | Default                                     |
+|---------------------------|---------------------------------------------------------|---------------------------------------------|
+| `image.repository`        | The image repository to pull from                       | gcr.io/google_containers/kube-state-metrics |
+| `image.tag`               | The image tag to pull from                              | v1.0.0                                      |
+| `image.pullPolicy`        | Image pull policy                                       | IfNotPresent                                |
+| `service.port`            | The port of the container                               | 8080                                        |
+| `prometheusScrape`        | Whether or not enable prom scrape                       | True                                        |
+| `rbac.create`             | If true, create & use RBAC resources                    | False                                       |
+| `rbac.serviceAccountName` | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -15,7 +15,7 @@ $ helm install stable/kube-state-metrics
 | Parameter                 | Description                                             | Default                                     |
 |---------------------------|---------------------------------------------------------|---------------------------------------------|
 | `image.repository`        | The image repository to pull from                       | gcr.io/google_containers/kube-state-metrics |
-| `image.tag`               | The image tag to pull from                              | v1.0.0                                      |
+| `image.tag`               | The image tag to pull from                              | v1.0.1                                      |
 | `image.pullPolicy`        | Image pull policy                                       | IfNotPresent                                |
 | `service.port`            | The port of the container                               | 8080                                        |
 | `prometheusScrape`        | Whether or not enable prom scrape                       | True                                        |

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+{{- end -}}

--- a/stable/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         version: "{{ .Values.image.tag }}"
         release: "{{ .Release.Name }}"
     spec:
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
       - name: {{ .Chart.Name }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/kube-state-metrics/templates/serviceaccount.yaml
+++ b/stable/kube-state-metrics/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+{{- end -}}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -6,3 +6,8 @@ image:
   pullPolicy: IfNotPresent
 service:
   port: 8080
+rbac:
+  # If true, create & use RBAC resources
+  create: false
+  # Ignored if rbac.create is true
+  serviceAccountName: default


### PR DESCRIPTION
This PR adds RBAC support for stable/kube-state-metrics.
RBAC comes from https://github.com/kubernetes/kube-state-metrics/tree/v1.0.1/kubernetes.