### PR TITLE
Add sleep after ns so resources can be cleaned properly

### DIFF
--- a/test/helm-test/main.go
+++ b/test/helm-test/main.go
@@ -273,6 +273,14 @@ func doMain() int {
 		})
 	}
 
+	xmlWrap(fmt.Sprintf("Sleeping so that resources can be cleaned up"), func() error {
+		o, execErr := output(exec.Command("sleep", "120"))
+		if execErr != nil {
+			return fmt.Errorf("%s Command output: %s", execErr, string(o[:]))
+		}
+		return nil
+	})
+
 	if suite.Failures > 0 {
 		return TEST_FAILURE_CODE
 	}


### PR DESCRIPTION
PVCs are not being given enough time to be deleted in the cloud provider so tests are failing due to leaked resources. This adds a sleep after the namespace for each chart is deleted.

Downside is that charts will take 2 minutes longer to test. 