### PR TITLE
[stable/chaoskube] #1899 add nodeSelector for chaoskube

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,5 +1,5 @@
 name: chaoskube
-version: 0.6.1-1
+version: 0.6.2
 appVersion: 0.6.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube

--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,5 +1,5 @@
 name: chaoskube
-version: 0.6.1
+version: 0.6.1-1
 appVersion: 0.6.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -52,6 +52,7 @@ $ helm install stable/chaoskube --set dryRun=false
 | `resources.memory`        | memory resource requests and limits                 | 16Mi                              |
 | `rbac.create`             | create rbac service account and roles               | false                             |
 | `rbac.serviceAccountName` | name of serviceAccount to use when create is false  | default                           |
+| `nodeSelector`            | node labels for pod assignment                      | `{}`                              |
 
 Setting label and namespaces selectors from the shell can be tricky but is possible (example with zsh):
 

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -36,3 +36,7 @@ spec:
             cpu: {{ .Values.resources.cpu }}
             memory: {{ .Values.resources.memory }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ printf "%s-%s" .Release.Name .Values.name }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end -}}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -36,3 +36,7 @@ rbac:
 
   # only used when create is false
   serviceAccountName: default
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}


### PR DESCRIPTION
[stable/chaoskube] Added nodeSelector for chaoskube.
related to https://github.com/kubernetes/charts/issues/1899