### PR TITLE
[stable/grafana] - allow for custom clusterIP to support headless services

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.6
+version: 0.6.1
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -49,6 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.service.loadBalancerSourceRanges` | List of IP CIDRs allowed access     | null                                              |
 | `server.service.nodePort`                 | For service type "NodePort"         | null                                              |
 | `server.service.externalIPs`              | External IP addresses               | null                                              |
+| `server.service.clusterIP`                | Custom clusterIP to use for service | null                                         |
 | `server.service.type`                     | ClusterIP, NodePort, or LoadBalancer| ClusterIP                                         |
 | `server.setDatasource.enabled`            | Creates grafana datasource with job | false                                             |
 | `server.extraEnv`                          | Extra environment variables to set in the server container | {} |

--- a/stable/grafana/templates/svc.yaml
+++ b/stable/grafana/templates/svc.yaml
@@ -27,6 +27,11 @@ spec:
   externalIPs:
 {{ toYaml .Values.server.service.externalIPs | indent 4 }}
 {{- end }}
+{{- if contains "ClusterIP" .Values.server.service.type }}
+  {{- if .Values.server.service.clusterIP }}
+  clusterIP:  {{ .Values.server.service.clusterIP }}
+  {{- end }}
+{{- end }}  
   selector:
     app: {{ template "grafana.fullname" . }}
     component: "{{ .Values.server.name }}"

--- a/stable/grafana/templates/svc.yaml
+++ b/stable/grafana/templates/svc.yaml
@@ -18,7 +18,7 @@ spec:
       port: {{ .Values.server.service.httpPort }}
       protocol: TCP
       targetPort: 3000
-{{- if contains "NodePort" .Values.server.service.type }}
+{{- if eq "NodePort" .Values.server.service.type }}
   {{- if .Values.server.service.nodePort }}
       nodePort:  {{ .Values.server.service.nodePort }}
   {{- end }}
@@ -27,7 +27,7 @@ spec:
   externalIPs:
 {{ toYaml .Values.server.service.externalIPs | indent 4 }}
 {{- end }}
-{{- if contains "ClusterIP" .Values.server.service.type }}
+{{- if eq "ClusterIP" .Values.server.service.type }}
   {{- if .Values.server.service.clusterIP }}
   clusterIP:  {{ .Values.server.service.clusterIP }}
   {{- end }}
@@ -36,7 +36,7 @@ spec:
     app: {{ template "grafana.fullname" . }}
     component: "{{ .Values.server.name }}"
   type: "{{ .Values.server.service.type }}"
-{{- if contains "LoadBalancer" .Values.server.service.type }}
+{{- if eq "LoadBalancer" .Values.server.service.type }}
   {{- if .Values.server.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.server.service.loadBalancerIP }}
   {{- end -}}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -133,6 +133,9 @@ server:
     ##
     httpPort: 80
 
+    ## ClusterIP to use for service
+    ## clusterIP: None
+
     ## Load balancer IP address
     ## Is not required, but allows for static address with
     ## serviceType LoadBalancer.
@@ -160,6 +163,7 @@ server:
     ##
     # externalIPs:
     # - 192.168.0.1
+
 
   ## Grafana local config path
   ## Default '/etc/grafana'


### PR DESCRIPTION
This PR adds a new field to the grafana values called clusterIP. When the specified service type is ClusterIP, specifying this value with allow for custom clusterIP values to be used. This allows for support of things like headless services with the grafana svc definition.