### PR TITLE
Add docker configuration space and opening of docker host to Nexus OSS

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 0.1.1
+version: 0.1.2
 appVersion: 3.5.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/deployment.yaml
+++ b/stable/sonatype-nexus/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+            {{- if .Values.docker.enabled }}
+            - containerPort: {{ .Values.docker.port }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/stable/sonatype-nexus/templates/ingress.yaml
+++ b/stable/sonatype-nexus/templates/ingress.yaml
@@ -16,6 +16,15 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- if .Values.docker.enabled }}
+    - host: {{ .Values.docker.host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ .Values.docker.port }}
+    {{- end }}
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:

--- a/stable/sonatype-nexus/templates/service.yaml
+++ b/stable/sonatype-nexus/templates/service.yaml
@@ -14,6 +14,12 @@ spec:
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
       name: {{ .Values.service.name }}
+    {{- if .Values.docker.enabled }}
+    - port: {{ .Values.docker.port }}
+      targetPort: {{ .Values.docker.port }}
+      protocol: TCP
+      name: {{ .Values.service.name }}-docker
+    {{- end }}
   selector:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -30,6 +30,12 @@ ingress:
   #  - secretName: nexus-tls
   #    hosts:
   #      - nexus.local
+## Configuration if choosing to host docker registry
+docker:
+  enabled: false
+  # Used to enable a docker registry
+  # port: 5509
+  # host: docker.local
 ## Persist data to a persitent volume
 persistence:
   enabled: true


### PR DESCRIPTION
Nexus OSS has the ability to host a Docker private registry. Docker private registries ignore the context-path on URLs. As a result, they have to be hosted at a port at the base path. The current helm chart does not provide the opportunity to open up a second port. This change allows a port to be opened specific to docker. It also lets you specify a domain name specific to the Docker endpoint, to make accessing it easier.