### PR TITLE
[stable/grafana] Allow setting extra env variables on server

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.5.0
+version: 0.5.1
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -49,3 +49,4 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.service.nodePort`                 | For service type "NodePort"         | null                                              |
 | `server.service.type`                     | ClusterIP, NodePort, or LoadBalancer| ClusterIP                                         |
 | `server.setDatasource.enabled`            | Creates grafana datasource with job | false                                             |
+| `server.extraEnv`                          | Extra environment variables to set in the server container | {} |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -51,10 +51,10 @@ spec:
                   name: {{ template "grafana.server.fullname" . }}-config
                   key: grafana-install-plugins
             {{- end }}
-            {{ range $key, $value := .Values.server.extraEnv -}}
+            {{- range $key, $value := .Values.server.extraEnv }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
-            {{ end -}}
+            {{- end }}
           ports:
             - containerPort: 3000
           readinessProbe:

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
                   name: {{ template "grafana.server.fullname" . }}-config
                   key: grafana-install-plugins
             {{- end }}
+            {{ range $key, $value := .Values.server.extraEnv -}}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{ end -}}
           ports:
             - containerPort: 3000
           readinessProbe:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -8,6 +8,7 @@ server:
   ##
   image: "grafana/grafana:latest"
 
+  extraEnv: {}
   nodeSelector: {}
   tolerations: []
 


### PR DESCRIPTION
This allows keeping secret config items (such as auth keys)
separate from non-secret config items by setting them in env variables.
  