### PR TITLE
[stable/rabbitmq] Rename RABBITMQ_VHOST

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.6.10
+version: 0.6.11
 appVersion: 3.6.14
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/deployment.yaml
+++ b/stable/rabbitmq/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           value: {{ printf "%s@%s" (default "rabbit" .Values.rabbitmqNodeName) "localhost" | quote }}
         - name: RABBITMQ_CLUSTER_NODE_NAME
           value: {{ default "" .Values.rabbitmqClusterNodeName | quote }}
-        - name: RABBITMQ_VHOST
+        - name: RABBITMQ_DEFAULT_VHOST
           value: {{ default "/" .Values.rabbitmqVhost | quote }}
         - name: RABBITMQ_MANAGER_PORT_NUMBER
           value: {{ default "15672" .Values.rabbitmqManagerPort | quote }}


### PR DESCRIPTION
Rename RABBITMQ_VHOST to RABBITMQ_DEFAULT_VHOST to work with latest rabbitmq:3 images. 
Source: https://hub.docker.com/_/rabbitmq/

Tested with helm version:

```
Client: &version.Version{SemVer:"v2.7.0", GitCommit:"08c1144f5eb3e3b636d9775617287cc26e53dba4", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.7.0", GitCommit:"08c1144f5eb3e3b636d9775617287cc26e53dba4", GitTreeState:"clean"}
```

and it's working well

```
=INFO REPORT==== 24-Nov-2017::14:24:19 ===
Adding vhost 'myvhost'

=INFO REPORT==== 24-Nov-2017::14:24:19 ===
Creating user 'guest'

=INFO REPORT==== 24-Nov-2017::14:24:19 ===
Setting user tags for user 'guest' to [administrator]

=INFO REPORT==== 24-Nov-2017::14:24:19 ===
Setting permissions for 'guest' in 'myvhost' to '.*', '.*', '.*'

```

With `RABBITMQ_VHOST` it sticks to `/`vhost when `rabbitmqVhost`is set to `myvhost`

