### PR TITLE
Update CI to use Helm 2.6.2

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -46,7 +46,7 @@ fi
 
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.5.1-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.6.2-linux-amd64.tar.gz
 INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 pushd /opt
   wget -q ${HELM_URL}/${HELM_TARBALL}

--- a/test/circle/install.sh
+++ b/test/circle/install.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Install Helm
-HELM_LATEST_VERSION="v2.6.1"
+HELM_LATEST_VERSION="v2.6.2"
 
 wget http://storage.googleapis.com/kubernetes-helm/helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz
 tar -xvf helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz

--- a/test/helm-test-e2e.sh
+++ b/test/helm-test-e2e.sh
@@ -7,7 +7,7 @@ set -o xtrace
 
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.4.2-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.6.2-linux-amd64.tar.gz
 
 wget -q ${HELM_URL}/${HELM_TARBALL}
 tar xzfv ${HELM_TARBALL}

--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -15,7 +15,7 @@
 
 # Setup Helm
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.5.1-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.6.2-linux-amd64.tar.gz
 STABLE_REPO_URL=https://kubernetes-charts.storage.googleapis.com/
 INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 wget -q ${HELM_URL}/${HELM_TARBALL}


### PR DESCRIPTION
Note, there are lint differences. Things that passed in 2.4.2 and 2.5.1 may fail in 2.6.1.