### PR TITLE
[incubator/docker-registry] General improvements

### DIFF
--- a/incubator/docker-registry/.helmignore
+++ b/incubator/docker-registry/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/docker-registry/Chart.yaml
+++ b/incubator/docker-registry/Chart.yaml
@@ -1,12 +1,12 @@
-version: 0.2.2
-appVersion: 2
-description: private docker registry
+apiVersion: v1
+description: A Helm chart for Docker Registry
 name: docker-registry
-keywords:
-- docker
-- registry
+version: 0.2.3
+appVersion: 2.6.2
+home: https://hub.docker.com/_/registry/
+icon: https://hub.docker.com/public/images/logos/mini-logo.svg
+sources:
+  - https://github.com/docker/distribution-library-image
 maintainers:
-- name: sbezverk
-  email: sbezverk@cisco.com
-- name: Andrey Arapov
-  email: andrey.arapov@nixaid.com
+  - name: jpds
+email: jpds@protonmail.com

--- a/incubator/docker-registry/Chart.yaml
+++ b/incubator/docker-registry/Chart.yaml
@@ -9,4 +9,4 @@ sources:
   - https://github.com/docker/distribution-library-image
 maintainers:
   - name: jpds
-email: jpds@protonmail.com
+    email: jpds@protonmail.com

--- a/incubator/docker-registry/README.md
+++ b/incubator/docker-registry/README.md
@@ -1,43 +1,43 @@
-# docker-registry Helm Chart
+# Docker Registry Helm Chart
 
-* Installs the [docker-registry cluster addon](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry).
+This directory contains a Kubernetes chart to deploy a private Docker Registry.
+
+## Prerequisites Details
+
+* PV support on underlying infrastructure (if persistence is required)
+
+## Chart Details
+
+This chart will do the following:
+
+* Implement a Docker registry deployment
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release`:
+To install the chart, use the following:
 
-```bash
+```console
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-$ helm install --name my-release incubator/docker-registry
+$ helm install incubator/docker-registry
 ```
 
 ## Configuration
 
-| Parameter               | Description                            | Default             |
-|-------------------------|----------------------------------------|---------------------|
-| `svcName`               | Service name                           | docker-registry     |
-| `nodePort`              | Port from the range 30000-32000        | 30400               |
-| `initialLoad`           | Load tarball with saved registry       | false               |
-| `replicas`              | Number of replicas                     | 1                   |
-| `distro`                | Used to as a part of tarball file name | \<blank>            |
-| `branch`                | Used to as a part of tarball file name | \<blank>            |
-| `initImage`             | Image to use for init container        | centos              |
-| `initImageVersion`      | Image version for init container       | latest              |
-| `registryImage`         | Registry image to use                  | registry            |
-| `registryImageVersion`  | Registry image version to use          | 2                   |
-| `tarballURL`            | URL to tarball location                | \<blank>            |
+The following tables lists the configurable parameters of the vault chart and
+their default values.
 
