### PR TITLE
[stable/sentry] Fix typo in Sentry and upgrade sentry to current

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.2
+version: 0.1.3
 keywords:
   - debugging
   - logging

--- a/stable/sentry/requirements.lock
+++ b/stable/sentry/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.1
+  version: 0.8.3
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.9.0
-digest: sha256:0aa3e19f66536a45484cadba0dd99b8ff6524d7e591a28cd6a00606e9fa3574a
-generated: 2017-09-10T13:14:34.931405983-05:00
+  version: 0.10.1
+digest: sha256:edf23e476cacd385037588df3226003e75fa5161f8c7556c370383bf9f9d1d71
+generated: 2017-09-29T15:01:25.29542-05:00

--- a/stable/sentry/requirements.yaml
+++ b/stable/sentry/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: postgresql
-    version: 0.7.1
+    version: 0.8.3
     repository: https://kubernetes-charts.storage.googleapis.com/
   - name: redis
-    version: 0.9.0
+    version: 0.10.1
     repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -40,7 +40,7 @@ spec:
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
           value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTRGES_PORT
+        - name: SENTRY_POSTGRES_PORT
           value: "5432"
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -34,7 +34,7 @@ worker:
   resources:
     limits:
       cpu: 300m
-      memory: 300Mi
+      memory: 500Mi
     requests:
       cpu: 100m
       memory: 100Mi

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: sentry
-  tag: "8.17"
+  tag: "8.20"
   pullPolicy: IfNotPresent
 
 # How many web UI instances to run


### PR DESCRIPTION
@unguiculus Please take a look. There was a typo in `stable/sentry` chart in an environment variable.