### PR TITLE
[stable/external-dns] update image tag to v0.4.5 and alter values with new flags

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.2.0
-appVersion: 0.4.3
+version: 0.3.0
+appVersion: 0.4.5
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
 - https://github.com/kubernetes-incubator/external-dns

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -26,6 +26,7 @@ The following tables lists the configurable parameters of the external-dns chart
 | `aws.access_key`          | `AWS_ACCESS_KEY_ID` to set in the environment (optional).                                                                  | `""`                                               |
 | `aws.secret_key`          | `AWS_SECRET_ACCESS_KEY` to set in the environment (optional).                                                              | `""`                                               |
 | `aws.region`              | `AWS_DEFAULT_REGION` to set in the environment (optional).                                                                 | `us-east-1`                                        |
+| `aws.zone_type`           | Filter for zones of this type (optional, options: public, private).                                                        | `""`                                               |
 | `cloudflare.api_key`      | `CF_API_KEY` to set in the environment (optional).                                                                 | `""`                                        |
 | `cloudflare.email`        | `CF_API_EMAIL` to set in the environment (optional).                                                                 | `""`                                        |
 | `domainFilters`           | Limit possible target zones by domain suffixes (optional).                                                                 | `[]`                                               |
@@ -33,9 +34,11 @@ The following tables lists the configurable parameters of the external-dns chart
 | `image.name`              | Container image name (Including repository name if not `hub.docker.com`).                                                  | `registry.opensource.zalan.do/teapot/external-dns` |
 | `image.pullPolicy`        | Container pull policy.                                                                                                     | `IfNotPresent`                                     |
 | `image.tag`               | Container image tag.                                                                                                       | `v0.4.3`                                           |
+| `logLevel`                | Verbosity of the logs (options: panic, debug, info, warn, error, fatal)                                                    | `info`                                             |
 | `podAnnotations`          | Additional annotations to apply to the pod.                                                                                | `{}`                                               |
 | `policy`                  | Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only ).                        | `upsert-only`                                      |
 | `provider`                | The DNS provider where the DNS records will be created (options: aws, google, azure, cloudflare, digitalocean, inmemory ). | `aws`                                              |
+| `publishInternalServices` | Allow external-dns to publish DNS records for ClusterIP services (optional).                                               | `false`                                            |
 | `rbac.create`             | If true, create & use RBAC resources                                                                                       | `false`                                            |
 | `rbac.serviceAccountName` | Existing ServiceAccount to use (ignored if rbac.create=true)                                                               | `default`                                          |
 | `resources`               | CPU/Memory resource requests/limits.                                                                                       | `{}`                                               |

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -18,8 +18,11 @@ spec:
           image: "{{.Values.image.name}}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
-          {{- if .Values.debug }}
-            - --debug
+          {{- if .Values.logLevel }}
+            - --log-level={{ .Values.logLevel }}
+          {{- end }}
+          {{- if .Values.publishInternalServices }}
+            - --publish-internal-services
           {{- end }}
           {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}
@@ -31,6 +34,9 @@ spec:
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
+          {{- end }}
+          {{- if .Values.aws.zone_type }}
+            - --zone-type={{ .Values.aws.zone_type }}
           {{- end }}
           env:
         {{- if and .Values.aws.secret_key .Values.aws.access_key }}

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -1,7 +1,7 @@
 ## Details about the image to be pulled.
 image:
   name: registry.opensource.zalan.do/teapot/external-dns
-  tag: v0.4.3
+  tag: v0.4.5
   pullPolicy: IfNotPresent
 
 ## This controls which types of resource external-dns should 'watch' for new
@@ -9,6 +9,9 @@ image:
 sources:
   - service
   - ingress
+
+# Allow external-dns to publish DNS records for ClusterIP services (optional)
+publishInternalServices: false
 
 ## The DNS provider where the DNS records will be created (options: aws, google, inmemory, azure )
 provider: aws
@@ -18,6 +21,8 @@ aws:
   secret_key: ""
   access_key: ""
   region: "us-east-1"
+  # Filter for zones of this type (optional, options: public, private)
+  zone_type: ""
 
 # Cloudflare keys to inject as environment variables
 cloudflare:
@@ -41,7 +46,8 @@ podAnnotations: {}
 
 podLabels: {}
 
-debug: false
+# Verbosity of the logs (options: panic, debug, info, warn, error, fatal)
+logLevel: info
 
 extraArgs: {}
 


### PR DESCRIPTION
See https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.4.4 and https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.4.5 for the associated release notes between the updated version.