### PR TITLE
[stable/kube-state-metrics] add readiness probe

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.0.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -22,5 +22,11 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         ports:
         - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
         resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
add same readiness probe that is present in [kubernetes/kube-state-metrics deployment manifest](https://github.com/kubernetes/kube-state-metrics/blob/0e47d8031505f19ae20cebc79d179bf4f98dc638/kubernetes/kube-state-metrics-deployment.yaml#L23-L28)