### PR TITLE
allow enabling tls passthrough

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.9
+version: 0.9.0
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -39,6 +39,9 @@ spec:
           {{- if (contains "0.9" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}
+          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.allowTLSPassthrough.enabled }}
+            - --enable-ssl-passthrough
+          {{- end }}
           {{- if (contains "0.9" .Values.controller.image.tag) }}
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -52,6 +52,11 @@ controller:
     enabled: false
     namespace: ""   # defaults to .Release.Namespace
 
+  ## Enable TLS passthrough globally
+  ## Only applies to annotated ingress
+  allowTLSPassthrough:
+      enabled: true
+
   extraArgs: {}
 
   ## DaemonSet or Deployment


### PR DESCRIPTION
The latest version of the nginx ingress controller requires specifically enabling tls passthrough via a command line flag.