### PR TITLE
[stable/kube-state-metrics] Add args value for passing additional flags

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.0.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -24,3 +24,5 @@ spec:
         - containerPort: 8080
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+        args: 
+{{ toYaml .Values.args | indent 12 }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -15,3 +15,5 @@ rbac:
   create: false
   # Ignored if rbac.create is true
   serviceAccountName: default
+# Arguments passed to kube-state-metrics
+args: []


### PR DESCRIPTION
I needed to pass additional parameters to kube-state-metrics in order to specify what collectors to run (via the "--collectors" flag). This PR adds that capability into the chart.