### PR TITLE
[stable/coredns] Add RBAC support

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 0.5.0
+version: 0.6.0
 description: CoreDNS is a DNS server that chains middleware and provides Kubernetes
   DNS Services
 keywords:

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -37,6 +37,13 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         {{- end }}
     spec:
+      {{- if .Values.middleware.kubernetes.enabled }}
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ template "coredns.fullname" . }}
+      {{- else }}
+      serviceAccountName: default
+      {{- end }}
+      {{- end }}
       {{- if .Values.isClusterService }}
       dnsPolicy: Default
       {{- end }}

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -38,11 +38,7 @@ spec:
         {{- end }}
     spec:
       {{- if .Values.middleware.kubernetes.enabled }}
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ template "coredns.fullname" . }}
-      {{- else }}
-      serviceAccountName: default
-      {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "coredns.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       {{- end }}
       {{- if .Values.isClusterService }}
       dnsPolicy: Default

--- a/stable/coredns/templates/rbac.yaml
+++ b/stable/coredns/templates/rbac.yaml
@@ -1,0 +1,35 @@
+{{- if (.Values.middleware.kubernetes.enabled) and (.Values.rbac.enabled) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "coredns.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "coredns.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "coredns.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "coredns.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "coredns.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/coredns/templates/rbac.yaml
+++ b/stable/coredns/templates/rbac.yaml
@@ -1,13 +1,35 @@
-{{- if (.Values.middleware.kubernetes.enabled) and (.Values.rbac.create) }}
+{{- if and .Values.middleware.kubernetes.enabled .Values.rbac.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "coredns.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- else }}
+    app: {{ template "coredns.fullname" . }}
+    {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: {{ template "coredns.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- else }}
+    app: {{ template "coredns.fullname" . }}
+    {{- end }}
 rules:
 - apiGroups:
   - ""
@@ -24,6 +46,17 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "coredns.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- else }}
+    app: {{ template "coredns.fullname" . }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/coredns/templates/rbac.yaml
+++ b/stable/coredns/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.middleware.kubernetes.enabled) and (.Values.rbac.enabled) }}
+{{- if (.Values.middleware.kubernetes.enabled) and (.Values.rbac.create) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -18,7 +18,10 @@ resources:
     memory: 128Mi
 
 rbac:
-  enabled: true
+  # If true, create & use RBAC resources
+  create: true
+  # Ignored if rbac.create is true
+  serviceAccountName: default
 
 # isClusterService specifies whether chart should be deployed as cluster-service or normal k8s app.
 isClusterService: true

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -17,6 +17,9 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+rbac:
+  enabled: true
+
 # isClusterService specifies whether chart should be deployed as cluster-service or normal k8s app.
 isClusterService: true
 

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -19,7 +19,7 @@ resources:
 
 rbac:
   # If true, create & use RBAC resources
-  create: true
+  create: false
   # Ignored if rbac.create is true
   serviceAccountName: default
 


### PR DESCRIPTION
This is needed in case of kubernetes' middleware being used.

Access rules are based on:
https://raw.githubusercontent.com/coredns/deployment/master/kubernetes/coredns-1.6.yaml.sed