### PR TITLE
Revert "Run helm dep build in circle lint.sh"

### DIFF
--- a/test/circle/lint.sh
+++ b/test/circle/lint.sh
@@ -115,10 +115,7 @@ for directory in ${CHANGED_FOLDERS}; do
   if [ "$directory" == "incubator/common" ]; then
     continue
   elif [ -d $directory ]; then
-    printf "\nRunning helm dep build on the chart at ${directory}\n"
-    run helm dep build ${directory}
-
-    printf "\nRunning helm lint on the chart at ${directory}\n"
+    printf "\nRuning helm lint on the chart at ${directory}\n"
     run helm lint ${directory}
 
     yamllinter ${directory}


### PR DESCRIPTION
Reverts kubernetes/charts#2919

The problem is that `helm init` has not been run and the incubator repo has not been added. So, `helm dep build` is going to error out.