### PR TITLE
[incubator/elasticsearch] Option for using EmptyDir and use a default StorageClass

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.2.1
+version: 0.3.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.2.0
+version: 0.2.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -76,14 +76,14 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
-| `master.persistence.size`         | Master persistent volume size                                       | `4Gi`                                |
+| `master.persistence.size`            | Master persistent volume size                                       | `4Gi`                                |
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `3`                                  |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |
 | `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                               |
-| `data.persistence.size`           | Data persistent volume size                                         | `30Gi`                               |
+| `data.persistence.size`              | Data persistent volume size                                         | `30Gi`                               |
 | `data.persistence.storageClass`      | Data persistent volume Class                                        | `nil`                                |
 | `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -76,14 +76,14 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
-| `master.persistence.storage`         | Master persistent volume size                                       | `4Gi`                                |
+| `master.persistence.size`         | Master persistent volume size                                       | `4Gi`                                |
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `3`                                  |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |
 | `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                               |
-| `data.persistence.storage`           | Data persistent volume size                                         | `30Gi`                               |
+| `data.persistence.size`           | Data persistent volume size                                         | `30Gi`                               |
 | `data.persistence.storageClass`      | Data persistent volume Class                                        | `nil`                                |
 | `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -75,13 +75,17 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `master.resources`                   | Master node resources requests & limits                             | `{} - cpu limit must be an integer`  |
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
 | `master.name`                        | Master component name                                               | `master`                             |
-| `master.storage`                     | Master persistent volume size                                       | `4Gi`                                |
-| `master.storageClass`                | Master persistent volume Class                                      | `nil`                                |
+| `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
+| `master.persistence.storage`         | Master persistent volume size                                       | `4Gi`                                |
+| `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
+| `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `3`                                  |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |
-| `data.storage`                       | Data persistent volume size                                         | `30Gi`                               |
-| `data.storageClass`                  | Data persistent volume Class                                        | `nil`                                |
+| `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                               |
+| `data.persistence.storage`           | Data persistent volume size                                         | `30Gi`                               |
+| `data.persistence.storageClass`      | Data persistent volume Class                                        | `nil`                                |
+| `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
 | `rbac.create`                        | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                              |

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -128,7 +128,8 @@ spec:
   - metadata:
       name: data
     spec:
-      accessModes: {{ .Values.data.persistence.accessMode | quote }}
+      accessModes:
+        - {{ .Values.data.persistence.accessMode | quote }}
     {{- if .Values.data.persistence.storageClass }}
     {{- if (eq "-" .Values.data.persistence.storageClass) }}
       storageClassName: ""

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -120,10 +120,10 @@ spec:
       - name: config
         configMap:
           name: {{ template "elasticsearch.fullname" . }}
-{{- if not .Values.data.persistence.enabled }}
+  {{- if not .Values.data.persistence.enabled }}
       - name: data
         emptyDir: {}
-{{- else }}
+  {{- else }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -138,5 +138,5 @@ spec:
     {{- end }}
       resources:
         requests:
-          storage: "{{ .Values.data.persistence.storage }}"
-{{- end }}
+          storage: "{{ .Values.data.persistence.size }}"
+  {{- end }}

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -120,14 +120,23 @@ spec:
       - name: config
         configMap:
           name: {{ template "elasticsearch.fullname" . }}
+{{- if not .Values.data.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+{{- else }}
   volumeClaimTemplates:
   - metadata:
       name: data
     spec:
-      accessModes: [ ReadWriteOnce ]
-    {{- if .Values.data.storageClass }}
-      storageClassName: "{{ .Values.data.storageClass }}"
+      accessModes: {{ .Values.data.persistence.accessMode | quote }}
+    {{- if .Values.data.persistence.storageClass }}
+    {{- if (eq "-" .Values.data.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.data.persistence.storageClass }}"
+    {{- end }}
     {{- end }}
       resources:
         requests:
-          storage: "{{ .Values.data.storage }}"
+          storage: "{{ .Values.data.persistence.storage }}"
+{{- end }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -124,7 +124,8 @@ spec:
   - metadata:
       name: data
     spec:
-      accessModes: {{ .Values.master.persistence.accessMode | quote }}
+      accessModes:
+        - {{ .Values.master.persistence.accessMode | quote }}
     {{- if .Values.master.persistence.storageClass }}
     {{- if (eq "-" .Values.master.persistence.storageClass) }}
       storageClassName: ""

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -116,10 +116,10 @@ spec:
       - name: config
         configMap:
           name: {{ template "elasticsearch.fullname" . }}
-{{- if not .Values.master.persistence.enabled }}
+  {{- if not .Values.master.persistence.enabled }}
       - name: data
         emptyDir: {}
-{{- else }}
+  {{- else }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -134,5 +134,5 @@ spec:
     {{- end }}
       resources:
         requests:
-          storage: "{{ .Values.master.persistence.storage }}"
-{{ end }}
+          storage: "{{ .Values.master.persistence.size }}"
+  {{ end }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -116,14 +116,23 @@ spec:
       - name: config
         configMap:
           name: {{ template "elasticsearch.fullname" . }}
+{{- if not .Values.master.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+{{- else }}
   volumeClaimTemplates:
   - metadata:
       name: data
     spec:
-      accessModes: [ ReadWriteOnce ]
-    {{- if .Values.master.storageClass }}
-      storageClassName: "{{ .Values.master.storageClass }}"
+      accessModes: {{ .Values.master.persistence.accessMode | quote }}
+    {{- if .Values.master.persistence.storageClass }}
+    {{- if (eq "-" .Values.master.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.master.persistence.storageClass }}"
+    {{- end }}
     {{- end }}
       resources:
         requests:
-          storage: "{{ .Values.master.storage }}"
+          storage: "{{ .Values.master.persistence.storage }}"
+{{ end }}

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -38,7 +38,7 @@ master:
   persistence:
     enabled: true
     accessMode: ReadWriteOnce
-    storage: "4Gi"
+    size: "4Gi"
     # storageClass: "ssd"
   antiAffinity: "soft"
   resources:
@@ -56,7 +56,7 @@ data:
   persistence:
     enabled: true
     accessMode: ReadWriteOnce
-    storage: "30Gi"
+    size: "30Gi"
     # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -35,8 +35,11 @@ master:
   name: master
   replicas: 3
   heapSize: "512m"
-  storage: "4Gi"
-  # storageClass: "ssd"
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    storage: "4Gi"
+    # storageClass: "ssd"
   antiAffinity: "soft"
   resources:
     limits:
@@ -50,8 +53,11 @@ data:
   name: data
   replicas: 2
   heapSize: "1536m"
-  storage: "30Gi"
-  # storageClass: "ssd"
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    storage: "30Gi"
+    # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"
   resources:


### PR DESCRIPTION
This PR enables functionality for using:
- slight restructuring for persistent options in the values.yaml for master and data nodes
- enabling/disabling persistent storage (default enabled). The use of EmptyDir which is great to help enable scratch storage for dev/test.
- the default StorageClass for persistence. Set master and data storageClass to "-" to use default storageClass

Updated the README to reflect the changes.

This chart has been tested in a Kubernetes 1.7 environment on GCE. This also closely matches the implementation in the Cassandra chart.

Referencing the old PR https://github.com/kubernetes/charts/pull/2415 for historical content.