### PR TITLE
Fixed prometheus server retention parameter, added target heapsize variable

### DIFF
--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - --alertmanager.url={{- if .Values.alertmanager.enabled }}http://{{ template "prometheus.alertmanager.fullname" . }}:{{ .Values.alertmanager.service.servicePort }}{{ .Values.alertmanager.baseURL }}{{- else }}{{ .Values.server.alertmanagerURL }}{{- end }}
           {{- end }}
           {{- if .Values.server.retention }}
-            - --storage.local.retention = {{ .Values.server.retention }}
+            - --storage.local.retention={{ .Values.server.retention }}
           {{- end }}
             - --config.file=/etc/config/prometheus.yml
             - --storage.local.path={{ .Values.server.persistentVolume.mountPath }}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -50,6 +50,9 @@ spec:
           {{- if .Values.server.retention }}
             - --storage.local.retention={{ .Values.server.retention }}
           {{- end }}
+          {{- if .Values.server.heapsize }}
+            - --storage.local.target-heap-size={{ .Values.server.heapsize }}
+          {{- end }}
             - --config.file=/etc/config/prometheus.yml
             - --storage.local.path={{ .Values.server.persistentVolume.mountPath }}
             - --web.console.libraries=/etc/prometheus/console_libraries

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -476,6 +476,12 @@ server:
   ##
   retention: ""
 
+  ## Prometheus target heapsize to control memory usage(i.e 1GiB, 512MiB)
+  ## A rule of thumb is to set it to 2/3 of its target physical memory to give space to underlying Go runtimes
+  ## e.g. With underlying target physical memory of 3GiB, set the heapsize to 2GiB
+  ##
+  heapsize: "2GiB"
+
 pushgateway:
   ## If false, pushgateway will not be installed
   ##


### PR DESCRIPTION
Removed some spaces which caused the Go variable to go undefined when prometheus is deployed with retention time enabled