### PR TITLE
[stable/kong] Add a chart for Kong

### DIFF
--- a/stable/kong/.helmignore
+++ b/stable/kong/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+description: Kong is open-source API Gateway and Microservices Management Layer,
+  delivering high performance and reliability.
+engine: gotpl
+home: https://getkong.org/
+icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
+maintainers:
+- name: shashiranjan84
+  email: shashi@konghq.com
+name: kong
+sources:
+- https://github.com/Kong/kong
+version: 0.1.0

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -1,0 +1,122 @@
+## Kong
+
+[Kong](https://getkong.org/) is an open-source API Gateway and Microservices
+Management Layer, delivering high performance and reliability.
+
+## TL;DR;
+
+```bash
+$ helm install stable/kong
+```
+
+## Introduction
+
+This chart bootstraps all the components needed to run Kong on a [Kubernetes](http://kubernetes.io)
+cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.6+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+  if persistence is needed
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/kong
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the
+chart and deletes the release.
+
+## Configuration
+
+### General Configuration Parameters
+
+The following tables lists the configurable parameters of the Kong chart
+and their default values.
+
+| Parameter                         | Description                                                            | Default               |
+| ------------------------------    | --------------------------------------------------------------------   | -------------------   |
+| image.repo                        | Kong image                                                             | `kong`                |
+| image.tag                         | Kong image version                                                     | `latest`              |
+| image.pullPolicy                  | Image pull policy                                                      | `IfNotPresent`        |
+| replicaCount                      | Kong instance count                                                    | `1`                   |
+| admin.servicePort                 | TCP port on which the Kong admin service is exposed                    | `8001`                |
+| admin.serviceSSLPort              | Secure TCP port on which the Kong admin service is exposed             | `8444`                |
+| admin.containerPort               | TCP port on which Kong app listens for admin traffic                   | `8001`                |
+| admin.containerSSLPort            | Secure TCP port on which Kong app listens for admin traffic            | `8444`                |
+| admin.type                        | k8s service type, Options: NodePort, ClusterIP, LoadBalancer                       | `NodePort`            |
+| admin.loadBalancerIP              | Will reuse an existing ingress static IP for the admin service         | `null`                |
+| admin.useTLS                      | Secure admin traffic                                                   | `true`                |
+| proxy.servicePort                 | TCP port on which the Kong proxy service is exposed                    | `8000`                |
+| proxy.serviceSSLPort              | Secure TCP port on which the Kong Proxy Service is exposed             | `8443`                |
+| proxy.containerPort               | TCP port on which the Kong app listens for Proxy traffic               | `8000`                |
+| proxy.containerSSLPort            | Secure TCP port on which the Kong app listens for Proxy traffic        | `8443`                |
+| proxy.type                        | k8s service type. Options: NodePort, ClusterIP, LoadBalancer            | `NodePort`            |
+| proxy.loadBalancerIP              | Will reuse an existing ingress static IP for the admin service         | `null`                |
+| proxy.useTLS                      | Secure Proxy traffic                                                   | `true`                |
+| logLevel                          | Kong [log level](https://getorg/docs/latest/configuration/#log_level)  | `debug`               |
+| customConfig                      | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)               |
+| runMigrations                     | Run Kong migrations job                                                | `true`                |
+| readinessProbe                    | Kong readiness probe                                                   |                       |
+| livenessProbe                     | Kong liveness probe                                                    |                       |
+| affinity                          | Node/pod affinities                                                    |                       |
+| nodeSelector                      | Node labels for pod assignment                                         | `{}`                  |
+| podAnnotations                    | Annotations to add to each pod                                         | `{}`                  |
+| resources                         | Pod resource requests & limits                                         | `{}`                  |
+| tolerations                       | List of node taints to tolerate                                        | `[]`                  |
+
+### Database-specific parameters
+
+Kong has a choice of either Postgres or Cassandra as a backend datatstore.
+This chart allows you to choose either of them with the `kong.database.type`
+parameter.  Postgres is chosen by default.
+
+Additionally, this chart allows you to use your own database or spin up a new
+instance by using the `postgres.enabled` or `cassandra.enabled` parameters.
+Enabling both will create both databases in your cluster, but only one
+will be used by Kong based on the `kong.database.type` parameter.
+Postgres is enabled by default.
+
+| Parameter                         | Description                                                            | Default               |
+| ------------------------------    | --------------------------------------------------------------------   | -------------------   |
+| cassandra.enabled                 | Spin up a new cassandra cluster for Kong                               | `false`               |
+| postgres.enabled                  | Spin up a new postgres instance for Kong                               | `true `               |
+| database.type                     | Choose either `postgres` or `cassandra`                                | `postgres`               |
+| database.postgres.username        | Postgres username                                                      | `kong`                |
+| database.postgres.database        | Postgres database name                                                 | `kong`                |
+| database.postgres.password        | Postgres database password                                             | `kong`                |
+| database.postgres.host            | Postgres database host (required if you are using your own database)   | ``                    |
+| database.postgres.port            | Postgres database port                                                 | `5432`                |
+| database.cassandra.contactPoints  | Cassandra contact points (required if you are using your own database) | ``                    |
+| database.cassandra.port           | Cassandra query port                                                   | `9042`                |
+| database.cassandra.keyspace       | Cassandra keyspace                                                     | `kong`                |
+| database.cassandra.replication    | Replication factor for the Kong keyspace                               | `2`                   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install stable/kong --name my-release \
+  --set=image.tag=0.11.2,database.type=caasandra,cassandra.enabled=true
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install stable/kong --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -68,7 +68,6 @@ and their default values.
 | proxy.type                        | k8s service type. Options: NodePort, ClusterIP, LoadBalancer            | `NodePort`            |
 | proxy.loadBalancerIP              | Will reuse an existing ingress static IP for the admin service         | `null`                |
 | proxy.useTLS                      | Secure Proxy traffic                                                   | `true`                |
-| logLevel                          | Kong [log level](https://getorg/docs/latest/configuration/#log_level)  | `debug`               |
 | customConfig                      | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)               |
 | runMigrations                     | Run Kong migrations job                                                | `true`                |
 | readinessProbe                    | Kong readiness probe                                                   |                       |
@@ -88,7 +87,7 @@ parameter.  Postgres is chosen by default.
 Additionally, this chart allows you to use your own database or spin up a new
 instance by using the `postgres.enabled` or `cassandra.enabled` parameters.
 Enabling both will create both databases in your cluster, but only one
-will be used by Kong based on the `kong.database.type` parameter.
+will be used by Kong based on the `database.type` parameter.
 Postgres is enabled by default.
 
 | Parameter                         | Description                                                            | Default               |

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -54,20 +54,20 @@ and their default values.
 | image.tag                         | Kong image version                                                     | `latest`              |
 | image.pullPolicy                  | Image pull policy                                                      | `IfNotPresent`        |
 | replicaCount                      | Kong instance count                                                    | `1`                   |
-| admin.servicePort                 | TCP port on which the Kong admin service is exposed                    | `8001`                |
-| admin.serviceSSLPort              | Secure TCP port on which the Kong admin service is exposed             | `8444`                |
-| admin.containerPort               | TCP port on which Kong app listens for admin traffic                   | `8001`                |
-| admin.containerSSLPort            | Secure TCP port on which Kong app listens for admin traffic            | `8444`                |
+| admin.http.servicePort            | TCP port on which the Kong admin service is exposed                    | `8001`                |
+| admin.https.servicePort           | Secure TCP port on which the Kong admin service is exposed             | `8444`                |
+| admin.http.containerPort          | TCP port on which Kong app listens for admin traffic                   | `8001`                |
+| admin.https.containerPort         | Secure TCP port on which Kong app listens for admin traffic            | `8444`                |
+| admin.nodePort                    | NodePort when service type is `NodePort`                                 | `32444`                |
 | admin.type                        | k8s service type, Options: NodePort, ClusterIP, LoadBalancer                       | `NodePort`            |
 | admin.loadBalancerIP              | Will reuse an existing ingress static IP for the admin service         | `null`                |
-| admin.useTLS                      | Secure admin traffic                                                   | `true`                |
-| proxy.servicePort                 | TCP port on which the Kong proxy service is exposed                    | `8000`                |
-| proxy.serviceSSLPort              | Secure TCP port on which the Kong Proxy Service is exposed             | `8443`                |
-| proxy.containerPort               | TCP port on which the Kong app listens for Proxy traffic               | `8000`                |
-| proxy.containerSSLPort            | Secure TCP port on which the Kong app listens for Proxy traffic        | `8443`                |
-| proxy.type                        | k8s service type. Options: NodePort, ClusterIP, LoadBalancer            | `NodePort`            |
+| proxy.http.servicePort            | TCP port on which the Kong proxy service is exposed                    | `8000`                |
+| proxy.https.servicePort           | Secure TCP port on which the Kong Proxy Service is exposed             | `8443`                |
+| proxy.http.containerPort          | TCP port on which the Kong app listens for Proxy traffic               | `8000`                |
+| proxy.https.containerPort         | Secure TCP port on which the Kong app listens for Proxy traffic        | `8443`                |
+| proxy.nodePort                    | NodePort when service type is `NodePort`                               | `32443`                |
+| proxy.type                        | k8s service type. Options: NodePort, ClusterIP, LoadBalancer           | `NodePort`            |
 | proxy.loadBalancerIP              | Will reuse an existing ingress static IP for the admin service         | `null`                |
-| proxy.useTLS                      | Secure Proxy traffic                                                   | `true`                |
 | customConfig                      | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)               |
 | runMigrations                     | Run Kong migrations job                                                | `true`                |
 | readinessProbe                    | Kong readiness probe                                                   |                       |
@@ -78,7 +78,7 @@ and their default values.
 | resources                         | Pod resource requests & limits                                         | `{}`                  |
 | tolerations                       | List of node taints to tolerate                                        | `[]`                  |
 
-### Database-specific parameters
+### Kong-specific parameters
 
 Kong has a choice of either Postgres or Cassandra as a backend datatstore.
 This chart allows you to choose either of them with the `kong.database.type`
@@ -87,23 +87,25 @@ parameter.  Postgres is chosen by default.
 Additionally, this chart allows you to use your own database or spin up a new
 instance by using the `postgres.enabled` or `cassandra.enabled` parameters.
 Enabling both will create both databases in your cluster, but only one
-will be used by Kong based on the `database.type` parameter.
+will be used by Kong based on the `env.database` parameter.
 Postgres is enabled by default.
 
 | Parameter                         | Description                                                            | Default               |
 | ------------------------------    | --------------------------------------------------------------------   | -------------------   |
 | cassandra.enabled                 | Spin up a new cassandra cluster for Kong                               | `false`               |
 | postgres.enabled                  | Spin up a new postgres instance for Kong                               | `true `               |
-| database.type                     | Choose either `postgres` or `cassandra`                                | `postgres`               |
-| database.postgres.username        | Postgres username                                                      | `kong`                |
-| database.postgres.database        | Postgres database name                                                 | `kong`                |
-| database.postgres.password        | Postgres database password                                             | `kong`                |
-| database.postgres.host            | Postgres database host (required if you are using your own database)   | ``                    |
-| database.postgres.port            | Postgres database port                                                 | `5432`                |
-| database.cassandra.contactPoints  | Cassandra contact points (required if you are using your own database) | ``                    |
-| database.cassandra.port           | Cassandra query port                                                   | `9042`                |
-| database.cassandra.keyspace       | Cassandra keyspace                                                     | `kong`                |
-| database.cassandra.replication    | Replication factor for the Kong keyspace                               | `2`                   |
+| env.database                      | Choose either `postgres` or `cassandra`                                | `postgres`            |
+| env.pg_user                       | Postgres username                                                      | `kong`                |
+| env.pg_database                   | Postgres database name                                                 | `kong`                |
+| env.pg_password                   | Postgres database password                                             | `kong`                |
+| env.pg_host                       | Postgres database host (required if you are using your own database)   | ``                    |
+| env.pg_port                       | Postgres database port                                                 | `5432`                |
+| env.cassandra_contact_points      | Cassandra contact points (required if you are using your own database) | ``                    |
+| env.cassandra_port                | Cassandra query port                                                   | `9042`                |
+| env.cassandra_keyspace            | Cassandra keyspace                                                     | `kong`                |
+| env.cassandra_repl_factor         | Replication factor for the Kong keyspace                               | `2`                   |
+
+For complete list of Kong configurations please check https://getkong.org/docs/0.11.x/configuration/.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kong/requirements.lock
+++ b/stable/kong/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.8.3
+- name: cassandra
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 0.1.6
+digest: sha256:2abab268d05c5579ad7be4df3fbe516518d64028965547b56f30f6134d63d478
+generated: 2017-12-08T11:53:15.064398-08:00

--- a/stable/kong/requirements.yaml
+++ b/stable/kong/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  version: 0.8.3
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: postgresql.enabled
+- name: cassandra
+  version: 0.1.6
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  condition: cassandra.enabled

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -1,0 +1,52 @@
+1. Kong Admin can be accessed via port {{ default "8001" .Values.admin.servicePort }} or SSL port {{ default "8444" .Values.admin.serviceSSLPort }} on the following DNS name from within your cluster:
+     '{{ template "kong.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+
+To connect from outside the K8s cluster:
+   {{- if contains "LoadBalancer" .Values.admin.type }}
+     HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.status.loadBalancer.ingress.ip}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "NodePort" .Values.admin.type }}
+     HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "ClusterIP" .Values.admin.type }}
+     HOST=127.0.0.1
+
+     {{- if .Values.admin.useTLS }}
+     # Execute the following commands to route the connection to Admin SSL port:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ default "8444" .Values.admin.serviceSSLPort }}:{{ default "8444" .Values.admin.serviceSSLPort }}
+     {{- else }}
+     # Execute the following commands to route the connection to Admin port:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ default "8001" .Values.admin.servicePort }}:{{ default "8001" .Values.admin.servicePort }}
+     {{- end }}
+   {{- end }}
+
+
+2. Kong Proxy can be accessed via port {{ default "8000" .Values.proxy.servicePort }} or SSL port {{ default "8443" .Values.proxy.serviceSSLPort }} on the following DNS name from within your cluster:
+     '{{ template "kong.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+
+To connect from outside the K8s cluster:
+   {{- if contains "LoadBalancer" .Values.proxy.type }}
+     HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress.ip}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "NodePort" .Values.proxy.type }}
+     HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "ClusterIP" .Values.proxy.type }}
+     HOST=127.0.0.1
+
+     {{- if .Values.proxy.useTLS }}
+     # Execute the following commands to route the connection to proxy SSL port:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ default "8443" .Values.proxy.serviceSSLPort }}:{{ default "8443" .Values.proxy.serviceSSLPort }}
+     {{- else }}
+     # Execute the following commands to route the connection to proxy port:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ default "8000" .Values.proxy.servicePort }}:{{ default "8000" .Values.proxy.servicePort }}
+     {{- end }}
+   {{- end }}

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -1,4 +1,4 @@
-1. Kong Admin can be accessed via port {{ .Values.admin.servicePort }} or SSL port {{ .Values.admin.serviceSSLPort }} on the following DNS name from within your cluster:
+1. Kong Admin can be accessed via port {{ .Values.admin.http.servicePort }} or SSL port {{ .Values.admin.https.servicePort }} on the following DNS name from within your cluster:
      '{{ template "kong.name" . }}.{{ .Release.Namespace }}.svc.cluster.local'
 
 To connect from outside the K8s cluster:
@@ -13,19 +13,19 @@ To connect from outside the K8s cluster:
    {{- else if contains "ClusterIP" .Values.admin.type }}
      HOST=127.0.0.1
 
-     {{- if .Values.admin.useTLS }}
+     {{- if .Values.admin.https }}
      # Execute the following commands to route the connection to Admin SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ .Values.admin.serviceSSLPort }}:{{ .Values.admin.serviceSSLPort }}
+     kubectl port-forward $POD_NAME {{ .Values.admin.https.servicePort }}:{{ .Values.admin.https.servicePort }}
      {{- else }}
      # Execute the following commands to route the connection to Admin port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ .Values.admin.servicePort }}:{{ .Values.admin.servicePort }}
+     kubectl port-forward $POD_NAME {{ .Values.admin.http.servicePort }}:{{ .Values.admin.http.servicePort }}
      {{- end }}
    {{- end }}
 
 
-2. Kong Proxy can be accessed via port {{ .Values.proxy.servicePort }} or SSL port {{ .Values.proxy.serviceSSLPort }} on the following DNS name from within your cluster:
+2. Kong Proxy can be accessed via port {{ .Values.proxy.http.servicePort }} or SSL port {{ .Values.proxy.https.servicePort }} on the following DNS name from within your cluster:
      '{{ template "kong.name" . }}.{{ .Release.Namespace }}.svc.cluster.local'
 
 To connect from outside the K8s cluster:
