### PR TITLE
mariadb: fix mariadb volume mountpoint

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 1.0.3
+version: 1.0.4
 appVersion: 10.1.26
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/mariadb
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
@@ -84,9 +87,6 @@ spec:
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
-        volumeMounts:
-        - name: data
-          mountPath: /bitnami/mariadb
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
The volume for the mariadb container gets mounted on the metrics container if
prometheus metrics reporting is emabled

/cc @prydonius please treat with high priority