### PR TITLE
introduce incubator/drone

### DIFF
--- a/incubator/drone/.helmignore
+++ b/incubator/drone/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,0 +1,15 @@
+name: drone
+version: 0.1.0
+description: Drone CI
+keywords:
+- continuous-deployment
+- continuous-integration
+- docker
+- drone
+- drone.io
+- go
+sources:
+- http://readme.drone.io/
+maintainers:
+- name: Matthew Fisher
+  email: mfisher@deis.com

--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,10 @@
 name: drone
+home: https://drone.io/
 version: 0.1.0
+appVersion: 0.8.1
 description: Drone CI
 keywords:
+- continuous-delivery
 - continuous-deployment
 - continuous-integration
 - docker
@@ -9,7 +12,7 @@ keywords:
 - drone.io
 - go
 sources:
-- http://readme.drone.io/
+- https://github.com/drone/drone
 maintainers:
-- name: Matthew Fisher
-  email: mfisher@deis.com
+- name: christian-roggia
+  email: christian.roggia@gmail.com

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -1,0 +1,50 @@
+# Drone.io
+
+[Drone](http://readme.drone.io/) is a Continuous Integration platform built on container technology. Every build is executed inside an ephemeral Docker container, giving developers complete control over their build environment with guaranteed isolation.
+
+## Introduction
+
+This chart stands up a Drone server. This includes:
+
+- A [Drone Server](http://readme.drone.io/admin/installation-guide/) Pod
+- A [Drone Agent](http://readme.drone.io/admin/installation-guide/) Pod
+
+## Prerequisites
+
+- Kubernetes 1.5+
+- The ability to point a DNS entry or URL at your Drone installation
+
+## Installing the Chart
+
+To install the chart, run:
+
+```bash
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm fetch incubator/drone --untar
+$ $EDITOR drone/values.yaml
+```
+
+You will need to specify custom git parameters in order for the drone server to work.
+Please refer to [values.yaml](values.yaml) for the full run-down on how to configure this.
+
+Once it's configured, you can then install drone.
+
+```
+$ helm install ./drone
+```
+
+## Configuration
+
+Please refer to [values.yaml](values.yaml) for the full run-down on defaults. These are a mixture
+of Kubernetes and drone directives.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example,
+
+```bash
+$ helm inspect values incubator/drone > values.yaml
+$ $EDITOR values.yaml # make some changes
+$ helm install -f values.yaml incubator/drone
+```

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -16,12 +16,11 @@ This chart stands up a Drone server. This includes:
 
 ## Installing the Chart
 
-To install the chart, run:
+To install the chart with the release name `my-release`:
 
 ```bash
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-$ helm fetch incubator/drone --untar
-$ $EDITOR drone/values.yaml
+$ helm install --name my-release incubator/drone
 ```
 
 You will need to specify custom git parameters in order for the drone server to work.
@@ -35,16 +34,6 @@ $ helm install ./drone
 
 ## Configuration
 
-Please refer to [values.yaml](values.yaml) for the full run-down on defaults. These are a mixture
-of Kubernetes and drone directives.
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
-
-Alternatively, a YAML file that specifies the values for the parameters can be provided while
-installing the chart. For example,
-
-```bash
-$ helm inspect values incubator/drone > values.yaml
-$ $EDITOR values.yaml # make some changes
-$ helm install -f values.yaml incubator/drone
-```
+The following tables lists the configurable parameters of the drone charts and their default values.
+|              Parameter               |                             Description                             |               Default                |
+| ------------------------------------ | ------------------------------------------------------------------- | ------------------------------------ |

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -1,39 +1,54 @@
 # Drone.io
 
-[Drone](http://readme.drone.io/) is a Continuous Integration platform built on container technology. Every build is executed inside an ephemeral Docker container, giving developers complete control over their build environment with guaranteed isolation.
+[Drone](http://readme.drone.io/) is a Continuous Integration platform built on container technology.
 
-## Introduction
+## TL;DR;
 
-This chart stands up a Drone server. This includes:
-
-- A [Drone Server](http://readme.drone.io/admin/installation-guide/) Pod
-- A [Drone Agent](http://readme.drone.io/admin/installation-guide/) Pod
-
-## Prerequisites
-
-- Kubernetes 1.5+
-- The ability to point a DNS entry or URL at your Drone installation
+```console
+$ helm install incubator/drone
+```
 
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:
 
-```bash
-$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+```console
 $ helm install --name my-release incubator/drone
 ```
 
-You will need to specify custom git parameters in order for the drone server to work.
-Please refer to [values.yaml](values.yaml) for the full run-down on how to configure this.
+## Uninstalling the Chart
 
-Once it's configured, you can then install drone.
+To uninstall/delete the `my-release` deployment:
 
+```console
+$ helm delete my-release
 ```
-$ helm install ./drone
-```
+
+The command removes nearly all the Kubernetes components associated with the
+chart and deletes the release.
 
 ## Configuration
 
 The following tables lists the configurable parameters of the drone charts and their default values.
-|              Parameter               |                             Description                             |               Default                |
-| ------------------------------------ | ------------------------------------------------------------------- | ------------------------------------ |
+
+| Parameter               | Description                                                                                   | Default                 |
+|-------------------------|-----------------------------------------------------------------------------------------------|-------------------------|
+| `image.repository`      | Drone **server** image                                                                        | `docker.io/drone/drone` |
+| `image.tag`             | Drone **server** image tag                                                                    | `0.8.1`                 |
+| `image.pullPolicy`      | Drone **server** image pull policy                                                            | `IfNotPresent`          |
+| `agentImage.repository` | Drone **agent** image                                                                         | `docker.io/drone/agent` |
+| `agentImage.tag`        | Drone **agent** image tag                                                                     | `0.8.1`                 |
+| `agentImage.pullPolicy` | Drone **agent** image pull policy                                                             | `IfNotPresent`          |
+| `service.httpPort`      | Drone's Web GUI HTTP port                                                                     | `80`                    |
+| `service.nodePort`      | If `service.type` is `NodePort` and this is non-empty, sets the http node port of the service | `32015`                 |
+| `service.type`          | Service type (ClusterIP, NodePort or LoadBalancer)                                            | `ClusterIP`             |
+| `ingress.enabled`       | Enables Ingress for Drone                                                                     | `false`                 |
+| `ingress.annotations`   | Ingress annotations                                                                           | `{}`                    |
+| `ingress.hosts`         | Ingress accepted hostnames                                                                    | `nil`                   |
+| `ingress.tls`           | Ingress TLS configuration                                                                     | `[]`                    |
+| `server.host`           | Drone **server** hostname                                                                     | `(internal hostname)`   |
+| `server.env`            | Drone **server** environment variables                                                        | `(default values)`      |
+| `server.resources`      | Drone **server** pod resource requests & limits                                               | `{}`                    |
+| `agent.env`             | Drone **agent** environment variables                                                         | `(default values)`      |
+| `agent.resources`       | Drone **agent** pod resource requests & limits                                                | `{}`                    |
+| `shared_secret`         | Drone server and agent shared secret                                                          | `(random value)`        |

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -51,4 +51,4 @@ The following tables lists the configurable parameters of the drone charts and t
 | `server.resources`      | Drone **server** pod resource requests & limits                                               | `{}`                    |
 | `agent.env`             | Drone **agent** environment variables                                                         | `(default values)`      |
 | `agent.resources`       | Drone **agent** pod resource requests & limits                                                | `{}`                    |
-| `shared_secret`         | Drone server and agent shared secret                                                          | `(random value)`        |
+| `sharedSecret`         | Drone server and agent shared secret                                                          | `(random value)`        |

--- a/incubator/drone/templates/NOTES.txt
+++ b/incubator/drone/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get your Drone URL by running:
+
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:{{ .Values.service.http.externalPort }}/
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.http.externalPort }}/
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc -w {{ template "fullname" . }}'
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}-server" -o jsonpath="{.items[0].metadata.name}")
+  kubectl port-forward $POD_NAME {{ .Values.service.http.internalPort }}
+  echo http://127.0.0.1:{{ .Values.service.http.internalPort }}/
+{{- end }}

--- a/incubator/drone/templates/NOTES.txt
+++ b/incubator/drone/templates/NOTES.txt
@@ -1,17 +1,64 @@
-1. Get your Drone URL by running:
+{{- if hasKey .Values.server.env "DRONE_PROVIDER" }}
+*********************************************************************************
+***        PLEASE BE PATIENT: drone may take a few minutes to install         ***
+*********************************************************************************
 
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:{{ .Values.service.http.externalPort }}/
+{{- if .Values.ingress.enabled }}
+From outside the cluster, the server URL(s) are:
+{{- range .Values.ingress.hosts }}
+     http://{{ . }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+Get the Drone URL by running:
+  export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "drone.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.http.externalPort }}/
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc -w {{ template "fullname" . }}'
-{{- else if contains "ClusterIP"  .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}-server" -o jsonpath="{.items[0].metadata.name}")
-  kubectl port-forward $POD_NAME {{ .Values.service.http.internalPort }}
-  echo http://127.0.0.1:{{ .Values.service.http.internalPort }}/
+        Watch the status with: 'kubectl get svc -w {{ template "drone.fullname" . }}'
+
+Get the Drone URL by running:
+  export SERVICE_IP=$(kubectl get svc {{ template "drone.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP/
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+Get the Drone URL by running:
+  export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app={{ template "drone.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8000/
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8000:8000
+{{- end }}
+{{- else -}}
+##############################################################################
+####        ERROR: You did not set a valid version control provider       ####
+##############################################################################
+
+This deployment will be incomplete until you configure a valid version
+control provider:
+
+    helm upgrade {{ .Release.Name }} \
+      --set server.env.DRONE_PROVIDER="github" \
+      --set server.env.DRONE_GITHUB="true" \
+      --set server.env.DRONE_ORGS="my-github-org" \
+      --set server.env.DRONE_GITHUB_CLIENT="github-oauth2-client-id" \
+      --set server.env.DRONE_GITHUB_SECRET="github-oauth2-client-secret" \
+      incubator/drone
+
+Currently supported providers:
+
+    - GitHub
+    - GitLab
+    - Gitea
+    - Gogs
+    - Bitbucket Cloud
+    - Bitbucket Server (Stash)
+    - Coding
+
+If you are having trouble with the configuration of a provider please visit
+the official documentation:
+
+    http://docs.drone.io/installation/
 {{- end }}

--- a/incubator/drone/templates/NOTES.txt
+++ b/incubator/drone/templates/NOTES.txt
@@ -40,6 +40,7 @@ This deployment will be incomplete until you configure a valid version
 control provider:
 
     helm upgrade {{ .Release.Name }} \
+      --reuse-values \
       --set server.env.DRONE_PROVIDER="github" \
       --set server.env.DRONE_GITHUB="true" \
       --set server.env.DRONE_ORGS="my-github-org" \

--- a/incubator/drone/templates/_helpers.tpl
+++ b/incubator/drone/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 -}}
+{{- end -}}

--- a/incubator/drone/templates/_helpers.tpl
+++ b/incubator/drone/templates/_helpers.tpl
@@ -2,15 +2,14 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 -}}
-{{- end -}}
+{{ define "drone.name" }}{{ default "drone" .Values.nameOverride | trunc 63 }}{{ end }}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 -}}
-{{- end -}}
+{{ define "drone.fullname" }}
+{{- $name := default "drone" .Values.nameOverride -}}
+{{ printf "%s-%s" .Release.Name $name | trunc 63 -}}
+{{ end }}

--- a/incubator/drone/templates/deployment-agent.yaml
+++ b/incubator/drone/templates/deployment-agent.yaml
@@ -1,0 +1,54 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-agent
+  labels:
+    app: {{ template "fullname" . }}-agent
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}-agent
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}-agent
+        image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - "agent"
+        env:
+          - name: DRONE_SERVER
+            value: ws://{{ template "fullname" . }}/ws/broker
+          - name: DRONE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: secret
+          - name: DOCKER_HOST
+            value: tcp://localhost:2375
+          {{ range $key, $value := .Values.agent.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{ end }}
+        resources:
+{{ toYaml .Values.agent.resources | indent 10 }}
+      - name: {{ template "fullname" . }}-dind
+        image: docker:17.05.0-ce-dind
+        env:
+        - name: DOCKER_DRIVER
+          value: overlay
+        securityContext:
+            privileged: true
+        volumeMounts:
+          - name: docker-graph-storage
+            mountPath: /var/lib/docker
+      volumes:
+      - name: docker-graph-storage
+        emptyDir: {}

--- a/incubator/drone/templates/deployment-agent.yaml
+++ b/incubator/drone/templates/deployment-agent.yaml
@@ -3,19 +3,19 @@ kind: Deployment
 metadata:
   name: {{ template "drone.fullname" . }}-agent
   labels:
-    app: {{ template "drone.fullname" . }}-agent
+    app: {{ template "drone.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    component: agent
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: {{ template "drone.fullname" . }}-agent
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        app: {{ template "drone.name" . }}
         release: "{{ .Release.Name }}"
-        heritage: "{{ .Release.Service }}"
+        component: agent
     spec:
       containers:
       - name: {{ template "drone.fullname" . }}-agent

--- a/incubator/drone/templates/deployment-agent.yaml
+++ b/incubator/drone/templates/deployment-agent.yaml
@@ -23,7 +23,7 @@ spec:
         imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
         env:
           - name: DRONE_SERVER
-            value: ws://{{ template "drone.fullname" . }}/ws/broker
+            value: {{ template "drone.fullname" . }}:9000
           - name: DRONE_SECRET
             valueFrom:
               secretKeyRef:

--- a/incubator/drone/templates/deployment-agent.yaml
+++ b/incubator/drone/templates/deployment-agent.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-agent
+  name: {{ template "drone.fullname" . }}-agent
   labels:
-    app: {{ template "fullname" . }}-agent
+    app: {{ template "drone.fullname" . }}-agent
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -12,24 +12,22 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}-agent
+        app: {{ template "drone.fullname" . }}-agent
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
       containers:
-      - name: {{ template "fullname" . }}-agent
-        image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args:
-          - "agent"
+      - name: {{ template "drone.fullname" . }}-agent
+        image: "{{ .Values.agentImage.repository }}:{{ .Values.agentImage.tag }}"
+        imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
         env:
           - name: DRONE_SERVER
-            value: ws://{{ template "fullname" . }}/ws/broker
+            value: ws://{{ template "drone.fullname" . }}/ws/broker
           - name: DRONE_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "fullname" . }}
+                name: {{ template "drone.fullname" . }}
                 key: secret
           - name: DOCKER_HOST
             value: tcp://localhost:2375
@@ -39,7 +37,7 @@ spec:
           {{ end }}
         resources:
 {{ toYaml .Values.agent.resources | indent 10 }}
-      - name: {{ template "fullname" . }}-dind
+      - name: {{ template "drone.fullname" . }}-dind
         image: docker:17.05.0-ce-dind
         env:
         - name: DOCKER_DRIVER

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-server
+  labels:
+    app: {{ template "fullname" . }}-server
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}-server
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}-server
+        image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: DRONE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "fullname" . }}
+                key: secret
+          {{ range $key, $value := .Values.server.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{ end }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.http.internalPort }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+        resources:
+{{ toYaml .Values.server.resources | indent 10 }}

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -4,19 +4,19 @@ kind: Deployment
 metadata:
   name: {{ template "drone.fullname" . }}-server
   labels:
-    app: {{ template "drone.fullname" . }}-server
+    app: {{ template "drone.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    component: server
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: {{ template "drone.fullname" . }}-server
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        app: {{ template "drone.name" . }}
         release: "{{ .Release.Name }}"
-        heritage: "{{ .Release.Service }}"
+        component: server
     spec:
       containers:
       - name: {{ template "drone.fullname" . }}-server

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -42,6 +42,9 @@ spec:
         - name: http
           containerPort: 8000
           protocol: TCP
+        - name: grpc
+          containerPort: 9000
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -1,9 +1,10 @@
+{{- if hasKey .Values.server.env "DRONE_PROVIDER" }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-server
+  name: {{ template "drone.fullname" . }}-server
   labels:
-    app: {{ template "fullname" . }}-server
+    app: {{ template "drone.fullname" . }}-server
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -12,31 +13,39 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}-server
+        app: {{ template "drone.fullname" . }}-server
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
       containers:
-      - name: {{ template "fullname" . }}-server
-        image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+      - name: {{ template "drone.fullname" . }}-server
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: DRONE_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ template "fullname" . }}
+                name: {{ template "drone.fullname" . }}
                 key: secret
+          - name: DRONE_HOST
+          {{- if hasKey .Values.server "host" }}
+            value: {{ .Values.server.host }}
+          {{- else }}
+            value: {{ template "drone.fullname" . }}
+          {{- end }}
           {{ range $key, $value := .Values.server.env }}
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{ end }}
         ports:
         - name: http
