### PR TITLE
[stable/sonatype-nexus]: Do not set targetPort for ClusterIP 

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 0.1.3
+version: 0.1.4
 appVersion: 3.5.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/service.yaml
+++ b/stable/sonatype-nexus/templates/service.yaml
@@ -15,12 +15,16 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.externalPort }}
+{{- if ne .Values.service.type "ClusterIP" }}
       targetPort: {{ .Values.service.internalPort }}
+{{- end }}
       protocol: TCP
       name: {{ .Values.service.name }}
     {{- if .Values.docker.enabled }}
     - port: {{ .Values.docker.port }}
+{{- if ne .Values.service.type "ClusterIP" }}
       targetPort: {{ .Values.docker.port }}
+{{- end }}
       protocol: TCP
       name: {{ .Values.service.name }}-docker
     {{- end }}


### PR DESCRIPTION
When deploying stable/sonatype-nexus with a service type of ClusterIP the targetPort must be omitted or the deploy will fail.