### PR TITLE
nginx-ingress: Allow controlling creation of cluster level RBAC separately

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.1
+version: 0.8.2
 appVersion: 0.9.0-beta.11
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -96,7 +96,9 @@ Parameter | Description | Default
 `defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `defaultBackend.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
-`rbac.create` | If true, create & use RBAC resources | `false`
+`rbac.create` | If true, create Role, RoleBinding, ClusterRole and ClusterRoleBinding resources | `false`
+`rbac.createRole` | If true, create Role and RoleBinding resources | `false`
+`rbac.createClusterRole` | If true, create ClusterRole and ClusterRoleBinding resources | `false`
 `rbac.serviceAccountName` | ServiceAccount to be used (ignored if rbac.create=true) | `default`
 `statsExporter.name` | name of the Prometheus metrics exporter component | `stats-exporter`
 `statsExporter.image.repository` | Prometheus metrics exporter container image repository | `quay.io/cy-play/vts-nginx-exporter`

--- a/stable/nginx-ingress/templates/clusterrole.yaml
+++ b/stable/nginx-ingress/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if or .Values.rbac.create .Values.rbac.createClusterRole -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/stable/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if or .Values.rbac.create .Values.rbac.createClusterRole -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -125,6 +125,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.controller.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ if or .Values.rbac.create .Values.rbac.createRole .Values.rbac.createClusterRole }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -126,6 +126,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.controller.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ if or .Values.rbac.create .Values.rbac.createRole .Values.rbac.createClusterRole }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
 {{- end }}

--- a/stable/nginx-ingress/templates/role.yaml
+++ b/stable/nginx-ingress/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if or .Values.rbac.create .Values.rbac.createRole -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/stable/nginx-ingress/templates/rolebinding.yaml
+++ b/stable/nginx-ingress/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if or .Values.rbac.create .Values.rbac.createRole -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:

--- a/stable/nginx-ingress/templates/serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if or .Values.rbac.create .Values.rbac.createRole .Values.rbac.createClusterRole -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -173,6 +173,8 @@ defaultBackend:
 ## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
 rbac:
   create: false
+  createRole: false
+  createClusterRole: false
   serviceAccountName: default
 
 ## If controller.stats.enabled = true, Prometheus metrics will be exported


### PR DESCRIPTION
This allows for installing nginx-ingress in a restricted permissions
setting where helm does not have permissions to create ClusterRoles and
ClusterRoleBindings.

This preserves the existing `rbac.create` variable for backwards
compatibility, but likely it could be removed in the future.

You can now create just the nginx Role/RoleBinding with rbac.createRole
and the ClusterRole/ClusterRoleBinding with rbac.createClusterRole.