### PR TITLE
Convert Kafka Chart values to lowercase

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.2.3
+version: 0.2.4
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -53,18 +53,18 @@ following configurable parameters:
 
 | Parameter                 | Description                                                       | Default                                                    |
 | ------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
-| `Image`                   | Kafka Container image name                                        | `solsson/kafka`                                            |
-| `ImageTag`                | Kafka Container image tag                                         | `0.11.0.0`                                                 |
-| `ImagePullPolicy`         | Kafka Container pull policy                                       | `Always`                                                   |
-| `Replicas`                | Kafka Brokers                                                     | `3`                                                        |
-| `Component`               | Kafka k8s selector key                                            | `kafka`                                                    |
+| `image`                   | Kafka Container image name                                        | `solsson/kafka`                                            |
+| `imageTag`                | Kafka Container image tag                                         | `0.11.0.0`                                                 |
+| `imagePullPolicy`         | Kafka Container pull policy                                       | `Always`                                                   |
+| `replicas`                | Kafka Brokers                                                     | `3`                                                        |
+| `component`               | Kafka k8s selector key                                            | `kafka`                                                    |
 | `resources`               | Kafka resource requests and limits                                | `{}`                                                       |
-| `DataDirectory`           | Kafka data directory                                              | `/opt/kafka/data`                                          |
-| `Storage`                 | Kafka Persistent volume size                                      | `1Gi`                                                      |
-| `schema-registry.Enabled` | If True, installs Schema Registry Chart                           | `false`                                                    |
-| `zookeeper.Enabled`       | If True, installs Zookeeper Chart                                 | `true`                                                     |
-| `zookeeper.Url`           | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart) | `""`                                                       |
-| `zookeeper.Port`          | Port of Zookeeper Cluster                                         | `2181`                                                     |
+| `dataDirectory`           | Kafka data directory                                              | `/opt/kafka/data`                                          |
+| `storage`                 | Kafka Persistent volume size                                      | `1Gi`                                                      |
+| `schema-registry.enabled` | If True, installs Schema Registry Chart                           | `false`                                                    |
+| `zookeeper.enabled`       | If True, installs Zookeeper Chart                                 | `true`                                                     |
+| `zookeeper.url`           | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart) | `""`                                                       |
+| `zookeeper.port`          | Port of Zookeeper Cluster                                         | `2181`                                                     |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/incubator/kafka/requirements.lock
+++ b/incubator/kafka/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: schema-registry
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   version: 0.1.0
-digest: sha256:1981e97ac6f1e2350c14b87a31990c771727e4c868715de0e3dc83aafead82de
-generated: 2017-11-29T15:08:12.834735-06:00
+digest: sha256:0591abba1e4a7ee22d5eb6b8f573fa40affe62f53c954a6399e32f5609ce968e
+generated: 2017-12-04T08:35:47.44854-06:00

--- a/incubator/kafka/requirements.yaml
+++ b/incubator/kafka/requirements.yaml
@@ -2,8 +2,8 @@ dependencies:
 - name: zookeeper
   version: 0.4.2
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  condition: zookeeper.Enabled
+  condition: zookeeper.enabled
 - name: schema-registry
   version: 0.1.0
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  condition: schema-registry.Enabled
+  condition: schema-registry.enabled

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -8,7 +8,7 @@ You can connect to Kafka by running a simple pod in the K8s cluster like this wi
   spec:
     containers:
     - name: kafka
-      image: {{ .Values.Image }}:{{ .Values.ImageTag }}
+      image: {{ .Values.image }}:{{ .Values.imageTag }}
       command:
         - sh
         - -c

--- a/incubator/kafka/templates/_helpers.tpl
+++ b/incubator/kafka/templates/_helpers.tpl
@@ -20,10 +20,10 @@ Form the Zookeeper URL. If zookeeper is installed as part of this chart, use k8s
 else use user-provided URL
 */}}
 {{- define "zookeeper.url" }}
-{{- $port := .Values.zookeeper.Port | toString }}
-{{- if .Values.zookeeper.Enabled -}}
+{{- $port := .Values.zookeeper.port | toString }}
+{{- if .Values.zookeeper.enabled -}}
 {{- printf "%s-zookeeper:%s" .Release.Name $port }}
 {{- else -}}
-{{- printf "%s:%s" .Values.zookeeper.Url $port }}
+{{- printf "%s:%s" .Values.zookeeper.url $port }}
 {{- end -}}
 {{- end -}}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   serviceName: {{ template "kafka.fullname" . }}-headless
-  replicas: {{ default 3 .Values.Replicas }}
+  replicas: {{ default 3 .Values.replicas }}
   template:
     metadata:
       labels:
@@ -18,8 +18,8 @@ spec:
     spec:
       containers:
       - name: {{ template "kafka.name" . }}-broker
-        image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
-        imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         livenessProbe:
           exec:
             command:
@@ -46,10 +46,10 @@ spec:
         command:
         - sh
         - -c
-        - "./bin/kafka-server-start.sh config/server.properties --override zookeeper.connect={{ template "zookeeper.url" . }}/ --override log.dirs={{ printf "%s/logs" .Values.DataDirectory }} --override broker.id=${HOSTNAME##*-}"
+        - "./bin/kafka-server-start.sh config/server.properties --override zookeeper.connect={{ template "zookeeper.url" . }}/ --override log.dirs={{ printf "%s/logs" .Values.dataDirectory }} --override broker.id=${HOSTNAME##*-}"
         volumeMounts:
         - name: datadir
-          mountPath: "{{ .Values.DataDirectory }}"
+          mountPath: "{{ .Values.dataDirectory }}"
   volumeClaimTemplates:
   - metadata:
       name: datadir
@@ -57,7 +57,7 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: {{ .Values.Storage }}
-      {{- if .Values.StorageClass }}
-      storageClassName: {{ .Values.StorageClass | quote }}
+          storage: {{ .Values.storage }}
+      {{- if .Values.storageClass }}
+      storageClassName: {{ .Values.storageClass | quote }}
       {{- end }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -2,10 +2,21 @@
 # Kafka:
 # ------------------------------------------------------------------------------
 
-Replicas: 3
-Image: "solsson/kafka"
-ImageTag: "0.11.0.0"
-ImagePullPolicy: "IfNotPresent"
+## The StatefulSet installs 3 pods by default
+replicas: 3
+
+## The kafka image repository
+image: "solsson/kafka"
+
+## The kafka image tag
+imageTag: "1.0.0"
+
+## Specify a imagePullPolicy
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+imagePullPolicy: "IfNotPresent"
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources: {}
   # limits:
   #   cpu: 200m
@@ -13,38 +24,44 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 1024Mi
-Storage: "1Gi"
-# StorageClass: default
-DataDirectory: "/opt/kafka/data"
+  #
+## The size of the persistentVolume to allocate to each Kafka Pod in the StatefulSet. For
+## production servers this number should likely be much larger.
+storage: "1Gi"
+
+## The name of the storage class which the cluster should use.
+# storageClass: default
+
+## The location within the Kafka container where the PV will mount its storage and Kafka will store
+## its logs
+dataDirectory: "/opt/kafka/data"
 
 # ------------------------------------------------------------------------------
 # Zookeeper:
 # ------------------------------------------------------------------------------
 
 zookeeper:
-  Enabled: true
-  Servers: 3
-  Resources: {}
-  Heap: "1G"
-  Storage: "2Gi"
-  # StorageClass: default
-  ServerPort: 2888
-  LeaderElectionPort: 3888
-  ClientPort: 2181
-  ImagePullPolicy: "IfNotPresent"
-  TickTimeMs: 2000
-  InitTicks: 10
-  SyncTicks: 5
-  ClientCnxns: 60
-  SnapRetain: 3
-  PurgeHours: 1
-  ProbeInitialDelaySeconds: 15
-  ProbeTimeoutSeconds: 5
-  AntiAffinity: "hard"
-  LogLevel: "INFO"
-  # If the Zookeeper Chart is disabled a URL and port are required to connect
-  Url: ""
-  Port: 2181
+  ## If true, install the Zookeeper chart alongside Kafka
+  ## ref: https://github.com/kubernetes/charts/tree/master/incubator/zookeeper
+  enabled: true
+
+  ## Configure Zookeeper resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  resources: {}
+
+  ## The JVM heap size to allocate to Zookeeper
+  heap: "1G"
+
+  ## The amount of PV storage allocated to each Zookeeper pod in the statefulset
+  storage: "2Gi"
+
+  ## Specify a Zookeeper imagePullPolicy
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  imagePullPolicy: "IfNotPresent"
+
+  ## If the Zookeeper Chart is disabled a URL and port are required to connect
+  url: ""
+  port: 2181
 
 # ------------------------------------------------------------------------------
 # Schema Registry:
@@ -52,4 +69,6 @@ zookeeper:
 
 ## Install Confluent Schema Registry server alongside Kafka to track Avro Schemas
 schema-registry:
-  Enabled: false
+  ## If true, install the Schema-Registry chart alongside Kafka
+  ## ref: https://github.com/kubernetes/charts/tree/master/incubator/schema-registry
+  enabled: false


### PR DESCRIPTION
@viglesiasce small cleanup of the Kafka chart to:

1. use `camelCase` instead of `CamelCase` variable names (in fact, some of the values dont work without this fix, namely resources and zookeeper overrides)
2. Adds explanatory comments to the `values.yaml` file in the style often found in charts in the `stable` repo.

Small note: I have another outstanding PR for affinity rules which is also versioned at `0.2.4`, so whichever PR gets merged second will need to have its version updated.