### PR TITLE
Adding prometheus-to-sd chart

### DIFF
--- a/stable/prometheus-to-sd/.helmignore
+++ b/stable/prometheus-to-sd/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/prometheus-to-sd/Chart.yaml
+++ b/stable/prometheus-to-sd/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: prometheus-to-sd
+version: 0.1.0

--- a/stable/prometheus-to-sd/Chart.yaml
+++ b/stable/prometheus-to-sd/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
+description: Scrape metrics stored in prometheus format and push them to the Stackdriver
 name: prometheus-to-sd
 version: 0.1.0

--- a/stable/prometheus-to-sd/Chart.yaml
+++ b/stable/prometheus-to-sd/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
 - prometheus
 - stackdriver
 maintainers:
-- name: Arcadie Condrat
+- name: acondrat
   email: arcadie.condrat@gmail.com
 name: prometheus-to-sd
 version: 0.1.0

--- a/stable/prometheus-to-sd/Chart.yaml
+++ b/stable/prometheus-to-sd/Chart.yaml
@@ -1,4 +1,12 @@
 apiVersion: v1
+appVersion: 0.2.2
 description: Scrape metrics stored in prometheus format and push them to the Stackdriver
+home: https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd
+keywords:
+- prometheus
+- stackdriver
+maintainers:
+- name: Arcadie Condrat
+  email: arcadie.condrat@gmail.com
 name: prometheus-to-sd
 version: 0.1.0

--- a/stable/prometheus-to-sd/README.md
+++ b/stable/prometheus-to-sd/README.md
@@ -38,14 +38,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters and their default values.
 
-| Parameter                             | Description                           | Default                                                   |
-| --------------------------            | ------------------------------------- | --------------------------------------------------------- |
-| `image.repository`                    | prometheus-to-sd image repository     | `gcr.io/google-containers/prometheus-to-sd`               |
-| `image.tag`                           | prometheus-to-sd image tag            | `v0.2.1`                                                  |
-| `image.pullPolicy`                    | Image pull policy                     | `IfNotPresent`                                            |
-| `resources`                           | CPU/Memory resource requests/limits   | Memory: `64Mi`, CPU: `50m`                                |
-| `port`                                | Profiler port                         | 6060                                                      |
-| `metricSources`                       | Sources for metrics in the next format: component-name:http://host:port?whitelisted=a,b,c | {}    |
+| Parameter          | Description                                                                               | Default                                    |
+| ------------------ | ----------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `image.repository` | prometheus-to-sd image repository                                                         | `gcr.io/google-containers/prometheus-to-sd`|
+| `image.tag`        | prometheus-to-sd image tag                                                                | `v0.2.2`                                   |
+| `image.pullPolicy` | Image pull policy                                                                         | `IfNotPresent`                             |
+| `resources`        | CPU/Memory resource requests/limits                                                       | {}                                         |
+| `port`             | Profiler port                                                                             | `6060`                                     |
+| `metricSources`    | Sources for metrics in the next format: component-name:http://host:port?whitelisted=a,b,c | {}                                         |
 
 For more information please refer to the [prometheus-to-sd](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd) documentation.
 

--- a/stable/prometheus-to-sd/README.md
+++ b/stable/prometheus-to-sd/README.md
@@ -1,0 +1,66 @@
+# prometheus-to-sd
+
+[prometheus-to-sd](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd) is a simple component that can scrape metrics stored in prometheus text format from one or multiple components and push them to the Stackdriver
+
+## TL;DR;
+
+```bash
+$ helm install stable/prometheus-to-sd
+```
+
+
+## Prerequisites
+
+- a service exposing metrics in prometheus format
+- k8s cluster should run on GCE or GKE
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/prometheus-to-sd
+```
+
+The command deploys prometheus-to-sd on the Kubernetes cluster in the default configuration.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters and their default values.
+
+| Parameter                             | Description                           | Default                                                   |
+| --------------------------            | ------------------------------------- | --------------------------------------------------------- |
+| `image.repository`                    | prometheus-to-sd image repository     | `gcr.io/google-containers/prometheus-to-sd`               |
+| `image.tag`                           | prometheus-to-sd image tag            | `v0.2.1`                                                  |
+| `image.pullPolicy`                    | Image pull policy                     | `IfNotPresent`                                            |
+| `resources`                           | CPU/Memory resource requests/limits   | Memory: `64Mi`, CPU: `50m`                                |
+| `port`                                | Profiler port                         | 6060                                                      |
+| `metricSources`                       | Sources for metrics in the next format: component-name:http://host:port?whitelisted=a,b,c | {}    |
+
+For more information please refer to the [prometheus-to-sd](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd) documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set "metricsSources.kube-state-metrics=http://kube-state-metrics:8080" \
+    stable/prometheus-to-sd
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/prometheus-to-sd
+```
+
+Multiple metrics sources can be defined.

--- a/stable/prometheus-to-sd/README.md
+++ b/stable/prometheus-to-sd/README.md
@@ -38,14 +38,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters and their default values.
 
