### PR TITLE
[stable/phpbb] allow use of external database

### DIFF
--- a/stable/phpbb/Chart.yaml
+++ b/stable/phpbb/Chart.yaml
@@ -1,5 +1,5 @@
 name: phpbb
-version: 0.5.0
+version: 0.6.0
 appVersion: 3.2.1
 description: Community forum that supports the notion of users and groups, file attachments,
   full-text search, notifications and more.

--- a/stable/phpbb/README.md
+++ b/stable/phpbb/README.md
@@ -57,6 +57,11 @@ The following tables lists the configurable parameters of the phpBB chart and th
 | `smtpPort`                        | SMTP port                             | `nil`                                                   |
 | `smtpUser`                        | SMTP user                             | `nil`                                                   |
 | `smtpPassword`                    | SMTP password                         | `nil`                                                   |
+| `externalDatabase.host`           | Host of the external database         | `nil`                                                   |
+| `externalDatabase.user`           | Existing username in the external db  | `bn_phpbb`                                              |
+| `externalDatabase.password`       | Password for the above username       | `nil`                                                   |
+| `externalDatabase.database`       | Name of the existing databse          | `bitnami_phpbb`                                         |
+| `mariadb.enabled`                 | Use or not the mariadb chart          | `true`                                                  |
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                   |
 | `mariadb.mariadbDatabase`         | Database name to create               | `bitnami_phpbb`                                         |
 | `mariadb.mariadbUser`             | Database user to create               | `bn_phpbb`                                              |

--- a/stable/phpbb/README.md
+++ b/stable/phpbb/README.md
@@ -52,11 +52,15 @@ The following tables lists the configurable parameters of the phpBB chart and th
 | `phpbbUser`                       | User of the application               | `user`                                                  |
 | `phpbbPassword`                   | Application password                  | _random 10 character long alphanumeric string_          |
 | `phpbbEmail`                      | Admin email                           | `user@example.com`                                      |
+| `allowEmptyPassword`              | Allow DB blank passwords              | `yes`                                                   |
 | `smtpHost`                        | SMTP host                             | `nil`                                                   |
 | `smtpPort`                        | SMTP port                             | `nil`                                                   |
 | `smtpUser`                        | SMTP user                             | `nil`                                                   |
 | `smtpPassword`                    | SMTP password                         | `nil`                                                   |
 | `mariadb.mariadbRootPassword`     | MariaDB admin password                | `nil`                                                   |
