### PR TITLE
Fix kubectl/helm paths for real

### DIFF
--- a/test/helm-test-e2e.sh
+++ b/test/helm-test-e2e.sh
@@ -9,19 +9,16 @@ set -o xtrace
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
 HELM_TARBALL=helm-v2.7.2-linux-amd64.tar.gz
 
-wget -q ${HELM_URL}/${HELM_TARBALL}
-tar xzfv ${HELM_TARBALL}
-
-# Clean up tarball
-rm -f ${HELM_TARBALL}
+wget -q ${HELM_URL}/${HELM_TARBALL} -P ${WORKSPACE}
+tar xzfv ${WORKSPACE}/${HELM_TARBALL} -C ${WORKSPACE}
 
 # Housekeeping
-kubernetes/client/bin/kubectl -n kube-system create sa tiller
-kubernetes/client/bin/kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-linux-amd64/helm init --service-account tiller --upgrade
+kubectl -n kube-system create sa tiller
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+${WORKSPACE}/linux-amd64/helm init --service-account tiller --upgrade
 
-linux-amd64/helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-linux-amd64/helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+${WORKSPACE}/linux-amd64/helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+${WORKSPACE}/linux-amd64/helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 
 # Run test framework
 pushd .
@@ -29,8 +26,3 @@ cd $GOPATH
 go get github.com/ghodss/yaml
 popd
 go run $GOPATH/src/k8s.io/charts/test/helm-test/main.go
-
-echo "#### Debugging ci-kubernetes-charts-gce ###"
-kubectl get pvc --all-namespaces -o wide
-kubectl get pv -o wide
-echo "####"

--- a/test/helm-test/main.go
+++ b/test/helm-test/main.go
@@ -111,8 +111,8 @@ var (
 	artifactsPath     = filepath.Join(os.Getenv("WORKSPACE"), "_artifacts")
 	chartsBasePath    = filepath.Join(os.Getenv("GOPATH"), "src/k8s.io/charts")
 	whiteListYamlPath = filepath.Join(chartsBasePath, "test/helm-test/whitelist.yaml")
-	helmPath          = "linux-amd64/helm"
-	kubectlPath       = "kubernetes/client/bin/kubectl"
+	helmPath          = filepath.Join(os.Getenv("WORKSPACE"), "linux-amd64/helm")
+	kubectlPath       = "kubectl"
 )
 
 func init() {


### PR DESCRIPTION
I tried to outsmart kubetest, but it's smarter than me and actually sets the right kubectl in path. This also handles the helm version in the workspace, in other to not dirty the current directory.

Fingers crossed, this might finally fix [charts-gce](https://k8s-testgrid.appspot.com/sig-apps#charts-gce)

/assign @viglesiasce 