### PR TITLE
[stable/concourse] Support Kubernetes Secrets as a credential manager

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 name: concourse
-version: 0.10.1
-appVersion: 3.6.0
+version: 1.0.0
+appVersion: 3.7.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -139,6 +139,7 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true` |
 | `credentialManager.kubernetes.enabled` | Enable Kubernetes Secrets Credential Manager | `true` |
 | `credentialManager.kubernetes.namespacePrefix` | Prefix for namespaces to look for secrets in | `concourse-` |
+| `credentialManager.kubernetes.teams` | Teams to allow secret access when rbac is enabled | `["main"]` |
 | `credentialManager.vault.enabled` | Enable Vault Credential Manager | `false` |
 | `credentialManager.vault.url` | Vault Server URL | `nil` |
 | `credentialManager.vault.pathPrefix` | Vault path to namespace secrets | `/concourse` |
@@ -309,7 +310,8 @@ Pipelines ususally need credentials to do things. Concourse supports the use of 
 
 #### Kubernetes Secrets
 
-By default, this chart will use Kubernetes Secrets as a credential manager. For a given Concourse *team*, a pipeline will look for secrets in a namespace named `[namespacePrefix][teamName]`, e.g. `concourse-main`. The service account used by Concourse must have `get` access to secrets in that namespace.
+By default, this chart will use Kubernetes Secrets as a credential manager. For a given Concourse *team*, a pipeline will look for secrets in a namespace named `[namespacePrefix][teamName]`, e.g. `concourse-main`. The service account used by Concourse must have `get` access to secrets in that namespace. When `rbac.create` is true, this access can be
+granted for each team listed under `credentialManager.kubernetes.teams`.
 
 Here are some examples of the lookup heuristics, given `credentialManager.kubernetes.namespacePrefix=concourse-`:
 

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -137,7 +137,9 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `postgresql.postgresPassword` | PostgreSQL Password for the new user | `concourse` |
 | `postgresql.postgresDatabase` | PostgreSQL Database to create | `concourse` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true` |
-| `credentialManager.enabled` | Enable Credential Manager | `false` |
+| `credentialManager.kubernetes.enabled` | Enable Kubernetes Secrets Credential Manager | `true` |
+| `credentialManager.kubernetes.namespacePrefix` | Prefix for namespaces to look for secrets in | `concourse-` |
+| `credentialManager.vault.enabled` | Enable Vault Credential Manager | `false` |
 | `credentialManager.vault.url` | Vault Server URL | `nil` |
 | `credentialManager.vault.pathPrefix` | Vault path to namespace secrets | `/concourse` |
 | `credentialManager.vault.caCert` | CA public certificate when using self-signed TLS with Vault | `nil` |
@@ -303,20 +305,45 @@ postgresql:
 
 ### Credential Management
 
