### PR TITLE
Fixes on the traefik - prometheus config

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.14.3
+version: 1.14.4
 appVersion: 1.4.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -89,7 +89,7 @@ data:
     {{- end }}
     {{ if .Values.metrics.prometheus.enabled }}
     [web.metrics.prometheus]
-      Buckets = {{ .Values.metrics.prometheus.buckets }}
+      Buckets = [{{ .Values.metrics.prometheus.buckets }}]
     {{- end }}
     {{ if .Values.metrics.datadog.enabled }}
     [web.metrics.datadog]

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -91,7 +91,7 @@ rbac:
 metrics:
   prometheus:
     enabled: false
-    buckets: 0.1,0.3,1.2,5
+    buckets: 0.1,0.3,1.2,5.0
   datadog:
     enabled: false
     # address: "localhost:8125"


### PR DESCRIPTION
I was getting some errors, first:

```
2017/12/07 18:12:50 Error reading TOML config file /config/traefik.toml : toml: cannot load TOML value of type string into a Go slice
```

fixed it by hand in the configmap, and then I got:

```
2017/12/07 18:14:35 Error reading TOML config file /config/traefik.toml : Near line 15 (last key parsed 'web.metrics.prometheus.Buckets'): Array contains values of type 'Float' and 'Integer', but arrays must be homogeneous.
```

these changes should fix those problems.