### PR TITLE
Initial release for Jaeger Helm Chart

### DIFF
--- a/incubator/jaeger/.helmignore
+++ b/incubator/jaeger/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+appVersion: 0.6.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 version: 0.1.0

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+description: A Jaeger Helm chart for Kubernetes
+name: jaeger
+version: 0.1.0
+keywords:
+  - jaeger
+  - opentracing
+  - tracing
+  - instrumentation
+home: https://github.com/uber/jaeger
+icon: https://camo.githubusercontent.com/afa87494e0753b4b1f5719a2f35aa5263859dffb/687474703a2f2f6a61656765722e72656164746865646f63732e696f2f656e2f6c61746573742f696d616765732f6a61656765722d766563746f722e737667
+sources:
+  - https://hub.docker.com/u/jaegertracing/
+maintainers:
+  - name: dvonthenen
+    email: david.vonthenen@dell.com

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -64,50 +64,50 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Jaeger chart and their default values.
 
-|             Parameter               |            Description             |                  Default               |
-|-------------------------------------|------------------------------------|----------------------------------------|
-| `cassandra.image.tag`               | The image tag/version              |  3.11                                  |
-| `cassandra.persistence.enabled`     | To enable storage persistence      |  false (Highly recommended to enable)  |
-| `cassandra.config.cluster_name`     | Cluster name                       |  jaeger                                |
-| `cassandra.config.seed_size`        | Seed size                          |  1                                     |
-| `cassandra.config.dc_name`          | Datacenter name                    |  dc1                                   |
-| `cassandra.config.rack_name`        | Rack name                          |  rack1                                 |
-| `cassandra.config.endpoint_snitch`  | Node discovery method              |  GossipingPropertyFileSnitch           |
-| `job.schema.annotations`            | Annotations for the schema job     |  nil                                   |
-| `job.schema.image`                  | Image to setup cassandra schema    |  jaegertracing/jaeger-cassandra-schema |
-| `job.schema.tag`                    | Image tag/version                  |  0.6                                   |
-| `job.schema.pullPolicy`             | Schema image pullPolicy            |  IfNotPresent                          |
-| `job.schema.mode`                   | Schema mode (prod or test)         |  prod                                  |
-| `daemonset.agent.annotations`       | Annotations for Agent              |  nil                                   |
-| `daemonset.agent.image`             | Image for Jaeger Agent             |  jaegertracing/jaeger-agent            |
-| `daemonset.agent.tag`               | Image tag/version                  |  0.6                                   |
-| `daemonset.agent.pullPolicy`        | Agent image pullPolicy             |  IfNotPresent                          |
-| `daemonset.agent.cmdlineParams`     | Additional command line parameters |  nil                                   |
-| `deployment.collector.annotations`  | Annotations for Collector          |  nil                                   |
-| `deployment.collector.image`        | Image for jaeger collector         |  jaegertracing/jaeger-collector        |
-| `deployment.collector.tag`          | Image tag/version                  |  0.6                                   |
-| `deployment.collector.pullPolicy`   | Collector image pullPolicy         |  IfNotPresent                          |
-| `deployment.collector.cmdlineParams`| Additional command line parameters |  nil                                   |
-| `deployment.query.annotations`      | Annotations for Query UI           |  nil                                   |
-| `deployment.query.image`            | Image for Jaeger Query UI          |  jaegertracing/jaeger-query            |
-| `deployment.query.tag`              | Image tag/version                  |  0.6                                   |
-| `deployment.query.pullPolicy`       | Query UI image pullPolicy          |  IfNotPresent                          |
-| `deployment.query.cmdlineParams`    | Additional command line parameters |  nil                                   |
-| `service.collector.annotations`     | Annotations for Collector SVC      |  nil                                   |
-| `service.collector.type`            | Service type                       |  ClusterIP                             |
-| `service.collector.tchannelPort`    | Jaeger Agent port for thrift       |  14267                                 |
-| `service.collector.httpPort`        | Client port for HTTP thrift        |  14268                                 |
-| `service.collector.zipkinPort`      | Zipkin port for JSON/thrift HTTP   |  9411                                  |
-| `service.query.annotations`         | Annotations for Query SVC          |  nil                                   |
-| `service.query.type`                | Service type                       |  ClusterIP                             |
-| `service.query.queryPort`           | External accessible port           |  80                                    |
-| `service.query.targetPort`          | Internal Query UI port             |  16686                                 |
-| `service.agent.annotations`         | Annotations for Agent SVC          |  nil                                   |
-| `service.agent.zipkinThriftPort`    | zipkin.thrift over compact thrift  |  5775                                  |
-| `service.agent.compactPort`         | jaeger.thrift over compact thrift  |  6831                                  |
-| `service.agent.binaryPort`          | jaeger.thrift over binary thrift   |  6832                                  |
-| `ingress.enabled`                   | Allow external traffic access      |  false                                 |
-|-------------------------------------|------------------------------------|----------------------------------------|
+|             Parameter             |            Description             |                  Default               |
+|-----------------------------------|------------------------------------|----------------------------------------|
+| `cassandra.image.tag`             | The image tag/version              |  3.11                                  |
+| `cassandra.persistence.enabled`   | To enable storage persistence      |  false (Highly recommended to enable)  |
+| `cassandra.config.cluster_name`   | Cluster name                       |  jaeger                                |
+| `cassandra.config.seed_size`      | Seed size                          |  1                                     |
+| `cassandra.config.dc_name`        | Datacenter name                    |  dc1                                   |
+| `cassandra.config.rack_name`      | Rack name                          |  rack1                                 |
+| `cassandra.config.endpoint_snitch`| Node discovery method              |  GossipingPropertyFileSnitch           |
+| `schema.annotations`              | Annotations for the schema job     |  nil                                   |
+| `schema.image`                    | Image to setup cassandra schema    |  jaegertracing/jaeger-cassandra-schema |
+| `schema.tag`                      | Image tag/version                  |  0.6                                   |
+| `schema.pullPolicy`               | Schema image pullPolicy            |  IfNotPresent                          |
+| `schema.mode`                     | Schema mode (prod or test)         |  prod                                  |
+| `agent.annotationsPod`            | Annotations for Agent              |  nil                                   |
+| `agent.image`                     | Image for Jaeger Agent             |  jaegertracing/jaeger-agent            |
+| `agent.tag`                       | Image tag/version                  |  0.6                                   |
+| `agent.pullPolicy`                | Agent image pullPolicy             |  IfNotPresent                          |
+| `agent.cmdlineParams`             | Additional command line parameters |  nil                                   |
+| `agent.annotationsSvc`            | Annotations for Agent SVC          |  nil                                   |
+| `agent.zipkinThriftPort`          | zipkin.thrift over compact thrift  |  5775                                  |
+| `agent.compactPort`               | jaeger.thrift over compact thrift  |  6831                                  |
+| `agent.binaryPort`                | jaeger.thrift over binary thrift   |  6832                                  |
+| `collector.annotationsPod`        | Annotations for Collector          |  nil                                   |
+| `collector.image`                 | Image for jaeger collector         |  jaegertracing/jaeger-collector        |
+| `collector.tag`                   | Image tag/version                  |  0.6                                   |
+| `collector.pullPolicy`            | Collector image pullPolicy         |  IfNotPresent                          |
+| `collector.cmdlineParams`         | Additional command line parameters |  nil                                   |
+| `collector.annotationsSvc`        | Annotations for Collector SVC      |  nil                                   |
+| `collector.type`                  | Service type                       |  ClusterIP                             |
+| `collector.tchannelPort`          | Jaeger Agent port for thrift       |  14267                                 |
+| `collector.httpPort`              | Client port for HTTP thrift        |  14268                                 |
+| `collector.zipkinPort`            | Zipkin port for JSON/thrift HTTP   |  9411                                  |
+| `query.annotationsPod`            | Annotations for Query UI           |  nil                                   |
+| `query.image`                     | Image for Jaeger Query UI          |  jaegertracing/jaeger-query            |
+| `query.tag`                       | Image tag/version                  |  0.6                                   |
+| `query.pullPolicy`                | Query UI image pullPolicy          |  IfNotPresent                          |
+| `query.cmdlineParams`             | Additional command line parameters |  nil                                   |
+| `query.annotationsSvc`            | Annotations for Query SVC          |  nil                                   |
+| `query.type`                      | Service type                       |  ClusterIP                             |
+| `query.queryPort`                 | External accessible port           |  80                                    |
+| `query.targetPort`                | Internal Query UI port             |  16686                                 |
+| `ingress.enabled`                 | Allow external traffic access      |  false                                 |
+|-----------------------------------|------------------------------------|----------------------------------------|
 
 For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
 

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -1,0 +1,134 @@
+# Jaeger
+
+[Jaeger](http://jaeger.readthedocs.io/en/latest/) is a distributed tracing system.
+
+## Introduction
+
+This chart adds all components required to run Jaeger as described in the [jaeger-kubernetes](https://github.com/jaegertracing/jaeger-kubernetes) GitHub page for a production-like deployment. The chart will initialize Cassandra using the cassandra-schema Job, deploy jaeger-agent as a DaemonSet and deploy the jaeger-collector and jaeger-query components as standard individual deployments. This chart also depends on the [cassandra chart](https://github.com/kubernetes/charts/tree/master/incubator/cassandra).
+
+## Prerequisites
+
+- Has been tested on Kubernetes 1.7+
+- The Cassandra chart calls out the following requirements (default) for a test environment (please see the important note in the installation section):
+```
+resources:
+  requests:
+    memory: 4Gi
+    cpu: 2
+  limits:
+    memory: 4Gi
+    cpu: 2
+```
+- The Cassandra chart calls out the following requirements for a production environment:
+```
+resources:
+  requests:
+    memory: 8Gi
+    cpu: 2
+  limits:
+    memory: 8Gi
+    cpu: 2
+```
+
+## Installing the Chart
+
+To install the chart with the release name `myrel`, run the following command:
+
+```bash
+$ helm install --name myrel
+```
+
+After a few minutes, you should see a 3 node Cassandra instance, a Jaeger DaemonSet, a Jaeger Collector, and a Jaeger Query (UI) pod deployed into your Kubernetes cluster.
+
+IMPORTANT NOTE: For testing purposes, the footprint for Cassandra can be reduced significantly in the event resources become constrained (such as running on your local laptop or in a Vagrant environment). You can override the resources required run running this command:
+
+```bash
+helm install incubator/jaeger --name myrel --set cassandra.config.max_heap_size=1024M --set cassandra.config.heap_new_size=256M --set cassandra.resources.requests.memory=2048Mi --set cassandra.resources.requests.cpu=0.4 --set cassandra.resources.limits.memory=2048Mi --set cassandra.resources.limits.cpu=0.4
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `myrel` deployment:
+
+```bash
+$ helm delete myrel
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+> **Tip**: To completely remove the release, run `helm delete --purge myrel`
+
+## Configuration
+
+The following tables lists the configurable parameters of the Jaeger chart and their default values.
+
+|             Parameter               |            Description             |                  Default               |
+|-------------------------------------|------------------------------------|----------------------------------------|
+| `cassandra.image.tag`               | The image tag/version              |  3.11                                  |
+| `cassandra.persistence.enabled`     | To enable storage persistence      |  false (Highly recommended to enable)  |
+| `cassandra.config.cluster_name`     | Cluster name                       |  jaeger                                |
+| `cassandra.config.seed_size`        | Seed size                          |  1                                     |
+| `cassandra.config.dc_name`          | Datacenter name                    |  dc1                                   |
+| `cassandra.config.rack_name`        | Rack name                          |  rack1                                 |
+| `cassandra.config.endpoint_snitch`  | Node discovery method              |  GossipingPropertyFileSnitch           |
+| `job.schema.annotations`            | Annotations for the schema job     |  nil                                   |
+| `job.schema.image`                  | Image to setup cassandra schema    |  jaegertracing/jaeger-cassandra-schema |
+| `job.schema.tag`                    | Image tag/version                  |  0.6                                   |
+| `job.schema.pullPolicy`             | Schema image pullPolicy            |  IfNotPresent                          |
+| `job.schema.mode`                   | Schema mode (prod or test)         |  prod                                  |
+| `daemonset.agent.annotations`       | Annotations for Agent              |  nil                                   |
+| `daemonset.agent.image`             | Image for Jaeger Agent             |  jaegertracing/jaeger-agent            |
+| `daemonset.agent.tag`               | Image tag/version                  |  0.6                                   |
+| `daemonset.agent.pullPolicy`        | Agent image pullPolicy             |  IfNotPresent                          |
+| `daemonset.agent.cmdlineParams`     | Additional command line parameters |  nil                                   |
+| `deployment.collector.annotations`  | Annotations for Collector          |  nil                                   |
+| `deployment.collector.image`        | Image for jaeger collector         |  jaegertracing/jaeger-collector        |
+| `deployment.collector.tag`          | Image tag/version                  |  0.6                                   |
+| `deployment.collector.pullPolicy`   | Collector image pullPolicy         |  IfNotPresent                          |
+| `deployment.collector.cmdlineParams`| Additional command line parameters |  nil                                   |
+| `deployment.query.annotations`      | Annotations for Query UI           |  nil                                   |
+| `deployment.query.image`            | Image for Jaeger Query UI          |  jaegertracing/jaeger-query            |
+| `deployment.query.tag`              | Image tag/version                  |  0.6                                   |
+| `deployment.query.pullPolicy`       | Query UI image pullPolicy          |  IfNotPresent                          |
+| `deployment.query.cmdlineParams`    | Additional command line parameters |  nil                                   |
+| `service.collector.annotations`     | Annotations for Collector SVC      |  nil                                   |
+| `service.collector.type`            | Service type                       |  ClusterIP                             |
+| `service.collector.tchannelPort`    | Jaeger Agent port for thrift       |  14267                                 |
+| `service.collector.httpPort`        | Client port for HTTP thrift        |  14268                                 |
+| `service.collector.zipkinPort`      | Zipkin port for JSON/thrift HTTP   |  9411                                  |
+| `service.query.annotations`         | Annotations for Query SVC          |  nil                                   |
+| `service.query.type`                | Service type                       |  ClusterIP                             |
+| `service.query.queryPort`           | External accessible port           |  80                                    |
+| `service.query.targetPort`          | Internal Query UI port             |  16686                                 |
+| `service.agent.annotations`         | Annotations for Agent SVC          |  nil                                   |
+| `service.agent.zipkinThriftPort`    | zipkin.thrift over compact thrift  |  5775                                  |
+| `service.agent.compactPort`         | jaeger.thrift over compact thrift  |  6831                                  |
+| `service.agent.binaryPort`          | jaeger.thrift over binary thrift   |  6832                                  |
+| `ingress.enabled`                   | Allow external traffic access      |  false                                 |
+|-------------------------------------|------------------------------------|----------------------------------------|
+
+For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
+
+For more information about some of the tunable parameters that Jaeger provides, please visit the official [Jaeger repo](https://github.com/uber/jaeger) at GitHub.com.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name myrel \
+    --set cassandra.config.rack_name=rack2 \
+    incubator/jaeger
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart.
+
+### Storage persistence
+
+Jaeger itself is a stateful application that by default uses Cassandra to store all related data. That means this helm chart has a dependency on the Cassandra helm chart for its data persistence. To deploy Jaeger with storage persistence, please take a look at the [README.md](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) for configuration details.
+
+Override any required configuration options in the Cassandra chart that is required and then enable persistence by setting the following option: `--set cassandra.persistence.enabled=true`
+
+### Image tags
+
+Jaeger offers a multitude of [tags](https://hub.docker.com/u/jaegertracing/) for the various components used in this chart.

--- a/incubator/jaeger/requirements.yaml
+++ b/incubator/jaeger/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: cassandra
+    version: 0.1.3
+    repository: https://kubernetes-charts-incubator.storage.googleapis.com/

--- a/incubator/jaeger/templates/NOTES.txt
+++ b/incubator/jaeger/templates/NOTES.txt
@@ -1,19 +1,19 @@
 You can log into the Jaeger Query UI here:
 
-{{- if contains "NodePort" .Values.service.query.type }}
+{{- if contains "NodePort" .Values.query.service.type }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jaeger.fullname" . }}-query)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/
 
-{{- else if contains "LoadBalancer" .Values.service.query.type }}
+{{- else if contains "LoadBalancer" .Values.query.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jaeger.fullname" . }}-query'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jaeger.fullname" . }}-query -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP/
-{{- else if contains "ClusterIP"  .Values.service.query.type }}
+{{- else if contains "ClusterIP"  .Values.query.service.type }}
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "jaeger.fullname" . }}-query" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8080/

--- a/incubator/jaeger/templates/NOTES.txt
+++ b/incubator/jaeger/templates/NOTES.txt
@@ -1,0 +1,21 @@
+You can log into the Jaeger Query UI here:
+
+{{- if contains "NodePort" .Values.service.query.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jaeger.fullname" . }}-query)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/
+
+{{- else if contains "LoadBalancer" .Values.service.query.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jaeger.fullname" . }}-query'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jaeger.fullname" . }}-query -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP/
+{{- else if contains "ClusterIP"  .Values.service.query.type }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "jaeger.fullname" . }}-query" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward $POD_NAME 8080:16686
+{{- end }}

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "jaeger" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "jaeger.fullname" -}}
+{{- $name := default "jaeger" .Values.nameOverride -}}
+{{- if ne .Chart.Name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cassandra.fullname" -}}
+{{- printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "jaeger" -}}
+{{- define "jaeger.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -9,9 +9,9 @@ metadata:
     component: "jaeger-agent"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.agent.annotationsPod }}
-  annotationsPod:
-{{ toYaml .Values.agent.annotationsPod | indent 6 }}
+{{- if .Values.agent.annotations }}
+  annotations:
+{{ toYaml .Values.agent.annotations | indent 6 }}
 {{- end }}
 spec:
   template:
@@ -30,16 +30,16 @@ spec:
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         command:
         - "/go/bin/agent-linux"
-        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.collector.tchannelPort }}"
+        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.collector.service.tchannelPort }}"
 {{- range $key, $value := .Values.agent.cmdlineParams }}
         - "{{ $value }}"
 {{- end }}
         ports:
