### PR TITLE
[stable/datadog] Tag pods for deployments service to only use deployment

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.10.2
+version: 0.10.3
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: {{ template "datadog.fullname" . }}
+        type: deployment
       name: {{ template "datadog.fullname" . }}
       annotations:
         checksum/autoconf-config: {{ toYaml .Values.datadog.autoconf | sha256sum }}

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -11,6 +11,7 @@ spec:
   type: {{ .Values.serviceType }}
   selector:
     app: {{ template "datadog.fullname" . }}
+    type: deployment
   ports:
   - port: 8125
     name: dogstatsdport


### PR DESCRIPTION
Currently the Datadog chart allows for both a DaemonSet and a Deployment release. If you choose the Deployment, a service is created which is intended to route traffic to the Deployment pod(s). However in the current state the DaemonSet pods are also included in the service, since the pods use the same labels. 

This simply adds a 'type' label to the Deployment pods so that the service can select only the appropriate pods.