### PR TITLE
[incubator/elasticsearch] pvc name value

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.3.0
+version: 0.4.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -76,6 +76,7 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
+| `master.persistence.name`            | Master statefulset PVC template name                                | `data`                               |
 | `master.persistence.size`            | Master persistent volume size                                       | `4Gi`                                |
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
@@ -83,6 +84,7 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |
 | `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                               |
+| `data.persistence.name`              | Data statefulset PVC template name                                  | `data`                               |
 | `data.persistence.size`              | Data persistent volume size                                         | `30Gi`                               |
 | `data.persistence.storageClass`      | Data persistent volume Class                                        | `nil`                                |
 | `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -126,7 +126,7 @@ spec:
   {{- else }}
   volumeClaimTemplates:
   - metadata:
-      name: data
+      name: {{ .Values.data.persistence.name }}
     spec:
       accessModes:
         - {{ .Values.data.persistence.accessMode | quote }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -122,7 +122,7 @@ spec:
   {{- else }}
   volumeClaimTemplates:
   - metadata:
-      name: data
+      name: {{ .Values.master.persistence.name }}
     spec:
       accessModes:
         - {{ .Values.master.persistence.accessMode | quote }}

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -38,6 +38,7 @@ master:
   persistence:
     enabled: true
     accessMode: ReadWriteOnce
+    name: data
     size: "4Gi"
     # storageClass: "ssd"
   antiAffinity: "soft"
@@ -56,6 +57,7 @@ data:
   persistence:
     enabled: true
     accessMode: ReadWriteOnce
+    name: data
     size: "30Gi"
     # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600


### PR DESCRIPTION
This sets a configurable template value for the name parameter of the pvc
section of the data and master statefulset templates. The default is set
to `data` and so remains unchanged to any dependent user.

A little background: We currently have a production ES cluster using a
locally maintained elasticsearch chart and we want to migrate to using
this chart. A blocker at the moment is that our pvc name is `storage`
instead of `data`. To avoid needing to create a new cluster (which is
close to a TB in storage) and migrating, we can simply set this
parameter to `storage` and we can continue to use the pvc currently in
place.