### PR TITLE
Make chart dependency builds immutable

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -35,7 +35,7 @@ The logic is as follows:
 1. [Get credentials for the Kubernetes cluster used for testing.](https://github.com/kubernetes/charts/blob/master/test/changed.sh#L42)
 1. [Install and initialize Helm](https://github.com/kubernetes/charts/blob/master/test/changed.sh#L47)
 1. [For any charts that have changed](https://github.com/kubernetes/charts/blob/master/test/changed.sh#L62):
-    - Download dependent charts, if any, with `helm dep update`
+    - Download dependent charts, if any, with `helm dep build`
     - Run `helm install` in a new namespace for this PR+build
     - Use the [test/verify-release.sh](https://github.com/kubernetes/charts/blob/master/test/verify-release.sh) to ensure that if any pods were launched that they get to the `Running` state
     - Run `helm test` on the release
@@ -62,7 +62,7 @@ to update the public repositories. The procedure is as follows:
 1. [Authenticate to Google Cloud so that we can upload to the Cloud Storage bucket that hosts the charts](https://github.com/kubernetes/charts/blob/master/test/repo-sync.sh#L27)
 1. For the stable and incubator folders:
    - Download the existing index.yaml from the repository
-   - Run `helm dep update` on all the charts in the current repository
+   - Run `helm dep build` on all the charts in the current repository
    - Run `helm package` on each chart
    - Recreate the index using `helm repo index`
    - Upload the repostory using `gsutil rsync`

--- a/test/changed.sh
+++ b/test/changed.sh
@@ -67,7 +67,7 @@ for directory in ${CHANGED_FOLDERS}; do
     CHART_NAME=`echo ${directory} | cut -d '/' -f2`
     RELEASE_NAME="${CHART_NAME:0:7}-${BUILD_NUMBER}"
     CURRENT_RELEASE=${RELEASE_NAME}
-    helm dep update ${directory}
+    helm dep build ${directory}
     helm install --timeout 600 --name ${RELEASE_NAME} --namespace ${NAMESPACE} ${directory} | tee install_output
     ./test/verify-release.sh ${NAMESPACE}
     kubectl get pods --namespace ${NAMESPACE}

--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -36,7 +36,7 @@ mkdir -p ${STABLE_REPO_DIR}
 cd ${STABLE_REPO_DIR}
   gsutil cp gs://kubernetes-charts/index.yaml .
   for dir in `ls ../stable`;do
-    helm dep update ../stable/$dir
+    helm dep build ../stable/$dir
     helm package ../stable/$dir
   done
   helm repo index --url ${STABLE_REPO_URL} --merge ./index.yaml .
@@ -50,7 +50,7 @@ mkdir -p ${INCUBATOR_REPO_DIR}
 cd ${INCUBATOR_REPO_DIR}
   gsutil cp gs://kubernetes-charts-incubator/index.yaml .
   for dir in `ls ../incubator`;do
-    helm dep update ../incubator/$dir
+    helm dep build ../incubator/$dir
     helm package ../incubator/$dir
   done
   helm repo index --url ${INCUBATOR_REPO_URL} --merge ./index.yaml .


### PR DESCRIPTION
The previous version of the sync script ran `helm dep update` which
would recreate the requirements.lock file. This caused new builds
of charts as a total package with different versions of dependencies
but the same chart version. The package was mutating.

This change works towards our goal of immutable charts for a chart
at a version.

/cc @viglesiasce 