### PR TITLE
[stable/neo4j] add optional sidecar container configuration for core pod.

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,6 +1,6 @@
 name: neo4j
 home: https://www.neo4j.com
-version: 0.3.1
+version: 0.4.0
 appVersion: 3.2.3
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/README.md
+++ b/stable/neo4j/README.md
@@ -1,6 +1,8 @@
 # Neo4j
 
-[Neo4j](https://neo4j.com/) is a highly scalable native graph database that leverages data relationships as first-class entities, helping enterprises build intelligent applications to meet today’s evolving data challenges.
+[Neo4j](https://neo4j.com/) is a highly scalable native graph database that
+leverages data relationships as first-class entities, helping enterprises build
+intelligent applications to meet today’s evolving data challenges.
 
 ## TL;DR;
 
@@ -10,12 +12,14 @@ $ helm install stable/neo4j
 
 ## Introduction
 
-This chart bootstraps a [Neo4j](https://github.com/neo4j/docker-neo4j) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Neo4j](https://github.com/neo4j/docker-neo4j)
+deployment on a [Kubernetes](http://kubernetes.io) cluster using the
+[Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
-- Kubernetes 1.6+ with Beta APIs enabled
-- PV provisioner support in the underlying infrastructure
+* Kubernetes 1.6+ with Beta APIs enabled
+* PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
 
@@ -25,7 +29,10 @@ To install the chart with the release name `neo4j-helm`:
 $ helm install --name neo4j-helm stable/neo4j --set neo4jPassword=mySecretPassword
 ```
 
-The command deploys Neo4j on the Kubernetes cluster in the default configuration but with the password set to `mySecretPassword`. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys Neo4j on the Kubernetes cluster in the default configuration
+but with the password set to `mySecretPassword`. The
+[configuration](#configuration) section lists the parameters that can be
+configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -37,37 +44,44 @@ To uninstall/delete the `neo4j-helm` deployment:
 $ helm delete neo4j-helm --purge
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Neo4j chart and their default values.
+The following tables lists the configurable parameters of the Neo4j chart and
+their default values.
 
-|         Parameter                    |             Description                        |                         Default                          |
-|--------------------------------------|------------------------------------------------|----------------------------------------------------------|
-| `image`                              | Neo4j image                                    | `neo4j`                                                  |
-| `imageTag`                           | Neo4j version                                  | `{VERSION}`                                              |
-| `imagePullPolicy`                    | Image pull policy                              | `IfNotPresent`                                           |
-| `authEnabled`                        | Is login/password required?                    | `true`                                                   |
-| `core.numberOfServers`               | Number of machines in CORE mode                | `3`                                                      |
-| `core.persistentVolume.storageClass` | Storage class of backing PVC                   | `standard` (uses beta storage class annotation)          |
-| `core.persistentVolume.size`         | Size of data volume                            | `10Gi`                                                   |
-| `core.persistentVolume.mountPath`    | Persistent Volume mount root path              | `/data`                                                  |
-| `core.persistentVolume.annotations`  | Persistent Volume Claim annotations            | `{}`                                                     |
-| `readReplica.numberOfServers`        | Number of machines in READ_REPLICA mode        | `0`                                                      |
-| `resources`                          | Resources required (e.g. CPU, memory)          | `{}`                                                     |
+| Parameter                            | Description                                                                                                                             | Default                                         |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `image`                              | Neo4j image                                                                                                                             | `neo4j`                                         |
+| `imageTag`                           | Neo4j version                                                                                                                           | `{VERSION}`                                     |
+| `imagePullPolicy`                    | Image pull policy                                                                                                                       | `IfNotPresent`                                  |
+| `authEnabled`                        | Is login/password required?                                                                                                             | `true`                                          |
+| `core.numberOfServers`               | Number of machines in CORE mode                                                                                                         | `3`                                             |
+| `core.sideCarContainers`             | Sidecar containers to add to the core pod. Example use case is a sidecar which identifies and labels the leader when using the http API | `{}`                                            |
+| `core.persistentVolume.storageClass` | Storage class of backing PVC                                                                                                            | `standard` (uses beta storage class annotation) |
+| `core.persistentVolume.size`         | Size of data volume                                                                                                                     | `10Gi`                                          |
+| `core.persistentVolume.mountPath`    | Persistent Volume mount root path                                                                                                       | `/data`                                         |
+| `core.persistentVolume.annotations`  | Persistent Volume Claim annotations                                                                                                     | `{}`                                            |
+| `readReplica.numberOfServers`        | Number of machines in READ_REPLICA mode                                                                                                 | `0`                                             |
+| `resources`                          | Resources required (e.g. CPU, memory)                                                                                                   | `{}`                                            |
 
-The above parameters map to the env variables defined in the [Neo4j docker image](https://github.com/neo4j/docker-neo4j).
+The above parameters map to the env variables defined in the
+[Neo4j docker image](https://github.com/neo4j/docker-neo4j).
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm
+install`. For example,
 
 ```bash
 $ helm install --name neo4j-helm --set core.numberOfServers=5,readReplica.numberOfServers=3 stable/neo4j
 ```
 
-The above command creates a cluster containing 5 core servers and 3 read replicas.
+The above command creates a cluster containing 5 core servers and 3 read
+replicas.
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example,
 
 ```bash
 $ helm install --name neo4j-helm -f values.yaml stable/neo4j

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -74,6 +74,9 @@ spec:
           subPath: "{{ .Values.core.persistentVolume.subPath }}"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.core.sidecarContainers }}
+{{ toYaml .Values.core.sidecarContainers | indent 6}}
+{{- end }}
 
   volumeClaimTemplates:
     - metadata:

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -55,6 +55,11 @@ core:
     # - name: EXTRA_VAR_2
     #   value: extra-var-value-2
 
+    sidecarContainers: {}
+    ## Additional containers to be added to the Neo4j core pod.
+    #  - name: my-sidecar
+    #    image: nginx:latest
+
 # Read Replicas
 readReplica:
   numberOfServers: 0


### PR DESCRIPTION
This allows the configuration of additional containers in the core pod, which can handle situations such as identifying and labeling leaders in the core pod when using the HTTP API, which can then be surfaced via HTTP - something which is not necessary when using a 1st party bolt driver.

If there's either:
* an alternative, preferred way to add sidecar containers to helm charts
* an alternative way of determining the leader and targeting it (for writes only) when running in kubernetes
then I'd be interested to hear suggestions,