### PR TITLE
[stable/spinnaker] use the /health endpoint instead of /env

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.3.5
+version: 0.3.6
 appVersion: 1.1.0
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/deployments/clouddriver.yaml
+++ b/stable/spinnaker/templates/deployments/clouddriver.yaml
@@ -31,7 +31,7 @@ spec:
               name: {{ template "fullname" . }}-registry
           readinessProbe:
             httpGet:
-              path: /credentials
+              path: /health
               port: 7002
             initialDelaySeconds: 20
             timeoutSeconds: 1

--- a/stable/spinnaker/templates/deployments/echo.yaml
+++ b/stable/spinnaker/templates/deployments/echo.yaml
@@ -29,7 +29,7 @@ spec:
               name: {{ template "fullname" . }}-spinnaker-config
           readinessProbe:
             httpGet:
-              path: /env
+              path: /health
               port: 8089
             initialDelaySeconds: 20
             timeoutSeconds: 1

--- a/stable/spinnaker/templates/deployments/front50.yaml
+++ b/stable/spinnaker/templates/deployments/front50.yaml
@@ -35,7 +35,7 @@ spec:
             {{ end }}
           readinessProbe:
             httpGet:
-              path: /env
+              path: /health
               port: 8080
             initialDelaySeconds: 20
             timeoutSeconds: 1

--- a/stable/spinnaker/templates/deployments/gate.yaml
+++ b/stable/spinnaker/templates/deployments/gate.yaml
@@ -28,7 +28,8 @@ spec:
             - mountPath: /opt/spinnaker/config
               name: {{ template "fullname" . }}-spinnaker-config
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: 8084
             initialDelaySeconds: 30
             timeoutSeconds: 1

--- a/stable/spinnaker/templates/deployments/igor.yaml
+++ b/stable/spinnaker/templates/deployments/igor.yaml
@@ -29,7 +29,7 @@ spec:
               name: {{ template "fullname" . }}-spinnaker-config
           readinessProbe:
             httpGet:
-              path: /env
+              path: /health
               port: 8088
             initialDelaySeconds: 20
             timeoutSeconds: 1

--- a/stable/spinnaker/templates/deployments/orca.yaml
+++ b/stable/spinnaker/templates/deployments/orca.yaml
@@ -29,7 +29,7 @@ spec:
               name: {{ template "fullname" . }}-spinnaker-config
           readinessProbe:
             httpGet:
-              path: /env
+              path: /health
               port: 8083
             initialDelaySeconds: 20
             timeoutSeconds: 1

--- a/stable/spinnaker/templates/deployments/rosco.yaml
+++ b/stable/spinnaker/templates/deployments/rosco.yaml
@@ -33,7 +33,7 @@ spec:
               name: docker-sock
           readinessProbe:
             httpGet:
-              path: /env
+              path: /health
               port: 8087
             initialDelaySeconds: 20
             timeoutSeconds: 1

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -56,7 +56,7 @@ deck:
       # ingress.kubernetes.io/ssl-redirect: 'true'
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-    #tls:
+    # tls:
     #  - secretName: -tls
     #    hosts:
     #      - domain.com
@@ -111,7 +111,7 @@ jenkins:
     ServiceType: ClusterIP
     CustomConfigMap: true
     InstallPlugins:
-      - kubernetes:0.11 
+      - kubernetes:0.11
       - workflow-aggregator:2.5
       - workflow-job:2.11
       - credentials-binding:1.12


### PR DESCRIPTION
/env is a protected endpoint in later versions of spring boot and using this will cause authentication issues.

given that health will also surface issues like redis connectivity, it should be preferred over credentials and env actuator endpoints