### PR TITLE
[incubator/nfs-pv-provider] ReadWriteMany NFS PV Provisioner

### DIFF
--- a/incubator/nfs-pv-provider/Chart.yaml
+++ b/incubator/nfs-pv-provider/Chart.yaml
@@ -1,0 +1,14 @@
+name: nfs-pv-provider
+description: Basic NFS server providing PVs
+version: 0.1.0
+keywords:
+  - nfs
+  - pv
+  - pvc
+  - storage
+home: https://github.com/kingdonb/examples-volumes-nfs
+sources:
+  - https://github.com/kingdonb/nfs-data
+maintainers:
+  - name: kingdonb
+    email: kingdon@tuesdaystudios.com

--- a/incubator/nfs-pv-provider/README.md
+++ b/incubator/nfs-pv-provider/README.md
@@ -1,0 +1,108 @@
+# nfs-pv-provider: a Kubernetes Helm Charts incubator project
+
+This chart creates a container and exports a PersistentVolume via NFS to other
+pods as a K8S Service.  Deployed on `k8s.gcr.io/volume-nfs` and derived from
+`kubernetes/examples/staging`:
+https://github.com/kubernetes/examples/tree/master/staging/volumes/nfs
+
+### Instructions Guide
+
+To exercise the nfs-pv-provider, first get the `nfs-pv-provider` Helm chart
+installed:
+
+```
+# .env: 
+NFS_NAMESPACE=nfs
+NFS_NAME=nfs
+
+$ git clone git@github.com:kubernetes/charts -b nfs-pv charts
+$ cd charts/incubator
+$ helm install --namespace $NFS_NAMESPACE --name $NFS_NAME nfs-pv-provider
+$ kubectl --namespace $NFS_NAMESPACE get svc -w
+```
+
+A single ClusterIP should become bound to the new `Service` that was created
+almost immediately, or immediately.   That is your NFS server.  You should save
+that address, or otherwise make a note of it:
+
+```
+$ kubectl -n $NFS_NAMESPACE get svc -o jsonpath="{.items[*].spec.clusterIP}"; echo
+```
+
+Then, for example, provision the PV and PVC from [kingdonb/nfs-data] in order
+to make a sub-volume under `/exports` available to pods.  You can specify a
+subpath or leave default `/` setting to expose `/exports` directly, but setting
+clusterIP in `values.yaml` as `nfs.path` is mandatory to inform the client PV
+you will create from the [templates/nfs-pv.yaml] in `kingdonb/nfs-data`.
+
+```
+git clone git@github.com:kingdonb/nfs-data
+cd nfs-data
+$EDITOR values.yaml
+helm install --namespace nfs .
+```
+
+You must edit the values.yaml and write a ClusterIP within as described above.
+
+(This is WIP!  Sorry, I know this is unorthodox)
+
+### Limitations of this configuration
+
+Due to limitations of the Kubernetes spec, it is not possible to use service
+discovery when binding a PV.  It seems one needs a publically resolvable DNS
+name for the NFS server, or an IP address, or if you're on Google COS I heard
+it may just work to say `my-nfs-pv-provider.svc.namespace.cluster.default`.
+
+If there's a way to solve this in Kubernetes with labels, I don't know it.
+
+### PV within a PV: What exactly is this for?
+
+A simple K8S PV provider built almost entirely from K8S primitive resources.
+
+If you are used to creating PVCs that automatically generate PVs, note that you
+must create both PV and PVC as the consumer of the NFS PV Provisioner service.
+
+The PV that you create here is a ReadWriteMany clusterIP/path with capacity
+settings maybe for quota purposes.  You may divide a single PV storage into
+multiple PVs and connect multiple pod volumes to each of them easily.
+
+As the PV has a ReadWriteMany semantics, you need not repeat this for each pod.
+As you scale the number of pods in client deployment(s), they may any or all
+select NFS volumes through any label/by name, so you can map arbitrary numbers
+of containers' volumes to any number of NFS volumes in any combination.
+
+This could be useful if in your organization's cloud account, too many storage
+resources are provisioned at too low utilization rates.  This may be meant as a
+tool to fight a proliferation of overprovisioned storage disk resources.
+
+You may not be able to get all guarantees available in the set of other similar
+storage solutions that may be baked into such as EFS or Azure File, but it is a
+foundation for ReadWriteMany that does not require anything outside of what is
+already provided by Kubernetes conformance.  (Fight vendor lock-in!)
+
+### Consuming the filesystem(s) of the NFS PV Provisioner
+
+Finally, mix in one or more of the example clients from [kingdonb/nfs-data]
+
+```
+kubectl -n nfs create -f example-sh-client/nfs-busybox-rc.yaml
+# and/or
+kubectl -n nfs create -f example-web-client/nfs-web-rc.yaml
+kubectl -n nfs create -f example-web-client/nfs-web-service.yaml
+```
+
+One or more pods can connect to a ReadWriteMany PV, so only one PV and PVC
+called `nfs` is created, and can serve client pods for any number of pods like
+the examples in this repo!  You can also create additional PVs against the
+single NFS service with a different path, using this approach to grab different
+slices of /export.
+
+Would be a nice addition to the spec to require cluster DNS is available within
+service definitions, I think maybe it could be added in a future version of K8S
+conformance suite requirements.  Maybe there is some technical reason relating
+to TTL or otherwise why it couldn't work reliably.
+
+I heard a rumor, that DNS in PV spec may already work if using Google's COS.
+
+[kingdonb/nfs-data]: https://github.com/kingdonb/nfs-data
+[templates/nfs-pv.yaml]: https://github.com/kingdonb/nfs-data/blob/9e7dc26a643ab8363064b84093e0dd4ef3a48523/templates/nfs-pv.yaml

