### PR TITLE
Provide a parameter to enable Thrift

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.1.7
+version: 0.1.8
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing
   high availability with no single point of failure.

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -87,11 +87,12 @@ The following tables lists the configurable parameters of the Cassandra chart an
 | `config.heap_new_size`     | Initdb Arguments                                | `512M`                                                     |
 | `config.ports.cql`         | Initdb Arguments                                | `9042`                                                     |
 | `config.ports.thrift`      | Initdb Arguments                                | `9160`                                                     |
+| `config.start_rpc`         | Initdb Arguments                                | `false`                                                    |
 | `persistence.enabled`      | Use a PVC to persist data                       | `true`                                                     |
 | `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
 | `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
 | `persistence.size`         | Size of data volume                             | `10Gi`                                                     |
-| `resources`                | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                               |
+| `resources`                | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
 | `service.type`             | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
 
 ## Scale cassandra

--- a/incubator/cassandra/templates/cassandra-statefulset.yaml
+++ b/incubator/cassandra/templates/cassandra-statefulset.yaml
@@ -75,6 +75,8 @@ spec:
           value: {{ default "DC1" .Values.config.dc_name | quote }}
         - name: CASSANDRA_RACK
           value: {{ default "RAC1" .Values.config.rack_name | quote }}
+        - name: CASSANDRA_START_RPC
+          value: {{ default "false" .Values.config.start_rpc | quote }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -55,6 +55,7 @@ config:
   endpoint_snitch: SimpleSnitch
   max_heap_size: 2048M
   heap_new_size: 512M
+  start_rpc: false
   ports:
     cql: 9042
     thrift: 9160


### PR DESCRIPTION
By default, Thrift is disabled with this chart.  Since this chart allows users to set `config.ports.thrift`, I figured we might as well give people a way to enable Thrift, too.

I left the default here as 'false' so it shouldn't change anyone's existing expectations.  

Let me know if you have any questions or concerns.