+| `mariadb.mariadbDatabase`         | Database name to create               | `bitnami_phpbb`                                         |
+| `mariadb.mariadbUser`             | Database user to create               | `bn_phpbb`                                              |
+| `mariadb.mariadbPassword`         | Password for the database             | _random 10 character long alphanumeric string_          |
 | `serviceType`                     | Kubernetes Service type               | `LoadBalancer`                                          |
 | `persistence.enabled`             | Enable persistence using PVC          | `true`                                                  |
 | `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `nil` (uses alpha storage class annotation)             |

--- a/stable/phpbb/requirements.lock
+++ b/stable/phpbb/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:57.521757713-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2017-12-05T17:17:21.788784+01:00

--- a/stable/phpbb/requirements.yaml
+++ b/stable/phpbb/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mariadb
   version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: mariadb.enabled

--- a/stable/phpbb/templates/NOTES.txt
+++ b/stable/phpbb/templates/NOTES.txt
@@ -37,7 +37,7 @@ This deployment will be incomplete until you configure phpBB with a resolvable d
 host. To configure phpBB to use and external database host:
 
 
-1. Complete your Ghost deployment by running:
+1. Complete your phpBB deployment by running:
 
   helm upgrade {{ .Release.Name }} --set serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/phpbb
 

--- a/stable/phpbb/templates/NOTES.txt
+++ b/stable/phpbb/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
 1. Get the phpBB URL by running:
 
@@ -25,3 +26,19 @@
 
     echo Username: {{ .Values.phpbbUser }}
     echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "phpbb.fullname" . }} -o jsonpath="{.data.phpbb-password}" | base64 --decode)
+
+{{- else -}}
+
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
+
+This deployment will be incomplete until you configure phpBB with a resolvable database
+host. To configure phpBB to use and external database host:
+
+
+1. Complete your Ghost deployment by running:
+
+  helm upgrade {{ .Release.Name }} --set serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/phpbb
+
+{{- end }}

--- a/stable/phpbb/templates/deployment.yaml
+++ b/stable/phpbb/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
-          value: "{{ .Values.allowEmptyPassword | quote}}"
+          value: {{ .Values.allowEmptyPassword | quote }}
         - name: MARIADB_HOST
         {{- if .Values.mariadb.enabled }}
           value: {{ template "phpbb.mariadb.fullname" . }}

--- a/stable/phpbb/templates/deployment.yaml
+++ b/stable/phpbb/templates/deployment.yaml
@@ -19,15 +19,25 @@ spec:
         image: "{{ .Values.image }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         env:
+        - name: ALLOW_EMPTY_PASSWORD
+        {{- if .Values.allowEmptyPassword }}
+          value: "yes"
+        {{- else }}
+          value: "no"
+        {{- end }}
         - name: MARIADB_HOST
           value: {{ template "phpbb.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
-        - name: MARIADB_PASSWORD
+        - name: PHPBB_DATABASE_NAME
+          value: {{ default "" .Values.mariadb.mariadbDatabase | quote }}
+        - name: PHPBB_DATABASE_USER
+          value: {{ default "" .Values.mariadb.mariadbUser | quote }}
+        - name: PHPBB_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "phpbb.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
         - name: PHPBB_USERNAME
           value: {{ default "" .Values.phpbbUser | quote }}
         - name: PHPBB_PASSWORD

--- a/stable/phpbb/templates/deployment.yaml
+++ b/stable/phpbb/templates/deployment.yaml
@@ -17,33 +17,33 @@ spec:
       containers:
       - name: {{ template "phpbb.fullname" . }}
         image: "{{ .Values.image }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
-        {{- if .Values.allowEmptyPassword }}
-          value: "yes"
-        {{- else }}
-          value: "no"
-        {{- end }}
+          value: "{{ .Values.allowEmptyPassword }}"
         - name: MARIADB_HOST
         {{- if .Values.mariadb.enabled }}
           value: {{ template "phpbb.mariadb.fullname" . }}
         {{- else }}
-          value: {{ default "" .Values.externalDatabase.host | quote }}
+          value: {{ .Values.externalDatabase.host | quote }}
         {{- end }}
         - name: MARIADB_PORT_NUMBER
+        {{- if .Values.mariadb.enabled }}
           value: "3306"
+        {{- else }}
+          value: {{ .Values.externalDatabase.port | quote }}
+        {{- end }}
         - name: PHPBB_DATABASE_NAME
         {{- if .Values.mariadb.enabled }}
-          value: {{ default "" .Values.mariadb.mariadbDatabase | quote }}
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
         {{- else }}
-          value: {{ default "" .Values.externalDatabase.database | quote }}
+          value: {{ .Values.externalDatabase.database | quote }}
         {{- end }}
         - name: PHPBB_DATABASE_USER
         {{- if .Values.mariadb.enabled }}
-          value: {{ default "" .Values.mariadb.mariadbUser | quote }}
+          value: {{ .Values.mariadb.mariadbUser | quote }}
         {{- else }}
-          value: {{ default "" .Values.externalDatabase.user | quote }}
+          value: {{ .Values.externalDatabase.user | quote }}
         {{- end }}
         - name: PHPBB_DATABASE_PASSWORD
           valueFrom:
@@ -56,20 +56,20 @@ spec:
               key: db-password
             {{- end }}
         - name: PHPBB_USERNAME
-          value: {{ default "" .Values.phpbbUser | quote }}
+          value: {{ .Values.phpbbUser | quote }}
         - name: PHPBB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "phpbb.fullname" . }}
               key: phpbb-password
         - name: PHPBB_EMAIL
-          value: {{ default "" .Values.phpbbEmail | quote }}
+          value: {{ .Values.phpbbEmail | quote }}
         - name: SMTP_HOST
-          value: {{ default "" .Values.smtpHost | quote }}
+          value: {{ .Values.smtpHost | quote }}
         - name: SMTP_PORT
-          value: {{ default "" .Values.smtpPort | quote }}
+          value: {{ .Values.smtpPort | quote }}
         - name: SMTP_USER
-          value: {{ default "" .Values.smtpUser | quote }}
+          value: {{ .Values.smtpUser | quote }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/phpbb/templates/deployment.yaml
+++ b/stable/phpbb/templates/deployment.yaml
@@ -25,24 +25,35 @@ spec:
         {{- else }}
           value: "no"
         {{- end }}
-        - name: MARIADB_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "phpbb.mariadb.fullname" . }}
-              key: mariadb-root-password
         - name: MARIADB_HOST
+        {{- if .Values.mariadb.enabled }}
           value: {{ template "phpbb.mariadb.fullname" . }}
+        {{- else }}
+          value: {{ default "" .Values.externalDatabase.host | quote }}
+        {{- end }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
         - name: PHPBB_DATABASE_NAME
+        {{- if .Values.mariadb.enabled }}
           value: {{ default "" .Values.mariadb.mariadbDatabase | quote }}
+        {{- else }}
+          value: {{ default "" .Values.externalDatabase.database | quote }}
+        {{- end }}
         - name: PHPBB_DATABASE_USER
+        {{- if .Values.mariadb.enabled }}
           value: {{ default "" .Values.mariadb.mariadbUser | quote }}
+        {{- else }}
+          value: {{ default "" .Values.externalDatabase.user | quote }}
+        {{- end }}
         - name: PHPBB_DATABASE_PASSWORD
+        {{- if .Values.mariadb.enabled }}
           valueFrom:
             secretKeyRef:
               name: {{ template "phpbb.mariadb.fullname" . }}
               key: mariadb-password
+        {{- else }}
+          value: {{ default "" .Values.externalDatabase.password | quote }}
+        {{- end }}
         - name: PHPBB_USERNAME
           value: {{ default "" .Values.phpbbUser | quote }}
         - name: PHPBB_PASSWORD

--- a/stable/phpbb/templates/deployment.yaml
+++ b/stable/phpbb/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -20,7 +21,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
-          value: "{{ .Values.allowEmptyPassword }}"
+          value: "{{ .Values.allowEmptyPassword | quote}}"
         - name: MARIADB_HOST
         {{- if .Values.mariadb.enabled }}
           value: {{ template "phpbb.mariadb.fullname" . }}
@@ -114,3 +115,4 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+{{- end }}

--- a/stable/phpbb/templates/deployment.yaml
+++ b/stable/phpbb/templates/deployment.yaml
@@ -25,6 +25,11 @@ spec:
         {{- else }}
           value: "no"
         {{- end }}
+        - name: MARIADB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "phpbb.mariadb.fullname" . }}
+              key: mariadb-root-password
         - name: MARIADB_HOST
           value: {{ template "phpbb.mariadb.fullname" . }}
         - name: MARIADB_PORT_NUMBER

--- a/stable/phpbb/templates/deployment.yaml
+++ b/stable/phpbb/templates/deployment.yaml
@@ -46,14 +46,15 @@ spec:
           value: {{ default "" .Values.externalDatabase.user | quote }}
         {{- end }}
         - name: PHPBB_DATABASE_PASSWORD
-        {{- if .Values.mariadb.enabled }}
           valueFrom:
             secretKeyRef:
+            {{- if .Values.mariadb.enabled }}
               name: {{ template "phpbb.mariadb.fullname" . }}
               key: mariadb-password
-        {{- else }}
-          value: {{ default "" .Values.externalDatabase.password | quote }}
-        {{- end }}
+            {{- else }}
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+            {{- end }}
         - name: PHPBB_USERNAME
           value: {{ default "" .Values.phpbbUser | quote }}
         - name: PHPBB_PASSWORD

--- a/stable/phpbb/templates/externaldb-secrets.yaml
+++ b/stable/phpbb/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/phpbb/templates/externaldb-secrets.yaml
+++ b/stable/phpbb/templates/externaldb-secrets.yaml
@@ -10,5 +10,5 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  db-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/stable/phpbb/values.yaml
+++ b/stable/phpbb/values.yaml
@@ -47,13 +47,13 @@ externalDatabase:
   port: 3306
 
   ## Database user
-  user: bn_mediawiki
+  user: bn_phpbb
 
   ## Database password
   password:
 
   ## Database name
-  database: bitnami_mediawiki
+  database: bitnami_phpbb
 
 ##
 ## MariaDB chart configuration

--- a/stable/phpbb/values.yaml
+++ b/stable/phpbb/values.yaml
@@ -26,7 +26,7 @@ phpbbEmail: user@example.com
 
 ## Set to `yes` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-allowEmptyPassword: yes
+allowEmptyPassword: "yes"
 
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-phpbb#smtp-configuration
@@ -41,22 +41,25 @@ allowEmptyPassword: yes
 ##
 externalDatabase:
   ## Database host
-  # host:
+  host:
+
+  ## Database host
+  port: 3306
 
   ## Database user
-  # user: bn_mediawiki
+  user: bn_mediawiki
 
   ## Database password
-  # password:
+  password:
 
   ## Database name
-  # database: bitnami_mediawiki
+  database: bitnami_mediawiki
 
 ##
 ## MariaDB chart configuration
 ##
 mariadb:
-  ## Whether to use the database specified as a requirement or not. For example, to configure the chart with an existing database server.
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
   enabled: true
 
   ## MariaDB admin password

--- a/stable/phpbb/values.yaml
+++ b/stable/phpbb/values.yaml
@@ -37,9 +37,31 @@ allowEmptyPassword: yes
 # smtpPassword:
 
 ##
+## External database configuration
+##
+externalDatabase:
+  ## Database host
+  # host:
+
+  ## Database user
+  # user: bn_mediawiki
+
+  ## Database password
+  # password:
+
+  ## Database name
+  # database: bitnami_mediawiki
+
+
+
+
+##
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to use the database specified as a requirement or not. For example, to configure the chart with an existing database server.
+  enabled: true
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##

--- a/stable/phpbb/values.yaml
+++ b/stable/phpbb/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami phpBB image version
 ## ref: https://hub.docker.com/r/bitnami/phpbb/tags/
 ##
-image: bitnami/phpbb:3.2.1-r1
+image: bitnami/phpbb:3.2.1-r2
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -24,6 +24,10 @@ phpbbUser: user
 ##
 phpbbEmail: user@example.com
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+allowEmptyPassword: yes
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-phpbb#smtp-configuration
 ##
@@ -40,6 +44,21 @@ mariadb:
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##
   # mariadbRootPassword:
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_phpbb
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_phpbb
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  # mariadbPassword:
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/stable/phpbb/values.yaml
+++ b/stable/phpbb/values.yaml
@@ -52,9 +52,6 @@ externalDatabase:
   ## Database name
   # database: bitnami_mediawiki
 
-
-
-
 ##
 ## MariaDB chart configuration
 ##


### PR DESCRIPTION
Since `bitnami/phpbb:3.2.1-r2` it is possible to configure phpBB to use an already existing database.
This PR makes the required changes in the chart to create the database using the MariaDB chart and use it for phpBB.