### PR TITLE
Adding a version comparison to the k8s CI tests

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -30,9 +30,17 @@ if [ -z "$CHANGED_FOLDERS" ]; then
   exit 0
 fi
 
+# include the semvercompare function
+curDir="$(dirname "$0")"
+source "$curDir/semvercompare.sh"
+
 # Cleanup any releases and namespaces left over from the test
 function cleanup {
-    if [ -n $CURRENT_RELEASE ];then
+    if [ $semvercomparePassed -eq 0 ]; then
+      echo "Error please increment the new chart version to be greater than the existing version of $semvercompareOldVer"
+    fi
+
+    if [ -n "$CURRENT_RELEASE" ]; then
       helm delete --purge ${CURRENT_RELEASE} > cleanup_log 2>&1 || true
     fi
     kubectl delete ns ${NAMESPACE} >> cleanup_log 2>&1 || true
@@ -58,6 +66,19 @@ popd
 helm init --client-only
 helm repo add incubator ${INCUBATOR_REPO_URL}
 
+mkdir /opt/bin
+pushd /opt/bin
+  # Install tools to check chart versions
+  # Install YAML Command line reader
+  wget -q -O yaml https://github.com/mikefarah/yaml/releases/download/1.13.1/yaml_linux_amd64
+  chmod +x yaml
+
+  # Install SemVer testing tool
+  wget -q -O vert https://github.com/Masterminds/vert/releases/download/v0.1.0/vert-v0.1.0-linux-amd64
+  chmod +x vert
+popd
+PATH=/opt/bin/:$PATH
+
 # Iterate over each of the changed charts
 #    Lint, install and delete
 for directory in ${CHANGED_FOLDERS}; do
@@ -65,6 +86,12 @@ for directory in ${CHANGED_FOLDERS}; do
     continue
   elif [ -d $directory ]; then
     CHART_NAME=`echo ${directory} | cut -d '/' -f2`
+    
+    # semvercompare is here as well as in the circleci tests. The circleci tests
+    # provide almost immediate feedback to chart authors. This test is also
+    # re-run right before the bot merges a PR so we can make sure the chart
+    # version is always incremented.
+    semvercompare ${directory}
     RELEASE_NAME="${CHART_NAME:0:7}-${BUILD_NUMBER}"
     CURRENT_RELEASE=${RELEASE_NAME}
     helm dep build ${directory}
@@ -82,3 +109,5 @@ for directory in ${CHANGED_FOLDERS}; do
     helm delete --purge ${RELEASE_NAME}
   fi
 done
+
+exit $exitCode

--- a/test/circle/lint.sh
+++ b/test/circle/lint.sh
@@ -53,53 +53,9 @@ yamllinter() {
   fi
 }
 
-# Verify that the semver for the chart was increased
-semvercompare() {
-  printf "\nChecking the Chart version has increased for the chart at ${1}\n"
-
-  # Checkout the Chart.yaml file on master to read the version for comparison
-  # Sending the output to a file and the error to /dev/null so that these
-  # messages do not clutter up the end user output
-  $(git show k8s/master:$1/Chart.yaml 1> /tmp/Chart.yaml 2> /dev/null)
-
-  ## If the chart is new git cannot checkout the chart. In that case return
-  if [ $? -ne 0 ]; then
-    echo "Unable to find Chart on master. New chart detected."
-    return
-  fi
-
-  local oldVer=`yaml r /tmp/Chart.yaml version`
-  local newVer=`yaml r $1/Chart.yaml version`
-
-  # Pre-releases may not be API compatible. So, when tools compare versions
-  # they often skip pre-releases. vert can force looking at pre-releases by
-  # adding a dash on the end followed by pre-release. -0 on the end will force
-  # looking for all valid pre-releases since a prerelease cannot start with a 0.
-  # For example, 1.2.3-0 will include looking for pre-releases.
-  local ret
-  local out
-  if [[ $oldVer == *"-"* ]]; then  # Found the - to denote it has a pre-release
-    out=$(vert ">$oldVer" $newVer)
-    ret=$?
-  else
-    # No pre-release was found so we increment the patch version and attach a
-    # -0 to enable pre-releases being found.
-    local ov=( ${oldVer//./ } )  # Turn the version into an array
-    ((ov[2]++))                  # Increment the patch release
-    out=$(vert ">${ov[0]}.${ov[1]}.${ov[2]}-0" $newVer)
-    ret=$?
-  fi
-
-  if [ $ret -ne 0 ]; then
-    echo "Error please increment the new chart version to be greater than the existing version of $oldVer"
-    exitCode=1
-  else
-    echo "New higher version $newVer found"
-  fi
-
-  # Clean up
-  rm /tmp/Chart.yaml
-}
+# include the semvercompare function
+curDir="$(dirname "$0")"
+source "$curDir/../semvercompare.sh"
 
 git remote add k8s https://github.com/kubernetes/charts
 git fetch k8s master

--- a/test/semvercompare.sh
+++ b/test/semvercompare.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exitCode=0
+
+semvercompareOldVer=""
+semvercompareNewVer=""
+semvercomparePassed=0
+
+# Verify that the semver for the chart was increased
+semvercompare() {
+  printf "\nChecking the Chart version has increased for the chart at ${1}\n"
+
+  # Checkout the Chart.yaml file on master to read the version for comparison
+  # Sending the output to a file and the error to /dev/null so that these
+  # messages do not clutter up the end user output
+  $(git show k8s/master:$1/Chart.yaml 1> /tmp/Chart.yaml 2> /dev/null)
+
+  ## If the chart is new git cannot checkout the chart. In that case return
+  if [ $? -ne 0 ]; then
+    echo "Unable to find Chart on master. New chart detected."
+    return
+  fi
+
+  semvercompareOldVer=`yaml r /tmp/Chart.yaml version`
+  semvercompareNewVer=`yaml r $1/Chart.yaml version`
+
+  # Pre-releases may not be API compatible. So, when tools compare versions
+  # they often skip pre-releases. vert can force looking at pre-releases by
+  # adding a dash on the end followed by pre-release. -0 on the end will force
+  # looking for all valid pre-releases since a prerelease cannot start with a 0.
+  # For example, 1.2.3-0 will include looking for pre-releases.
+  local ret
+  local out
+  if [[ $semvercompareOldVer == *"-"* ]]; then  # Found the - to denote it has a pre-release
+    out=$(vert ">$semvercompareOldVer" $semvercompareNewVer)
+    ret=$?
+  else
+    # No pre-release was found so we increment the patch version and attach a
+    # -0 to enable pre-releases being found.
+    local ov=( ${semvercompareOldVer//./ } )  # Turn the version into an array
+    ((ov[2]++))                  # Increment the patch release
+    out=$(vert ">${ov[0]}.${ov[1]}.${ov[2]}-0" $semvercompareNewVer)
+    ret=$?
+  fi
+
+  if [ $ret -ne 0 ]; then
+    echo "Error please increment the new chart version to be greater than the existing version of $semvercompareOldVer"
+    exitCode=1
+  else
+    echo "New higher version $semvercompareNewVer found"
+    semvercomparePassed=1
+  fi
+
+  # Clean up
+  rm /tmp/Chart.yaml
+}


### PR DESCRIPTION
The bot that merges PRs re-runs the e2e job before merging a pull
request. By also having it here (circleci provides fast response
to PR authors) we make sure the version has been incremented in
the chart prior to it being merged.