### PR TITLE
Adding linting to Chart and values yaml files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,5 +10,5 @@ jobs:
            name: install tools
            command: test/circle/install.sh
        - run: 
-           name: helm lint
+           name: lint
            command: test/circle/lint.sh

--- a/test/circle/install.sh
+++ b/test/circle/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 # Copyright 2017 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,3 +21,7 @@ tar -xvf helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz
 sudo mv linux-amd64/helm /usr/local/bin
 rm -f helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz
 rm -rf linux-amd64
+
+# Install A YAML Linter
+# Pinning to a version for consistency
+sudo pip install yamllint==1.8.1

--- a/test/circle/lintconf.yml
+++ b/test/circle/lintconf.yml
@@ -1,0 +1,43 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 2
+  comments-indentation: enable
+  document-end: disable
+  document-start: disable           # No --- to start a file
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever      # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable              # Lines can be any length
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning


### PR DESCRIPTION
This does not lint yaml templates as they are templates rather
than valid yaml files. They cannot be linted with a normal linter

yamllint is used for linting. This is an existing Python project
https://github.com/adrienverge/yamllint

The rules are not the default rules and are stored in their
entirity so they can be controlled over time

The existance of a Chart.yaml file and values.yaml file is checked
and an error is thrown if one is missing. Helm lint will not
detect a chart if Chart.yaml is missing and if a values.yaml file
is missing it is noted as info.

The run function is introduced to enable running all the linters,
capturing non-zero exit codes, and exiting with a non-zdero code
if any of them fail. This is used instead of exiting when the
first failure happens to provide more feedback to chart developers.

/cc @prydonius @viglesiasce @unguiculus 

You can see an example of a failure at https://circleci.com/gh/mattfarina/charts/41

There are [docs on configuring yamllint](https://yamllint.readthedocs.io/en/latest/index.html) including the [rules](https://yamllint.readthedocs.io/en/latest/rules.html). I tried to tailor our rules to the existing charts. Though, many of the charts fail the rules and are inconsistent.

You can take a look at all the lint failures we have in the existing stable and incubator charts in [this gist](https://gist.github.com/mattfarina/7bf1ee3a757a8959fc8e4ea67e5a6d85) based on the rules in the config file here.

Once we agree on a set of rules I can create separate PRs to clean up the existing charts.

References #2373