### PR TITLE
[incubator/jaeger] Ingress issue

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.8.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.2.0
+version: 0.2.1
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/templates/ingress.yaml
+++ b/incubator/jaeger/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "jaeger.name" . -}}
+{{- $serviceName := printf "%s%s" (include "jaeger.fullname" .) "-query" -}}
 {{- $servicePort := .Values.query.service.queryPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/incubator/jaeger/templates/ingress.yaml
+++ b/incubator/jaeger/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "jaeger.name" . -}}
-{{- $servicePort := .Values.service.externalPort -}}
+{{- $servicePort := .Values.query.service.queryPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:


### PR DESCRIPTION
There's a bug when enabling the ingress, effectively the `service.externalPort` is not defined.

Here's the error when deploying it:

```
Error: UPGRADE FAILED: render error in "jaeger/templates/ingress.yaml": template: jaeger/templates/ingress.yaml:3:27: executing "jaeger/templates/ingress.yaml" at <.Values.service.exte...>: can't evaluate field externalPort in type interface {}
```

I think that only the Query component needs an ingress and I was able to deploy it with the provided fix.