### PR TITLE
[stable/external-dns] Fixing incorrect parameter name

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.4.5
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- if .Values.aws.zoneType }}
-            - --zone-type={{ .Values.aws.zoneType }}
+            - --aws-zone-type={{ .Values.aws.zoneType }}
           {{- end }}
           env:
         {{- if and .Values.aws.secretKey .Values.aws.accessKey }}


### PR DESCRIPTION
As per the release referenced of `external-dns` inside the chart the name of the `aws.zone_type` parameter was setting an incorrect cli parameter. 

This PR addresses the bug found inside `external-dns`'s deployment.yaml.