### PR TITLE
[incubator/elasticsearch]StatefulSet: Remove pod.alpha.kubernetes.io/initialized annotation annotation which has been deprecated

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.1.10
+version: 0.1.11
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
@@ -17,8 +17,6 @@ spec:
         app: {{ template "elasticsearch.name" . }}
         component: "{{ .Values.data.name }}"
         release: {{ .Release.Name }}
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
     spec:
       serviceAccountName: {{ template "elasticsearch.fullname" . }}
       {{- if eq .Values.data.antiAffinity "hard" }}


### PR DESCRIPTION
The pod.alpha.kubernetes.io/initialized annotation was originally a tool for validating StatefulSet's ordered Pod creation guarantees during the feature's alpha phase.

If set to "false" on a given Pod, it would interrupt StatefulSet's normal behavior. In v1.5.0, the annotation was deprecated and the default became "true" as part of StatefulSet's graduation to beta.

The annotation is now ignored, meaning it cannot be used to interrupt StatefulSet Pod management.

StatefulSet: The deprecated `pod.alpha.kubernetes.io/initialized` annotation for interrupting StatefulSet Pod management is now ignored. If you were setting it to `true` or leaving it unset, no action is required. However, if you were setting it to `false`, be aware that previously-dormant StatefulSets may become active after upgrading.
https://github.com/kubernetes/kubernetes/pull/49251