### PR TITLE
Fix variable path in Grafana set-datasource job.

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.5.1
+version: 0.5.2
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/job.yaml
+++ b/stable/grafana/templates/job.yaml
@@ -33,7 +33,7 @@ spec:
               name: {{ template "grafana.server.fullname" . }}
               key: grafana-admin-password
         args:
-          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.fullname" . }}:{{ .Values.server.httpPort }}/api/datasources"
+          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/datasources"
           - "--max-time"
           - "10"
           - "-H"


### PR DESCRIPTION
The set-datasource job uses a json path for the grafana port that is not used anywhere else. This PR fixes by using the same path as used for all other references to the grafana port.