### PR TITLE
Prefix with release name to prevent name collision

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 1.0.1
+version: 1.0.2
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
 maintainers:

--- a/stable/redis-ha/templates/redis-sentinel-service.yaml
+++ b/stable/redis-ha/templates/redis-sentinel-service.yaml
@@ -5,7 +5,7 @@ metadata:
     name: {{ template "name" . }}-sentinel-svc
     role: service
 {{ include "labels.standard" . | indent 4 }}
-  name: {{ .Release.Name }}-redis-sentinel
+  name: {{ template "fullname" . }}-sentinel
 spec:
   ports:
     - port: 26379

--- a/stable/redis-ha/templates/redis-sentinel-service.yaml
+++ b/stable/redis-ha/templates/redis-sentinel-service.yaml
@@ -5,7 +5,7 @@ metadata:
     name: {{ template "name" . }}-sentinel-svc
     role: service
 {{ include "labels.standard" . | indent 4 }}
-  name: redis-sentinel
+  name: {{ .Release.Name }}-redis-sentinel
 spec:
   ports:
     - port: 26379


### PR DESCRIPTION
Prefix with the release name in order to prevent a name collision while deploying multiple apps depending on this chart in the same k8s namespace
