### PR TITLE
[stable/gcloud-sqlproxy] Bump image tag to 1.11

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-sqlproxy
-version: 0.2.0
+version: 0.2.1
 description: Google Cloud SQL Proxy
 keywords:
 - google

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://cloud.google.com/sql/docs/mysql/sql-proxy
 ## ref: https://cloud.google.com/sql/docs/postgres/sql-proxy
 image: b.gcr.io/cloudsql-docker/gce-proxy
-imageTag: "1.10"
+imageTag: "1.11"
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Bumps the gcloud-sqlproxy image tag and updates the README.