### PR TITLE
[stable/concourse] Allow injection of add'l env vars to workers

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.8.1
+version: 0.8.2
 appVersion: 3.5.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -98,6 +98,9 @@ spec:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: worker-fatal-errors
+{{- if .Values.worker.env }}
+{{ toYaml .Values.worker.env | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
           securityContext:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -379,6 +379,20 @@ worker:
       cpu: "100m"
       memory: "512Mi"
 
+  ## Configure additional environment variables for the
+  ## worker container(s)
+  # env:
+  #   - name: http_proxy
+  #     value: "http://proxy.your-domain.com:3128"
+  #   - name: https_proxy
+  #     value: "http://proxy.your-domain.com:3128"
+  #   - name: no_proxy
+  #     value: "your-domain.com"
+  #   - name: CONCOURSE_GARDEN_DNS_SERVER
+  #     value: "8.8.8.8"
+  #   - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
+  #     value: "true"
+
   ## Annotations to be added to the worker pods.
   ##
   # annotations:


### PR DESCRIPTION
This can be helpful for users behind a corporate proxy who wish
to use resource types which require fetching containers images
from outside the organization's network.