### PR TITLE
Add option to log acme debug messages

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.14.5
+version: 1.15.0
 appVersion: 1.4.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.15.0
+version: 1.15.1
 appVersion: 1.4.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -106,6 +106,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `acme.enabled`                  | Whether to use Let's Encrypt to obtain certificates                  | `false`                                   |
 | `acme.email`                    | Email address to be used in certificates obtained from Let's Encrypt | `admin@example.com`                       |
 | `acme.staging`                  | Whether to get certs from Let's Encrypt's staging environment        | `true`                                    |
+| `acme.logging`                  | display debug log messages from the acme client library              | `false`                                   |
 | `acme.persistence.enabled`      | Create a volume to store ACME certs (if ACME is enabled)             | `true`                                    |
 | `acme.persistence.storageClass` | Type of `StorageClass` to request-- will be cluster-specific         | `nil` (uses alpha storage class annotation) |
 | `acme.persistence.accessMode`   | `ReadWriteOnce` or `ReadOnly`                                        | `ReadWriteOnce`                           |

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -71,6 +71,9 @@ data:
     {{- if .Values.acme.staging }}
     caServer = "https://acme-staging.api.letsencrypt.org/directory"
     {{- end }}
+    {{- if .Values.acme.logging }}
+    acmeLogging = true
+    {{- end }}
     {{- end }}
     {{- if .Values.dashboard.enabled }}
     [web]

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -33,6 +33,7 @@ acme:
   enabled: false
   email: admin@example.com
   staging: true
+  logging: false
   ## Save ACME certs to a persistent volume. WARNING: If you do not do this, you will re-request
   ## certs every time a pod (re-)starts and you WILL be rate limited!
   persistence:


### PR DESCRIPTION
Useful when debugging issues (i.e. not able to get certificates). This bumps the minor version since this is a new feature.

Formerly https://github.com/kubernetes/charts/pull/2603 but could not find a way to reopen the pull request.