### PR TITLE
[stable/zetcd] Fixing lint issues

### DIFF
--- a/stable/zetcd/Chart.yaml
+++ b/stable/zetcd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS zetcd Helm chart for Kubernetes
 name: zetcd
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.0.3
 home: https://github.com/coreos/zetcd
 sources:

--- a/stable/zetcd/values.yaml
+++ b/stable/zetcd/values.yaml
@@ -13,16 +13,16 @@ service:
   externalPort: 2181
   internalPort: 2181
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious 
-  # choice for the user. This also increases chances charts run on environments with little 
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following 
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+#   We usually recommend not to specify default resources and to leave this as a conscious
+#   choice for the user. This also increases chances charts run on environments with little
+#   resources, such as Minikube. If you do want to specify resources, uncomment the following
+#   lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+#   limits:
+#     cpu: 100m
+#     memory: 128Mi
+#   requests:
+#     cpu: 100m
+#     memory: 128Mi
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
Noted by yamllint:
16:3      error    comment not indented like content  (comments-indentation)
16:91     error    trailing spaces  (trailing-spaces)
17:92     error    trailing spaces  (trailing-spaces)
18:94     error    trailing spaces  (trailing-spaces)

Note, doing this prior to the next change PR so that the person who does that does not need to fix lint issues outside the scope of their change.