### PR TITLE
SSH_DOMAIN	 parameter support

### DIFF
--- a/incubator/gogs/templates/configmap.yaml
+++ b/incubator/gogs/templates/configmap.yaml
@@ -22,6 +22,7 @@ data:
     [server]
     PROTOCOL = http
     DOMAIN = {{ .Values.service.gogs.serverDomain }}
+    SSH_DOMAIN = {{ .Values.service.gogs.sshDomain }}
     ROOT_URL = {{ .Values.service.gogs.serverRootUrl }}
     LANDING_PAGE = {{ .Values.service.gogs.serverLandingPage }}
 


### PR DESCRIPTION
guys, need the SSH_DOMAIN as a supported parameter.  I am re-using a separate ingress, thus the domain is different for web/ssh requests in GCE :P
https://gogs.io/docs/advanced/configuration_cheat_sheet