### PR TITLE
[incubator/vault] various improvements aimed at production use

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
 version: 0.2.0
-appVersion: 0.8.3
+appVersion: 0.9.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.9.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -49,8 +49,9 @@ The following tables lists the configurable parameters of the vault chart and th
 |-------------------------|-------------------------------------|-----------------------------------------------------|
 | `image.pullPolicy`      | Container pull policy               | `IfNotPresent`                                      |
 | `image.repository`      | Container image to use              | `vault`                                             |
-| `image.tag`             | Container image tag to deploy       | `0.8.2`                                             |
+| `image.tag`             | Container image tag to deploy       | `0.9.0`                                             |
 | `vault.dev`             | Use Vault in dev mode               | true (set to false in production)                   |
+| `vault.customSecrets`   | Custom secrets available to Vault   | `[]`                                                |
 | `vault.config`          | Vault configuration                 | No default backend                                  |
 | `replicaCount`          | k8s replicas                        | `1`                                                 |
 | `resources.limits.cpu`  | Container requested CPU             | `nil`                                               |

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
           mountPath: /vault/config/
         - name: vault-root
           mountPath: /root/
+        {{- range .Values.vault.customSecrets }}
+        - name: {{ .secretName }}
+          mountPath: {{ .mountPath }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       affinity:
@@ -60,3 +64,8 @@ spec:
             name: "{{ template "vault.fullname" . }}-config-{{ .Release.Revision }}"
         - name: vault-root
           emptyDir: {}
+        {{- range .Values.vault.customSecrets }}
+        - name: {{ .secretName }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -10,32 +10,32 @@ service:
   name: vault
   type: ClusterIP
   port: 8200
-  #annotations:
-    # cloud.google.com/load-balancer-type: "Internal"
+  # annotations:
+  #   cloud.google.com/load-balancer-type: "Internal"
 ingress:
   enabled: false
   # Used to create Ingress record (should used with service.type: ClusterIP).
-  #hosts:
+  # hosts:
   #  - chart-example.local
-  #annotations:
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  #tls:
-    # Secrets must be manually created in the namespace.
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
+  # tls:
+  #   Secrets must be manually created in the namespace.
+  #   - secretName: chart-example-tls
+  #     hosts:
+  #       - chart-example.local
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 100m
+  #   memory: 128Mi
   # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #   cpu: 100m
+  #   memory: 128Mi
 vault:
   # Only used to enable dev mode. When in dev mode, the rest of this config
   # section below is not used to configure Vault. See
@@ -48,8 +48,8 @@ vault:
   # the Kuberentes secret (created outside of this chart), and the mountPath
   # at which it should be mounted in the Vault container.
   customSecrets: []
-    #- secretName: vault-tls
-    #  mountPath: /vault/tls
+    # - secretName: vault-tls
+    #   mountPath: /vault/tls
   config:
     # A YAML representation of a final vault config.json file.
     # See https://www.vaultproject.io/docs/configuration/ for more information.
@@ -57,25 +57,26 @@ vault:
       tcp:
         address: '[::]:8200'
         tls_disable: true
-        #tls_cert_file: /vault/tls/server.crt
-        #tls_key_file: /vault/tls/server.key
+        # tls_cert_file: /vault/tls/server.crt
+        # tls_key_file: /vault/tls/server.key
     # See https://www.vaultproject.io/docs/configuration/storage/ for storage backends
     storage:
-      #consul:
-      #  address: ""
-      #  path: ""
+      # consul:
+      #   address: ""
+      #   path: ""
       #
-      #etcd:
-      #  address: ""
-      #  path: "vault/"
+      # etcd:
+      #   address: ""
+      #   path: "vault/"
       #
-      #s3:
-      #  bucket: ""
-      #  region: ""
-      #  access_key: ""
-      #  secret_key: ""
-      #  endpoint: "" # When not using AWS S3
-      #gcs:
-      #  bucket: ""
-      #  # Use a custom secret to mount this file.
-      #  credentials_file: ""
+      # s3:
+      #   bucket: ""
+      #   region: ""
+      #   access_key: ""
+      #   secret_key: ""
+      #   endpoint: "" # When not using AWS S3
+      #
+      # gcs:
+      #   bucket: ""
+      #   # Use a custom secret to mount this file.
+      #   credentials_file: ""

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -42,13 +42,23 @@ vault:
   # https://www.vaultproject.io/intro/getting-started/dev-server.html for more
   # information.
   dev: true
+  # Allows the mounting of various custom secrets th enable production vault
+  # configurations. The comments show an example usage for mounting a TLS
+  # secret. The two fields required are a secretName indicating the name of
+  # the Kuberentes secret (created outside of this chart), and the mountPath
+  # at which it should be mounted in the Vault container.
+  customSecrets: []
+    #- secretName: vault-tls
+    #  mountPath: /vault/tls
   config:
     # A YAML representation of a final vault config.json file.
     # See https://www.vaultproject.io/docs/configuration/ for more information.
     listener:
       tcp:
         address: '[::]:8200'
-        tls_disable: 1
+        tls_disable: true
+        #tls_cert_file: /vault/tls/server.crt
+        #tls_key_file: /vault/tls/server.key
     # See https://www.vaultproject.io/docs/configuration/storage/ for storage backends
     storage:
       #consul:
@@ -65,3 +75,7 @@ vault:
       #  access_key: ""
       #  secret_key: ""
       #  endpoint: "" # When not using AWS S3
+      #gcs:
+      #  bucket: ""
+      #  # Use a custom secret to mount this file.
+      #  credentials_file: ""

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -10,6 +10,8 @@ service:
   name: vault
   type: ClusterIP
   port: 8200
+  #annotations:
+    # cloud.google.com/load-balancer-type: "Internal"
 ingress:
   enabled: false
   # Used to create Ingress record (should used with service.type: ClusterIP).

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: vault
-  tag: 0.8.3
+  tag: 0.9.0
   pullPolicy: IfNotPresent
 service:
   name: vault


### PR DESCRIPTION
This PR adds functionality to the vault chart allowing it to be configured to leverage Vault's full capabilities. The main goals were to enable TLS in vault itself, and enable the `gcs` storage type. I've also added the ability to set annotations on the service, which facilitates the use of [GKE internal  load balancers](https://cloud.google.com/kubernetes-engine/docs/internal-load-balancing). I also bumped the version of Vault to use the latest `0.9.0` tag.

---

I didn't include it in this PR in it's current state, but I would also suggest that the `ingress` component be removed from this Chart. With something as security focused as Vault, TLS should be terminated with the application itself rather than anywhere external, per their own recommendations: https://www.vaultproject.io/guides/production.html. I don't see any particular advantage to using ingress here. I'd be happy to document how to setup TLS more explicitly in the README along with this change to make configuring it easier for users of the chart.