-          containerPort: {{ .Values.service.http.internalPort }}
-        readinessProbe:
+          containerPort: 8000
+          protocol: TCP
+        livenessProbe:
           httpGet:
             path: /
             port: http
         resources:
 {{ toYaml .Values.server.resources | indent 10 }}
+{{ end }}

--- a/incubator/drone/templates/ingress.yaml
+++ b/incubator/drone/templates/ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.hostname }}
+    secretName: {{ template "fullname" . }}-tls
+{{- end }}
+  rules:
+  - host: {{ .Values.ingress.hostname }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: {{ .Values.service.http.externalPort }}
+{{- end -}}

--- a/incubator/drone/templates/ingress.yaml
+++ b/incubator/drone/templates/ingress.yaml
@@ -1,28 +1,32 @@
 {{- if .Values.ingress.enabled -}}
+{{- $fullName := include "drone.fullname" . }}
+{{- $httpPort := .Values.service.httpPort }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}
-  labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+    app: {{ template "drone.name" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  name: {{ template "drone.fullname" . }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  - hosts:
-    - {{ .Values.ingress.hostname }}
-    secretName: {{ template "fullname" . }}-tls
-{{- end }}
   rules:
-  - host: {{ .Values.ingress.hostname }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ template "fullname" . }}
-          servicePort: {{ .Values.service.http.externalPort }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $httpPort }}
+  {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
 {{- end -}}

--- a/incubator/drone/templates/secrets.yaml
+++ b/incubator/drone/templates/secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if .Values.shared_secret }}
+  secret: "{{ .Values.shared_secret | b64enc }}"
+  {{ else }}
+  secret: "{{ randAlphaNum 24 | b64enc }}"
+  {{ end }}

--- a/incubator/drone/templates/secrets.yaml
+++ b/incubator/drone/templates/secrets.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ template "drone.fullname" . }}
   labels:
