### PR TITLE
incubator/oauth-proxy Allow htpasswd auth.

### DIFF
--- a/incubator/oauth-proxy/Chart.yaml
+++ b/incubator/oauth-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth-proxy
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/incubator/oauth-proxy/README.md
+++ b/incubator/oauth-proxy/README.md
@@ -77,7 +77,11 @@ $ helm install incubator/oauth-proxy --name my-release -f values.yaml
 
 ### Configuration of htpasswd config file
 
-If you want to, in adition to oauth2, have some basic auth working, specify the `htpasswd` section.
+If you want to, in adition to oauth2, have some basic auth working, specify the `htpasswd` section. Basic auth works if you don't already have been authenticated with Oauth2, so the order is:
+
+ 1. Oauth2
+ 1. Basic Auth
+
 You can see an example of how to generate the contents of this file below.
 
 You will have to specify the `htpasswd-file` parameter pointing to the directory `/htpasswd/htpasswd` in the values.yaml:
@@ -90,6 +94,6 @@ You can generate a password file with:
 ```
 htpasswd -sbc /tmp/pwfile username password
 ```
-Which will add a username/password of `username/password` to the file `/tmp/pwfile`.
+Which will add a username/password of `username/password` to the file `/tmp/pwfile`. The contents of this file will have to be added to the section `htpasswd.file.htpasswd`. You will also need to use option `-s` to generate a SHA password as per the documentation on https://github.com/bitly/oauth2_proxy.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/incubator/oauth-proxy/README.md
+++ b/incubator/oauth-proxy/README.md
@@ -50,6 +50,8 @@ Parameter | Description | Default
 `image.repository` | Image repository | `a5huynh/oauth2_proxy`
 `image.tag` | Image tag | `2.2`
 `ingress.enabled` | enable ingress | `false`
+`htpasswd.enabled` | enable htpasswd support | `false`
+`htpasswd.file.htpasswd` | File definition with the list of SHA username/passwords to be used. One per line as per a standard htpasswd file. | `Bogus password hash.`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
 `podLabels` | additional labesl to add to each pod | `{}`
@@ -72,5 +74,22 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 $ helm install incubator/oauth-proxy --name my-release -f values.yaml
 ```
+
+### Configuration of htpasswd config file
+
+If you want to, in adition to oauth2, have some basic auth working, specify the `htpasswd` section.
+You can see an example of how to generate the contents of this file below.
+
+You will have to specify the `htpasswd-file` parameter pointing to the directory `/htpasswd/htpasswd` in the values.yaml:
+```
+extraArgs:
+  htpasswd-file: "/htpasswd/htpasswd"
+```
+
+You can generate a password file with:
+```
+htpasswd -sbc /tmp/pwfile username password
+```
+Which will add a username/password of `username/password` to the file `/tmp/pwfile`.
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/incubator/oauth-proxy/templates/deployment.yaml
+++ b/incubator/oauth-proxy/templates/deployment.yaml
@@ -58,6 +58,11 @@ spec:
             port: {{ .Values.service.internalPort }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.htpasswd.enabled }}
+        volumeMounts:
+          - name: htpasswd-volume
+            mountPath: /htpasswd
+        {{- end -}}
     {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
@@ -68,3 +73,9 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+      {{- if .Values.htpasswd.enabled }}
+      volumes:
+        - name: htpasswd-volume
+          configMap:
+            name: {{ template "oauth-proxy.fullname" . }}
+      {{- end -}}

--- a/incubator/oauth-proxy/templates/htpasswd-configmap.yaml
+++ b/incubator/oauth-proxy/templates/htpasswd-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.htpasswd.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "oauth-proxy.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth-proxy.fullname" . }}
+data:
+{{ toYaml .Values.htpasswd.file | indent 2 }}
+{{- end }}

--- a/incubator/oauth-proxy/values.yaml
+++ b/incubator/oauth-proxy/values.yaml
@@ -23,6 +23,12 @@ service:
   externalPort: 443
   internalPort: 4180
 
+htpasswd:
+  enabled: false
+  file:
+    htpasswd: |-
+      prom:{SHA}XXXXXXXXXXXXXXXXXXXXXXXXX+s=
+
 ingress:
   enabled: false
   # Used to create an Ingress record.


### PR DESCRIPTION
This will allow the system to be configured to use htpasswd authentication at the same time as oauth2.

Please, let me know if you are happy with these proposed changes or if you want me to change anything.

Thank you.

