### PR TITLE
[stable/kubernetes-dashboard] Fixed ingress configuration when no hostname provided

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.4.1
+version: 0.4.2
 appVersion: 1.7.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/templates/ingress.yaml
+++ b/stable/kubernetes-dashboard/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
 spec:
   rules:
+  {{- if .Values.ingress.hosts }}
   {{- range .Values.ingress.hosts }}
     - host: {{ . }}
       http:
@@ -24,6 +25,14 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $httpPort }}
+  {{- end -}}
+  {{- else }}
+  - http:
+      paths:
+        - path: /
+          backend:
+            serviceName: {{ $fullName }}
+            servicePort: {{ $httpPort }}
   {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/stable/kubernetes-dashboard/templates/ingress.yaml
+++ b/stable/kubernetes-dashboard/templates/ingress.yaml
@@ -27,12 +27,12 @@ spec:
               servicePort: {{ $httpPort }}
   {{- end -}}
   {{- else }}
-  - http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ $fullName }}
-            servicePort: {{ $httpPort }}
+    - http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $httpPort }}
   {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
Fixed kubernetes-dsahboard creation when no hostname is provided. It will use public ingress service IP to serve the traffic. 

I can also move the dashboard to **/dashboard** if you think it's better place to serve dashboard when IP is used instead of hostname.