### PR TITLE
Add suport for prometheus 2.1

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.6.18
+version: 5.0.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -95,10 +95,10 @@ Parameter | Description | Default
 `alertmanager.enabled` | If true, create alertmanager | `true`
 `alertmanager.name` | alertmanager container name | `alertmanager`
 `alertmanager.image.repository` | alertmanager container image repository | `prom/alertmanager`
-`alertmanager.image.tag` | alertmanager container image tag | `v0.5.1`
+`alertmanager.image.tag` | alertmanager container image tag | `v0.13.0`
 `alertmanager.image.pullPolicy` | alertmanager container image pull policy | `IfNotPresent`
 `alertmanager.prefixURL` | The prefix slug at which the server can be accessed | ``
-`alertmanager.baseURL` | The external url at which the server can be accessed | ``
+`alertmanager.baseURL` | The external url at which the server can be accessed | `/`
 `alertmanager.extraArgs` | Additional alertmanager container arguments | `{}`
 `alertmanager.configMapOverrideName` | Prometheus alertmanager ConfigMap override where full-name is `{{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName}}` and setting this value will prevent the default alertmanager ConfigMap from being generated | `""`
 `alertmanager.ingress.enabled` | If true, alertmanager Ingress will be created | `false`
@@ -134,7 +134,7 @@ Parameter | Description | Default
 `kubeStateMetrics.enabled` | If true, create kube-state-metrics | `true`
 `kubeStateMetrics.name` | kube-state-metrics container name | `kube-state-metrics`
 `kubeStateMetrics.image.repository` | kube-state-metrics container image repository| `k8s.gcr.io/kube-state-metrics`
-`kubeStateMetrics.image.tag` | kube-state-metrics container image tag | `v0.4.1`
+`kubeStateMetrics.image.tag` | kube-state-metrics container image tag | `v1.1.0`
 `kubeStateMetrics.image.pullPolicy` | kube-state-metrics container image pull policy | `IfNotPresent`
 `kubeStateMetrics.args` | kube-state-metrics container arguments | `{}`
 `kubeStateMetrics.nodeSelector` | node labels for kube-state-metrics pod assignment | `{}`
@@ -152,7 +152,7 @@ Parameter | Description | Default
 `nodeExporter.enabled` | If true, create node-exporter | `true`
 `nodeExporter.name` | node-exporter container name | `node-exporter`
 `nodeExporter.image.repository` | node-exporter container image repository| `prom/node-exporter`
-`nodeExporter.image.tag` | node-exporter container image tag | `v0.13.0`
+`nodeExporter.image.tag` | node-exporter container image tag | `v0.15.2`
 `nodeExporter.image.pullPolicy` | node-exporter container image pull policy | `IfNotPresent`
 `nodeExporter.extraArgs` | Additional node-exporter container arguments | `{}`
 `nodeExporter.extraHostPathMounts` | Additional node-exporter hostPath mounts | `[]`
@@ -192,7 +192,7 @@ Parameter | Description | Default
 `rbac.create` | If true, create & use RBAC resources | `false`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
-`server.image.tag` | Prometheus server container image tag | `v1.5.1`
+`server.image.tag` | Prometheus server container image tag | `v2.0.0`
 `server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -38,9 +38,53 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Prometheus 2.0
+
+Prometheus version 2.0 has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/)
+
+Users of this chart will need to update their alerting rules to the new format before they can upgrade.
+
 ## Upgrading from previous chart versions.
 
-As of Chart version 5.0 this chart uses Prometheus 2.0. This version of prometheus introduces a new data format and is not compatible with the old format. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
+As of version 5.0, this chart uses Prometheus 2.0. This version of prometheus introduces a new data format and is not compatible with prometheus 1.x. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
+
+### Example migration
+
+Assuming you have an existing release of the prometheus chart, named `prometheus-old`. In order to update to prometheus 2.0 while keeping your old data do the following:
+
+1. Update the `prometheus-old` release. Disable scraping and every component besides the prometheus server, similar to the configuration below:
+
+	```
+	alertmanager:
+	  enabled: false
+	alertmanagerFiles:
+	  alertmanager.yml: ""
+	kubeStateMetrics:
+	  enabled: false
+	nodeExporter:
+	  enabled: false
+	pushgateway:
+	  enabled: false
+	server:
+	  extraArgs:
+	    storage.local.retention: 720h
+	serverFiles:
+	  alerts: ""
+	  prometheus.yml: ""
+	  rules: ""
+	```
+	
+1. Deploy a new release of the chart with version 5.0+ using prometheus 2.0. In the values.yaml set the scrape config as usual, and also add the `prometheus-old` instance as a remote-read target.
+
+   ```
+	  prometheus.yml: |
+	    ...
+	    remote_read:
+	    - url: http://prometheus-old/api/v1/read
+	    ...
+   ```
+   
+   Old data will be available when you query the new prometheus instance. 
 
 ## Configuration
 
@@ -202,12 +246,6 @@ $ helm install stable/prometheus --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
-
-### Prometheus 2.0
-
-Prometheus version 2.0 has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/)
-
-Users of this chart will need to update their alerting rules to the new format before they can upgrade.
 
 ### ConfigMap Files
 AlertManager is configured through [alertmanager.yml](https://prometheus.io/docs/alerting/configuration/). This file (and any others listed in `alertmanagerFiles`) will be mounted into the `alertmanager` pod.

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -146,7 +146,7 @@ Parameter | Description | Default
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
 `server.image.tag` | Prometheus server container image tag | `v1.5.1`
 `server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
