### PR TITLE
[stable/mysql] Add option to specify service type

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.3.2
+version: 0.3.3
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.
 keywords:

--- a/stable/mysql/templates/NOTES.txt
+++ b/stable/mysql/templates/NOTES.txt
@@ -3,7 +3,7 @@ MySQL can be accessed via port 3306 on the following DNS name from within your c
 
 To get your root password run:
 
-    kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mysql.fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode; echo
+    MYSQL_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mysql.fullname" . }} -o jsonpath="{.data.mysql-root-password}" | base64 --decode; echo)
 
 To connect to your database:
 
@@ -17,3 +17,20 @@ To connect to your database:
 
 3. Connect using the mysql cli, then provide your password:
     $ mysql -h {{ template "mysql.fullname" . }} -p
+
+To connect to your database directly from outside the K8s cluster:
+    {{- if contains "NodePort" .Values.service.type }}
+    MYSQL_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+    MYSQL_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mysql.fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}')
+
+    {{- else if contains "ClusterIP" .Values.service.type }}
+    MYSQL_HOST=127.0.0.1
+    MYSQL_PORT={{ default "3306" .Values.service.port }}
+
+    # Execute the following commands to route the connection:
+    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mysql.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+    kubectl port-forward $POD_NAME {{ default "3306" .Values.service.port }}:{{ default "3306" .Values.service.port }}
+
+    {{- end }}
+
+    mysql -h ${MYSQL_HOST} -P${MYSQL_PORT} -u root -p${MYSQL_ROOT_PASSWORD}

--- a/stable/mysql/templates/svc.yaml
+++ b/stable/mysql/templates/svc.yaml
@@ -8,9 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  type: {{ .Values.service.type }}
   ports:
   - name: mysql
-    port: 3306
+    port: {{ .Values.service.port }}
     targetPort: mysql
   selector:
     app: {{ template "mysql.fullname" . }}

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -69,3 +69,12 @@ configurationFiles:
 #  mysql.cnf: |-
 #    [mysqld]
 #    skip-name-resolve
+
+
+## Configure the service
+## ref: http://kubernetes.io/docs/user-guide/services/
+service:
+  ## Specify a service type
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types
+  type: ClusterIP
+  port: 3306


### PR DESCRIPTION
The MySQL chart only allowed the service type to be ClusterIP,
preventing its use with Minikube. This patch adds the ability to create
the service with the `NodePort` type.

Drive-by:
* Update the `NOTES.txt` file to provide similar instructions to the
PostreSQL chart.

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