@@ -40,13 +40,13 @@ To connect from outside the K8s cluster:
    {{- else if contains "ClusterIP" .Values.proxy.type }}
      HOST=127.0.0.1
 
-     {{- if .Values.proxy.useTLS }}
+     {{- if .Values.proxy.https }}
      # Execute the following commands to route the connection to proxy SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ .Values.proxy.serviceSSLPort }}:{{ .Values.proxy.serviceSSLPort }}
+     kubectl port-forward $POD_NAME {{ .Values.proxy.https.servicePort }}:{{ .Values.proxy.https.servicePort }}
      {{- else }}
      # Execute the following commands to route the connection to proxy port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ .Values.proxy.servicePort }}:{{ .Values.proxy.servicePort }}
+     kubectl port-forward $POD_NAME {{ .Values.proxy.http.servicePort }}:{{ .Values.proxy.http.servicePort }}
      {{- end }}
    {{- end }}

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -1,52 +1,52 @@
-1. Kong Admin can be accessed via port {{ default "8001" .Values.admin.servicePort }} or SSL port {{ default "8444" .Values.admin.serviceSSLPort }} on the following DNS name from within your cluster:
-     '{{ template "kong.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+1. Kong Admin can be accessed via port {{ .Values.admin.servicePort }} or SSL port {{ .Values.admin.serviceSSLPort }} on the following DNS name from within your cluster:
+     '{{ template "kong.name" . }}.{{ .Release.Namespace }}.svc.cluster.local'
 
 To connect from outside the K8s cluster:
    {{- if contains "LoadBalancer" .Values.admin.type }}
-     HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.status.loadBalancer.ingress.ip}')
-     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
+     HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.name" . }}-admin -o jsonpath='{.status.loadBalancer.ingress.ip}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.name" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
 
    {{- else if contains "NodePort" .Values.admin.type }}
      HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
-     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.name" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
 
    {{- else if contains "ClusterIP" .Values.admin.type }}
      HOST=127.0.0.1
 
      {{- if .Values.admin.useTLS }}
      # Execute the following commands to route the connection to Admin SSL port:
-     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ default "8444" .Values.admin.serviceSSLPort }}:{{ default "8444" .Values.admin.serviceSSLPort }}
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ .Values.admin.serviceSSLPort }}:{{ .Values.admin.serviceSSLPort }}
      {{- else }}
      # Execute the following commands to route the connection to Admin port:
-     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ default "8001" .Values.admin.servicePort }}:{{ default "8001" .Values.admin.servicePort }}
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ .Values.admin.servicePort }}:{{ .Values.admin.servicePort }}
      {{- end }}
    {{- end }}
 
 
