### PR TITLE
[stable/nginx-ingress] fix render and validation errors in nginx-ingress template

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.16
+version: 0.8.17
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/controller-hpa.yaml
+++ b/stable/nginx-ingress/templates/controller-hpa.yaml
@@ -4,23 +4,23 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "controller.fullname" . }}
+  name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta1
     kind: Deployment
-    name:  {{ template "controller.fullname" . }}
-  minReplicas: "{{ .Values.controller.autoscaling.minReplicas }}"
-  maxReplicas: "{{ .Values.controller.autoscaling.maxReplicas }}"
+    name:  {{ template "nginx-ingress.controller.fullname" . }}
+  minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
   metrics:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: "{{ .Values.controller.autoscaling.targetAverageUtilization }}"
+      targetAverageUtilization: {{ .Values.controller.autoscaling.targetAverageUtilization }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
I got some errors when I tried to enable horizontal pod autoscaler in nginx-ingress v0.8.16.

```
$ helm version
Client: &version.Version{SemVer:"v2.7.2", GitCommit:"8478fb4fc723885b155c924d1c8c410b7a9444e6", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.7.2", GitCommit:"8478fb4fc723885b155c924d1c8c410b7a9444e6", GitTreeState:"clean"}

$ pwd
(...)/charts/stable/nginx-ingress

$ helm install --debug --dry-run -f values.yaml .
Error: render error in "nginx-ingress/templates/controller-hpa.yaml": template: nginx-ingress/templates/controller-hpa.yaml:7:21: executing "nginx-ingress/templates/controller-hpa.yaml" at <{{template "name" .}...>: template "name" not defined

$ helm install --debug --dry-run -f values.yaml .
Error: error validating "": error validating data: [expected type int, for field spec.minReplicas, got string, expected type int, for field spec.maxReplicas, got string, expected type int, for field spec.metrics[0].resource.targetAverageUtilization, got string]