-| Parameter          | Description                                                                               | Default                                    |
-| ------------------ | ----------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `image.repository` | prometheus-to-sd image repository                                                         | `gcr.io/google-containers/prometheus-to-sd`|
-| `image.tag`        | prometheus-to-sd image tag                                                                | `v0.2.2`                                   |
-| `image.pullPolicy` | Image pull policy                                                                         | `IfNotPresent`                             |
-| `resources`        | CPU/Memory resource requests/limits                                                       | {}                                         |
-| `port`             | Profiler port                                                                             | `6060`                                     |
-| `metricSources`    | Sources for metrics in the next format: component-name:http://host:port?whitelisted=a,b,c | {}                                         |
+| Parameter          | Description                                                                               | Default                                     |
+| ------------------ | ----------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `image.repository` | prometheus-to-sd image repository                                                         | `gcr.io/google-containers/prometheus-to-sd` |
+| `image.tag`        | prometheus-to-sd image tag                                                                | `v0.2.2`                                    |
+| `image.pullPolicy` | Image pull policy                                                                         | `IfNotPresent`                              |
+| `resources`        | CPU/Memory resource requests/limits                                                       | `{}`                                        |
+| `port`             | Profiler port                                                                             | `6060`                                      |
+| `metricSources`    | Sources for metrics in the next format: component-name:http://host:port?whitelisted=a,b,c | `{}`                                        |
+| `nodeSelector`     | node labels for pod assignment                                                            | `{}`                                        |
 
 For more information please refer to the [prometheus-to-sd](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd) documentation.
 

--- a/stable/prometheus-to-sd/templates/NOTES.txt
+++ b/stable/prometheus-to-sd/templates/NOTES.txt
@@ -1,0 +1,2 @@
+Check prometheus-to-sd pod
+  $ kubectl get pods --namespace={{ .Release.Namespace }}

--- a/stable/prometheus-to-sd/templates/_helpers.tpl
+++ b/stable/prometheus-to-sd/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/prometheus-to-sd/templates/_helpers.tpl
+++ b/stable/prometheus-to-sd/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "prometheus-to-sd.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "prometheus-to-sd.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/prometheus-to-sd/templates/_helpers.tpl
+++ b/stable/prometheus-to-sd/templates/_helpers.tpl
@@ -11,6 +11,5 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "prometheus-to-sd.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/prometheus-to-sd/templates/deployment.yaml
+++ b/stable/prometheus-to-sd/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "prometheus-to-sd.fullname" . }}
+  name: {{ .Release.Name }}
   labels:
     app: {{ template "prometheus-to-sd.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/stable/prometheus-to-sd/templates/deployment.yaml
+++ b/stable/prometheus-to-sd/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-to-sd.fullname" . }}

--- a/stable/prometheus-to-sd/templates/deployment.yaml
+++ b/stable/prometheus-to-sd/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "prometheus-to-sd.fullname" . }}
   labels:
     app: {{ template "prometheus-to-sd.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/stable/prometheus-to-sd/templates/deployment.yaml
+++ b/stable/prometheus-to-sd/templates/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: profiler
+              containerPort: {{ .Values.port }}
+          command:
+            - /monitor
+            - --stackdriver-prefix=custom.googleapis.com
+            {{- range $key, $value := .Values.metricsSources }}
+            - --source={{ $key }}:{{ $value }}
+            {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/stable/prometheus-to-sd/templates/deployment.yaml
+++ b/stable/prometheus-to-sd/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "prometheus-to-sd.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "prometheus-to-sd.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "prometheus-to-sd.name" . }}
         release: {{ .Release.Name }}
     spec:
       containers:

--- a/stable/prometheus-to-sd/values.yaml
+++ b/stable/prometheus-to-sd/values.yaml
@@ -4,13 +4,5 @@ image:
   tag: v0.2.2
   pullPolicy: IfNotPresent
 resources: {}
-  # limits:
-  #  cpu: 50m
-  #  memory: 64Mi
-  # requests:
-  #  cpu: 50m
-  #  memory: 64Mi
 port: 6060
 metricsSources: {}
-  # kube-state-metrics: http://kube-state-metrics:8080
-  # component-name: http://host:port?whitelisted=a,b,c

--- a/stable/prometheus-to-sd/values.yaml
+++ b/stable/prometheus-to-sd/values.yaml
@@ -1,0 +1,16 @@
+replicaCount: 1
+image:
+  repository: gcr.io/google-containers/prometheus-to-sd
+  tag: v0.2.1
+  pullPolicy: IfNotPresent
+resources:
+  limits:
+   cpu: 50m
+   memory: 64Mi
+  requests:
+   cpu: 50m
+   memory: 64Mi
+port: 6060
+metricsSources: {}
+  # kube-state-metrics: http://kube-state-metrics:8080
+  # component-name: http://host:port?whitelisted=a,b,c

--- a/stable/prometheus-to-sd/values.yaml
+++ b/stable/prometheus-to-sd/values.yaml
@@ -3,13 +3,13 @@ image:
   repository: gcr.io/google-containers/prometheus-to-sd
   tag: v0.2.2
   pullPolicy: IfNotPresent
-resources:
-  limits:
-   cpu: 50m
-   memory: 64Mi
-  requests:
-   cpu: 50m
-   memory: 64Mi
+resources: {}
+  # limits:
+  #  cpu: 50m
+  #  memory: 64Mi
+  # requests:
+  #  cpu: 50m
+  #  memory: 64Mi
 port: 6060
 metricsSources: {}
   # kube-state-metrics: http://kube-state-metrics:8080

--- a/stable/prometheus-to-sd/values.yaml
+++ b/stable/prometheus-to-sd/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: gcr.io/google-containers/prometheus-to-sd
-  tag: v0.2.1
+  tag: v0.2.2
   pullPolicy: IfNotPresent
 resources:
   limits:

--- a/stable/prometheus-to-sd/values.yaml
+++ b/stable/prometheus-to-sd/values.yaml
@@ -6,3 +6,4 @@ image:
 resources: {}
 port: 6060
 metricsSources: {}
+nodeSelector: {}


### PR DESCRIPTION
The chart deploys [prometheus-to-sd](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd) with an optional list of metrics sources to scrape from.