### PR TITLE
[stable/datadog] Allow multiple agents to collect events

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.9.2
+version: 0.9.3
 description: Datadog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/serviceaccount.yaml
+++ b/stable/datadog/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "datadog.fullname" . }}
+automountServiceAccountToken: true
 {{- end -}}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -118,6 +118,14 @@ datadog:
       instances:
         - kube_state_url: http://%%host%%:%%port%%/metrics
 
+          ## Allow agents to elect a leader to collect agents. Requires
+          ## `datadog.collectEvents`, and an RBAC role that allows the
+          ## agents to talk to the API server.
+          ## ref:
+          #https://github.com/DataDog/integrations-core/tree/b7591f2ddec3b28a7eaa9e4d479b03784182d82c/kubernetes#gathering-kubernetes-events
+          ##
+          # leader_candidate: true
+
   ## Provide additonal service definitions
   ## Each key will become a file in /conf.d
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files


### PR DESCRIPTION
Datadog now has the ability to have multiple agents elect a single event collector. This depends on having a role that allows the agents to manage a `datadog-leader-elector` resource, as described by this document:

https://github.com/DataDog/integrations-core/tree/master/kubernetes

This patch adds an RBAC role to enable support this action.

One downside of this is that datadog currently hardcodes the resource name to be `datadog-leader-elector`.

cc-ing the maintainers @gtaylor and @hkaj.