### PR TITLE
[stable/nginx-ingress] Update stats exporter

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.5
+version: 0.8.6
 appVersion: 0.9.0-beta.12
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -101,8 +101,8 @@ Parameter | Description | Default
 `rbac.create` | If true, create & use RBAC resources | `false`
 `rbac.serviceAccountName` | ServiceAccount to be used (ignored if rbac.create=true) | `default`
 `statsExporter.name` | name of the Prometheus metrics exporter component | `stats-exporter`
-`statsExporter.image.repository` | Prometheus metrics exporter container image repository | `quay.io/cy-play/vts-nginx-exporter`
-`statsExporter.image.tag` | Prometheus metrics exporter image tag | `v0.0.3`
+`statsExporter.image.repository` | Prometheus metrics exporter container image repository | `sophos/nginx-vts-exporter`
+`statsExporter.image.tag` | Prometheus metrics exporter image tag | `v0.6`
 `statsExporter.image.pullPolicy` | Prometheus metrics exporter image pull policy | `IfNotPresent`
 `statsExporter.endpoint` | path at which Prometheus metrics are exposed | `/metrics`
 `statsExporter.extraArgs` | Additional Prometheus metrics exporter container arguments | `{}`

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -201,8 +201,8 @@ rbac:
 statsExporter:
   name: stats-exporter
   image:
-    repository: quay.io/cy-play/vts-nginx-exporter
-    tag: v0.0.3
+    repository: sophos/nginx-vts-exporter
+    tag: v0.6
     pullPolicy: IfNotPresent
 
   endpoint: /metrics


### PR DESCRIPTION
Use 'sophos/nginx-vts-exporter' instead of 'quay.io/cy-play/vts-nginx-exporter'
which is based on an outdated fork. The new image is built from the original repo
at https://github.com/hnlq715/nginx-vts-exporter.