### PR TITLE
Add option for disabling the Prometheus server component.

### DIFF
--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if (empty .Values.server.configMapOverrideName) -}}
+{{- if and .Values.server.enabled (empty .Values.server.configMapOverrideName) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -107,3 +108,4 @@ spec:
           hostPath:
             path: {{ .hostPath }}
       {{- end }}
+{{- end }}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - --storage.local.retention={{ .Values.server.retention }}
           {{- end }}
             - --config.file=/etc/config/prometheus.yml
-            - --storage.local.path={{ .Values.server.persistentVolume.mountPath }}
+            - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
           {{- range $key, $value := .Values.server.extraArgs }}

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.ingress.enabled -}}
+{{- if and .Values.server.enabled .Values.server.ingress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.server.fullname" . }}
 {{- $servicePort := .Values.server.service.servicePort -}}

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,3 +46,4 @@ spec:
     component: "{{ .Values.server.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.server.service.type }}"
+{{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -313,6 +313,10 @@ nodeExporter:
     type: ClusterIP
 
 server:
+  ## If false, alertmanager will not be installed
+  ##
+  enabled: true
+  
   ## Prometheus server container name
   ##
   name: server


### PR DESCRIPTION
When deploying components individually, there is no option to deploy
without the server component of Prometheus. This PR adds support for
deploying the Prometheus Gateway/Aletmanager/NodeExport, without being
coupled to the Server Deployment.