### PR TITLE
[incubator/burrow] Add Chart for Hyperledger Burrow Cluster

### DIFF
--- a/incubator/burrow/.helmignore
+++ b/incubator/burrow/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/burrow/Chart.yaml
+++ b/incubator/burrow/Chart.yaml
@@ -1,0 +1,20 @@
+name: burrow
+version: 0.3.0
+appVersion: 0.17.1
+description: Burrow is a permissionable smart contract machine
+icon: https://pbs.twimg.com/profile_images/697035383679295488/_6vl74tM_400x400.png
+keywords:
+- blockchain
+- smart_contracts
+- smartContracts
+- smart contracts
+- ethereum
+- hyperledger
+- evm
+maintainers:
+- name: compleatang
+  email: casey@monax.io
+sources:
+- https://github.com/hyperledger/burrow
+- https://quay.io/monax/db
+engine: gotpl

--- a/incubator/burrow/README.md
+++ b/incubator/burrow/README.md
@@ -1,0 +1,164 @@
+# burrow
+
+[burrow](https://github.com/hyperledger/burrow) is a permissioned Ethereum smart-contract blockchain node. It executes Ethereum smart contract code on a permissioned virtual machine. Burrow provides transaction finality and high transaction throughput on a proof-of-stake Tendermint consensus engine.
+
+## TL;DR;
+
+```console
+$ helm install incubator/burrow
+```
+
+## Introduction
+
+This chart bootstraps a burrow network on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install incubator/burrow --name my-release
+```
+
+The command deploys burrow on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+There is a zero percent chance that you will want the default configuration. Please see the [runtime configuration](#runtime) section for more information on how to setup your network properly.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the kibana chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`affinity` | node/pod affinities | None
+`chain.extraSeeds` | network seeds to dial in addition to the cluster booted by the chart; each entry in the array should be in the form `ip:port` (noting that because the p2p connects over tcp that the port is absolutely required) | `[]`
+`chain.id` | machine readable (and preferably unique) ID for the blockchain network | `simpleTestChain`
+`chain.logLevel` | log level for the nodes (`debug`, `info`, `warn`) | `info`
+`chain.name` | human readable name of the blockchain network | `simpleTestChain`
+`chain.numberOfNodes` | number of nodes for the blockchain network | `1`
+`env` | Environment variables to configure burrow | `{}`
+`extraArgs` | extra arguments to give to the build in `burrow serve` command | `{}`
+`genesisFile` | base64 encoded string for the genesis.json file | See values.yaml
+`image.pullPolicy` | Image pull policy | `IfNotPresent`
+`image.repository` | Image repository | `quay.io/monax/db`
+`image.tag` | Image tag | `0.17.1`
+`ingress.annotations` | Ingress annotations | None
+`ingress.enabled` | Enables Ingress | `false`
+`ingress.hosts` | Ingress accepted hostnames | None
+`ingress.tls` | Ingress TLS configuration | None
+`keysFiles` | base64 encoded strings for the priv_validator.json files | See values.yaml
+`nodeSelector` | node labels for pod assignment | `{}`
+`organization` | name of the organization running these nodes (used in the peer's moniker) | `myOrg`
+`persistence.accessMode` | access mode for the chain data pvc | None
+`persistence.annotations` | annotations for the chain data pvc | None
+`persistence.enabled` | enable pvc for the chain data | `false`
+`persistence.size` | size of the chain data pvc | None
+`persistence.storageClass` | storage class for the chain data pvc | None
+`podAnnotations` | annotations to add to each pod | `{}`
+`podLabels` | labels to add to each pod | `{}`
+`resources` | pod resource requests & limits | `{}`
+`service.api.loadBalance` | if `true` then the api service will load balance across the nodes | `true`
+`service.api.node` | node number to link the api service to (ignored if loadBalance is `true`) | `""`
+`service.api.port` | api port | `46656`
+`service.api.type` | service type for the api port | `ClusterIP`
+`service.peer.port` | peer port | `46656`
+`service.peer.type` | service type for the peer port | `ClusterIP`
+`service.rpc.loadBalance` | if `true` then the rpc service will load balance across the nodes | `false`
+`service.rpc.node` | node number to link the rpc service to (ignored if loadBalance is `true`) | `000`
+`service.rpc.port` | rpc port | `46656`
+`service.rpc.type` | service type for the rpc port | `ClusterIP`
+`tolerations` | List of node taints to tolerate | `[]`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install incubator/burrow --name my-release \
+  --set=image.tag=0.16.0,resources.limits.cpu=200m
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install incubator/burrow --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Runtime
+
+As noted above, there is a zero percent chance that you will want to deploy this chart with the default runtime configuration. When booting permissioned blockchains in a cloud environment there are three predominant considerations in addition to the normal configuration of any cloud application.
+
+1. What access rights to place on the ports?
+2. What is the set of initial accounts and validators for the chain?
+3. What keys should the validating nodes have?
+
+Each of these considerations will be dealt with in more detail below.
+
+### Configuration of the Ports
+
+Burrow utilizes three different ports by default:
+
+* `peer`: Burrow's peer port is the port on which the p2p communication within the blockchain network is conducted. The peer port is utilized by burrow's consensus engine (which is the [Tendermint](https://github.com/tendermint/tendermint) engine) to perform bilateral gossiping communication.
+* `rpc`: Burrow's rpc port is the port on which remote procedures are conducted. It is utilized by tools such as, e.g., the [Monax](https://github.com/monax/monax) tools which can be utilized to deploy smart contracts and perform other functions.
+* `api`: Burrow's api port is the port on which javascript libraries interact with the chain utilizing websockets. It is generally utilized by tools.
+
+The default configuration for the chart sets up the port access rights in the following manner:
+
+* `peer`: Peer ports are **only** opened within the cluster. By default, there is no p2p communication exposed to the general internet. Each node within the cluster has its own distinct peer service built by the chart which utilizes a `ClusterIP` service type.
+* `rpc`: The RPC port is **only** opened within the cluster. By default, there is no rpc communication exposed to the general internet. There is **one** rpc service built by the chart which utilizes a `ClusterIP` service type. The default rpc service used by the chart is strongly linked to node number `000` and is not load balanced across the nodes by default so as to reduce any challenges with tooling that conduct long-polling after sending transactions. The chart offers an ingress which is connected to the `rpc` service. This is `disabled` by default.
+* `api`: The API port is **only** opened within the cluster. By default, there is no api communication exposed to the general internet. There is **one** api service built by the chart which utilizes a `ClusterIP` service type. The default api service used by the chart is load balanced across the nodes within the cluster by default because libraries which utilize this port typical do so on websockets and the service is able to utilize a sessionAffinity setting.
+
+The following options are available to increase the exposure of the `peer` port:
+
+* In order to expose the peers to the general internet change the `service.peer.type` to `NodePort`. It is not advised to run p2p traffic through an ingress or other load balancing service as there is uncertainty with respect to the IP address which the blockchain node advertises and gossips. As such, the best way to expose p2p traffic to the internet is to utilize a `NodePort` service type. While such service types can be a challenge to work with in many instances, the p2p libraries that blockchains utilize are very resilient to movement between machine nodes by a blockchain node. The biggest gotcha with `NodePort` service types is the ensure that the machine nodes have proper egress within the cloud or data center provider. As long as the machine nodes do not have egress restrictions disabling the utilization of `NodePort` service types the p2p traffic will be exposed fluidly.
+
+The following options are available to increase the exposure of the `rpc` port:
+
+* To expose the rpc service to the general internet change the default `ingress.enabled` to `true` and add the appropriate fields to the ingress for your Kubernetes cluster. This will enable developers to connect to the rpc from their local machines and the general internet will be able to access the rpc service.
+* To change from a non-loadBalanced rpc service to a loadBalanced service change the `service.rpc.loadBalance` to `true`. Making this change is not advised if developers or services will be deploying contracts, however it is helpful if developers or services will simply be accessing the informational aspects of the rpc with the caveat that some of the `rpc` end points (e.g., `net_info`) will only return information for a single node and as such will be non-deterministic.
+* To change the node that a non-loadBalanced rpc service connects to change the default `service.rpc.node` from `000` to another node number.
+
+The following options are available to increase the exposure of the `api` port:
+
+* To change from a loadBalanced api service to a non-loadBalanced servie change the `service.api.loadBalance` to `false` and add the node number to the `service.api.node` field.
+* To denote the node that a non-loadBalanced api service connects to add the `service.api.node` to a node number such as `000`.
+
+### Configuration of the `genesis.json`
+
+Burrow initializes any single blockchain via use of a `genesis.json` which defines what validators and accounts are given access to the permissioned blockchain when it is booted.
+
+Anyone that works with either the `monax` toolkit or `burrow` will be familiar with the `genesis.json`. This file is utilized by the blockchain nodes within the cluster to set up their initial state.
+
+The chart imports the `genesis.json` file as a Kubernetes secret and then mounts the secret in each of the deployments utilized. The chart provides a default genesis file so as to ensure this chart is testable. The genesis file may be used to test out the blockchain, but otherwise should **absolutely not be used**. For more information on how to integrate your own genesis file for this chart see the [examples](examples/) folder.
+
+### Configuration of the validator keys
+
+**NOTE the chart has not been security audited and as such one should use the validator keys functionality of the chart at one's own risk**.
+
+Burrow blockchain nodes need to have a key available to them which has been properly registered within the `genesis.json` initial state. The registered key is what enables a blockchain node to participate in the p2p validation of the network.
+
+Anyone that works with either the `monax` toolkit, `burrow`, or `tendermint` will be familiar with the key files known as: `priv_validator.json` files used to initialize an individual blockchain node.
+
+The chart imports the `priv_validator.json` files as Kubernetes secrets, as such the security of the blockchain is only as strong as the Kubernetes secrets utilized via helm. The chart provides a default keys file so as to ensure that this chart is testable. The key file may be used to test out the blockchain, but otherwise should **absolutely not be used**. For more information on how to integrate your own keys files for this chart see the [examples](examples/) folder.
+
+## Other considerations
+
+There are a few other considerations underpinning how this chart was developed.
+
+### Deployments versus StatefulSets
+
+The first consideration is whether to utilize multiple deployments or a statefulSet. The chart maintainer has (to date) found it significantly easier to work with multiple deployments than with a statefulSet because the config files and keys differ subltely between and across each blockchain node. StatefulSets are currently not able to as elegantly handle the 1-to-1 linkages between the various key secrets and config files that are necessary to operate each blockchain node within the cluster.
+
+### Running multiple chains within your cluster
+
+Many users run multiple blockchains within their cluster. To run more than one blockchain it is best to utilize the `nameOverride` Value and set that to the `$CHAIN_ID` of any one blockchain network. That will allow easy use of multiple chains within a single cluster. For an example of this see the examples directory.

--- a/incubator/burrow/examples/1.human_deployment/README.md
+++ b/incubator/burrow/examples/1.human_deployment/README.md
@@ -1,0 +1,41 @@
+The steps to utilize the chart with a human deploying the blockchain network to the Kubernetes cluster and then deploying smart contracts and configuring the accounts on the blockchain, the following sequence can be utilized.
+
+## Prerequisites
+
+The easiest way to interact with `burrow` is via the [monax](https://github.com/monax/monax) toolkit. This command line application is built to provide a seamless toolkit for developers seeking to provision and operate burrow networks. The below deployment sequence relies upon a developer having that toolkit installed on their local machine.
+
+This sequence also requires the very fine [jq](https://stedolan.github.io/jq/) binary to be installed.
+
+## Deployment Sequence
+
+The following is an example deployment sequence.
+
+```bash
+CHAIN_NODES=4
+CHAIN_ID=myTestChain
+monax chains make $CHAIN_ID \
+  --account-types=Root:1,Validator:$CHAIN_NODES
+
+genesisFile=$(cat \
+  $HOME/.monax/chains/$CHAIN_ID/$(echo $CHAIN_ID \
+  | tr '[:upper:]' '[:lower:]')_root_000/genesis.json \
+  | jq -rc '@base64')
+
+keysFilesPrefix="keysFiles."
+keysFiles=""
+for d in $HOME/.monax/chains/$CHAIN_ID/*validator*/; do
+  key=key-$(basename $d | cut -d "_" -f 3)
+  val=$(cat $d/priv_validator.json | jq -rc '@base64')
+  keysFiles+=$keysFilesPrefix$key=$val,
+done
+
+helm install \
+  --set chain.name=$CHAIN_ID \
+  --set chain.id=$CHAIN_ID \
+  --set chain.numberOfNodes=$CHAIN_NODES \
+  --set genesisFile=$genesisFile \
+  --set $keysFiles \
+  incubator/burrow
+
+unset $keysFiles
+```

--- a/incubator/burrow/examples/2.service_deployment/README.md
+++ b/incubator/burrow/examples/2.service_deployment/README.md
@@ -1,0 +1,116 @@
+The steps to utilize the chart with a service (predominantly a CI/CD service) deploying the blockchain network to the Kubernetes cluster and then deploying smart contracts and configuring the accounts on the blockchain, the following sequence can be utilized.
+
+## Prerequisites
+
+The easiest way to interact with `burrow` is via the [monax](https://github.com/monax/monax) toolkit. This command line application is built to provide a seamless toolkit for developers seeking to provision and operate burrow networks. The below deployment sequence relies upon a developer having that toolkit installed on their local machine. This sequence also requires the very fine [jq](https://stedolan.github.io/jq/) binary to be installed.
+
+Monax offers a [docker image](https://quay.io/repository/monax/monax?tag=latest&tab=tags) that includes various tools necessary for deploying blockchains and contracts to Kubernetes clusters via a CI/CD system. If your CI/CD system offers an ability to utilize a custom docker image as the base of the CI/CD sequence then the easiest way to utilize this chart is to use the image: `quay.io/monax/monax-$VERSION-platform_deployer`. That image includes both the monax binary and the jq binary which will be used below.
+
+Obviously the container performing the CI/CD sequence will need to be able to connect with tiller within the cluster you are seeking to deploy to with the proper credentials.
+
+## Deployment Script
+
+The following is an example `.gitlab-ci.yml` that can be used, obviously if you use a different CI/CD system you will need to adjust the fields accordingly to fit your system. However, the yaml below should be approachable for most operators.
+
+```yaml
+image: quay.io/monax/monax:0.18.0-platform_deployer
+
+stages:
+  - test
+  - deploy
+
+before_script:
+  - monax init --yes --pull-images=false
+
+variables:
+  DOCKER_DRIVER: overlay2
+  MONAX_PULL_APPROVE: "true"
+
+test:
+  stage: test
+  script:
+    - true
+
+deploy:
+  stage: deploy
+  only:
+    - master@YOUR_REPO
+  environment:
+    name: production
+    url: https://YOUR_URL
+  variables:
+    CHAIN_SOURCE_DIRECTORY: "deploy/chain"
+    CHAIN_DEPLOY_NAME: "YOUR_NAME"
+    CHAIN_ID: "YOUR_ID"
+    CHAIN_NODES: 7
+    KUBERNETES_NAMESPACE: "YOUR_NAMESPACE"
+    ORGANIZATION_NAME: "YOUR_ORG"
+  script:
+    - deploy/deploy
+  after_script:
+    - rm -rf $HOME/.monax/keys; true
+  retry: 1
+```
+
+The following is a sample deploy/deploy script that could be used.
+
+```bash
+#!/usr/bin/env bash
+start=`pwd`
+export MONAX_PULL_APPROVE="true"
+
+main() {
+  make_chain
+  deploy_chain
+  exit 0
+}
+
+make_chain() {
+  monax chains make $CHAIN_ID \
+    --account-types=Full:0,Validator:$CHAIN_NODES 2>/dev/null
+  mv ~/.monax/chains/$CHAIN_ID/* $CHAIN_SOURCE_DIRECTORY/.
+  rm -rf ~/.monax/chains/$CHAIN_ID
+  cat $CHAIN_SOURCE_DIRECTORY/accounts.csv.default >> $CHAIN_SOURCE_DIRECTORY/accounts.csv
+  GENESIS_FILE=$(monax chains make $CHAIN_ID \
+    --known \
+    --accounts $CHAIN_SOURCE_DIRECTORY/accounts.csv \
+    --validators $CHAIN_SOURCE_DIRECTORY/validators.csv \
+    | jq -rc '@base64')
+  keysFilesPrefix="keysFiles."
+  KEYS_FILES=""
+  for d in $CHAIN_SOURCE_DIRECTORY/*validator*/; do
+    key=key-$(basename $d | cut -d "_" -f 3)
+    val=$(cat $d/priv_validator.json | jq -rc '@base64')
+    KEYS_FILES+=$keysFilesPrefix$key=$val,
+  done
+  rm -rf $CHAIN_SOURCE_DIRECTORY/*validator*/ && unset keysFilesPrefix
+}
+
+deploy_chain() {
+  set +e
+  helm delete --purge $CHAIN_DEPLOY_NAME
+  set -e
+  helm install \
+    --name $CHAIN_DEPLOY_NAME \
+    --values $CHAIN_SOURCE_DIRECTORY/values.yaml \
+    --namespace $KUBERNETES_NAMESPACE \
+    --set chain.name=$CHAIN_ID \
+    --set chain.id=$CHAIN_ID \
+    --set chain.numberOfNodes=$CHAIN_NODES \
+    --set nameOverride=$CHAIN_ID \
+    --set organization=$ORGANIZATION_NAME \
+    --set genesisFile=$GENESIS_FILE \
+    --set $KEYS_FILES \
+    incubator/burrow
+  unset $KEYS_FILES
+}
+
+set -e
+main $@
+```
+
+A few notes about the above script.
+
+* `CHAIN_SOURCE_DIR`: It is likely convenient when running this chart via CI/CD system to establish within the application's repository a place where default files such as a configured values.yaml and also a csv with accounts can be kept. The above script utilizes such a directory.
+* `values.yaml`: The above script utilizes a relatively fixed values.yaml that is kept within the application repository. This is used to configure variables that move infrequently such as the `image.tag` or ingress|persistence which is utilized by the cluster.
+* `accounts.csv.default`: The chain that is made uses dynamic validator keys and combines those with fixed keys that are used by the application developers. These keys have been collected during the development process and a .csv was built in the form that is outputted by `monax chains make`. This enables a combination of the accounts with a simple `cat ... >> ...` call as demonstrated in the script.

--- a/incubator/burrow/templates/NOTES.txt
+++ b/incubator/burrow/templates/NOTES.txt
@@ -1,0 +1,1 @@
+You have now installed Burrow! Congratulations.

--- a/incubator/burrow/templates/_helpers.tpl
+++ b/incubator/burrow/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "burrow.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "burrow.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 -}}
+{{- end -}}

--- a/incubator/burrow/templates/config-configs.yaml
+++ b/incubator/burrow/templates/config-configs.yaml
@@ -1,0 +1,100 @@
+{{ range (until (.Values.chain.numberOfNodes | int)) }}
+{{- $nodeNumber := printf "%03d" . }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "burrow.name" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+  name: {{ template "burrow.fullname" $ }}-config-{{ $nodeNumber }}
+data:
+  config.toml: |-
+    [chain]
+    assert_chain_id = {{ $.Values.chain.id | quote }}
+    major_version = 0
+    minor_version = 17
+    genesis_file = "genesis.json"
+      [chain.consensus]
+      name = "tendermint"
+      major_version = 0
+      minor_version = 8
+      relative_root = "tendermint"
+      [chain.manager]
+      name = "burrowmint"
+      major_version = 0
+      minor_version = 17
+      relative_root = "burrowmint"
+    [servers]
+      [servers.bind]
+      address = ""
+      port = {{ $.Values.service.api.port }}
+      [servers.tls]
+      tls = false
+      cert_path = ""
+      key_path = ""
+      [servers.cors]
+      enable = false
+      allow_origins = []
+      allow_credentials = false
+      allow_methods = []
+      allow_headers = []
+      expose_headers = []
+      max_age = 0
+      [servers.http]
+      json_rpc_endpoint = "/rpc"
+      [servers.websocket]
+      endpoint = "/socketrpc"
+      max_sessions = 50
+      read_buffer_size = 4096
+      write_buffer_size = 4096
+      [servers.tendermint]
+      rpc_local_address = "0.0.0.0:{{ $.Values.service.rpc.port }}"
+      endpoint = "/websocket"
+      [servers.logging]
+      console_log_level = {{ $.Values.chain.logLevel | quote }}
+      file_log_level = "warn"
+      log_file = "burrow-logs.log"
+    [tendermint]
+    private_validator_file = "priv_validator.json"
+      [tendermint.configuration]
+      moniker = {{ printf "%s-%s-validator-%s" $.Values.organization $.Values.chain.id $nodeNumber | quote }}
+      seeds = "{{ range (until (sub $.Values.chain.numberOfNodes 1 | int)) }}{{ template "burrow.fullname" $ }}-peer-{{ printf "%03d" . }}:{{ $.Values.service.peer.port }},{{ end }}{{ template "burrow.fullname" $ }}-peer-{{ sub $.Values.chain.numberOfNodes 1 | printf "%03d" }}:{{ $.Values.service.peer.port }}{{ if not (eq (len $.Values.chain.extraSeeds) 0) }}{{ range $.Values.chain.extraSeeds }},{{ . }}{{ end }}{{ end }}"
+      fast_sync = true
+      db_backend = "leveldb"
+      log_level = {{ $.Values.chain.logLevel | quote }}
+      node_laddr = "tcp://0.0.0.0:{{ $.Values.service.peer.port }}"
+      rpc_laddr = "tcp://0.0.0.0:{{ $.Values.service.rpc.port }}"
+      proxy_app = "tcp://127.0.0.1:46658"
+        [tendermint.configuration.p2p]
+        dial_timeout_seconds = 1
+        handshake_timeout_seconds = 5
+        max_num_peers = 20
+        authenticated_encryption = true
+        send_rate = 512000
+        recv_rate = 512000
+        fuzz_enable = false # use the fuzz wrapped conn
+        fuzz_active = false # toggle fuzzing
+        fuzz_mode = "drop"  # eg. drop, delay
+        fuzz_max_delay_milliseconds = 3000
+        fuzz_prob_drop_rw = 0.2
+        fuzz_prob_drop_conn = 0.00
+        fuzz_prob_sleep = 0.00
+    [burrowmint]
+    db_backend = "leveldb"
+    tendermint_host = "0.0.0.0:{{ $.Values.service.rpc.port }}"
+    [logging]
+      [logging.root_sink]
+        [logging.root_sink.transform]
+          transform_type = "filter"
+          filter_mode = "exclude_when_all_match"
+          [[logging.root_sink.transform.predicates]]
+            key_regex = "log_channel"
+            value_regex = "Trace"
+        [[logging.root_sink.sinks]]
+          [logging.root_sink.sinks.output]
+            output_type = "stderr"
+            format = "json"
+{{- end }}

--- a/incubator/burrow/templates/deployments.yaml
+++ b/incubator/burrow/templates/deployments.yaml
@@ -1,0 +1,137 @@
+{{ range (until (.Values.chain.numberOfNodes | int)) }}
+{{- $nodeNumber := printf "%03d" . }}
+{{- $workDir := printf "/work" }}
+{{- $dataDir := printf "/data" }}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "burrow.name" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+  name: {{ template "burrow.fullname" $ }}-{{ $nodeNumber }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+    {{- if $.Values.podAnnotations }}
+      annotations:
+{{ toYaml $.Values.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app: {{ template "burrow.name" $ }}
+        release: {{ $.Release.Name }}
+        nodeNumber: {{ $nodeNumber | quote }}
+      {{- if $.Values.podLabels }}
+{{ toYaml $.Values.podLabels | indent 8 }}
+      {{- end }}
+    spec:
+      initContainers:
+        - name: init-node
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          command:
+            - 'sh'
+            - '-xc'
+            - 'echo Initializing...; sleep {{ mul 5 . }}; echo Ready to go!'
+        - name: init-dir
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: {{ $workDir }}
+              name: work-dir
+          command:
+            - 'sh'
+            - '-c'
+            - 'chown -R 1000:101 {{ $workDir }}'
+      containers:
+        - name: node-{{ $nodeNumber }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          args:
+          {{- range $key, $value := $.Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
+          env:
+            - name: BURROW_WORKDIR
+              value: {{ $workDir }}
+            - name: BURROW_DATADIR
+              value: {{ $dataDir }}
+          {{- range $key, $value := $.Values.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+          {{- end }}
+          volumeMounts:
+            - mountPath: {{ $workDir }}
+              name: work-dir
+            - mountPath: {{ $dataDir }}
+              name: data-dir
+          ports:
+            - name: peer
+              protocol: TCP
+              containerPort: {{ $.Values.service.peer.port }}
+            - name: rpc
+              protocol: TCP
+              containerPort: {{ $.Values.service.rpc.port }}
+            - name: api
+              protocol: TCP
+              containerPort: {{ $.Values.service.api.port }}
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: rpc
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 1
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: rpc
+              scheme: HTTP
+            initialDelaySeconds: 1
+        {{- if $.Values.resources }}
+          resources:
+{{ toYaml $.Values.resources | indent 12 }}
+        {{- end }}
+      volumes:
+        - name: work-dir
+          projected:
+            sources:
+              - configMap:
+                  name: {{ template "burrow.fullname" $ }}-config-{{ $nodeNumber }}
+                  items:
+                    - key: config.toml
+                      path: config.toml
+              - secret:
+                  name: {{ template "burrow.fullname" $ }}-genesis
+                  items:
+                    - key: genesis.json
+                      path: genesis.json
+              - secret:
+                  name: {{ template "burrow.fullname" $ }}-keys
+                  items:
+                    - key: key-{{ $nodeNumber }}
+                      path: priv_validator.json
+        - name: data-dir
+        {{- if $.Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "burrow.fullname" $ }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      securityContext:
+        fsGroup: 101
+    {{- if $.Values.affinity }}
+      affinity:
+{{ toYaml $.Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if $.Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml $.Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml $.Values.tolerations | indent 8 }}
+{{- end }}

--- a/incubator/burrow/templates/ingress.yaml
+++ b/incubator/burrow/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := printf "%s-rpc" (include "burrow.fullname" .) -}}
+{{- $servicePort := .Values.service.rpc.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    app: {{ template "burrow.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "burrow.fullname" . }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/incubator/burrow/templates/pvc.yaml
+++ b/incubator/burrow/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "burrow.fullname" . }}
+  annotations:
+  {{- range $key, $value := .Values.persistence.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/burrow/templates/secret-genesis.yaml
+++ b/incubator/burrow/templates/secret-genesis.yaml
@@ -1,0 +1,12 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "burrow.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "burrow.fullname" . }}-genesis
+type: Opaque
+data:
+  genesis.json: {{ .Values.genesisFile }}

--- a/incubator/burrow/templates/secret-keys.yaml
+++ b/incubator/burrow/templates/secret-keys.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "burrow.name" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+  name: {{ template "burrow.fullname" $ }}-keys
+type: Opaque
+data:
+{{ toYaml .Values.keysFiles | indent 2 }}

--- a/incubator/burrow/templates/service-api.yaml
+++ b/incubator/burrow/templates/service-api.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app:  {{ template "burrow.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "burrow.fullname" . }}-api
+spec:
+  type: {{ .Values.service.api.type }}
+  sessionAffinity: ClientIP
+  ports:
+    - name: api
+      port: {{ .Values.service.api.port }}
+      targetPort: api
+      protocol: TCP
+  selector:
+    app: {{ template "burrow.name" $ }}
+    release: {{ .Release.Name }}
+  {{- if not .Values.service.api.loadBalance }}
+    nodeNumber: {{ .Values.service.api.node | quote }}
+  {{- end }}

--- a/incubator/burrow/templates/service-peers.yaml
+++ b/incubator/burrow/templates/service-peers.yaml
@@ -1,0 +1,25 @@
+{{ range (until (.Values.chain.numberOfNodes | int)) }}
+{{- $nodeNumber := printf "%03d" . }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "burrow.name" $ }}
+    chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+    nodeNumber: {{ $nodeNumber | quote }}
+  name: {{ template "burrow.fullname" $ }}-peer-{{ $nodeNumber }}
+spec:
+  type: {{ $.Values.service.peer.type }}
+  ports:
+    - name: peer
+      port: {{ $.Values.service.peer.port }}
+      targetPort: peer
+      protocol: TCP
+  selector:
+    app: {{ template "burrow.name" $ }}
+    release: {{ $.Release.Name }}
+    nodeNumber: {{ $nodeNumber | quote }}
+{{- end }}

--- a/incubator/burrow/templates/service-rpc.yaml
+++ b/incubator/burrow/templates/service-rpc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "burrow.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name:  {{ template "burrow.fullname" . }}-rpc
+spec:
+  type: {{ .Values.service.rpc.type }}
+  ports:
+    - name: rpc
+      port: {{ .Values.service.rpc.port }}
+      targetPort: rpc
+      protocol: TCP
+  selector:
+    app: {{ template "burrow.name" $ }}
+    release: {{ .Release.Name }}
+  {{- if not .Values.service.rpc.loadBalance }}
+    nodeNumber: {{ .Values.service.rpc.node | quote }}
+  {{- end }}

--- a/incubator/burrow/values.yaml
+++ b/incubator/burrow/values.yaml
@@ -1,0 +1,78 @@
+image:
+  repository: quay.io/monax/db
+  tag: 0.17.1
+  pullPolicy: IfNotPresent
+
+chain:
+  name: simpleTestChain
+  id: simpleTestChain
+  numberOfNodes: 1
+  logLevel: info
+  extraSeeds: []
+
+env: {}
+extraArgs: {}
+
+organization: myOrg
+
+service:
+  peer:
+    type: "ClusterIP"
+    port: 46656
+  rpc:
+    port: 46657
+    type: "ClusterIP"
+    loadBalance: false
+    node: "000"
+  api:
+    port: 1337
+    type: "ClusterIP"
+    loadBalance: true
+
+persistence:
+  enabled: false
+  # annotations: {}
+  # size: ""
+  # storageClass: ""
+  # accessMode: ""
+
+ingress:
+  enabled: false
+  # hosts:
+  #   - rpc.chain.example.com
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  # tls:
+  #   - secretName: rpc-chain-tls
+  #     hosts:
+  #       - rpc.chain.example.com
+
+resources:
+  # limits:
+  #  cpu: 500m
+  #  memory: 512Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+podAnnotations: {}
+podLabels: {}
+
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+# The below file is used **only** for testing and quick evaluation purposes. Please see the examples.
+genesisFile: "eyJnZW5lc2lzX3RpbWUiOiIyMDE3LTEyLTA4VDEwOjEwOjQ5Ljc4MloiLCJjaGFpbl9pZCI6InNpbXBsZVRlc3RDaGFpbiIsInBhcmFtcyI6eyJnbG9iYWxfcGVybWlzc2lvbnMiOnsiYmFzZSI6eyJwZXJtcyI6MjMwMiwic2V0IjoxNjM4M30sInJvbGVzIjpbXX19LCJhY2NvdW50cyI6W3siYWRkcmVzcyI6IjgzRjBEMTk5NzhGQjFDMkFBNzc2MUUxQ0Q2QUZCOTQxNzYxRkE2NUQiLCJhbW91bnQiOjk5OTk5OTk5OTk5OTk5LCJuYW1lIjoic2ltcGxldGVzdGNoYWluX2Z1bGxfMDAwIiwicGVybWlzc2lvbnMiOnsiYmFzZSI6eyJwZXJtcyI6MTYzODMsInNldCI6MTYzODN9LCJyb2xlcyI6W119fV0sInZhbGlkYXRvcnMiOlt7InB1Yl9rZXkiOlsxLCJENEU4MTRBMjFFMjU2QkZGQTNENzkyOEI4N0Q0NDU1OUJGOTQzN0YzMzg2REI4MUMyNDk0RUM4RDVGN0QzMDkwIl0sImFtb3VudCI6OTk5OTk5OTk5OSwibmFtZSI6InNpbXBsZXRlc3RjaGFpbl9mdWxsXzAwMCIsInVuYm9uZF90byI6W3siYWRkcmVzcyI6IjgzRjBEMTk5NzhGQjFDMkFBNzc2MUUxQ0Q2QUZCOTQxNzYxRkE2NUQiLCJhbW91bnQiOjk5OTk5OTk5OTl9XX1dfQ=="
+
+# The below file is used **only** for testing and quick evaluation purposes. Please see the examples.
+keysFiles:
+  key-000: "eyJhZGRyZXNzIjoiODNGMEQxOTk3OEZCMUMyQUE3NzYxRTFDRDZBRkI5NDE3NjFGQTY1RCIsInB1Yl9rZXkiOlsxLCJENEU4MTRBMjFFMjU2QkZGQTNENzkyOEI4N0Q0NDU1OUJGOTQzN0YzMzg2REI4MUMyNDk0RUM4RDVGN0QzMDkwIl0sInByaXZfa2V5IjpbMSwiMkVGMjNDRTE0MkFGMEEwNUY0MzY1NzY3NTk5MzA4QkUzOUNBODBBODg2N0M1OTQxMzAwMjc0MjJEQjY2OTU3OUQ0RTgxNEEyMUUyNTZCRkZBM0Q3OTI4Qjg3RDQ0NTU5QkY5NDM3RjMzODZEQjgxQzI0OTRFQzhENUY3RDMwOTAiXSwibGFzdF9oZWlnaHQiOjAsImxhc3Rfcm91bmQiOjAsImxhc3Rfc3RlcCI6MH0="


### PR DESCRIPTION
This pull request adds a chart to boot a cluster of the Linux Foundation's Hyperledger Burrow blockchain nodes. The chart is built to enable fast, easy, and flexible blockchain deployment to Kubernetes clusters. 

Included in the chart are relatively extensive user notes including examples of how to deploy a chart from an individual developer's perspective as well as from CI/CD services that automatically deploy blockchains.

My Company, Monax, is one of the maintainers of the codebase and we've used this chart extensively for months now (in its various iterations). We would consider it relatively stable and are happy to contribute it to the community. 
