### PR TITLE
[stable/mariadb] Update to mariadb non-root image

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 2.0.0
+version: 2.0.1
 appVersion: 10.1.28
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -13,6 +13,14 @@ spec:
       labels:
         app: {{ template "mariadb.fullname" . }}
     spec:
+      initContainers:
+      - name: "fix-non-root-permissions"
+        image: "busybox"
+        imagePullPolicy: "Always"
+        command: [ "sh" , "-c", "mkdir -p /bitnami/mariadb/conf/ && chmod -R g+rwX /bitnami" ]
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/mariadb
       containers:
       - name: mariadb
         image: "{{ .Values.image }}"

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -13,12 +13,17 @@ spec:
       labels:
         app: {{ template "mariadb.fullname" . }}
     spec:
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001
       initContainers:
-      - name: "fix-non-root-permissions"
+      - name: "copy-custom-config"
         image: "busybox"
-        imagePullPolicy: "Always"
-        command: [ "sh" , "-c", "mkdir -p /bitnami/mariadb/conf/ && chmod -R g+rwX /bitnami" ]
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        command: ["sh", "-c", "mkdir -p /bitnami/mariadb/conf && cp /bitnami/mariadb_config/my.cnf /bitnami/mariadb/conf/my_custom.cnf"]
         volumeMounts:
+        - name: config
+          mountPath: /bitnami/mariadb_config
         - name: data
           mountPath: /bitnami/mariadb
       containers:
@@ -67,9 +72,6 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - name: config
-          mountPath: /bitnami/mariadb/conf/my_custom.cnf
-          subPath: my.cnf
         - name: data
           mountPath: /bitnami/mariadb
 {{- if .Values.metrics.enabled }}

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/bitnami/mariadb/tags/
 ##
 ## Default: none
-image: bitnami/mariadb:10.1.28-r1
+image: bitnami/mariadb:10.1.28-r2
 
 ## Specify an imagePullPolicy (Required)
 ## It's recommended to change this to 'Always' if the image tag is 'latest'


### PR DESCRIPTION
This PR adapts the chart to the latest MariaDB image (`10.1.28-r2`) that has been migrated to a non-root approach.