### PR TITLE
change etcd-operator version from v0.3.3 to v0.6.1

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.5.1
-appVersion: 0.3.3
+version: 0.5.2
+appVersion: 0.6.1
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png
 sources:

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -53,7 +53,7 @@ The following tables lists the configurable parameters of the etcd-operator char
 | ------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------- |
 | `replicaCount`                                    | Number of etcd-operator replicas to create (only 1 is supported)     | `1`                                            |
 | `image.repository`                                | etcd-operator container image                                        | `quay.io/coreos/etcd-operator`                 |
-| `image.tag`                                       | etcd-operator container image tag                                    | `v0.3.2`                                       |
+| `image.tag`                                       | etcd-operator container image tag                                    | `v0.6.1`                                       |
 | `image.pullPolicy`                                | etcd-operator container image pull policy                            | `IfNotPresent`                                 |
 | `resources.limits.cpu`                            | CPU limit per etcd-operator pod                                      | `100m`                                         |
 | `resources.limits.memory`                         | Memory limit per etcd-operator pod                                   | `128Mi`                                        |

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: quay.io/coreos/etcd-operator
-  tag: v0.3.3
+  tag: v0.6.1
   pullPolicy: IfNotPresent
 resources:
   limits:


### PR DESCRIPTION
when deploy etcd-operator using version v0.3.3, we cant update the release,so change the version to v0.6.1
`[root@master3 ~]# helm upgrade --namespace kube-system --set cluster.enabled=true etcd-operator stable/etcd-operator
Error: UPGRADE FAILED: apiVersion "etcd.database.coreos.com/v1beta2" in etcd-operator/templates/cluster.yaml is not available`