### PR TITLE
Add ingress service

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.4.0
+version: 0.5.0
 appVersion: 1.7.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -37,20 +37,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the kubernetes-dashboard chart and their default values.
 
-| Parameter             | Description                        | Default                                                                  |
-|-----------------------|------------------------------------|--------------------------------------------------------------------------|
-| `image`               | Image                              | `gcr.io/google_containers/kubernetes-dashboard-amd64`                    |
-| `imageTag`            | Image tag                          | `v1.7.0`                                                                 |
-| `imagePullPolicy`     | Image pull policy                  | `IfNotPresent`                                                           |
-| `nodeSelector`        | node labels for pod assignment     | `{}`                                                                     |
-| `httpPort`            | Dashboard port                     | 80                                                                       |
-| `resources`           | Pod resource requests & limits     | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
-| `ingress.annotations` | Specify ingress class              | `kubernetes.io/ingress.class: nginx`                                     |
-| `ingress.enabled`     | Enable ingress controller resource | `false`                                                                  |
-| `ingress.hosts`       | Dashboard Hostnames                | `nil`                                                                    |
-| `ingress.tls`         | Ingress TLS configuration          | `[]`                                                                     |
-| `rbac.create`         | Create & use RBAC resources        | `false`                                                                  |
-| `rbac.serviceAccountName` |  ServiceAccount kubernetes-dashboard will use (ignored if rbac.create=true) | `default`        |
+Parameter | Description | Default
+--- | --- | ---
+`image` | Image | `gcr.io/google_containers/kubernetes-dashboard-amd64`
+`imageTag` | Image tag | `v1.7.0`
+`imagePullPolicy` | Image pull policy | `IfNotPresent`
+`nodeSelector` | node labels for pod assignment | `{}`
+`httpPort` | Dashboard port | `80`
+`resources` | Pod resource requests & limits | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}`
+`ingress.annotations` | Specify ingress class | `kubernetes.io/ingress.class: nginx`
+`ingress.enabled` | Enable ingress controller resource | `false`
+`ingress.hosts` | Dashboard Hostnames | `nil`
+`ingress.tls` | Ingress TLS configuration | `[]`
+`ingress.service.enabled` | Create a service for the Ingress (currently needed for AWS ELBs) | `false`
+`ingress.service.appSelector` | App selector | `nginx-ingress`
+`ingress.service.type` | Type of Service to create | `LoadBalancer`
+`ingress.service.annotations` | Annotations for ingress service  | `{}`
+`ingress.service.loadBalancerSourceRanges` | IP whitelist | `[]`
+`rbac.create` | Create & use RBAC resources | `false`
+`rbac.serviceAccountName` | ServiceAccount kubernetes-dashboard will use (ignored if rbac.create=true) | `default`
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kubernetes-dashboard/templates/ingress-svc.yaml
+++ b/stable/kubernetes-dashboard/templates/ingress-svc.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.service.enabled }}
+
+{{- $fullName := include "kubernetes-dashboard.fullname" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}-ingress
+  annotations:
+  {{- range $key, $value := .Values.ingress.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+    app: {{ template "kubernetes-dashboard.name" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    kubernetes.io/cluster-service: "true"
+spec:
+  type: {{ .Values.ingress.service.type }}
+  ports:
+  - port: {{ .Values.httpPort }}
+    targetPort: http
+{{- if hasKey .Values "nodePort" }}
+    nodePort: {{ .Values.nodePort }}
+{{- end }}
+  selector:
+    app: {{ .Values.ingress.service.appSelector }}
+{{- if .Values.ingress.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.ingress.service.loadBalancerSourceRanges | indent 4}}
+{{- end }}
+
+{{- end }}

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -45,6 +45,11 @@ ingress:
   #   - secretName: kubernetes-dashboard-tls
   #     hosts:
   #       - kubernetes-dashboard.domain.com
+  service:
+    enabled: false
+    type: LoadBalancer
+    appSelector: nginx-ingress
+    loadBalancerSourceRanges: []
 
 rbac:
   ## If true, create & use RBAC resources


### PR DESCRIPTION
In order to have an AWS ELB target an Ingress, you must have a Service with an app selector of the ingress controller.  This work enabled my use case for adding basic-auth via the Ingress:

```yaml
httpPort: 443
ingress:
  enabled: true
  hosts:
  - dashboard.mydomain.com
  annotations:
    ingress.kubernetes.io/auth-type: basic
    ingress.kubernetes.io/auth-secret: myteam-user-basic-auth
    ingress.kubernetes.io/auth-realm: "Authentication Required"
    ingress.kubernetes.io/class: "nginx"
  service:
    enabled: true
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:123456789:certificate/foo-123-bar-456
      dns.alpha.kubernetes.io/external: dashboard.mydomain.com
    loadBalancerSourceRanges:
    - 1.2.3.4/27 # My Office
```

Also, some Readme cleanup to match the style of other charts.  