### PR TITLE
[stable/cluster-autoscaler] Fix cluster autoscaler with default dns policy

### DIFF
--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -74,3 +74,4 @@ spec:
         - name: ssl-certs
           hostPath:
             path: /etc/ssl/certs/ca-certificates.crt
+      dnsPolicy: "Default"


### PR DESCRIPTION
This adds the default dns policy to the cluster autoscaler as seen in kops -- https://github.com/kubernetes/kops/pull/3395

Full discussion for the fix and bug can be seen here -- https://github.com/kubernetes/kops/issues/1796