### PR TITLE
[stable/kube-lego] Adding options, fixing lint, bumping default version

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.12
+version: 0.2.0
 keywords:
   - kube-lego
   - letsencrypt

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -46,6 +46,9 @@ Parameter | Description | Default
 `config.LEGO_EMAIL` | email address to use for registration with Let's Encrypt | none
 `config.LEGO_URL` | Let's Encrypt API endpoint. To get "real" certificates set to the production API of Let's Encrypt: https://acme-v01.api.letsencrypt.org/directory | `https://acme-staging.api.letsencrypt.org/directory` (staging)
 `config.LEGO_PORT` | kube-lego port | `8080`
+`config.LEGO_SUPPORTED_INGRESS_CLASS` | Which ingress class to watch | none
+`config.LEGO_SUPPORTED_INGRESS_PROVIDER` | Which ingress provider is being used | none
+`config.LEGO_DEFAULT_INGRESS_CLASS` | What ingress class should something be if no ingress class is specified | none
 `image.repository` | kube-lego container image repository | `jetstack/kube-lego`
 `image.tag` | kube-lego container image tag | `0.1.3`
 `image.pullPolicy` | kube-lego container image pull policy | `IfNotPresent`

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -5,7 +5,7 @@ config:
   ## Email address to use for registration with Let's Encrypt
   ##
   # LEGO_EMAIL: my@email.tld
-  LEGO_EMAIL: foo@bar.com
+  LEGO_EMAIL: foo@example.com
 
   ## Let's Encrypt API endpoint
   ## Production: https://acme-v01.api.letsencrypt.org/directory

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -5,6 +5,7 @@ config:
   ## Email address to use for registration with Let's Encrypt
   ##
   # LEGO_EMAIL: my@email.tld
+  LEGO_EMAIL: foo@bar.com
 
   ## Let's Encrypt API endpoint
   ## Production: https://acme-v01.api.letsencrypt.org/directory
@@ -16,11 +17,25 @@ config:
   ##
   LEGO_PORT: 8080
 
+  ## Specify which ingress class to watch
+  ##
+  #LEGO_SUPPORTED_INGRESS_CLASS: nginx
+
+  ## Specify which ingress provider should be watched
+  ## nginx and gce are the only two options presently
+  ##
+  #LEGO_SUPPORTED_INGRESS_PROVIDER: nginx
+
+  ## Specify what ingress class should something be
+  ## if no ingress class is specified
+  ##
+  #LEGO_DEFAULT_INGRESS_CLASS: nginx
+
 ## kube-lego image
 ##
 image:
   repository: jetstack/kube-lego
-  tag: 0.1.4
+  tag: 0.1.5
   pullPolicy: IfNotPresent
 
 ## Node labels for pod assignment

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -19,17 +19,17 @@ config:
 
   ## Specify which ingress class to watch
   ##
-  #LEGO_SUPPORTED_INGRESS_CLASS: nginx
+  # LEGO_SUPPORTED_INGRESS_CLASS: nginx
 
   ## Specify which ingress provider should be watched
   ## nginx and gce are the only two options presently
   ##
-  #LEGO_SUPPORTED_INGRESS_PROVIDER: nginx
+  # LEGO_SUPPORTED_INGRESS_PROVIDER: nginx
 
   ## Specify what ingress class should something be
   ## if no ingress class is specified
   ##
-  #LEGO_DEFAULT_INGRESS_CLASS: nginx
+  # LEGO_DEFAULT_INGRESS_CLASS: nginx
 
 ## kube-lego image
 ##


### PR DESCRIPTION
This PR does a couple of things
* Makes clear it has support for multiple kube-legos running in a cluster by indicating there is a way to set `LEGO_SUPPORTED_INGRESS_CLASS`, `LEGO_SUPPORTED_INGRESS_PROVIDER`, and `LEGO_DEFAULT_INGRESS_CLASS` environmental variables.

These are needed in solutions for multiple ingress controllers [Issue 233](https://github.com/jetstack/kube-lego/issues/233) and [Issue 189](https://github.com/jetstack/kube-lego/issues/189)

These variables have been listed on the project page's [README.md](https://github.com/jetstack/kube-lego#environment-variables) - and while they are useful to an unreleased fix, they're still useful regardless

* Fixes lint by having LEGO_EMAIL no longer commented out

* Bumps default version of kube-lego to 0.1.5

I bumped the chart version to v0.2.0 to indicate the additional options that are available.

LMK if there's any problems - thanks
