### PR TITLE
Upgrade to 3.8.1

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,6 +1,6 @@
 name: selenium
-version: 0.2.3
-appVersion: 3.7.1
+version: 0.2.4
+appVersion: 3.8.1
 description: Chart for selenium grid
 keywords:
 - qa
@@ -9,6 +9,6 @@ icon: http://docs.seleniumhq.org/images/big-logo.png
 sources:
 - https://github.com/SeleniumHQ/docker-selenium
 maintainers:
-- name: flah00
-  email: techops@adaptly.com
+- name: diemol
+  email: diemol@gmail.com
 engine: gotpl

--- a/stable/selenium/README.md
+++ b/stable/selenium/README.md
@@ -43,7 +43,7 @@ The following tables lists the configurable parameters of the Selenium chart and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `hub.image` | The selenium hub image | `selenium/hub` |
-| `hub.tag` | The selenium hub image tag | `3.7.1` |
+| `hub.tag` | The selenium hub image tag | `3.8.1` |
 | `hub.pullPolicy` | The pull policy for the hub image | `IfNotPresent` |
 | `hub.port` | The port the hub listens on | `4444` |
 | `hub.javaOpts` | The java options for the selenium hub JVM, default sets the maximum heap size to 1,000 mb | `-Xmx1000m` |
@@ -62,7 +62,7 @@ The following tables lists the configurable parameters of the Selenium chart and
 | `hub.timeZone` | The time zone for the container | `nil` |
 | `chrome.enabled` | Schedule a chrome node pod | `false` |
 | `chrome.image` | The selenium node chrome image | `selenium/node-chrome` |
-| `chrome.tag` | The selenium node chrome tag | `3.7.1` |
+| `chrome.tag` | The selenium node chrome tag | `3.8.1` |
 | `chrome.pullPolicy` | The pull policy for the node chrome image | `IfNotPresent` |
 | `chrome.replicas` | The number of selenium node chrome pods | `1` |
 | `chrome.javaOpts` | The java options for the selenium node chrome JVM, default sets the maximum heap size to 900 mb | `-Xmx900m` |
@@ -82,7 +82,7 @@ The following tables lists the configurable parameters of the Selenium chart and
 | `chrome.timeZone` | The time zone for the container | `nil` |
 | `chromeDebug.enabled` | Schedule a selenium node chrome debug pod | `false` |
 | `chromeDebug.image` | The selenium node chrome debug image | `selenium/node-chrome-debug` |
-| `chromeDebug.tag` | The selenium node chrome debug tag | `3.7.1` |
+| `chromeDebug.tag` | The selenium node chrome debug tag | `3.8.1` |
 | `chromeDebug.pullPolicy` | The selenium node chrome debug pull policy | `IfNotPresent` |
 | `chromeDebug.replicas` | The number of selenium node chrome debug pods | `1` |
 | `chromeDebug.javaOpts` | The java options for a selenium node chrome debug JVM, default sets the max heap size to 900 mb | `-Xmx900m` |
@@ -102,7 +102,7 @@ The following tables lists the configurable parameters of the Selenium chart and
 | `chromeDebug.timeZone` | The time zone for the container | `nil` |
 | `firefox.enabled` | Schedule a selenium node firefox pod | `false` |
 | `firefox.image` | The selenium node firefox image | `selenium/node-firefox` |
-| `firefox.tag` | The selenium node firefox tag | `3.7.1` |
+| `firefox.tag` | The selenium node firefox tag | `3.8.1` |
 | `firefox.pullPolicy` | The selenium node firefox pull policy | `IfNotPresent` |
 | `firefox.replicas` | The number of selenium node firefox pods | `1` |
 | `firefox.javaOpts` | The java options for a selenium node firefox JVM, default sets the max heap size to 900 mb | `-Xmx900m` |
@@ -120,7 +120,7 @@ The following tables lists the configurable parameters of the Selenium chart and
 | `firefox.timeZone` | The time zone for the container | `nil` |
 | `firefoxDebug.enabled` | Schedule a selenium node firefox debug pod | `false` |
 | `firefoxDebug.image` | The selenium node firefox debug image | `selenium/node-firefox-debug` |
-| `firefoxDebug.tag` | The selenium node firefox debug tag | `3.7.1` |
+| `firefoxDebug.tag` | The selenium node firefox debug tag | `3.8.1` |
 | `firefoxDebug.pullPolicy` | The selenium node firefox debug pull policy | `IfNotPresent` |
 | `firefoxDebug.replicas` | The numer of selenium node firefox debug pods | `1` |
 | `firefoxDebug.javaOpts` | The java options for a selenium node firefox debug JVM, default sets the max heap size to 900 mb | `-Xmx900m` |

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -5,7 +5,7 @@ hub:
 
   ## The tag for the image
   ## ref: https://hub.docker.com/r/selenium/hub/tags/
-  tag: "3.7.1"
+  tag: "3.8.1"
 
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -82,7 +82,7 @@ chrome:
 
   ## The tag for the image
   ## ref: https://hub.docker.com/r/selenium/hub/tags/
-  tag: "3.7.1"
+  tag: "3.8.1"
 
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -153,7 +153,7 @@ chromeDebug:
 
   ## The tag for the image
   ## ref: https://hub.docker.com/r/selenium/hub/tags/
-  tag: "3.7.1"
+  tag: "3.8.1"
 
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -224,7 +224,7 @@ firefox:
 
   ## The tag for the image
   ## ref: https://hub.docker.com/r/selenium/hub/tags/
-  tag: "3.7.1"
+  tag: "3.8.1"
 
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -282,7 +282,7 @@ firefoxDebug:
 
   ## The tag for the image
   ## ref: https://hub.docker.com/r/selenium/hub/tags/
-  tag: "3.7.1"
+  tag: "3.8.1"
 
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Upgrading tag to newest released version: 3.8.1
I also changed the maintainer and added myself since there was not so much activity before I started sending PRs. I am also the one who is usually releasing docker-selenium in the official repo, so it just made sense to me.