### PR TITLE
[stable/postgresql] add annotations to pvc

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.8.4
+version: 0.8.5
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 | `persistence.existingClaim`| Provide an existing PersistentVolumeClaim       | `nil`                                                      |
 | `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
 | `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
+| `persistence.annotations`  | Persistent Volume annotations                   | `{}`                                                       |
 | `persistence.size`         | Size of data volume                             | `8Gi`                                                      |
 | `persistence.subPath`      | Subdirectory of the volume to mount at          | `postgresql-db`                                            |
 | `resources`                | CPU/Memory resource requests/limits             | Memory: `256Mi`, CPU: `100m`                               |

--- a/stable/postgresql/templates/pvc.yaml
+++ b/stable/postgresql/templates/pvc.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -47,6 +47,8 @@ persistence:
   size: 8Gi
   subPath: "postgresql-db"
 
+  # annotations: {}
+
 metrics:
   enabled: false
   image: wrouesnel/postgres_exporter


### PR DESCRIPTION
PR adds annotations to the PVC; this is predominantly important for a helm based annotation such as `helm.sh/resource-policy: keep` but may also be helpful for other annotations. 