### PR TITLE
[stable/sonatype-nexus] Fix default in sonatype nexus readme

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 0.1.2
+version: 0.1.3
 appVersion: 3.5.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -41,14 +41,14 @@ The following tables lists the configurable parameters of the Nexus chart and th
 
 | Parameter                                   | Description                         | Default                                    |
 | ------------------------------------------  | ----------------------------------  | -------------------------------------------|
-| `imageTag`                                  | `nexus` image tag.                  | 3.5.1-02                                   |
-| `imagePullPolicy`                           | Image pull policy                   | `IfNotPresent`                             |
+| `image.tag`                                 | `nexus` image tag.                  | 3.5.1-02                                   |
+| `image.pullPolicy`                          | Image pull policy                   | `IfNotPresent`                             |
 | `ingress.enabled`                           | Flag for enabling ingress           | false                                      |
 | `persistence.enabled`                       | Create a volume to store data       | true                                       |
 | `persistence.size`                          | Size of persistent volume to claim  | 8Gi RW                                     |
 | `persistence.storageClass`                  | Type of persistent volume claim     | nil  (uses alpha storage class annotation) |
 | `persistence.accessMode`                    | ReadWriteOnce or ReadOnly           | ReadWriteOnce                              |
-| `service.type`                              | Kubernetes Service type             | `ClusterIP`                                |
+| `service.type`                              | Kubernetes Service type             | `LoadBalancer`                             |
 | `service.readinessProbe.initialDelaySeconds`| ReadinessProbe initial delay        | 30                                         |
 | `service.readinessProbe.periodSeconds`      | Seconds between polls               | 30                                         |
 | `service.readinessProbe.failureThreshold`   | Number of attempts before failure   | 6                                          |


### PR DESCRIPTION
Update the configuration in README to reflect the defaults set in values.yaml.

According to the README I was not expecting this chart to create a LoadBalancer on deploy.

While I was at it, I also looked through the other configuration params in the README and fixed them to match values.yaml.