### PR TITLE
[stable/concourse] add node affinity and nodeport

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.4.1
+version: 0.4.2
 appVersion: 3.3.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -129,14 +129,23 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |
 | `web.service.type` | Concourse Web service type | `NodePort` |
+| `web.service.nodePort.fixed` | Concourse Web NodePort fixed if web.service.type is NodePort | `false`|
+| `web.service.nodePort.atc` | Concourse Web ATC NodePort | `nil` |
+| `web.service.nodePort.tsa` | Concourse Web TSA NodePort | `nil` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |
 | `web.ingress.annotations` | Concourse Web Ingress annotations | `{}` |
 | `web.ingress.hosts` | Concourse Web Ingress Hostnames | `[]` |
 | `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
+| `web.nodeAffinity.enabled` | Concourse Web use nodeAffinity | `false` |
+| `web.nodeAffinity.key` | Concourse Web nodeAffinity key | `nil` |
+| `web.nodeAffinity.value` | Concourse Web nodeAffinity value | `nil` |
 | `worker.nameOverride` | Override the Concourse Worker components name| `worker` |
 | `worker.replicas` | Number of Concourse Worker replicas | `2` |
 | `worker.minAvailable` | Minimun number of workers available after an eviction | `1` |
 | `worker.resources` | Concourse Worker resource requests and limits | `{requests: {cpu: "100m", memory: "512Mi"}}` |
+| `worker.nodeAffinity.enabled` | Concourse Worker use nodeAffinity | `false` |
+| `worker.nodeAffinity.key` | Concourse Worker nodeAffinity key | `nil` |
+| `worker.nodeAffinity.value` | Concourse Worker nodeAffinity value | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |
 | `persistence.worker.class` | Concourse Worker Persistent Volume Storage Class | `generic` |
 | `persistence.worker.accessMode` | Concourse Worker Persistent Volume Access Mode | `ReadWriteOnce` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -265,6 +265,19 @@ spec:
             - name: concourse-keys
               mountPath: /concourse-keys
               readOnly: true
+      {{ if .Values.web.nodeAffinity.enabled }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: {{ .Values.web.nodeAffinity.key | quote }}
+                  operator: In
+                  values:
+                  {{- range .Values.web.nodeAffinity.values }}
+                  - {{ . }}
+                  {{ end }}
+      {{ end }}
       volumes:
         - name: concourse-keys
           secret:

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -13,8 +13,14 @@ spec:
     - name: atc
       port: {{ .Values.concourse.atcPort }}
       targetPort: atc
+      {{ if .Values.web.service.nodePort.fixed }}
+      nodePort: {{ .Values.web.service.nodePort.atc }}
+      {{ end }}
     - name: tsa
       port: {{ .Values.concourse.tsaPort }}
       targetPort: tsa
+      {{ if .Values.web.service.nodePort.fixed }}
+      nodePort: {{ .Values.web.service.nodePort.tsa }}
+      {{ end }}
   selector:
     app: {{ template "web.fullname" . }}

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -13,13 +13,13 @@ spec:
     - name: atc
       port: {{ .Values.concourse.atcPort }}
       targetPort: atc
-      {{ if .Values.web.service.nodePort.fixed }}
+      {{ if and (eq "NodePort" .Values.web.service.type) .Values.web.service.nodePort.fixed }}
       nodePort: {{ .Values.web.service.nodePort.atc }}
       {{ end }}
     - name: tsa
       port: {{ .Values.concourse.tsaPort }}
       targetPort: tsa
-      {{ if .Values.web.service.nodePort.fixed }}
+      {{ if and (eq "NodePort" .Values.web.service.type) .Values.web.service.nodePort.fixed }}
       nodePort: {{ .Values.web.service.nodePort.tsa }}
       {{ end }}
   selector:

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -77,6 +77,18 @@ spec:
             - name: concourse-work-dir
               mountPath: /concourse-work-dir
       affinity:
+      {{ if .Values.worker.nodeAffinity.enabled }}
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: {{ .Values.worker.nodeAffinity.key | quote }}
+                  operator: In
+                  values:
+                  {{- range .Values.worker.nodeAffinity.values }}
+                  - {{ . }}
+                  {{ end }}
+      {{ end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -304,6 +304,8 @@ web:
     ## ref: https://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
     ##
     type: ClusterIP
+    nodePort:
+      fixed: false
 
   ## Ingress configuration.
   ## ref: https://kubernetes.io/docs/user-guide/ingress/
@@ -332,6 +334,9 @@ web:
     #   - secretName: concourse-web-tls
     #     hosts:
     #       - concourse.domain.com
+    #
+  nodeAffinity:
+    enabled: false
 
 ## Configuration values for Concourse Worker components.
 ##
@@ -361,6 +366,9 @@ worker:
   ##
   # annotations:
   #   iam.amazonaws.com/role: arn:aws:iam::123456789012:role/concourse
+  #
+  nodeAffinity:
+    enabled: false
 
 ## Persistent Volume Storage configuration.
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes


### PR DESCRIPTION
- with node affinity, allow to place pods in specific node
  - both web and worker
- if ```web.service.type``` is ```NodePort```, allow to specify a nodeport(tsa, atc)