### PR TITLE
[stabe/rabbitmq]: Add rabbitmqDiskFreeLimit

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.6.9
+version: 0.6.10
 appVersion: 3.6.14
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the RabbitMQ chart and
 | `rabbitmqClusterNodeName`   | Node name to cluster with. e.g.: `clusternode@hostname` | `nil`                                                    |
 | `rabbitmqVhost`             | RabbitMQ application vhost                              | `/`                                                      |
 | `rabbitmqManagerPort`       | RabbitMQ Manager port                                   | `15672`                                                  |
+| `rabbitmqDiskFreeLimit`     | Disk free limit                                         | `"8Gi"`                                    |
 | `serviceType`               | Kubernetes Service type                                 | `ClusterIP`                                              |
 | `persistence.enabled`       | Use a PVC to persist data                               | `true`                                                   |
 | `persistence.existingClaim` | Use an existing PVC to persist data                     | `nil`                                                    |

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -56,7 +56,7 @@ The following tables lists the configurable parameters of the RabbitMQ chart and
 | `rabbitmqClusterNodeName`   | Node name to cluster with. e.g.: `clusternode@hostname` | `nil`                                                    |
 | `rabbitmqVhost`             | RabbitMQ application vhost                              | `/`                                                      |
 | `rabbitmqManagerPort`       | RabbitMQ Manager port                                   | `15672`                                                  |
-| `rabbitmqDiskFreeLimit`     | Disk free limit                                         | `"8Gi"`                                    |
+| `rabbitmqDiskFreeLimit`     | Disk free limit                                         | `"8GiB"`                                    |
 | `serviceType`               | Kubernetes Service type                                 | `ClusterIP`                                              |
 | `persistence.enabled`       | Use a PVC to persist data                               | `true`                                                   |
 | `persistence.existingClaim` | Use an existing PVC to persist data                     | `nil`                                                    |

--- a/stable/rabbitmq/templates/deployment.yaml
+++ b/stable/rabbitmq/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
           value: {{ default "/" .Values.rabbitmqVhost | quote }}
         - name: RABBITMQ_MANAGER_PORT_NUMBER
           value: {{ default "15672" .Values.rabbitmqManagerPort | quote }}
+        - name: RABBITMQ_DISK_FREE_LIMIT
+          value: {{ default "{mem_relative, 1.0}" .Values.rabbitmqDiskFreeLimit | quote }}
         ports:
         - name: epmd
           containerPort: 4369

--- a/stable/rabbitmq/templates/deployment.yaml
+++ b/stable/rabbitmq/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: RABBITMQ_MANAGER_PORT_NUMBER
           value: {{ default "15672" .Values.rabbitmqManagerPort | quote }}
         - name: RABBITMQ_DISK_FREE_LIMIT
-          value: {{ default "{mem_relative, 1.0}" .Values.rabbitmqDiskFreeLimit | quote }}
+          value: {{ default '"8GiB"' .Values.rabbitmqDiskFreeLimit | quote }}
         ports:
         - name: epmd
           containerPort: 4369

--- a/stable/rabbitmq/templates/deployment.yaml
+++ b/stable/rabbitmq/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: RABBITMQ_MANAGER_PORT_NUMBER
           value: {{ default "15672" .Values.rabbitmqManagerPort | quote }}
         - name: RABBITMQ_DISK_FREE_LIMIT
-          value: {{ default '"8GiB"' .Values.rabbitmqDiskFreeLimit | quote }}
+          value: {{ default "\"8GiB\"" .Values.rabbitmqDiskFreeLimit | quote }}
         ports:
         - name: epmd
           containerPort: 4369

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -58,7 +58,7 @@ rabbitmqManagerPort: 15672
 ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
 ## ref: https://www.rabbitmq.com/disk-alarms.html
 ##
-rabbitmqDiskFreeLimit: '"8Gi"'
+rabbitmqDiskFreeLimit: '"8GiB"'
 
 ## Kubernetes service type
 serviceType: ClusterIP

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -54,6 +54,12 @@ rabbitmqVhost: /
 ##
 rabbitmqManagerPort: 15672
 
+## RabbitMQ Disk free limit
+## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+## ref: https://www.rabbitmq.com/disk-alarms.html
+##
+rabbitmqDiskFreeLimit: '"8Gi"'
+
 ## Kubernetes service type
 serviceType: ClusterIP
 
@@ -74,6 +80,8 @@ persistence:
   ##
   # storageClass: "-"
   accessMode: ReadWriteOnce
+
+  # If you change this value, you might have to adjust `rabbitmqDiskFreeLimit` as well.
   size: 8Gi
 
 ## Configure resource requests and limits


### PR DESCRIPTION
This PR adds support to adjust the env var `RABBITMQ_DISK_FREE_LIMIT` via value rabbitmqDiskFreeLimit.
The default is set the size of the PVC. The bitnami default of `{mem_relative, 1.0}` causes the deployment to fail if memory size is bigger than disk size.

Closes #2082