### PR TITLE
[stable/grafana] Allow Grafana dashboards to be read from folder

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.4.5
+version: 0.4.6
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -49,3 +49,5 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.service.nodePort`                 | For service type "NodePort"         | null                                              |
 | `server.service.type`                     | ClusterIP, NodePort, or LoadBalancer| ClusterIP                                         |
 | `server.setDatasource.enabled`            | Creates grafana datasource with job | false                                             |
+| `dashboards.enabled`                      | Are there dashboards to upload?     | false                                             |
+| `dashboards.folderName`                   | Directory of dashboards `json` files to be uploaded | null                              |

--- a/stable/grafana/templates/dashboards-configmap.yaml
+++ b/stable/grafana/templates/dashboards-configmap.yaml
@@ -9,4 +9,8 @@ metadata:
     release: "{{ .Release.Name }}"
   name: {{ template "grafana.server.fullname" . }}-dashs
 data:
+{{- if .Values.dashboards.enabled | default false }}
+{{ ( printf "%s/*" .Values.dashboards.folderName | .Files.Glob ).AsConfig | indent 2 }}
+{{- else }}
 {{ toYaml .Values.serverDashboardFiles | indent 2 }}
+{{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -387,3 +387,13 @@ serverConfigFile:
 ## and add it below.
 ##
 serverDashboardFiles: {}
+
+## Grafana dashboard files from local directory
+## for example, if you create the following structure:
+##  dashboards/
+##    dashboard1.json
+##    dashboard2.json
+## both these dashboard will be added to the deployment and automatically populated in grafana
+dashboards:
+  enabled: false
+  folderName: "dashboards"


### PR DESCRIPTION
This PR allows users of the Grafana chart to upload their dashboards from a folder instead of dumping their `json` content in their `values.yaml` file. This makes it a lot more manageable to maintain multiple dashboards that are supposed to be created automatically.