### PR TITLE
Making pod labels configurable for Redis, Jaeger and Cassandra

### DIFF
--- a/incubator/cassandra/templates/cassandra-statefulset.yaml
+++ b/incubator/cassandra/templates/cassandra-statefulset.yaml
@@ -45,6 +45,9 @@ spec:
     metadata:
       labels:
         app: {{ template "cassandra.fullname" . }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
     spec:
 {{- if .Values.selector }}
 {{ toYaml .Values.selector | indent 6 }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -61,3 +61,7 @@ config:
 # selector:
   # nodeSelector:
     # cloud.google.com/gke-nodepool: pool-db
+
+## Additional pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -21,6 +21,9 @@ spec:
         component: "agent"
         release: "{{ .Release.Name }}"
         jaeger-infra: agent-instance
+{{- if .Values.agent.podLabels }}
+{{ toYaml .Values.agent.podLabels | indent 8 }}
+{{- end }}
     spec:
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -18,6 +18,10 @@ spec:
   template:
     metadata:
       name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+{{- if .Values.schema.podLabels }}
+      labels:
+{{ toYaml .Values.schema.podLabels | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
@@ -30,4 +34,6 @@ spec:
             value: "{{ .Values.schema.mode }}"
           - name: DATACENTER
             value: "{{ .Values.cassandra.config.dc_name }}"
+        resources:
+{{ toYaml .Values.schema.resources | indent 10 }}
       restartPolicy: Never

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -24,6 +24,9 @@ spec:
         component: "collector"
         release: "{{ .Release.Name }}"
         jaeger-infra: collector-pod
+{{- if .Values.collector.podLabels }}
+{{ toYaml .Values.collector.podLabels | indent 8 }}
+{{- end }}
     spec:
       nodeSelector:
 {{ toYaml .Values.collector.nodeSelector | indent 8 }}

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -24,6 +24,9 @@ spec:
         component: "query"
         release: "{{ .Release.Name }}"
         jaeger-infra: query-pod
+{{- if .Values.query.podLabels }}
+{{ toYaml .Values.query.podLabels | indent 8 }}
+{{- end }}
     spec:
       nodeSelector:
 {{ toYaml .Values.query.nodeSelector | indent 8 }}

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -30,6 +30,16 @@ schema:
   pullPolicy: IfNotPresent
   # Acceptable values are test and prod. Default is for production use.
   mode: prod
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 256m
+    #   memory: 128Mi
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
 agent:
   annotations: {}
   image: jaegertracing/jaeger-agent
@@ -52,6 +62,9 @@ agent:
     #   cpu: 256m
     #   memory: 128Mi
   nodeSelector: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
 collector:
   annotations: {}
   image: jaegertracing/jaeger-collector
@@ -76,6 +89,9 @@ collector:
     #   cpu: 1024m
     #   memory: 1024Mi
   nodeSelector: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
 query:
   annotations: {}
   image: jaegertracing/jaeger-query
@@ -98,6 +114,9 @@ query:
     #    cpu: 256m
     #    memory: 128Mi
   nodeSelector: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
 # End: Default values for the various components of Jaeger
 
 ingress:

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -12,6 +12,9 @@ spec:
     metadata:
       labels:
         app: {{ template "redis.fullname" . }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -75,6 +75,10 @@ resources:
 nodeSelector: {}
 tolerations: []
 
+## Additional pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
 networkPolicy:
   ## Enable creation of NetworkPolicy resources.
   ##


### PR DESCRIPTION
Hi,

Ideally we would make use of custom pod labels using the opensource Helm charts.
We use Labels mostly to enforce _Advanced network policy_ (https://docs.projectcalico.org/v2.0/getting-started/kubernetes/tutorials/advanced-policy)

There's probably other usage that would be unlocked by that as per: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

This merge request is only for Redis, Jaeger and Cassandra. It could probably be added to other charts at some point

Best regards!