### PR TITLE
[stable/prometheus] Add option for defining strategy for AlertManager

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.5.0
+version: 4.6.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -67,6 +67,10 @@ spec:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
+    {{- if .Values.alertmanager.strategy }}
+      strategy:
+{{ toYaml .Values.alertmanager.strategy | indent 8 }}
+    {{- end }}
     {{- if .Values.alertmanager.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -65,6 +65,10 @@ alertmanager:
     #     hosts:
     #       - alertmanager.domain.com
 
+  ## Server Deployment Strategy type
+  # strategy:
+  #   type: Recreate
+
   ## Node labels for alertmanager pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##


### PR DESCRIPTION
Similar to #2218, we have a usecase of defining deployment strategy as "Recreate" instead of the default "RollingUpdate". Added a section for defining strategy now. Default remains the same as before.