### PR TITLE
[stable/postgresql] Fixed service name to be able to override it

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.8.1
+version: 0.9.0
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -91,6 +91,8 @@ $ helm install --name my-release -f values.yaml stable/postgresql
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+If you wish to use a custom name for the service. Use the `nameOverride` value.
+
 ## Persistence
 
 The [postgres](https://github.com/docker-library/postgres) image stores the PostgreSQL data and configurations at the `/var/lib/postgresql/data/pgdata` path of the container.

--- a/stable/postgresql/templates/svc.yaml
+++ b/stable/postgresql/templates/svc.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "postgresql.fullname" . }}
+
+  name: {{ template "postgresql.name" . }}
   labels:
     app: {{ template "postgresql.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -73,9 +73,20 @@ resources:
     memory: 256Mi
     cpu: 100m
 
+
+## Configure the service
+##
 service:
+  ## k8s service type exposing ports, e.g. NodePort| ClusterIP
+  ##
   type: ClusterIP
+
+  ## TCP port to listen on
+  ##
   port: 5432
+
+  ## External IPs to listen on
+  ##
   externalIPs: []
 
 networkPolicy:


### PR DESCRIPTION
Changed the name of the service to not use the name of the release.

This currently prevents the chart from being used as requirements since addressing the service from another chart requires to know the name of the future release.

Given an umbrella chart that would provide both `postgresql` and another chart that would use `postgresql`:
```
# requirement.yaml
dependencies:
- name: postgresql
  version: 0.8.1
  repository: @stable
- name: my-chart
  version: 0.1.0
  repository: @local
```
If my-chart has the following required values (to find the `postgresql` service):
```
# values.yaml

# This currently cannot be achieved since we would need to know ahead
# of time the name of the release
my-chart:
  pgdb_service: <name of the service>
```
The proposed changed would allow: 
```
# values.yaml
postgresql:
  nameOverride: my-postgresql
my-chart:
  pgdb_service: my-postgresql
```