-## Usage
+|       Parameter            |           Description                       |                         Default                     |
+|----------------------------|---------------------------------------------|-----------------------------------------------------|
+| `image.pullPolicy`         | Container pull policy                       | `IfNotPresent`                                      |
+| `image.repository`         | Container image to use                      | `registry`                                          |
+| `image.tag`                | Container image tag to deploy               | `2.6.2`                                             |
+| `persistence.accessMode    | Access mode to use for PVC                  | `ReadWriteOnce`                                     |
+| `persistence.enabled`      | Whether to use a PVC for the Docker storage | `false`                                             |
+| `persistence.size`         | Amount of space to claim for PVC            | `10Gi`                                              |
+| `persistence.storageClass` | Storage Class to use for PVC                | `-`                                                 |
+| `replicaCount`             | k8s replicas                                | `1`                                                 |
+| `resources.limits.cpu`     | Container requested CPU                     | `nil`                                               |
+| `resources.limits.memory`  | Container requested memory                  | `nil`                                               |
 
-When docker registry is running, you can push and pull containers by using following commands:
-
-To push local docker container to the registry:
-```bash
-$ docker tag {local docker container ID} 127.0.0.1:{node_port}/{local docker image name}
-$ docker push 127.0.0.1:{node_port}/{local docker image name}
-```
-
-To pull a container from the registry:
-```bash
-$ docker pull 127.0.0.1:{node_port}/{container name}
-```
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.

--- a/incubator/docker-registry/templates/NOTES.txt
+++ b/incubator/docker-registry/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "docker-registry.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "docker-registry.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "docker-registry.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "docker-registry.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.port }}
+{{- end }}

--- a/incubator/docker-registry/templates/_helpers.tpl
+++ b/incubator/docker-registry/templates/_helpers.tpl
@@ -1,8 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
 {{- define "docker-registry.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
 {{- define "docker-registry.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" $name .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/incubator/docker-registry/templates/deployment.yaml
+++ b/incubator/docker-registry/templates/deployment.yaml
@@ -3,60 +3,46 @@ kind: Deployment
 metadata:
   name: {{ template "docker-registry.fullname" . }}
   labels:
-    app: {{ template "docker-registry.name" . }} 
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
         app: {{ template "docker-registry.name" . }}
         release: {{ .Release.Name }}
     spec:
-      initContainers:
-      - name: init-myservice
-        image: "{{ .Values.initImage }}:{{ .Values.initImageVersion }}"
-        imagePullPolicy: IfNotPresent
-        command:
-          - /bin/bash
-          - -ec
-          - |
-{{- if .Values.initLoad }}
-            fn='{{ .Values.distro }}-{{ .Values.type }}-registry-{{ .Values.branch }}.tar.gz';
-            echo $fn;
-            curl {{ .Values.tarballURL }}$fn | tar -C /var/lib/registry/ -xzvf -;
-{{- end }}
-            echo Registry is all ready serving images...;
-        volumeMounts:
-        - name: image-store
-          mountPath: /var/lib/registry
       containers:
-      - name: registry
-        image: "{{ .Values.registryImage }}:{{ .Values.registryImageVersion }}"
-        imagePullPolicy: IfNotPresent
-        resources:
-          limits:
-            cpu: 100m
-            memory: 256Mi
-        env:
-        - name: REGISTRY_HTTP_ADDR
-          value: ":4000"
-        - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
-          value: "/var/lib/registry"
-        volumeMounts:
-        - name: image-store
-          mountPath: /var/lib/registry
-        ports:
-        - containerPort: 4000
-          name: registry
-          protocol: TCP
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.port }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/registry/
       volumes:
-      - name: image-store
-      {{- if .Values.persistentVolume.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ if .Values.persistentVolume.existingClaim }}{{ .Values.persistentVolume.existingClaim }}{{- else }}{{ template "docker-registry.fullname" . }}{{- end }}
+        - name: data
+      {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "docker-registry.fullname" . }}
       {{- else }}
-        emptyDir: {}
+          emptyDir: {}
       {{- end -}}

--- a/incubator/docker-registry/templates/ingress.yaml
+++ b/incubator/docker-registry/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "docker-registry.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "docker-registry.fullname" . }}
+  labels:
+    app: {{ template "docker-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/incubator/docker-registry/templates/pvc.yaml
+++ b/incubator/docker-registry/templates/pvc.yaml
@@ -1,30 +1,24 @@
-{{- if .Values.persistentVolume.enabled -}}
-{{- if not .Values.persistentVolume.existingClaim -}}
-apiVersion: v1
+{{- if .Values.persistence.enabled }}
 kind: PersistentVolumeClaim
+apiVersion: v1
 metadata:
-  annotations:
-  {{- if .Values.persistentVolume.annotations }}
-{{ toYaml .Values.persistentVolume.annotations | indent 4 }}
-  {{- end }}
-  labels:
-    app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
   name: {{ template "docker-registry.fullname" . }}
+  labels:
+    app: {{ template "docker-registry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   accessModes:
-{{ toYaml .Values.persistentVolume.accessModes | indent 4 }}
+    - {{ .Values.persistence.accessMode | quote }}
   resources:
     requests:
-      storage: "{{ .Values.persistentVolume.size }}"
-{{- if .Values.persistentVolume.storageClass }}
-{{- if (eq "-" .Values.persistentVolume.storageClass) }}
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+  storageClassName: "{{ .Values.persistence.storageClass }}"
 {{- end }}
 {{- end }}
-{{- end -}}
-{{- end -}}
+{{- end }}

--- a/incubator/docker-registry/templates/service.yaml
+++ b/incubator/docker-registry/templates/service.yaml
@@ -4,16 +4,15 @@ metadata:
   name: {{ template "docker-registry.fullname" . }}
   labels:
     app: {{ template "docker-registry.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
   selector:
     app: {{ template "docker-registry.name" . }}
     release: {{ .Release.Name }}
-  ports:
-  - name: registry
-    port: 4000
-    protocol: TCP
-    nodePort: {{ .Values.nodePort }}
-  type: NodePort

--- a/incubator/docker-registry/values.yaml
+++ b/incubator/docker-registry/values.yaml
@@ -1,26 +1,41 @@
-nodePort: 30400
-initialLoad: false
-replicas: 1
-distro:
-type:
-branch:
-initImage: centos
-initImageVersion: latest
-registryImage: registry
-registryImageVersion: 2
-tarballURL:
-persistentVolume:
+# Default values for docker-registry.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: registry
+  tag: 2.6.2
+  pullPolicy: IfNotPresent
+service:
+  name: registry
+  type: ClusterIP
+  port: 5000
+ingress:
   enabled: false
-  accessModes:
-    - ReadWriteOnce
-  existingClaim: ""
-  size: 20Gi
-  ## docker-registry data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  storageClass: "-"
-  annotations: {}
+  # Used to create an Ingress record.
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+persistence:
+  accessMode: 'ReadWriteOnce'
+  enabled: false
+  size: 10Gi
+  # storageClass: '-'


### PR DESCRIPTION
* Do not use an init container to import a tarball
* Use ingress definition to provide external access to registry.
* Make values.yaml match what `helm create` generates.
* Default port the image uses is `5000`, use that instead.
* `_helpers.tpl` swap variables around to match all other charts,