### PR TITLE
incubator/oauth-proxy Allow path to be configured

### DIFF
--- a/incubator/oauth-proxy/Chart.yaml
+++ b/incubator/oauth-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth-proxy
-version: 0.1.0
+version: 0.1.2
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/incubator/oauth-proxy/templates/ingress.yaml
+++ b/incubator/oauth-proxy/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/incubator/oauth-proxy/templates/ingress.yaml
+++ b/incubator/oauth-proxy/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "oauth-proxy.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
+{{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -20,7 +21,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/incubator/oauth-proxy/values.yaml
+++ b/incubator/oauth-proxy/values.yaml
@@ -25,6 +25,7 @@ service:
 
 ingress:
   enabled: false
+  path: /
   # Used to create an Ingress record.
   # hosts:
     # - chart-example.local


### PR DESCRIPTION
Allow path to be configured on the ingress. If one has a vhost that
needs to be shared with oauth proxy, then we need to be able to proxy
pass just /oauth2 to the proxy. Thus allowing it to be configured here.
