### PR TITLE
Remove Spinnaker from e2e tests

### DIFF
--- a/test/helm-test/whitelist.yaml
+++ b/test/helm-test/whitelist.yaml
@@ -3,6 +3,5 @@ charts:
   - stable/cockroachdb #StatefulSet
   - stable/etcd-operator #Operator & CustomResource
   - stable/prometheus
-  - stable/spinnaker
   - stable/jenkins
   - incubator/zookeeper


### PR DESCRIPTION
This should fix https://github.com/kubernetes/charts/issues/2978 by removing the chart that is timing out in the upstream e2e tests for charts.

cc @mattfarina @spiffxp @foxish 