### PR TITLE
stable/concourse: trunc of service name causes failures when the helm generated name is too long

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.10.1
+version: 0.10.2
 appVersion: 3.6.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -33,3 +33,11 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
 {{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create secretname variable, untruncated
+*/}}
+{{- define "concourse.postgresql.secretname" -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/concourse/templates/configmap.yaml
+++ b/stable/concourse/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  postgresql-host: {{ template "concourse.postgresql.fullname" . }}
+  postgresql-host: {{ template "concourse.postgresql.secretname" . }}
   postgresql-database: {{ .Values.postgresql.postgresDatabase | quote }}
   concourse-atc-port: {{ .Values.concourse.atcPort | quote }}
   concourse-tsa-host: {{ template "concourse.web.fullname" . }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "concourse.postgresql.fullname" . }}
+                  name: {{ template "concourse.postgresql.secretname" . }}
                   key: postgres-password
             - name: POSTGRES_DATABASE
               valueFrom:


### PR DESCRIPTION
Attempting to get this chart online I had to fiddle with why the web process wasn't connecting to postgresql correctly. Turns out that the truncate to 24 chars on the concourse.postgresql.fullname was incorrectly truncating the service name too much and dns wouldn't properly resolve.

Putting this out here in case someone else has encountered this problem.
