### PR TITLE
[stable/datadog] Dependency bump of kube-state-metrics

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.8.0
+version: 0.8.1
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.2.2
-digest: sha256:7e23248167ba51887c8fcc610107a66e884d35efa2a18a273d1567a0672d6f66
-generated: 2017-09-10T13:38:29.338405876-05:00
+  version: 0.3.1
+digest: sha256:4a48468276205a7a903e1ec28396687d531c05b1d3f09bfdb76f79367a98a9db
+generated: 2017-11-07T16:20:11.29260398-07:00

--- a/stable/datadog/requirements.yaml
+++ b/stable/datadog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
-    version: 0.2.2
+    version: 0.3.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: kubeStateMetrics.enabled


### PR DESCRIPTION
Main thing gained here is being able to use RBAC for kube-state-metrics