### PR TITLE
[stable/sonarqube]: Do not set targetPort for ClusterIP service

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.3.1
+version: 0.3.2
 appVersion: 6.5
 keywords:
   - coverage

--- a/stable/sonarqube/templates/service.yaml
+++ b/stable/sonarqube/templates/service.yaml
@@ -11,7 +11,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.externalPort }}
+{{- if ne .Values.service.type "ClusterIP" }}
       targetPort: {{ .Values.service.internalPort }}
+{{- end }}
       protocol: TCP
       name: {{ .Values.service.name }}
   selector:


### PR DESCRIPTION
I am trying to deploy sonarqube with a Service of the kind "ClusterIP". With that type of service specifying a targetPort seems to be invalid. This change leaves out the targetPort if the type is set to ClusterIP and lets me deploy sonarqube as a service internal to a cluster.

The k8s docs say this field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. At least on k8s 1.7 setting it to equal the port field makes helm throw this: "Error: UPGRADE FAILED: Service "prod-sonarqube-sonarqube" is invalid: spec.ports: Required value".

Please let me know if you consider this an error in either helm or k8s and I'll report it where needed. This fix was the fastest way to get sonarqube up and running with only a ClusterIP.