-`server.alertmanagerURL` | (optional) alertmanager URL; only used if alertmanager.enabled = false | `""`
+`server.alertmanagerHostname` | (optional) alertmanager hostname; only used if alertmanager.enabled = false | `""`
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``
 `server.baseURL` | The external url at which the server can be accessed | ``
@@ -180,8 +180,8 @@ Parameter | Description | Default
 `server.service.type` | type of Prometheus server service to create | `ClusterIP`
 `server.terminationGracePeriodSeconds` | Prometheus server Pod termination grace period | `300`
 `server.retention` | (optional) Prometheus data retention | `""`
-`serverFiles.alerts` | Prometheus server alerts configuration | `""`
-`serverFiles.rules` | Prometheus server rules configuration | `""`
+`serverFiles.alerts` | Prometheus server alerts configuration | `{}`
+`serverFiles.rules` | Prometheus server rules configuration | `{}`
 `serverFiles.prometheus.yml` | Prometheus server scrape configuration | example configuration
 `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 
@@ -199,6 +199,12 @@ $ helm install stable/prometheus --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Prometheus 2.0
+
+Prometheus version 2.0 has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/)
+
+Users of this chart will need to update their alerting rules to the new format before they can upgrade.
 
 ### ConfigMap Files
 AlertManager is configured through [alertmanager.yml](https://prometheus.io/docs/alerting/configuration/). This file (and any others listed in `alertmanagerFiles`) will be mounted into the `alertmanager` pod.

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -38,19 +38,19 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
-## Prometheus 2.0
+## Prometheus 2.x
 
-Prometheus version 2.0 has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/)
+Prometheus version 2.x has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/)
 
 Users of this chart will need to update their alerting rules to the new format before they can upgrade.
 
 ## Upgrading from previous chart versions.
 
-As of version 5.0, this chart uses Prometheus 2.0. This version of prometheus introduces a new data format and is not compatible with prometheus 1.x. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
+As of version 5.0, this chart uses Prometheus 2.1. This version of prometheus introduces a new data format and is not compatible with prometheus 1.x. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
 
 ### Example migration
 
-Assuming you have an existing release of the prometheus chart, named `prometheus-old`. In order to update to prometheus 2.0 while keeping your old data do the following:
+Assuming you have an existing release of the prometheus chart, named `prometheus-old`. In order to update to prometheus 2.1 while keeping your old data do the following:
 
 1. Update the `prometheus-old` release. Disable scraping and every component besides the prometheus server, similar to the configuration below:
 
@@ -74,7 +74,7 @@ Assuming you have an existing release of the prometheus chart, named `prometheus
 	  rules: ""
 	```
 	
-1. Deploy a new release of the chart with version 5.0+ using prometheus 2.0. In the values.yaml set the scrape config as usual, and also add the `prometheus-old` instance as a remote-read target.
+1. Deploy a new release of the chart with version 5.0+ using prometheus 2.x. In the values.yaml set the scrape config as usual, and also add the `prometheus-old` instance as a remote-read target.
 
    ```
 	  prometheus.yml: |
@@ -192,7 +192,7 @@ Parameter | Description | Default
 `rbac.create` | If true, create & use RBAC resources | `false`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
