### PR TITLE
Fixing edge case for patch version of 0

### DIFF
--- a/test/semvercompare.sh
+++ b/test/semvercompare.sh
@@ -51,7 +51,7 @@ semvercompare() {
     # No pre-release was found so we increment the patch version and attach a
     # -0 to enable pre-releases being found.
     local ov=( ${semvercompareOldVer//./ } )  # Turn the version into an array
-    ((ov[2]++))                  # Increment the patch release
+    ((ov[2]+=1))                  # Increment the patch release
     out=$(vert ">${ov[0]}.${ov[1]}.${ov[2]}-0" $semvercompareNewVer)
     ret=$?
   fi


### PR DESCRIPTION
When the array splitting happen there are cases where the patch
(maj.min.patch) is 0. Using ++ to increment that 0 causes a
return code of 1. Using +=1 instead increments the value but has
a return code of 0.

/cc @unguiculus 