### PR TITLE
Delete Jenkins lock directories

### DIFF
--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -137,7 +137,7 @@ data:
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
 {{- if .Values.Master.InstallPlugins }}
     cp /var/jenkins_config/plugins.txt /var/jenkins_home;
-    rm /usr/share/jenkins/ref/plugins/*.lock
+    rm -rf /usr/share/jenkins/ref/plugins/*.lock
     /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
 {{- end }}
 {{- if .Values.Master.ScriptApproval }}


### PR DESCRIPTION
The Jenkins init script tries to delete directories as files. This commit lets it delete directories. See #1586 