-`server.image.tag` | Prometheus server container image tag | `v2.0.0`
+`server.image.tag` | Prometheus server container image tag | `v2.1.0`
 `server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -38,6 +38,10 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Upgrading from previous chart versions.
+
+As of Chart version 5.0 this chart uses Prometheus 2.0. This version of prometheus introduces a new data format and is not compatible with the old format. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
+
 ## Configuration
 
 The following tables lists the configurable parameters of the Prometheus chart and their default values.
@@ -146,7 +150,6 @@ Parameter | Description | Default
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
 `server.image.tag` | Prometheus server container image tag | `v1.5.1`
 `server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
-`server.alertmanagerHostname` | (optional) alertmanager hostname; only used if alertmanager.enabled = false | `""`
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``
 `server.baseURL` | The external url at which the server can be accessed | ``

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -70,15 +70,3 @@ Return the appropriate apiVersion for networkpolicy.
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Return the alertmanager hostname and port, or empty if alertmanager is disabled and .Values.server.alertManagerHostname
-is not set.
-*/}}
-{{- define "prometheus.alertmanager.hostname" -}}
-{{- if .Values.alertmanager.enabled -}}
-{{ template "prometheus.alertmanager.fullname" .}}:{{.Values.alertmanager.service.servicePort}}
-{{- else if .Values.alertmanagerHostname}}
-{{- print .Values.server.alertmanagerHostname -}}
-{{- end }}
-{{- end }}

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -70,3 +70,15 @@ Return the appropriate apiVersion for networkpolicy.
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the alertmanager hostname and port, or empty if alertmanager is disabled and .Values.server.alertManagerHostname
+is not set.
+*/}}
+{{- define "prometheus.alertmanager.hostname" -}}
+{{- if .Values.alertmanager.enabled -}}
+{{ template "prometheus.alertmanager.fullname" .}}:{{.Values.alertmanager.service.servicePort}}
+{{- else if .Values.alertmanagerHostname}}
+{{- print .Values.server.alertmanagerHostname -}}
+{{- end }}
+{{- end }}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -10,5 +10,20 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "prometheus.server.fullname" . }}
 data:
-{{ toYaml .Values.serverFiles | indent 2 }}
-{{- end }}
+{{- $alertmanagerHostname := include "prometheus.alertmanager.hostname" . -}}
+{{- $root := . -}}
+{{- range $key, $value := .Values.serverFiles }}
+  {{ $key }}: |
+{{ toYaml $value | default "{}" | indent 4 }}
+{{- if eq $key "prometheus.yml" -}}
+{{- if $alertmanagerHostname -}}
+    alerting:
+      alertmanagers:
+      - path_prefix: {{ $root.Values.alertmanager.baseURL }}
+        static_configs:
+        - targets:
+          - {{ $alertmanagerHostname }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -10,19 +10,32 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "prometheus.server.fullname" . }}
 data:
-{{- $alertmanagerHostname := include "prometheus.alertmanager.hostname" . -}}
 {{- $root := . -}}
 {{- range $key, $value := .Values.serverFiles }}
   {{ $key }}: |
 {{ toYaml $value | default "{}" | indent 4 }}
 {{- if eq $key "prometheus.yml" -}}
-{{- if $alertmanagerHostname -}}
+{{- if $root.Values.alertmanager.enabled -}}
     alerting:
       alertmanagers:
-      - path_prefix: {{ $root.Values.alertmanager.baseURL }}
-        static_configs:
-        - targets:
-          - {{ $alertmanagerHostname }}
+      - kubernetes_sd_configs:
+          - role: pod
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace]
+          regex: {{ $root.Release.Namespace }} ## maybe not works in configmap, you need assigned to 1 variable first.
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          regex: prometheus
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_label_component]
+          regex: alertmanager
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_container_port_number]
+          regex:
+          action: drop
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -25,7 +25,7 @@ data:
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         relabel_configs:
         - source_labels: [__meta_kubernetes_namespace]
-          regex: {{ $root.Release.Namespace }} ## maybe not works in configmap, you need assigned to 1 variable first.
+          regex: {{ $root.Release.Namespace }}
           action: keep
         - source_labels: [__meta_kubernetes_pod_label_app]
           regex: prometheus

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         component: "{{ .Values.server.name }}"
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        runAsUser: 0
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "prometheus.server.fullname" . }}{{ else }}"{{ .Values.server.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.name }}
@@ -44,16 +46,14 @@ spec:
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
-          {{- if or .Values.alertmanager.enabled .Values.server.alertmanagerURL }}
-            - --alertmanager.url={{- if .Values.alertmanager.enabled }}http://{{ template "prometheus.alertmanager.fullname" . }}:{{ .Values.alertmanager.service.servicePort }}{{ .Values.alertmanager.prefixURL }}{{- else }}{{ .Values.server.alertmanagerURL }}{{- end }}
-          {{- end }}
           {{- if .Values.server.retention }}
