### PR TITLE
More reasonable default for Grafana storage-volume PVC

### DIFF
--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: dashboard-volume
               mountPath: {{ default "/var/lib/grafana/dashboards" .Values.server.dashboardLocalPath | quote }}
             - name: storage-volume
-              mountPath: {{ default "/var/lib/grafana/data" .Values.server.storageLocalPath | quote }}
+              mountPath: {{ default "/var/lib/grafana" .Values.server.storageLocalPath | quote }}
               subPath: "{{ .Values.server.persistentVolume.subPath }}"
       terminationGracePeriodSeconds: {{ default 300 .Values.server.terminationGracePeriodSeconds }}
       volumes:


### PR DESCRIPTION
Mounting the `storage-volume` persistentVolumeClaim to `/var/lib/grafana/data` by default causes plugins installed via `grafana-cli` to disappear on pod termination. While this can be avoided by overriding `.Values.server.storageLocalPath` to `/var/lib/grafana`, it makes more sense to me to have that as the default so that the out-of-the-box experience is one of full persistence.