### PR TITLE
Handling the case of a new chart in the e2e tests

### DIFF
--- a/test/semvercompare.sh
+++ b/test/semvercompare.sh
@@ -13,11 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exitCode=0
-
 semvercompareOldVer=""
 semvercompareNewVer=""
-semvercomparePassed=0
 
 # Verify that the semver for the chart was increased
 semvercompare() {
@@ -61,7 +58,6 @@ semvercompare() {
     exitCode=1
   else
     echo "New higher version $semvercompareNewVer found"
-    semvercomparePassed=1
   fi
 
   # Clean up


### PR DESCRIPTION
/cc @viglesiasce @unguiculus 

This change fixes semver checking in the e2e tests for the case of a new chart. If you look at the testing history on https://k8s-gubernator.appspot.com/pr/charts/3083 you'll see different cases I ran this against for a new chart vs a chart with a changing feature but no version bump vs everything aligned.