-2. Kong Proxy can be accessed via port {{ default "8000" .Values.proxy.servicePort }} or SSL port {{ default "8443" .Values.proxy.serviceSSLPort }} on the following DNS name from within your cluster:
-     '{{ template "kong.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local'
+2. Kong Proxy can be accessed via port {{ .Values.proxy.servicePort }} or SSL port {{ .Values.proxy.serviceSSLPort }} on the following DNS name from within your cluster:
+     '{{ template "kong.name" . }}.{{ .Release.Namespace }}.svc.cluster.local'
 
 To connect from outside the K8s cluster:
    {{- if contains "LoadBalancer" .Values.proxy.type }}
-     HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress.ip}')
-     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+     HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.name" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress.ip}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.name" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
 
    {{- else if contains "NodePort" .Values.proxy.type }}
      HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
-     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.name" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
 
    {{- else if contains "ClusterIP" .Values.proxy.type }}
      HOST=127.0.0.1
 
      {{- if .Values.proxy.useTLS }}
      # Execute the following commands to route the connection to proxy SSL port:
-     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ default "8443" .Values.proxy.serviceSSLPort }}:{{ default "8443" .Values.proxy.serviceSSLPort }}
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ .Values.proxy.serviceSSLPort }}:{{ .Values.proxy.serviceSSLPort }}
      {{- else }}
      # Execute the following commands to route the connection to proxy port:
