### PR TITLE
Update redis-sentinel service name to be templated

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 1.0.1
+version: 2.0.0
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
 maintainers:

--- a/stable/redis-ha/templates/_helpers.tpl
+++ b/stable/redis-ha/templates/_helpers.tpl
@@ -17,6 +17,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "sentinel_service_name" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-sentinel" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "sentinel_service_hostname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-sentinel.%s" .Release.Name $name .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 
 {{- /*
 Credit: @technosophos

--- a/stable/redis-ha/templates/redis-master-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-master-statefulset.yaml
@@ -35,6 +35,10 @@ spec:
           resources:
 {{ toYaml .Values.resources.master | indent 12 }}
           env:
+            - name: REDIS_SENTINEL_SERVICE_HOST
+              value: {{ template "sentinel_service_hostname" . }}
+            - name: REDIS_SENTINEL_SERVICE_PORT
+              value: "26379"
             - name: MASTER
               value: "true"
           ports:
@@ -48,6 +52,10 @@ spec:
           resources:
 {{ toYaml .Values.resources.sentinel | indent 12 }}
           env:
+            - name: REDIS_SENTINEL_SERVICE_HOST
+              value: {{ template "sentinel_service_hostname" . }}
+            - name: REDIS_SENTINEL_SERVICE_PORT
+              value: "26379"
             - name: SENTINEL
               value: "true"
           ports:

--- a/stable/redis-ha/templates/redis-sentinel-deployment.yaml
+++ b/stable/redis-ha/templates/redis-sentinel-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-sentinel
+  name: {{ template "sentinel_service_name" . }}
 spec:
   replicas: {{ .Values.replicas.sentinel }}
   template:
@@ -26,6 +26,10 @@ spec:
         resources:
 {{ toYaml .Values.resources.sentinel | indent 10 }}
         env:
+          - name: REDIS_SENTINEL_SERVICE_HOST
+            value: {{ template "sentinel_service_hostname" . }}
+          - name: REDIS_SENTINEL_SERVICE_PORT
+            value: "26379"
           - name: SENTINEL
             value: "true"
         ports:

--- a/stable/redis-ha/templates/redis-sentinel-service.yaml
+++ b/stable/redis-ha/templates/redis-sentinel-service.yaml
@@ -5,7 +5,7 @@ metadata:
     name: {{ template "name" . }}-sentinel-svc
     role: service
 {{ include "labels.standard" . | indent 4 }}
-  name: redis-sentinel
+  name: {{ template "fullname" . }}-sentinel
 spec:
   ports:
     - port: 26379

--- a/stable/redis-ha/templates/redis-slave-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-slave-statefulset.yaml
@@ -34,6 +34,11 @@ spec:
           volumeMounts:
             - mountPath: /redis-master-data
               name: data
+          env:
+            - name: REDIS_SENTINEL_SERVICE_HOST
+              value: {{ template "sentinel_service_hostname" . }}
+            - name: REDIS_SENTINEL_SERVICE_PORT
+              value: "26379"
       volumes:
       - name: data
       {{- if .Values.persistentVolume.enabled }}


### PR DESCRIPTION
Need service name to be templated so we can deploy multiple releases in the same namespace.

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
