### PR TITLE
Fix NOTES.txt for kafka chart

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.2.6
+version: 0.2.7
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -17,20 +17,20 @@ You can connect to Kafka by running a simple pod in the K8s cluster like this wi
 Once you have the testclient pod above running, you can list all kafka
 topics with:
 
-  kubectl -n {{ .Release.Namespace }} exec testclient -- ./bin/kafka-topics.sh --zookeeper {{ .Release.Name }}-zookeeper:2181 --list
+  kubectl -n {{ .Release.Namespace }} exec testclient -- /usr/bin/kafka-topics --zookeeper {{ .Release.Name }}-zookeeper:2181 --list
 
 To create a new topic:
 
-  kubectl -n {{ .Release.Namespace }} exec testclient -- ./bin/kafka-topics.sh --zookeeper {{ .Release.Name }}-zookeeper:2181 --topic test1 --create --partitions 1 --replication-factor 1
+  kubectl -n {{ .Release.Namespace }} exec testclient -- /usr/bin/kafka-topics --zookeeper {{ .Release.Name }}-zookeeper:2181 --topic test1 --create --partitions 1 --replication-factor 1
 
 To listen for messages on a topic:
 
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- ./bin/kafka-console-consumer.sh --bootstrap-server {{ .Release.Name }}-kafka:9092 --topic test1 --from-beginning
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-consumer --bootstrap-server {{ .Release.Name }}-kafka:9092 --topic test1 --from-beginning
 
 To stop the listener session above press: Ctrl+C
 
 To start an interactive message producer session:
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- ./bin/kafka-console-producer.sh --broker-list {{ .Release.Name }}-kafka-headless:9092 --topic test1
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-producer --broker-list {{ .Release.Name }}-kafka-headless:9092 --topic test1
 
 To create a message in the above session, simply type the message and press "enter"
 To end the producer session try: Ctrl+C


### PR DESCRIPTION
It appears demo scripts are in "/usr/bin", and have no ".sh" extension.
