### PR TITLE
[stable/prometheus] add additional permissions for kube-state-metrics

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.5.0
+version: 4.5.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
@@ -19,6 +19,7 @@ rules:
       - resourcequotas
       - replicationcontrollers
       - limitranges
+      - persistentvolumeclaims
     verbs:
       - list
       - watch
@@ -28,6 +29,21 @@ rules:
       - daemonsets
       - deployments
       - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
     verbs:
       - list
       - watch


### PR DESCRIPTION
kube-state-metrics did require some additional permissions in my cluster to be able to gather all stats