### PR TITLE
[incubator/patroni] fix svc to being headless

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.5
+version: 0.5.1
 appVersion: 1.2-p17
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/templates/svc-patroni.yaml
+++ b/incubator/patroni/templates/svc-patroni.yaml
@@ -9,6 +9,9 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Component }}"
 spec:
   type: ClusterIP
+  clusterIP: None
   ports:
   - port: 5432
     targetPort: 5432
+  selector:
+    component: "{{ .Release.Name }}-{{ .Values.Component }}"


### PR DESCRIPTION
This seems reqired in kubenetes 1.8 and should also include previous releases.

Ref: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#components