### PR TITLE
Add rbac support to chaoskube chart.

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,5 +1,5 @@
 name: chaoskube
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.6.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube

--- a/stable/chaoskube/templates/_helpers.tpl
+++ b/stable/chaoskube/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "serviceName" -}}
+{{- printf "%s-%s" .Release.Name .Values.name }}
+{{- end -}}

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      {{- if .Values.rbac.install }}
+      serviceAccount: {{ template "serviceName" . }}
+      {{- end }}
       containers:
       - name: {{ .Values.name }}
         image: {{ .Values.image }}:{{ .Values.imageTag }}

--- a/stable/chaoskube/templates/rbac.yaml
+++ b/stable/chaoskube/templates/rbac.yaml
@@ -1,0 +1,36 @@
+{{ if .Values.rbac.install }}
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+kind: ClusterRole
+metadata:
+  name: {{ template "serviceName" . }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name .Values.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: 
+  - ""
+  resources:
+  - pods
+  verbs:
+  - "*"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+metadata:
+  name: {{ template "serviceName" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ printf "%s-%s" .Release.Name .Values.name }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ template "serviceName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "serviceName" . }}
+{{ end }}

--- a/stable/chaoskube/templates/serviceAccount.yaml
+++ b/stable/chaoskube/templates/serviceAccount.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.rbac.install }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "serviceName" . }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name .Values.name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{ end }}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -29,3 +29,7 @@ dryRun: true
 resources:
   cpu: 10m
   memory: 16Mi
+
+rbac:
+  install: false
+  apiVersion: v1beta1


### PR DESCRIPTION
Adds values field `rbac` with `install` boolean to control generating a
an appropriate cluster role, binding and service account to allow the
chaoskube to operate.

*****************************************************************************************

Testing on this is pretty manual: I installed it into a test cluster with a short interval and watched it kill pods.
