### PR TITLE
CI Check that a chart version was incremented

### DIFF
--- a/test/circle/install.sh
+++ b/test/circle/install.sh
@@ -25,3 +25,13 @@ rm -rf linux-amd64
 # Install A YAML Linter
 # Pinning to a version for consistency
 sudo pip install yamllint==1.8.1
+
+# Install YAML Command line reader
+wget https://github.com/mikefarah/yaml/releases/download/1.13.1/yaml_linux_amd64
+chmod +x yaml_linux_amd64
+sudo mv yaml_linux_amd64 /usr/local/bin/yaml
+
+# Install SemVer testing tool
+wget https://github.com/Masterminds/vert/releases/download/v0.1.0/vert-v0.1.0-linux-amd64
+chmod +x vert-v0.1.0-linux-amd64
+sudo mv vert-v0.1.0-linux-amd64 /usr/local/bin/vert

--- a/test/circle/lint.sh
+++ b/test/circle/lint.sh
@@ -30,6 +30,67 @@ run() {
   fi
 }
 
+# Lint the Chart.yaml and values.yaml files for Helm
+yamllinter() {
+  printf "\nLinting the Chart.yaml and values.yaml files at ${1}\n"
+
+  # If a Chart.yaml file is present lint it. Otherwise report an error
+  # because one should exist
+  if [ -e $1/Chart.yaml ]; then
+    run yamllint -c test/circle/lintconf.yml $1/Chart.yaml
+  else
+    echo "Error $1/Chart.yaml file is missing"
+    exitCode=1
+  fi
+
+  # If a values.yaml file is present lint it. Otherwise report an error
+  # because one should exist
+  if [ -e $1/values.yaml ]; then
+    run yamllint -c test/circle/lintconf.yml $1/values.yaml
+  else
+    echo "Error $1/values.yaml file is missing"
+    exitCode=1
+  fi
+}
+
+# Verify that the semver for the chart was increased
+semvercompare() {
+  printf "\nChecking the Chart version has increased for the chart at ${1}\n"
+
+  # Checkout the Chart.yaml file on master to read the version for comparison
+  git show k8s/master:$1/Chart.yaml > /tmp/Chart.yaml
+
+  local oldVer=`yaml r /tmp/Chart.yaml version`
+  local newVer=`yaml r $1/Chart.yaml version`
+
+  # Pre-releases may not be API compatible. So, when tools compare versions
+  # they often skip pre-releases. vert can force looking at pre-releases by
+  # adding a dash on the end followed by pre-release. -0 on the end will force
+  # looking for all valid pre-releases since a prerelease cannot start with a 0.
+  # For example, 1.2.3-0 will include looking for pre-releases.
+  local ret
+  local out
+  if [[ $oldVer == *"-"* ]]; then  # Found the - to denote it has a pre-release
+    out=$(vert ">$oldVer" $newVer)
+    ret=$?
+  else
+    # No pre-release was found so we increment the patch version and attach a
+    # -0 to enable pre-releases being found.
+    local ov=( ${oldVer//./ } )  # Turn the version into an array
+    ((ov[2]++))                  # Increment the patch release
+    out=$(vert ">${ov[0]}.${ov[1]}.${ov[2]}-0" $newVer)
+    ret=$?
+  fi
+
+  if [ $ret -ne 0 ]; then
+    echo "Error please increment the new chart version to be greater than the existing version of $oldVer"
+    exitCode=1
+  fi
+
+  # Clean up
+  rm /tmp/Chart.yaml
+}
+
 git remote add k8s https://github.com/kubernetes/charts
 git fetch k8s master
 CHANGED_FOLDERS=`git diff --find-renames --name-only $(git merge-base k8s/master HEAD) stable/ incubator/ | awk -F/ '{print $1"/"$2}' | uniq`
@@ -44,25 +105,12 @@ for directory in ${CHANGED_FOLDERS}; do
   if [ "$directory" == "incubator/common" ]; then
     continue
   elif [ -d $directory ]; then
+    printf "\nRuning helm lint on the chart at ${directory}\n"
     run helm lint ${directory}
 
-    # If a Chart.yaml file is present lint it. Otherwise report an error
-    # because one should exist
-    if [ -e ${directory}/Chart.yaml ]; then
-      run yamllint -c test/circle/lintconf.yml ${directory}/Chart.yaml
-    else
-      echo "Error ${directory}/Chart.yaml file is missing"
-      exitCode=1
-    fi
+    yamllinter ${directory}
 
-    # If a values.yaml file is present lint it. Otherwise report an error
-    # because one should exist
-    if [ -e ${directory}/values.yaml ]; then
-      run yamllint -c test/circle/lintconf.yml ${directory}/values.yaml
-    else
-      echo "Error ${directory}/values.yaml file is missing"
-      exitCode=1
-    fi
+    semvercompare ${directory}
   fi
 done
 


### PR DESCRIPTION
This commit does a couple things
1. It reformats the layout to have checks via self contained
   functions rather than all in one loop.
2  Adds a check that the chart.version was incremented

Ref #2373 

For an example failure on version bump see https://circleci.com/gh/mattfarina/charts/52
For an example pass on version bump see https://circleci.com/gh/mattfarina/charts/51

/cc @viglesiasce @prydonius 