### PR TITLE
[stable/artifactory] Service annotations

### DIFF
--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 6.2.3
+version: 6.2.4
 appVersion: 5.6.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/artifactory-service.yaml
+++ b/stable/artifactory/templates/artifactory-service.yaml
@@ -8,6 +8,10 @@ metadata:
     component: "{{ .Values.artifactory.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.artifactory.service.annotations }}
+  annotations:
+{{ toYaml .Values.artifactory.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.artifactory.service.type }}
   ports:

--- a/stable/artifactory/templates/nginx-service.yaml
+++ b/stable/artifactory/templates/nginx-service.yaml
@@ -8,6 +8,10 @@ metadata:
     component: "{{ .Values.nginx.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.nginx.service.annotations }}
+  annotations:
+{{ toYaml .Values.nginx.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.nginx.service.type }}
 {{- if eq .Values.nginx.service.type "LoadBalancer" }}

--- a/stable/artifactory/templates/postgresql-service.yaml
+++ b/stable/artifactory/templates/postgresql-service.yaml
@@ -8,6 +8,10 @@ metadata:
     component: "{{ .Values.database.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.database.service.annotations }}
+  annotations:
+{{ toYaml .Values.database.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.database.service.type }}
   ports:

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -24,6 +24,7 @@ database:
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
+    annotations: {}
   externalPort: 5432
   internalPort: 5432
   persistence:
@@ -59,6 +60,7 @@ artifactory:
   service:
     name: artifactory
     type: ClusterIP
+    annotations: {}
   externalPort: 8081
   internalPort: 8081
   persistence:
@@ -107,6 +109,7 @@ nginx:
     ## or pass from helm command line
     ## Example: helm install ... --set nginx.service.loadBalancerSourceRanges='{10.10.10.5/32,10.11.10.5/32}'
     loadBalancerSourceRanges: []
+    annotations: {}
   externalPortHttp: 80
   internalPortHttp: 80
   externalPortHttps: 443


### PR DESCRIPTION
Allow full customization of service annotations for all three services
in artifactory chart: artifactory, postgres and nginx. Purpose of the
change is to allow end user to provide configuration for other
kubernetes components to act on.