--- a/incubator/nfs-pv-provider/templates/NOTES.txt
+++ b/incubator/nfs-pv-provider/templates/NOTES.txt
@@ -1,0 +1,8 @@
+This chart is a (WIP) dynamic provider of NFS volumes for NFS
+PersistentVolumeClaims.
+
+Submit issues about this chart to kingdonb/nfs-data:
+https://github.com/kingdonb/nfs-data
+
+For an example that shows how to connect in ReadWriteMany from pods in a
+deployment and scale it up, check out README.md and kingdonb/nfs-data

--- a/incubator/nfs-pv-provider/templates/_helpers.tpl
+++ b/incubator/nfs-pv-provider/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nfs-pv-provider.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nfs-pv-provider.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nfs-pv-provider.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/nfs-pv-provider/templates/nfs-server-deploy.yaml
+++ b/incubator/nfs-pv-provider/templates/nfs-server-deploy.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: nfs-server
+  labels:
+    app: {{ template "nfs-pv-provider.name" . }}
+    chart: {{ template "nfs-pv-provider.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role: nfs-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "nfs-pv-provider.name" . }}
+      release: {{ .Release.Name }}
+      role: nfs-server
+  template:
+    metadata:
+      labels:
+        app: {{ template "nfs-pv-provider.name" . }}
+        release: {{ .Release.Name }}
+        role: nfs-server
+    spec:
+      containers:
+        - name: nfs-server
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - name: nfs
+              containerPort: 2049
+            - name: mountd
+              containerPort: 20048
+            - name: rpcbind
+              containerPort: 111
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /exports
+              name: mypvc
+      volumes:
+        - name: mypvc
+          persistentVolumeClaim:
+            claimName: {{ template "nfs-pv-provider.fullname" . }}

--- a/incubator/nfs-pv-provider/templates/nfs-server-pvc.yaml
+++ b/incubator/nfs-pv-provider/templates/nfs-server-pvc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "nfs-pv-provider.fullname" . }}
+  labels:
+    app: {{ template "nfs-pv-provider.name" . }}
+    chart: {{ template "nfs-pv-provider.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- if .Values.server.persistentVolume.annotations }}
+  annotations:
+{{ toYaml .Values.server.persistentVolume.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+{{- if .Values.server.persistentVolume.storageClass }}
+{{- if (eq "-" .Values.server.persistentVolume.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
+{{- end }}
+{{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.server.persistentVolume.capacity }}"

--- a/incubator/nfs-pv-provider/templates/nfs-server-service.yaml
+++ b/incubator/nfs-pv-provider/templates/nfs-server-service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "nfs-pv-provider.fullname" . }}
+  labels:
+    app: {{ template "nfs-pv-provider.name" . }}
+    chart: {{ template "nfs-pv-provider.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+  selector:
+    role: nfs-server

--- a/incubator/nfs-pv-provider/values.yaml
+++ b/incubator/nfs-pv-provider/values.yaml
@@ -1,0 +1,10 @@
+image:
+  repository: gcr.io/google-containers/volume-nfs
+  tag: 0.8
+  pullPolicy: IfNotPresent
+
+server:
+  persistentVolume:
+    capacity: 50Gi
+    storageClass: default
+    annotations: {}


### PR DESCRIPTION
from https://github.com/kubernetes/examples/pull/108

@ahmetb had suggested that [kubernetes/charts Incubator](/kubernetes/charts/tree/master/incubator) was a better home for this

There should not be any changes here that were not included in https://github.com/kubernetes/examples/pull/108/commits/92d1ddff6b7d4ade82ef208c849aece4bb09998a which was what I had previously submitted as kubernetes/examples#108