### PR TITLE
Update changed test to focus on changes introduced in current PR

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -21,7 +21,7 @@ set -o xtrace
 git fetch --tags https://github.com/kubernetes/charts master
 
 NAMESPACE="pr-${PULL_NUMBER}-${BUILD_NUMBER}"
-CHANGED_FOLDERS=`git diff --find-renames --name-only FETCH_HEAD stable/ incubator/ | awk -F/ '{print $1"/"$2}' | uniq`
+CHANGED_FOLDERS=`git diff --find-renames --name-only $(git merge-base master HEAD) stable/ incubator/ | awk -F/ '{print $1"/"$2}' | uniq`
 CURRENT_RELEASE=""
 
 # Exit early if no charts have changed


### PR DESCRIPTION
The previous diff was a comparison against master. If master had
changed since the current PR was created the changed charts would
be re-tested. This could create a problem when helm was upgraded
and lint changed causing previously passing charts to fail. Since
they were not associated with the current PR it was an outlier
problem for the PR author.

The new diff does a comparison to the merge-base which ties to look
for changes introduced by the current pull request.