### PR TITLE
Add missing permission update for kube-lego

### DIFF
--- a/stable/kube-lego/templates/role.yaml
+++ b/stable/kube-lego/templates/role.yaml
@@ -17,6 +17,7 @@ rules:
   - create
   - get
   - delete
+  - update
 - apiGroups:
   - extensions
   resources:


### PR DESCRIPTION
I got the following message in my log:

> RBAC DENY: user "system:serviceaccount:kube-lego:kube-lego-kube-lego" groups ["system:serviceaccounts" "system:serviceaccounts:kube-lego" "system:authenticated"] cannot "update" resource "services" named "kube-lego-nginx" in namespace "kube-lego"

It seems like it's missing update permission on services resource.