### PR TITLE
[stable/concourse] Worker lifecycle management

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.6.0
+version: 0.7.0
 appVersion: 3.3.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
@@ -16,4 +16,6 @@ maintainers:
   email: frodenas@gmail.com
 - name: viglesiasce
   email: viglesias@google.com
+- name: william-tran
+  email: will@autonomic.ai
 engine: gotpl

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -57,6 +57,10 @@ $ kubectl scale statefulset my-release-worker --replicas=3
 
 If a worker isn't taking on work, you can restart the worker with `kubectl delete pod`. This will initiate a graceful shutdown by "retiring" the worker, with some waiting time before the worker starts up again to ensure concourse doesn't try looking for old volumes on the new worker. The values `worker.postStopDelaySeconds` and `worker.terminationGracePeriodSeconds` can be used to tune this.
 
+### Worker Liveness Probe
+
+The worker's Liveness Probe will trigger a restart of the worker if it detects unrecoverable errors, by looking at the worker's logs. The set of strings used to identify such errors could change in the future, but can be tuned with `worker.fatalErrors`. See [values.yaml](values.yaml) for the defaults.
+
 ## Configuration
 
 The following tables lists the configurable parameters of the Concourse chart and their default values.
@@ -120,6 +124,7 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `nil` |
 | `worker.postStopDelaySeconds` | Time to wait after graceful shutdown of worker before starting up again | `60` |
 | `worker.terminationGracePeriodSeconds` | Upper bound for graceful shutdown, including `worker.postStopDelaySeconds` | `120` |
+| `worker.fatalErrors` | Newline delimited strings which, when logged, should trigger a restart of the worker | *See [values.yaml](values.yaml)* |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |
 | `persistence.worker.class` | Concourse Worker Persistent Volume Storage Class | `generic` |
 | `persistence.worker.accessMode` | Concourse Worker Persistent Volume Access Mode | `ReadWriteOnce` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -55,27 +55,7 @@ $ kubectl scale statefulset my-release-worker --replicas=3
 
 ### Restarting workers
 
-If worker pods go down, their persistent volumes are changed, or if you're having other issues with them, you'll need to restart the workers. Concourse workers were designed to be deployed onto infrastructure VMs which are less "ephemeral" than pods, so it isn't good at detecting when a worker goes down and comes back under the same hostname.
-
-Scale the workers down to 0:
-
-```
-kubectl scale statefulset concourse-worker --replicas=0
-
-```
-
-And then `fly workers` until the workers are detected to be `stalled`. Then for each worker
-```
-fly prune-worker -w concourse-worker-0
-fly prune-worker -w concourse-worker-1
-...
-
-```
-And finally
-
-```
-kubectl scale statefulset concourse-worker --replicas=3
-```
+If a worker isn't taking on work, you can restart the worker with `kubectl delete pod`. This will initiate a graceful shutdown by "retiring" the worker, with some waiting time before the worker starts up again to ensure concourse doesn't try looking for old volumes on the new worker. The values `worker.postStopDelaySeconds` and `worker.terminationGracePeriodSeconds` can be used to tune this.
 
 ## Configuration
 
@@ -135,9 +115,11 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
 | `worker.nameOverride` | Override the Concourse Worker components name| `worker` |
 | `worker.replicas` | Number of Concourse Worker replicas | `2` |
