### PR TITLE
[incubator/etcd]StatefulSet: Remove pod.alpha.kubernetes.io/initialized annotation annotation which has been deprecated

### DIFF
--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.3.4
+version: 0.3.5
 description: Distributed reliable key-value store for the most critical data of a
   distributed system.
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/incubator/etcd/templates/statefulset.yaml
+++ b/incubator/etcd/templates/statefulset.yaml
@@ -18,8 +18,6 @@ spec:
         release: {{ .Release.Name | quote }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: "{{ .Release.Name }}-{{ .Values.Component }}"
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
     spec:
       containers:
       - name: {{ template "etcd.fullname" . }}


### PR DESCRIPTION
The pod.alpha.kubernetes.io/initialized annotation was originally a tool for validating StatefulSet's ordered Pod creation guarantees during the feature's alpha phase.

If set to "false" on a given Pod, it would interrupt StatefulSet's normal behavior. In v1.5.0, the annotation was deprecated and the default became "true" as part of StatefulSet's graduation to beta.

The annotation is now ignored, meaning it cannot be used to interrupt StatefulSet Pod management.

StatefulSet: The deprecated `pod.alpha.kubernetes.io/initialized` annotation for interrupting StatefulSet Pod management is now ignored. If you were setting it to `true` or leaving it unset, no action is required. However, if you were setting it to `false`, be aware that previously-dormant StatefulSets may become active after upgrading.
https://github.com/kubernetes/kubernetes/pull/49251