### PR TITLE
[incubator/gogs] Customize service annotations

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.11.29
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/incubator/gogs/templates/service.yaml
+++ b/incubator/gogs/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "gogs.fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.serviceType }}
   ports:

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -222,6 +222,12 @@ service:
     #     hosts:
     #       - gogs.domain.com
 
+  ## Service annotations.
+  ## Allows attaching metadata to services for kubernetes components to act on.
+  ##
+  # annotations:
+  #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+
 
 ## Persistent Volume Storage configuration.
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes


### PR DESCRIPTION
Purpose is for users to attach annotation metadata to gogs service for
custom kubernetes components to act on. By allowing free configuration
of annotations in values.yaml we allow maximum flexibility in
configuration.