### PR TITLE
[incubator/jaeger] Support for external Cassandra or ElasticSearch backing store

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.8.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.1.3
+version: 0.2.0
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -48,6 +48,30 @@ helm install incubator/jaeger --name myrel --set cassandra.config.max_heap_size=
 
 > **Tip**: List all releases using `helm list`
 
+## Installing the Chart using an Existing Cassandra Cluster
+
+If you already have an existing running Cassandra cluster, you can configure the chart as follows to use it as your backing store (replace `cassandra` with whatever hostname the cluster has been configured with):
+
+```bash
+helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=false --set cassandra.config.host=cassandra
+```
+
+> **Tip**: It is highly encouraged to run the Cassandra cluster with storage persistence.
+
+## Installing the Chart using a New ElasticSearch Cluster
+
+**Currently unsupported**
+
+## Installing the Chart using an Existing ElasticSearch Cluster
+
+If you already have an existing running ElasticSearch cluster, you can configure the chart as follows to use it as your backing store (replace `http://elasticsearch:9200` with whatever hostname the cluster has been configured with):
+
+```bash
+helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=false --set elasticsearch.config.host=http://elasticsearch:9200
+```
+
+> **Tip**: It is highly encouraged to run the ElasticSearch cluster with storage persistence.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `myrel` deployment:
@@ -68,11 +92,15 @@ The following tables lists the configurable parameters of the Jaeger chart and t
 |-----------------------------------|------------------------------------|----------------------------------------|
 | `cassandra.image.tag`             | The image tag/version              |  3.11                                  |
 | `cassandra.persistence.enabled`   | To enable storage persistence      |  false (Highly recommended to enable)  |
+| `cassandra.config.host`           | Existing Cassandra hostname        |  ""                                    |
 | `cassandra.config.cluster_name`   | Cluster name                       |  jaeger                                |
 | `cassandra.config.seed_size`      | Seed size                          |  1                                     |
 | `cassandra.config.dc_name`        | Datacenter name                    |  dc1                                   |
 | `cassandra.config.rack_name`      | Rack name                          |  rack1                                 |
 | `cassandra.config.endpoint_snitch`| Node discovery method              |  GossipingPropertyFileSnitch           |
+| `elasticsearch.config.host`       | Existing ElasticSearch hostname    |  ""                                    |
+| `elasticsearch.config.username`   | Existing ElasticSearch username    |  "elastic"                             |
+| `elasticsearch.config.password`   | Existing ElasticSearch password    |  "changeme"                            |
 | `schema.annotations`              | Annotations for the schema job     |  nil                                   |
 | `schema.image`                    | Image to setup cassandra schema    |  jaegertracing/jaeger-cassandra-schema |
 | `schema.tag`                      | Image tag/version                  |  0.6                                   |

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -60,7 +60,15 @@ helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags
 
 ## Installing the Chart using a New ElasticSearch Cluster
 
