### PR TITLE
[incubator/spring-cloud-data-flow] Fix appVersion in Chart.yaml

### DIFF
--- a/incubator/spring-cloud-data-flow/Chart.yaml
+++ b/incubator/spring-cloud-data-flow/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Open source, multi-cloud toolkit for building data integration and real-time data processing pipelines.
 name: spring-cloud-data-flow
 version: 0.1.0
-appVersion: 1.2.1.RELEASE
+appVersion: 1.2.2.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:
 - https://github.com/spring-cloud/spring-cloud-dataflow

--- a/incubator/spring-cloud-data-flow/README.md
+++ b/incubator/spring-cloud-data-flow/README.md
@@ -51,7 +51,7 @@ The following tables lists the configurable parameters and their default values.
 
 | Parameter                         | Description                                        | Default          |
 | --------------------------------- | -------------------------------------------------- | ---------------- |
-| server.version                    | The version/tag of the Data Flow server            | 1.2.1.RELEASE
+| server.version                    | The version/tag of the Data Flow server            | 1.2.2.RELEASE
 | server.imagePullPolicy            | The imagePullPolicy of the Data Flow server        | IfNotPresent
 | server.service.type               | The service type for the Data Flow server          | LoadBalancer
 | server.service.externalPort       | The external port for the Data Flow server         | 80


### PR DESCRIPTION
- the Values.yaml already uses the latest 1.2.2.RELEASE version

- needed to change appVersion to match that