### PR TITLE
[stable/nginx-ingress] Added update strategy for controller daemonset and deployment

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.9
+version: 0.8.10
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -135,4 +135,6 @@ spec:
     {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       terminationGracePeriodSeconds: 60
+  updateStrategy:
+{{ toYaml .Values.controller.updateStrategy | indent 4 }}
 {{- end }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -11,6 +11,8 @@ metadata:
   name: {{ template "controller.fullname" . }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
+  strategy:
+{{ toYaml .Values.controller.updateStrategy | indent 4 }}
   template:
     metadata:
       annotations:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -58,6 +58,13 @@ controller:
   ##
   kind: Deployment
 
+  # The update strategy to apply to the Deployment or DaemonSet
+  ##
+  updateStrategy: {}
+  #  rollingUpdate:
+  #    maxUnavailable: 1
+  #  type: RollingUpdate
+
   ## Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##


### PR DESCRIPTION
By default updateStrategy is OnDelete which needs manual deletion of all daemonsets for change to take affect. This also lets users determine what settings they want when using a deployment