### PR TITLE
[stable/sentry] add config features

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.9
+version: 0.1.10
 appVersion: 8.17
 keywords:
   - debugging

--- a/stable/sentry/requirements.yaml
+++ b/stable/sentry/requirements.yaml
@@ -2,6 +2,8 @@ dependencies:
   - name: postgresql
     version: 0.8.3
     repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: requiredBackend.postgresql
   - name: redis
     version: 0.10.1
     repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: requiredBackend.redis

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -39,18 +39,26 @@ spec:
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
+          {{- if .Values.postgresql.remoteHost }}
+          value: {{ .Values.postgresql.remoteHost }}
+          {{- else }}
           value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          {{- end }}
+        - name: SENTRY_POSTRGES_PORT
+          value: {{ .Values.postgresql.postgresPort | quote }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "redis.fullname" . }}
               key: redis-password
         - name: SENTRY_REDIS_HOST
+          {{- if .Values.redis.remoteHost }}
+          value: {{ .Values.redis.remoteHost }}
+          {{- else }}
           value: {{ template "redis.fullname" . }}
+          {{- end }}
         - name: SENTRY_REDIS_PORT
-          value: "6379"
+          value: {{ .Values.redis.redisPort | quote }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -62,12 +70,5 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
-{{- if .Values.cron.env }}
-{{ toYaml .Values.cron.env | indent 8 }}
-{{- end }}
         resources:
 {{ toYaml .Values.cron.resources | indent 12 }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -42,18 +42,26 @@ spec:
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
+          {{- if .Values.postgresql.remoteHost }}
+          value: {{ .Values.postgresql.remoteHost }}
+          {{- else }}
           value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          {{- end }}
+        - name: SENTRY_POSTRGES_PORT
+          value: {{ .Values.postgresql.postgresPort | quote }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "redis.fullname" . }}
               key: redis-password
         - name: SENTRY_REDIS_HOST
+          {{- if .Values.redis.remoteHost }}
+          value: {{ .Values.redis.remoteHost }}
+          {{- else }}
           value: {{ template "redis.fullname" . }}
+          {{- end }}
         - name: SENTRY_REDIS_PORT
-          value: "6379"
+          value: {{ .Values.redis.redisPort | quote }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.smtpHost | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -65,7 +73,3 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.user.exists }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -41,18 +42,26 @@ spec:
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
+          {{- if .Values.postgresql.remoteHost }}
+          value: {{ .Values.postgresql.remoteHost }}
+          {{- else }}
           value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          {{- end }}
+        - name: SENTRY_POSTRGES_PORT
+          value: {{ .Values.postgresql.postgresPort | quote }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "redis.fullname" . }}
               key: redis-password
         - name: SENTRY_REDIS_HOST
+          {{- if .Values.redis.remoteHost }}
+          value: {{ .Values.redis.remoteHost }}
+          {{- else }}
           value: {{ template "redis.fullname" . }}
+          {{- end }}
         - name: SENTRY_REDIS_PORT
-          value: "6379"
+          value: {{ .Values.redis.redisPort | quote }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.smtpHost | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -69,7 +78,4 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: user-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
+{{- end }}

--- a/stable/sentry/templates/ingress.yaml
+++ b/stable/sentry/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "fullname" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -24,5 +25,13 @@ spec:
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end -}}
+{{- if .Values.ingress.tlsHosts }}
+  tls:
+  {{- range $host := .Values.ingress.tlsHosts }}
+  - hosts:
+    - {{ $host }}
+    secretName: {{ $serviceName }}-tls
+  {{- end }}
 {{- end -}}
 {{- end -}}

--- a/stable/sentry/templates/postresql-remote-secrets.yaml
+++ b/stable/sentry/templates/postresql-remote-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.postgresql.remoteHost (not .Values.requiredBackend.postgresql) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-postgresql
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  postgres-password: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
+{{- end }}

--- a/stable/sentry/templates/redis-remote-secrets.yaml
+++ b/stable/sentry/templates/redis-remote-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.redis.remoteHost (not .Values.requiredBackend.redis) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-redis
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  redis-password: {{ .Values.redis.redisPassword | b64enc | quote }}
+{{- end }}

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -15,4 +15,8 @@ data:
   sentry-secret: {{ randAlphaNum 40 | b64enc | quote }}
   {{ end }}
   smtp-password: {{ default "" .Values.email.password | b64enc | quote }}
+  {{ if .Values.user.password }}
+  user-password: {{ .Values.user.password | b64enc | quote }}
+  {{ else }}
   user-password: {{ randAlphaNum 16 | b64enc | quote }}
+  {{ end }}

--- a/stable/sentry/templates/tls-secrets.yaml
+++ b/stable/sentry/templates/tls-secrets.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.tlsSecret }}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ template "fullname" . }}-tls
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  tls.key: {{ .Values.tlsSecret.key | b64enc }}
+  tls.crt: {{ .Values.tlsSecret.crt | b64enc }}
+{{- end }}

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -38,18 +38,26 @@ spec:
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
+          {{- if .Values.postgresql.remoteHost }}
+          value: {{ .Values.postgresql.remoteHost }}
+          {{- else }}
           value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          {{- end }}
