### PR TITLE
[stable/redis] release 1.0.0

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 name: redis
-version: 0.11.0
-appVersion: 3.2.9
+version: 1.0.0
+appVersion: 4.0.2
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:
 - redis

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 0.10.2
+version: 0.11.0
 appVersion: 3.2.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -104,7 +104,7 @@ after a successful install.
 
 ## Persistence
 
-The [Bitnami Redis](https://github.com/bitnami/bitnami-docker-redis) image stores the Redis data and configurations at the `/bitnami/redis` path of the container.
+The [Bitnami Redis](https://github.com/bitnami/bitnami-docker-redis) image stores the Redis data and configurations at the `/bitnami` path of the container.
 
 By default, the chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning. If a Persistent Volume Claim already exists, specify it during installation.
 

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -21,6 +21,14 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      initContainers:
+      - name: "fix-non-root-permissions"
+        image: "busybox"
+        imagePullPolicy: "Always"
+        command: [ "chmod", "-R", "g+rwX", "/bitnami" ]
+        volumeMounts:
+        - name: redis-data
+          mountPath: /bitnami
       containers:
       - name: {{ template "redis.fullname" . }}
         image: "{{ .Values.image }}"

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: redis-data
-          mountPath: /bitnami/redis
+          mountPath: /bitnami
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: {{ template "redis.fullname" . }}
     spec:
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
@@ -21,14 +24,6 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
-      initContainers:
-      - name: "fix-non-root-permissions"
-        image: "busybox"
-        imagePullPolicy: "Always"
-        command: [ "chmod", "-R", "g+rwX", "/bitnami" ]
-        volumeMounts:
-        - name: redis-data
-          mountPath: /bitnami
       containers:
       - name: {{ template "redis.fullname" . }}
         image: "{{ .Values.image }}"

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -86,4 +86,3 @@ networkPolicy:
   ## (with the correct destination port).
   ##
   allowExternal: true
-

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Redis image version
 ## ref: https://hub.docker.com/r/bitnami/redis/tags/
 ##
-image: bitnami/redis:3.2.9-r2
+image: bitnami/redis:4.0.2-r0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Changes:
 - mount persistent volume at `/bitnami` 
 - upgrade to redis 4.0 image
 - bump version to `0.11.0`, new minor series

Closes #2359