### PR TITLE
[stable/nginx-ingress] Add flag for daemonset controllers so that hostPort can optionally be used

### DIFF
--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -74,13 +74,22 @@ spec:
           ports:
             - name: http
               containerPort: 80
+              {{- if .Values.controller.daemonset.hostPort }}
+              hostPort: 80
+              {{- end }}
               protocol: TCP
             - name: https
               containerPort: 443
+              {{- if .Values.controller.daemonset.hostPort }}
+              hostPort: 443
+              {{- end }}
               protocol: TCP
           {{- if .Values.controller.stats.enabled }}
             - name: stats
               containerPort: 18080
+              {{- if .Values.controller.daemonset.hostPort }}
+              hostPort: 18080
+              {{- end }}
               protocol: TCP
           {{- end }}
           {{- range $key, $value := .Values.tcp }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -54,6 +54,9 @@ controller:
   ##
   kind: Deployment
 
+  daemonset:
+    hostPort: false
+
   ## Node labels for controller pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##


### PR DESCRIPTION
This supports use cases that don't rely on the Service resource, such as a user pointing their own load balancer at a set of ingress nodes.