### PR TITLE
Add Better ServiceType support to MariaDB

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 2.0.3
+version: 2.1.0
 appVersion: 10.1.29
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -48,6 +48,9 @@ The following tables lists the configurable parameters of the MariaDB chart and 
 |          Parameter          |                Description                 |                   Default                   |
 | --------------------------- | ------------------------------------------ | ------------------------------------------- |
 | `image`                     | MariaDB image                              | `bitnami/mariadb:{VERSION}`                 |
+| `service.type`              | Kubernetes service type to expose          | `ClusterIP`                                 |
+| `service.nodePort`          | Port to bind to for NodePort service type  | `nil`                                       |
+| `service.annotations`       | Additional annotations to add to service   | `nil`                                       |
 | `imagePullPolicy`           | Image pull policy.                         | `IfNotPresent`                              |
 | `usePassword`               | Enable password authentication             | `true`                                      |
 | `mariadbRootPassword`       | Password for the `root` user.              | Randomly generated                          |

--- a/stable/mariadb/templates/svc.yaml
+++ b/stable/mariadb/templates/svc.yaml
@@ -7,16 +7,22 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-{{- if .Values.metrics.enabled }}
   annotations:
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
 {{ toYaml .Values.metrics.annotations | indent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: {{ .Values.service.type }}
   ports:
   - name: mysql
     port: 3306
     targetPort: mysql
+{{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
 {{- if .Values.metrics.enabled }}
   - name: metrics
     port: 9104

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -31,8 +31,20 @@ usePassword: true
 # mariadbDatabase:
 
 
-## Kubernetes service type
-serviceType: ClusterIP
+service:
+  ## Kubernetes service type
+  type: ClusterIP
+
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+
+  ## Provide any additonal annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  # annotations:
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -72,8 +72,8 @@ persistence:
 ## ref: https://mariadb.com/kb/en/mariadb/configuring-mariadb-with-mycnf/#example-of-configuration-file
 ##
 # config: |-
-  # [mysqld]
-  # innodb_buffer_pool_size=2G
+#   [mysqld]
+#   innodb_buffer_pool_size=2G
 
 metrics:
   enabled: false


### PR DESCRIPTION
This commit adds logic to better support the NodePort and LoadBalancer
service types. Annotations can be used by the LoadBalancer service to
make the load balancer internal only. The nodePort parameter can be used
to specify the exact port that NodePort (and LoadBalancer) uses.