### PR TITLE
More sane default for Grafana storage-volume PVC

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.4.5
+version: 0.5.0
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: dashboard-volume
               mountPath: {{ default "/var/lib/grafana/dashboards" .Values.server.dashboardLocalPath | quote }}
             - name: storage-volume
-              mountPath: {{ default "/var/lib/grafana/data" .Values.server.storageLocalPath | quote }}
+              mountPath: {{ default "/var/lib/grafana" .Values.server.storageLocalPath | quote }}
               subPath: "{{ .Values.server.persistentVolume.subPath }}"
       terminationGracePeriodSeconds: {{ default 300 .Values.server.terminationGracePeriodSeconds }}
       volumes:


### PR DESCRIPTION
Mounting the `storage-volume` persistentVolumeClaim to `/var/lib/grafana/data` by default causes plugins installed via `grafana-cli` to disappear on pod termination. While this can be avoided by overriding `.Values.server.storageLocalPath` to `/var/lib/grafana`, it makes more sense to have that as the default so that the out-of-the-box experience is one of full persistence.