### PR TITLE
Document how to override service name

### DIFF
--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -35,6 +35,7 @@ The default configuration values for this chart are listed in `values.yaml`.
 | `image.repository`                    | Repository for container image                               | gcr.io/google_containers/heapster                 |
 | `image.tag`                           | Container image tag                                          | v1.3.0                                            |
 | `image.pullPolicy`                    | Image pull policy                                            | IfNotPresent                                      |
+| `service.nameOverride`                | Service name                                                 | `.Chart.Name`                                      |
 | `service.name`                        | Service port name                                            | api                                               |
 | `service.type`                        | Type for the service                                         | ClusterIP                                         |
 | `service.externalPort`                | Service external port                                        | 8082                                              |


### PR DESCRIPTION
Add instructions to override service name (via `.Values.service.nameOverride `).
This comes handy,  in conjunction with `install ... --namespace kube-system`, to be able to `kubectl top ...` without the `--heapster-service` flag.