### PR TITLE
[stable/mariadb] fix metrics data collection and remove use of initContainers

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 1.0.4
+version: 1.0.5
 appVersion: 10.1.26
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -13,19 +13,6 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
-      initContainers:
-      - name: "copy-custom-config"
-        image: "{{ .Values.image }}"
-        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-        command:
-          - "sh"
-          -  "-c"
-          -  "mkdir -p /bitnami/mariadb/conf && cp -n /bitnami/mariadb_config/my.cnf /bitnami/mariadb/conf/my_custom.cnf"
-        volumeMounts:
-        - name: data
-          mountPath: /bitnami/mariadb
-        - name: config
-          mountPath: /bitnami/mariadb_config
       containers:
       - name: mariadb
         image: "{{ .Values.image }}"
@@ -72,6 +59,9 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+        - name: config
+          mountPath: /bitnami/mariadb/conf/my_custom.cnf
+          subPath: my.cnf
         - name: data
           mountPath: /bitnami/mariadb
 {{- if .Values.metrics.enabled }}

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: config
           mountPath: /bitnami/mariadb_config
       containers:
-      - name: {{ template "fullname" . }}
+      - name: mariadb
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
@@ -90,6 +90,18 @@ spec:
         ports:
         - name: metrics
           containerPort: 9104
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -79,8 +79,14 @@ spec:
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
         imagePullPolicy: {{ .Values.metrics.imagePullPolicy | quote }}
         env:
-        - name: DATA_SOURCE_NAME
-          value: "root:{{ .Values.mariadbRootPassword }}@(localhost:3306)/"
+        {{- if .Values.usePassword }}
+        - name: MARIADB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: mariadb-root-password
+        {{- end }}
+        command: [ 'sh', '-c', 'DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter' ]
         ports:
         - name: metrics
           containerPort: 9104


### PR DESCRIPTION
- The prometheus support was broken since the addition of random passwords
 - With newer bitnami/mariadb images, the my.cnf customizations can be mounted 
   directly at `/bitnami/mariadb/conf/my_custom.cnf` instead of making use of
   initContainers to copy the configuration.

/cc @prydonius