### PR TITLE
[stable/nginx-ingress] fix unnecessary truncation

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.13
+version: 0.8.14
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/_helpers.tpl
+++ b/stable/nginx-ingress/templates/_helpers.tpl
@@ -27,7 +27,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Construct the path for the publish-service.
 
-By convention this will simply use the <namesapce>/<controller-name> to match the name of the
+By convention this will simply use the <namespace>/<controller-name> to match the name of the
 service generated.
 
 Users can provide an override for an explicit service they want bound via `.Values.controller.publishService.pathOverride`
@@ -36,7 +36,7 @@ Users can provide an override for an explicit service they want bound via `.Valu
 {{- define "nginx-ingress.controller.publishServicePath" -}}
 {{- $defServiceName := printf "%s/%s" .Release.Namespace (include "nginx-ingress.controller.fullname" .) -}}
 {{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
-{{- print $servicePath | trunc 63 | trimSuffix "-" -}}
+{{- print $servicePath | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
The `nginx-ingress.controller.fullname` is already truncated.
Further truncation where the length of the namespace is part of
the character count results in the service not being found when
the namespace is of significant length.
