### PR TITLE
[stable/rabbitmq-ha] Use ClusterIP as default service type

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.0
-version: 0.1.0
+version: 0.1.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -34,6 +34,19 @@ that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
+## Upgrading the Chart
+
+To upgrade the chart, you need to make sure that you are using the same value
+of the `rabbitmqErlangCookie` amongst the releases. If you didn't define it at
+the first place, you can upgrade using the following command:
+
+```
+$ export ERLANGCOOKIE=$(kubectl get secrets -n <NAMESPACE> <HELM_RELEASE_NAME>-rabbitmq-ha -o jsonpath={.data.rabbitmq-erlang-cookie}
+$ helm upgrade --name <HELM_RELEASE_NAME> \
+    --set rabbitmqErlangCookie=$ERLANGCOOKIE \
+    stable/rabbitmq-ha
+```
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -41,7 +41,7 @@ of the `rabbitmqErlangCookie` amongst the releases. If you didn't define it at
 the first place, you can upgrade using the following command:
 
 ```
-$ export ERLANGCOOKIE=$(kubectl get secrets -n <NAMESPACE> <HELM_RELEASE_NAME>-rabbitmq-ha -o jsonpath={.data.rabbitmq-erlang-cookie}
+$ export ERLANGCOOKIE=$(kubectl get secrets -n <NAMESPACE> <HELM_RELEASE_NAME>-rabbitmq-ha -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
 $ helm upgrade --name <HELM_RELEASE_NAME> \
     --set rabbitmqErlangCookie=$ERLANGCOOKIE \
     stable/rabbitmq-ha

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -55,7 +55,7 @@ service:
 
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
-  type: NodePort
+  type: ClusterIP
 
 ## Statefulsets rolling update update strategy
 ## Ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-update


### PR DESCRIPTION
* Use ClusterIP as default service type, was already mentioned as default value in the README.md (reported by @AceHack)
* Add instruction on how to upgrade the chart (mentioned in https://github.com/kubernetes/charts/issues/3075)