### PR TITLE
[incubator/elasticsearch] Add the ability for the ElasticSearch chart to use emptyDir.

### DIFF
--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -76,6 +76,7 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `data.replicas`                      | Data node replicas (statefulset)        | `3`                                 |
 | `data.resources`                     | Data node resources requests & limits   | `{} - cpu limit must be an integer` |
 | `data.heapSize`                      | Data node heap size                     | `1536m`                             |
+| `data.persistence`                   | Data persistent disabled/enabled        | `true`                              |
 | `data.storage`                       | Data persistent volume size             | `30Gi`                              |
 | `data.storageClass`                  | Data persistent volume Class            | `nil`                               |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds) | `3600`                              |

--- a/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
@@ -111,7 +111,11 @@ spec:
     spec:
       accessModes: [ ReadWriteOnce ]
     {{- if .Values.data.storageClass }}
+    {{- if (eq "-" .Values.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
       storageClassName: "{{ .Values.data.storageClass }}"
+    {{- end }}
     {{- end }}
       resources:
         requests:

--- a/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
@@ -111,7 +111,7 @@ spec:
     spec:
       accessModes: [ ReadWriteOnce ]
     {{- if .Values.data.storageClass }}
-    {{- if eq .Values.data.storageClass "-" }}
+    {{- if (eq "-" .Values.data.storageClass) }}
       storageClassName: ""
     {{- else }}
       storageClassName: "{{ .Values.data.storageClass }}"

--- a/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
@@ -111,7 +111,7 @@ spec:
     spec:
       accessModes: [ ReadWriteOnce ]
     {{- if .Values.data.storageClass }}
-    {{- if (eq "-" .Values.persistence.storageClass) }}
+    {{- if eq .Values.data.storageClass "-" }}
       storageClassName: ""
     {{- else }}
       storageClassName: "{{ .Values.data.storageClass }}"

--- a/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/elasticsearch-data-statefulset.yaml
@@ -105,6 +105,10 @@ spec:
       - name: config
         configMap:
           name: {{ template "elasticsearch.fullname" . }}
+{{- if not .Values.data.persistence }}
+      - name: data
+        emptyDir: {}
+{{- else }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -120,3 +124,4 @@ spec:
       resources:
         requests:
           storage: "{{ .Values.data.storage }}"
+{{- end }}

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -44,6 +44,7 @@ data:
   replicas: 3
   heapSize: "1536m"
   storage: "30Gi"
+  persistence: true
   # If storageClass: "-", this sets storageClassName: "" which uses emptyDir
   # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ image:
 cluster:
   name: "elasticsearch"
   config:
-    
+
 
 client:
   name: client
@@ -44,6 +44,7 @@ data:
   replicas: 3
   heapSize: "1536m"
   storage: "30Gi"
+  # If storageClass: "-", this sets storageClassName: "" which uses emptyDir
   # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"


### PR DESCRIPTION
This is useful for testing, debugging, and demo env to set the ElasticSearch persistent data to be saved to emptyDir. Also, enable functionality to allow using the default storageClass by --set data.storageClass="-"

README has been updated to document the new data.persistence flag. The default is true to keep the original behavior of the chart the same.

This chart has been tested in a Kubernetes 1.7 environment on GCE. This also closely matches the implementation in the Cassandra chart.