### PR TITLE
pull-charts-e2e should grab deps before running lint

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -66,8 +66,8 @@ for directory in ${CHANGED_FOLDERS}; do
     CHART_NAME=`echo ${directory} | cut -d '/' -f2`
     RELEASE_NAME="${CHART_NAME:0:7}-${BUILD_NUMBER}"
     CURRENT_RELEASE=${RELEASE_NAME}
-    helm lint ${directory}
     helm dep update ${directory}
+    helm lint ${directory}
     helm install --timeout 600 --name ${RELEASE_NAME} --namespace ${NAMESPACE} ${directory} | tee install_output
     ./test/verify-release.sh ${NAMESPACE}
     kubectl get pods --namespace ${NAMESPACE}


### PR DESCRIPTION
my chart is listing common-0.0.1 as a dependency so the jenkins job is failing with
`template: no template "common.fullname" associated with template "gotpl"`

please see https://github.com/kubernetes/charts/pull/2302