### PR TITLE
 Use Values.uuid for cluster id with default of uuidv4

### DIFF
--- a/stable/spartakus/Chart.yaml
+++ b/stable/spartakus/Chart.yaml
@@ -1,5 +1,5 @@
 name: spartakus
-version: 1.1.1
+version: 1.1.2
 description: Collect information about Kubernetes clusters to help improve the project.
 sources:
   - https://github.com/kubernetes-incubator/spartakus

--- a/stable/spartakus/templates/deployment.yaml
+++ b/stable/spartakus/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
             - volunteer
-            - --cluster-id="{{ uuidv4 | default .Values.uuid }}"
+            - --cluster-id="{{ .Values.uuid | default uuidv4 }}"
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}


### PR DESCRIPTION
Currently uses uuidv4 for cluster-id and the "default" Values.uuid isn't used.

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
