### PR TITLE
[stable/nginx-ingress] Custom NGINX template support

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.12
+version: 0.8.13
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -82,6 +82,8 @@ Parameter | Description | Default
 `controller.stats.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.stats.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `controller.stats.service.type` | type of controller stats service to create | `ClusterIP`
+`controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
+`controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`
 `defaultBackend.image.tag` | default backend container image tag | `1.3`

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -102,6 +102,12 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
+{{- if .Values.controller.customTemplate.configMapName }}
+          volumeMounts:
+            - mountPath: /etc/nginx/template
+              name: nginx-template-volume
+              readOnly: true
+{{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
       {{- if .Values.controller.stats.enabled }}
@@ -135,6 +141,15 @@ spec:
     {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "nginx-ingress.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
+{{- if .Values.controller.customTemplate.configMapName }}
+      volumes:
+        - name: nginx-template-volume
+          configMap:
+            name: {{ .Values.controller.customTemplate.configMapName }}
+            items:
+            - key: {{ .Values.controller.customTemplate.configMapKey }}
+              path: nginx.tmpl
+{{- end }}
   updateStrategy:
 {{ toYaml .Values.controller.updateStrategy | indent 4 }}
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -108,6 +108,12 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
+{{- if .Values.controller.customTemplate.configMapName }}
+          volumeMounts:
+            - mountPath: /etc/nginx/template
+              name: nginx-template-volume
+              readOnly: true
+{{- end }}
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
       {{- if .Values.controller.stats.enabled }}
@@ -141,4 +147,13 @@ spec:
     {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "nginx-ingress.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
+{{- if .Values.controller.customTemplate.configMapName }}
+      volumes:
+        - name: nginx-template-volume
+          configMap:
+            name: {{ .Values.controller.customTemplate.configMapName }}
+            items:
+            - key: {{ .Values.controller.customTemplate.configMapKey }}
+              path: nginx.tmpl
+{{- end }}
 {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -93,6 +93,11 @@ controller:
   #    cpu: 100m
   #    memory: 64Mi
 
+  ## Override NGINX template
+  customTemplate:
+    configMapName: ""
+    configMapKey: ""
+
   service:
     annotations: {}
     clusterIP: ""


### PR DESCRIPTION
Many NGINX configuration parameters cannot be overridden with the
nginx-ingress Helm chart. With this change, a custom nginx.tmpl
template can be provided, which allows for any configuration value to
be changed.