### PR TITLE
[stable/spinnaker] bump dependencies to 1.3.1

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.3.8
+version: 0.4.0
 appVersion: 1.3.1
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.3.7
-appVersion: 1.1.0
+version: 0.3.8
+appVersion: 1.3.1
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -36,14 +36,14 @@ slack:
 
 # Images for each component
 images:
-  clouddriver: gcr.io/spinnaker-marketplace/clouddriver:0.5.0-72
-  echo: gcr.io/spinnaker-marketplace/echo:0.4.0-72
-  deck: gcr.io/spinnaker-marketplace/deck:1.3.0-72
-  igor: gcr.io/spinnaker-marketplace/igor:0.4.0-72
-  orca: gcr.io/spinnaker-marketplace/orca:0.5.0-72
-  gate: gcr.io/spinnaker-marketplace/gate:0.5.0-72
-  front50: gcr.io/spinnaker-marketplace/front50:0.4.1-72
-  rosco: gcr.io/spinnaker-marketplace/rosco:0.4.0-72
+  clouddriver: gcr.io/spinnaker-marketplace/clouddriver:0.7.1-20170918142556
+  echo: gcr.io/spinnaker-marketplace/echo:0.5.0-20170918142556
+  deck: gcr.io/spinnaker-marketplace/deck:1.5.0-20170918142556
+  igor: gcr.io/spinnaker-marketplace/igor:0.6.0-20170918142556
+  orca: gcr.io/spinnaker-marketplace/orca:0.7.0-20170918142556
+  gate: gcr.io/spinnaker-marketplace/gate:0.7.1-20170918142556
+  front50: gcr.io/spinnaker-marketplace/front50:0.6.0-20170918142556
+  rosco: gcr.io/spinnaker-marketplace/rosco:0.4.2-20170918142556
 
 # Change this if youd like to expose Spinnaker outside the cluster
 deck:


### PR DESCRIPTION
Bumps spinnaker to version 1.3.1. https://www.spinnaker.io/community/releases/versions/1-3-1-changelog . 

There are currently issues with minio integration and version 1.4.2 (https://github.com/spinnaker/spinnaker/issues/1988) so 1.3.1  is the latest version that works with the current setup in the helm charts.