-        - containerPort: {{ .Values.agent.zipkinThriftPort }}
+        - containerPort: {{ .Values.agent.service.zipkinThriftPort }}
           protocol: UDP
-        - containerPort: {{ .Values.agent.compactPort }}
+        - containerPort: {{ .Values.agent.service.compactPort }}
           protocol: UDP
-        - containerPort: {{ .Values.agent.binaryPort }}
+        - containerPort: {{ .Values.agent.service.binaryPort }}
           protocol: UDP
         resources:
 {{ toYaml .Values.agent.resources | indent 10 }}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -1,38 +1,45 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-agent"
+  name: "jaeger-agent"
   labels:
-    app: "{{ template "jaeger" . }}"
+    app: "{{ template "jaeger.name" . }}"
     jaeger-infra: agent-daemonset
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "{{ template "jaeger.fullname" . }}-agent"
+    component: "jaeger-agent"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.daemonset.agent.annotations }}
-  annotations:
-{{ toYaml .Values.daemonset.agent.annotations | indent 6 }}
+{{- if .Values.agent.annotationsPod }}
+  annotationsPod:
+{{ toYaml .Values.agent.annotationsPod | indent 6 }}
 {{- end }}
 spec:
   template:
     metadata:
       labels:
+        app: "{{ template "jaeger.name" . }}"
+        component: "jaeger-agent"
+        release: "{{ .Release.Name }}"
         jaeger-infra: agent-instance
     spec:
