### PR TITLE
[incubator/redis-cache]StatefulSet: Remove  pod.alpha.kubernetes.io/initialized annotation  annotation which has been deprecated

### DIFF
--- a/incubator/redis-cache/Chart.yaml
+++ b/incubator/redis-cache/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A pure in-memory redis cache, using statefulset and redis-sentinel-micro
 name: redis-cache
-version: 0.3.0
+version: 0.3.1
 icon: https://redis.io/images/redis-white.png
 sources:
 - https://github.com/antirez/redis

--- a/incubator/redis-cache/templates/ss.yaml
+++ b/incubator/redis-cache/templates/ss.yaml
@@ -17,8 +17,6 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
     spec:
       terminationGracePeriodSeconds: 60 
       affinity:


### PR DESCRIPTION
The pod.alpha.kubernetes.io/initialized annotation was originally a tool for validating StatefulSet's ordered Pod creation guarantees during the feature's alpha phase.

If set to "false" on a given Pod, it would interrupt StatefulSet's normal behavior. In v1.5.0, the annotation was deprecated and the default became "true" as part of StatefulSet's graduation to beta.

The annotation is now ignored, meaning it cannot be used to interrupt StatefulSet Pod management.

StatefulSet: The deprecated `pod.alpha.kubernetes.io/initialized` annotation for interrupting StatefulSet Pod management is now ignored. If you were setting it to `true` or leaving it unset, no action is required. However, if you were setting it to `false`, be aware that previously-dormant StatefulSets may become active after upgrading.
https://github.com/kubernetes/kubernetes/pull/49251