-    app: {{ template "drone.fullname" . }}
+    app: {{ template "drone.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/incubator/drone/templates/secrets.yaml
+++ b/incubator/drone/templates/secrets.yaml
@@ -9,8 +9,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  {{ if .Values.shared_secret }}
-  secret: "{{ .Values.shared_secret | b64enc }}"
+  {{ if .Values.sharedSecret }}
+  secret: "{{ .Values.sharedSecret | b64enc }}"
   {{ else }}
   secret: "{{ randAlphaNum 24 | b64enc }}"
   {{ end }}

--- a/incubator/drone/templates/secrets.yaml
+++ b/incubator/drone/templates/secrets.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "drone.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "drone.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/incubator/drone/templates/service.yaml
+++ b/incubator/drone/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.http.externalPort }}
+    targetPort: {{ .Values.service.http.internalPort }}
+  selector:
+    app: {{ template "fullname" . }}-server

--- a/incubator/drone/templates/service.yaml
+++ b/incubator/drone/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "drone.fullname" . }}
   labels:
-    app: {{ template "drone.fullname" . }}
+    app: {{ template "drone.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -20,5 +20,6 @@ spec:
     port: 9000
     targetPort: 9000
   selector:
-    app: {{ template "drone.fullname" . }}-server
+    app: {{ template "drone.name" . }}
     release: {{ .Release.Name | quote }}
+    component: server

--- a/incubator/drone/templates/service.yaml
+++ b/incubator/drone/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "drone.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "drone.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -11,7 +11,11 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - name: http
-    port: {{ .Values.service.http.externalPort }}
-    targetPort: {{ .Values.service.http.internalPort }}
+    port: {{ .Values.service.httpPort }}
+    targetPort: 8000
+{{- if hasKey .Values.service "nodePort" }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
   selector:
-    app: {{ template "fullname" . }}-server
+    app: {{ template "drone.fullname" . }}-server
+    release: {{ .Release.Name | quote }}

--- a/incubator/drone/templates/service.yaml
+++ b/incubator/drone/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
 {{- if hasKey .Values.service "nodePort" }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
+  - name: grpc
+    port: 9000
+    targetPort: 9000
   selector:
     app: {{ template "drone.fullname" . }}-server
     release: {{ .Release.Name | quote }}

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -58,7 +58,7 @@ ingress:
 server:
   ## If not set, it will be autofilled with the cluster host.
   ##
-  # host: "drone.domain.io"
+  # host: "https://drone.domain.io"
 
   ## Drone server configuration.
   ## Values in here get injected as environment variables.

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -112,4 +112,4 @@ agent:
 ## Uncomment this if you want to set a specific shared secret between
 ## the agents and servers, otherwise this will be auto-generated.
 ##
-# shared_secret: supersecret
+# sharedSecret: supersecret

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -1,38 +1,88 @@
+appVersion: "0.8.1"
+
+## The official drone image, change tag to use a different version.
+## https://hub.docker.com/r/drone/drone/tags/
+##
 image:
-  registry: docker.io
-  org: drone
-  name: drone
-  tag: 0.5
-  pullPolicy: IfNotPresent
+  repository: "docker.io/drone/drone"
+  tag: "0.8.1"
+  pullPolicy: "IfNotPresent"
+
+## Since version 8.x drone splitted agent and server into two
+## different images.
+##
+## NOTE: Older versions of drone are **not** supported.
+## https://hub.docker.com/r/drone/agent/tags/
+##
+agentImage:
+  repository: "docker.io/drone/agent"
+  tag: "0.8.1"
+  pullPolicy: "IfNotPresent"
 
 service:
-  http:
-    externalPort: 80
-    internalPort: 8000
+  httpPort: 80
+
+  ## If service.type is not set to NodePort, the following statement
+  ## will be ignored.
+  ##
+  # nodePort: 32015
+
+  ## Service type can be set to ClusterIP, NodePort or LoadBalancer.
+  ##
   type: ClusterIP
 
 ingress:
+  ## If true, Drone Ingress will be created.
+  ##
   enabled: false
-  # enable TLS via kube-lego
-  tls: false
-  hostname: drone.example.com
+
+  ## Drone Ingress annotations
+  ##
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: 'true'
+
+  ## Drone hostnames must be provided if Ingress is enabled
+  ##
+  # hosts:
+  #   - drone.domain.io
+
+  ## Drone Ingress TLS configuration secrets
+  ## Must be manually created in the namespace
+  ##
+  # tls:
+  #   - secretName: drone-tls
+  #     hosts:
+  #       - drone.domain.io
 
 server:
-  # Drone server configuration. Values in here get injected as environment variables.
-  # See http://readme.drone.io/admin/installation-reference#server-options for a list of possible values.
+  ## If not set, it will be autofilled with the cluster host.
+  ##
+  # host: "drone.domain.io"
+
+  ## Drone server configuration.
+  ## Values in here get injected as environment variables.
+  ## http://readme.drone.io/admin/installation-reference
+  ##
   env:
     DRONE_DEBUG: "false"
     DRONE_DATABASE_DRIVER: "sqlite3"
     DRONE_DATABASE_DATASOURCE: "drone.sqlite"
-    # Drone requires some environment variables to bootstrap the git service or it won't start up.
-    # Uncomment this and add your own custom configuration.
-    #
-    # See http://readme.drone.io/admin/installation-reference/ for more info on these envvars.
-    #DRONE_OPEN: "true"
-    #DRONE_GITHUB: "true"
-    #DRONE_ORGS: "my-github-org,my-other-github-org"
-    #DRONE_GITHUB_CLIENT: "github-oauth2-client-id"
-    #DRONE_GITHUB_SECRET: "github-oauth2-client-secret"
+
+    ## Drone requires some environment variables to bootstrap the
+    ## git service or it won't start up.
+    ## Uncomment this and add your own custom configuration.
+    ##
+    # DRONE_PROVIDER: "github"
+    # DRONE_OPEN: "true"
+    # DRONE_GITHUB: "true"
+    # DRONE_ORGS: "my-github-org,my-other-github-org"
+    # DRONE_ADMIN:"admin-1,admin-2"
+    # DRONE_GITHUB_CLIENT: "github-oauth2-client-id"
+    # DRONE_GITHUB_SECRET: "github-oauth2-client-secret"
+
+  ## CPU and memory limits for drone server
+  ##
   resources:
     requests:
       memory: 32Mi
@@ -42,10 +92,15 @@ server:
       cpu: 1
 
 agent:
-  # Drone agent configuration. Values in here get injected as environment variables.
-  # See http://readme.drone.io/admin/installation-reference#server-options for a list of possible values.
+  ## Drone agent configuration.
+  ## Values in here get injected as environment variables.
+  ## http://readme.drone.io/admin/installation-reference
+  ##
   env:
     DRONE_DEBUG: "false"
+
+  ## CPU and memory limits for drone agent
+  ##
   resources:
     requests:
       memory: 32Mi
@@ -54,6 +109,7 @@ agent:
       memory: 2Gi
       cpu: 1
 
-# Uncomment this if you want to set a specific shared secret between
-# the agents and servers, otherwise this will be auto-generated.
-#shared_secret: supersecret
+## Uncomment this if you want to set a specific shared secret between
+## the agents and servers, otherwise this will be auto-generated.
+##
+# shared_secret: supersecret

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -1,0 +1,59 @@
+image:
+  registry: docker.io
+  org: drone
+  name: drone
+  tag: 0.5
+  pullPolicy: IfNotPresent
+
+service:
+  http:
+    externalPort: 80
+    internalPort: 8000
+  type: ClusterIP
+
+ingress:
+  enabled: false
+  # enable TLS via kube-lego
+  tls: false
+  hostname: drone.example.com
+
+server:
+  # Drone server configuration. Values in here get injected as environment variables.
+  # See http://readme.drone.io/admin/installation-reference#server-options for a list of possible values.
+  env:
+    DRONE_DEBUG: "false"
+    DRONE_DATABASE_DRIVER: "sqlite3"
+    DRONE_DATABASE_DATASOURCE: "drone.sqlite"
+    # Drone requires some environment variables to bootstrap the git service or it won't start up.
+    # Uncomment this and add your own custom configuration.
+    #
+    # See http://readme.drone.io/admin/installation-reference/ for more info on these envvars.
+    #DRONE_OPEN: "true"
+    #DRONE_GITHUB: "true"
+    #DRONE_ORGS: "my-github-org,my-other-github-org"
+    #DRONE_GITHUB_CLIENT: "github-oauth2-client-id"
+    #DRONE_GITHUB_SECRET: "github-oauth2-client-secret"
+  resources:
+    requests:
+      memory: 32Mi
+      cpu: 40m
+    limits:
+      memory: 2Gi
+      cpu: 1
+
+agent:
+  # Drone agent configuration. Values in here get injected as environment variables.
+  # See http://readme.drone.io/admin/installation-reference#server-options for a list of possible values.
+  env:
+    DRONE_DEBUG: "false"
+  resources:
+    requests:
+      memory: 32Mi
+      cpu: 40m
+    limits:
+      memory: 2Gi
+      cpu: 1
+
+# Uncomment this if you want to set a specific shared secret between
+# the agents and servers, otherwise this will be auto-generated.
+#shared_secret: supersecret

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -83,13 +83,13 @@ server:
 
   ## CPU and memory limits for drone server
   ##
-  resources:
-    requests:
-      memory: 32Mi
-      cpu: 40m
-    limits:
-      memory: 2Gi
-      cpu: 1
+  resources: {}
+  #  requests:
+  #    memory: 32Mi
+  #    cpu: 40m
+  #  limits:
+  #    memory: 2Gi
+  #    cpu: 1
 
 agent:
   ## Drone agent configuration.
@@ -101,13 +101,13 @@ agent:
 
   ## CPU and memory limits for drone agent
   ##
-  resources:
-    requests:
-      memory: 32Mi
-      cpu: 40m
-    limits:
-      memory: 2Gi
-      cpu: 1
+  resources: {}
+  #  requests:
+  #    memory: 32Mi
+  #    cpu: 40m
+  #  limits:
+  #    memory: 2Gi
+  #    cpu: 1
 
 ## Uncomment this if you want to set a specific shared secret between
 ## the agents and servers, otherwise this will be auto-generated.


### PR DESCRIPTION
This is a continuation of the PRs https://github.com/kubernetes/charts/pull/821 and https://github.com/kubernetes/charts/pull/353.

TODO:

- [x] upgrade to version 0.8.1
- [x] standardize source to helm 2.7
- [x] test service.type=ClusterIP
- [x] test service.type=NodePort
- [x] test service.type=LoadBalancer
- [x] test ingress
- [x] test bare install
- [x] test source control provider installation
- [x] README

The Chart has been tested on a cluster configured via kubeadm with niginx-ingress installed and configured. The cluster version is 1.8.2. This cluster was installed on bare metal (Ubuntu 16.04) and unfortunately I do not have access to a LoadBalancer right now.

If you can contribute to the Chart by testing it on your cluster with different configurations and report if everything is working correctly it would be really appreciated.

Also, I really need help with the README, if anyone can improve it please let me know.