### PR TITLE
[stable/jenkins] Allow extra hosts and paths in ingress

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.9.0
+version: 0.9.1
 appVersion: 2.67
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -47,6 +47,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |
 | `Master.CustomConfigMap`          | Use a custom ConfigMap               | `false`                                                                      |
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
+| `Master.Ingress.Hosts`            | Ingress hosts                        | `[]`                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
 | `Master.InstallPlugins`           | List of Jenkins plugins to install   | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |

--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -3,7 +3,7 @@
 
 {{- if .Values.Master.Ingress.Hosts }}
 
-2. Visit http://{{ .Values.Master.Ingress.Hosts[0] }}
+2. Visit http://{{ index .Values.Master.Ingress.Hosts 0 }}
 {{- else }}
 2. Get the Jenkins URL to visit by running these commands in the same shell:
 {{- if contains "NodePort" .Values.Master.ServiceType }}

--- a/stable/jenkins/templates/NOTES.txt
+++ b/stable/jenkins/templates/NOTES.txt
@@ -1,9 +1,9 @@
 1. Get your '{{ .Values.Master.AdminUser }}' user password by running:
   printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
 
-{{- if .Values.Master.HostName }}
+{{- if .Values.Master.Ingress.Hosts }}
 
-2. Visit http://{{ .Values.Master.HostName }}
+2. Visit http://{{ .Values.Master.Ingress.Hosts[0] }}
 {{- else }}
 2. Get the Jenkins URL to visit by running these commands in the same shell:
 {{- if contains "NodePort" .Values.Master.ServiceType }}

--- a/stable/jenkins/templates/home-pvc.yaml
+++ b/stable/jenkins/templates/home-pvc.yaml
@@ -2,6 +2,10 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
+{{- if .Values.Persistence.Annotations }}
+  annotations:
+{{ toYaml .Values.Persistence.Annotations | indent 4 }}
+{{- end }}
   name: {{ template "jenkins.fullname" . }}
   labels:
     app: {{ template "jenkins.fullname" . }}

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.Master.Ingress.Hosts }}
 {{- $serviceName := include "jenkins.fullname" . }}
-{{- $servicePort := .Values.Master.ServicePort -}}
+{{- $servicePort := .Values.Master.ServicePort }}
 apiVersion: {{ .Values.NetworkPolicy.ApiVersion }}
 kind: Ingress
 metadata:
@@ -17,21 +17,27 @@ spec:
       paths:
       {{- if .paths }}
         {{- range .paths }}
+          {{- if .backend }}
       - backend:
           serviceName: {{ .backend.serviceName | default $serviceName | quote }}
           servicePort: {{ .backend.servicePort | default $servicePort }}
+          {{- else }}
+      - backend:
+          serviceName: {{ $serviceName | quote }}
+          servicePort: {{ $servicePort }}
+          {{- end }}
           {{- if .path }}
         path: {{ .path | quote }}
-          {{- end -}}
-        {{- end -}}
+          {{- end }}
+        {{- end }}
       {{- else }}
       - backend:
           serviceName: {{ $serviceName | quote }}
           servicePort: {{ $servicePort }}
-      {{- end -}}
-  {{- end -}}
+      {{- end }}
+  {{- end }}
 {{- if .Values.Master.Ingress.TLS }}
   tls:
 {{ toYaml .Values.Master.Ingress.TLS | indent 4 }}
-{{- end -}}
+{{- end }}
 {{- end }}

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.Master.HostName }}
+{{- if .Values.Master.Ingress.Hosts }}
+{{- $serviceName := include "jenkins.fullname" . }}
+{{- $servicePort := .Values.Master.ServicePort -}}
 apiVersion: {{ .Values.NetworkPolicy.ApiVersion }}
 kind: Ingress
 metadata:
@@ -9,12 +11,25 @@ metadata:
   name: {{ template "jenkins.fullname" . }}
 spec:
   rules:
-  - host: {{ .Values.Master.HostName | quote }}
+  {{- range .Values.Master.Ingress.Hosts }}
+  - host: {{ .name | quote }}
     http:
       paths:
+      {{- if .paths }}
+        {{- range .paths }}
       - backend:
