### PR TITLE
Remove comment indentation checking due to false errors

### DIFF
--- a/test/circle/lintconf.yml
+++ b/test/circle/lintconf.yml
@@ -20,7 +20,6 @@ rules:
   comments:
     require-starting-space: true
     min-spaces-from-content: 2
-  comments-indentation: enable
   document-end: disable
   document-start: disable           # No --- to start a file
   empty-lines:


### PR DESCRIPTION
Indentation checking was catching catching out the commenting of
whole sections of indented code in values.yaml files as being
errors. Yet, code editors and other tools automatically indented
to this level. Removing the check.

For example, the following code would fail...
```yaml
  annotations:
    # kubernetes.io/ingress.class: nginx
    # ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/24,172.10.0.1"
```

The failure is because the comment is indented more than the level above. Yet, code editors like VSCode indent this way when this level section is commented. Commenting like this should be ok in YAML.

This PR simply disables the check.

cc: @unguiculus @prydonius 