### PR TITLE
Add a chart for Stack2Slack

### DIFF
--- a/stable/stack2slack/.helmignore
+++ b/stable/stack2slack/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/stack2slack/Chart.yaml
+++ b/stable/stack2slack/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+description: A Slack bot to monitor StackOverflow/StackExchange tags
+name: stack2slack
+version: 0.1.0
+sources:
+- https://github.com/dunglas/stack2slack
+maintainers:
+- name: Kévin Dunglas
+  email: dunglas@gmail.com

--- a/stable/stack2slack/Chart.yaml
+++ b/stable/stack2slack/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: A Slack bot to monitor StackOverflow/StackExchange tags
 name: stack2slack
 version: 0.1.0
+appVersion: 0.1.0
 sources:
 - https://github.com/dunglas/stack2slack
 maintainers:
-- name: Kévin Dunglas
-  email: dunglas@gmail.com
+- dunglas

--- a/stable/stack2slack/Chart.yaml
+++ b/stable/stack2slack/Chart.yaml
@@ -6,4 +6,5 @@ appVersion: 0.1.0
 sources:
 - https://github.com/dunglas/stack2slack
 maintainers:
-- dunglas
+- name: dunglas
+  email: dunglas@gmail.com

--- a/stable/stack2slack/README.md
+++ b/stable/stack2slack/README.md
@@ -1,0 +1,69 @@
+# Stack to Slack
+
+[Stack to Slack](https://github.com/dunglas/stack2slack) is a Slack bot that monitors StackExchange tags and automatically
+publishes new questions in configured Slack channels.
+
+## Introduction
+
+This chart adds a Stack to Slack deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
+package manager.
+
+## Prerequisites
+
+- Kubernetes 1.2+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`, [retrieve a Slack API token for bot](https://my.slack.com/services/new/bot) and run:
+
+```bash
+$ helm install --name my-release \
+    --set slackApiToken=<slackApiToken> \
+    --set tagToChannel.stackExchangeTag=slackChannel stable/stack2slack
+```
+
+Then, from Slack, invite the bot in the channel: `/invite @theBotName`
+
+After a few minutes, you should see all new questions posted on StackExchange appearing in the Slack channel.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Stack to Slack chart and their default values.
+
+|      Parameter              |          Description                     |               Default               |
+|-----------------------------|------------------------------------------|-------------------------------------|
+| `slackApiToken`             | The Slack API token for the bot          | `Nil` You must provide your own key |
+| `tagToChannel`              | StackExchange tags to Slack channels map | Empty                               |
+| `debug`                     | Enable debug logs                        |  0                                  |
+| `stackSite`                 | The StackExchange site to monitor        |  stackoverflow                      |
+| `image.repository`          | The image repository to pull from        | `sysdig/agent`                      |
+| `image.tag`                 | The image tag to pull                    | `latest`                            |
+| `image.pullPolicy`          | The Image pull policy                    | `Always`                            |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set slackApiToken=YOUR-KEY-HERE,tagToChannel.mytag=mychan \
+    stable/stack2slack
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/stack2slack
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/stack2slack/README.md
+++ b/stable/stack2slack/README.md
@@ -10,7 +10,7 @@ package manager.
 
 ## Prerequisites
 
-- Kubernetes 1.2+ with Beta APIs enabled
+- Kubernetes 1.7+ with Beta APIs enabled
 
 ## Installing the Chart
 

--- a/stable/stack2slack/templates/NOTES.txt
+++ b/stable/stack2slack/templates/NOTES.txt
@@ -1,0 +1,14 @@
+{{- if eq (printf "%s" .Values.slackApiToken) "" }}
+#######################################################################################
+####   ERROR: You did not provided a Slack API token in your 'helm install' call.  ####
+#######################################################################################
+
+This deployment will be incomplete until you provide a Slack API token:
+
+    helm upgrade {{ .Release.Name }} \
+        --set slackApiToken=<your-token> stable/stack2slack
+{{- end }}
+
+Don't forget to invite the bot in channels it will post.
+
+From Slack: `/invite @bot-name`

--- a/stable/stack2slack/templates/_helpers.tpl
+++ b/stable/stack2slack/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/stack2slack/templates/_helpers.tpl
+++ b/stable/stack2slack/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "stack2slack.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "stack2slack.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/stack2slack/templates/configmap.yaml
+++ b/stable/stack2slack/templates/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "stack2slack.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "stack2slack.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/stable/stack2slack/templates/configmap.yaml
+++ b/stable/stack2slack/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  tagToChannel: |-
+    {{ toJson .Values.tagToChannel }}
+  stackSite: {{ .Values.stackSite | quote }}
+  debug: {{ .Values.debug | quote }}

--- a/stable/stack2slack/templates/deployment.yaml
+++ b/stable/stack2slack/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "stack2slack.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "stack2slack.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "stack2slack.name" . }}
         release: {{ .Release.Name }}
     spec:
       containers:
@@ -22,22 +22,22 @@ spec:
           - name: SLACK_API_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "fullname" . }}
+                name: {{ template "stack2slack.fullname" . }}
                 key: slackApiToken
           - name: TAG_TO_CHANNEL
             valueFrom:
               configMapKeyRef:
-                name: {{ template "fullname" . }}
+                name: {{ template "stack2slack.fullname" . }}
                 key: tagToChannel
           - name: STACK_SITE
             valueFrom:
               configMapKeyRef:
-                name: {{ template "fullname" . }}
+                name: {{ template "stack2slack.fullname" . }}
                 key: stackSite
           - name: DEBUG
             valueFrom:
               configMapKeyRef:
-                name: {{ template "fullname" . }}
+                name: {{ template "stack2slack.fullname" . }}
                 key: debug
           livenessProbe:
             exec:

--- a/stable/stack2slack/templates/deployment.yaml
+++ b/stable/stack2slack/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: SLACK_API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: slackApiToken
+          - name: TAG_TO_CHANNEL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "fullname" . }}
+                key: tagToChannel
+          - name: STACK_SITE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "fullname" . }}
+                key: stackSite
+          - name: DEBUG
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "fullname" . }}
+                key: debug
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - ps -ef | grep /go/bin/stack2slack | grep -v grep
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - ps -ef | grep /go/bin/stack2slack | grep -v grep
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/stable/stack2slack/templates/secrets.yaml
+++ b/stable/stack2slack/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+ slackApiToken : {{ default "MISSING" .Values.slackApiToken | b64enc | quote }}

--- a/stable/stack2slack/templates/secrets.yaml
+++ b/stable/stack2slack/templates/secrets.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "stack2slack.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "stack2slack.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/stable/stack2slack/values.yaml
+++ b/stable/stack2slack/values.yaml
@@ -6,5 +6,5 @@ tagToChannel:
 stackSite: 'stackoverflow'
 image:
   repository: dunglas/stack2slack
-  tag: latest
+  tag: 0.1.0
   pullPolicy: IfNotPresent

--- a/stable/stack2slack/values.yaml
+++ b/stable/stack2slack/values.yaml
@@ -2,7 +2,7 @@
 slackApiToken: ''
 debug: '0'
 tagToChannel:
-  #api-platform.com: stackoverflow
+  # api-platform.com: stackoverflow
 stackSite: 'stackoverflow'
 image:
   repository: dunglas/stack2slack

--- a/stable/stack2slack/values.yaml
+++ b/stable/stack2slack/values.yaml
@@ -1,0 +1,10 @@
+# Required
+slackApiToken: ''
+debug: '0'
+tagToChannel:
+  #api-platform.com: stackoverflow
+stackSite: 'stackoverflow'
+image:
+  repository: dunglas/stack2slack
+  tag: latest
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
[Stack to Slack](https://github.com/dunglas/stack2slack) is a Slack that bot monitors StackExchange tags and automatically publishes new questions in configured Slack channels.
