### PR TITLE
Allow resource-specific opt-in for Istio auto-inject

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -3,7 +3,7 @@ description: Istio Helm chart for Kubernetes
 name: istio
 # To avoid confusion the helm chart version stays in sync with the istio version - DO NOT UNSYNC -- ldemailly@google.com
 # https://github.com/kubernetes/charts/issues/1501
-version: 0.2.7-chart2
+version: 0.2.7-chart3
 appVersion: 0.2.7
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png

--- a/incubator/istio/templates/configmap/initializer-config.yaml
+++ b/incubator/istio/templates/configmap/initializer-config.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $serviceName }}-inject
 data:
   config: |-
-    policy: "enabled"
+    policy: {{ .Values.initializer.policy | quote }}
     namespaces: [""] # everything, aka v1.NamepsaceAll, aka cluster-wide
     initializerName: "sidecar.initializer.istio.io"
     params:

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -16,6 +16,7 @@ auth:
 initializer:
   customConfigMap: false
   enabled: false
+  policy: enabled
 
   deployment:
     name: initializer


### PR DESCRIPTION
This PR allows configuring Istio initializer for resource-specific opt-in.
```
helm install --set initializer.enabled=true --set initializer.policy=disabled incubator/istio
```