### PR TITLE
[incubator/webpagetest-server] Add WebPageTest to k8s

### DIFF
--- a/incubator/webpagetest-server/Chart.yaml
+++ b/incubator/webpagetest-server/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: webpagetest-server
+version: 0.1.0

--- a/incubator/webpagetest-server/Chart.yaml
+++ b/incubator/webpagetest-server/Chart.yaml
@@ -2,3 +2,12 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-server
 version: 0.1.0
+home: https://www.webpagetest.org/
+icon: https://www.webpagetest.org/images/logo_wpt.png
+sources:
+  - https://github.com/WPO-Foundation/webpagetest
+maintainers:
+  - name: timothyclarke
+    email: ghtimothy@timothy.fromnz.net
+  - name: pmeenan
+    email: pmeenan@webpagetest.org

--- a/incubator/webpagetest-server/README.md
+++ b/incubator/webpagetest-server/README.md
@@ -51,6 +51,7 @@ The following tables lists the configurable parameters of the WebPageTest chart 
 | `image`                              | WebPageTest server image                   | `webpagetest/server:{VERSION}`                              |
 | `imagePullPolicy`                    | Image pull policy                          | `IfNotPresent`                                             |
 | `ec2Locations.enabled`               | Enables use of EC2 AMI's                   | `false`                                                     |
+| `ec2Locations.customUserDataSecret`  | Controlls if this chart should use an externally created secret | `false` |
 | `ec2Locations.userData`              | Data Structure which is used to generate settings | sample data only                                    |
 | `ec2Locations.userData.ec2_key`      | EC2 API key with create permissions        | `nil`                                                      |
 | `ec2Locations.userData.ec2_secret`   | Secret portion of the above key            | `nil`                                                      |
@@ -208,6 +209,9 @@ Ones to note are
 ;archive_s3_bucket=<bucket>
 ;archive_s3_url=http://s3.amazonaws.com/
 ```
+
+## ec2Locations.customUserDataSecret
+If you would like to use ec2 AMI's but would prefer to create the secret outside of the chart then supply the name of the secret here
 
 ## Future
 * Add options for 'locations.ini' from configmap so you can use other agents

--- a/incubator/webpagetest-server/README.md
+++ b/incubator/webpagetest-server/README.md
@@ -210,4 +210,5 @@ Ones to note are
 ```
 
 ## Future
-Add persistant storage to buffer content between runs and s3 archiving
+* Add persistant storage to buffer content between runs and s3 archiving
+* Add options for 'locations.ini' from configmap so you can use other agents