-**Currently unsupported**
+To install the chart with the release name `myrel` using a new ElasticSearch cluster instead of Cassandra (default), run the following command:
+
+```bash
+$ helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=true
+```
+
+After a few minutes, you should see 2 ElasticSearch client nodes, 2 ElasticSearch data nodes, 3 ElasticSearch master nodes, a Jaeger DaemonSet, a Jaeger Collector, and a Jaeger Query (UI) pod deployed into your Kubernetes cluster.
+
+> **Tip**: If the ElasticSearch client nodes do not enter the running state, try --set elasticsearch.rbac.create=true
 
 ## Installing the Chart using an Existing ElasticSearch Cluster
 

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-This chart adds all components required to run Jaeger as described in the [jaeger-kubernetes](https://github.com/jaegertracing/jaeger-kubernetes) GitHub page for a production-like deployment. The chart will initialize Cassandra using the cassandra-schema Job, deploy jaeger-agent as a DaemonSet and deploy the jaeger-collector and jaeger-query components as standard individual deployments. This chart also depends on the [cassandra chart](https://github.com/kubernetes/charts/tree/master/incubator/cassandra).
+This chart adds all components required to run Jaeger as described in the [jaeger-kubernetes](https://github.com/jaegertracing/jaeger-kubernetes) GitHub page for a production-like deployment. The chart default will deploy a new Cassandra cluster, but also supports using an existing Cassandra cluster, deploying a new ElasticSearch cluster, or connecting to an existing ElasticSearch cluster. Once the back storage available, the chart will deploy jaeger-agent as a DaemonSet and deploy the jaeger-collector and jaeger-query components as standard individual deployments.
 
 ## Prerequisites
 
@@ -28,6 +28,39 @@ resources:
   limits:
     memory: 8Gi
     cpu: 2
+```
+
+- The ElasticSearch chart calls out the following requirements for a production environment:
+```
+client:
+  ...
+  resources:
+    limits:
+      cpu: "1"
+      # memory: "1024Mi"
+    requests:
+      cpu: "25m"
+      memory: "512Mi"
+
+master:
+  ...
+  resources:
+    limits:
+      cpu: "1"
+      # memory: "1024Mi"
+    requests:
+      cpu: "25m"
+      memory: "512Mi"
+
+data:
+  ...
+  resources:
+    limits:
+      cpu: "1"
+      # memory: "2048Mi"
+    requests:
+      cpu: "25m"
+      memory: "1536Mi"
 ```
 
 ## Installing the Chart
@@ -168,3 +201,7 @@ Override any required configuration options in the Cassandra chart that is requi
 ### Image tags
 
 Jaeger offers a multitude of [tags](https://hub.docker.com/u/jaegertracing/) for the various components used in this chart.
+
+### Pending enhancements
+- Moving configurable parameters to use ConfigMap
+- Sidecar deployment support

--- a/incubator/jaeger/requirements.yaml
+++ b/incubator/jaeger/requirements.yaml
@@ -1,4 +1,13 @@
 dependencies:
-  - name: cassandra
-    version: 0.1.3
+  - name: elasticsearch
+    version: 0.3.0
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    condition: elasticsearch.enable
+    tags:
+      - elasticsearch
+  - name: cassandra
+    version: 0.1.5
+    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    condition: cassandra.enable
+    tags:
+      - cassandra

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -26,3 +26,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "cassandra.fullname" -}}
 {{- printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.fullname" -}}
+{{- printf "%s-%s" .Release.Name "elasticsearch" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -1,4 +1,4 @@
-{{ if ne .Values.cassandra.config.host "" }}
+{{ if not (empty .Values.cassandra.config.host) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -1,3 +1,44 @@
+{{ if ne .Values.cassandra.config.host "" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+  labels:
+    app: "{{ template "jaeger.name" . }}"
+    jaeger-infra: cassandra-schema-job
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: "cassandra-schema"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- if .Values.schema.annotations }}
+  annotations:
+{{ toYaml .Values.schema.annotations | indent 6 }}
+{{- end }}
+spec:
+  activeDeadlineSeconds: 120
+  template:
+    metadata:
+      name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+{{- if .Values.schema.podLabels }}
+      labels:
+{{ toYaml .Values.schema.podLabels | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+      - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+        image: "{{ .Values.schema.image }}:{{ .Values.schema.tag }}"
+        imagePullPolicy: {{ .Values.schema.pullPolicy }}
+        env:
+          - name: CQLSH_HOST
+            value: "{{ .Values.cassandra.config.host }}"
+          - name: MODE
+            value: "{{ .Values.schema.mode }}"
+          - name: DATACENTER
+            value: "{{ .Values.cassandra.config.dc_name }}"
+        resources:
+{{ toYaml .Values.schema.resources | indent 10 }}
+      restartPolicy: OnFailure
+{{ else if .Values.tags.cassandra }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -37,3 +78,4 @@ spec:
         resources:
 {{ toYaml .Values.schema.resources | indent 10 }}
       restartPolicy: OnFailure
+{{ end }}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -45,8 +45,21 @@ spec:
 {{ toYaml .Values.collector.resources | indent 10 }}
         command:
         - "/go/bin/collector-linux"
+{{ if ne .Values.elasticsearch.config.host "" }}
+        - "--span-storage.type=elasticsearch"
+        - "--es.server-urls={{ .Values.elasticsearch.config.host }}"
+        - "--es.username={{ .Values.elasticsearch.config.username }}"
+        - "--es.password={{ .Values.elasticsearch.config.password }}"
+{{ else if .Values.tags.elasticsearch }}
+        - "--span-storage.type=elasticsearch"
+        - "--es.server-urls=http://{{ template "elasticsearch.fullname" . }}-client:9200"
+{{ else if ne .Values.cassandra.config.host "" }}
+        - "--cassandra.servers={{ .Values.cassandra.config.host }}"
+        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
+{{ else }}
         - "--cassandra.servers={{ template "cassandra.fullname" . }}"
         - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
+{{ end }}
         - "--collector.zipkin.http-port={{ .Values.collector.service.zipkinPort }}"
 {{- range $key, $value := .Values.collector.cmdlineParams }}
         - "{{ $value }}"

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -45,7 +45,7 @@ spec:
 {{ toYaml .Values.collector.resources | indent 10 }}
         command:
         - "/go/bin/collector-linux"
-{{ if ne .Values.elasticsearch.config.host "" }}
+{{ if not (empty .Values.elasticsearch.config.host) }}
         - "--span-storage.type=elasticsearch"
         - "--es.server-urls={{ .Values.elasticsearch.config.host }}"
         - "--es.username={{ .Values.elasticsearch.config.username }}"
@@ -53,7 +53,7 @@ spec:
 {{ else if .Values.tags.elasticsearch }}
         - "--span-storage.type=elasticsearch"
         - "--es.server-urls=http://{{ template "elasticsearch.fullname" . }}-client:9200"
-{{ else if ne .Values.cassandra.config.host "" }}
+{{ else if not (empty .Values.cassandra.config.host) }}
         - "--cassandra.servers={{ .Values.cassandra.config.host }}"
         - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
 {{ else }}

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -41,7 +41,7 @@ spec:
 {{ toYaml .Values.query.resources | indent 10 }}
         command:
         - "/go/bin/query-linux"
-{{ if ne .Values.elasticsearch.config.host "" }}
+{{ if not (empty .Values.elasticsearch.config.host) }}
         - "--span-storage.type=elasticsearch"
         - "--es.server-urls={{ .Values.elasticsearch.config.host }}"
         - "--es.username={{ .Values.elasticsearch.config.username }}"
@@ -49,7 +49,7 @@ spec:
 {{ else if .Values.tags.elasticsearch }}
         - "--span-storage.type=elasticsearch"
         - "--es.server-urls=http://{{ template "elasticsearch.fullname" . }}-client:9200"
-{{ else if ne .Values.cassandra.config.host "" }}
+{{ else if not (empty .Values.cassandra.config.host) }}
         - "--cassandra.servers={{ .Values.cassandra.config.host }}"
         - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
 {{ else }}

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -41,8 +41,21 @@ spec:
 {{ toYaml .Values.query.resources | indent 10 }}
         command:
         - "/go/bin/query-linux"
+{{ if ne .Values.elasticsearch.config.host "" }}
+        - "--span-storage.type=elasticsearch"
+        - "--es.server-urls={{ .Values.elasticsearch.config.host }}"
+        - "--es.username={{ .Values.elasticsearch.config.username }}"
+        - "--es.password={{ .Values.elasticsearch.config.password }}"
+{{ else if .Values.tags.elasticsearch }}
+        - "--span-storage.type=elasticsearch"
+        - "--es.server-urls=http://{{ template "elasticsearch.fullname" . }}-client:9200"
+{{ else if ne .Values.cassandra.config.host "" }}
+        - "--cassandra.servers={{ .Values.cassandra.config.host }}"
+        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
+{{ else }}
         - "--cassandra.servers={{ template "cassandra.fullname" . }}"
         - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
+{{ end }}
         - "--query.static-files=/go/jaeger-ui/"
 {{- range $key, $value := .Values.query.cmdlineParams }}
         - "{{ $value }}"

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -1,8 +1,10 @@
 # Default values for jaeger.
 # This is a YAML-formatted file.
-# Jaeger values are grouped by component. Cassandra values override subchart values
 
-# Begin: Override values on the Cassandra subchart to customize for Jaeger
+# Begin: Override values on the Cassandra/ElasticSearch subchart to customize for Jaeger
+# This chart has been based on the Kubernetes integration found in the following repo:
+# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production/cassandra.yml
+# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production-elasticsearch/elasticsearch.yml
 cassandra:
   image:
     tag: 3.11
@@ -10,19 +12,30 @@ cassandra:
     # To enable persistence, please see the documentation for the Cassandra chart
     enabled: false
   config:
+    # Change the host value to point to an existing Cassandra instance
+    # Be sure to set both tags.cassandra and tags.elasticsearch to false
+    host: ""
     cluster_name: jaeger
     seed_size: 1
     dc_name: dc1
     rack_name: rack1
     endpoint_snitch: GossipingPropertyFileSnitch
-# End: Override values on the Cassandra subchart to customize for Jaeger
+
+elasticsearch:
+  config:
+    # Change the host value to point to an existing ElasticSearch instance
+    # Be sure to set both tags.cassandra and tags.elasticsearch to false
+    host: ""
+    username: "elastic"
+    password: "changeme"
+# End: Override values on the Cassandra/ElasticSearch subchart to customize for Jaeger
 
 # Begin: Default values for the various components of Jaeger
-# This chart has been based on the Kubernetes integration found in the following repo:
-# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production/jaeger-production-template.yml
-#
-# This is the jaeger-cassandra-schema Job which sets up the Cassandra schema for
-# use by Jaeger
+tags:
+  # Chose which backing store to use. By default Cassandra is enabled.
+  cassandra: true
+  elasticsearch: false
+
 schema:
   annotations: {}
   image: jaegertracing/jaeger-cassandra-schema


### PR DESCRIPTION
This PR adds support for using either Cassandra or ElasticSearch as a backing store. The options are exposed through the following options as described in the README:

By default, the chart will deploy a new Cassandra cluster as the backing store. The command for install remains unchanged.
helm install incubator/jaeger --name <your release name>

There is a new option for deploying a new ElasticSearch cluster instead of a Cassandra cluster. The command looks like:
helm install incubator/jaeger --set tags.cassandra=false --set tags.elasticsearch=true --name <your release name>

To use an existing Cassandra cluster named "cassandra-hostname", you enable by adding the following options:
helm install incubator/jaeger --set tags.cassandra=false --set tags.elasticsearch=false --set cassandra.config.host=cassandra-hostname --name <your release name>

To use an existing ElasticSearch cluster at "http://elasticsearch:9200", you enable by adding the following options:
helm install incubator/jaeger --set tags.cassandra=false --set tags.elasticsearch=false --set elasticsearch.config.host=http://elasticsearch:9200 --name <your release name>

You can optionally change the username and password by setting the following (defaults shown):
--set elasticsearch.config.username=elastic
--set elasticsearch.config.password=changeme

I have provided YAML files to deploy either a Cassandra or ElasticSearch cluster for testing purposes. You can create either cluster by running the following:
kubectl create -f cassandra.yml
OR
kubectl create -f elasticsearch.yml

[yaml.zip](https://github.com/kubernetes/charts/files/1451694/yaml.zip)

**UPDATED** to include new ES cluster directions