+      nodeSelector:
+{{ toYaml .Values.agent.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-agent"
-        image: "{{ .Values.daemonset.agent.image }}:{{ .Values.daemonset.agent.tag }}"
-        imagePullPolicy: {{ .Values.daemonset.agent.pullPolicy }}
+      - name: "jaeger-agent"
+        image: "{{ .Values.agent.image }}:{{ .Values.agent.tag }}"
+        imagePullPolicy: {{ .Values.agent.pullPolicy }}
         command:
         - "/go/bin/agent-linux"
-        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.service.collector.tchannelPort }}"
-{{- range $key, $value := .Values.daemonset.agent.cmdlineParams }}
+        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.collector.tchannelPort }}"
+{{- range $key, $value := .Values.agent.cmdlineParams }}
         - "{{ $value }}"
 {{- end }}
         ports:
-        - containerPort: {{ .Values.service.agent.zipkinThriftPort }}
+        - containerPort: {{ .Values.agent.zipkinThriftPort }}
           protocol: UDP
-        - containerPort: {{ .Values.service.agent.compactPort }}
+        - containerPort: {{ .Values.agent.compactPort }}
           protocol: UDP
-        - containerPort: {{ .Values.service.agent.binaryPort }}
+        - containerPort: {{ .Values.agent.binaryPort }}
           protocol: UDP
+        resources:
+{{ toYaml .Values.agent.resources | indent 10 }}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -30,7 +30,7 @@ spec:
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         command:
         - "/go/bin/agent-linux"
-        - "--collector.host-port={{ template "jaeger.name" . }}-collector:{{ .Values.collector.service.tchannelPort }}"
+        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.collector.service.tchannelPort }}"
 {{- range $key, $value := .Values.agent.cmdlineParams }}
         - "{{ $value }}"
 {{- end }}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -1,12 +1,12 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: "jaeger-agent"
+  name: "{{ template "jaeger.fullname" . }}-agent"
   labels:
     app: "{{ template "jaeger.name" . }}"
     jaeger-infra: agent-daemonset
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "jaeger-agent"
+    component: "agent"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 {{- if .Values.agent.annotations }}
@@ -18,14 +18,14 @@ spec:
     metadata:
       labels:
         app: "{{ template "jaeger.name" . }}"
-        component: "jaeger-agent"
+        component: "agent"
         release: "{{ .Release.Name }}"
         jaeger-infra: agent-instance
     spec:
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}
       containers:
-      - name: "jaeger-agent"
+      - name: "{{ template "jaeger.fullname" . }}-agent"
         image: "{{ .Values.agent.image }}:{{ .Values.agent.tag }}"
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         command:

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -30,7 +30,7 @@ spec:
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         command:
         - "/go/bin/agent-linux"
-        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.collector.service.tchannelPort }}"
+        - "--collector.host-port={{ template "jaeger.name" . }}-collector:{{ .Values.collector.service.tchannelPort }}"
 {{- range $key, $value := .Values.agent.cmdlineParams }}
         - "{{ $value }}"
 {{- end }}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   name: "{{ template "jaeger.fullname" . }}-agent"
   labels:
-    app: "{{ template "jaeger.fullname" . }}-agent"
+    app: "{{ template "jaeger" . }}"
     jaeger-infra: agent-daemonset
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: "{{ template "jaeger.fullname" . }}-agent"

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: "{{ template "jaeger.fullname" . }}-agent"
+  labels:
+    app: "{{ template "jaeger.fullname" . }}-agent"
+    jaeger-infra: agent-daemonset
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: "{{ template "jaeger.fullname" . }}-agent"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.daemonset.agent.annotations }}
+  annotations:
+{{ toYaml .Values.daemonset.agent.annotations | indent 6 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        jaeger-infra: agent-instance
+    spec:
+      containers:
+      - name: "{{ template "jaeger.fullname" . }}-agent"
+        image: "{{ .Values.daemonset.agent.image }}:{{ .Values.daemonset.agent.tag }}"
+        imagePullPolicy: {{ .Values.daemonset.agent.pullPolicy }}
+        command:
+        - "/go/bin/agent-linux"
+        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.service.collector.tchannelPort }}"
+{{- range $key, $value := .Values.daemonset.agent.cmdlineParams }}
+        - "{{ $value }}"
+{{- end }}
+        ports:
+        - containerPort: {{ .Values.service.agent.zipkinThriftPort }}
+          protocol: UDP
+        - containerPort: {{ .Values.service.agent.compactPort }}
+          protocol: UDP
+        - containerPort: {{ .Values.service.agent.binaryPort }}
+          protocol: UDP

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: "{{ template "jaeger.fullname" . }}-agent"
   labels:
