### PR TITLE
[stable/external-dns] Fix README to reflect latest cloudflare parameter changes

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.4.5
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -27,9 +27,8 @@ The following tables lists the configurable parameters of the external-dns chart
 | `aws.secret_key`          | `AWS_SECRET_ACCESS_KEY` to set in the environment (optional).                                                              | `""`                                               |
 | `aws.region`              | `AWS_DEFAULT_REGION` to set in the environment (optional).                                                                 | `us-east-1`                                        |
 | `aws.zone_type`           | Filter for zones of this type (optional, options: public, private).                                                        | `""`                                               |
-| `cloudflare.api_key`      | `CF_API_KEY` to set in the environment (optional).                                                                 | `""`                                        |
-| `cloudflare.email`        | `CF_API_EMAIL` to set in the environment (optional).                                                                 | `""`                                        |
-| `cloudflare.api_key`      | `CF_API_KEY` to set in the environment (optional).                                                                         | `""`                                               |
+| `cloudflare.email`        | `CF_API_EMAIL` to set in the environment (optional).                                                                       | `""`                                               |
+| `cloudflare.apiKey`       | `CF_API_KEY` to set in the environment (optional).                                                                         | `""`                                               |
 | `cloudflare.email`        | `CF_API_EMAIL` to set in the environment (optional).                                                                       | `""`                                               |
 | `domainFilters`           | Limit possible target zones by domain suffixes (optional).                                                                 | `[]`                                               |
 | `extraArgs`               | Optional object of extra args, as `name`: `value` pairs. Where the name is the command line arg to external-dns.           | `{}`                                               |

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -29,7 +29,6 @@ The following tables lists the configurable parameters of the external-dns chart
 | `aws.zone_type`           | Filter for zones of this type (optional, options: public, private).                                                        | `""`                                               |
 | `cloudflare.email`        | `CF_API_EMAIL` to set in the environment (optional).                                                                       | `""`                                               |
 | `cloudflare.apiKey`       | `CF_API_KEY` to set in the environment (optional).                                                                         | `""`                                               |
-| `cloudflare.email`        | `CF_API_EMAIL` to set in the environment (optional).                                                                       | `""`                                               |
 | `domainFilters`           | Limit possible target zones by domain suffixes (optional).                                                                 | `[]`                                               |
 | `extraArgs`               | Optional object of extra args, as `name`: `value` pairs. Where the name is the command line arg to external-dns.           | `{}`                                               |
 | `image.name`              | Container image name (Including repository name if not `hub.docker.com`).                                                  | `registry.opensource.zalan.do/teapot/external-dns` |


### PR DESCRIPTION
* Removed redundant cloudflare.apiKey from the configuration table
* fixed change to camelCase format recently introduced
