### PR TITLE
[stable/chaoskube]: update to v0.6.1

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,5 +1,6 @@
 name: chaoskube
-version: 0.6.1
+version: 0.6.0
+appVersion: 0.6.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube
 sources:

--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,5 +1,5 @@
 name: chaoskube
-version: 0.5.0
+version: 0.6.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube
 sources:

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -21,7 +21,6 @@ spec:
       - name: {{ .Values.name }}
         image: {{ .Values.image }}:{{ .Values.imageTag }}
         args:
-        - --in-cluster
         - --interval={{ .Values.interval }}
         - --labels={{ .Values.labels }}
         - --annotations={{ .Values.annotations }}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -5,7 +5,7 @@ name: chaoskube
 image: quay.io/linki/chaoskube
 
 # docker image tag
-imageTag: v0.5.0
+imageTag: v0.6.1
 
 # number of replicas to run
 replicas: 1


### PR DESCRIPTION
This updates the `chaoskube` chart to its latest version which includes a flag change and a newer version of `client-go` (last update was around March which doesn't work well with newer clusters).