### PR TITLE
[stable/kube-lego] Bump image tag to 1.1.5

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.12
+version: 0.1.13
 keywords:
   - kube-lego
   - letsencrypt

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -47,7 +47,7 @@ Parameter | Description | Default
 `config.LEGO_URL` | Let's Encrypt API endpoint. To get "real" certificates set to the production API of Let's Encrypt: https://acme-v01.api.letsencrypt.org/directory | `https://acme-staging.api.letsencrypt.org/directory` (staging)
 `config.LEGO_PORT` | kube-lego port | `8080`
 `image.repository` | kube-lego container image repository | `jetstack/kube-lego`
-`image.tag` | kube-lego container image tag | `0.1.3`
+`image.tag` | kube-lego container image tag | `0.1.5`
 `image.pullPolicy` | kube-lego container image pull policy | `IfNotPresent`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to be added to pods | `{}`

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -20,7 +20,7 @@ config:
 ##
 image:
   repository: jetstack/kube-lego
-  tag: 0.1.4
+  tag: 0.1.5
   pullPolicy: IfNotPresent
 
 ## Node labels for pod assignment


### PR DESCRIPTION
Bumps the kube-lego image tag and updates the README.