### PR TITLE
[incubator/logstash] Add README file and change service type

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
-description: A Helm chart for logstash
+description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
+home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.3.0
+version: 0.3.1
 appVersion: 6.0.0
 sources:
 - https://www.docker.elastic.co
@@ -12,3 +13,5 @@ maintainers:
   email: pete.brown@powerhrg.com
 - name: jar361
   email: jrodgers@powerhrg.com
+- name: christian-roggia
+  email: christian.roggia@gmail.com

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -1,0 +1,54 @@
+# Logstash
+
+[Logstash](https://www.elastic.co/products/logstash) is an open source, server-side data processing pipeline that ingests data from a multitude of sources simultaneously, transforms it, and then sends it to your favorite “stash.”
+
+## TL;DR;
+
+```console
+$ helm install incubator/logstash
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release incubator/logstash
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes nearly all the Kubernetes components associated with the
+chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the drone charts and their default values.
+
+| Parameter              | Description                                        | Default                                          |
+| ---------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| `replicaCount`         | Number of replicas                                 | `1`                                              |
+| `nodeSelector`         | Node selectors                                     | `{}`                                             |
+| `image.repository`     | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
+| `image.tag`            | Container image tag                                | `6.0.0`                                          |
+| `image.pullPolicy`     | Container image pull policy                        | `IfNotPresent`                                   |
+| `service.type`         | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                       |
+| `service.internalPort` | Logstash internal port                             | `1514`                                           |
+| `service.ports`        | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
+| `ingress.enabled`      | Enables Ingress                                    | `false`                                          |
+| `ingress.annotations`  | Ingress annotations                                | `{}`                                             |
+| `ingress.hosts`        | Ingress accepted hostnames                         | `[]`                                             |
+| `ingress.tls`          | Ingress TLS configuration                          | `nil`                                            |
+| `resources`            | Pod resource requests & limits                     | `{}`                                             |
+| `elasticsearch.host`   | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
+| `elasticsearch.port`   | ElasticSearch port                                 | `9200`                                           |
+| `patterns`             | Logstash patterns configuration                    | `nil`                                            |
+| `inputs`               | Logstash inputs configuration                      | `(basic)`                                        |
+| `filters`              | Logstash filters configuration                     | `nil`                                            |
+| `outputs`              | Logstash outputs configuration                     | `(basic)`                                        |

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
+nodeSelector: {}
 image:
   repository: docker.elastic.co/logstash/logstash-oss
   tag: 6.0.0

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -8,7 +8,7 @@ image:
   tag: 6.0.0
   pullPolicy: IfNotPresent
 service:
-  type: NodePort
+  type: ClusterIP
   internalPort: 1514
   ports:
     - name: "syslog-tcp"


### PR DESCRIPTION
# TL;DR
This PR adds the required README to the chart in order to provide basic documentation. Some information about the chart has also been updated.

# ClusterIP vs NodePort
Since most user won't send requests to Logstash from outside the cluster the default service type has been changed from NodePort to ClusterIP. This decision has been made since we assume that all the traffic will be generated from within the cluster, the same decision has been applied to most charts available in this repository and also to the ElasticSearch chart itself. Also, exposing the logstash service by default with NodePort is a security issue.

