### PR TITLE
[stable/nginx-ingress] Enable configuration of default SSL certificate

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.9
+version: 0.8.10
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -52,6 +52,7 @@ Parameter | Description | Default
 `controller.config` | nginx ConfigMap entries | none
 `controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace | false
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
+`controller.defaultSSLCertificate` | catch-all SSL certificate which do not match any of the configured server names. Defaults to self signed certificate | `""`
 `controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
 `controller.ingressClass` | name of the ingress class to route through this controller | `nginx`
 `controller.scope.enabled` | limit the scope of the ingress controller | `false` (watch all namespaces)

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -56,6 +56,9 @@ spec:
           {{- if .Values.controller.scope.enabled }}
             - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
           {{- end }}
+          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.defaultSSLCertificate }}
+            - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
+          {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
             {{- if $value }}
             - --{{ $key }}={{ $value }}


### PR DESCRIPTION
This option was added #1235 by @jsulinski, but as best as I can tell, `defaultSSLCertificate` was not wired up.

cc the reviewers @jackzampolin, @mgoodness, and @chancez