### PR TITLE
Add vault capability to concourse chart

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.8.1
+version: 0.8.2
 appVersion: 3.5.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -109,6 +109,17 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `concourse.genericOauthAuthUrlParam` | Parameters (comma separated) to pass to the authentication server AuthURL | `nil` |
 | `concourse.genericOauthScope` | Optional scope required to authorize user | `nil` |
 | `concourse.genericOauthTokenUrl` | Generic OAuth provider TokenURL endpoint | `nil` |
+| `concourse.vault.vaultUrl` | Vault server address used to access secrets. | `nil` |
+| `concourse.vault.vaultPathPrefix` | Path under which to namespace credential lookup. (default: /concourse) | `nil` |
+| `concourse.vault.vaultCaCert` | Path to a PEM-encoded CA cert file to use to verify the vault server SSL cert. | `nil` |
+| `concourse.vault.vaultCaPath` | Path to a directory of PEM-encoded CA cert files to verify the vault server SSL cert. | `nil` |
+| `concourse.vault.vaultClientCert` | Path to the client certificate for Vault authorization. | `nil` |
+| `concourse.vault.vaultClientKey` | Path to the client private key for Vault authorization. | `nil` |
+| `concourse.vault.vaultServerName` | If set, is used to set the SNI host when connecting via TLS. | `nil` |
+| `concourse.vault.vaultInsecureSkipVerify` | Enable insecure SSL verification. | `nil` |
+| `concourse.vault.vaultClientToken` | Client token for accessing secrets within the Vault server. | `nil` |
+| `concourse.vault.vaultAuthBackend` | Auth backend to use for logging in to Vault. | `nil` |
+| `concourse.vault.vaultAuthParam` | Parameter to pass when logging in via the backend. Can be specified multiple times. | `nil` |
 | `web.nameOverride` | Override the Concourse Web components name | `web` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -109,6 +109,7 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `concourse.genericOauthAuthUrlParam` | Parameters (comma separated) to pass to the authentication server AuthURL | `nil` |
 | `concourse.genericOauthScope` | Optional scope required to authorize user | `nil` |
 | `concourse.genericOauthTokenUrl` | Generic OAuth provider TokenURL endpoint | `nil` |
+| `concourse.vault.enabled` | Global enable or disable of vault functionality. | `false` |
 | `concourse.vault.vaultUrl` | Vault server address used to access secrets. | `nil` |
 | `concourse.vault.vaultPathPrefix` | Path under which to namespace credential lookup. (default: /concourse) | `nil` |
 | `concourse.vault.vaultCaCert` | Path to a PEM-encoded CA cert file to use to verify the vault server SSL cert. | `nil` |

--- a/stable/concourse/templates/configmap.yaml
+++ b/stable/concourse/templates/configmap.yaml
@@ -39,4 +39,16 @@ data:
   generic-oauth-token-url: {{ default "" .Values.concourse.genericOauthTokenUrl | quote }}
   worker-post-stop-delay-seconds: {{ .Values.worker.postStopDelaySeconds | quote }}
   worker-fatal-errors: {{ default "" .Values.worker.fatalErrors | quote }}