+        - name: SENTRY_POSTRGES_PORT
+          value: {{ .Values.postgresql.postgresPort | quote }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "redis.fullname" . }}
               key: redis-password
         - name: SENTRY_REDIS_HOST
+          {{- if .Values.redis.remoteHost }}
+          value: {{ .Values.redis.remoteHost }}
+          {{- else }}
           value: {{ template "redis.fullname" . }}
+          {{- end }}
         - name: SENTRY_REDIS_PORT
-          value: "6379"
+          value: {{ .Values.redis.redisPort | quote }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -61,13 +69,6 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
-{{- if .Values.web.env }}
-{{ toYaml .Values.web.env | indent 8 }}
-{{- end }}
         volumeMounts:
         - mountPath: {{ .Values.persistence.filestore_dir }}
           name: sentry-data

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -39,18 +39,26 @@ spec:
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
         - name: SENTRY_POSTGRES_HOST
+          {{- if .Values.postgresql.remoteHost }}
+          value: {{ .Values.postgresql.remoteHost }}
+          {{- else }}
           value: {{ template "postgresql.fullname" . }}
+          {{- end }}
         - name: SENTRY_POSTGRES_PORT
-          value: "5432"
+          value: {{ .Values.postgresql.postgresPort | quote }}
         - name: SENTRY_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "redis.fullname" . }}
               key: redis-password
         - name: SENTRY_REDIS_HOST
+          {{- if .Values.redis.remoteHost }}
+          value: {{ .Values.redis.remoteHost }}
+          {{- else }}
           value: {{ template "redis.fullname" . }}
+          {{- end }}
         - name: SENTRY_REDIS_PORT
-          value: "6379"
+          value: {{ .Values.redis.redisPort | quote }}
         - name: SENTRY_EMAIL_HOST
           value: {{ default "" .Values.email.host | quote }}
         - name: SENTRY_EMAIL_PORT
@@ -62,12 +70,5 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
-{{- if .Values.worker.env }}
-{{ toYaml .Values.worker.env | indent 8 }}
-{{- end }}
         resources:
 {{ toYaml .Values.worker.resources | indent 12 }}

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -45,8 +45,12 @@ worker:
       memory: 100Mi
 
 # Initial admin user to create
+# an empty password issues random; any helm upgrade replaces it
+# after an initial installation, setting exists to true will skip
 user:
+  exists: false
   email: admin@sentry.local
+  password:
 
 # BYO Email server
 # TODO: Add exim4 template
@@ -110,9 +114,32 @@ ingress:
   #     hosts:
   #       - sentry.local
 
+  ## or, if using tlsSecret, enumerate the cert hostnames here
+  tlsHosts: []
+
+## tlsSecret allows a cert to be used for ingress
+#  consider putting this w/ other secrets in seperate encrypted values file
+# tlsSecret:
+#    key:  |
+#    ---BEGIN
+#    ...
+#    ---END
+#    crt: |
+#    ...
+
 # TODO: add support for plugins https://docs.sentry.io/server/plugins/
 
+## allow these chart requirements to be omitted
+## and replaced with external services (using remoteHost)
+requiredBackend:
+    postgresql: true
+    redis: true
+
 postgresql:
+  ## to use remoteHost, set this requiredBackend to false
+  # remoteHost:
+  # postgresPassword:
+  postgresPort: 5432
   postgresDatabase: sentry
   postgresUser: sentry
   imageTag: "9.5"
@@ -120,5 +147,10 @@ postgresql:
     enabled: true
 
 redis:
+  ## to use remoteHost, set this requiredBackend to false
+  # remoteHost:
+  # redisPassowrd:
+  ## redisPort need only change for use with remoteHost
+  redisPort: 6379
   persistence:
     enabled: true


### PR DESCRIPTION
### summary

This PR adds new functionality for the Sentry chart to make it
more flexible and production-worthy.

### `required_backend`

A new top level object flags requirements for installation.
Both PG/Redis are default `true`.  
Example: install only Redis, put your Postgres on AWS RDS:

```
required_backend:
  redis: true
  postgresql: false
```

### `remoteHost` and alternate ports

if a required backend is false, `remoteHost` stands in.
Additionally, a template for the secret is rendered and 
creates the secret without the required chart; eg.

```
postgresql:
  remoteHost: sentry.xxxx.us-east-1.rds.amazonaws.com
  postgresUser: sentry
  postgresPassword: changeMe
  postgresDatabase: sentry
  postgresPort: "6432"
```

###  `tls_secret` and `ingress.tls_hosts`

A new top-level value for key/cert can be added automatically
with the notation, eg.

```
tls_secret:
  key: | 
  ....
  crt: |
  ...
```

This will populate a new TLS secret that can be used by ingress.
Leverage its use by leaving `ingress.tls` empty and instead using
`tls_hosts` to enumerate all hostnames on the cert. eg.

```
ingress:
  tls_hosts:
    - example.com
    - www.example.com
```

### fixup `user.password`

Whereas `user.password` did not take a value, a helm update on the
chart would overwrite this value with a new random.  Now, we allow
an input value to keep things pre-ordained and consistent.
