### PR TITLE
[stable/nginx-ingress] Enable nginx-ingress daemonset hostports 80 443

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.23
+version: 0.8.24
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -94,9 +94,15 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPorts }}
+              hostPort: 80
+              {{- end }}
             - name: https
               containerPort: 443
               protocol: TCP
+              {{- if .Values.controller.daemonset.useHostPorts }}
+              hostPort: 443
+              {{- end }}
           {{- if .Values.controller.stats.enabled }}
             - name: stats
               containerPort: 18080

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -17,6 +17,10 @@ controller:
   # is merged
   hostNetwork: false
 
+  ## Use host ports 80 and 443
+  daemonset:
+    useHostPort: false
+
   ## Required only if defaultBackend.enabled = false
   ## Must be <namespace>/<service_name>
   ##


### PR DESCRIPTION
Adds a new value `controller.daemonset.useHostPorts` that exposes ports 80 and 443 as hostports when run as a DaemonSet. This allows transparent access to web services managed by the ingress controller without looking up nodePorts, or enabling a LoadBalancer which may not be available in some Kubernetes deployments.