### PR TITLE
Elasticsearch localhost persistence

### DIFF
--- a/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
@@ -105,14 +105,20 @@ spec:
       - name: config
         configMap:
           name: {{ template "elasticsearch.fullname" . }}
+  {{- if .Values.data.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: data
+      name: data-{{ .Release.Name }}
     spec:
       accessModes: [ ReadWriteOnce ]
-    {{- if .Values.data.storageClass }}
-      storageClassName: "{{ .Values.data.storageClass }}"
-    {{- end }}
       resources:
         requests:
           storage: "{{ .Values.data.storage }}"
+    {{- if .Values.data.storageClass }}
+      storageClassName: "{{ .Values.data.storageClass }}"
+    {{ else }}
+    {{- end }}
+  {{- else }}
+      - name: data-{{ .Release.Name }}
+        emptyDir: {}
+  {{- end -}}

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ image:
 cluster:
   name: "elasticsearch"
   config:
-    
+
 
 client:
   name: client
@@ -43,7 +43,6 @@ data:
   name: data
   replicas: 3
   heapSize: "1536m"
-  storage: "30Gi"
   # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"
@@ -54,3 +53,6 @@ data:
     requests:
       cpu: "25m"
       memory: "256Mi"
+  persistence:
+    enabled: true
+    storage: "30Gi"


### PR DESCRIPTION
Add persistence.enable option; this allows for either provisioning a volume or using localhost/emptyDir for data storage. The release.name part is to avoid having multiple pods attached the same volume as a pvc (sounds odd but it happened during testing).
Also updated the values file with what's needed to use the persistence/localhost settings