### PR TITLE
Add Affinity Rules for Kafka/Zookeeper pods

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.2.3
+version: 0.2.4
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.2.4
+version: 0.2.5
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -51,25 +51,25 @@ This chart includes a ZooKeeper chart as a dependency to the Kafka
 cluster in its `requirement.yaml` by default. The chart can be customized using the
 following configurable parameters:
 
-| Parameter                 | Description                                                       | Default                                                    |
-| ------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
-| `image`                   | Kafka Container image name                                        | `solsson/kafka`                                            |
-| `imageTag`                | Kafka Container image tag                                         | `0.11.0.0`                                                 |
-| `imagePullPolicy`         | Kafka Container pull policy                                       | `Always`                                                   |
+| Parameter                      | Description                                                                                                            | Default                                                    |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `image`                        | Kafka Container image name                                                                                             | `solsson/kafka`                                            |
+| `imageTag`                     | Kafka Container image tag                                                                                              | `1.0.0`                                                    |
+| `imagePullPolicy`              | Kafka Container pull policy                                                                                            | `Always`                                                   |
 | `kafkaAntiAffinityEnabled`     | If `true`, apply anti-affinity rules between kafka pods.                                                               | `true`                                                     |
-| `kafkaAntiAffinity`            | If `hard` disallow colocation of Kafka pods, if `soft`, make a best effort-attempt to prevent colocation.              | `hard`                                                     |
-| `replicas`                | Kafka Brokers                                                     | `3`                                                        |
-| `component`               | Kafka k8s selector key                                            | `kafka`                                                    |
-| `resources`               | Kafka resource requests and limits                                | `{}`                                                       |
-| `dataDirectory`           | Kafka data directory                                              | `/opt/kafka/data`                                          |
-| `storage`                 | Kafka Persistent volume size                                      | `1Gi`                                                      |
-| `schema-registry.enabled` | If True, installs Schema Registry Chart                           | `false`                                                    |
+| `kafkaAntiAffinity`            | If `hard` disallow colocation of Kafka pods, if `soft`, make a best effort-attempt to prevent colocation.              | `soft`                                                     |
+| `replicas`                     | Kafka Brokers                                                                                                          | `3`                                                        |
+| `component`                    | Kafka k8s selector key                                                                                                 | `kafka`                                                    |
+| `resources`                    | Kafka resource requests and limits                                                                                     | `{}`                                                       |
+| `dataDirectory`                | Kafka data directory                                                                                                   | `/opt/kafka/data`                                          |
+| `storage`                      | Kafka Persistent volume size                                                                                           | `1Gi`                                                      |
+| `schema-registry.enabled`      | If True, installs Schema Registry Chart                                                                                | `false`                                                    |
 | `zookeeperAntiAffinityEnabled` | If `true`, apply anti-affinity rules between kafka and zookeeper pods.                                                 | `true`                                                     |
-| `zookeeperAntiAffinity`        | If `hard` disallow colocation of Kafka and Zookeeper pods, if `soft`, make a best effort-attempt to prevent colocation | `hard`                                                     |
+| `zookeeperAntiAffinity`        | If `hard` disallow colocation of Kafka and Zookeeper pods, if `soft`, make a best effort-attempt to prevent colocation | `soft`                                                     |
 | `zookeeperAntiAffinityPodName` | Pod Metadata app label of zookeeper pods for anti-affinity rules for use with `In` prefix of affinity rules.           | `zookeeper`                                                |
-| `zookeeper.enabled`       | If True, installs Zookeeper Chart                                 | `true`                                                     |
-| `zookeeper.url`           | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart) | `""`                                                       |
-| `zookeeper.port`          | Port of Zookeeper Cluster                                         | `2181`                                                     |
+| `zookeeper.enabled`            | If True, installs Zookeeper Chart                                                                                      | `true`                                                     |
+| `zookeeper.url`                | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart)                                                      | `""`                                                       |
+| `zookeeper.port`               | Port of Zookeeper Cluster                                                                                              | `2181`                                                     |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -51,20 +51,25 @@ This chart includes a ZooKeeper chart as a dependency to the Kafka
 cluster in its `requirement.yaml` by default. The chart can be customized using the
 following configurable parameters:
 