-            - --storage.local.retention={{ .Values.server.retention }}
+            - --storage.tsdb.retention={{ .Values.server.retention }}
           {{- end }}
             - --config.file=/etc/config/prometheus.yml
-            - --storage.local.path={{ .Values.server.persistentVolume.mountPath }}
+            - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
+            - --web.enable-lifecycle
           {{- range $key, $value := .Values.server.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -25,9 +25,16 @@ spec:
         component: "{{ .Values.server.name }}"
         release: {{ .Release.Name }}
     spec:
-      securityContext:
-        runAsUser: 0
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "prometheus.server.fullname" . }}{{ else }}"{{ .Values.server.serviceAccountName }}"{{ end }}
+      initContainers:
+      - name: "init-chown-data"
+        image: "busybox"
+        # 65534 is the nobody user that prometheus uses.
+        command: ["chown", "-R", "65534:65534", "{{ .Values.server.persistentVolume.mountPath }}"]
+        volumeMounts:
+        - name: storage-volume
+          mountPath: {{ .Values.server.persistentVolume.mountPath }}
+          subPath: "{{ .Values.server.persistentVolume.subPath }}"
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.name }}
           image: "{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -17,7 +17,7 @@ alertmanager:
   ##
   image:
     repository: prom/alertmanager
-    tag: v0.10.0
+    tag: v0.13.0
     pullPolicy: IfNotPresent
 
   ## Additional alertmanager container arguments

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -253,7 +253,7 @@ nodeExporter:
   ##
   image:
     repository: prom/node-exporter
-    tag: v0.15.1
+    tag: v0.15.2
     pullPolicy: IfNotPresent
 
   ## Custom Update Strategy

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -332,7 +332,7 @@ server:
   ##
   image:
     repository: prom/prometheus
-    tag: v2.0.0
+    tag: v2.1.0
     pullPolicy: IfNotPresent
 
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -17,7 +17,7 @@ alertmanager:
   ##
   image:
     repository: prom/alertmanager
-    tag: v0.9.1
+    tag: v0.10.0
     pullPolicy: IfNotPresent
 
   ## Additional alertmanager container arguments
@@ -31,7 +31,7 @@ alertmanager:
 
   ## External URL which can access alertmanager
   ## Maybe same with Ingress host name
-  baseURL: ""
+  baseURL: "/"
 
   ## Additional alertmanager container environment variable
   ## For instance to add a http_proxy
@@ -191,7 +191,7 @@ kubeStateMetrics:
   ##
   image:
     repository: k8s.gcr.io/kube-state-metrics
-    tag: v1.1.0-rc.0
+    tag: v1.1.0
     pullPolicy: IfNotPresent
 
   ## kube-state-metrics container arguments
@@ -253,7 +253,7 @@ nodeExporter:
   ##
   image:
     repository: prom/node-exporter
-    tag: v0.15.0
+    tag: v0.15.1
     pullPolicy: IfNotPresent
 
   ## Custom Update Strategy
@@ -332,12 +332,12 @@ server:
   ##
   image:
     repository: prom/prometheus
-    tag: v1.8.1
+    tag: v2.0.0
     pullPolicy: IfNotPresent
 
-  ## (optional) alertmanager URL
+  ## (optional) alertmanager hostname
   ## only used if alertmanager.enabled = false
-  alertmanagerURL: ""
+  alertmanagerHostname: ""
 
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug
   ## so that the various internal URLs are still able to access as they are in the default case.
@@ -598,10 +598,10 @@ alertmanagerFiles:
 ## Prometheus server ConfigMap entries
 ##
 serverFiles:
-  alerts: ""
-  rules: ""
+  alerts: {}
+  rules: {}
 
-  prometheus.yml: |-
+  prometheus.yml:
     rule_files:
       - /etc/config/rules
       - /etc/config/alerts

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -335,10 +335,6 @@ server:
     tag: v2.0.0
     pullPolicy: IfNotPresent
 
-  ## (optional) alertmanager hostname
-  ## only used if alertmanager.enabled = false
-  alertmanagerHostname: ""
-
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug
   ## so that the various internal URLs are still able to access as they are in the default case.
   ## (Optional)


### PR DESCRIPTION
Most changes are in the configmap due to the new rules format and the
different method of setting the alertmanager target.

Migration notes: https://prometheus.io/docs/prometheus/latest/migration/