### PR TITLE
[stable/sentry] add env var to set sender email

### DIFF
--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -51,6 +51,8 @@ spec:
           value: {{ template "redis.fullname" . }}
         - name: SENTRY_REDIS_PORT
           value: "6379"
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -50,6 +50,8 @@ spec:
           value: {{ template "redis.fullname" . }}
         - name: SENTRY_REDIS_PORT
           value: "6379"
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -51,6 +51,8 @@ spec:
           value: {{ template "redis.fullname" . }}
         - name: SENTRY_REDIS_PORT
           value: "6379"
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT


### PR DESCRIPTION
Adding SENTRY_SERVER_EMAIL populated from Values.email.from_address (that already exists in documentation) to set the sender email address.