### PR TITLE
[stable/traefik] Bump Traefik version to 1.4.0

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.11.5
-appVersion: 1.3.8
+version: 1.12.0
+appVersion: 1.4.0
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -86,7 +86,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | Parameter                       | Description                                                          | Default                                   |
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
-| `imageTag`                      | The version of the official Traefik image to use                     | `1.3.8`                                  |
+| `imageTag`                      | The version of the official Traefik image to use                     | `1.4.0`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
 | `loadBalancerSourceRanges`      | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,9 +1,9 @@
-# Default values for Traefik
+## Default values for Traefik
 image: traefik
 imageTag: 1.4.0
 serviceType: LoadBalancer
 loadBalancerIP:
-#loadBalancerSourceRanges: []
+# loadBalancerSourceRanges: []
 replicas: 1
 cpuRequest: 100m
 memoryRequest: 20Mi
@@ -12,12 +12,12 @@ memoryLimit: 30Mi
 debug:
   enabled: false
 nodeSelector: {}
-  #key: value
+  # key: value
 tolerations: []
-  #- key: "key"
-  #operator: "Equal|Exists"
-  #value: "value"
-  #effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+# - key: "key"
+#   operator: "Equal|Exists"
+#   value: "value"
+#   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 ssl:
   enabled: false
   enforced: false
@@ -27,8 +27,8 @@ acme:
   enabled: false
   email: admin@example.com
   staging: true
-  # Save ACME certs to a persistent volume. WARNING: If you do not do this, you will re-request
-  # certs every time a pod (re-)starts and you WILL be rate limited!
+  ## Save ACME certs to a persistent volume. WARNING: If you do not do this, you will re-request
+  ## certs every time a pod (re-)starts and you WILL be rate limited!
   persistence:
     enabled: true
     ## acme data Persistent Volume Storage Class
@@ -65,25 +65,24 @@ accessLogs:
   ## Path to the access logs file. If not provided, Traefik defaults it to stdout.
   # filePath: ""
   format: common  # choices are: common, json
-# Kubernetes ingress filters
-#kubernetes:
-#  namespaces:
-#  - default
-#  labelSelector:
+  ## Kubernetes ingress filters
+  # kubernetes:
+  #   namespaces:
+  #   - default
+  #   labelSelector:
 rbac:
   enabled: false
-# Enable the /metrics endpoint, for now only supports prometheus
-# set to true to enable metric collection by prometheus
+## Enable the /metrics endpoint, for now only supports prometheus
+## set to true to enable metric collection by prometheus
 metrics:
   prometheus:
     enabled: false
     buckets: 0.1,0.3,1.2,5
   datadog:
     enabled: false
-#    address: "localhost:8125"
-#    pushInterval: 30s
+    # address: "localhost:8125"
+    # pushInterval: 30s
   statsd:
     enabled: false
-#    address: "localhost:8125"
-#    pushInterval: 30s
-
+    # address: "localhost:8125"
+    # pushInterval: 30s

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Traefik
 image: traefik
-imageTag: 1.3.8
+imageTag: 1.4.0
 serviceType: LoadBalancer
 loadBalancerIP:
 #loadBalancerSourceRanges: []


### PR DESCRIPTION
See https://github.com/containous/traefik/releases
