### PR TITLE
[stable/kube-state-metrics] allow configuring collectors

### DIFF
--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -12,12 +12,26 @@ $ helm install stable/kube-state-metrics
 
 ## Configuration
 
-| Parameter                 | Description                                             | Default                                     |
-|---------------------------|---------------------------------------------------------|---------------------------------------------|
-| `image.repository`        | The image repository to pull from                       | gcr.io/google_containers/kube-state-metrics |
-| `image.tag`               | The image tag to pull from                              | v1.0.1                                      |
-| `image.pullPolicy`        | Image pull policy                                       | IfNotPresent                                |
-| `service.port`            | The port of the container                               | 8080                                        |
-| `prometheusScrape`        | Whether or not enable prom scrape                       | True                                        |
-| `rbac.create`             | If true, create & use RBAC resources                    | False                                       |
-| `rbac.serviceAccountName` | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
+| Parameter                           | Description                                             | Default                                     |
+|-------------------------------------|---------------------------------------------------------|---------------------------------------------|
+| `image.repository`                  | The image repository to pull from                       | gcr.io/google_containers/kube-state-metrics |
+| `image.tag`                         | The image tag to pull from                              | v1.0.1                                      |
+| `image.pullPolicy`                  | Image pull policy                                       | IfNotPresent                                |
+| `service.port`                      | The port of the container                               | 8080                                        |
+| `prometheusScrape`                  | Whether or not enable prom scrape                       | True                                        |
+| `rbac.create`                       | If true, create & use RBAC resources                    | False                                       |
+| `rbac.serviceAccountName`           | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
+| `resources`                         | kube-state-metrics resource requests and limits         | {}                                          |
+| `collectors.daemonsets`             | Enable the daemonsets collector.                        | true                                        |
+| `collectors.deployments`            | Enable the deployments collector.                       | true                                        |
+| `collectors.limitranges`            | Enable the limitranges collector.                       | true                                        |
+| `collectors.nodes`                  | Enable the nodes collector.                             | true                                        |
+| `collectors.pods`                   | Enable the pods collector.                              | true                                        |
+| `collectors.replicasets`            | Enable the replicasets collector.                       | true                                        |
+| `collectors.replicationcontrollers` | Enable the replicationcontrollers collector.            | true                                        |
+| `collectors.resourcequotas`         | Enable the resourcequotas collector.                    | true                                        |
+| `collectors.services`               | Enable the services collector.                          | true                                        |
+| `collectors.jobs`                   | Enable the jobs collector.                              | true                                        |
+| `collectors.cronjobs`               | Enable the cronjobs collector.                          | true                                        |
+| `collectors.statefulsets`           | Enable the statefulsets collector.                      | true                                        |
+| `collectors.persistentvolumeclaims` | Enable the persistentvolumeclaims collector.            | true                                        |

--- a/stable/kube-state-metrics/templates/NOTES.txt
+++ b/stable/kube-state-metrics/templates/NOTES.txt
@@ -1,5 +1,6 @@
 kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
-The exposed metrics can be found here: https://github.com/kubernetes/kube-state-metrics/#node-metrics.
+The exposed metrics can be found here:
+https://github.com/kubernetes/kube-state-metrics/tree/master/Documentation#documentation.
 
 The metrics are exported on the HTTP endpoint /metrics on the listening port.
 In your case, {{ template "kube-state-metrics.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -9,29 +9,82 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "kube-state-metrics.fullname" . }}
 rules:
-- apiGroups: [""]
-  resources:
-  - nodes
-  - pods
-  - services
-  - resourcequotas
-  - replicationcontrollers
-  - limitranges
-  - persistentvolumeclaims
-  verbs: ["list", "watch"]
+{{ if .Values.collectors.daemonsets }}
 - apiGroups: ["extensions"]
   resources:
   - daemonsets
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.deployments }}
+- apiGroups: ["extensions"]
+  resources:
   - deployments
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.limitranges }}
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.nodes }}
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.pods }}
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.replicasets }}
+- apiGroups: ["extensions"]
+  resources:
   - replicasets
   verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.replicationcontrollers }}
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.resourcequotas }}
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.services }}
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.jobs }}
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.cronjobs }}
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.statefulsets }}
 - apiGroups: ["apps"]
   resources:
   - statefulsets
   verbs: ["list", "watch"]
