### PR TITLE
[incubator/jaeger] update images from 0.6 to 0.8

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.6.0
+appVersion: 0.8.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.1.0
+version: 0.1.1
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -26,14 +26,14 @@ cassandra:
 schema:
   annotations: {}
   image: jaegertracing/jaeger-cassandra-schema
-  tag: 0.6
+  tag: 0.8
   pullPolicy: IfNotPresent
   # Acceptable values are test and prod. Default is for production use.
   mode: prod
 agent:
   annotations: {}
   image: jaegertracing/jaeger-agent
-  tag: 0.6
+  tag: 0.8
   pullPolicy: IfNotPresent
   cmdlineParams: {}
   service:
@@ -55,7 +55,7 @@ agent:
 collector:
   annotations: {}
   image: jaegertracing/jaeger-collector
-  tag: 0.6
+  tag: 0.8
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
@@ -79,7 +79,7 @@ collector:
 query:
   annotations: {}
   image: jaegertracing/jaeger-query
-  tag: 0.6
+  tag: 0.8
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}


### PR DESCRIPTION
Update jaeger images to latest version 0.8

Current verison 0.6 is quite old and does not support zipkin traces in json format as stated in [values.yaml](https://github.com/kubernetes/charts/blob/master/incubator/jaeger/values.yaml#L69) (this was introduced in [0.7](https://github.com/jaegertracing/jaeger/releases/tag/v0.7.0) see [348](https://github.com/jaegertracing/jaeger/pull/348) )