### PR TITLE
Add Schema Registry Chart as an optional dependency for Kafka

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.2.2
+version: 0.2.3
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -51,19 +51,20 @@ This chart includes a ZooKeeper chart as a dependency to the Kafka
 cluster in its `requirement.yaml` by default. The chart can be customized using the
 following configurable parameters:
 
-| Parameter               | Description                                                       | Default                                                    |
-| ----------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
-| `Image`                 | Kafka Container image name                                        | `solsson/kafka`                                            |
-| `ImageTag`              | Kafka Container image tag                                         | `0.11.0.0`                                                 |
-| `ImagePullPolicy`       | Kafka Container pull policy                                       | `Always`                                                   |
-| `Replicas`              | Kafka Brokers                                                     | `3`                                                        |
-| `Component`             | Kafka k8s selector key                                            | `kafka`                                                    |
-| `resources`             | Kafka resource requests and limits                                | `{}`                                                       |
-| `DataDirectory`         | Kafka data directory                                              | `/opt/kafka/data`                                          |
-| `Storage`               | Kafka Persistent volume size                                      | `1Gi`                                                      |
-| `zookeeper.Enabled`     | If True, installs Zookeeper Chart                                 | `true`                                                     |
-| `zookeeper.Url`         | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart) | `""`                                                       |
-| `zookeeper.Port`        | Port of Zookeeper Cluster                                         | `2181`                                                     |
+| Parameter                 | Description                                                       | Default                                                    |
+| ------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
+| `Image`                   | Kafka Container image name                                        | `solsson/kafka`                                            |
+| `ImageTag`                | Kafka Container image tag                                         | `0.11.0.0`                                                 |
+| `ImagePullPolicy`         | Kafka Container pull policy                                       | `Always`                                                   |
+| `Replicas`                | Kafka Brokers                                                     | `3`                                                        |
+| `Component`               | Kafka k8s selector key                                            | `kafka`                                                    |
+| `resources`               | Kafka resource requests and limits                                | `{}`                                                       |
+| `DataDirectory`           | Kafka data directory                                              | `/opt/kafka/data`                                          |
+| `Storage`                 | Kafka Persistent volume size                                      | `1Gi`                                                      |
+| `schema-registry.Enabled` | If True, installs Schema Registry Chart                           | `false`                                                    |
+| `zookeeper.Enabled`       | If True, installs Zookeeper Chart                                 | `true`                                                     |
+| `zookeeper.Url`           | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart) | `""`                                                       |
+| `zookeeper.Port`          | Port of Zookeeper Cluster                                         | `2181`                                                     |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/incubator/kafka/requirements.lock
+++ b/incubator/kafka/requirements.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.3.1
-digest: sha256:c197b38e625338ff66f9129b592bb44081a1287e4dbc4281c6b2f5034ebde4cf
-generated: 2017-10-31T13:53:27.072136696-05:00
+  version: 0.4.2
+- name: schema-registry
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 0.1.0
+digest: sha256:1981e97ac6f1e2350c14b87a31990c771727e4c868715de0e3dc83aafead82de
+generated: 2017-11-29T15:08:12.834735-06:00

--- a/incubator/kafka/requirements.yaml
+++ b/incubator/kafka/requirements.yaml
@@ -3,3 +3,7 @@ dependencies:
   version: 0.4.2
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: zookeeper.Enabled
+- name: schema-registry
+  version: 0.1.0
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  condition: schema-registry.Enabled

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -45,3 +45,11 @@ zookeeper:
   # If the Zookeeper Chart is disabled a URL and port are required to connect
   Url: ""
   Port: 2181
+
+# ------------------------------------------------------------------------------
+# Schema Registry:
+# ------------------------------------------------------------------------------
+
+## Install Confluent Schema Registry server alongside Kafka to track Avro Schemas
+schema-registry:
+  Enabled: false


### PR DESCRIPTION
Depends on #2884 for merging. Allows the installation of the Schema Registry as an optional dependency for Kafka.