### PR TITLE
[stable/rabbitmq-ha] Add RabbitMQ HA chart

### DIFF
--- a/stable/rabbitmq-ha/.helmignore
+++ b/stable/rabbitmq-ha/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -14,5 +14,5 @@ sources:
 - https://github.com/rabbitmq/rabbitmq
 - https://github.com/docker-library/rabbitmq
 maintainers:
-- name: Etienne Tremel
+- name: etiennetremel
   email: etienne.tremel@container-solutions.com

--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,0 +1,18 @@
+name: rabbitmq-ha
+apiVersion: v1
+appVersion: 3.7.0
+version: 0.1.0
+description: Highly available RabbitMQ cluster, the open source message broker
+  software that implements the Advanced Message Queuing Protocol (AMQP).
+keywords:
+- rabbitmq
+- message queue
+- AMQP
+home: https://www.rabbitmq.com
+icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
+sources:
+- https://github.com/rabbitmq/rabbitmq
+- https://github.com/docker-library/rabbitmq
+maintainers:
+- name: Etienne Tremel
+  email: etienne.tremel@container-solutions.com

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -79,7 +79,7 @@ and their default values.
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)            | `""`                                                     |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`                                                     |
 | `service.type`                     | Type of service to create                                       | `ClusterIP`                                              |
-| `tolerations`                      | Toleration labels for pod assignment                            | `[]`                                                       |
+| `tolerations`                      | Toleration labels for pod assignment                            | `[]`                                                     |
 | `updateStrategy`                   | Statefulset update strategy                                     | `OnDelete`                                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -73,9 +73,9 @@ and their default values.
 | `rabbitmqUsername`                 | RabbitMQ application username                                   | `guest`                                                  |
 | `rabbitmqVhost`                    | RabbitMQ application vhost                                      | `/`                                                      |
 | `rbac.create`                      | If true, create & use RBAC resources                            | `true`                                                   |
+| `rbac.serviceAccountName`          | Service account name to use (ignored if rbac.create=true)       | `default`                                                |
 | `replicaCount`                     | Number of replica                                               | `3`                                                      |
 | `resources`                        | CPU/Memory resource requests/limits                             | `{}`                                                     |
-| `serviceAccountName`               | Service account name to use (ignored if rbac.create=true)       | `default`                                                |
 | `service.annotations`              | Annotations to add to service                                   | `none`                                                   |
 | `service.clusterIP`                | IP address to assign to service                                 | `""`                                                     |
 | `service.externalIPs`              | Service external IP addresses                                   | `[]`                                                     |

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -1,0 +1,112 @@
+# RabbitMQ High Available
+
+[RabbitMQ](https://www.rabbitmq.com) is an open source message broker software
+that implements the Advanced Message Queuing Protocol (AMQP).
+
+## TL;DR;
+
+```bash
+$ helm install stable/rabbitmq-ha
+```
+
+## Introduction
+
+This chart bootstraps a [RabbitMQ](https://hub.docker.com/r/_/rabbitmq)
+deployment on a [Kubernetes](http://kubernetes.io) cluster using the
+[Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.5+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/rabbitmq-ha
+```
+
+The command deploys RabbitMQ on the Kubernetes cluster in the default
+configuration. The [configuration](#configuration) section lists the parameters
+that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the RabbitMQ chart
+and their default values.
+
+|          Parameter                 |                       Description                               |                         Default                          |
+|------------------------------------|-----------------------------------------------------------------|----------------------------------------------------------|
+| `customConfigMap`                  | Use a custom ConfigMap                                          | `false`                                                  |
+| `image.pullPolicy`                 | Image pull policy                                               | `Always` if `image` tag is `latest`, else `IfNotPresent` |
+| `image.repository`                 | RabbitMQ container image repository                             | `rabbitmq`                                               |
+| `image.tag`                        | RabbitMQ container image tag                                    | `3.7-alpine`                                             |
+| `nodeSelector`                     | Node labels for pod assignment                                  | {}                                                       |
+| `persistentVolume.accessMode`      | Persistent volume access modes                                  | [ReadWriteOnce]                                          |
+| `persistentVolume.annotations`     | Persistent volume annotations                                   | {}                                                       |
+| `persistentVolume.enabled`         | If `true`, persistent volume claims are created                 | `false`                                                  |
+| `persistentVolume.size`            | Persistent volume size                                          | `8Gi`                                                    |
+| `persistentVolume.storageClass`    | Persistent volume storage class                                 | `-`                                                      |
+| `podAntiAffinity`                  | Pod antiaffinity, `hard` or `soft`                              | `hard`                                                   |
+| `rabbitmqErlangCookie`             | Erlang cookie                                                   | _random 32 character long alphanumeric string_           |
+| `rabbitmqHipeCompile`              | Precompile parts of RabbitMQ using HiPE                         | `false`                                                  |
+| `rabbitmqManagerPort`              | RabbitMQ Manager port                                           | `15672`                                                  |
+| `rabbitmqMemoryHighWatermark`      | Memory high watermark                                           | `2GB`                                                    |
+| `rabbitmqNodePort`                 | Node port                                                       | `5672`                                                   |
+| `rabbitmqPassword`                 | RabbitMQ application password                                   | _random 10 character long alphanumeric string_           |
+| `rabbitmqUsername`                 | RabbitMQ application username                                   | `guest`                                                  |
+| `rabbitmqVhost`                    | RabbitMQ application vhost                                      | `/`                                                      |
+| `replicaCount`                     | Number of replica                                               | `3`                                                      |
+| `resources`                        | CPU/Memory resource requests/limits                             | `{}`                                                     |
+| `service.annotations`              | Annotations to add to service                                   | none                                                     |
+| `service.clusterIP`                | IP address to assign to service                                 | `""`                                                     |
+| `service.externalIPs`              | Service external IP addresses                                   | `[]`                                                     |
+| `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)            | `""`                                                     |
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`                                                     |
+| `service.type`                     | Type of service to create                                       | `ClusterIP`                                              |
+| `tolerations`                      | Toleration labels for pod assignment                            | `[]`                                                       |
+| `updateStrategy`                   | Statefulset update strategy                                     | `OnDelete`                                               |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set rabbitmqUsername=admin,rabbitmqPassword=secretpassword,rabbitmqErlangCookie=secretcookie \
+    stable/rabbitmq-ha
+```
+
+The above command sets the RabbitMQ admin username and password to `admin` and
+`secretpassword` respectively. Additionally the secure erlang cookie is set to
+`secretcookie`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/rabbitmq-ha
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Custom ConfigMap
+
+When creating a new chart with this chart as a dependency, `customConfigMap`
+can be used to override the default configmap.yaml provided. It also allows for
+providing additional configuration files that will be mounted into
+`/etc/rabbitmq`. In the parent chart's values.yaml, set the value to true and
+provide the file `templates/configmap.yaml` for your use case.

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -63,10 +63,11 @@ and their default values.
 | `persistentVolume.size`            | Persistent volume size                                          | `8Gi`                                                    |
 | `persistentVolume.storageClass`    | Persistent volume storage class                                 | `-`                                                      |
 | `podAntiAffinity`                  | Pod antiaffinity, `hard` or `soft`                              | `hard`                                                   |
+| `rabbitmqEpmdPort`                 | EPMD port used for cross cluster replication                    | `4369`                                                   |
 | `rabbitmqErlangCookie`             | Erlang cookie                                                   | _random 32 character long alphanumeric string_           |
 | `rabbitmqHipeCompile`              | Precompile parts of RabbitMQ using HiPE                         | `false`                                                  |
 | `rabbitmqManagerPort`              | RabbitMQ Manager port                                           | `15672`                                                  |
-| `rabbitmqMemoryHighWatermark`      | Memory high watermark                                           | `2GB`                                                    |
+| `rabbitmqMemoryHighWatermark`      | Memory high watermark                                           | `256MB`                                                  |
 | `rabbitmqNodePort`                 | Node port                                                       | `5672`                                                   |
 | `rabbitmqPassword`                 | RabbitMQ application password                                   | _random 10 character long alphanumeric string_           |
 | `rabbitmqUsername`                 | RabbitMQ application username                                   | `guest`                                                  |

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -56,9 +56,9 @@ and their default values.
 | `image.pullPolicy`                 | Image pull policy                                               | `Always` if `image` tag is `latest`, else `IfNotPresent` |
 | `image.repository`                 | RabbitMQ container image repository                             | `rabbitmq`                                               |
 | `image.tag`                        | RabbitMQ container image tag                                    | `3.7-alpine`                                             |
-| `nodeSelector`                     | Node labels for pod assignment                                  | {}                                                       |
-| `persistentVolume.accessMode`      | Persistent volume access modes                                  | [ReadWriteOnce]                                          |
-| `persistentVolume.annotations`     | Persistent volume annotations                                   | {}                                                       |
+| `nodeSelector`                     | Node labels for pod assignment                                  | `{}`                                                     |
+| `persistentVolume.accessMode`      | Persistent volume access modes                                  | `[ReadWriteOnce]`                                        |
+| `persistentVolume.annotations`     | Persistent volume annotations                                   | `{}`                                                     |
 | `persistentVolume.enabled`         | If `true`, persistent volume claims are created                 | `false`                                                  |
 | `persistentVolume.size`            | Persistent volume size                                          | `8Gi`                                                    |
 | `persistentVolume.storageClass`    | Persistent volume storage class                                 | `-`                                                      |
@@ -71,9 +71,11 @@ and their default values.
 | `rabbitmqPassword`                 | RabbitMQ application password                                   | _random 10 character long alphanumeric string_           |
 | `rabbitmqUsername`                 | RabbitMQ application username                                   | `guest`                                                  |
 | `rabbitmqVhost`                    | RabbitMQ application vhost                                      | `/`                                                      |
+| `rbac.create`                      | If true, create & use RBAC resources                            | `true`                                                   |
 | `replicaCount`                     | Number of replica                                               | `3`                                                      |
 | `resources`                        | CPU/Memory resource requests/limits                             | `{}`                                                     |
-| `service.annotations`              | Annotations to add to service                                   | none                                                     |
+| `serviceAccountName`               | Service account name to use (ignored if rbac.create=true)       | `default`                                                |
+| `service.annotations`              | Annotations to add to service                                   | `none`                                                   |
 | `service.clusterIP`                | IP address to assign to service                                 | `""`                                                     |
 | `service.externalIPs`              | Service external IP addresses                                   | `[]`                                                     |
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)            | `""`                                                     |

--- a/stable/rabbitmq-ha/templates/NOTES.txt
+++ b/stable/rabbitmq-ha/templates/NOTES.txt
@@ -1,0 +1,60 @@
+** Please be patient while the chart is being deployed **
+
+  Credentials:
+
+    echo Username      : {{ .Values.rabbitmqUsername }}
+    echo Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
+    echo ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
+
+  RabbitMQ can be accessed within the cluster on port {{ .Values.rabbitmqNodePort }} at {{ template "rabbitmq-ha.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+  To access for outside the cluster execute the following commands:
+
+{{- if contains "NodePort" .Values.service.type }}
+
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT_AMQP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "rabbitmq-ha.fullname" . }})
+    export NODE_PORT_STATS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[3].nodePort}" services {{ template "rabbitmq-ha.fullname" . }})
+
+  To Access the RabbitMQ AMQP port:
+
+    echo amqp://$NODE_IP:$NODE_PORT_AMQP/
+
+  To Access the RabbitMQ Management interface:
+
+    echo http://$NODE_IP:$NODE_PORT_STATS/
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "rabbitmq-ha.name" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+  To Access the RabbitMQ AMQP port:
+
+    echo amqp://$SERVICE_IP:{{ .Values.rabbitmqNodePort }}/
+
+  To Access the RabbitMQ Management interface:
+
+    echo http://$SERVICE_IP:{{ .Values.rabbitmqManagerPort }}/
+
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rabbitmq-ha.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+    kubectl port-forward $POD_NAME --namespace {{ .Release.Namespace }} {{ .Values.rabbitmqNodePort }}:{{ .Values.rabbitmqNodePort }} {{ .Values.rabbitmqManagerPort }}:{{ .Values.rabbitmqManagerPort }}
+
+  To Access the RabbitMQ AMQP port:
+
+    echo amqp://127.0.0.1:{{ .Values.rabbitmqNodePort }}/
+
+  To Access the RabbitMQ Management interface:
+
+    echo URL : http://127.0.0.1:{{ .Values.rabbitmqManagerPort }}
+{{- end }}
+
+
+To enable mirroring for all the host:
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rabbitmq-ha.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl exec $POD_NAME --namespace {{ .Release.Namespace }} -- rabbitmqctl set_policy ha-all "." '{"ha-mode":"all", "ha-sync-mode":"automatic"}' --apply-to all --priority 0

--- a/stable/rabbitmq-ha/templates/_helpers.tpl
+++ b/stable/rabbitmq-ha/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rabbitmq-ha.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "rabbitmq-ha.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -1,0 +1,33 @@
+{{- if not .Values.customConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "rabbitmq-ha.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq-ha.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  enabled_plugins: |
+    [rabbitmq_consistent_hash_exchange,rabbitmq_federation,rabbitmq_federation_management,rabbitmq_management,rabbitmq_mqtt,rabbitmq_peer_discovery_k8s,rabbitmq_shovel,rabbitmq_shovel_management,rabbitmq_stomp,rabbitmq_web_stomp].
+
+  rabbitmq.conf: |
+    ## RabbitMQ configuration
+    ## Ref: https://github.com/rabbitmq/rabbitmq-server/blob/master/docs/rabbitmq.conf.example
+
+    ## Clustering
+    cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
+    cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+    cluster_formation.k8s.address_type = ip
+    cluster_formation.node_cleanup.interval = 10
+    cluster_formation.node_cleanup.only_log_warning = false
+    cluster_partition_handling = autoheal
+
+    ## The default "guest" user is only permitted to access the server
+    ## via a loopback interface (e.g. localhost)
+    loopback_users.guest = false
+
+    ## Memory-based Flow Control threshold
+    vm_memory_high_watermark.absolute = {{ .Values.rabbitmqMemoryHighWatermark }}
+{{- end }}

--- a/stable/rabbitmq-ha/templates/role.yaml
+++ b/stable/rabbitmq-ha/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   labels:
-    app: {{ template "rabbitmq-ha.fullname" . }}
+    app: {{ template "rabbitmq-ha.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/rabbitmq-ha/templates/role.yaml
+++ b/stable/rabbitmq-ha/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "rabbitmq-ha.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  name: {{ template "rabbitmq-ha.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get"]
+{{- end }}

--- a/stable/rabbitmq-ha/templates/rolebinding.yaml
+++ b/stable/rabbitmq-ha/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ template "rabbitmq-ha.fullname" . }}
+    app: {{ template "rabbitmq-ha.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/rabbitmq-ha/templates/rolebinding.yaml
+++ b/stable/rabbitmq-ha/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "rabbitmq-ha.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  name: {{ template "rabbitmq-ha.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "rabbitmq-ha.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "rabbitmq-ha.fullname" . }}
+{{- end }}

--- a/stable/rabbitmq-ha/templates/secret.yaml
+++ b/stable/rabbitmq-ha/templates/secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rabbitmq-ha.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq-ha.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if .Values.rabbitmqPassword }}
+  rabbitmq-password: {{ .Values.rabbitmqPassword | b64enc | quote }}
+  {{ else }}
+  rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  {{ if .Values.rabbitmqErlangCookie }}
+  rabbitmq-erlang-cookie: {{ .Values.rabbitmqErlangCookie | b64enc | quote }}
+  {{ else }}
+  rabbitmq-erlang-cookie: {{ randAlphaNum 32 | b64enc | quote }}
+  {{ end }}

--- a/stable/rabbitmq-ha/templates/secret.yaml
+++ b/stable/rabbitmq-ha/templates/secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}
   labels:
-    app: {{ template "rabbitmq-ha.fullname" . }}
+    app: {{ template "rabbitmq-ha.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -33,6 +33,10 @@ spec:
       protocol: TCP
       port: {{ .Values.rabbitmqNodePort }}
       targetPort: amqp
+    - name: epmd
+      protocol: TCP
+      port: {{ .Values.rabbitmqEpmdPort }}
+      targetPort: epmd
   selector:
     app: {{ template "rabbitmq-ha.name" . }}
     release: {{ .Release.Name }}

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "rabbitmq-ha.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq-ha.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: "{{ .Values.service.clusterIP }}"
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.rabbitmqManagerPort }}
+      targetPort: http
+    - name: amqp
+      protocol: TCP
+      port: {{ .Values.rabbitmqNodePort }}
+      targetPort: amqp
+  selector:
+    app: {{ template "rabbitmq-ha.name" . }}
+    release: {{ .Release.Name }}
+  type: {{ .Values.service.type }}

--- a/stable/rabbitmq-ha/templates/serviceaccount.yaml
+++ b/stable/rabbitmq-ha/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "rabbitmq-ha.fullname" . }}
+    app: {{ template "rabbitmq-ha.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/rabbitmq-ha/templates/serviceaccount.yaml
+++ b/stable/rabbitmq-ha/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "rabbitmq-ha.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  name: {{ template "rabbitmq-ha.fullname" . }}
+{{- end }}

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -25,12 +25,15 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
+            - name: epmd
               protocol: TCP
-              containerPort: 15672
+              containerPort: 4369
             - name: amqp
               protocol: TCP
               containerPort: 5672
+            - name: http
+              protocol: TCP
+              containerPort: 15672
           livenessProbe:
             exec:
               command:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -1,0 +1,150 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ template "rabbitmq-ha.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq-ha.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  serviceName: {{ template "rabbitmq-ha.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "rabbitmq-ha.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 15672
+            - name: amqp
+              protocol: TCP
+              containerPort: 5672
+          livenessProbe:
+            exec:
+              command:
+                - rabbitmqctl
+                - status
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - rabbitmqctl
+                - status
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: RABBITMQ_USE_LONGNAME
+              value: "true"
+            - name: RABBITMQ_NODENAME
+              value: "rabbit@$(MY_POD_IP)"
+            - name: K8S_SERVICE_NAME
+              value: {{ template "rabbitmq-ha.fullname" . }}
+            - name: RABBITMQ_ERLANG_COOKIE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "rabbitmq-ha.fullname" . }}
+                  key: rabbitmq-erlang-cookie
+            {{- if .Values.rabbitmqHipeCompile }}
+            - name: RABBITMQ_HIPE_COMPILE
+              value: {{ .Values.rabbitmqHipeCompile | quote }}
+            {{- end }}
+            - name: RABBITMQ_DEFAULT_USER
+              value: {{ .Values.rabbitmqUsername | quote }}
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "rabbitmq-ha.fullname" . }}
+                  key: rabbitmq-password
+            - name: RABBITMQ_DEFAULT_VHOST
+              value: {{ .Values.rabbitmqVhost | quote }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/rabbitmq
+            - name: config
+              mountPath: /etc/rabbitmq
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if eq .Values.podAntiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: {{ template "rabbitmq-ha.name" . }}
+                  release: {{ .Release.Name }}
+      {{- else if eq .Values.podAntiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "rabbitmq-ha.name" . }}
+                    release: {{ .Release.Name }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "rabbitmq-ha.fullname" . }}
+        # - name: data
+        #   emptyDir:
+        #     sizeLimit: {{ .Values.persistentDiskSizeLimit | quote }}
+
+{{- if .Values.persistentVolume.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+        {{- range $key, $value := .Values.persistentVolume.annotations }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistentVolume.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistentVolume.size | quote }}
+      {{- if .Values.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+      {{- end }}
+      {{- end }}
+{{- else }}
+        - name: data
+          emptyDir: {}
+{{- end }}
+
+
+
+

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -19,7 +19,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "rabbitmq-ha.fullname" . }}{{ else }}"{{ .Values.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "rabbitmq-ha.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -144,7 +144,3 @@ spec:
         - name: data
           emptyDir: {}
 {{- end }}
-
-
-
-

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -19,6 +19,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       terminationGracePeriodSeconds: 10
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "rabbitmq-ha.fullname" . }}{{ else }}"{{ .Values.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -113,10 +114,6 @@ spec:
         - name: config
           configMap:
             name: {{ template "rabbitmq-ha.fullname" . }}
-        # - name: data
-        #   emptyDir:
-        #     sizeLimit: {{ .Values.persistentDiskSizeLimit | quote }}
-
 {{- if .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -107,3 +107,9 @@ podAntiAffinity: soft
 ## Create default configMap
 ##
 customConfigMap: false
+
+rbac:
+  create: true
+
+# Defines the serviceAccountName to use when `rbac.create=false`
+serviceAccountName: default

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -1,0 +1,109 @@
+## RabbitMQ application credentials
+## Ref: http://rabbitmq.com/access-control.html
+##
+rabbitmqUsername: guest
+# rabbitmqPassword:
+
+## RabbitMQ default VirtualHost
+## Ref: https://www.rabbitmq.com/vhosts.html
+##
+rabbitmqVhost: "/"
+
+## Erlang cookie to determine whether different nodes are allowed to communicate with each other
+## Ref: https://www.rabbitmq.com/clustering.html
+##
+# rabbitmqErlangCookie:
+
+## RabbitMQ Memory high watermark
+## Ref: http://www.rabbitmq.com/memory.html
+##
+rabbitmqMemoryHighWatermark: 50MB
+
+## Node port
+rabbitmqNodePort: 5672
+
+## Manager port
+rabbitmqManagerPort: 15672
+
+## Set to true to precompile parts of RabbitMQ with HiPE, a just-in-time
+## compiler for Erlang. This will increase server throughput at the cost of
+## increased startup time. You might see 20-50% better performance at the cost
+## of a few minutes delay at startup.
+rabbitmqHipeCompile: false
+
+## Number of replicas
+replicaCount: 3
+
+image:
+  repository: rabbitmq
+  tag: 3.7
+  pullPolicy: IfNotPresent
+
+service:
+  annotations: {}
+  clusterIP: ""
+
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  type: NodePort
+
+## Statefulsets rolling update update strategy
+## Ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-update
+##
+updateStrategy: OnDelete
+
+## We usually recommend not to specify default resources and to leave this as
+## a conscious choice for the user. This also increases chances charts run on
+## environments with little resources, such as Minikube. If you do want to
+## specify resources, uncomment the following lines, adjust them as necessary,
+## and remove the curly braces after 'resources:'.
+## If you decide to set the memory limit, make sure to also change the
+## rabbitmqMemoryHighWatermark following the formula:
+##   rabbitmqMemoryHighWatermark = 0.4 * resources.limits.memory
+##
+resources: {}
+# limits:
+#  cpu: 100m
+#  memory: 1Gi
+# requests:
+#  cpu: 100m
+#  memory: 1Gi
+
+
+## Data Persistency
+persistentVolume:
+  enabled: false
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessModes:
+    - ReadWriteOnce
+  size: 8Gi
+  annotations: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+##
+nodeSelector: {}
+
+## Node tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+##
+tolerations: []
+
+## Pod affinity
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+podAntiAffinity: soft
+
+## Create default configMap
+##
+customConfigMap: false

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -119,5 +119,6 @@ customConfigMap: false
 rbac:
   create: true
 
-# Defines the serviceAccountName to use when `rbac.create=false`
-serviceAccountName: default
+  # Defines the serviceAccountName to use when `rbac.create=false`
+  serviceAccountName: default
+

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -121,4 +121,3 @@ rbac:
 
   # Defines the serviceAccountName to use when `rbac.create=false`
   serviceAccountName: default
-

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -36,7 +36,7 @@ replicaCount: 3
 
 image:
   repository: rabbitmq
-  tag: 3.7
+  tag: 3.7-alpine
   pullPolicy: IfNotPresent
 
 service:

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -17,7 +17,12 @@ rabbitmqVhost: "/"
 ## RabbitMQ Memory high watermark
 ## Ref: http://www.rabbitmq.com/memory.html
 ##
-rabbitmqMemoryHighWatermark: 50MB
+rabbitmqMemoryHighWatermark: 256MB
+
+## EPMD port for peer discovery service used by RabbitMQ nodes and CLI tools
+## Ref: https://www.rabbitmq.com/clustering.html
+##
+rabbitmqEpmdPort: 4369
 
 ## Node port
 rabbitmqNodePort: 5672
@@ -108,6 +113,9 @@ podAntiAffinity: soft
 ##
 customConfigMap: false
 
+## Role Based Access
+## Ref: https://kubernetes.io/docs/admin/authorization/rbac/
+##
 rbac:
   create: true
 


### PR DESCRIPTION
Add RabbitMQ Hight Available chart. It rely on Statefulsets, use the official RabbitMQ image and the official Kubernetes node discovery plugin.

This PR can only be tested after the official RabbitMQ 3.7 image get merged to the official Docker repository, see https://github.com/docker-library/official-images/pull/3795. Hopefully in the coming days.