-    app: "{{ template "jaeger.fullname" . }}-agent"
+    app: "{{ template "jaeger" . }}"
     jaeger-infra: {{ .Values.service.agent.name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: "{{ template "jaeger.fullname" . }}-agent"

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "jaeger-agent"
+  name: "{{ template "jaeger.fullname" . }}-agent"
   labels:
     app: "{{ template "jaeger.name" . }}"
     jaeger-infra: {{ .Values.agent.name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "jaeger-agent"
+    component: "agent"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 {{- if .Values.agent.service.annotations }}
@@ -30,6 +30,6 @@ spec:
   clusterIP: None
   selector:
     app: "{{ template "jaeger.name" . }}"
-    component: "jaeger-agent"
+    component: "agent"
     release: "{{ .Release.Name }}"
     jaeger-infra: agent-instance

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "jaeger.fullname" . }}-agent"
+  labels:
+    app: "{{ template "jaeger.fullname" . }}-agent"
+    jaeger-infra: {{ .Values.service.agent.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: "{{ template "jaeger.fullname" . }}-agent"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.service.query.annotations }}
+  annotations:
+{{ toYaml .Values.service.query.annotations | indent 6 }}
+{{- end }}
+spec:
+  ports:
+  - name: agent-zipkin-thrift
+    port: {{ .Values.service.agent.zipkinThriftPort }}
+    protocol: UDP
+    targetPort: {{ .Values.service.agent.zipkinThriftPort }}
+  - name: agent-compact
+    port: {{ .Values.service.agent.compactPort }}
+    protocol: UDP
+    targetPort: {{ .Values.service.agent.compactPort }}
+  - name: agent-binary
+    port: {{ .Values.service.agent.binaryPort }}
+    protocol: UDP
+    targetPort: {{ .Values.service.agent.binaryPort }}
+  clusterIP: None
+  selector:
+    jaeger-infra: agent-instance

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -1,32 +1,35 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-agent"
+  name: "jaeger-agent"
   labels:
-    app: "{{ template "jaeger" . }}"
-    jaeger-infra: {{ .Values.service.agent.name }}
+    app: "{{ template "jaeger.name" . }}"
+    jaeger-infra: {{ .Values.agent.name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "{{ template "jaeger.fullname" . }}-agent"
+    component: "jaeger-agent"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.service.query.annotations }}
+{{- if .Values.agent.annotationsSvc }}
   annotations:
-{{ toYaml .Values.service.query.annotations | indent 6 }}
+{{ toYaml .Values.agent.annotationsSvc | indent 6 }}
 {{- end }}
 spec:
   ports:
   - name: agent-zipkin-thrift
-    port: {{ .Values.service.agent.zipkinThriftPort }}
+    port: {{ .Values.agent.zipkinThriftPort }}
     protocol: UDP
-    targetPort: {{ .Values.service.agent.zipkinThriftPort }}
+    targetPort: {{ .Values.agent.zipkinThriftPort }}
   - name: agent-compact
-    port: {{ .Values.service.agent.compactPort }}
+    port: {{ .Values.agent.compactPort }}
     protocol: UDP
-    targetPort: {{ .Values.service.agent.compactPort }}
+    targetPort: {{ .Values.agent.compactPort }}
   - name: agent-binary
-    port: {{ .Values.service.agent.binaryPort }}
+    port: {{ .Values.agent.binaryPort }}
     protocol: UDP
-    targetPort: {{ .Values.service.agent.binaryPort }}
+    targetPort: {{ .Values.agent.binaryPort }}
   clusterIP: None
   selector:
+    app: "{{ template "jaeger.name" . }}"
+    component: "jaeger-agent"
+    release: "{{ .Release.Name }}"
     jaeger-infra: agent-instance

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -9,24 +9,24 @@ metadata:
     component: "jaeger-agent"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.agent.annotationsSvc }}
+{{- if .Values.agent.service.annotations }}
   annotations:
-{{ toYaml .Values.agent.annotationsSvc | indent 6 }}
+{{ toYaml .Values.agent.service.annotations | indent 6 }}
 {{- end }}
 spec:
   ports:
   - name: agent-zipkin-thrift
-    port: {{ .Values.agent.zipkinThriftPort }}
+    port: {{ .Values.agent.service.zipkinThriftPort }}
     protocol: UDP
-    targetPort: {{ .Values.agent.zipkinThriftPort }}
+    targetPort: {{ .Values.agent.service.zipkinThriftPort }}
   - name: agent-compact
-    port: {{ .Values.agent.compactPort }}
+    port: {{ .Values.agent.service.compactPort }}
     protocol: UDP
-    targetPort: {{ .Values.agent.compactPort }}
+    targetPort: {{ .Values.agent.service.compactPort }}
   - name: agent-binary
-    port: {{ .Values.agent.binaryPort }}
+    port: {{ .Values.agent.service.binaryPort }}
     protocol: UDP
-    targetPort: {{ .Values.agent.binaryPort }}
+    targetPort: {{ .Values.agent.service.binaryPort }}
   clusterIP: None
   selector:
     app: "{{ template "jaeger.name" . }}"

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+  labels:
+    app: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+    jaeger-infra: cassandra-schema-job
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.job.schema.annotations }}
+  annotations:
+{{ toYaml .Values.job.schema.annotations | indent 6 }}
+{{- end }}
+spec:
+  activeDeadlineSeconds: 120
+  template:
+    metadata:
+      name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+    spec:
+      containers:
+      - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+        image: "{{ .Values.job.schema.image }}:{{ .Values.job.schema.tag }}"
+        imagePullPolicy: {{ .Values.job.schema.pullPolicy }}
+        env:
+          - name: CQLSH_HOST
+            value: "{{ template "cassandra.fullname" . }}"
+          - name: MODE
+            value: "{{ .Values.job.schema.mode }}"
+          - name: DATACENTER
+            value: "{{ .Values.cassandra.config.dc_name }}"
+      restartPolicy: Never

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -17,9 +17,6 @@ spec:
   activeDeadlineSeconds: 120
   template:
     metadata:
-      app: "{{ template "jaeger.name" . }}"
-      component: "jaeger-cassandra-schema"
-      release: "{{ .Release.Name }}"
       name: "jaeger-cassandra-schema"
     spec:
       containers:

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -9,9 +9,9 @@ metadata:
     component: "jaeger-cassandra-schema"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.schema.annotationsPod }}
-  annotationsPod:
-{{ toYaml .Values.schema.annotationsPod | indent 6 }}
+{{- if .Values.schema.annotations }}
+  annotations:
+{{ toYaml .Values.schema.annotations | indent 6 }}
 {{- end }}
 spec:
   activeDeadlineSeconds: 120

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -1,33 +1,36 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+  name: "jaeger-cassandra-schema"
   labels:
-    app: "{{ template "jaeger" . }}"
+    app: "{{ template "jaeger.name" . }}"
     jaeger-infra: cassandra-schema-job
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+    component: "jaeger-cassandra-schema"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.job.schema.annotations }}
-  annotations:
-{{ toYaml .Values.job.schema.annotations | indent 6 }}
+{{- if .Values.schema.annotationsPod }}
+  annotationsPod:
+{{ toYaml .Values.schema.annotationsPod | indent 6 }}
 {{- end }}
 spec:
   activeDeadlineSeconds: 120
   template:
     metadata:
-      name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+      app: "{{ template "jaeger.name" . }}"
+      component: "jaeger-cassandra-schema"
+      release: "{{ .Release.Name }}"
+      name: "jaeger-cassandra-schema"
     spec:
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-        image: "{{ .Values.job.schema.image }}:{{ .Values.job.schema.tag }}"
-        imagePullPolicy: {{ .Values.job.schema.pullPolicy }}
+      - name: "jaeger-cassandra-schema"
+        image: "{{ .Values.schema.image }}:{{ .Values.schema.tag }}"
+        imagePullPolicy: {{ .Values.schema.pullPolicy }}
         env:
           - name: CQLSH_HOST
             value: "{{ template "cassandra.fullname" . }}"
           - name: MODE
-            value: "{{ .Values.job.schema.mode }}"
+            value: "{{ .Values.schema.mode }}"
           - name: DATACENTER
             value: "{{ .Values.cassandra.config.dc_name }}"
       restartPolicy: Never

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -1,12 +1,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "jaeger-cassandra-schema"
+  name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
   labels:
     app: "{{ template "jaeger.name" . }}"
     jaeger-infra: cassandra-schema-job
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "jaeger-cassandra-schema"
+    component: "cassandra-schema"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 {{- if .Values.schema.annotations }}
@@ -17,10 +17,10 @@ spec:
   activeDeadlineSeconds: 120
   template:
     metadata:
