### PR TITLE
[stable/nginx-ingress] update version to 0.9.0-beta.12

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 name: nginx-ingress
-version: 0.8.1
-appVersion: 0.9.0-beta.11
+version: 0.8.2
+appVersion: 0.9.0-beta.12
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png
 keywords:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -5,7 +5,7 @@ controller:
   name: controller
   image:
     repository: gcr.io/google_containers/nginx-ingress-controller
-    tag: "0.9.0-beta.11"
+    tag: "0.9.0-beta.12"
     pullPolicy: IfNotPresent
 
   config: {}


### PR DESCRIPTION
**Image:**  `gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.12`

*Breaking changes:*

- SSL passthrough is disabled by default. To enable the feature use `--enable-ssl-passthrough`

*New Features:*

- Support for arm64
- New flags to customize listen ports
- Per minute rate limiting
- Rate limit whitelist
- Configuration of nginx worker timeout (to avoid zombie nginx workers processes)
- Redirects from non-www to www
- Custom default backend (per Ingress)
- Graceful shutdown for NGINX

Complete changelog [here](https://github.com/kubernetes/ingress/blob/master/controllers/nginx/Changelog.md)
