### PR TITLE
[stable/mariadb] fix failing test

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 2.0.1
+version: 2.0.2
 appVersion: 10.1.28
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/templates/tests.yaml
+++ b/stable/mariadb/templates/tests.yaml
@@ -5,5 +5,5 @@ metadata:
 data:
   run.sh: |-
     @test "Testing MariaDB is accessible" {
-      mysql -h {{ template "mariadb.fullname" . }} {{- if .Values.usePassword }} -p$MARIADB_ROOT_PASSWORD{{ end }} -e 'show databases;'
+      mysql -h {{ template "mariadb.fullname" . }} -uroot {{- if .Values.usePassword }} -p$MARIADB_ROOT_PASSWORD{{ end }} -e 'show databases;'
     }


### PR DESCRIPTION
The mysql binary now seems to default to an unknown user so we need to
specify the root user explicitly in the test.