-      name: "jaeger-cassandra-schema"
+      name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
     spec:
       containers:
-      - name: "jaeger-cassandra-schema"
+      - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
         image: "{{ .Values.schema.image }}:{{ .Values.schema.tag }}"
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
         env:

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
   labels:
-    app: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+    app: "{{ template "jaeger" . }}"
     jaeger-infra: cassandra-schema-job
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: "{{ template "jaeger.fullname" . }}-cassandra-schema"

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: "{{ template "jaeger.fullname" . }}-collector"
   labels:
-    app: "{{ template "jaeger.fullname" . }}-collector"
+    app: "{{ template "jaeger" . }}"
     jaeger-infra: collector-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: "{{ template "jaeger.fullname" . }}-collector"

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -1,0 +1,45 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "jaeger.fullname" . }}-collector"
+  labels:
+    app: "{{ template "jaeger.fullname" . }}-collector"
+    jaeger-infra: collector-deployment
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: "{{ template "jaeger.fullname" . }}-collector"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.deployment.collector.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.collector.annotations | indent 6 }}
+{{- end }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        jaeger-infra: collector-pod
+    spec:
+      containers:
+      - name: "{{ template "jaeger.fullname" . }}-collector"
+        image: "{{ .Values.deployment.collector.image }}:{{ .Values.deployment.collector.tag }}"
+        imagePullPolicy: {{ .Values.deployment.collector.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.collector.tchannelPort }}
+          protocol: TCP
+        - containerPort: {{ .Values.service.collector.httpPort }}
+          protocol: TCP
+        - containerPort: {{ .Values.service.collector.zipkinPort }}
+          protocol: TCP
+        command:
+        - "/go/bin/collector-linux"
+        - "--cassandra.servers={{ template "cassandra.fullname" . }}"
+        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
+        - "--collector.zipkin.http-port={{ .Values.service.collector.zipkinPort }}"
+{{- range $key, $value := .Values.deployment.collector.cmdlineParams }}
+        - "{{ $value }}"
+{{- end }}
+      dnsPolicy: {{ .Values.deployment.collector.dnsPolicy }}
+      restartPolicy: Always

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -1,12 +1,12 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "jaeger-collector"
+  name: "{{ template "jaeger.fullname" . }}-collector"
   labels:
     app: "{{ template "jaeger.name" . }}"
     jaeger-infra: collector-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "jaeger-collector"
+    component: "collector"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 {{- if .Values.collector.annotations }}
@@ -21,14 +21,14 @@ spec:
     metadata:
       labels:
         app: "{{ template "jaeger.name" . }}"
-        component: "jaeger-collector"
+        component: "collector"
         release: "{{ .Release.Name }}"
         jaeger-infra: collector-pod
     spec:
       nodeSelector:
 {{ toYaml .Values.collector.nodeSelector | indent 8 }}
       containers:
-      - name: "jaeger-collector"
+      - name: "{{ template "jaeger.fullname" . }}-collector"
         image: "{{ .Values.collector.image }}:{{ .Values.collector.tag }}"
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         ports:

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -9,9 +9,9 @@ metadata:
     component: "jaeger-collector"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.collector.annotationsPod }}
-  annotationsPod:
-{{ toYaml .Values.collector.annotationsPod | indent 6 }}
+{{- if .Values.collector.annotations }}
+  annotations:
+{{ toYaml .Values.collector.annotations | indent 6 }}
 {{- end }}
 spec:
   replicas: 1
@@ -32,11 +32,11 @@ spec:
         image: "{{ .Values.collector.image }}:{{ .Values.collector.tag }}"
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.collector.tchannelPort }}
+        - containerPort: {{ .Values.collector.service.tchannelPort }}
           protocol: TCP
-        - containerPort: {{ .Values.collector.httpPort }}
+        - containerPort: {{ .Values.collector.service.httpPort }}
           protocol: TCP
-        - containerPort: {{ .Values.collector.zipkinPort }}
+        - containerPort: {{ .Values.collector.service.zipkinPort }}
           protocol: TCP
         resources:
 {{ toYaml .Values.collector.resources | indent 10 }}
@@ -44,7 +44,7 @@ spec:
         - "/go/bin/collector-linux"
         - "--cassandra.servers={{ template "cassandra.fullname" . }}"
         - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-        - "--collector.zipkin.http-port={{ .Values.collector.zipkinPort }}"
+        - "--collector.zipkin.http-port={{ .Values.collector.service.zipkinPort }}"
 {{- range $key, $value := .Values.collector.cmdlineParams }}
         - "{{ $value }}"
 {{- end }}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -1,17 +1,17 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-collector"
+  name: "jaeger-collector"
   labels:
-    app: "{{ template "jaeger" . }}"
+    app: "{{ template "jaeger.name" . }}"
     jaeger-infra: collector-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "{{ template "jaeger.fullname" . }}-collector"
+    component: "jaeger-collector"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.deployment.collector.annotations }}
-  annotations:
-{{ toYaml .Values.deployment.collector.annotations | indent 6 }}
+{{- if .Values.collector.annotationsPod }}
+  annotationsPod:
+{{ toYaml .Values.collector.annotationsPod | indent 6 }}
 {{- end }}
 spec:
   replicas: 1
@@ -20,26 +20,33 @@ spec:
   template:
     metadata:
       labels:
+        app: "{{ template "jaeger.name" . }}"
+        component: "jaeger-collector"
+        release: "{{ .Release.Name }}"
         jaeger-infra: collector-pod
     spec:
+      nodeSelector:
+{{ toYaml .Values.collector.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-collector"
-        image: "{{ .Values.deployment.collector.image }}:{{ .Values.deployment.collector.tag }}"
-        imagePullPolicy: {{ .Values.deployment.collector.pullPolicy }}
+      - name: "jaeger-collector"
+        image: "{{ .Values.collector.image }}:{{ .Values.collector.tag }}"
+        imagePullPolicy: {{ .Values.collector.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.service.collector.tchannelPort }}
+        - containerPort: {{ .Values.collector.tchannelPort }}
           protocol: TCP
-        - containerPort: {{ .Values.service.collector.httpPort }}
+        - containerPort: {{ .Values.collector.httpPort }}
           protocol: TCP
-        - containerPort: {{ .Values.service.collector.zipkinPort }}
+        - containerPort: {{ .Values.collector.zipkinPort }}
           protocol: TCP
+        resources:
+{{ toYaml .Values.collector.resources | indent 10 }}
         command:
         - "/go/bin/collector-linux"
         - "--cassandra.servers={{ template "cassandra.fullname" . }}"
         - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-        - "--collector.zipkin.http-port={{ .Values.service.collector.zipkinPort }}"
-{{- range $key, $value := .Values.deployment.collector.cmdlineParams }}
+        - "--collector.zipkin.http-port={{ .Values.collector.zipkinPort }}"
+{{- range $key, $value := .Values.collector.cmdlineParams }}
         - "{{ $value }}"
 {{- end }}
-      dnsPolicy: {{ .Values.deployment.collector.dnsPolicy }}
+      dnsPolicy: {{ .Values.collector.dnsPolicy }}
       restartPolicy: Always

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -1,32 +1,35 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-collector"
+  name: "jaeger-collector"
   labels:
-    app: "{{ template "jaeger" . }}"
+    app: "{{ template "jaeger.name" . }}"
     jaeger-infra: collector-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "{{ template "jaeger.fullname" . }}-collector"
+    component: "jaeger-collector"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.service.collector.annotations }}
+{{- if .Values.collector.annotationsSvc }}
   annotations:
-{{ toYaml .Values.service.collector.annotations | indent 6 }}
+{{ toYaml .Values.collector.annotationsSvc | indent 6 }}
 {{- end }}
 spec:
   ports:
   - name: jaeger-collector-tchannel
-    port: {{ .Values.service.collector.tchannelPort }}
+    port: {{ .Values.collector.tchannelPort }}
     protocol: TCP
-    targetPort: {{ .Values.service.collector.tchannelPort }}
+    targetPort: {{ .Values.collector.tchannelPort }}
   - name: jaeger-collector-http
-    port: {{ .Values.service.collector.httpPort }}
+    port: {{ .Values.collector.httpPort }}
     protocol: TCP
