### PR TITLE
Fix #2644 traefik chart duplicate value

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.13.0
+version: 1.13.1
 appVersion: 1.4.1
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
           CertFile = "/ssl/tls.crt"
           KeyFile = "/ssl/tls.key"
       {{- else }}
-      [entryPoints.httpx]
+      [entryPoints.httpn]
       address = ":84"
       compress = {{ .Values.gzip.enabled }}
       {{- end }}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
     {{- if .Values.ssl.enabled }}
     defaultEntryPoints = ["http","https"]
     {{- else }}
-    defaultEntryPoints = ["http"]
+    defaultEntryPoints = ["http", "httpn"]
     {{- end }}
     [entryPoints]
       [entryPoints.http]
@@ -35,6 +35,10 @@ data:
           [[entryPoints.https.tls.certificates]]
           CertFile = "/ssl/tls.crt"
           KeyFile = "/ssl/tls.key"
+      {{- else }}
+      [entryPoints.httpx]
+      address = ":84"
+      compress = {{ .Values.gzip.enabled }}
       {{- end }}
     [kubernetes]
     {{- if .Values.kubernetes}}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
           KeyFile = "/ssl/tls.key"
       {{- else }}
       [entryPoints.httpn]
-      address = ":8080"
+      address = ":8880"
       compress = {{ .Values.gzip.enabled }}
       {{- end }}
     [kubernetes]

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
           KeyFile = "/ssl/tls.key"
       {{- else }}
       [entryPoints.httpn]
-      address = ":84"
+      address = ":8080"
       compress = {{ .Values.gzip.enabled }}
       {{- end }}
     [kubernetes]

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: 80
-        - containerPort: 84
+        - containerPort: 8080
         - containerPort: 443
         {{- if .Values.dashboard.enabled }}
         - containerPort: 8080

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -72,11 +72,19 @@ spec:
           name: acme
         {{- end }}
         ports:
-        - containerPort: 80
-        - containerPort: 8080
-        - containerPort: 443
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        - name: httpn
+          containerPort: 8880
+          protocol: TCP
+        - name: https
+          containerPort: 443
+          protocol: TCP
         {{- if .Values.dashboard.enabled }}
-        - containerPort: 8080
+        - name: dash
+          containerPort: 8080
+          protocol: TCP
         {{- end }}
         args:
         - --configfile=/config/traefik.toml

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -73,6 +73,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: 80
+        - containerPort: 84
         - containerPort: 443
         {{- if .Values.dashboard.enabled }}
         - containerPort: 8080

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -37,13 +37,14 @@ spec:
     {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.service.nodePorts.http)))}}
     nodePort: {{ .Values.service.nodePorts.http }}
     {{- end }}
+    targetPort: 80
   - port: 443
     name: https
     {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.service.nodePorts.https)))}}
     nodePort: {{ .Values.service.nodePorts.https }}
     {{- end }}
     {{- if not .Values.ssl.enabled }}
-    targetPort: 80
+    targetPort: 84
     {{- end }}
   {{- if or .Values.metrics.prometheus.enabled .Values.metrics.datadog.enabled .Values.metrics.statsd.enabled }}
   - port: 8080

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -37,16 +37,17 @@ spec:
     {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.service.nodePorts.http)))}}
     nodePort: {{ .Values.service.nodePorts.http }}
     {{- end }}
-    targetPort: 80
+    targetPort: http
   - port: 443
     name: https
     {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.service.nodePorts.https)))}}
     nodePort: {{ .Values.service.nodePorts.https }}
     {{- end }}
     {{- if not .Values.ssl.enabled }}
-    targetPort: 8080
+    targetPort: httpn
     {{- end }}
   {{- if or .Values.metrics.prometheus.enabled .Values.metrics.datadog.enabled .Values.metrics.statsd.enabled }}
   - port: 8080
     name: metrics
+    targetPort: dash
   {{- end }}

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -44,7 +44,7 @@ spec:
     nodePort: {{ .Values.service.nodePorts.https }}
     {{- end }}
     {{- if not .Values.ssl.enabled }}
-    targetPort: 84
+    targetPort: 8080
     {{- end }}
   {{- if or .Values.metrics.prometheus.enabled .Values.metrics.datadog.enabled .Values.metrics.statsd.enabled }}
   - port: 8080


### PR DESCRIPTION
The logic in place states that if ssl is **NOT** enabled in traefik,
then have the kube service listen on 443 and send to 80. There is
already a port/targetPort setup for 80.

This results in the error described in issue #2644

    Error: release traefik failed: Service "traefik-traefik" is invalid:
spec.ports[1].targetPort: Duplicate value: intstr.IntOrString{Type:0,
IntVal:80, StrVal:""}

My fix is when ssl is not enabled, to add a second traefik listening
port at 84. Which means the service is setup with the following port
mappings:

    80  -> 80
    443 -> 84

The ssl.enabled logic in this chart does not seem to refer to the
service, only traefik itself. My solution is a little copy pasta in that
I add the second http listener, but then I'm not changing/breaking the
ssl.enabled logic.