### PR TITLE
add optional serviceAccountName

### DIFF
--- a/stable/spotify-docker-gc/README.md
+++ b/stable/spotify-docker-gc/README.md
@@ -29,7 +29,7 @@ See the [spotify/docker-gc GitHub repository][] for more settings which may be a
 | `env.dockerAPIVersion`            | Docker API Version for docker-gc client  | Not set                                 |
 | `exclude.images`                  | images to be excluded                    | Not set                                 |
 | `exclude.containers`              | containers to be excluded                | Not set                                 |
-
+| `serviceAccount`                  | service account to attach to deamonset   | Not set                                 |
 
 ## Design/Evolution
 

--- a/stable/spotify-docker-gc/templates/daemonset.yaml
+++ b/stable/spotify-docker-gc/templates/daemonset.yaml
@@ -12,6 +12,9 @@ spec:
       labels:
         daemonset: {{ template "name" . }}
     spec:
+      {{- if .Values.serviceAccount }}
+      serviceAccountName: {{ .Values.serviceAccount }}
+      {{- end }}
       containers:
       - name: {{ template "name" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Add `serviceAccount` variable for cases were RBAC is enabled and we need to allow mounting of docker socket.