-    targetPort: {{ .Values.service.collector.httpPort }}
+    targetPort: {{ .Values.collector.httpPort }}
   - name: jaeger-collector-zipkin
-    port: {{ .Values.service.collector.zipkinPort }}
+    port: {{ .Values.collector.zipkinPort }}
     protocol: TCP
-    targetPort: {{ .Values.service.collector.zipkinPort }}
+    targetPort: {{ .Values.collector.zipkinPort }}
   selector:
+    app: "{{ template "jaeger.name" . }}"
+    component: "jaeger-collector"
+    release: "{{ .Release.Name }}"
     jaeger-infra: collector-pod
-  type: {{ .Values.service.collector.type }}
+  type: {{ .Values.collector.type }}

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: "{{ template "jaeger.fullname" . }}-collector"
   labels:
-    app: "{{ template "jaeger.fullname" . }}-collector"
+    app: "{{ template "jaeger" . }}"
     jaeger-infra: collector-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: "{{ template "jaeger.fullname" . }}-collector"

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -9,24 +9,24 @@ metadata:
     component: "jaeger-collector"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.collector.annotationsSvc }}
+{{- if .Values.collector.service.annotations }}
   annotations:
-{{ toYaml .Values.collector.annotationsSvc | indent 6 }}
+{{ toYaml .Values.collector.service.annotations | indent 6 }}
 {{- end }}
 spec:
   ports:
   - name: jaeger-collector-tchannel
-    port: {{ .Values.collector.tchannelPort }}
+    port: {{ .Values.collector.service.tchannelPort }}
     protocol: TCP
-    targetPort: {{ .Values.collector.tchannelPort }}
+    targetPort: {{ .Values.collector.service.tchannelPort }}
   - name: jaeger-collector-http
-    port: {{ .Values.collector.httpPort }}
+    port: {{ .Values.collector.service.httpPort }}
     protocol: TCP
-    targetPort: {{ .Values.collector.httpPort }}
+    targetPort: {{ .Values.collector.service.httpPort }}
   - name: jaeger-collector-zipkin
-    port: {{ .Values.collector.zipkinPort }}
+    port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
-    targetPort: {{ .Values.collector.zipkinPort }}
+    targetPort: {{ .Values.collector.service.zipkinPort }}
   selector:
     app: "{{ template "jaeger.name" . }}"
     component: "jaeger-collector"

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "jaeger-collector"
+  name: "{{ template "jaeger.fullname" . }}-collector"
   labels:
     app: "{{ template "jaeger.name" . }}"
     jaeger-infra: collector-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "jaeger-collector"
+    component: "collector"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 {{- if .Values.collector.service.annotations }}
@@ -29,7 +29,7 @@ spec:
     targetPort: {{ .Values.collector.service.zipkinPort }}
   selector:
     app: "{{ template "jaeger.name" . }}"
-    component: "jaeger-collector"
+    component: "collector"
     release: "{{ .Release.Name }}"
     jaeger-infra: collector-pod
   type: {{ .Values.collector.service.type }}

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -32,4 +32,4 @@ spec:
     component: "jaeger-collector"
     release: "{{ .Release.Name }}"
     jaeger-infra: collector-pod
-  type: {{ .Values.collector.type }}
+  type: {{ .Values.collector.service.type }}

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "jaeger.fullname" . }}-collector"
+  labels:
+    app: "{{ template "jaeger.fullname" . }}-collector"
+    jaeger-infra: collector-service
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: "{{ template "jaeger.fullname" . }}-collector"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.service.collector.annotations }}
+  annotations:
+{{ toYaml .Values.service.collector.annotations | indent 6 }}
+{{- end }}
+spec:
+  ports:
+  - name: jaeger-collector-tchannel
+    port: {{ .Values.service.collector.tchannelPort }}
+    protocol: TCP
+    targetPort: {{ .Values.service.collector.tchannelPort }}
+  - name: jaeger-collector-http
+    port: {{ .Values.service.collector.httpPort }}
+    protocol: TCP
+    targetPort: {{ .Values.service.collector.httpPort }}
+  - name: jaeger-collector-zipkin
+    port: {{ .Values.service.collector.zipkinPort }}
+    protocol: TCP
+    targetPort: {{ .Values.service.collector.zipkinPort }}
+  selector:
+    jaeger-infra: collector-pod
+  type: {{ .Values.service.collector.type }}

--- a/incubator/jaeger/templates/ingress.yaml
+++ b/incubator/jaeger/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/incubator/jaeger/templates/ingress.yaml
+++ b/incubator/jaeger/templates/ingress.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "fullname" . -}}
+{{- $serviceName := include "jaeger.name" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "jaeger.fullname" . }}
+  name: {{ template "jaeger.name" . }}
   labels:
     app: "{{ template "jaeger.name" . }}"
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/incubator/jaeger/templates/ingress.yaml
+++ b/incubator/jaeger/templates/ingress.yaml
@@ -6,7 +6,7 @@ kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: "{{ template "jaeger" . }}"
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/incubator/jaeger/templates/ingress.yaml
+++ b/incubator/jaeger/templates/ingress.yaml
@@ -4,9 +4,9 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "jaeger.fullname" . }}
   labels:
-    app: "{{ template "jaeger" . }}"
+    app: "{{ template "jaeger.name" . }}"
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: "{{ template "jaeger.fullname" . }}-query"
   labels:
-    app: "{{ template "jaeger.fullname" . }}-query"
+    app: "{{ template "jaeger" . }}"
     jaeger-infra: query-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: "{{ template "jaeger.fullname" . }}-query"

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -1,0 +1,45 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "jaeger.fullname" . }}-query"
+  labels:
+    app: "{{ template "jaeger.fullname" . }}-query"
+    jaeger-infra: query-deployment
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: "{{ template "jaeger.fullname" . }}-query"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.deployment.collector.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.collector.annotations | indent 6 }}
+{{- end }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        jaeger-infra: query-pod
+    spec:
+      containers:
+      - name: "{{ template "jaeger.fullname" . }}-query"
+        image: "{{ .Values.deployment.query.image }}:{{ .Values.deployment.query.tag }}"
+        imagePullPolicy: {{ .Values.deployment.query.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.query.targetPort }}
+          protocol: TCP
+        command:
+        - "/go/bin/query-linux"
+        - "--cassandra.servers={{ template "cassandra.fullname" . }}"
+        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
+        - "--query.static-files=/go/jaeger-ui/"
+{{- range $key, $value := .Values.deployment.query.cmdlineParams }}
+        - "{{ $value }}"
+{{- end }}
+        readinessProbe:
+          httpGet:
+            path: "/"
+            port: {{ .Values.service.query.targetPort }}
+      dnsPolicy: {{ .Values.deployment.collector.dnsPolicy }}
+      restartPolicy: Always

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -9,9 +9,9 @@ metadata:
     component: "jaeger-query"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.query.annotationsPod }}
-  annotationsPod:
-{{ toYaml .Values.query.annotationsPod | indent 6 }}
+{{- if .Values.query.annotations }}
+  annotations:
+{{ toYaml .Values.query.annotations | indent 6 }}
 {{- end }}
 spec:
   replicas: 1
@@ -32,7 +32,7 @@ spec:
         image: "{{ .Values.query.image }}:{{ .Values.query.tag }}"
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.service.query.targetPort }}
+        - containerPort: {{ .Values.service.query.service.targetPort }}
           protocol: TCP
         resources:
 {{ toYaml .Values.query.resources | indent 10 }}
@@ -47,6 +47,6 @@ spec:
         readinessProbe:
           httpGet:
             path: "/"
-            port: {{ .Values.service.query.targetPort }}
+            port: {{ .Values.query.service.targetPort }}
       dnsPolicy: {{ .Values.query.dnsPolicy }}
       restartPolicy: Always

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -1,12 +1,12 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "jaeger-query"
+  name: "{{ template "jaeger.fullname" . }}-query"
   labels:
     app: "{{ template "jaeger.name" . }}"
     jaeger-infra: query-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "jaeger-query"
+    component: "query"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 {{- if .Values.query.annotations }}
@@ -21,14 +21,14 @@ spec:
     metadata:
       labels:
         app: "{{ template "jaeger.name" . }}"
