### PR TITLE
[kubernetes-dashboard] clean up and allow for labels, annotations, and custom service names

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -5,6 +5,10 @@ description: General-purpose web UI for Kubernetes clusters
 keywords:
 - kubernetes
 - dashboard
+home: https://github.com/kubernetes/dashboard
+sources:
+- https://github.com/kubernetes/dashboard
 maintainers:
 - name: kfox1111
   email: Kevin.Fox@pnnl.gov
+icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg

--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 name: kubernetes-dashboard
-version: 0.4.4
-appVersion: 1.7.1
+version: 0.5.0
+appVersion: 1.8.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:
 - kubernetes

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -37,26 +37,27 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the kubernetes-dashboard chart and their default values.
 
-| Parameter             | Description                        | Default                                                                  |
-|-----------------------|------------------------------------|--------------------------------------------------------------------------|
-| `image`               | Image                              | `k8s.gcr.io/kubernetes-dashboard-amd64`                                  |
-| `imageTag`            | Image tag                          | `v1.7.0`                                                                 |
-| `imagePullPolicy`     | Image pull policy                  | `IfNotPresent`                                                           |
-| `nodeSelector`        | node labels for pod assignment     | `{}`                                                                     |
-| `httpPort`            | Dashboard port                     | 80                                                                       |
-| `resources`           | Pod resource requests & limits     | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
-| `ingress.annotations` | Specify ingress class              | `kubernetes.io/ingress.class: nginx`                                     |
-| `ingress.enabled`     | Enable ingress controller resource | `false`                                                                  |
-| `ingress.hosts`       | Dashboard Hostnames                | `nil`                                                                    |
-| `ingress.tls`         | Ingress TLS configuration          | `[]`                                                                     |
-| `rbac.create`         | Create & use RBAC resources        | `false`                                                                  |
+| Parameter              | Description                        | Default                                                                  |
+|------------------------|------------------------------------|--------------------------------------------------------------------------|
+| `image.repository`     | Repository for container image     | `gcr.io/google_containers/kubernetes-dashboard-amd64`                    |
+| `image.tag`            | Image tag                          | `v1.8.1`                                                                 |
+| `image.pullPolicy`     | Image pull policy                  | `IfNotPresent`                                                           |
+| `nodeSelector`         | node labels for pod assignment     | `{}`                                                                     |
+| `service.externalPort` | Dashboard internal port            | 80                                                                       |
+| `service.internalPort` | Dashboard external port            | 80                                                                       |
+| `ingress.annotations`  | Specify ingress class              | `kubernetes.io/ingress.class: nginx`                                     |
+| `ingress.enabled`      | Enable ingress controller resource | `false`                                                                  |
+| `ingress.hosts`        | Dashboard Hostnames                | `nil`                                                                    |
+| `ingress.tls`          | Ingress TLS configuration          | `[]`                                                                     |
+| `resources`            | Pod resource requests & limits     | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
+| `rbac.create`          | Create & use RBAC resources        | `false`                                                                  |
 | `rbac.serviceAccountName` |  ServiceAccount kubernetes-dashboard will use (ignored if rbac.create=true) | `default`        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 $ helm install stable/kubernetes-dashboard --name my-release \
-  --set=httpPort=8080,resources.limits.cpu=200m
+  --set=service.externalPort=8080,resources.limits.cpu=200m
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/stable/kubernetes-dashboard/templates/NOTES.txt
+++ b/stable/kubernetes-dashboard/templates/NOTES.txt
@@ -8,14 +8,14 @@ From outside the cluster, the server URL(s) are:
      http://{{ . }}
 {{- end }}
 
-{{- else if contains "NodePort" .Values.serviceType }}
+{{- else if contains "NodePort" .Values.service.type }}
 
 Get the Kubernetes Dashboard URL by running:
   export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kubernetes-dashboard.fullname" . }})
   export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/
 