+  vault-url: {{ default "" .Values.concourse.vault.vaultUrl | quote }}
+  vault-path-prefix: {{ default "" .Values.concourse.vault.vaultPathPrefix | quote }}
+  vault-ca-cert: {{ default "" .Values.concourse.vault.vaultCaCert | quote }}
+  vault-ca-path: {{ default "" .Values.concourse.vault.vaultCaPath | quote }}
+  vault-client-cert: {{ default "" .Values.concourse.vault.vaultClientCert | quote }}
+  vault-client-key: {{ default "" .Values.concourse.vault.vaultClientKey | quote }}
+  vault-server-name: {{ default "" .Values.concourse.vault.vaultServerName | quote }}
+  vault-insecure-skip-verify: {{ default "" .Values.concourse.vault.vaultInsecureSkipVerify | quote }}
+  vault-client-token: {{ default "" .Values.concourse.vault.vaultClientToken | quote }}
+  vault-auth-backend: {{ default "" .Values.concourse.vault.vaultAuthBackend | quote }}
+  vault-auth-param: {{ default "" .Values.concourse.vault.vaultAuthParam | quote }}
+
   

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -236,83 +236,83 @@ spec:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: generic-oauth-token-url
-            {{- if .Values.concourse.vault.vaultUrl }}
+            {{ if .Values.concourse.vault.vaultUrl }}
             - name: CONCOURSE_VAULT_URL
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-url
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultPathPrefix }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultPathPrefix }}
             - name: CONCOURSE_VAULT_PATH_PREFIX
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-path-prefix
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultCaCert }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultCaCert }}
             - name: CONCOURSE_VAULT_CA_CERT
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-ca-cert
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultCaPath }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultCaPath }}
             - name: CONCOURSE_VAULT_CA_PATH
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-ca-path
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultClientCert }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultClientCert }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-cert
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultClientKey }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultClientKey }}
             - name: CONCOURSE_VAULT_CLIENT_KEY
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-key
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultServerName }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultServerName }}
             - name: CONCOURSE_VAULT_SERVER_NAME
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-server-name
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultInsecureSkipVerify }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultInsecureSkipVerify }}
             - name: CONCOURSE_VAULT_INSECURE_SKIP_VERIFY
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-insecure-skip-verify
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultClientToken }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultClientToken }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-token
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultAuthBackend }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultAuthBackend }}
             - name: CONCOURSE_VAULT_AUTH_BACKEND
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-auth-backend
-            {{- end }}
-            {{- if .Values.concourse.vault.vaultAuthParam }}
+            {{ end }}
+            {{ if .Values.concourse.vault.vaultAuthParam }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-auth-param
-            {{- end }}
+            {{ end }}
             - name: CONCOURSE_TSA_HOST_KEY
               value: "/concourse-keys/host_key"
             - name: CONCOURSE_SESSION_SIGNING_KEY

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -236,85 +236,85 @@ spec:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: generic-oauth-token-url
-            {{- if .Values.concourse.vault.enabled -}}
-            {{- if .Values.concourse.vault.vaultUrl -}}
+            {{- if .Values.concourse.vault.enabled }}
+            {{- if .Values.concourse.vault.vaultUrl }}
             - name: CONCOURSE_VAULT_URL
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-url
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultPathPrefix -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultPathPrefix }}
             - name: CONCOURSE_VAULT_PATH_PREFIX
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-path-prefix
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultCaCert -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultCaCert }}
             - name: CONCOURSE_VAULT_CA_CERT
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-ca-cert
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultCaPath -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultCaPath }}
             - name: CONCOURSE_VAULT_CA_PATH
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-ca-path
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultClientCert -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultClientCert }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-cert
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultClientKey -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultClientKey }}
             - name: CONCOURSE_VAULT_CLIENT_KEY
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-key
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultServerName -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultServerName }}
             - name: CONCOURSE_VAULT_SERVER_NAME
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-server-name
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultInsecureSkipVerify -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultInsecureSkipVerify }}
             - name: CONCOURSE_VAULT_INSECURE_SKIP_VERIFY
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-insecure-skip-verify
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultClientToken -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultClientToken }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-token
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultAuthBackend -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultAuthBackend }}
             - name: CONCOURSE_VAULT_AUTH_BACKEND
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-auth-backend
-            {{- end -}}
-            {{- if .Values.concourse.vault.vaultAuthParam -}}
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultAuthParam }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-auth-param
-            {{- end -}}
-            {{- end -}}
+            {{- end }}
+            {{- end }}
             - name: CONCOURSE_TSA_HOST_KEY
               value: "/concourse-keys/host_key"
             - name: CONCOURSE_SESSION_SIGNING_KEY

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -236,83 +236,85 @@ spec:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: generic-oauth-token-url
-            {{ if .Values.concourse.vault.vaultUrl }}
+            {{- if .Values.concourse.vault.enabled -}}
+            {{- if .Values.concourse.vault.vaultUrl -}}
             - name: CONCOURSE_VAULT_URL
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-url
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultPathPrefix }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultPathPrefix -}}
             - name: CONCOURSE_VAULT_PATH_PREFIX
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-path-prefix
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultCaCert }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultCaCert -}}
             - name: CONCOURSE_VAULT_CA_CERT
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-ca-cert
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultCaPath }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultCaPath -}}
             - name: CONCOURSE_VAULT_CA_PATH
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-ca-path
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultClientCert }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultClientCert -}}
             - name: CONCOURSE_VAULT_CLIENT_CERT
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-cert
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultClientKey }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultClientKey -}}
             - name: CONCOURSE_VAULT_CLIENT_KEY
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-key
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultServerName }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultServerName -}}
             - name: CONCOURSE_VAULT_SERVER_NAME
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-server-name
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultInsecureSkipVerify }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultInsecureSkipVerify -}}
             - name: CONCOURSE_VAULT_INSECURE_SKIP_VERIFY
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-insecure-skip-verify
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultClientToken }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultClientToken -}}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-token
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultAuthBackend }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultAuthBackend -}}
             - name: CONCOURSE_VAULT_AUTH_BACKEND
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-auth-backend
-            {{ end }}
-            {{ if .Values.concourse.vault.vaultAuthParam }}
+            {{- end -}}
+            {{- if .Values.concourse.vault.vaultAuthParam -}}
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-auth-param
-            {{ end }}
+            {{- end -}}
+            {{- end -}}
             - name: CONCOURSE_TSA_HOST_KEY
               value: "/concourse-keys/host_key"
             - name: CONCOURSE_SESSION_SIGNING_KEY

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -236,6 +236,83 @@ spec:
                 configMapKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: generic-oauth-token-url
