### PR TITLE
[stable/gcloud-endpoints] fix broken image url

### DIFF
--- a/stable/gcloud-endpoints/Chart.yaml
+++ b/stable/gcloud-endpoints/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-endpoints
-version: 0.1.0
+version: 0.1.1
 description: Develop, deploy, protect and monitor your APIs with Google Cloud Endpoints.
 keywords:
 - google

--- a/stable/gcloud-endpoints/values.yaml
+++ b/stable/gcloud-endpoints/values.yaml
@@ -1,6 +1,6 @@
 ## Google Cloud Endpoints Runtime image
 ## ref: https://cloud.google.com/endpoints/docs/quickstart-container-engine#deploying_the_sample_api_to_the_cluster
-image: b.gcr.io/endpoints/endpoints-runtime:1
+image: gcr.io/endpoints/endpoints-runtime:1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/stable/gcloud-endpoints/values.yaml
+++ b/stable/gcloud-endpoints/values.yaml
@@ -1,6 +1,6 @@
 ## Google Cloud Endpoints Runtime image
 ## ref: https://cloud.google.com/endpoints/docs/quickstart-container-engine#deploying_the_sample_api_to_the_cluster
-image: gcr.io/endpoints/endpoints-runtime:1
+image: gcr.io/endpoints-release/endpoints-runtime:1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Google deprecated the `b.gcr.io/` registry.
The image moved to `gcr.io`