### PR TITLE
[stable/datadog]Give the daemonset the option to use the host network

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.7.4
+version: 0.8.0
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -53,9 +53,10 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `resources.requests.memory` | Memory resource requests           | `128Mi`                                   |
 | `resources.limits.memory`   | Memory resource limits             | `512Mi`                                   |
 | `kubeStateMetrics.enabled`  | If true, create kube-state-metrics | `true`                                    |
-| `daemonset.hostNetwork`     | If true, use the host's network    | `nil`                                     |
 | `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
 | `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |
+| `daemonset.useHostNetwork`  | If true, use the host's network    | `nil`                                     |
+| `daemonset.useHostPort`     | If true, use the same ports for both host and container  | `nil`               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -53,6 +53,7 @@ The following tables lists the configurable parameters of the Datadog chart and 
 | `resources.requests.memory` | Memory resource requests           | `128Mi`                                   |
 | `resources.limits.memory`   | Memory resource limits             | `512Mi`                                   |
 | `kubeStateMetrics.enabled`  | If true, create kube-state-metrics | `true`                                    |
+| `daemonset.hostNetwork`     | If true, use the host's network    | `nil`                                     |
 | `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
 | `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |
 

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -41,9 +41,6 @@ spec:
           name: traceport
           protocol: TCP
         - containerPort: 7777
-          {{- if .Values.daemonset.useHostPort }}
-          hostPort: 7777
-          {{- end }}
           name: legacytraceport
           protocol: TCP
         {{- end }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -17,6 +17,9 @@ spec:
 {{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.daemonset.hostNetwork }}
+      hostNetwork: {{ .Values.daemonset.hostNetwork }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -17,8 +17,8 @@ spec:
 {{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.daemonset.hostNetwork }}
-      hostNetwork: {{ .Values.daemonset.hostNetwork }}
+      {{- if .Values.daemonset.useHostNetwork }}
+      hostNetwork: {{ .Values.daemonset.useHostNetwork }}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
@@ -28,13 +28,22 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
         ports:
         - containerPort: 8125
+          {{- if .Values.daemonset.useHostPort }}
+          hostPort: 8125
+          {{- end }}
           name: dogstatsdport
           protocol: UDP
         {{- if .Values.datadog.apmEnabled }}
         - containerPort: 8126
+          {{- if .Values.daemonset.useHostPort }}
+          hostPort: 8126
+          {{- end }}
           name: traceport
           protocol: TCP
         - containerPort: 7777
+          {{- if .Values.daemonset.useHostPort }}
+          hostPort: 7777
+          {{- end }}
           name: legacytraceport
           protocol: TCP
         {{- end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -12,6 +12,9 @@ image:
 # get guaranteed delivery of the metrics in Datadog-per-namespace setup!
 daemonset:
   enabled: true
+  ## Bind ports on the hostNetwork. The ports will need to be available on all
+  ## hosts. Can be used for custom metrics instead of a service endpoint
+  # hostNetwork: true
 
   ## Annotations to add to the DaemonSet's Pods
   # podAnnotations:
@@ -31,7 +34,7 @@ daemonset:
 deployment:
   enabled: false
   replicas: 1
- 
+
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
 ##

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -12,9 +12,17 @@ image:
 # get guaranteed delivery of the metrics in Datadog-per-namespace setup!
 daemonset:
   enabled: true
-  ## Bind ports on the hostNetwork. The ports will need to be available on all
-  ## hosts. Can be used for custom metrics instead of a service endpoint
-  # hostNetwork: true
+  ## Bind ports on the hostNetwork. Useful for CNI networking where hostPort might
+  ## not be supported. The ports will need to be available on all hosts. Can be
+  ## used for custom metrics instead of a service endpoint.
+  # useHostNetwork: true
+
+  ## Sets the hostPort to the same value of the container port. Can be used as
+  ## for sending custom metrics. The ports will need to be available on all
+  ## hosts.
+  ## WARNING: Make sure that hosts using this are properly firewalled otherwise
+  ## otherwise metrics will be accepted from any host able to connect to this host.
+  # useHostPort: true
 
   ## Annotations to add to the DaemonSet's Pods
   # podAnnotations:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -16,14 +16,14 @@ daemonset:
   ## not be supported. The ports will need to be available on all hosts. Can be
   ## used for custom metrics instead of a service endpoint.
   ## WARNING: Make sure that hosts using this are properly firewalled otherwise
-  ## otherwise metrics and traces will be accepted from any host able to connect to this host.
+  ## metrics and traces will be accepted from any host able to connect to this host.
   # useHostNetwork: true
 
   ## Sets the hostPort to the same value of the container port. Can be used as
   ## for sending custom metrics. The ports will need to be available on all
   ## hosts.
   ## WARNING: Make sure that hosts using this are properly firewalled otherwise
-  ## otherwise metrics and traces will be accepted from any host able to connect to this host.
+  ## metrics and traces will be accepted from any host able to connect to this host.
   # useHostPort: true
 
   ## Annotations to add to the DaemonSet's Pods

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -15,13 +15,15 @@ daemonset:
   ## Bind ports on the hostNetwork. Useful for CNI networking where hostPort might
   ## not be supported. The ports will need to be available on all hosts. Can be
   ## used for custom metrics instead of a service endpoint.
+  ## WARNING: Make sure that hosts using this are properly firewalled otherwise
+  ## otherwise metrics and traces will be accepted from any host able to connect to this host.
   # useHostNetwork: true
 
   ## Sets the hostPort to the same value of the container port. Can be used as
   ## for sending custom metrics. The ports will need to be available on all
   ## hosts.
   ## WARNING: Make sure that hosts using this are properly firewalled otherwise
-  ## otherwise metrics will be accepted from any host able to connect to this host.
+  ## otherwise metrics and traces will be accepted from any host able to connect to this host.
   # useHostPort: true
 
   ## Annotations to add to the DaemonSet's Pods


### PR DESCRIPTION
Allows the DaemonSet to bind to the host network. This allows for the pattern of having the DaemonSet listen bind to a known port and have other containers to send custom metrics to the host IP via the downward API