### PR TITLE
[incubator/gogs] Fix SSH port and domain settings

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.11.29
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/incubator/gogs/requirements.lock
+++ b/incubator/gogs/requirements.lock
@@ -1,9 +1,6 @@
 dependencies:
-- condition: ""
-  enabled: false
-  name: postgresql
+- name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  tags: null
   version: 0.6.0
-digest: sha256:a9c23d133496833af520073553aff46280d9cd53d09c87bd2c8202c812dbf10a
-generated: 2017-03-22T20:02:35.379453692-04:00
+digest: sha256:711e4e8a93ba272728e7f04b65f8f3345b6bae19f83cf3d53b9fc844ef6309d5
+generated: 2017-11-25T16:04:31.861896792+01:00

--- a/incubator/gogs/templates/configmap.yaml
+++ b/incubator/gogs/templates/configmap.yaml
@@ -24,6 +24,9 @@ data:
     DOMAIN = {{ .Values.service.gogs.serverDomain }}
     ROOT_URL = {{ .Values.service.gogs.serverRootUrl }}
     LANDING_PAGE = {{ .Values.service.gogs.serverLandingPage }}
+    SSH_DOMAIN = {{ default .Values.service.gogs.serverDomain .Values.service.sshDomain }}
+    SSH_PORT = {{ .Values.service.sshPort }}
+    SSH_LISTEN_PORT = {{ .Values.service.sshPort }}
 
     [service]
     ENABLE_CAPTCHA = {{ .Values.service.gogs.serviceEnableCaptcha }}

--- a/incubator/gogs/templates/deployment.yaml
+++ b/incubator/gogs/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - containerPort: 3000
-            - containerPort: 2222
+            - containerPort: {{ .Values.service.sshPort | int }}
           livenessProbe:
             httpGet:
               path: /

--- a/incubator/gogs/templates/service.yaml
+++ b/incubator/gogs/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
     targetPort: 3000
     name: {{ default "gogs" .Values.service.nameOverride }}-http
   - port: {{ .Values.service.sshPort | int }}
-    targetPort: 2222
+    targetPort:  {{ .Values.service.sshPort | int }}
     name: {{ default "gogs" .Values.service.nameOverride }}-ssh
   selector:
     app: {{ template "gogs.fullname" . }}

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -28,6 +28,11 @@ service:
   ##
   sshPort: 22
 
+  ## SSH_DOMAIN - Domain name to be exposed in SSH clone URL.
+  ## ref: https://gogs.io/docs/advanced/configuration_cheat_sheet
+  ##
+  sshDomain: localhost
+
   ## Gogs configuration values
   ## ref: https://gogs.io/docs/advanced/configuration_cheat_sheet
   ##


### PR DESCRIPTION
SSH port/domain settings were hard coded which led to unusable git repository. This commit introduces values which are being referenced in the config map which in turn govern the way the ssh daemon is being launched. 