-By default, this chart will not use a [Credential Manager](https://concourse.ci/creds.html).
+Pipelines ususally need credentials to do things. Concourse supports the use of a [Credential Manager](https://concourse.ci/creds.html) so your pipelines can contain references to secrets instead of the actual secret values. You can't use more than one credential manager at a time.
+
+#### Kubernetes Secrets
+
+By default, this chart will use Kubernetes Secrets as a credential manager. For a given Concourse *team*, a pipeline will look for secrets in a namespace named `[namespacePrefix][teamName]`, e.g. `concourse-main`. The service account used by Concourse must have `get` access to secrets in that namespace.
+
+Here are some examples of the lookup heuristics, given `credentialManager.kubernetes.namespacePrefix=concourse-`:
+
+In team `accounting-dev`, pipeline `my-app`; the expression `((api-key))` resolves to:
+
+1. the secret value in namespace: `concourse-accounting-dev` secret: `my-app.api-key`, key: `value`
+2. and if not found, is the value in namespace: `concourse-accounting-dev` secret: `api-key`, key: `value`
+
+In team accounting-dev, pipeline `my-app`, the expression `((common-secrets.api-key))` resolves to:
+
+1. the secret value in namespace: `concourse-accounting-dev` secret: `my-app.common-secrets`, key: `api-key`
+2. and if not found, is the value in namespace: `concourse-accounting-dev` secret: `common-secrets`, key: `api-key`
+
+Be mindful of your team and pipeline names, to ensure they can be used in namespace and secret names, e.g. no underscores.
+
+#### Hashicorp Vault
+
+To use Vault, set `credentialManager.kubernetes.enabled` to false, and set the following values:
+
 
 ```yaml
-## Configuration values for the Credential Manager.
+## Configuration values for using a Credential Manager. Only one can be enabled.
 ## ref: https://concourse.ci/creds.html
 ##
 credentialManager:
-  ## Enable Credential Manager using below configuration.
-  ##
-  enabled: true
 
-  ## use Hashicorp Vault for Credential Manager.
+  ## Configuration for Hashicorp Vault as the Credential Manager.
   ##
   vault:
+
+    ## Enable the use of Hashicorp Vault.
+    ##
+    enabled: true
+
     ## URL pointing to vault addr (i.e. http://vault:8200).
     ##
     url: http://vault:8200
@@ -324,5 +351,5 @@ credentialManager:
     ## initial periodic token issued for concourse
     ## ref: https://www.vaultproject.io/docs/concepts/tokens.html#periodic-tokens
     ##
-    clientToken: PERIODIC_VAULT_TOKEN 
+    clientToken: PERIODIC_VAULT_TOKEN
 ```

--- a/stable/concourse/templates/configmap.yaml
+++ b/stable/concourse/templates/configmap.yaml
@@ -39,8 +39,11 @@ data:
   generic-oauth-token-url: {{ default "" .Values.concourse.genericOauthTokenUrl | quote }}
   worker-post-stop-delay-seconds: {{ .Values.worker.postStopDelaySeconds | quote }}
   worker-fatal-errors: {{ default "" .Values.worker.fatalErrors | quote }}
-  {{ if .Values.credentialManager.vault }}
+  {{ if .Values.credentialManager.vault.enabled }}
   vault-url: {{ default "" .Values.credentialManager.vault.url | quote }}
   vault-path-prefix: {{ default "/concourse" .Values.credentialManager.vault.pathPrefix | quote }} 
   vault-auth-backend: {{ default "" .Values.credentialManager.vault.authBackend | quote }}
+  {{ end }}
+  {{ if .Values.credentialManager.kubernetes.enabled }}
+  kubernetes-namespace-prefix: {{ default "concourse-" .Values.credentialManager.kubernetes.namespacePrefix | quote }}
   {{ end }}

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -29,7 +29,7 @@ data:
   generic-oauth-client-secret: {{ default "" .Values.concourse.genericOauthClientSecret | b64enc | quote }}
   encryption-key: {{ default "" .Values.concourse.encryptionKey | b64enc | quote }}
   old-encryption-key: {{ default "" .Values.concourse.oldEncryptionKey | b64enc | quote }}
-  {{ if .Values.credentialManager.vault }}
+  {{ if .Values.credentialManager.vault.enabled }}
   vault-ca-cert: {{ default "" .Values.credentialManager.vault.caCert | b64enc | quote }}
   vault-client-token: {{ default "" .Values.credentialManager.vault.clientToken | b64enc | quote }}
   vault-approle-id: {{ default "" .Values.credentialManager.vault.appRoleId | b64enc | quote }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -22,13 +22,16 @@ spec:
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           args:
             - "web"
-            {{- if .Values.credentialManager.enabled }}
-            {{- if default "" .Values.credentialManager.vault.appRoleId }}
+            {{- if .Values.credentialManager.vault.enabled }}
+            {{- if .Values.credentialManager.vault.appRoleId }}
             - "--vault-auth-param"
             - "role_id=${CONCOURSE_VAULT_APPROLE_ID}"
             - "--vault-auth-param"
             - "secret_id=${CONCOURSE_VAULT_APPROLE_SECRET_ID}"
             {{- end }}
+            {{- end }}
+            {{- if .Values.credentialManager.kubernetes.enabled }}
+            - "--kubernetes-in-cluster"
             {{- end }}
           env:
             {{ if .Values.postgresql.enabled }}
@@ -252,7 +255,7 @@ spec:
               value: "/concourse-keys/session_signing_key"
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
               value: "/concourse-keys/worker_key.pub"
-            {{- if .Values.credentialManager.enabled }}
+            {{- if .Values.credentialManager.vault.enabled }}
             - name: CONCOURSE_VAULT_URL
               valueFrom:
                 configMapKeyRef:
@@ -296,6 +299,15 @@ spec:
                   key: vault-approle-secret-id
             {{- end }}
             {{- end }}
+            {{- if .Values.credentialManager.kubernetes.enabled }}
+            {{- if .Values.credentialManager.kubernetes.namespacePrefix }}
+            - name: CONCOURSE_KUBERNETES_NAMESPACE_PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: kubernetes-namespace-prefix
+            {{- end }}
+            {{- end }}
           ports:
             - name: atc
               containerPort: {{ .Values.concourse.atcPort }}
@@ -319,7 +331,7 @@ spec:
             - name: concourse-keys
               mountPath: /concourse-keys
               readOnly: true
-            {{- if .Values.credentialManager.vault }}
+            {{- if .Values.credentialManager.vault.enabled }}
             - name: vault-keys
               mountPath: /concourse-vault
               readOnly: true
@@ -340,7 +352,7 @@ spec:
                 path: session_signing_key
               - key: worker-key-pub
                 path: worker_key.pub
-        {{- if .Values.credentialManager.vault }}
+        {{- if .Values.credentialManager.vault.enabled }}
         - name: vault-keys
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -13,7 +13,7 @@ image: concourse/concourse
 ## Concourse image version.
 ## ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "3.5.0"
+imageTag: "3.7.0"
 
 ## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
 ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -519,17 +519,31 @@ postgresql:
     ##
     enabled: true
 
-## Configuration values for the Credential Manager.
+## Configuration values for using a Credential Manager. Only one can be enabled.
 ## ref: https://concourse.ci/creds.html
 ##
 credentialManager:
-  ## Enable Credential Manager using below configuration.
-  ##
-  enabled: false
 
-  ## use Hashicorp Vault for Credential Manager.
+  ## Configuration for Kubernetes Secrets as the Credential Manager. Supported in Concourse 3.7.0.
   ##
-  # vault:
+  kubernetes:
+
+    ## Enable the use of Kubernetes Secrets.
+    ##
+    enabled: true
+
+    ## Prefix to use for Kubernetes namespaces under which secrets will be looked up, defaults to 'concourse-'.
+    ##
+    # namespacePrefix:
+
+  ## Configuration for Hashicorp Vault as the Credential Manager.
+  ##
+  vault:
+
+    ## Enable the use of Hashicorp Vault.
+    ##
+    enabled: false
+
     ## URL pointing to vault addr (i.e. http://vault:8200).
     ##
     # url:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -536,6 +536,11 @@ credentialManager:
     ##
     # namespacePrefix:
 
+    ## When rbac.create is true, get access to secrets can be granted for each team listed here.
+    ## Ignored if rbac.create is false.
+    teams:
+      - main
+
   ## Configuration for Hashicorp Vault as the Credential Manager.
   ##
   vault:


### PR DESCRIPTION
Upgrade Concourse to 3.7.0 to support the feature. It will be on by default as it requires no additional dependencies and is super useful. 

Breaking change to users of `credentialManager.enabled` and `credentialManager.vault`, as each credential manager needs its own enabled flag. I should've paid more attention to the previous PR that added vault support. Alternatively, we could leave `credentialManager.enabled` where it is and do `credentialManager.kubernetes: true` or `credentialManager.kubernetes.namespacePrefix: something-` to enable it, so that `{{ if .Values.credentialManager.vault }}` and `{{ if .Values.credentialManager.kubernetes }}` are used as control statements. 

The above breaking causes the major version of the chart to bump to 1.0.0.

This is a WIP, a subsequent commit will add RBAC support as an option to control access to the secrets. I'm putting this out early to gather feedback about how to structure the values of multiple credential managers.

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