-          serviceName: {{ template "jenkins.fullname" . }}
-          servicePort: {{ .Values.Master.ServicePort }}
+          serviceName: {{ .backend.serviceName | default $serviceName | quote }}
+          servicePort: {{ .backend.servicePort | default $servicePort }}
+          {{- if .path }}
+        path: {{ .path | quote }}
+          {{- end -}}
+        {{- end -}}
+      {{- else }}
+      - backend:
+          serviceName: {{ $serviceName | quote }}
+          servicePort: {{ $servicePort }}
+      {{- end -}}
+  {{- end -}}
 {{- if .Values.Master.Ingress.TLS }}
   tls:
 {{ toYaml .Values.Master.Ingress.TLS | indent 4 }}

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -15,27 +15,21 @@ spec:
   - host: {{ .name | quote }}
     http:
       paths:
-      {{- if .paths }}
-        {{- range .paths }}
-          {{- if .backend }}
+      {{- if .paths }}{{- range .paths }}{{- if .backend }}
       - backend:
           serviceName: {{ .backend.serviceName | default $serviceName | quote }}
           servicePort: {{ .backend.servicePort | default $servicePort }}
-          {{- else }}
-      - backend:
-          serviceName: {{ $serviceName | quote }}
-          servicePort: {{ $servicePort }}
-          {{- end }}
-          {{- if .path }}
-        path: {{ .path | quote }}
-          {{- end }}
-        {{- end }}
       {{- else }}
       - backend:
           serviceName: {{ $serviceName | quote }}
           servicePort: {{ $servicePort }}
-      {{- end }}
-  {{- end }}
+      {{- end }}{{- if .path }}
+        path: {{ .path | quote }}
+      {{- end }}{{- end }}{{- else }}
+      - backend:
+          serviceName: {{ $serviceName | quote }}
+          servicePort: {{ $servicePort }}
+  {{- end }}{{- end }}
 {{- if .Values.Master.Ingress.TLS }}
   tls:
 {{ toYaml .Values.Master.Ingress.TLS | indent 4 }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -111,6 +111,7 @@ Persistence:
   ##
   # StorageClass: "-"
 
+  Annotations: {}
   AccessMode: ReadWriteOnce
   Size: 8Gi
   volumes:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -43,11 +43,11 @@ Master:
 # JMXPort: 4000
 # List of plugins to be install during Jenkins master start
   InstallPlugins:
-      - kubernetes:0.11
-      - workflow-aggregator:2.5
-      - workflow-job:2.13
-      - credentials-binding:1.12
-      - git:3.4.0
+    - kubernetes:0.11
+    - workflow-aggregator:2.5
+    - workflow-job:2.13
+    - credentials-binding:1.12
+    - git:3.4.0
 # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   # ScriptApproval:
   #   - "method groovy.json.JsonSlurperClassic parseText java.lang.String"

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -26,7 +26,6 @@ Master:
   ServiceAnnotations: {}
     #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
 # Used to create Ingress record (should used with ServiceType: ClusterIP)
-# HostName: jenkins.cluster.local
 # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
   SlaveListenerPort: 50000
@@ -67,7 +66,9 @@ Master:
     Annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-
+    Hosts:
+      # - name: "jenkins.cluster.local"
+      #   paths: []
     TLS:
       # - secretName: jenkins.cluster.local
       #   hosts:


### PR DESCRIPTION
I have this jenkins chart listed as a requirement from a higher level `CI/CD` chart.
I plan to handle the letsencrypt stuff in my wrapper module but I need to set some ingress paths. I hope this will be useful to more people too.

In `values.yaml` setting `Master.Ingress.Hosts` to...
```yaml
Hosts:
  - name: "jenkins.mydomain.com"
    paths:
      - path: "/*"
      - path: "/.well-known/*"
        backend:
          serviceName: "letsencrypt"
          servicePort: 80
```

...will produce the ingress resource below...
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: jenkins-jenkins
spec:
  rules:
  - host: "jenkins.mydomain.com"
    http:
      paths:
      - path: "/*"
        backend:
          serviceName: "jenkins-jenkins"
          servicePort: 8080
      - path: "/.well-known/*"
        backend:
          serviceName: "letsencrypt"
          servicePort: 80
```
...so I can handle the letsencrypt stuff in a different service/pod.
Be aware that I am also deprecating the use of `Master.HostName`.
I am using [this post](https://runnable.com/blog/how-to-use-lets-encrypt-on-kubernetes) as a reference for my implementation.