### PR TITLE
[incubator/kube-spot-termination-notice-handler] change repo

### DIFF
--- a/incubator/kube-spot-termination-notice-handler/Chart.yaml
+++ b/incubator/kube-spot-termination-notice-handler/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 description: Watch and action AWS spot termination events
 name: kube-spot-termination-notice-handler
-version: 0.1.0
-home: https://github.com/mumoshu/kube-spot-termination-notice-handler
+version: 0.1.1
+home: https://github.com/egeland/kube-spot-termination-notice-handler
 source:
-  - https://hub.docker.com/r/mumoshu/kube-spot-termination-notice-handler/
+  - https://hub.docker.com/r/egeland/kube-spot-termination-notice-handler/
 maintainers:
   - name: FFX Blue Operations
     email: blueops@fairfaxmedia.com.au

--- a/incubator/kube-spot-termination-notice-handler/values.yaml
+++ b/incubator/kube-spot-termination-notice-handler/values.yaml
@@ -2,8 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: mumoshu/kube-spot-termination-notice-handler
-  tag: 1.7.0-0.9.2
+  repository: egeland/kube-spot-termination-notice-handler
+  tag: 1.8.1-1
   pullPolicy: IfNotPresent
 
 # Poll the metadata every pollInterval seconds for termination events:
@@ -16,13 +16,13 @@ pollInterval: 5
 enableLogspout: false
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#  cpu: 100m
+#  memory: 128Mi
+# requests:
+#  cpu: 100m
+#  memory: 128Mi


### PR DESCRIPTION
Because the original app maintainer appears to not be available anymore,
a fork of the project (not of this chart) has been created, incorporating new features and a simpler
build process (now is an auto-build project in Docker Hub, not a
locally executed makefile).