### PR TITLE
[stable/cluster-autoscaler] Bump to 1.0.3, allow patching pod status and scaling down

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.2.1
+version: 0.3.0
+appVersion: 1.0.3
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -16,6 +16,19 @@ rules:
       - endpoints
     verbs:
       - create
+      - patch
+  - apiGroups:
+    - ""
+    resources:
+    - pods/eviction
+    verbs:
+    - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/status
+    verbs:
+      - update
   - apiGroups:
       - ""
     resources:
@@ -29,6 +42,14 @@ rules:
       - ""
     resources:
       - nodes
+    verbs:
+    - watch
+    - list
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
       - pods
       - services
       - replicationcontrollers
@@ -37,13 +58,7 @@ rules:
     verbs:
       - watch
       - list
-  - apiGroups:
-      - apps
-    resources:
-      - statefulsets
-    verbs:
-      - watch
-      - list
+      - get
   - apiGroups:
       - extensions
     resources:
@@ -52,6 +67,7 @@ rules:
     verbs:
       - watch
       - list
+      - get
   - apiGroups:
       - policy
     resources:
@@ -59,4 +75,12 @@ rules:
     verbs:
       - watch
       - list
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - watch
+    - list
+    - get
 {{- end -}}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -11,7 +11,7 @@ cloudProvider: aws
 
 image:
   repository: gcr.io/google_containers/cluster-autoscaler
-  tag: v0.6.0
+  tag: v1.0.3
   pullPolicy: IfNotPresent
 
 tolerations: []


### PR DESCRIPTION
This updates the autoscaler to 1.0.3, and adds a few new permissions
that were implemented by Kops:

* https://github.com/kubernetes/kops/pull/3145 - Fixing clusterautoscaler
  rbac.
* https://github.com/kubernetes/kops/pull/3419 - Allow cluster autoscaler
  to scale down.

cc the maintainer @mgoodness 