### PR TITLE
[stable/mongodb-replicaset] Fix non TLS support

### DIFF
--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -70,14 +70,14 @@ configmap:
     dbPath: /data/db
   net:
     port: 27017
-    ssl:
     # Uncomment for TLS support
-    # mode: requireSSL
-    # CAFile: /ca/tls.crt
-    # PEMKeyFile: /work-dir/mongo.pem
+    #ssl:
+    #  mode: requireSSL
+    #  CAFile: /ca/tls.crt
+    #  PEMKeyFile: /work-dir/mongo.pem
   replication:
     replSetName: rs0
-  security:
   # Uncomment for TLS support or keyfile access control without TLS
-  # authorization: enabled
-  # keyFile: /keydir/key.txt
+  #security:
+  #  authorization: enabled
+  #  keyFile: /keydir/key.txt


### PR DESCRIPTION
Since the new TLS support was added, upon deploying mongodb-replicaset with a simple `helm install`, the bootstrap container produces these logs (albeit not to stdout, but to `/work-dir/log.txt`).

```
[2017-10-18T14:50:16,318650298+0000] [on-start.sh] Bootstrapping MongoDB replica set member: mongodb-mongodb-replicaset-0
[2017-10-18T14:50:16,322173167+0000] [on-start.sh] Reading standard input...
[2017-10-18T14:50:16,324194462+0000] [on-start.sh] Peers:
[2017-10-18T14:50:16,324970138+0000] [on-start.sh] Starting a MongoDB instance...
[2017-10-18T14:50:16,326852188+0000] [on-start.sh] Waiting for MongoDB to be ready...
Unrecognized option: net.ssl
try 'mongod --help' for more information
[2017-10-18T14:50:16,416738108+0000] [on-start.sh] Retrying...
[2017-10-18T14:50:18,460786234+0000] [on-start.sh] Retrying...
[2017-10-18T14:50:20,504623572+0000] [on-start.sh] Retrying...
[2017-10-18T14:50:22,547639035+0000] [on-start.sh] Retrying...
[2017-10-18T14:50:24,590944773+0000] [on-start.sh] Retrying...
```