### PR TITLE
Update readme

### DIFF
--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -26,6 +26,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 $ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+$ helm dependency update
 $ helm install --name my-release incubator/patroni
 ```
 

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -25,7 +25,7 @@ This chart will do the following:
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 $ helm install --name my-release incubator/patroni
 ```
 


### PR DESCRIPTION
* While installing the chart, ran into an error-
```
$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
"incubator" has been added to your repositories
$ helm dependency update
Error: no repository definition for https://kubernetes-charts-incubator.storage.googleapis.com/. Try 'helm repo add'
```
Turns out, the etcd dependency in `requirements.yaml` had a different repo url - `https://kubernetes-charts-incubator.storage.googleapis.com/` than the one provided in the instructions.

* Added step to build helm dependencies.