### PR TITLE
support adding optional ingress path

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.5.0
+version: 0.5.1
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/ingress.yaml
+++ b/stable/grafana/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.server.ingress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $servicePort := .Values.server.service.httpPort -}}
+{{- $path := .Values.server.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -24,6 +25,9 @@ spec:
           - backend:
               serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
               servicePort: {{ $servicePort }}
+            {{- if $path }}
+            path: {{ $path }}
+            {{- end -}}
   {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -28,6 +28,12 @@ server:
     # hosts:
     #   - grafana.domain.com
 
+    ## Grafana Ingress path
+    ## Optional, allows specifying paths for more flexibility
+    ## E.g. Traefik ingress likes paths
+    ##
+    # path: /
+
     ## Grafana Ingress TLS configuration
     ## Secrets must be manually created in the namespace
     ##


### PR DESCRIPTION
  some ingress' (e.g. Traefik) can benefit from "paths.path" set,
  in addition to "paths.backend" - this change allows adding path