### PR TITLE
Upgrading zookeeper chart k8szk version

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.4.2
+version: 0.5.0
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -122,11 +122,13 @@ The servers in the ensemble have both liveness and readiness checks specified. T
 | `probeInitialDelaySeconds` | The initial delay before the liveness and readiness probes will be invoked. | `15` |
 | `probeTimeoutSeconds` | The amount of time before the probes are considered to be failed due to a timeout. | `5` |
 
-### ImagePull
-This parameter controls when the image is pulled from the repository.
+### Image
+This parameter controls which image is pulled and when.
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
+| `image` | The image to pull. | `gcr.io/google_samples/k8szk` |
+| `imageTag` | The tag to pull. | `v3` |
 | `imagePullPolicy` | The policy for pulling the image from the repository. | `Always` |
 
 # Deep dive

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
       - name: {{ template "zookeeper.name" . }}-server
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        image: gcr.io/google_samples/k8szk:v2
+        image: {{ .Values.image }}:{{ .Values.imageTag }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -17,6 +17,8 @@ storage: "50Gi"
 serverPort: 2888
 leaderElectionPort: 3888
 clientPort: 2181
+image: gcr.io/google_samples/k8szk
+imageTag: v3
 imagePullPolicy: "Always"
 tickTimeMs: 2000
 initTicks: 10


### PR DESCRIPTION
v3 of gcr.io/google_samples/k8szk has significantly fewer vulnerabilities than v2.

This commit defaults to the newer image while adding the ability to specify another image and tag.

Below are images from [clair scans of the two images.](https://github.com/coreos/clair)

v2:
![image](https://user-images.githubusercontent.com/596137/33146474-4974f2ea-cf92-11e7-8221-ece75460c88c.png)


v3:
![image](https://user-images.githubusercontent.com/596137/33146489-559116bc-cf92-11e7-9e20-f00333dc15b3.png)