-| Parameter                 | Description                                                       | Default                                                    |
-| ------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
-| `Image`                   | Kafka Container image name                                        | `solsson/kafka`                                            |
-| `ImageTag`                | Kafka Container image tag                                         | `0.11.0.0`                                                 |
-| `ImagePullPolicy`         | Kafka Container pull policy                                       | `Always`                                                   |
-| `Replicas`                | Kafka Brokers                                                     | `3`                                                        |
-| `Component`               | Kafka k8s selector key                                            | `kafka`                                                    |
-| `resources`               | Kafka resource requests and limits                                | `{}`                                                       |
-| `DataDirectory`           | Kafka data directory                                              | `/opt/kafka/data`                                          |
-| `Storage`                 | Kafka Persistent volume size                                      | `1Gi`                                                      |
-| `schema-registry.Enabled` | If True, installs Schema Registry Chart                           | `false`                                                    |
-| `zookeeper.Enabled`       | If True, installs Zookeeper Chart                                 | `true`                                                     |
-| `zookeeper.Url`           | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart) | `""`                                                       |
-| `zookeeper.Port`          | Port of Zookeeper Cluster                                         | `2181`                                                     |
+| Parameter                      | Description                                                                                                            | Default                                                    |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `Image`                        | Kafka Container image name                                                                                             | `solsson/kafka`                                            |
+| `ImageTag`                     | Kafka Container image tag                                                                                              | `0.11.0.0`                                                 |
+| `ImagePullPolicy`              | Kafka Container pull policy                                                                                            | `Always`                                                   |
+| `kafkaAntiAffinityEnabled`     | If `true`, apply anti-affinity rules between kafka pods.                                                               | `true`                                                     |
+| `kafkaAntiAffinity`            | If `hard` disallow colocation of Kafka pods, if `soft`, make a best effort-attempt to prevent colocation.              | `hard`                                                     |
+| `zookeeperAntiAffinityEnabled` | If `true`, apply anti-affinity rules between kafka and zookeeper pods.                                                 | `true`                                                     |
+| `zookeeperAntiAffinity`        | If `hard` disallow colocation of Kafka and Zookeeper pods, if `soft`, make a best effort-attempt to prevent colocation | `hard`                                                     |
+| `zookeeperAntiAffinityPodName` | Pod Metadata app label of zookeeper pods for anti-affinity rules for use with `In` prefix of affinity rules.           | `zookeeper`                                                |
+| `Replicas`                     | Kafka Brokers                                                                                                          | `3`                                                        |
+| `Component`                    | Kafka k8s selector key                                                                                                 | `kafka`                                                    |
+| `resources`                    | Kafka resource requests and limits                                                                                     | `{}`                                                       |
+| `DataDirectory`                | Kafka data directory                                                                                                   | `/opt/kafka/data`                                          |
+| `Storage`                      | Kafka Persistent volume size                                                                                           | `1Gi`                                                      |
+| `schema-registry.Enabled`      | If True, installs Schema Registry Chart                                                                                | `false`                                                    |
+| `zookeeper.Enabled`            | If True, installs Zookeeper Chart                                                                                      | `true`                                                     |
+| `zookeeper.Url`                | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart)                                                      | `""`                                                       |
+| `zookeeper.Port`               | Port of Zookeeper Cluster                                                                                              | `2181`                                                     |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -16,6 +16,47 @@ spec:
         app: {{ include "kafka.name" . | quote }}
         release: {{ .Release.Name | quote }}
     spec:
+      {{ if or .Values.kafkaAntiAffinityEnabled  .Values.zookeeperAntiAffinityEnabled  }}
+      affinity:
+        podAntiAffinity:
+          {{ if or (eq .Values.kafkaAntiAffinity "hard")  (eq .Values.zookeeperAntiAffinity "hard") }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            {{ if and .Values.kafkaAntiAffinityEnabled (eq .Values.kafkaAntiAffinity "hard") }}
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: {{ include "kafka.name" . | quote }}
+                  release: {{ .Release.Name | quote }}
+            {{ end }}
+            {{ if and .Values.zookeeperAntiAffinityEnabled (eq .Values.zookeeperAntiAffinity "hard") }}
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: {{ .Values.zookeeperAntiAffinityPodName }}
+                  release: {{ .Release.Name | quote }}
+            {{ end }}
+          {{ end }}
+          {{ if or (eq .Values.kafkaAntiAffinity "soft") (eq .Values.zookeeperAntiAffinity "soft") }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            {{ if and .Values.kafkaAntiAffinityEnabled (eq .Values.kafkaAntiAffinity "soft") }}
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels:
+                    app: {{ include "kafka.name" . | quote }}
+                    release: {{ .Release.Name | quote }}
+            {{ end }}
+            {{ if and .Values.zookeeperAntiAffinityEnabled (eq .Values.zookeeperAntiAffinity "soft") }}
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels:
+                    app: {{ .Values.zookeeperAntiAffinityPodName }}
+            {{ end }}
+          {{ end }}
+      {{ end }}
       containers:
       - name: {{ template "kafka.name" . }}-broker
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -17,6 +17,25 @@ Storage: "1Gi"
 # StorageClass: default
 DataDirectory: "/opt/kafka/data"
 
+## Attempt to prevent Kafka pods from being colocated with eachother.
+kafkaAntiAffinityEnabled: true
+## Prevent Kafka pods from being colocated on the same node.
+## Any value other than `hard` simply defaults to `soft` antiaffinity rules.
+## See: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature
+kafkaAntiAffinity: "hard"
+
+## Attempt to prevent Kafka and Zookeeper pods from being colocated.
+zookeeperAntiAffinityEnabled: true
+## Prevent Kafka and Zookeeper pods from being colocated.
+## Any value other than `hard` simply defaults to `soft` antiaffinity rules.
+## See: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature
+zookeeperAntiAffinity: "hard"
+## The zookeeper pod name which K8s will fuzzy-match against to prevent kafka
+## pods from being colocated with zookeeper. If you have more than one zookeeper
+## installation in your cluster, make sure to use a more specific pod name to
+## indicate which zookeeper pods should be filtered.
+zookeeperAntiAffinityPodName: "zookeeper"
+
 # ------------------------------------------------------------------------------
 # Zookeeper:
 # ------------------------------------------------------------------------------

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -39,16 +39,20 @@ dataDirectory: "/opt/kafka/data"
 ## Attempt to prevent Kafka pods from being colocated with eachother.
 kafkaAntiAffinityEnabled: true
 ## Prevent Kafka pods from being colocated on the same node.
-## Any value other than `hard` simply defaults to `soft` antiaffinity rules.
+## `hard` means the scheduler must satisfy the constraints or the pod fails to schedule
+## `soft` means the scheduler makes a best-effort to satisfy the constraint and schedules it where
+##   it can if the constraints cannot be met.
 ## See: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature
-kafkaAntiAffinity: "hard"
+kafkaAntiAffinity: "soft"
 
 ## Attempt to prevent Kafka and Zookeeper pods from being colocated.
 zookeeperAntiAffinityEnabled: true
 ## Prevent Kafka and Zookeeper pods from being colocated.
-## Any value other than `hard` simply defaults to `soft` antiaffinity rules.
+## `hard` means the scheduler must satisfy the constraints or the pod fails to schedule
+## `soft` means the scheduler makes a best-effort to satisfy the constraint and schedules it where
+##   it can if the constraints cannot be met.
 ## See: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature
-zookeeperAntiAffinity: "hard"
+zookeeperAntiAffinity: "soft"
 ## The zookeeper pod name which K8s will fuzzy-match against to prevent kafka
 ## pods from being colocated with zookeeper. If you have more than one zookeeper
 ## installation in your cluster, make sure to use a more specific pod name to


### PR DESCRIPTION
This PR adds affinity rules that prevent Kafka pods from being colocated both with eachother and with Zookeeper pods. Many best practice guides recommend:
1. Not colocating Kafka brokers on the same node in case of node failure
2. Not colocating Zookeeper on the same nodes 
3. Not colocating Kafka nodes in the same zone (which [Kubernetes already handles gracefully](https://kubernetes.io/docs/admin/multiple-zones/#functionality))

@viglesiasce another in my series of Kafka PRs. I have a couple more I'll put up tomorrow relating to renaming the values to `camelCase` instead of `CamelCase` and another which allows users to pass arbitrary args to the pod runtime. 