### PR TITLE
[stable/consul] Consul 1.0.0

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 0.5.0
+version: 1.0.0
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 icon: https://raw.githubusercontent.com/hashicorp/consul/bce3809dfca37b883828c3715b84143dd71c0f85/website/source/assets/images/favicons/android-chrome-512x512.png

--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,7 +1,7 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 0.4.2
-appVersion: 0.8.3
+version: 0.5.0
+appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store designed with support for the modern data center to make distributed systems and configuration easy.
 icon: https://raw.githubusercontent.com/hashicorp/consul/bce3809dfca37b883828c3715b84143dd71c0f85/website/source/assets/images/favicons/android-chrome-512x512.png
 sources:

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -46,11 +46,13 @@ The following tables lists the configurable parameters of the consul chart and t
 | `SerfwanUdpPort`        | Container serf wan UDP listening port | `8302`                                                     |
 | `ServerPort`            | Container server listening port       | `8300`                                                     |
 | `ConsulDnsPort`         | Container dns listening port          | `8600`                                                     |
+| `antiAffinity`          | Consul pod anti-affinity setting      | `hard`                                                     |
+| `maxUnavailable`        | Pod disruption Budget maxUnavailable  | `1`                                                        |
 | `ui.enabled`            | Enable Consul Web UI                  | `false`                                                    |
 | `uiService.enabled`     | Create dedicated Consul Web UI svc    | `false`                                                    |
 | `uiService.type`        | Dedicate Consul Web UI svc type       | `NodePort`                                                 |
-| `test.image`        | Test container image requires kubectl + bash (used for helm test)      | `lachlanevenson/k8s-kubectl`                                                 |
-| `test.imageTag`        | Test container image tag  (used for helm test)     | `v1.4.8-bash`                                                 |
+| `test.image`            | Test container image requires kubectl + bash (used for helm test)      | `lachlanevenson/k8s-kubectl`                                                 |
+| `test.imageTag`         | Test container image tag  (used for helm test)     | `v1.4.8-bash`                                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -28,7 +28,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
 | `Name`                  | Consul statefulset name               | `consul`                                                   |
 | `Image`                 | Container image name                  | `consul`                                                   |
-| `ImageTag`              | Container image tag                   | `v0.7.5`                                                   |
+| `ImageTag`              | Container image tag                   | `1.0.0`                                                    |
 | `ImagePullPolicy`       | Container pull policy                 | `Always`                                                   |
 | `Replicas`              | k8s statefulset replicas              | `3`                                                        |
 | `Component`             | k8s selector key                      | `consul`                                                   |

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -102,6 +102,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+      {{- if eq .Values.antiAffinity "hard" }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -112,6 +113,20 @@ spec:
                 values:
                 - "{{ .Release.Name }}-{{ .Values.Component }}"
             topologyKey: kubernetes.io/hostname
+      {{- else if eq .Values.antiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - "{{ .Release.Name }}-{{ .Values.Component }}"
+      {{- end }}
       containers:
       - name: "{{ template "fullname" . }}"
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -77,6 +77,8 @@ metadata:
 spec:
   serviceName: "{{ template "fullname" . }}"
   replicas: {{ default 3 .Values.Replicas }}
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       name: "{{ template "fullname" . }}"

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -25,6 +25,18 @@ spec:
   type: "{{ .Values.uiService.type }}"
 {{- end }}
 ---
+{{- if .Values.maxUnavailable }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: "{{ template "fullname" . }}-pdb"
+spec:
+  maxUnavailable: {{ .Values.maxUnavailable }}
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-{{ .Values.Component }}"
+{{- end }}
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -88,6 +88,16 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: component
+                operator: In
+                values:
+                - "{{ .Release.Name }}-{{ .Values.Component }}"
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: "{{ template "fullname" . }}"
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -43,6 +43,14 @@ EncryptGossip: true
 ## StorageClass name for use with Persistent Volume Claim (PVC) using beta notations
 # StorageClass:
 
+## Setting maxUnavailable will create a pod disruption budget that will prevent
+## voluntarty cluster administration from taking down too many consul pods. If
+## you set maxUnavailable, you should set it to ceil((n/2) - 1), where
+## n = Replicas. For example, if you have 5 or 6 Replicas, you'll want to set
+## maxUnavailable = 2. If you are using the default of 3 Replicas, you'll want
+## to set maxUnavailable to 1.
+maxUnavailable: 1
+
 ## Enable Consul Web UI
 ##
 ui:

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -16,7 +16,7 @@ ConsulDnsPort: 8600
 Component: "consul"
 Replicas: 3
 Image: "consul"
-ImageTag: "0.8.3"
+ImageTag: "1.0.0"
 ImagePullPolicy: "Always"
 Resources: {}
  # requests:

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -51,6 +51,13 @@ EncryptGossip: true
 ## to set maxUnavailable to 1.
 maxUnavailable: 1
 
+## Anti-Affinity setting. The default "hard" will use pod anti-affinity that is
+## requiredDuringSchedulingIgnoredDuringExecution to ensure 2 services don't
+## end up on the same node. Setting this to "soft" will use
+## preferredDuringSchedulingIgnoredDuringExecution. If set to anything else,
+## no anti-affinity rules will be configured.
+antiAffinity: "hard"
+
 ## Enable Consul Web UI
 ##
 ui:


### PR DESCRIPTION
I'm hoping this resolves #1892. I'd like to get a few more people to test this out before merging.

We've run a 5 pod cluster at work with this configuration, and it seemed to survive a Kubernetes upgrade without issue.

With the [release of consul 1.0.0](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#100-october-16-2017), the raft protocol now defaults to v3 which seems to handle changing IPs much better.

In addition to bumping the consul image tag to `1.0.0`, these changes also:

* Add pod anti-affinity to ensure that we don't schedule 2 pods on the same node as this defeats the purpose.
* Use a rolling update strategy for updating consul's stateful set.
* Add a pod disruption budget so that scheduled cluster maintenance doesn't take down the consul service.