### PR TITLE
add optional image pull secrets

### DIFF
--- a/stable/spotify-docker-gc/README.md
+++ b/stable/spotify-docker-gc/README.md
@@ -29,7 +29,7 @@ See the [spotify/docker-gc GitHub repository][] for more settings which may be a
 | `env.dockerAPIVersion`            | Docker API Version for docker-gc client  | Not set                                 |
 | `exclude.images`                  | images to be excluded                    | Not set                                 |
 | `exclude.containers`              | containers to be excluded                | Not set                                 |
-
+| `imagePullSecrets`                | Specify image pull secrets               | Not set                                 |
 
 ## Design/Evolution
 

--- a/stable/spotify-docker-gc/templates/daemonset.yaml
+++ b/stable/spotify-docker-gc/templates/daemonset.yaml
@@ -12,6 +12,10 @@ spec:
       labels:
         daemonset: {{ template "name" . }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "name" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/spotify-docker-gc/values.yaml
+++ b/stable/spotify-docker-gc/values.yaml
@@ -24,3 +24,10 @@ env:
 #   containers: |-
 #     mariadb-data
 #     inimitable_quokka
+
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+#
+# imagePullSecrets:
+#   - name: myRegistryKeySecretName


### PR DESCRIPTION
Add optional `imagePullSecrets` This is helpful when we build our own trusted docker gc image which is stored in a private registry