-{{- else if contains "LoadBalancer" .Values.serviceType }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc -w {{ template "kubernetes-dashboard.fullname" . }}'
@@ -23,7 +23,7 @@ Get the Kubernetes Dashboard URL by running:
 Get the Kubernetes Dashboard URL by running:
   export SERVICE_IP=$(kubectl get svc {{ template "kubernetes-dashboard.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP/
-{{- else if contains "ClusterIP"  .Values.serviceType }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
 
 Get the Kubernetes Dashboard URL by running:
   export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app={{ template "kubernetes-dashboard.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")

--- a/stable/kubernetes-dashboard/templates/_helpers.tpl
+++ b/stable/kubernetes-dashboard/templates/_helpers.tpl
@@ -14,3 +14,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a service name that defaults to app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kubernetes-dashboard.service.fullname" -}}
+{{- .Values.service.nameOverride | default .Chart.Name }}
+{{- end -}}

--- a/stable/kubernetes-dashboard/templates/_helpers.tpl
+++ b/stable/kubernetes-dashboard/templates/_helpers.tpl
@@ -2,15 +2,15 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{ define "kubernetes-dashboard.name" }}{{ default "kubernetes-dashboard" .Values.nameOverride | trunc 63 }}{{ end }}
+{{- define "kubernetes-dashboard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-
-We truncate at 63 chars because some Kubernetes name fields are limited to this
-(by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{ define "kubernetes-dashboard.fullname" }}
-{{- $name := default "kubernetes-dashboard" .Values.nameOverride -}}
-{{ printf "%s-%s" .Release.Name $name | trunc 63 -}}
-{{ end }}
+{{- define "kubernetes-dashboard.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     kubernetes.io/cluster-service: "true"
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
 spec:
   replicas: 1
   strategy:

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
   labels:
-    app: {{ template "kubernetes-dashboard.name" . }}
+    app: {{ template "kubernetes-dashboard.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
@@ -19,20 +19,20 @@ spec:
     metadata:
       labels:
         app: {{ template "kubernetes-dashboard.name" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kubernetes-dashboard.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 10 }}
       containers:
-      - name: main
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: {{ .Values.imagePullPolicy }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: 9090
+          protocol: TCP
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -43,7 +43,9 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 30
-        ports:
-        - name: http
-          containerPort: 9090
-          protocol: TCP
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}

--- a/stable/kubernetes-dashboard/templates/ingress.yaml
+++ b/stable/kubernetes-dashboard/templates/ingress.yaml
@@ -1,38 +1,38 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "kubernetes-dashboard.fullname" . }}
-{{- $httpPort := .Values.httpPort }}
+{{- $serviceName := include "kubernetes-dashboard.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  annotations:
-  {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-  name: {{ template "kubernetes-dashboard.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   rules:
   {{- if .Values.ingress.hosts }}
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+  {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
           - path: /
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $httpPort }}
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
   {{- end -}}
   {{- else }}
     - http:
         paths:
           - path: /
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $httpPort }}
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
   {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/stable/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/stable/kubernetes-dashboard/templates/rolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}

--- a/stable/kubernetes-dashboard/templates/serviceaccount.yaml
+++ b/stable/kubernetes-dashboard/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     kubernetes.io/cluster-service: "true"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kubernetes-dashboard.fullname" . }}
+  name: {{ template "kubernetes-dashboard.service.fullname" . }}
   labels:
-    app: {{ template "kubernetes-dashboard.name" . }}
+    app: {{ template "kubernetes-dashboard.fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -24,5 +24,5 @@ spec:
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
   selector:
-    app: {{ template "kubernetes-dashboard.name" . }}
+    app: {{ template "kubernetes-dashboard.fullname" . }}
     release: {{ .Release.Name }}

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -4,22 +4,22 @@ metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
     kubernetes.io/cluster-service: "true"
-{{- if .Values.serviceAnnotations }}
+{{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.serviceAnnotations | indent 4 }}
+{{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: {{ .Values.service.type }}
   ports:
-  - port: {{ .Values.httpPort }}
+  - port: {{ .Values.service.externalPort }}
     targetPort: http
-{{- if hasKey .Values "nodePort" }}
-    nodePort: {{ .Values.nodePort }}
+{{- if hasKey .Values.service "nodePort" }}
+    nodePort: {{ .Values.service.nodePort }}
 {{- end }}
   selector:
     app: {{ template "kubernetes-dashboard.name" . }}
-    release: {{ .Release.Name | quote }}
+    release: {{ .Release.Name }}

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -3,16 +3,23 @@
 # Declare name/value pairs to be passed into your templates.
 # name: value
 
-image: k8s.gcr.io/kubernetes-dashboard-amd64
-imageTag: "v1.7.1"
-imagePullPolicy: "IfNotPresent"
+image:
+  repository: k8s.gcr.io/kubernetes-dashboard-amd64
+  tag: v1.8.1
+  pullPolicy: IfNotPresent
 
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
 nodeSelector: {}
 
-httpPort: 80
+service:
+  type: ClusterIP
+  externalPort: 80
 
-serviceType: ClusterIP
-serviceAnnotations: {}
+  ## Kubernetes Dashboard Service annotations
+  ##
+  annotations: {}
   # foo.io/bar: "true"
 
 resources:

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -8,6 +8,12 @@ image:
   tag: v1.8.1
   pullPolicy: IfNotPresent
 
+## Here labels can be added to the kubernets dashboard deployment
+##
+labels: {}
+# kubernetes.io/cluster-service: "true"
+# kubernetes.io/name: "Kuberetes Dashboard"
+
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
@@ -21,6 +27,11 @@ service:
   ##
   annotations: {}
   # foo.io/bar: "true"
+
+  ## Here labels can be added to the Kubernetes Dashboard service
+  ##
+  labels: {}
+  # kubernetes.io/name: "Kubernetes Dashboard"
 
 resources:
   limits:

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -23,6 +23,11 @@ service:
   type: ClusterIP
   externalPort: 80
 
+  ## This allows an overide of the heapster service name
+  ## Default: {{ .Chart.Name }}
+  ##
+  # nameOverride:
+
   ## Kubernetes Dashboard Service annotations
   ##
   annotations: {}


### PR DESCRIPTION
This updates kubernetes-dashboard to help clean it up, and ultimately allow it to be used for the <api-server.com>/ui link, which can be implemented by running:

```
% helm install --set service.nameOverride=kubernetes-dashboard --namespace kube-system .
```

In addition, it does:

* move the image definition into a map
* move the service definition into a map
* rename httpPort to externalPort
* reordered files to match the `helm create` order
* Made sure chart names don't contain '+'
* allow for custom deployment and service labels
* allow service name to be overridden
* add service annotations
* Add links and the k8s logo

Finally this bumps the version from 0.4 to 0.5 since this is not backwards compatible.

Closes #2099, slightly overlaps with #2427