+            {{- if .Values.concourse.vault.vaultUrl }}
+            - name: CONCOURSE_VAULT_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-url
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultPathPrefix }}
+            - name: CONCOURSE_VAULT_PATH_PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-path-prefix
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultCaCert }}
+            - name: CONCOURSE_VAULT_CA_CERT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-ca-cert
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultCaPath }}
+            - name: CONCOURSE_VAULT_CA_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-ca-path
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultClientCert }}
+            - name: CONCOURSE_VAULT_CLIENT_CERT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-client-cert
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultClientKey }}
+            - name: CONCOURSE_VAULT_CLIENT_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-client-key
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultServerName }}
+            - name: CONCOURSE_VAULT_SERVER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-server-name
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultInsecureSkipVerify }}
+            - name: CONCOURSE_VAULT_INSECURE_SKIP_VERIFY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-insecure-skip-verify
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultClientToken }}
+            - name: CONCOURSE_VAULT_CLIENT_TOKEN
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-client-token
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultAuthBackend }}
+            - name: CONCOURSE_VAULT_AUTH_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-auth-backend
+            {{- end }}
+            {{- if .Values.concourse.vault.vaultAuthParam }}
+            - name: CONCOURSE_VAULT_AUTH_PARAM
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-auth-param
+            {{- end }}
             - name: CONCOURSE_TSA_HOST_KEY
               value: "/concourse-keys/host_key"
             - name: CONCOURSE_SESSION_SIGNING_KEY

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -279,7 +279,12 @@ concourse:
 
   ## Parent for vault configurations.
   ##
-  # vault:
+  vault:
+
+    ## Use the vault chart dependency.
+    ## Set to false if bringing your own PostgreSQL.
+    ##
+    enabled: false
 
     ## Vault server address used to access secrets..
     ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -279,7 +279,7 @@ concourse:
 
   ## Parent for vault configurations.
   ##
-  # vault:
+  vault:
 
     ## Vault server address used to access secrets..
     ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -277,6 +277,54 @@ concourse:
   ##
   # genericOauthTokenUrl:
 
+  ## Parent for vault configurations.
+  ##
+  # vault:
+
+    ## Vault server address used to access secrets..
+    ##
+    # vaultUrl:
+
+    ## Path under which to namespace credential lookup. (default: /concourse).
+    ##
+    # vaultPathPrefix:
+
+    ## Path to a PEM-encoded CA cert file to use to verify the vault server SSL cert.
+    ##
+    # vaultCaCert:
+
+    ## Path to a directory of PEM-encoded CA cert files to verify the vault server SSL cert.
+    ##
+    # vaultCaPath:
+
+    ## Path to the client certificate for Vault authorization.
+    ##
+    # vaultClientCert:
+
+    ## Path to the client private key for Vault authorization.
+    ##
+    # vaultClientKey:
+
+    ## If set, is used to set the SNI host when connecting via TLS.
+    ##
+    # vaultServerName:
+
+    ## Enable insecure SSL verification.
+    ##
+    # vaultInsecureSkipVerify:
+
+    ## Client token for accessing secrets within the Vault server.
+    ##
+    # vaultClientToken:
+
+    ## Auth backend to use for logging in to Vault.
+    ##
+    # vaultAuthBackend:
+
+    ## Parameter to pass when logging in via the backend. Can be specified multiple times.
+    ##
+    # vaultAuthParam:
+
 ## Configuration values for Concourse Web components.
 ##
 web:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -279,7 +279,7 @@ concourse:
 
   ## Parent for vault configurations.
   ##
-  vault:
+  # vault:
 
     ## Vault server address used to access secrets..
     ##


### PR DESCRIPTION
Concourse now supports vault out of the box and to be truly useful in an organisation it makes sense to use it. This change allows for helm users to connect to a vault instance and greatly simplifies and hardens secret management.

All of the new settings are described in the readme so there is not a lot of point duplicating them here but it has been very useful so far and it made sense to share it back to the helm community