### PR TITLE
[stable/mongodb-replicaset] Adjusting storage to non alpha/beta if using v1.7 or higher

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 1.4.0
+version: 1.4.1
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 icon: https://webassets.mongodb.com/_com_assets/cms/mongodb-logo-rgb-j6w271g1xn.jpg
 sources:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -166,10 +166,12 @@ spec:
     - metadata:
         name: datadir
         annotations:
+        {{- if lt .Capabilities.KubeVersion.Minor "7" }}
         {{- if .Values.persistentVolume.storageClass | quote }}
           volume.beta.kubernetes.io/storage-class: {{ .Values.persistentVolume.storageClass | quote }}
         {{- else }}
           volume.alpha.kubernetes.io/storage-class: default
+        {{- end }}
         {{- end }}
         {{- range $key, $value := .Values.persistentVolume.annotations }}
           {{ $key }}: {{ $value }}
@@ -178,6 +180,13 @@ spec:
         accessModes:
         {{- range .Values.persistentVolume.accessModes }}
           - {{ . | quote }}
+        {{- end }}
+        {{- if ge .Capabilities.KubeVersion.Minor "7" }}
+        {{- if .Values.persistentVolume.storageClass }}
+        storageClassName: {{ .Values.persistentVolume.storageClass | quote }}
+        {{- else }}
+        storageClassName: default
+        {{- end }}
         {{- end }}
         resources:
           requests:


### PR DESCRIPTION
Per https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1 moving storage class setting to `spec.storageClassName`

Also incrementing the version to account for the change