### PR TITLE
Fix indentation to allow for persitence being disabled

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 0.1.0
+version: 0.1.1
 appVersion: 3.5.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/deployment.yaml
+++ b/stable/sonatype-nexus/templates/deployment.yaml
@@ -44,10 +44,10 @@ spec:
             - mountPath: /nexus-data
               name: nexus-data-volume
       volumes:
-      - name: nexus-data-volume
-        {{- if .Values.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
-        {{- else }}
+        - name: nexus-data-volume
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "fullname" . }}
+          {{- else }}
           emptyDir: {}
-        {{- end -}}
+          {{- end -}}


### PR DESCRIPTION
In the current deployment.yaml file, the else statement for persistentVolumes will fail if you pass a values.yaml file that disables persistence. Increasing the indentation as done in this PR resolves this.

How to test?
Modify the values.yaml file and disable the persistence value, or pass it in as a command line param.