### PR TITLE
[stable/neo4j] add additional persistence configuration to neo4j

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,6 +1,6 @@
 name: neo4j
 home: https://www.neo4j.com
-version: 0.5.0
+version: 0.6.0
 appVersion: 3.2.3
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -90,3 +90,24 @@ $ helm install --name neo4j-helm -f values.yaml stable/neo4j
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [neo4j](https://github.com/neo4j/docker-neo4j) image stores the Neo4j data
+at the `/data` path of the container by default.
+
+The chart mounts a
+[Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/)
+volume at this location. The volume is created using dynamic volume
+provisioning. If the PersistentVolumeClaim should not be managed by the chart,
+define `persistence.existingClaim`.
+
+### Existing PersistentVolumeClaims
+
+1. Create the PersistentVolume
+2. Create the PersistentVolumeClaim
+3. Install the chart
+
+```bash
+$ helm install --set core.persistentVolume.existingClaim=PVC_NAME incubator/neo4j
+```

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -61,6 +61,7 @@ their default values.
 | `core.numberOfServers`               | Number of machines in CORE mode                                                                                                         | `3`                                             |
 | `core.sideCarContainers`             | Sidecar containers to add to the core pod. Example use case is a sidecar which identifies and labels the leader when using the http API | `{}`                                            |
 | `core.initContainers`                | Init containers to add to the core pod. Example use case is a script that installs the APOC library                                     | `{}`                                            |
+| `core.persistentVolume.enabled`      | Is writing to a persistent volume required?                                                                                             | `true`                                          |
 | `core.persistentVolume.storageClass` | Storage class of backing PVC                                                                                                            | `standard` (uses beta storage class annotation) |
 | `core.persistentVolume.size`         | Size of data volume                                                                                                                     | `10Gi`                                          |
 | `core.persistentVolume.mountPath`    | Persistent Volume mount root path                                                                                                       | `/data`                                         |
@@ -72,8 +73,7 @@ their default values.
 The above parameters map to the env variables defined in the
 [Neo4j docker image](https://github.com/neo4j/docker-neo4j).
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm
-install`. For example,
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
 $ helm install --name neo4j-helm --set core.numberOfServers=5,readReplica.numberOfServers=3 stable/neo4j
@@ -109,5 +109,5 @@ define `persistence.existingClaim`.
 3. Install the chart
 
 ```bash
-$ helm install --set core.persistentVolume.existingClaim=PVC_NAME incubator/neo4j
+$ helm install --set core.persistentVolume.existingClaim=PVC_NAME stable/neo4j
 ```

--- a/stable/neo4j/templates/core-pvc.yaml
+++ b/stable/neo4j/templates/core-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.core.persistentVolume.enabled (not .Values.core.persistentVolume.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "neo4j.core.fullname" . }}
+  labels:
+    app: {{ template "neo4j.core.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+{{- if .Values.core.persistentVolume.annotations }}
+{{ toYaml .Values.core.persistentVolume.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.core.persistentVolume.size | quote }}
+{{- if .Values.core.persistentVolume.storageClass }}
+{{- if (eq "-" .Values.core.persistentVolume.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.core.persistentVolume.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -77,7 +77,6 @@ spec:
         - name: datadir
           mountPath: "{{ .Values.core.persistentVolume.mountPath }}"
           subPath: "{{ .Values.core.persistentVolume.subPath }}"
-        volumeMounts:
         - name: plugins
           mountPath: /plugins
         resources:
@@ -92,23 +91,10 @@ spec:
       volumes:
         - name: plugins
           emptyDir: {}
-  volumeClaimTemplates:
-    - metadata:
-        name: datadir
-        annotations:
-        {{- if .Values.core.persistentVolume.annotations }}
-{{ toYaml .Values.core.persistentVolume.annotations | indent 12 }}
+        - name: datadir
+        {{- if .Values.core.persistentVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.core.persistentVolume.existingClaim | default (include "neo4j.core.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
         {{- end }}
-      spec:
-        accessModes:
-          - ReadWriteOnce
-      {{- if .Values.core.persistentVolume.storageClass }}
-      {{- if (eq "-" .Values.core.persistentVolume.storageClass) }}
-        storageClassName: ""
-      {{- else }}
-        storageClassName: "{{ .Values.core.persistentVolume.storageClass }}"
-      {{- end }}
-      {{- end }}
-        resources:
-          requests:
-            storage: "{{ .Values.core.persistentVolume.size }}"

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -26,6 +26,8 @@ core:
   numberOfServers: 3
   persistentVolume:
 
+    enabled: true
+
     ## core server data Persistent Volume mount root path
     ##
     mountPath: /data


### PR DESCRIPTION
This commit leverages existing charts with persistence (including [postgreqsl](https://github.com/kubernetes/charts/blob/92fd7ac0e102005a342291b847a3ec1f14668bbc/stable/postgresql/templates/pvc.yaml), [redis](https://github.com/kubernetes/charts/blob/92fd7ac0e102005a342291b847a3ec1f14668bbc/stable/redis/templates/pvc.yaml)) to add more configuration with regard to persistence.

This allows the consumer to disable persistent volumes for Neo4j core servers entirely, or specify and existing volume claim to be used by the core servers, rather than using dynamic provisioning.

@mneedham could you verify this please?