### PR TITLE
Enable prometheus server

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.6.13
+version: 4.6.14
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -140,6 +140,7 @@ Parameter | Description | Default
 `pushgateway.service.servicePort` | pushgateway service port | `9091`
 `pushgateway.service.type` | type of pushgateway service to create | `ClusterIP`
 `rbac.create` | If true, create & use RBAC resources | `false`
+`server.enabled` | If true, create prometheus server | `true`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
 `server.image.tag` | Prometheus server container image tag | `v1.5.1`

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if (empty .Values.server.configMapOverrideName) -}}
+{{- if and .Values.server.enabled (empty .Values.server.configMapOverrideName) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -110,3 +111,4 @@ spec:
           hostPath:
             path: {{ .hostPath }}
       {{- end }}
+{{- end -}}

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.ingress.enabled -}}
+{{- if and .Values.server.enabled .Values.server.ingress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.server.fullname" . }}
 {{- $servicePort := .Values.server.service.servicePort -}}

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.persistentVolume.enabled -}}
+{{- if and .Values.server.enabled .Values.server.persistentVolume.enabled -}}
 {{- if not .Values.server.persistentVolume.existingClaim -}}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,3 +46,4 @@ spec:
     component: "{{ .Values.server.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.server.service.type }}"
+{{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -313,6 +313,10 @@ nodeExporter:
     type: ClusterIP
 
 server:
+  ## If false, prometheus server will not be installed
+  ##
+
+  enabled: true
   ## Prometheus server container name
   ##
   name: server


### PR DESCRIPTION
Make the installation of the prometheus server optional.
The use case is for when you want to install a HA cluster of alert managers, for example, using helm.