### PR TITLE
Bump CockroachDB chart's version and other small improvements to it

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.5.3
+version: 0.5.4
 appVersion: 1.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.5.2
-appVersion: 1.1.0
+version: 0.5.3
+appVersion: 1.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.5.1
+version: 0.5.2
 appVersion: 1.1.0
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -31,23 +31,25 @@ helm install --name my-release incubator/cockroachdb
 
 The following tables lists the configurable parameters of the CockroachDB chart and their default values.
 
-| Parameter               | Description                        | Default                                                    |
-| ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
-| `Name`                  | Chart name                         | `cockroachdb`                                              |
-| `Image`                 | Container image name               | `cockroachdb/cockroach`                                    |
-| `ImageTag`              | Container image tag                | `v1.0`                                                     |
-| `ImagePullPolicy`       | Container pull policy              | `Always`                                                   |
-| `Replicas`              | k8s statefulset replicas           | `3`                                                        |
-| `MinAvailable`          | k8s PodDisruptionBudget parameter  | `67%`                                                      |
-| `Component`             | k8s selector key                   | `cockroachdb`                                              |
-| `GrpcPort`              | CockroachDB primary serving port   | `26257`                                                    |
-| `HttpPort`              | CockroachDB HTTP port              | `8080`                                                     |
-| `Cpu`                   | Container requested cpu            | `100m`                                                     |
-| `Memory`                | Container requested memory         | `512Mi`                                                    |
-| `Storage`               | Persistent volume size             | `1Gi`                                                      |
-| `StorageClass`          | Persistent volume class            | `anything`                                                 |
-| `ClusterDomain`         | Cluster's default DNS domain       | `cluster.local`                                            |
-| `NetworkPolicy.Enabled` | Enable NetworkPolicy               | `false`                                                    |
+| Parameter                     | Description                                | Default                                      |
+| ----------------------------- | ------------------------------------------ | -------------------------------------------- |
+| `Name`                        | Chart name                                 | `cockroachdb`                                |
+| `Image`                       | Container image name                       | `cockroachdb/cockroach`                      |
+| `ImageTag`                    | Container image tag                        | `v1.0`                                       |
+| `ImagePullPolicy`             | Container pull policy                      | `Always`                                     |
+| `Replicas`                    | k8s statefulset replicas                   | `3`                                          |
+| `MinAvailable`                | k8s PodDisruptionBudget parameter          | `67%`                                        |
+| `Component`                   | k8s selector key                           | `cockroachdb`                                |
+| `GrpcPort`                    | CockroachDB primary serving port           | `26257`                                      |
+| `HttpPort`                    | CockroachDB HTTP port                      | `8080`                                       |
+| `Cpu`                         | Container requested cpu                    | `100m`                                       |
+| `Memory`                      | Container requested memory                 | `512Mi`                                      |
+| `Storage`                     | Persistent volume size                     | `1Gi`                                        |
+| `StorageClass`                | Persistent volume class                    | `anything`                                   |
+| `CacheSize`                   | Size of CockroachDB's in-memory cache      | `25%`                                        |
+| `MaxSQLMemory`                | Max memory to use processing SQL queries   | `25%`                                        |
+| `ClusterDomain`               | Cluster's default DNS domain               | `cluster.local`                              |
+| `NetworkPolicy.Enabled`       | Enable NetworkPolicy                       | `false`                                      |
 | `NetworkPolicy.AllowExternal` | Don't require client label for connections | `true`                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -1,7 +1,8 @@
 # CockroachDB Helm Chart
 
 ## Prerequisites Details
-* Kubernetes 1.5 (for StatefulSet support)
+* Kubernetes 1.7 (for PodDisruptionBudget `MaxUnavailable` support -- you can
+  run at Kubernetes 1.5 if you don't care about the PodDisruptionBudget)
 * PV support on the underlying infrastructure
 
 ## StatefulSet Details
@@ -38,7 +39,7 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | `ImageTag`                    | Container image tag                        | `v1.0`                                       |
 | `ImagePullPolicy`             | Container pull policy                      | `Always`                                     |
 | `Replicas`                    | k8s statefulset replicas                   | `3`                                          |
-| `MinAvailable`                | k8s PodDisruptionBudget parameter          | `67%`                                        |
+| `MaxUnavailable`              | k8s PodDisruptionBudget parameter          | `1`                                          |
 | `Component`                   | k8s selector key                           | `cockroachdb`                                |
 | `GrpcPort`                    | CockroachDB primary serving port           | `26257`                                      |
 | `HttpPort`                    | CockroachDB HTTP port                      | `8080`                                       |

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -153,7 +153,7 @@ spec:
           - |
             # The use of qualified `hostname -f` is crucial:
             # Other nodes aren't able to look up the unqualified hostname.
-            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0")
+            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0" "--cache" "{{ .Values.CacheSize }}" "--max-sql-memory" "{{ .Values.MaxSQLMemory }}")
             # We only want to initialize a new cluster (by omitting the join flag)
             # if we're sure that we're the first node (i.e. index 0) and that
             # there aren't any other nodes running as part of the cluster that

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
   selector:
     matchLabels:
       component: "{{ .Release.Name }}-{{ .Values.Component }}"
-  minAvailable: {{ .Values.MinAvailable }}
+  maxUnavailable: {{ .Values.MaxUnavailable }}
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -5,7 +5,7 @@
 
 Name: "cockroachdb"
 Image: "cockroachdb/cockroach"
-ImageTag: "v1.1.0"
+ImageTag: "v1.1.3"
 ImagePullPolicy: "Always"
 BootstrapImage: "cockroachdb/cockroach-k8s-init"
 BootstrapImageTag: "0.2"

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -10,7 +10,7 @@ ImagePullPolicy: "Always"
 BootstrapImage: "cockroachdb/cockroach-k8s-init"
 BootstrapImageTag: "0.2"
 Replicas: 3
-MinAvailable: "67%"
+MaxUnavailable: 1
 Component: "cockroachdb"
 GrpcPort: 26257
 HttpPort: 8080

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -20,6 +20,8 @@ Resources:
     memory: "512Mi"
 Storage: "1Gi"
 StorageClass: "anything"
+CacheSize: "25%"
+MaxSQLMemory: "25%"
 ClusterDomain: "cluster.local"
 NetworkPolicy:
   Enabled: false


### PR DESCRIPTION
All changes tested locally on minikube.

**Add options for configuring cache and SQL memory to CockroachDB chart**

**Bump CockroachDB version to v1.1.3**

**Improve CockroachDB's PodDisruptionBudget**

Letting only 1 go down is much safer and more accurately reflects the
desire of operators than allowing up to 33% to go down. It's
unfortunate that this bumps the minimum version by so much, but 1.7 is a
full two releases ago.