### PR TITLE
name kubeStateMetrics port as 'metrics'

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.0.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -28,7 +28,8 @@ spec:
           image: "{{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}"
           imagePullPolicy: "{{ .Values.kubeStateMetrics.image.pullPolicy }}"
           ports:
-            - containerPort: 8080
+            - name: metrics
+              containerPort: 8080
           resources:
 {{ toYaml .Values.kubeStateMetrics.resources | indent 12 }}
     {{- if .Values.kubeStateMetrics.nodeSelector }}


### PR DESCRIPTION
Name the kube state metrics port to be consistent with the node exporter spec. This is useful for those of us who depend on port names to determine Prometheus scrape targets.