### PR TITLE
[stable/redis-ha] Update redis image + Fix  persistance volume claim 

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,12 +5,12 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 0.2.1
+version: 0.2.3
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
 maintainers:
   - email: ikaboubi@gmail.com
-    name: KABOUBI
+    name: smileisak
 details:
   This package provides a highly available Redis cluster with multiple sentinels and standbys.
   Note the `redis-master` pod is used for bootstrapping only and can be deleted once

--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -15,3 +15,5 @@ details:
   This package provides a highly available Redis cluster with multiple sentinels and standbys.
   Note the `redis-master` pod is used for bootstrapping only and can be deleted once
   the cluster is up and running.
+sources:
+  - https://github.com/smileisak/docker-images/tree/master/redis

--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 0.2.3
+version: 0.2.2
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
 maintainers:

--- a/stable/redis-ha/templates/redis-master-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-master-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       - name: data
       {{- if .Values.persistentVolume.enabled }}
         persistentVolumeClaim:
-          claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "name" . }}{{- end }}
+          claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "fullname" . }}{{- end }}
       {{- else }}
         emptyDir: {}
       {{- end -}}

--- a/stable/redis-ha/templates/redis-pvc.yaml
+++ b/stable/redis-ha/templates/redis-pvc.yaml
@@ -3,7 +3,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}-pvc
+  name: {{ template "fullname" . }}
   labels:
 {{ include "labels.standard" . | indent 4 }}
   annotations:

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -20,8 +20,7 @@ resources:
       cpu: 100m
     limits:
       memory: 200Mi
-
-
+      
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
@@ -69,10 +68,7 @@ persistentVolume:
 ## Redis image version
 redis_image: quay.io/smile/redis:4.0.2
 
-
-
 ## replicas number for each component
-
 replicas:
   master: 1
   slave: 1

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -67,7 +67,7 @@ persistentVolume:
   subPath: ""
 
 ## Redis image version
-redis_image: gcr.io/google_containers/redis:v1
+redis_image: quay.io/smile/redis:4.0.2
 
 
 

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -65,4 +65,3 @@ replicas:
   master: 1
   slave: 1
   sentinel: 3
-  

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -65,3 +65,4 @@ replicas:
   master: 1
   slave: 1
   sentinel: 3
+  

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -20,7 +20,6 @@ resources:
       cpu: 100m
     limits:
       memory: 200Mi
-      
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
@@ -29,7 +28,6 @@ persistentVolume:
   ## If false, use emptyDir
   ##
   enabled: false
-
   ## Redis data Persistent Volume access modes
   ## Must match those of existing PV or dynamic provisioner
   ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -40,16 +38,13 @@ persistentVolume:
   ## Redis data Persistent Volume Claim annotations
   ##
   annotations: {}
-
   ## Redis data Persistent Volume existing claim name
   ## Requires alertmanager.persistentVolume.enabled: true
   ## If defined, PVC must be created manually before volume will be bound
   existingClaim: ""
-
   ## Redis data Persistent Volume mount root path
   ##
   mountPath: /data
-
   ## alertmanager data Persistent Volume size
   ##
   size: 2Gi
@@ -59,15 +54,12 @@ persistentVolume:
   ## Default: volume.alpha.kubernetes.io/storage-class: default
   ##
   storageClass: ""
-
   ## Subdirectory of redis data Persistent Volume to mount
   ## Useful if the volume's root directory is not empty
   ##
   subPath: ""
-
 ## Redis image version
 redis_image: quay.io/smile/redis:4.0.2
-
 ## replicas number for each component
 replicas:
   master: 1


### PR DESCRIPTION
Update default redis image used within this chart. Related with these issues https://github.com/kubernetes/charts/issues/2527, https://github.com/kubernetes/charts/issues/2394

    quay.io/smile/redis:4.0.2

Dockerfile can be found [here](https://github.com/smileisak/docker-images/tree/master/redis).

And fix Persistance Volume Claim name to enable persistance correctly. Related with these issues: 
https://github.com/kubernetes/charts/issues/2539, https://github.com/kubernetes/charts/issues/2386
