### PR TITLE
Fix testgrid

### DIFF
--- a/test/helm-test/main.go
+++ b/test/helm-test/main.go
@@ -196,7 +196,7 @@ func doMain() int {
 	}
 
 	log.Printf("Charts for Testing: %+v", chartList)
-	defer writeXML("/workspace/_artifacts", time.Now())
+	defer writeXML("/go/src/k8s.io/charts/_artifacts", time.Now())
 	if !terminate.Stop() {
 		<-terminate.C // Drain the value if necessary.
 	}


### PR DESCRIPTION
The path changed :( This should enable reporting again via https://k8s-testgrid.appspot.com/kubernetes-apps#charts-gce
long-term fix is fixing the script itself to be more resilient - but hopefully this gives us quick signal.

@kubernetes/charts-maintainers 