-| `worker.minAvailable` | Minimun number of workers available after an eviction | `1` |
+| `worker.minAvailable` | Minimum number of workers available after an eviction | `1` |
 | `worker.resources` | Concourse Worker resource requests and limits | `{requests: {cpu: "100m", memory: "512Mi"}}` |
 | `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `nil` |
+| `worker.postStopDelaySeconds` | Time to wait after graceful shutdown of worker before starting up again | `60` |
+| `worker.terminationGracePeriodSeconds` | Upper bound for graceful shutdown, including `worker.postStopDelaySeconds` | `120` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |
 | `persistence.worker.class` | Concourse Worker Persistent Volume Storage Class | `generic` |
 | `persistence.worker.accessMode` | Concourse Worker Persistent Volume Access Mode | `ReadWriteOnce` |

--- a/stable/concourse/templates/configmap.yaml
+++ b/stable/concourse/templates/configmap.yaml
@@ -37,3 +37,5 @@ data:
   generic-oauth-auth-url-param: {{ default "" .Values.concourse.genericOauthAuthUrlParam | quote }}
   generic-oauth-scope: {{ default "" .Values.concourse.genericOauthScope | quote }}
   generic-oauth-token-url: {{ default "" .Values.concourse.genericOauthTokenUrl | quote }}
+  worker-post-stop-delay-seconds: {{ .Values.worker.postStopDelaySeconds | quote }}
+  

--- a/stable/concourse/templates/configmap.yaml
+++ b/stable/concourse/templates/configmap.yaml
@@ -38,4 +38,5 @@ data:
   generic-oauth-scope: {{ default "" .Values.concourse.genericOauthScope | quote }}
   generic-oauth-token-url: {{ default "" .Values.concourse.genericOauthTokenUrl | quote }}
   worker-post-stop-delay-seconds: {{ .Values.worker.postStopDelaySeconds | quote }}
+  worker-fatal-errors: {{ default "" .Values.worker.fatalErrors | quote }}
   

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -20,20 +20,25 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       containers:
         - name: {{ template "concourse.worker.fullname" . }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+          command:
+            - /bin/sh
           args:
-            - "worker"
+            - -c
+            - |-
+              concourse worker --name=${HOSTNAME}
+              sleep ${POST_STOP_DELAY_SECONDS}
           lifecycle:
             preStop:
               exec:
                 command:
-                  - "concourse"
-                  - "land-worker"
-                  - "--name=${HOSTNAME}"
+                  - "/bin/sh"
+                  - "-c"
+                  - "concourse retire-worker --name=${HOSTNAME}"
           env:
             - name: CONCOURSE_TSA_HOST
               valueFrom:
@@ -66,6 +71,11 @@ spec:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: concourse-baggageclaim-driver
+            - name: POST_STOP_DELAY_SECONDS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: worker-post-stop-delay-seconds
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
           securityContext:

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -30,8 +30,25 @@ spec:
           args:
             - -c
             - |-
-              concourse worker --name=${HOSTNAME}
+              cp /dev/null /concourse-work-dir/.liveness_probe
+              concourse worker --name=${HOSTNAME} | tee -a /concourse-work-dir/.liveness_probe
               sleep ${POST_STOP_DELAY_SECONDS}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |-
+                  FATAL_ERRORS=$( echo "${LIVENESS_PROBE_FATAL_ERRORS}" | grep -q '\S' && \
+                      grep -F "${LIVENESS_PROBE_FATAL_ERRORS}" /concourse-work-dir/.liveness_probe )
+                  cp /dev/null /concourse-work-dir/.liveness_probe
+                  if [ ! -z "${FATAL_ERRORS}" ]; then
+                    >&2 echo "Fatal error detected: ${FATAL_ERRORS}"
+                    exit 1
+                  fi
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
           lifecycle:
             preStop:
               exec:
@@ -76,6 +93,11 @@ spec:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: worker-post-stop-delay-seconds
+            - name: LIVENESS_PROBE_FATAL_ERRORS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: worker-fatal-errors
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
           securityContext:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -386,6 +386,15 @@ worker:
   ## https://concourse.ci/worker-internals.html for worker lifecycle semantics.
   terminationGracePeriodSeconds: 120
 
+  ## If any of the strings are found in logs, the worker's livenessProbe will fail and trigger a pod restart.
+  ## Specify one string per line, exact matching is used.
+  ##
+  ## "guardian.api.garden-server.create.failed" appears when the worker's filesystem has issues.
+  ## "unknown handle" appears if a worker didn't cleanly restart.
+  fatalErrors: |-
+    guardian.api.garden-server.create.failed
+    unknown handle
+
 ## Persistent Volume Storage configuration.
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes
 ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -376,6 +376,16 @@ worker:
   #               values:
   #                 - "true"
 
+  ## Time to delay after the worker process shuts down. This inserts time between shutdown and startup
+  ## to avoid errors caused by a worker restart.
+  postStopDelaySeconds: 60
+
+  ## Time to allow the pod to terminate before being forcefully terminated. This should include
+  ## postStopDelaySeconds, and should additionally provide time for the worker to retire, e.g.
+  ## = postStopDelaySeconds + max time to allow the worker to drain its tasks. See
+  ## https://concourse.ci/worker-internals.html for worker lifecycle semantics.
+  terminationGracePeriodSeconds: 120
+
 ## Persistent Volume Storage configuration.
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes
 ##


### PR DESCRIPTION
Makes Concourse resilient to worker pod restarts, and adds a liveness probe to make workers restart when they encounter issues that prevent them from taking on work. 

Fixes #2103 and #2104

I want this to bake in our environment for a bit, but there's gotta be others that have been running into these problems so I'm putting this up now for visibility and for others to try it out. Our environment is Helm 2.3.1, Kubernetes 1.5.2 (KOPS deployed debian jesse) and using `btrfs` FS driver, it would be nice to see if this works for other versions of k8s and other FS drivers. 