### PR TITLE
[stable/concourse] Allow for additional affinities

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.5.0
+version: 0.6.0
 appVersion: 3.3.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -137,6 +137,7 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `worker.replicas` | Number of Concourse Worker replicas | `2` |
 | `worker.minAvailable` | Minimun number of workers available after an eviction | `1` |
 | `worker.resources` | Concourse Worker resource requests and limits | `{requests: {cpu: "100m", memory: "512Mi"}}` |
+| `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `nil` |
 | `persistence.enabled` | Enable Concourse persistence using Persistent Volume Claims | `true` |
 | `persistence.worker.class` | Concourse Worker Persistent Volume Storage Class | `generic` |
 | `persistence.worker.accessMode` | Concourse Worker Persistent Volume Access Mode | `ReadWriteOnce` |

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -77,6 +77,9 @@ spec:
             - name: concourse-work-dir
               mountPath: /concourse-work-dir
       affinity:
+{{- if .Values.worker.additionalAffinities }}
+{{ toYaml .Values.worker.additionalAffinities | indent 8 }}
+{{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -362,6 +362,20 @@ worker:
   # annotations:
   #   iam.amazonaws.com/role: arn:aws:iam::123456789012:role/concourse
 
+  ## Additional affinities to add to the worker pods.
+  ## Useful if you prefer to run workers on non-spot instances, for example
+  ##
+  # additionalAffinities:
+  #   nodeAffinity:
+  #     preferredDuringSchedulingIgnoredDuringExecution:
+  #       - weight: 50
+  #         preference:
+  #           matchExpressions:
+  #             - key: spot
+  #               operator: NotIn
+  #               values:
+  #                 - "true"
+
 ## Persistent Volume Storage configuration.
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes
 ##


### PR DESCRIPTION
This adds the ability to supply additional affinity settings.

Our use case is to add node affinity to non-spot instances, but any affinity can be added.