### PR TITLE
[stable/prometheus] Add nodePort to AlertManager

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.5.0
+version: 4.6.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/alertmanager-service.yaml
+++ b/stable/prometheus/templates/alertmanager-service.yaml
@@ -38,6 +38,9 @@ spec:
       port: {{ .Values.alertmanager.service.servicePort }}
       protocol: TCP
       targetPort: 9093
+    {{- if .Values.alertmanager.service.nodePort }}
+      nodePort: {{ .Values.alertmanager.service.nodePort }}
+    {{- end }}
   selector:
     app: {{ template "prometheus.name" . }}
     component: "{{ .Values.alertmanager.name }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -141,7 +141,6 @@ alertmanager:
     ##
     externalIPs: []
 
-
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     servicePort: 80

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -141,9 +141,11 @@ alertmanager:
     ##
     externalIPs: []
 
+
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
     servicePort: 80
+    # nodePort: 30000
     type: ClusterIP
 
 ## Monitors ConfigMap changes and POSTs to a URL


### PR DESCRIPTION
There is already an option to change service type, but there is no way to define nodePort if NodePort type is chosen. This patch ensures that.

cc @mgoodness 