### PR TITLE
Fixing OWNERS file to have correct naming conventions

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-maintainers:
+approvers:
   - lachie83
   - linki
   - mgoodness


### PR DESCRIPTION
`maintainers` is not currently a used term. For testing tooling to work the proper naming needs to be here and that's `approvers`