### PR TITLE
Add Traefik Metrics Collection docs

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.11.5
+version: 1.11.6
 appVersion: 1.3.8
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.11.6
+version: 1.11.5
 appVersion: 1.3.8
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -123,12 +123,12 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `accessLogs.enabled`            | Whether to enable Traefik's access logs                              | `false`                                   |
 | `accessLogs.filePath`           | The path to the log file. Logs to stdout if omitted                  | None                                      |
 | `accessLogs.format`             | What format the log entries should be in. Either `common` or `json`  | `common`                                  |
-| `metrics.prometheus.enabled`    | Enable/ Disable the `/metrics` endpoint for metric collection by Prometheus. | `false`                           |
+| `metrics.prometheus.enabled`    | Whether to enable the `/metrics` endpoint for metric collection by Prometheus. | `false`                           |
 | `metrics.prometheus.buckets`    | A list of response times (in seconds) - for each list element, Traefik will report all response times less than the element. | `0.1,0.3,1.2,5` |
-| `metrics.datadog.enabled`       | Enable/ Disable pushing metrics to Datadog.                          | `false`                                   |
+| `metrics.datadog.enabled`       | Whether to enable pushing metrics to Datadog.                          | `false`                                   |
 | `metrics.datadog.address`       | Datadog host in the format <hostname>:<port>                         | `localhost:8125`                          |
 | `metrics.datadog.pushInterval`  | How often to push metrics to Datadog.                                | `10s`                                     |
-| `metrics.statsd.enabled`        | Enable/ Disable pushing metrics to Statsd.                           | `false`                                   |
+| `metrics.statsd.enabled`        | Whether to enable pushing metrics to Statsd.                           | `false`                                   |
 | `metrics.statsd.address`        | Statsd host in the format <hostname>:<port>                          | `localhost:8125`                          |
 | `metrics.statsd.pushInterval`   | How often to push metrics to Statsd.                                 | `10s`                                     |
 

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -124,7 +124,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `accessLogs.filePath`           | The path to the log file. Logs to stdout if omitted                  | None                                      |
 | `accessLogs.format`             | What format the log entries should be in. Either `common` or `json`  | `common`                                  |
 | `metrics.prometheus.enabled`    | Enable/ Disable the `/metrics` endpoint for metric collection by Prometheus. | `false`                           |
-| `metrics.prometheus.buckets`    | Buckets of observation values, response times less than each value (in seconds) in the bucket. | `0.1,0.3,1.2,5` |
+| `metrics.prometheus.buckets`    | A list of response times (in seconds) - for each list element, Traefik will report all response times less than the element. | `0.1,0.3,1.2,5` |
 | `metrics.datadog.enabled`       | Enable/ Disable pushing metrics to Datadog.                          | `false`                                   |
 | `metrics.datadog.address`       | Datadog host in the format <hostname>:<port>                         | `localhost:8125`                          |
 | `metrics.datadog.pushInterval`  | How often to push metrics to Datadog.                                | `10s`                                     |

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -123,7 +123,14 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `accessLogs.enabled`            | Whether to enable Traefik's access logs                              | `false`                                   |
 | `accessLogs.filePath`           | The path to the log file. Logs to stdout if omitted                  | None                                      |
 | `accessLogs.format`             | What format the log entries should be in. Either `common` or `json`  | `common`                                  |
-
+| `metrics.prometheus.enabled`    | Enable/ Disable the `/metrics` endpoint for metric collection by Prometheus. | `false`                           |
+| `metrics.prometheus.buckets`    | Buckets of observation values, response times less than each value (in seconds) in the bucket. | `0.1,0.3,1.2,5` |
+| `metrics.datadog.enabled`       | Enable/ Disable pushing metrics to Datadog.                          | `false`                                   |
+| `metrics.datadog.address`       | Datadog host in the format <hostname>:<port>                         | `localhost:8125`                          |
+| `metrics.datadog.pushInterval`  | How often to push metrics to Datadog.                                | `10s`                                     |
+| `metrics.statsd.enabled`        | Enable/ Disable pushing metrics to Statsd.                           | `false`                                   |
+| `metrics.statsd.address`        | Statsd host in the format <hostname>:<port>                          | `localhost:8125`                          |
+| `metrics.statsd.pushInterval`   | How often to push metrics to Statsd.                                 | `10s`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 


### PR DESCRIPTION
* Document Traefik configuration for Prometheus, Datadog and Statsd metric collection.