### PR TITLE
add optional persistence to chartmuseum and upgrade image to latest r…

### DIFF
--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
 version: 0.1.1
-appVersion: 0.1.0
+appVersion: 0.2.6
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png
 maintainers:

--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/incubator/chartmuseum/requirements.lock
+++ b/incubator/chartmuseum/requirements.lock
@@ -1,11 +1,6 @@
 dependencies:
-- alias: ""
-  condition: ""
-  enabled: false
-  import-values: null
-  name: common
+- name: common
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  tags: null
   version: 0.0.1
-digest: sha256:321cd050dce9ef5f3665adff9323163820ac4c7d18b91876a520e6f0e8b49d46
-generated: 2017-09-20T00:29:42.620906219-05:00
+digest: sha256:306378be27e855f6823d057c0d90ba3be227d44dc75b2c70c484a03c2515511e
+generated: 2017-11-14T11:12:37.260876101Z

--- a/incubator/chartmuseum/templates/NOTES.txt
+++ b/incubator/chartmuseum/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -40,3 +40,14 @@ spec:
           name: storage-volume
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+      volumes:
+{{- if .Values.persistence.volumes }}
+{{ toYaml .Values.persistence.volumes | indent 6 }}
+{{- end }}
+      - name: storage-volume
+      {{- if .Values.persistence.Enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.ExistingClaim | default (include "common.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}

--- a/incubator/chartmuseum/templates/pvc.yaml
+++ b/incubator/chartmuseum/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.persistence.Enabled (not .Values.persistence.ExistingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+    app: {{ include "common.fullname" . }}
+    release: {{ .Release.Name | quote }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.AccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.Size | quote }}
+{{- if .Values.persistence.StorageClass }}
+{{- if (eq "-" .Values.persistence.StorageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.StorageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: chartmuseum/chartmuseum
-  tag: v0.1.0
+  tag: v0.2.4
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
@@ -14,3 +14,20 @@ resources:
   requests:
     cpu: 80m
     memory: 64Mi
+persistence:
+  Enabled: true
+  AccessMode: ReadWriteOnce
+  Size: 8Gi
+  ## A manually managed Persistent Volume and Claim
+  ## Requires Persistence.Enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # ExistingClaim:
+
+  ## jenkins data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # StorageClass: "-"

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: chartmuseum/chartmuseum
-  tag: v0.2.4
+  tag: v0.2.6
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
@@ -15,7 +15,7 @@ resources:
     cpu: 80m
     memory: 64Mi
 persistence:
-  Enabled: true
+  Enabled: false
   AccessMode: ReadWriteOnce
   Size: 8Gi
   ## A manually managed Persistent Volume and Claim


### PR DESCRIPTION
…elease

- upgrade chartmuseum image to v0.2.4
- add a PVC to persist the storage folder so charts published charts surive pod restarts
- add option to disable persistance