### PR TITLE
Add Flag for Default Certificate to Nginx-Ingress

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.9
+version: 0.8.10
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -52,6 +52,7 @@ Parameter | Description | Default
 `controller.config` | nginx ConfigMap entries | none
 `controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace | false
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
+`controller.defaultSSLCertificate` | Name of the secret that contains an SSL certificate to be used as default for an HTTPS catch-all server | `""`
 `controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
 `controller.ingressClass` | name of the ingress class to route through this controller | `nginx`
 `controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -32,6 +32,9 @@ spec:
           {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "controller.publishServicePath" . }}
           {{- end }}
+          {{- if (not (eq .Values.controller.defaultSSLCertificate "")) }}
+            - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
+          {{- end }}
           {{- if (contains "0.9" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -36,6 +36,9 @@ spec:
           {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "controller.publishServicePath" . }}
           {{- end }}
+          {{- if (not (eq .Values.controller.defaultSSLCertificate "")) }}
+            - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
+          {{- end }}
           {{- if (contains "0.9" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}


### PR DESCRIPTION
This setting is listed in the nginx-ingress chart's Values.yaml, and is
supported by the nginx-ingress image, but was never passed to the image.
This commit adds the logic required to pass the default-ssl-certificate
flag to the nginx-ingress image.