### PR TITLE
[stable/jenkins] added useSecurity and adminUser to params

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -51,9 +51,11 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.ScriptApproval`           | List of groovy functions to approve  | Not set                                                                      |
 | `Master.NodeSelector`             | Node labels for pod assignment       | `{}`                                                                         |
 | `Master.Tolerations`              | Toleration labels for pod assignment | `{}`                                                                         |
-| `rbac.install`           | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                                                                      |
-| `rbac.apiVersion`           | RBAC API version | `v1beta1`                                                                      |
-| `rbac.roleRef`           | Cluster role name to bind to | `cluster-admin`                                                                      |
+| `rbac.install`                    | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                                       |
+| `rbac.apiVersion`                 | RBAC API version                     | `v1beta1`                                                                    |
+| `rbac.roleRef`                    | Cluster role name to bind to         | `cluster-admin`                                                              |
+| `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
+| `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
 
 ### Jenkins Agent
 

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -33,6 +33,8 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.ImageTag`                 | Master image tag                     | `2.46.1`                                                                     |
 | `Master.ImagePullPolicy`          | Master image pull policy             | `Always`                                                                     |
 | `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
+| `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
+| `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
 | `Master.Cpu`                      | Master requested cpu                 | `200m`                                                                       |
 | `Master.Memory`                   | Master requested memory              | `256Mi`                                                                      |
 | `Master.ServiceType`              | k8s service type                     | `LoadBalancer`                                                               |
@@ -54,8 +56,6 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `rbac.install`                    | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                                       |
 | `rbac.apiVersion`                 | RBAC API version                     | `v1beta1`                                                                    |
 | `rbac.roleRef`                    | Cluster role name to bind to         | `cluster-admin`                                                              |
-| `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
-| `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
 
 ### Jenkins Agent
 


### PR DESCRIPTION
If your jenkins doesn't need a username/password to login (i.e - it's behind SSO login or any other kind of login)
can be seen in values - 
https://github.com/kubernetes/charts/blob/master/stable/jenkins/values.yaml