### PR TITLE
[incubator/cassandra] Increase the max length of cassandra service name

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.1.5
+version: 0.1.6
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing
   high availability with no single point of failure.

--- a/incubator/cassandra/templates/_helpers.tpl
+++ b/incubator/cassandra/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "cassandra.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 21 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 -}}
 {{- end -}}
 
 {{/*
@@ -13,5 +13,5 @@ and Statefulset will append -xx at the end of name.
 */}}
 {{- define "cassandra.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 21 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 -}}
 {{- end -}}


### PR DESCRIPTION
Other services are limiting the service name to 63 char instead of the old 24 char limit.

For example DockroachDB and elasticsearch limit to 63: https://github.com/kubernetes/charts/blob/master/stable/cockroachdb/templates/cockroachdb-statefulset.yaml#L6
https://github.com/kubernetes/charts/blob/master/incubator/elasticsearch/templates/_helpers.tpl#L6