### PR TITLE
[incubator/jaeger] Collector Service ports

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.8.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.2.3
+version: 0.2.4
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -35,11 +35,11 @@ spec:
         image: "{{ .Values.collector.image }}:{{ .Values.collector.tag }}"
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.collector.service.tchannelPort }}
+        - containerPort: 14267
           protocol: TCP
-        - containerPort: {{ .Values.collector.service.httpPort }}
+        - containerPort: 14268
           protocol: TCP
-        - containerPort: {{ .Values.collector.service.zipkinPort }}
+        - containerPort: 9411
           protocol: TCP
         resources:
 {{ toYaml .Values.collector.resources | indent 10 }}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -36,10 +36,13 @@ spec:
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         ports:
         - containerPort: 14267
+          name: tchannel
           protocol: TCP
         - containerPort: 14268
+          name: http
           protocol: TCP
         - containerPort: 9411
+          name: zipkin
           protocol: TCP
         resources:
 {{ toYaml .Values.collector.resources | indent 10 }}

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -18,15 +18,15 @@ spec:
   - name: jaeger-collector-tchannel
     port: {{ .Values.collector.service.tchannelPort }}
     protocol: TCP
-    targetPort: {{ .Values.collector.service.tchannelPort }}
+    targetPort: 14267
   - name: jaeger-collector-http
     port: {{ .Values.collector.service.httpPort }}
     protocol: TCP
-    targetPort: {{ .Values.collector.service.httpPort }}
+    targetPort: 14268
   - name: jaeger-collector-zipkin
     port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
-    targetPort: {{ .Values.collector.service.zipkinPort }}
+    targetPort: 9411
   selector:
     app: "{{ template "jaeger.name" . }}"
     component: "collector"

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -18,15 +18,15 @@ spec:
   - name: jaeger-collector-tchannel
     port: {{ .Values.collector.service.tchannelPort }}
     protocol: TCP
-    targetPort: 14267
+    targetPort: tchannel
   - name: jaeger-collector-http
     port: {{ .Values.collector.service.httpPort }}
     protocol: TCP
-    targetPort: 14268
+    targetPort: http
   - name: jaeger-collector-zipkin
     port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
-    targetPort: 9411
+    targetPort: zipkin
   selector:
     app: "{{ template "jaeger.name" . }}"
     component: "collector"


### PR DESCRIPTION
I dont think that changing `collector.service.*Port` should only affect the Service and not the Deployment.

I was trying to deploy the Collector but with different ports but with the current way the chart is implemented, it will change which port are exposed on the container as well.

With this PR, only the Service ports will change but the `targetPort` and the `containerPort` will stay the same as the default one.