-     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ default "8000" .Values.proxy.servicePort }}:{{ default "8000" .Values.proxy.servicePort }}
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ .Values.proxy.servicePort }}:{{ .Values.proxy.servicePort }}
      {{- end }}
    {{- end }}

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "kong.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kong.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kong.postgresql.fullname" -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kong.cassandra.fullname" -}}
+{{- $name := default "cassandra" .Values.cassandra.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -57,22 +57,22 @@ spec:
             value: {{ $val | quote }}
         {{- end}}
         ports:
-        {{- if .Values.admin.useTLS }}
+        {{- if .Values.admin.https }}
         - name: admin-ssl
-          containerPort: {{ .Values.admin.containerSSLPort }}
+          containerPort: {{ .Values.admin.https.containerPort }}
           protocol: TCP
         {{- else }}
         - name: admin
-          containerPort: {{ .Values.admin.containerPort }}
+          containerPort: {{ .Values.admin.http.containerPort }}
           protocol: TCP
         {{ end }}
-        {{- if .Values.proxy.useTLS }}
+        {{- if .Values.proxy.https }}
         - name: proxy-ssl
-          containerPort: {{ .Values.proxy.containerSSLPort }}
+          containerPort: {{ .Values.proxy.https.containerPort }}
           protocol: TCP
         {{- else}}
         - name: proxy
-          containerPort: {{ .Values.proxy.containerPort }}
+          containerPort: {{ .Values.proxy.http.containerPort }}
           protocol: TCP
         {{- end }}
         readinessProbe:

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: "{{ template "kong.fullname" . }}"
   labels:
-    app: "{{ template "kong.fullname" . }}"
+    app: "{{ template "kong.name" . }}"
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
@@ -16,24 +16,24 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: "{{ template "kong.fullname" . }}"
+        app: "{{ template "kong.name" . }}"
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
     spec:
       containers:
-      - name: {{ template "kong.fullname" . }}
-        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+      - name: {{ template "kong.name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: KONG_ADMIN_LISTEN
-            value: 0.0.0.0:{{ default 8001 .Values.admin.containerPort }}
+            value: 0.0.0.0:{{ .Values.admin.containerPort }}
           - name: KONG_ADMIN_LISTEN_SSL
-            value: 0.0.0.0:{{ default 8444 .Values.admin.containerSSLPort }}
+            value: 0.0.0.0:{{ .Values.admin.containerSSLPort }}
           - name: KONG_PROXY_LISTEN
-            value: 0.0.0.0:{{ default 8000 .Values.proxy.containerPort }}
+            value: 0.0.0.0:{{ .Values.proxy.containerPort }}
           - name: KONG_PROXY_LISTEN_SSL
-            value: 0.0.0.0:{{ default 8443 .Values.proxy.containerSSLPort }}
+            value: 0.0.0.0:{{ .Values.proxy.containerSSLPort }}
           - name: KONG_NGINX_DAEMON
             value: "off"
           - name: KONG_PROXY_ACCESS_LOG
@@ -44,62 +44,35 @@ spec:
             value: "/dev/stderr"
           - name: KONG_ADMIN_ERROR_LOG
             value: "/dev/stderr"
-          - name: KONG_LOG_LEVEL
-            value: {{ .Values.logLevel }}
-        {{- if eq .Values.database.type "cassandra" }}
-          - name: KONG_DATABASE
-            value: "cassandra"
           {{- if .Values.cassandra.enabled }}
           - name: KONG_CASSANDRA_CONTACT_POINTS
             value: {{ template "kong.cassandra.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-          {{- else }}
-          - name: KONG_CASSANDRA_CONTACT_POINTS
-            value: {{ .Values.database.cassandra.contactPoints }}
           {{- end }}
-          - name: KONG_CASSANDRA_PORT
-            value: {{ .Values.database.cassandra.port | quote }}
-          - name: KONG_CASSANDRA_KEYSPACE
-            value: {{ .Values.database.cassandra.keyspace}}
-          - name: KONG_CASSANDRA_REPL_FACTOR
-            value: {{ .Values.database.cassandra.replication | quote }}
-        {{- else if eq .Values.database.type "postgres" }}
-          - name: KONG_PG_DATABASE
-            value: {{ .Values.database.postgres.database }}
-          - name: KONG_PG_USER
-            value: {{ .Values.database.postgres.username }}
-          - name: KONG_PG_PASSWORD
-            value: {{ .Values.database.postgres.password }}
           {{- if .Values.postgresql.enabled }}
           - name: KONG_PG_HOST
             value: {{ template "kong.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-          {{- else }}
-          - name: KONG_PG_HOST
-            value: {{ .Values.database.postgres.host }}
           {{- end }}
-          - name: KONG_PG_PORT
-            value: {{ .Values.database.postgres.port | quote }}
-        {{- end }}
-        {{- range $key, $val := .Values.customConfig }}
+        {{- range $key, $val := .Values.env }}
           - name: KONG_{{ $key | upper}}
             value: {{ $val | quote }}
         {{- end}}
         ports:
         {{- if .Values.admin.useTLS }}
         - name: admin-ssl
-          containerPort: {{ default 8444 .Values.admin.containerSSLPort }}
+          containerPort: {{ .Values.admin.containerSSLPort }}
           protocol: TCP
         {{- else }}
         - name: admin
-          containerPort: {{ default 8001 .Values.admin.containerPort }}
+          containerPort: {{ .Values.admin.containerPort }}
           protocol: TCP
         {{ end }}
         {{- if .Values.proxy.useTLS }}
         - name: proxy-ssl
-          containerPort: {{ default 8443 .Values.proxy.containerSSLPort }}
+          containerPort: {{ .Values.proxy.containerSSLPort }}
           protocol: TCP
         {{- else}}
         - name: proxy
-          containerPort: {{ default 8000 .Values.proxy.containerPort }}
+          containerPort: {{ .Values.proxy.containerPort }}
           protocol: TCP
         {{- end }}
         readinessProbe:

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "kong.fullname" . }}"
+  labels:
+    app: "{{ template "kong.fullname" . }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app: "{{ template "kong.fullname" . }}"
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        heritage: "{{ .Release.Service }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: {{ template "kong.fullname" . }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: KONG_ADMIN_LISTEN
+            value: 0.0.0.0:{{ default 8001 .Values.admin.containerPort }}
+          - name: KONG_ADMIN_LISTEN_SSL
+            value: 0.0.0.0:{{ default 8444 .Values.admin.containerSSLPort }}
+          - name: KONG_PROXY_LISTEN
+            value: 0.0.0.0:{{ default 8000 .Values.proxy.containerPort }}
+          - name: KONG_PROXY_LISTEN_SSL
+            value: 0.0.0.0:{{ default 8443 .Values.proxy.containerSSLPort }}
+          - name: KONG_NGINX_DAEMON
+            value: "off"
+          - name: KONG_PROXY_ACCESS_LOG
+            value: "/dev/stdout"
+          - name: KONG_ADMIN_ACCESS_LOG
+            value: "/dev/stdout"
+          - name: KONG_PROXY_ERROR_LOG
+            value: "/dev/stderr"
+          - name: KONG_ADMIN_ERROR_LOG
+            value: "/dev/stderr"
+          - name: KONG_LOG_LEVEL
+            value: {{ .Values.logLevel }}
+        {{- if eq .Values.database.type "cassandra" }}
+          - name: KONG_DATABASE
+            value: "cassandra"
+          {{- if .Values.cassandra.enabled }}
+          - name: KONG_CASSANDRA_CONTACT_POINTS
+            value: {{ template "kong.cassandra.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          {{- else }}
+          - name: KONG_CASSANDRA_CONTACT_POINTS
+            value: {{ .Values.database.cassandra.contactPoints }}
+          {{- end }}
+          - name: KONG_CASSANDRA_PORT
+            value: {{ .Values.database.cassandra.port | quote }}
+          - name: KONG_CASSANDRA_KEYSPACE
+            value: {{ .Values.database.cassandra.keyspace}}
+          - name: KONG_CASSANDRA_REPL_FACTOR
+            value: {{ .Values.database.cassandra.replication | quote }}
+        {{- else if eq .Values.database.type "postgres" }}
+          - name: KONG_PG_DATABASE
+            value: {{ .Values.database.postgres.database }}
+          - name: KONG_PG_USER
+            value: {{ .Values.database.postgres.username }}
+          - name: KONG_PG_PASSWORD
+            value: {{ .Values.database.postgres.password }}
+          {{- if .Values.postgresql.enabled }}
+          - name: KONG_PG_HOST
+            value: {{ template "kong.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          {{- else }}
+          - name: KONG_PG_HOST
+            value: {{ .Values.database.postgres.host }}
+          {{- end }}
+          - name: KONG_PG_PORT
+            value: {{ .Values.database.postgres.port | quote }}
+        {{- end }}
+        {{- range $key, $val := .Values.customConfig }}
+          - name: KONG_{{ $key | upper}}
+            value: {{ $val | quote }}
+        {{- end}}
+        ports:
+        {{- if .Values.admin.useTLS }}
+        - name: admin-ssl
+          containerPort: {{ default 8444 .Values.admin.containerSSLPort }}
+          protocol: TCP
+        {{- else }}
+        - name: admin
+          containerPort: {{ default 8001 .Values.admin.containerPort }}
+          protocol: TCP
+        {{ end }}
+        {{- if .Values.proxy.useTLS }}
+        - name: proxy-ssl
+          containerPort: {{ default 8443 .Values.proxy.containerSSLPort }}
+          protocol: TCP
+        {{- else}}
+        - name: proxy
+          containerPort: {{ default 8000 .Values.proxy.containerPort }}
+          protocol: TCP
+        {{- end }}
+        readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 10 }}
+        livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 10 }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -4,63 +4,36 @@ kind: Job
 metadata:
   name: {{ template "kong.fullname" . }}-migrations
   labels:
-    app: "{{ template "kong.fullname" . }}"
+    app: "{{ template "kong.name" . }}"
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
 spec:
   template:
     metadata:
-      name: {{ template "kong.fullname" . }}-migrations
+      name: {{ template "kong.name" . }}-migrations
       labels:
-        app: "{{ template "kong.fullname" . }}"
+        app: "{{ template "kong.name" . }}"
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
     spec:
       containers:
-      - name: {{ template "kong.fullname" . }}-migrations
+      - name: {{ template "kong.name" . }}-migrations
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: KONG_NGINX_DAEMON
             value: "off"
-          - name: KONG_LOG_LEVEL
-            value: {{ .Values.logLevel }}
-        {{- if eq .Values.database.type "cassandra" }}
-          - name: KONG_DATABASE
-            value: "cassandra"
           {{- if .Values.cassandra.enabled }}
           - name: KONG_CASSANDRA_CONTACT_POINTS
             value: {{ template "kong.cassandra.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-          {{- else }}
-          - name: KONG_CASSANDRA_CONTACT_POINTS
-            value: {{ .Values.database.cassandra.contactPoints }}
           {{- end }}
-          - name: KONG_CASSANDRA_PORT
-            value: {{ .Values.database.cassandra.port | quote }}
-          - name: KONG_CASSANDRA_KEYSPACE
-            value: {{ .Values.database.cassandra.keyspace}}
-          - name: KONG_CASSANDRA_REPL_FACTOR
-            value: {{ .Values.database.cassandra.replication | quote }}
-        {{- else if eq .Values.database.type "postgres" }}
-          - name: KONG_PG_DATABASE
-            value: {{ .Values.database.postgres.database }}
-          - name: KONG_PG_USER
-            value: {{ .Values.database.postgres.username }}
-          - name: KONG_PG_PASSWORD
-            value: {{ .Values.database.postgres.password }}
           {{- if .Values.postgresql.enabled }}
           - name: KONG_PG_HOST
             value: {{ template "kong.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-          {{- else }}
-          - name: KONG_PG_HOST
-            value: {{ .Values.database.postgres.host }}
           {{- end }}
-          - name: KONG_PG_PORT
-            value: {{ .Values.database.postgres.port | quote }}
-        {{- end }}
-        {{- range $key, $val := .Values.customConfig }}
+        {{- range $key, $val := .Values.env }}
           - name: KONG_{{ $key | upper}}
             value: {{ $val | quote }}
         {{- end}}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.runMigrations }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kong.fullname" . }}-migrations
+  labels:
+    app: "{{ template "kong.fullname" . }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      name: {{ template "kong.fullname" . }}-migrations
+      labels:
+        app: "{{ template "kong.fullname" . }}"
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        heritage: "{{ .Release.Service }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: {{ template "kong.fullname" . }}-migrations
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: KONG_NGINX_DAEMON
+            value: "off"
+          - name: KONG_LOG_LEVEL
+            value: {{ .Values.logLevel }}
+        {{- if eq .Values.database.type "cassandra" }}
+          - name: KONG_DATABASE
+            value: "cassandra"
+          {{- if .Values.cassandra.enabled }}
+          - name: KONG_CASSANDRA_CONTACT_POINTS
+            value: {{ template "kong.cassandra.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          {{- else }}
+          - name: KONG_CASSANDRA_CONTACT_POINTS
+            value: {{ .Values.database.cassandra.contactPoints }}
+          {{- end }}
+          - name: KONG_CASSANDRA_PORT
+            value: {{ .Values.database.cassandra.port | quote }}
+          - name: KONG_CASSANDRA_KEYSPACE
+            value: {{ .Values.database.cassandra.keyspace}}
+          - name: KONG_CASSANDRA_REPL_FACTOR
+            value: {{ .Values.database.cassandra.replication | quote }}
+        {{- else if eq .Values.database.type "postgres" }}
+          - name: KONG_PG_DATABASE
+            value: {{ .Values.database.postgres.database }}
+          - name: KONG_PG_USER
+            value: {{ .Values.database.postgres.username }}
+          - name: KONG_PG_PASSWORD
+            value: {{ .Values.database.postgres.password }}
+          {{- if .Values.postgresql.enabled }}
+          - name: KONG_PG_HOST
+            value: {{ template "kong.postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+          {{- else }}
+          - name: KONG_PG_HOST
+            value: {{ .Values.database.postgres.host }}
+          {{- end }}
+          - name: KONG_PG_PORT
+            value: {{ .Values.database.postgres.port | quote }}
+        {{- end }}
+        {{- range $key, $val := .Values.customConfig }}
+          - name: KONG_{{ $key | upper}}
+            value: {{ $val | quote }}
+        {{- end}}
+        command: [ "/bin/sh", "-c", "kong migrations up" ]
+      restartPolicy: OnFailure
+{{- end }}

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-admin
+spec:
+  type: {{ .Values.admin.type }}
+  {{- if and (eq .Values.admin.type "LoadBalancer") .Values.admin.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
+  {{- end }}
+  ports:
+  {{- if .Values.admin.useTLS }}
+  - name: kong-admin-ssl
+    port: {{ default 8444 .Values.admin.serviceSSLPort }}
+    targetPort: {{ default 8444 .Values.admin.containerSSLPort }}
+    protocol: TCP
+  {{- else }}
+  - name: kong-admin
+    port: {{ default 8001 .Values.admin.servicePort }}
+    targetPort: {{ default 8001 .Values.admin.containerPort }}
+    protocol: TCP
+  {{- end }}
+  selector:
+    app: {{ template "kong.fullname" . }}

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -1,24 +1,26 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kong.name" . }}-admin
+  name: {{ template "kong.fullname" . }}-admin
 spec:
   type: {{ .Values.admin.type }}
   {{- if and (eq .Values.admin.type "LoadBalancer") .Values.admin.loadBalancerIP }}
   loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
   {{- end }}
   ports:
-  {{- if .Values.admin.useTLS }}
-  - name: kong-admin-ssl
-    port: {{ .Values.admin.serviceSSLPort }}
-    targetPort: {{ .Values.admin.containerSSLPort }}
-    protocol: TCP
-  {{- else }}
   - name: kong-admin
-    port: {{ .Values.admin.servicePort }}
-    targetPort: {{ .Values.admin.containerPort }}
     protocol: TCP
+  {{- if .Values.admin.https }}
+    port: {{ .Values.admin.https.servicePort }}
+    targetPort: {{ .Values.admin.https.containerPort }}
+  {{- else }}
+    port: {{ .Values.admin.http.servicePort }}
+    targetPort: {{ .Values.admin.http.containerPort }}
   {{- end }}
+  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.nodePort))) }}
+    nodePort: {{ .Values.admin.nodePort }}
+  {{- end }}
+  protocol: TCP
   selector:
     app: {{ template "kong.name" . }}
     release: {{ .Release.Name }}

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kong.fullname" . }}-admin
+  name: {{ template "kong.name" . }}-admin
 spec:
   type: {{ .Values.admin.type }}
   {{- if and (eq .Values.admin.type "LoadBalancer") .Values.admin.loadBalancerIP }}
@@ -10,14 +10,15 @@ spec:
   ports:
   {{- if .Values.admin.useTLS }}
   - name: kong-admin-ssl
-    port: {{ default 8444 .Values.admin.serviceSSLPort }}
-    targetPort: {{ default 8444 .Values.admin.containerSSLPort }}
+    port: {{ .Values.admin.serviceSSLPort }}
+    targetPort: {{ .Values.admin.containerSSLPort }}
     protocol: TCP
   {{- else }}
   - name: kong-admin
-    port: {{ default 8001 .Values.admin.servicePort }}
-    targetPort: {{ default 8001 .Values.admin.containerPort }}
+    port: {{ .Values.admin.servicePort }}
+    targetPort: {{ .Values.admin.containerPort }}
     protocol: TCP
   {{- end }}
   selector:
-    app: {{ template "kong.fullname" . }}
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -1,24 +1,26 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kong.name" . }}-proxy
+  name: {{ template "kong.fullname" . }}-proxy
 spec:
   type: {{ .Values.proxy.type }}
   {{- if and (eq .Values.proxy.type "LoadBalancer") .Values.proxy.loadBalancerIP }}
   loadBalancerIP: {{ .Values.proxy.loadBalancerIP }}
   {{- end }}
   ports:
-  {{- if .Values.proxy.useTLS }}
-  - name: kong-proxy-ssl
-    port: {{ default 8443 .Values.proxy.serviceSSLPort }}
-    targetPort: {{ .Values.proxy.containerSSLPort }}
-    protocol: TCP
-  {{ else }}
   - name: kong-proxy
-    port: {{ .Values.proxy.servicePort }}
-    targetPort: {{ .Values.proxy.containerPort }}
     protocol: TCP
-  {{ end }}
+  {{- if .Values.proxy.https }}
+    port: {{ .Values.proxy.https.servicePort }}
+    targetPort: {{ .Values.proxy.https.containerPort }}
+  {{- else }}
+    port: {{ .Values.proxy.http.servicePort }}
+    targetPort: {{ .Values.proxy.http.containerPort }}
+  {{- end }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.nodePort))) }}
+    nodePort: {{ .Values.proxy.nodePort }}
+  {{- end }}
+  protocol: TCP
   selector:
     app: {{ template "kong.name" . }}
     release: {{ .Release.Name }}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-proxy
+spec:
+  type: {{ .Values.proxy.type }}
+  {{- if and (eq .Values.proxy.type "LoadBalancer") .Values.proxy.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.proxy.loadBalancerIP }}
+  {{- end }}
+  ports:
+  {{- if .Values.proxy.useTLS }}
+  - name: kong-proxy-ssl
+    port: {{ default 8443 .Values.proxy.serviceSSLPort }}
+    targetPort: {{ default 8443 .Values.proxy.containerSSLPort }}
+    protocol: TCP
+  {{ else }}
+  - name: kong-proxy
+    port: {{ default 8000 .Values.proxy.servicePort }}
+    targetPort: {{ default 8000 .Values.proxy.containerPort }}
+    protocol: TCP
+  {{ end }}
+  selector:
+    app: {{ template "kong.fullname" . }}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kong.fullname" . }}-proxy
+  name: {{ template "kong.name" . }}-proxy
 spec:
   type: {{ .Values.proxy.type }}
   {{- if and (eq .Values.proxy.type "LoadBalancer") .Values.proxy.loadBalancerIP }}
@@ -11,13 +11,14 @@ spec:
   {{- if .Values.proxy.useTLS }}
   - name: kong-proxy-ssl
     port: {{ default 8443 .Values.proxy.serviceSSLPort }}
-    targetPort: {{ default 8443 .Values.proxy.containerSSLPort }}
+    targetPort: {{ .Values.proxy.containerSSLPort }}
     protocol: TCP
   {{ else }}
   - name: kong-proxy
-    port: {{ default 8000 .Values.proxy.servicePort }}
-    targetPort: {{ default 8000 .Values.proxy.containerPort }}
+    port: {{ .Values.proxy.servicePort }}
+    targetPort: {{ .Values.proxy.containerPort }}
     protocol: TCP
   {{ end }}
   selector:
-    app: {{ template "kong.fullname" . }}
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -6,32 +6,32 @@ image:
   tag: 0.11.2
   pullPolicy: IfNotPresent
 
-# Kong admin and proxy service configs
+# Specify Kong admin and proxy services configurations
 admin:
   # HTTPS traffic on the admin port
-  useTLS: true
-  # Kong admin external SSL port
-  serviceSSLPort: 8444
-  # Kong admin internal SSL port
-  containerSSLPort: 8444
-  # Kong admin service type
+  https:
+    # Kong admin external SSL port
+    servicePort: 8444
+    # Kong admin internal SSL port
+    containerPort: 8444
+    # Kong admin service type
   type: NodePort
+  nodePort: 32444
 proxy:
   # HTTPS traffic on the proxy port
-  useTLS: true
-  # Kong proxy external SSL port
-  serviceSSLPort: 8443
-  # Kong proxy internal SSL port
-  containerSSLPort: 8443
+  https:
+    # Kong proxy external SSL port
+    servicePort: 8443
+    # Kong proxy internal SSL port
+    containerPort: 8443
   # Kong proxy service type
   type: NodePort
+  nodePort: 32443
 
-
-# set it to run Kong migrations
+# Set runMigrations to run Kong migrations
 runMigrations: true
 
-# If you want to specify additional Kong configurations, you can define them
-# in here as yaml list.
+# Specify Kong configurations
 # Kong configurations guide https://getkong.org/docs/latest/configuration/
 env:
   database: postgres

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -1,0 +1,256 @@
+# Default values for kong.
+# Declare variables to be passed into your templates.
+
+image:
+  repo: kong
+  tag: 0.11.2
+  pullPolicy: IfNotPresent
+admin:
+  servicePort: 8001
+  serviceSSLPort: 8444
+  containerPort: 8001
+  containerSSLPort: 8444
+  type: NodePort
+  loadBalancerIP: null
+  useTLS: true
+proxy:
+  servicePort: 8000
+  serviceSSLPort: 8443
+  containerPort: 8000
+  containerSSLPort: 8443
+  type: NodePort
+  loadBalancerIP: null
+  useTLS: true
+logLevel: debug
+database:
+  type: postgres
+  postgres:
+    username: kong
+    database: kong
+    password: kong
+    host: postgres
+    port: 5432
+  cassandra:
+    contactPoints: cassandra
+    port: 9042
+    keyspace: kong
+    replication: 2
+runMigrations: true
+customConfig:
+  # If you want to specify additional Kong configurations, you can define them
+  # in here as yaml list.
+  # Kong configurations guide https://getkong.org/docs/latest/configuration/
+  nginx_worker_processes: auto
+resources: {}
+  # If you want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+readinessProbe:
+  httpGet:
+    path: "/status"
+    port: admin-ssl
+    scheme: HTTPS
+  initialDelaySeconds: 150
+  timeoutSeconds: 60
+  periodSeconds: 30
+  successThreshold: 1
+  failureThreshold: 5
+livenessProbe:
+  httpGet:
+    path: "/status"
+    port: admin-ssl
+    scheme: HTTPS
+  initialDelaySeconds: 150
+  timeoutSeconds: 60
+  periodSeconds: 30
+  successThreshold: 1
+  failureThreshold: 5
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+podAnnotations: {}
+replicaCount: 1
+
+# Cassandra sub chart is fetched from
+# https://github.com/kubernetes/charts/tree/master/incubator/cassandra
+
+cassandra:
+  enabled: false
+  ## Cassandra image version
+  ## ref: https://hub.docker.com/r/library/cassandra/
+  image:
+    repo: "cassandra"
+    tag: "3"
+    pullPolicy: IfNotPresent
+
+  ## Specify a service type
+  ## ref: http://kubernetes.io/docs/user-guide/services/
+  service:
+    type: ClusterIP
+
+  ## Persist data to a persistent volume
+  persistence:
+    enabled: false
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## Minimum memory for development is 4GB and 2 CPU cores
+  ## Minimum memory for production is 8GB and 4 CPU cores
+  ## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
+  resources:
+    requests:
+      memory: 4Gi
+      cpu: 2
+    limits:
+      memory: 4Gi
+      cpu: 2
+
+  ## Change cassandra configuration paramaters below:
+  ## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html
+  ## Recommended max heap size is 1/2 of system memory
+  ## Recommeneed heap new size is 1/4 of max heap size
+  ## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/operations/opsTuneJVM.html
+  config:
+    cluster_name: cassandra
+    cluster_size: 3
+    seed_size: 2
+    num_tokens: 256
+    dc_name: DC1
+    rack_name: RAC1
+    endpoint_snitch: SimpleSnitch
+    max_heap_size: 2048M
+    heap_new_size: 512M
+    ports:
+      cql: 9042
+      thrift: 9160
+
+  ## Configure node selector. Edit code below for adding selector to pods
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # selector:
+    # nodeSelector:
+      # cloud.google.com/gke-nodepool: pool-db
+
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+# PostgreSQL sub chart is fetched from
+# https://github.com/kubernetes/charts/tree/master/stable/postgresql
+postgresql:
+  enabled: true
+  image: "postgres"
+  ## postgres image version
+  ## ref: https://hub.docker.com/r/library/postgres/tags/
+  ##
+  imageTag: "9.6.2"
+
+  ## Specify a imagePullPolicy
+  ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  # imagePullPolicy:
+
+  ## Create a database user
+  ## Default: postgres
+  postgresUser: kong
+  ## Default: random 10 character string
+  postgresPassword: kong
+
+  ## Create a database
+  ## Default: the postgres user
+  postgresDatabase: kong
+
+  ## Specify initdb arguments, e.g. --data-checksums
+  ## ref: https://github.com/docker-library/docs/blob/master/postgres/content.md#postgres_initdb_args
+  ## ref: https://www.postgresql.org/docs/current/static/app-initdb.html
+  # postgresInitdbArgs:
+
+  ## Persist data to a persitent volume
+  persistence:
+    enabled: false
+
+    ## A manually managed Persistent Volume and Claim
+    ## Requires persistence.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
+
+    ## database data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 8Gi
+    subPath: "postgresql-db"
+
+  metrics:
+    enabled: false
+    image: wrouesnel/postgres_exporter
+    imageTag: v0.1.1
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 100m
+      ## Define additional custom metrics
+      ## ref: https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file
+      # customMetrics:
+      #   pg_database:
+      #     query: "SELECT d.datname AS name, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
+      #     metrics:
+      #       - name:
+      #           usage: "LABEL"
+      #           description: "Name of the database"
+      #       - size_bytes:
+      #           usage: "GAUGE"
+      #           description: "Size of the database in bytes"
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+
+  service:
+    type: ClusterIP
+    port: 5432
+    externalIPs: []
+
+  networkPolicy:
+    ## Enable creation of NetworkPolicy resources.
+    ##
+    enabled: false
+
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## client label will have network access to the port PostgreSQL is listening
+    ## on. When true, PostgreSQL will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    allowExternal: true
+
+  ## Node labels and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -2,48 +2,47 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repo: kong
+  repository: kong
   tag: 0.11.2
   pullPolicy: IfNotPresent
+
+# Kong admin and proxy service configs
 admin:
-  servicePort: 8001
+  # HTTPS traffic on the admin port
+  useTLS: true
+  # Kong admin external SSL port
   serviceSSLPort: 8444
-  containerPort: 8001
+  # Kong admin internal SSL port
   containerSSLPort: 8444
+  # Kong admin service type
   type: NodePort
-  loadBalancerIP: null
-  useTLS: true
 proxy:
-  servicePort: 8000
-  serviceSSLPort: 8443
-  containerPort: 8000
-  containerSSLPort: 8443
-  type: NodePort
-  loadBalancerIP: null
+  # HTTPS traffic on the proxy port
   useTLS: true
-logLevel: debug
-database:
-  type: postgres
-  postgres:
-    username: kong
-    database: kong
-    password: kong
-    host: postgres
-    port: 5432
-  cassandra:
-    contactPoints: cassandra
-    port: 9042
-    keyspace: kong
-    replication: 2
+  # Kong proxy external SSL port
+  serviceSSLPort: 8443
+  # Kong proxy internal SSL port
+  containerSSLPort: 8443
+  # Kong proxy service type
+  type: NodePort
+
+
+# set it to run Kong migrations
 runMigrations: true
-customConfig:
-  # If you want to specify additional Kong configurations, you can define them
-  # in here as yaml list.
-  # Kong configurations guide https://getkong.org/docs/latest/configuration/
-  nginx_worker_processes: auto
+
+# If you want to specify additional Kong configurations, you can define them
+# in here as yaml list.
+# Kong configurations guide https://getkong.org/docs/latest/configuration/
+env:
+  database: postgres
+  pg_password: kong
+  pg_host: postgres
+  pg_port: 5432
+
+
+# If you want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
 resources: {}
-  # If you want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #  cpu: 100m
   #  memory: 128Mi
@@ -51,6 +50,7 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+# readinessProbe for Kong pods
 readinessProbe:
   httpGet:
     path: "/status"
@@ -61,6 +61,8 @@ readinessProbe:
   periodSeconds: 30
   successThreshold: 1
   failureThreshold: 5
+
+# livenessProbe for Kong pods
 livenessProbe:
   httpGet:
     path: "/status"
@@ -71,6 +73,7 @@ livenessProbe:
   periodSeconds: 30
   successThreshold: 1
   failureThreshold: 5
+
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 # affinity: {}
@@ -83,12 +86,24 @@ tolerations: []
 # Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}
 
+# Annotation to be added to Kong pods
 podAnnotations: {}
+
+# Kong pod count
 replicaCount: 1
 
-# Cassandra sub chart is fetched from
-# https://github.com/kubernetes/charts/tree/master/incubator/cassandra
 
+# Kong has a choice of either Postgres or Cassandra as a backend datatstore.
+# This chart allows you to choose either of them with the `database.type`
+# parameter.  Postgres is chosen by default.
+
+# Additionally, this chart allows you to use your own database or spin up a new
+# instance by using the `postgres.enabled` or `cassandra.enabled` parameters.
+# Enabling both will create both databases in your cluster, but only one
+# will be used by Kong based on the `env.database` parameter.
+# Postgres is enabled by default.
+
+# Cassandra chart configs
 cassandra:
   enabled: false
   ## Cassandra image version
@@ -149,8 +164,7 @@ cassandra:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
 
-# PostgreSQL sub chart is fetched from
-# https://github.com/kubernetes/charts/tree/master/stable/postgresql
+# PostgreSQL chart configs
 postgresql:
   enabled: true
   image: "postgres"

--- a/stable/swift/templates/deployment.yaml
+++ b/stable/swift/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: mi
 kind: Deployment
 metadata:
   name: {{ template "swift.fullname" . }}


### PR DESCRIPTION
- Chart deploys Kong and its backing datastore either Cassandra or
  PostgreSql
- Uses official [Kong](https://hub.docker.com/_/kong/) Docker image
