### PR TITLE
Add support for custom header Configmap to Nginx-ingress

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.13
+version: 0.8.14
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -84,6 +84,7 @@ Parameter | Description | Default
 `controller.stats.service.type` | type of controller stats service to create | `ClusterIP`
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
+`controller.headers` | configMap key:value pairs containing the [custome headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`
 `defaultBackend.image.tag` | default backend container image tag | `1.3`

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -84,7 +84,7 @@ Parameter | Description | Default
 `controller.stats.service.type` | type of controller stats service to create | `ClusterIP`
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
-`controller.headers` | configMap key:value pairs containing the [custome headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
+`controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`
 `defaultBackend.image.tag` | default backend container image tag | `1.3`

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -10,8 +10,8 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
   enable-vts-status: "{{ .Values.controller.stats.enabled }}"
-{{- if .Values.headers}}
-  proxy-set-headers: {{ .Release.NameSpace }}/{{ template "nginx-ingress.fullname" . }} -custom-headers
+{{- if .Values.controller.headers }}
+  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }} -custom-headers
 {{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   enable-vts-status: "{{ .Values.controller.stats.enabled }}"
 {{- if .Values.controller.headers }}
-  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }} -custom-headers
+  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
 {{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -10,6 +10,9 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
 data:
   enable-vts-status: "{{ .Values.controller.stats.enabled }}"
+{{- if .Values.headers}}
+  proxy-set-headers: {{ .Release.NameSpace }}/{{ template "nginx-ingress.fullname" . }} -custom-headers
+{{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}
 {{- end }}

--- a/stable/nginx-ingress/templates/headers-configmap.yaml
+++ b/stable/nginx-ingress/templates/headers-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.conroller.headers }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "nginx-ingress.fullname" . }}-custom-headers
+data:
+{{ toYaml .Values.conroller.headers | indent 2 }}
+{{- end }}

--- a/stable/nginx-ingress/templates/headers-configmap.yaml
+++ b/stable/nginx-ingress/templates/headers-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.conroller.headers }}
+{{- if .Values.controller.headers }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,5 +10,5 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-custom-headers
 data:
-{{ toYaml .Values.conroller.headers | indent 2 }}
+{{ toYaml .Values.controller.headers | indent 2 }}
 {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -9,7 +9,6 @@ controller:
     pullPolicy: IfNotPresent
 
   config: {}
-  
   # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
   headers: {}
 

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -9,6 +9,9 @@ controller:
     pullPolicy: IfNotPresent
 
   config: {}
+  
+  # Will add custome header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
+  headers: {}
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -10,7 +10,7 @@ controller:
 
   config: {}
   
-  # Will add custome header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
+  # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
   headers: {}
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),


### PR DESCRIPTION
I Added support for a custom header for Nginx-Ingress per this example: https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers

The Chart will create a custom header Configmap if controller.header is present and reference to it in the controller ConfigMap