### PR TITLE
Sentry chart not using mail.use_tls and mail.from_address (#2569)

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.5
+version: 0.1.6
 appVersion: 8.17
 keywords:
   - debugging

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -62,5 +62,9 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
         resources:
 {{ toYaml .Values.cron.resources | indent 12 }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -65,3 +65,7 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -69,3 +69,7 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: user-password
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -61,6 +61,10 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
         volumeMounts:
         - mountPath: {{ .Values.persistence.filestore_dir }}
           name: sentry-data

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -62,5 +62,9 @@ spec:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
+        - name: SENTRY_EMAIL_USE_TLS
+          value: {{ default "" .Values.email.use_tls | quote }}
+        - name: SENTRY_SERVER_EMAIL
+          value: {{ default "" .Values.email.from_address | quote }}
         resources:
 {{ toYaml .Values.worker.resources | indent 12 }}


### PR DESCRIPTION
Fix for #2569 