-        component: "jaeger-query"
+        component: "query"
         release: "{{ .Release.Name }}"
         jaeger-infra: query-pod
     spec:
       nodeSelector:
 {{ toYaml .Values.query.nodeSelector | indent 8 }}
       containers:
-      - name: "jaeger-query"
+      - name: "{{ template "jaeger.fullname" . }}-query"
         image: "{{ .Values.query.image }}:{{ .Values.query.tag }}"
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         ports:

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -1,17 +1,17 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-query"
+  name: "jaeger-query"
   labels:
-    app: "{{ template "jaeger" . }}"
+    app: "{{ template "jaeger.name" . }}"
     jaeger-infra: query-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "{{ template "jaeger.fullname" . }}-query"
+    component: "jaeger-query"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.deployment.collector.annotations }}
-  annotations:
-{{ toYaml .Values.deployment.collector.annotations | indent 6 }}
+{{- if .Values.query.annotationsPod }}
+  annotationsPod:
+{{ toYaml .Values.query.annotationsPod | indent 6 }}
 {{- end }}
 spec:
   replicas: 1
@@ -20,26 +20,33 @@ spec:
   template:
     metadata:
       labels:
+        app: "{{ template "jaeger.name" . }}"
+        component: "jaeger-query"
+        release: "{{ .Release.Name }}"
         jaeger-infra: query-pod
     spec:
+      nodeSelector:
+{{ toYaml .Values.query.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-query"
-        image: "{{ .Values.deployment.query.image }}:{{ .Values.deployment.query.tag }}"
-        imagePullPolicy: {{ .Values.deployment.query.pullPolicy }}
+      - name: "jaeger-query"
+        image: "{{ .Values.query.image }}:{{ .Values.query.tag }}"
+        imagePullPolicy: {{ .Values.query.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.query.targetPort }}
           protocol: TCP
+        resources:
+{{ toYaml .Values.query.resources | indent 10 }}
         command:
         - "/go/bin/query-linux"
         - "--cassandra.servers={{ template "cassandra.fullname" . }}"
         - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
         - "--query.static-files=/go/jaeger-ui/"
-{{- range $key, $value := .Values.deployment.query.cmdlineParams }}
+{{- range $key, $value := .Values.query.cmdlineParams }}
         - "{{ $value }}"
 {{- end }}
         readinessProbe:
           httpGet:
             path: "/"
             port: {{ .Values.service.query.targetPort }}
-      dnsPolicy: {{ .Values.deployment.collector.dnsPolicy }}
+      dnsPolicy: {{ .Values.query.dnsPolicy }}
       restartPolicy: Always

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -32,7 +32,7 @@ spec:
         image: "{{ .Values.query.image }}:{{ .Values.query.tag }}"
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.service.query.service.targetPort }}
+        - containerPort: {{ .Values.query.service.targetPort }}
           protocol: TCP
         resources:
 {{ toYaml .Values.query.resources | indent 10 }}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "jaeger-query"
+  name: "{{ template "jaeger.fullname" . }}-query"
   labels:
     app: "{{ template "jaeger.name" . }}"
     jaeger-infra: query-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "jaeger-query"
+    component: "query"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 {{- if .Values.query.service.annotations }}
@@ -21,7 +21,7 @@ spec:
     targetPort: {{ .Values.query.service.targetPort }}
   selector:
     app: "{{ template "jaeger.name" . }}"
-    component: "jaeger-query"
+    component: "query"
     release: "{{ .Release.Name }}"
     jaeger-infra: query-pod
   type: {{ .Values.query.service.type }}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "jaeger.fullname" . }}-query"
+  labels:
+    app: "{{ template "jaeger.fullname" . }}-query"
+    jaeger-infra: query-service
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: "{{ template "jaeger.fullname" . }}-query"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.service.query.annotations }}
+  annotations:
+{{ toYaml .Values.service.query.annotations | indent 6 }}
+{{- end }}
+spec:
+  ports:
+  - name: jaeger-query
+    port: {{ .Values.service.query.queryPort }}
+    protocol: TCP
+    targetPort: {{ .Values.service.query.targetPort }}
+  selector:
+    jaeger-infra: query-pod
+  type: {{ .Values.service.query.type }}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -24,4 +24,4 @@ spec:
     component: "jaeger-query"
     release: "{{ .Release.Name }}"
     jaeger-infra: query-pod
-  type: {{ .Values.query.type }}
+  type: {{ .Values.query.service.type }}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -9,16 +9,16 @@ metadata:
     component: "jaeger-query"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.query.annotationsSvc }}
+{{- if .Values.query.service.annotations }}
   annotations:
-{{ toYaml .Values.query.annotationsSvc | indent 6 }}
+{{ toYaml .Values.query.service.annotations | indent 6 }}
 {{- end }}
 spec:
   ports:
   - name: jaeger-query
-    port: {{ .Values.query.queryPort }}
+    port: {{ .Values.query.service.queryPort }}
     protocol: TCP
-    targetPort: {{ .Values.query.targetPort }}
+    targetPort: {{ .Values.query.service.targetPort }}
   selector:
     app: "{{ template "jaeger.name" . }}"
     component: "jaeger-query"

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -1,24 +1,27 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-query"
+  name: "jaeger-query"
   labels:
-    app: "{{ template "jaeger" . }}"
+    app: "{{ template "jaeger.name" . }}"
     jaeger-infra: query-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "{{ template "jaeger.fullname" . }}-query"
+    component: "jaeger-query"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-{{- if .Values.service.query.annotations }}
+{{- if .Values.query.annotationsSvc }}
   annotations:
-{{ toYaml .Values.service.query.annotations | indent 6 }}
+{{ toYaml .Values.query.annotationsSvc | indent 6 }}
 {{- end }}
 spec:
   ports:
   - name: jaeger-query
-    port: {{ .Values.service.query.queryPort }}
+    port: {{ .Values.query.queryPort }}
     protocol: TCP
-    targetPort: {{ .Values.service.query.targetPort }}
+    targetPort: {{ .Values.query.targetPort }}
   selector:
+    app: "{{ template "jaeger.name" . }}"
+    component: "jaeger-query"
+    release: "{{ .Release.Name }}"
     jaeger-infra: query-pod
-  type: {{ .Values.service.query.type }}
+  type: {{ .Values.query.type }}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: "{{ template "jaeger.fullname" . }}-query"
   labels:
-    app: "{{ template "jaeger.fullname" . }}-query"
+    app: "{{ template "jaeger" . }}"
     jaeger-infra: query-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     component: "{{ template "jaeger.fullname" . }}-query"

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -44,13 +44,13 @@ agent:
     compactPort: 6831
     # binaryPort: accept jaeger.thrift over binary thrift protocol
     binaryPort: 6832
-  resources:
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
-    requests:
-      cpu: 256m
-      memory: 128Mi
+    # requests:
+    #   cpu: 256m
+    #   memory: 128Mi
   nodeSelector: {}
 collector:
   annotations: {}
@@ -68,13 +68,13 @@ collector:
     httpPort: 14268
     # can accept Zipkin spans in JSON or Thrift
     zipkinPort: 9411
-  resources:
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
-    requests:
-      cpu: 1024m
-      memory: 1024Mi
+    # requests:
+    #   cpu: 1024m
+    #   memory: 1024Mi
   nodeSelector: {}
 query:
   annotations: {}
@@ -90,13 +90,13 @@ query:
     queryPort: 80
     # targetPort: the internal port the UI and API are exposed on
     targetPort: 16686
-  resources:
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
-    requests:
-      cpu: 256m
-      memory: 128Mi
+    # requests:
+    #    cpu: 256m
+    #    memory: 128Mi
   nodeSelector: {}
 # End: Default values for the various components of Jaeger
 

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -1,6 +1,6 @@
 # Default values for jaeger.
 # This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# Jaeger values are grouped by component. Cassandra values override subchart values
 
 # Begin: Override values on the Cassandra subchart to customize for Jaeger
 cassandra:

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -14,55 +14,69 @@ cassandra:
     rack_name: rack1
     endpoint_snitch: GossipingPropertyFileSnitch
 
