### PR TITLE
[stable/prometheus] Add option for defining strategy for server

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.5.0
+version: 4.6.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -71,6 +71,10 @@ spec:
               mountPath: {{ .mountPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+    {{- if .Values.server.strategy }}
+      strategy:
+{{ toYaml .Values.server.strategy | indent 8 }}
+    {{- end }}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -369,6 +369,10 @@ server:
     #     hosts:
     #       - prometheus.domain.com
 
+  ## Server Deployment Strategy type
+  # strategy:
+  #   type: Recreate
+
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##


### PR DESCRIPTION
We have a usecase of defining deployment strategy as "Recreate" instead of the default "RollingUpdate". Added a section for defining strategy now. Default remains the same as before.

cc @mgoodness