### PR TITLE
fixing pvc template for v1.7, bumping chart version

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.9.0
+version: 0.9.1
 appVersion: 3.2.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,7 +1,7 @@
 name: redis
-version: 0.9.1
+version: 0.10.1
 appVersion: 3.2.9
-description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
+description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.  Requires Kubernetes v1.6+
 keywords:
 - redis
 - keyvalue

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -14,8 +14,10 @@ This chart bootstraps a [Redis](https://github.com/bitnami/bitnami-docker-redis)
 
 ## Prerequisites
 
-- Kubernetes 1.4+ with Beta APIs enabled
-- PV provisioner support in the underlying infrastructure
+- Kubernetes 1.6+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure, including
+  DefaultStorageClass admission controller enabled if default storage
+  provisioning is desired.
 
 ## Installing the Chart
 

--- a/stable/redis/templates/pvc.yaml
+++ b/stable/redis/templates/pvc.yaml
@@ -15,6 +15,10 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
   {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.alertmanager.persistentVolume.storageClass) }}
+  storageClassName: ""
+  {{- else }}
   storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/redis/templates/pvc.yaml
+++ b/stable/redis/templates/pvc.yaml
@@ -9,10 +9,12 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
+  {{- if lt .Capabilities.KubeVersion.Minor "7" }}
   {{- if .Values.persistence.storageClass }}
     volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
   {{- else }}
     volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
   {{- end }}
 spec:
   accessModes:
@@ -20,4 +22,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+  {{- if ge .Capabilities.KubeVersion.Minor "7" }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+  storageClassName: default
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/stable/redis/templates/pvc.yaml
+++ b/stable/redis/templates/pvc.yaml
@@ -8,25 +8,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-  {{- if lt .Capabilities.KubeVersion.Minor "7" }}
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
-  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{- if ge .Capabilities.KubeVersion.Minor "7" }}
   {{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-  storageClassName: default
-  {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -40,6 +40,7 @@ persistence:
   ## Note: the following properties are only used if existingClaim is not set
 
   ## If defined, storageClassName: <storageClass>
+  ## unless storageClass is set to "-" - in which the storageClassName will be set to "", to bypass dynamic creation
   ## Default: not set - uses DefaultStorageClass admission controller to decide storage class
   # storageClass:
   accessMode: ReadWriteOnce

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -37,9 +37,10 @@ persistence:
   ## If defined, PVC must be created manually before volume will be bound
   # existingClaim:
 
-  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-  ## Default: volume.alpha.kubernetes.io/storage-class: default
-  ##
+  ## Note: the following properties are only used if existingClaim is not set
+
+  ## If defined, storageClassName: <storageClass>
+  ## Default: not set - uses DefaultStorageClass admission controller to decide storage class
   # storageClass:
   accessMode: ReadWriteOnce
   size: 8Gi


### PR DESCRIPTION
This chart would not work for my on 1.7 (using the defaults) but does work fine on 1.6.

Added clause for 1.7 and updated the PVC to be compliant.