-job:
-  schema:
-    annotations: {}
-    image: jaegertracing/jaeger-cassandra-schema
-    tag: 0.6
-    pullPolicy: IfNotPresent
-    mode: prod
-
-daemonset:
-  agent:
-    annotations: {}
-    image: jaegertracing/jaeger-agent
-    tag: 0.6
-    pullPolicy: IfNotPresent
-    cmdlineParams: {}
-
-deployment:
-  collector:
-    annotations: {}
-    image: jaegertracing/jaeger-collector
-    tag: 0.6
-    pullPolicy: IfNotPresent
-    dnsPolicy: ClusterFirst
-    cmdlineParams: {}
-  query:
-    annotations: {}
-    image: jaegertracing/jaeger-query
-    tag: 0.6
-    pullPolicy: IfNotPresent
-    dnsPolicy: ClusterFirst
-    cmdlineParams: {}
-
-service:
-  collector:
-    annotations: {}
-    type: ClusterIP
-    tchannelPort: 14267
-    httpPort: 14268
-    zipkinPort: 9411
-  query:
-    annotations: {}
-    type: NodePort
-    queryPort: 80
-    targetPort: 16686
-  agent:
-    annotations: {}
-    zipkinThriftPort: 5775
-    compactPort: 6831
-    binaryPort: 6832
+schema:
+  annotationsPod: {}
+  image: jaegertracing/jaeger-cassandra-schema
+  tag: 0.6
+  pullPolicy: IfNotPresent
+  mode: prod
+agent:
+  annotationsPod: {}
+  image: jaegertracing/jaeger-agent
+  tag: 0.6
+  pullPolicy: IfNotPresent
+  cmdlineParams: {}
+  annotationsSvc: {}
+  zipkinThriftPort: 5775
+  compactPort: 6831
+  binaryPort: 6832
+  resources:
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    requests:
+      cpu: 256m
+      memory: 128Mi
+  nodeSelector: {}
+collector:
+  annotationsPod: {}
+  image: jaegertracing/jaeger-collector
+  tag: 0.6
+  pullPolicy: IfNotPresent
+  dnsPolicy: ClusterFirst
+  cmdlineParams: {}
+  annotationsSvc: {}
+  type: ClusterIP
+  tchannelPort: 14267
+  httpPort: 14268
+  zipkinPort: 9411
+  resources:
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    requests:
+      cpu: 1024m
+      memory: 1024Mi
+  nodeSelector: {}
+query:
+  annotationsPod: {}
+  image: jaegertracing/jaeger-query
+  tag: 0.6
+  pullPolicy: IfNotPresent
+  dnsPolicy: ClusterFirst
+  cmdlineParams: {}
+  annotationsSvc: {}
+  type: NodePort
+  queryPort: 80
+  targetPort: 16686
+  resources:
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    requests:
+      cpu: 256m
+      memory: 128Mi
+  nodeSelector: {}
 
 ingress:
   enabled: false

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -1,0 +1,79 @@
+# Default values for jaeger.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+cassandra:
+  image:
+    tag: 3.11
+  persistence:
+    enabled: false
+  config:
+    cluster_name: jaeger
+    seed_size: 1
+    dc_name: dc1
+    rack_name: rack1
+    endpoint_snitch: GossipingPropertyFileSnitch
+
+job:
+  schema:
+    annotations: {}
+    image: jaegertracing/jaeger-cassandra-schema
+    tag: 0.6
+    pullPolicy: IfNotPresent
+    mode: prod
+
+daemonset:
+  agent:
+    annotations: {}
+    image: jaegertracing/jaeger-agent
+    tag: 0.6
+    pullPolicy: IfNotPresent
+    cmdlineParams: {}
+
+deployment:
+  collector:
+    annotations: {}
+    image: jaegertracing/jaeger-collector
+    tag: 0.6
+    pullPolicy: IfNotPresent
+    dnsPolicy: ClusterFirst
+    cmdlineParams: {}
+  query:
+    annotations: {}
+    image: jaegertracing/jaeger-query
+    tag: 0.6
+    pullPolicy: IfNotPresent
+    dnsPolicy: ClusterFirst
+    cmdlineParams: {}
+
+service:
+  collector:
+    annotations: {}
+    type: ClusterIP
+    tchannelPort: 14267
+    httpPort: 14268
+    zipkinPort: 9411
+  query:
+    annotations: {}
+    type: NodePort
+    queryPort: 80
+    targetPort: 16686
+  agent:
+    annotations: {}
+    zipkinThriftPort: 5775
+    compactPort: 6831
+    binaryPort: 6832
+
+ingress:
+  enabled: false
+  # Used to create an Ingress record.
+  # hosts:
+  #   - chart-example.local
+  #annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  #tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -2,10 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Begin: Override values on the Cassandra subchart to customize for Jaeger
 cassandra:
   image:
     tag: 3.11
   persistence:
+    # To enable persistence, please see the documentation for the Cassandra chart
     enabled: false
   config:
     cluster_name: jaeger
@@ -13,23 +15,35 @@ cassandra:
     dc_name: dc1
     rack_name: rack1
     endpoint_snitch: GossipingPropertyFileSnitch
+# End: Override values on the Cassandra subchart to customize for Jaeger
 
+# Begin: Default values for the various components of Jaeger
+# This chart has been based on the Kubernetes integration found in the following repo:
+# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production/jaeger-production-template.yml
+#
+# This is the jaeger-cassandra-schema Job which sets up the Cassandra schema for
+# use by Jaeger
 schema:
-  annotationsPod: {}
+  annotations: {}
   image: jaegertracing/jaeger-cassandra-schema
   tag: 0.6
   pullPolicy: IfNotPresent
+  # Acceptable values are test and prod. Default is for production use.
   mode: prod
 agent:
-  annotationsPod: {}
+  annotations: {}
   image: jaegertracing/jaeger-agent
   tag: 0.6
   pullPolicy: IfNotPresent
   cmdlineParams: {}
-  annotationsSvc: {}
-  zipkinThriftPort: 5775
-  compactPort: 6831
-  binaryPort: 6832
+  service:
+    annotations: {}
+    # zipkinThriftPort :accept zipkin.thrift over compact thrift protocol
+    zipkinThriftPort: 5775
+    # compactPort: accept jaeger.thrift over compact thrift protocol
+    compactPort: 6831
+    # binaryPort: accept jaeger.thrift over binary thrift protocol
+    binaryPort: 6832
   resources:
     # limits:
     #   cpu: 500m
@@ -39,17 +53,21 @@ agent:
       memory: 128Mi
   nodeSelector: {}
 collector:
-  annotationsPod: {}
+  annotations: {}
   image: jaegertracing/jaeger-collector
   tag: 0.6
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
-  annotationsSvc: {}
-  type: ClusterIP
-  tchannelPort: 14267
-  httpPort: 14268
-  zipkinPort: 9411
+  service:
+    annotations: {}
+    type: ClusterIP
+    # tchannelPort: used by jaeger-agent to send spans in jaeger.thrift format
+    tchannelPort: 14267
+    # httpPort: can accept spans directly from clients in jaeger.thrift format
+    httpPort: 14268
+    # can accept Zipkin spans in JSON or Thrift
+    zipkinPort: 9411
   resources:
     # limits:
     #   cpu: 500m
@@ -59,16 +77,19 @@ collector:
       memory: 1024Mi
   nodeSelector: {}
 query:
-  annotationsPod: {}
+  annotations: {}
   image: jaegertracing/jaeger-query
   tag: 0.6
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
-  annotationsSvc: {}
-  type: NodePort
-  queryPort: 80
-  targetPort: 16686
+  service:
+    annotations: {}
+    type: NodePort
+    # queryPort: externally accessible port for UI and API
+    queryPort: 80
+    # targetPort: the internal port the UI and API are exposed on
+    targetPort: 16686
   resources:
     # limits:
     #   cpu: 500m
@@ -77,6 +98,7 @@ query:
       cpu: 256m
       memory: 128Mi
   nodeSelector: {}
+# End: Default values for the various components of Jaeger
 
 ingress:
   enabled: false


### PR DESCRIPTION
This is the initial release for the Jaeger Helm Chart.

helm lint: Pass
helm install .: Works with the minimum required resources
data persistence: Done in the cassandra subchart
README.md: Included
NOTES.txt: Included
Best practices labels and values: Yes, with exception. Some of the values override values in the cassandra chart. Those keys do not follow the lowercase/camelcase convention.