### PR TITLE
[incubator/kafka] make volume storage class configurable

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.2.1
+version: 0.2.2
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -53,10 +53,11 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
           storage: {{ .Values.Storage }}
+      {{- if .Values.StorageClass }}
+      storageClassName: {{ .Values.StorageClass | quote }}
+      {{- end }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -14,6 +14,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 1024Mi
 Storage: "1Gi"
+# StorageClass: default
 DataDirectory: "/opt/kafka/data"
 
 #------------------------------------------------------------------------------
@@ -25,6 +26,7 @@ zookeeper:
   Resources: {}
   Heap: "1G"
   Storage: "2Gi"
+  # StorageClass: default
   ServerPort: 2888
   LeaderElectionPort: 3888
   ClientPort: 2181


### PR DESCRIPTION
This pull request adds a new optional configurable value, StorageClass, for when the cluster default storage class is not suitable for Kafka.

This brings the chart into line with incubator/zookeeper which already has this feature.