### PR TITLE
Added serviceAccount to initializer.

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -3,7 +3,7 @@ description: Istio Helm chart for Kubernetes
 name: istio
 # To avoid confusion the helm chart version stays in sync with the istio version - DO NOT UNSYNC -- ldemailly@google.com
 # https://github.com/kubernetes/charts/issues/1501
-version: 0.2.7-chart3
+version: 0.2.7-chart4
 appVersion: 0.2.7
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png

--- a/incubator/istio/templates/deployment/initializer.yaml
+++ b/incubator/istio/templates/deployment/initializer.yaml
@@ -34,7 +34,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ $serviceName }}-initializer-service-account
+      serviceAccountName: {{ $serviceName }}-{{ .Values.initializer.deployment.name }}-service-account
       containers:
       - name: {{ $serviceName }}-{{ .Values.initializer.deployment.name }}
         image: "{{ .Values.initializer.deployment.image }}:{{ .Values.istio.release }}"

--- a/incubator/istio/templates/deployment/initializer.yaml
+++ b/incubator/istio/templates/deployment/initializer.yaml
@@ -34,6 +34,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ $serviceName }}-initializer-service-account
       containers:
       - name: {{ $serviceName }}-{{ .Values.initializer.deployment.name }}
         image: "{{ .Values.initializer.deployment.image }}:{{ .Values.istio.release }}"


### PR DESCRIPTION
Without the serviceAccount, the initializer will be failed to
retrive the unintialized objects and thus caused all of the
deployment stuck in pending for 30s and then timeout.

Fixed https://github.com/kubernetes/charts/issues/2442

/cc @lachie83 