--- a/incubator/webpagetest-server/README.md
+++ b/incubator/webpagetest-server/README.md
@@ -1,0 +1,213 @@
+# WebPageTest
+
+[WebPageTest](https://webpagetest.org/) is a website testing tool
+
+## TL;DR;
+
+```console
+$ helm install incubator/webpagetest-server
+```
+
+## Introduction
+
+This chart bootstraps a private [WebPageTest Server](https://github.com/WPO-Foundation/webpagetest-docs/blob/master/user/Private%20Instances/README.md) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Depending on your configuration you can then use Official WPT agent instances to test your websites
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release incubator/webpagetest-server
+```
+
+The command deploys WebPageTest on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+Please note the default install probably won't do much without some configuration of the values.yaml file
+
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the WordPress chart and their default values.
+
+| Parameter                            | Description                                | Default                                                    |
+| -------------------------------      | -------------------------------            | ---------------------------------------------------------- |
+| `image`                              | WebPageTest server image                   | `webpagetest/server:{VERSION}`                              |
+| `imagePullPolicy`                    | Image pull policy                          | `IfNotPresent`                                             |
+| `ec2Locations.enabled`               | Enables use of EC2 AMI's                   | `false`                                                     |
+| `ec2Locations.userData`              | Data Structure which is used to generate settings | sample data only                                    |
+| `ec2Locations.userData.ec2_key`      | EC2 API key with create permissions        | `nil`                                                      |
+| `ec2Locations.userData.ec2_secret`   | Secret portion of the above key            | `nil`                                                      |
+| `ec2Locations.userData.headless`     | API Only Flag, 0=has user UI               | `0`                                                        |
+| `ec2Locations.userData.'EC2.default'`| default testing location when using AMI's  | `eu-west-1`                                                |
+| `serviceType`                        | Kubernetes Service type                    | `LoadBalancer`                                             |
+| `healthcheckHttps`                   | Use https for liveliness and readiness     | `false`                                                    |
+| `ingress.enabled`                    | Enable ingress controller resource         | `false`                                                    |
+| `ingress.hosts.[0]`                  | host header for access                     | `web-page-test.local`                                      |
+| `ingress.hosts.annotations`          | Annotations for the host's ingress records | `[]`                                                       |
+| `ingress.tls`                        | Utilize TLS backend in ingress             | `false`                                                    |
+| `ingress.tls.[0].secretName`         | TLS Secret (certificates) name             | `web-page-test.local-tls`                                  |
+| `ingress.tls.[0].hosts`              | host headers to get ssl certs for          | `[web-page-test.local]`                                    |
+| `agentIngress.*`                     | As ingress above, but used for WPT agents  | `false`                                                    |
+| `nodeSelector`                       | Node labels for pod assignment             | `{}`                                                       |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+  --set ingress.enabled=true,ingress.hosts.[0]=web-page-test.local \
+    incubator/webpagetest-server
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml incubator/webpagetest-server
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+
+## Ingress(es)
+
+This chart provides support for ingress resources. If you have an
+ingress controller installed on your cluster, such as [nginx-ingress](https://kubeapps.com/charts/stable/nginx-ingress)
+or [traefik](https://kubeapps.com/charts/stable/traefik) you can utilize
+the ingress controller to service your WordPress application.
+
+To enable ingress integration, please set `ingress.enabled` to `true`
+
+### Hosts
+Most likely you will only want to have one hostname that maps to this
+WebPageTest installation for scripts or end users to interact, then a
+seperate instance for the AMI's to operate on (see AgentIngress below).
+It is however possible to have more than one host.
+To facilitate this, the `ingress.hosts` object is an array.
+
+For each item, please indicate a `name`, `tls`, `tlsSecret`, and any
+`annotations` that you may want the ingress controller to know about.
+
+Indicating TLS will cause WebPageTest generate HTTPS urls, and
+WebPageTest will be connected to at port 443.  The actual secret that
+`tlsSecret` references does not have to be generated by this chart.
+However, please note that if TLS is enabled, the ingress record will not
+work until this secret exists.
+
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md).
+Not all annotations are supported by all ingress controllers, but this
+document does a good job of indicating which annotation is supported by
+many popular ingress controllers.
+
+
+### TLS Secrets
+This chart will facilitate the creation of TLS secrets for use with the
+ingress controller, however this is not required.  There are three
+common use cases:
+
+* helm generates / manages certificate secrets
+* user generates / manages certificates separately
+* an additional tool (like [kube-lego](https://kubeapps.com/charts/stable/kube-lego))
+manages the secrets for the application
+
+In the first two cases, one will need a certificate and a key.  We would
+expect them to look like this:
+
+* certificate files should look like (and there can be more than one
+certificate if there is a certificate chain)
+
+```
+-----BEGIN CERTIFICATE-----
+MIID6TCCAtGgAwIBAgIJAIaCwivkeB5EMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
+...
+jScrvkiBO65F46KioCL9h5tDvomdU1aqpI/CBzhvZn1c0ZTf87tGQR8NK7v7
+-----END CERTIFICATE-----
+```
+* keys should look like:
+```
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAvLYcyu8f3skuRyUgeeNpeDvYBCDcgq+LsWap6zbX5f8oLqp4
+...
+wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
+-----END RSA PRIVATE KEY-----
+````
+
+If you are going to use helm to manage the certificates, please copy
+these values into the `certificate` and `key` values for a given
+`ingress.secrets` entry.
+
+If you are going are going to manage TLS secrets outside of helm, please
+know that you can create a TLS secret by doing the following:
+
+```
+kubectl create secret tls web-page-test.local-tls --key /path/to/key.key --cert /path/to/cert.crt
+```
+
+Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls)
+for more information.
+
+## AgentIngress
+Generally speaking WebPageTest is difficult to secure / restrict access. In creating this chart the design is that
+a user would use the ingress listed above. The ingress above would have appropriate access restrictions using either
+whitelisted IP's, http basic auth or both.
+This however would block access to the agents without significant additional config. Agents in a remote region would
+probably need a region to region VPN to get access. Rather thn doing that we create a second host header and restrict
+the url path to /work, /cron and /jpeginfo. The agents use /work and the server connects to itself on /cron and
+/jpeginfo. This way 3rd parties do not have access to create tests, but any host (with the correct keys) can get work
+units and post results.
+
+## ec2Locations.userData
+All of the content within here is provided to the init scripting used to provision the server. It is used by the same
+processing which configures AMI's. Generally it's parsed to create key value pairs for settings.ini.
+Please any key which contains a dot should be quoted so it is not interpreted by k8s which uses '.' for its data structure
+eg EC2.default should be
+```
+ec2Locations:
+  userData:
+    'EC2.default':  'eu-west-1'
+```
+which is ```ec2Locations.userData.'EC2.default':'eu-west-1'```
+
+rather than
+```
+ec2Locations:
+  userData:
+    EC2.default:  'eu-west-1'
+```
+which is ```ec2Locations.userData.EC2.default:'eu-west-1'```
+or the same as
+```
+ec2Locations:
+  userData:
+    EC2:
+      default:  'eu-west-1'
+```
+For a complete list of these you will need to look at the WebPageTest Docs.
+Ones to note are
+```
+; archiving to s3 (using the s3 protocol, not necessarily just s3)
+;archive_s3_server=s3.amazonaws.com
+;archive_s3_key=<access key>
+;archive_s3_secret=<secret>
+;archive_s3_bucket=<bucket>
+;archive_s3_url=http://s3.amazonaws.com/
+```
+
+## Future
+Add persistant storage to buffer content between runs and s3 archiving

--- a/incubator/webpagetest-server/README.md
+++ b/incubator/webpagetest-server/README.md
@@ -44,7 +44,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the WordPress chart and their default values.
+The following tables lists the configurable parameters of the WebPageTest chart and their default values.
 
 | Parameter                            | Description                                | Default                                                    |
 | -------------------------------      | -------------------------------            | ---------------------------------------------------------- |
@@ -90,7 +90,7 @@ $ helm install --name my-release -f values.yaml incubator/webpagetest-server
 This chart provides support for ingress resources. If you have an
 ingress controller installed on your cluster, such as [nginx-ingress](https://kubeapps.com/charts/stable/nginx-ingress)
 or [traefik](https://kubeapps.com/charts/stable/traefik) you can utilize
-the ingress controller to service your WordPress application.
+the ingress controller to service your WebPageTest application.
 
 To enable ingress integration, please set `ingress.enabled` to `true`
 

--- a/incubator/webpagetest-server/README.md
+++ b/incubator/webpagetest-server/README.md
@@ -1,4 +1,4 @@
-# WebPageTest
+# WebPageTest Server
 
 [WebPageTest](https://webpagetest.org/) is a website testing tool
 

--- a/incubator/webpagetest-server/README.md
+++ b/incubator/webpagetest-server/README.md
@@ -210,5 +210,4 @@ Ones to note are
 ```
 
 ## Future
-* Add persistant storage to buffer content between runs and s3 archiving
 * Add options for 'locations.ini' from configmap so you can use other agents

--- a/incubator/webpagetest-server/templates/NOTES.txt
+++ b/incubator/webpagetest-server/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.hostname }}
+  http://{{- .Values.ingress.hostname }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
+{{- end }}

--- a/incubator/webpagetest-server/templates/NOTES.txt
+++ b/incubator/webpagetest-server/templates/NOTES.txt
@@ -2,16 +2,16 @@
 {{- if .Values.ingress.hostname }}
   http://{{- .Values.ingress.hostname }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "webpagetest.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "webpagetest.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "webpagetest.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "webpagetest.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
 {{- end }}

--- a/incubator/webpagetest-server/templates/_helpers.tpl
+++ b/incubator/webpagetest-server/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/webpagetest-server/templates/_helpers.tpl
+++ b/incubator/webpagetest-server/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "webpagetest.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "webpagetest.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/incubator/webpagetest-server/templates/agentIngress.yaml
+++ b/incubator/webpagetest-server/templates/agentIngress.yaml
@@ -6,9 +6,9 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}-agent
+  name: {{ template "webpagetest.fullname" . }}-agent
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "webpagetest.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/incubator/webpagetest-server/templates/agentIngress.yaml
+++ b/incubator/webpagetest-server/templates/agentIngress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.agentIngress.enabled -}}
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $rejectSvcName := .Values.agentIngress.rejectServiceName -}}
+{{- $rejectSvcPort := .Values.agentIngress.rejectServicePort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}-agent
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.agentIngress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.agentIngress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $rejectSvcName }}
+              servicePort: {{ $rejectSvcPort }}
+          - path: /work
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+          - path: /cron
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+          - path: /jpeginfo
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.agentIngress.tls }}
+  tls:
+{{ toYaml .Values.agentIngress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/incubator/webpagetest-server/templates/deployment.yaml
+++ b/incubator/webpagetest-server/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "webpagetest.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "webpagetest.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "webpagetest.name" . }}
         release: {{ .Release.Name }}
     spec:
       containers:
@@ -59,5 +59,5 @@ spec:
       {{- if .Values.persistence.enabled }}
       - name: wpt-local-archive
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
+          claimName: {{ template "webpagetest.fullname" . }}
       {{- end }}

--- a/incubator/webpagetest-server/templates/deployment.yaml
+++ b/incubator/webpagetest-server/templates/deployment.yaml
@@ -31,23 +31,33 @@ spec:
               port: {{ .Values.service.internalPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-        {{- if .Values.ec2Locations.enabled }}
           env:
+          {{- if .Values.ec2Locations.enabled }}
           - name: EC2_INIT
             value: 'true'
+          {{- end }}
           volumeMounts:
+          {{- if .Values.ec2Locations.enabled }}
           - name: wpt-user-data
             mountPath: /user-data
             readOnly: true
-#            subPath: user-data
-        {{- end }}
+          {{- end }}
+          {{- if .Values.persistence.enabled }}
+          - name: wpt-local-archive
+            mountPath: /data/archive
+          {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
-      {{- if .Values.ec2Locations.enabled }}
       volumes:
+      {{- if .Values.ec2Locations.enabled }}
       - name: wpt-user-data
         secret:
           secretName: {{ printf "%s-%s" .Release.Name "user-data"  }}
+      {{- end }}
+      {{- if .Values.persistence.enabled }}
+      - name: wpt-local-archive
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}
       {{- end }}

--- a/incubator/webpagetest-server/templates/deployment.yaml
+++ b/incubator/webpagetest-server/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.internalPort }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        {{- if .Values.ec2Locations.enabled }}
+          env:
+          - name: EC2_INIT
+            value: 'true'
+          volumeMounts:
+          - name: wpt-user-data
+            mountPath: /user-data
+            readOnly: true
+#            subPath: user-data
+        {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      {{- if .Values.ec2Locations.enabled }}
+      volumes:
+      - name: wpt-user-data
+        secret:
+          secretName: {{ printf "%s-%s" .Release.Name "user-data"  }}
+      {{- end }}

--- a/incubator/webpagetest-server/templates/deployment.yaml
+++ b/incubator/webpagetest-server/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "webpagetest.fullname" . }}
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "webpagetest.name" . }}
   template:
     metadata:
       labels:
@@ -54,7 +57,11 @@ spec:
       {{- if .Values.ec2Locations.enabled }}
       - name: wpt-user-data
         secret:
+        {{- if not .Values.ec2Locations.customUserDataSecret }}
           secretName: {{ printf "%s-%s" .Release.Name "user-data"  }}
+        {{ else }}
+          secretName: {{ .Values.ec2Locations.customUserDataSecret }}
+        {{- end }}
       {{- end }}
       {{- if .Values.persistence.enabled }}
       - name: wpt-local-archive

--- a/incubator/webpagetest-server/templates/ingress.yaml
+++ b/incubator/webpagetest-server/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/incubator/webpagetest-server/templates/ingress.yaml
+++ b/incubator/webpagetest-server/templates/ingress.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "fullname" . -}}
+{{- $serviceName := include "webpagetest.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "webpagetest.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "webpagetest.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/incubator/webpagetest-server/templates/pvc.yaml
+++ b/incubator/webpagetest-server/templates/pvc.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.persistence.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/incubator/webpagetest-server/templates/pvc.yaml
+++ b/incubator/webpagetest-server/templates/pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "webpagetest.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "webpagetest.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/incubator/webpagetest-server/templates/secrets-user-details.yaml
+++ b/incubator/webpagetest-server/templates/secrets-user-details.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ec2Locations.enabled }}
+{{- if not .Values.ec2Locations.customUserDataSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -34,4 +35,5 @@ data:
 {{- end }}
 
 
+{{- end }}
 {{- end }}

--- a/incubator/webpagetest-server/templates/secrets-user-details.yaml
+++ b/incubator/webpagetest-server/templates/secrets-user-details.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ec2Locations.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "user-data"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "user-data"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  ec2_locations: {{ "1"  | toString | b64enc | quote }}
+  ec2: {{ "1"  | toString | b64enc | quote }}
+{{- if .Values.agentIngress.enabled }}
+  {{- range $host := .Values.agentIngress.hosts }}
+  host: {{ $host | toString | b64enc | quote }}
+  {{- end }}
+{{- else }}
+
+{{- if .Values.ingress.enabled -}}
+  {{- range $host := .Values.ingress.hosts }}
+  host: {{ $host | toString | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- range $name, $value := .Values.ec2Locations.userData }}
+{{- if not (empty $value) }}
+{{- if not (eq $name "enabled") }}
+  {{ $name }}: {{ $value  | toString | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{- end }}

--- a/incubator/webpagetest-server/templates/service.yaml
+++ b/incubator/webpagetest-server/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/webpagetest-server/templates/service.yaml
+++ b/incubator/webpagetest-server/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "webpagetest.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "webpagetest.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -15,5 +15,5 @@ spec:
       protocol: TCP
       name: {{ .Values.service.name }}
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "webpagetest.name" . }}
     release: {{ .Release.Name }}

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -44,6 +44,23 @@ agentIngress:
     - secretName: agent-web-page-test.local-tls
       hosts:
         - agent-web-page-test.local
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  ## wordpress data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 image:
-  repository: webpagetest/server
-  tag: latest
+  repository: timothyclarke/wptserver
+  tag: 2018-01-12
   pullPolicy: IfNotPresent
 service:
   name: webpagetest-server

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: webpagetest/server
-  tag: release
+  tag: latest
   pullPolicy: IfNotPresent
 service:
   name: webpagetest-server

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -1,0 +1,68 @@
+# Default values for wpt-test.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: webpagetest/server
+  tag: release
+  pullPolicy: IfNotPresent
+service:
+  name: webpagetest-server
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 80
+
+# Front end for users.
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - web-page-test.local
+  # It's best to add annotations to restrict who can access
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # ingress.kubernetes.io/force-ssl-redirect: "true"
+    # ingress.kubernetes.io/whitelist-source-range: '127.0.0.1/32,192.168.0.0/24'
+  tls:
+    # Secrets must be manually created in the namespace.
+    - secretName: web-page-test.local-tls
+      hosts:
+        - web-page-test.local
+
+# Front end for agents to collect their work from. This one will probably be wide open so agents can collect their work
+agentIngress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - agent-web-page-test.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    - secretName: agent-web-page-test.local-tls
+      hosts:
+        - agent-web-page-test.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  #requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+
+ec2Locations:
+  # This enables ec2 setup and locations
+  enabled: false
+  # Used to create k8s secrets which will in turn be used to configure WPT. See README.md
+  userData:
+    ec2_key:        ''
+    ec2_secret:     ''
+    headless:       0
+    'EC2.default':  'eu-west-1'

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -52,7 +52,7 @@ resources: {}
   # limits:
   #  cpu: 100m
   #  memory: 128Mi
-  #requests:
+  # requests:
   #  cpu: 100m
   #  memory: 128Mi
 
@@ -62,7 +62,7 @@ ec2Locations:
   enabled: false
   # Used to create k8s secrets which will in turn be used to configure WPT. See README.md
   userData:
-    ec2_key:        ''
-    ec2_secret:     ''
-    headless:       0
-    'EC2.default':  'eu-west-1'
+    ec2_key: ''
+    ec2_secret: ''
+    headless: 0
+    'EC2.default': 'eu-west-1'

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -78,7 +78,9 @@ resources: {}
 ec2Locations:
   # This enables ec2 setup and locations
   enabled: false
-  # Used to create k8s secrets which will in turn be used to configure WPT. See README.md
+  # Create secret from the data below, or use custom name instead. See README.md
+  customUserDataSecret: false
+  # Content of the secret
   userData:
     ec2_key: ''
     ec2_secret: ''

--- a/incubator/webpagetest-server/values.yaml
+++ b/incubator/webpagetest-server/values.yaml
@@ -50,7 +50,8 @@ agentIngress:
 ##
 persistence:
   enabled: true
-  ## wordpress data Persistent Volume Storage Class
+  ## Used to store test reports.
+  ## Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is


### PR DESCRIPTION
This one currently relies on [WPO-Foundation/webpagetest PR#1071](https://github.com/WPO-Foundation/webpagetest/pull/1071/)

This is to run a webpagetest server instance in an existing k8s cluster. That server instance can spawn AMI's to run tests against the desired url