### PR TITLE
Add chart name, "stable/msoms" to install command with inline parameters

### DIFF
--- a/stable/msoms/README.md
+++ b/stable/msoms/README.md
@@ -49,7 +49,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```bash
 $ helm install --name omsagent \
-  --set omsagent.secret.wsid=<your_workspace_id>,omsagent.secret.key=<your_workspace_key>
+  --set omsagent.secret.wsid=<your_workspace_id>,omsagent.secret.key=<your_workspace_key> stable/msoms
 
 ```
 


### PR DESCRIPTION
The chart name is missing from the command