### PR TITLE
updated chart for Istio 0.2.12

### DIFF
--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -3,8 +3,8 @@ description: Istio Helm chart for Kubernetes
 name: istio
 # To avoid confusion the helm chart version stays in sync with the istio version - DO NOT UNSYNC -- ldemailly@google.com
 # https://github.com/kubernetes/charts/issues/1501
-version: 0.2.8-chart2
-appVersion: 0.2.8
+version: 0.3.0-chart3
+appVersion: 0.3.0
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png
 sources:

--- a/incubator/istio/Chart.yaml
+++ b/incubator/istio/Chart.yaml
@@ -3,8 +3,8 @@ description: Istio Helm chart for Kubernetes
 name: istio
 # To avoid confusion the helm chart version stays in sync with the istio version - DO NOT UNSYNC -- ldemailly@google.com
 # https://github.com/kubernetes/charts/issues/1501
-version: 0.3.0-chart3
-appVersion: 0.3.0
+version: 0.2.12-chart3
+appVersion: 0.2.12
 home: https://istio.io/
 icon: https://raw.githubusercontent.com/istio/istio.github.io/master/favicons/mstile-150x150.png
 sources:

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -5,7 +5,7 @@ rbac:
 
 istio:
   install: false
-  release: 0.3.0
+  release: 0.2.12
 
 ## Enable Istio auth feature
 ## This deploys a CA in the namespace and enables mTLS between the services

--- a/incubator/istio/values.yaml
+++ b/incubator/istio/values.yaml
@@ -5,7 +5,7 @@ rbac:
 
 istio:
   install: false
-  release: 0.2.8
+  release: 0.3.0
 
 ## Enable Istio auth feature
 ## This deploys a CA in the namespace and enables mTLS between the services


### PR DESCRIPTION
Updated the Istio Chart to support 0.3.0. Current chart was broken as Istio removed 0.2.8 Docker images were removed from Dockerhub. 

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
