### PR TITLE
[stable/kibana] fix chart name in README

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.1.0
+version: 0.1.1
 appVersion: 5.4.3
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -5,7 +5,7 @@
 ## TL;DR;
 
 ```console
-$ helm install incubator/kibana
+$ helm install stable/kibana
 ```
 
 ## Introduction
@@ -17,7 +17,7 @@ This chart bootstraps a kibana deployment on a [Kubernetes](http://kubernetes.io
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install incubator/kibana --name my-release
+$ helm install stable/kibana --name my-release
 ```
 
 The command deploys kibana on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -59,14 +59,14 @@ Parameter | Description | Default
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install incubator/kibana --name my-release \
+$ helm install stable/kibana --name my-release \
   --set=image.tag=v0.0.2,resources.limits.cpu=200m
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install incubator/kibana --name my-release -f values.yaml
+$ helm install stable/kibana --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
Minor change:
This fixes the README references to the chart as `stable/kibana`.

This change was originally requested in #2719.