### PR TITLE
[stable/kube-lego] Fix the 'ClusterRole' for 'kube-lego'.

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.11
+version: 0.1.12
 keywords:
   - kube-lego
   - letsencrypt

--- a/stable/kube-lego/templates/role.yaml
+++ b/stable/kube-lego/templates/role.yaml
@@ -32,6 +32,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
   - secrets
   verbs:
   - get


### PR DESCRIPTION
I believe one needs `["create", "get", "update"]` on `endpoints` as well — at least on GKE 1.7.6 with `kube-lego` 0.1.5 and `kubernetes.io/ingress-class: gce`. I was getting the following messages:

```text
(...)
time="2017-09-25T13:08:56Z" level=error msg="User \"system:serviceaccount:kube-lego:kube-lego\" cannot get endpoints in the namespace \"my-namespace\".: \"Unknown user \\\"system:serviceaccount:kube-lego:kube-lego\\\"\" (get endpoints kube-lego-gce)" context=provider provider=gce
(...)
time="2017-09-25T13:11:48Z" level=error msg="User \"system:serviceaccount:kube-lego:kube-lego\" cannot update endpoints in the namespace \"my-namespace\".: \"Unknown user \\\"system:serviceaccount:kube-lego:kube-lego\\\"\" (put endpoints kube-lego-gce)" context=provider provider=gce
(...)
time="2017-09-25T13:21:53Z" level=error msg="User \"system:serviceaccount:kube-lego:kube-lego\" cannot create endpoints in the namespace \"my-namespace\".: \"Unknown user \\\"system:serviceaccount:kube-lego:kube-lego\\\"\" (post endpoints)" context=provider provider=gce
(...)
```