-- apiGroups: ["batch"]
+{{ end -}}
+{{ if .Values.collectors.persistentvolumeclaims }}
+- apiGroups: [""]
   resources:
-  - cronjobs
-  - jobs
+  - persistentvolumeclaims
   verbs: ["list", "watch"]
+{{ end }}
 {{- end -}}

--- a/stable/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/stable/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -13,7 +13,7 @@ roleRef:
   kind: ClusterRole
   name: {{ template "kube-state-metrics.fullname" . }}
 subjects:
-  - kind: ServiceAccount
-    name: {{ template "kube-state-metrics.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ template "kube-state-metrics.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -18,6 +18,46 @@ spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-state-metrics.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
       - name: {{ .Chart.Name }}
+        args:
+{{ if .Values.collectors.daemonsets }}
+        - --collectors=daemonsets
+{{  end  }}
+{{  if .Values.collectors.deployments }}
+        - --collectors=deployments
+{{  end  }}
+{{  if .Values.collectors.limitranges  }}
+        - --collectors=limitranges
+{{  end  }}
+{{  if .Values.collectors.nodes  }}
+        - --collectors=nodes
+{{  end  }}
+{{  if .Values.collectors.pods  }}
+        - --collectors=pods
+{{  end  }}
+{{  if .Values.collectors.replicasets  }}
+        - --collectors=replicasets
+{{  end  }}
+{{  if .Values.collectors.replicationcontrollers  }}
+        - --collectors=replicationcontrollers
+{{  end  }}
+{{  if .Values.collectors.resourcequotas  }}
+        - --collectors=resourcequotas
+{{  end  }}
+{{  if .Values.collectors.services  }}
+        - --collectors=services
+{{  end  }}
+{{  if .Values.collectors.jobs  }}
+        - --collectors=jobs
+{{  end  }}
+{{  if .Values.collectors.cronjobs  }}
+        - --collectors=cronjobs
+{{  end  }}
+{{  if .Values.collectors.statefulsets  }}
+        - --collectors=statefulsets
+{{  end  }}
+{{  if .Values.collectors.persistentvolumeclaims  }}
+        - --collectors=persistentvolumeclaims
+{{  end  }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         ports:

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -11,3 +11,20 @@ rbac:
   create: false
   # Ignored if rbac.create is true
   serviceAccountName: default
+
+# Available collectors for kube-state-metrics. By default all available
+# collectors are enabled.
+collectors:
+  daemonsets: true
+  deployments: true
+  limitranges: true
+  nodes: true
+  pods: true
+  replicasets: true
+  replicationcontrollers: true
+  resourcequotas: true
+  services: true
+  jobs: true
+  cronjobs: true
+  statefulsets: true
+  persistentvolumeclaims: true


### PR DESCRIPTION
kube-state-metrics has a collector for each kind of Kubernetes resource
it collects metrics from. Each of those collectors directly influences
the RBAC requirements for the Pods. Additionally due to the nature of
how kube-state-metrics is versioned and released it is not easy to
determine which collectors are using "alpha" APIs, which are not
necessarily enabled in a cluster, but kube-state-metrics by default has
all collectors enabled so individual collectors should be able to be disabled.

@mgoodness 

I have a couple more improvements to the chart, mainly regarding that the [official image is now hosted on quay.io](https://github.com/kubernetes/kube-state-metrics#container-image), adding a readiness probe to the deployment as well as introduce the addon-resizer [like the example upstream manifests](https://github.com/kubernetes/kube-state-metrics/blob/6a95e48df4d462da08a5e863d2bfae65aa6c9cd3/kubernetes/kube-state-metrics-deployment.yaml). Let me know whether you want me to include these improvements in this PR or follow-up PRs.

Let me know whether you already want a version bump with these changes or wait for the additional changes I suggested above and which (major/minor/patch) we should be bumping.