### PR TITLE
Add debugging output to find PV errors in CI

### DIFF
--- a/test/helm-test-e2e.sh
+++ b/test/helm-test-e2e.sh
@@ -29,3 +29,8 @@ cd $GOPATH
 go get github.com/ghodss/yaml
 popd
 go run $GOPATH/src/k8s.io/charts/test/helm-test/main.go
+
+echo "#### Debugging ci-kubernetes-charts-gce ###"
+kubectl get pvc --all-namespaces -o wide
+kubectl get pv -o wide
+echo "####"


### PR DESCRIPTION
/assign @viglesiasce 

This should output after the main test loop has happened (and the sleep) what PVCs and PVs are leftover.