### PR TITLE
[stable/coredns] support custom zone files in coredns

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 0.6.0
+version: 0.7.0
 description: CoreDNS is a DNS server that chains middleware and provides Kubernetes
   DNS Services
 keywords:

--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -41,4 +41,10 @@ data:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- range .Values.zoneFiles }}
+        file /etc/coredns/{{ .filename }} {{ .domain }}
+      {{- end }}
     }
+  {{- range .Values.zoneFiles }}
+  {{ .filename }}: {{ toYaml .contents | indent 4 }}
+  {{- end }}

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -85,3 +85,7 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+            {{ range .Values.zoneFiles }}
+            - key: {{ .filename }}
+              path: {{ .filename }}
+            {{ end }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -65,3 +65,13 @@ middleware:
       - "k8s.io"
     path: "/skydns"
     endpoint: "http://localhost:2379"
+# configure custom zone files as per https://coredns.io/2017/05/08/custom-dns-entries-for-kubernetes/
+zoneFiles: []
+#  - filename: example.db
+#    domain: example.com
+#    contents: |
+#      example.com.   IN SOA sns.dns.icann.com. noc.dns.icann.com. 2015082541 7200 3600 1209600 3600
+#      example.com.   IN NS  b.iana-servers.net.
+#      example.com.   IN NS  a.iana-servers.net.
+#      example.com.   IN A   192.168.99.102
+#      *.example.com. IN A   192.168.99.102


### PR DESCRIPTION
Adding support for custom zone files as outlined in [this coreos article](https://coredns.io/2017/05/08/custom-dns-entries-for-kubernetes).