### PR TITLE
[stable/neo4j] add matchLabels with subset of labels for deployments

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,6 +1,6 @@
 name: neo4j
 home: https://www.neo4j.com
-version: 0.4.0
+version: 0.4.1
 appVersion: 3.2.3
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -7,6 +7,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "neo4j.name" . }}
+      release: {{ .Release.Name }}
       component: core
   replicas: {{ .Values.core.numberOfServers }}
   template:

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -4,6 +4,10 @@ metadata:
   name: "{{ template "neo4j.core.fullname" . }}"
 spec:
   serviceName: {{ template "neo4j.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "neo4j.name" . }}
+      component: core
   replicas: {{ .Values.core.numberOfServers }}
   template:
     metadata:

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app: {{ template "neo4j.name" . }}
     component: replica
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "neo4j.name" . }}
+      component: replica
   replicas: {{ .Values.readReplica.numberOfServers }}
   template:
     metadata:

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "neo4j.name" . }}
+      release: {{ .Release.Name }}
       component: replica
   replicas: {{ .Values.readReplica.numberOfServers }}
   template:


### PR DESCRIPTION
This was missing from the core statefulset and read replica deployment. This can result in some weirdness when updating deployments where the release metadata changes: https://github.com/kubernetes/helm/issues/1844.

Additionally, these will _not_ be added by default in apps/v1beta2 and is [recommended as a best practise in helm](https://github.com/kubernetes/helm/blob/3ee50ccf8620e14efee7c15097a25bed7233afe9/docs/chart_best_practices/pods.md).