### PR TITLE
fix(stable/coredns): listen on all interfaces for prometheus metrics

### DIFF
--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
         health
       {{- end }}
       {{- if eq "prometheus" $key }}
-        prometheus localhost:{{ $middleware.port }}
+        prometheus 0.0.0.0:{{ $middleware.port }}
       {{- end }}
       {{- if eq "proxy" $key }}
         proxy . /etc/resolv.conf

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -61,6 +61,11 @@ spec:
           name: dns-tcp
           protocol: TCP
         {{- end }}
+        {{- if .Values.middleware.prometheus.enabled }}
+        - containerPort: 9153
+          name: metrics-tcp
+          protocol: TCP
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
This makes the prometheus middleware listen not only on localhost but on all interfaces so prometheus can actually reach it.
Also open up a port on the container for prometheus to reach the metrics port.

fixes #1888 