### PR TITLE
istio add missing service accounts and fix names

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -3,7 +3,7 @@ description: Istio Helm chart for Kubernetes
 name: istio
 # To avoid confusion the helm chart version stays in sync with the istio version - DO NOT UNSYNC -- ldemailly@google.com
 # https://github.com/kubernetes/charts/issues/1501
-version: 0.2.7-chart4
+version: 0.2.7-chart5
 appVersion: 0.2.7
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png

--- a/incubator/istio/templates/deployment/ca.yaml
+++ b/incubator/istio/templates/deployment/ca.yaml
@@ -27,7 +27,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ $serviceName }}-ca-service-account
+      serviceAccountName: {{ $serviceName }}-{{ .Values.ca.deployment.name }}-service-account
       containers:
       - name: {{ .Values.ca.deployment.name }}
         image: "{{ .Values.ca.deployment.image }}:{{ .Values.istio.release }}"

--- a/incubator/istio/templates/deployment/egress.yaml
+++ b/incubator/istio/templates/deployment/egress.yaml
@@ -25,6 +25,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ $serviceName }}-{{ .Values.egress.deployment.name }}-service-account
       containers:
       - name: proxy
         image: "{{ .Values.egress.deployment.image }}:{{ .Values.istio.release }}"

--- a/incubator/istio/templates/deployment/ingress.yaml
+++ b/incubator/istio/templates/deployment/ingress.yaml
@@ -25,7 +25,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ $serviceName }}-ingress-service-account
+      serviceAccountName: {{ $serviceName }}-{{ .Values.ingress.deployment.name }}-service-account
       containers:
       - name: istio-ingress
         image: "{{ .Values.ingress.deployment.image }}:{{ .Values.istio.release }}"

--- a/incubator/istio/templates/deployment/mixer.yaml
+++ b/incubator/istio/templates/deployment/mixer.yaml
@@ -26,6 +26,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+      serviceAccountName: {{ $serviceName }}-{{ .Values.mixer.deployment.name }}-service-account
       containers:
       - name: statsd-to-prometheus
         image: prom/statsd-exporter

--- a/incubator/istio/templates/deployment/pilot.yaml
+++ b/incubator/istio/templates/deployment/pilot.yaml
@@ -26,7 +26,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ $serviceName }}-pilot-service-account
+      serviceAccountName: {{ $serviceName }}-{{ .Values.pilot.name }}-service-account
       containers:
       - name: {{ .Values.pilot.deployment.discovery.name }}
         image: "{{ .Values.pilot.deployment.discovery.image }}:{{ .Values.istio.release }}"


### PR DESCRIPTION
* egress and mixer deployments were missing a `serviceAccountName`
* others had a hard-coded name, now uses the values to match the generated service account

/cc @lachie83 