### PR TITLE
[stable/datadog] Fix volumes/volumeMounts typo in example values

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.8.3
+version: 0.8.4
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -97,11 +97,11 @@ datadog:
   ## or deployment.
   ## ref: https://docs.datadoghq.com/guides/process/
   ##
-  # volume:
+  # volumes:
   #  - hostPath:
   #      path: /etc/passwd
   #    name: passwd
-  # volumeMount:
+  # volumeMounts:
   #   - name: passwd
   #     mountPath: /etc/passwd
   #     readOnly: true

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -78,7 +78,7 @@ datadog:
   ## Enables event collection from the kubernetes API
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
   ##
-  collectEvents: False
+  collectEvents: false
 
   ## Un-comment this to enable APM and tracing, on ports 7777 and 8126
   ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host


### PR DESCRIPTION
The chart looks for values named `volumes` and `volumeMounts`.