### PR TITLE
[stable/sumologic-fluentd] Update env variables

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.2.0
+version: 0.2.1
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -89,7 +89,7 @@ The following tables lists the configurable parameters of the sumologic-fluentd 
 | `sumologic.concatSeparator` | The character to use to delimit lines within the final concatenated message. Most multi-line messages contain a newline at the end of each line | `Nil` |
 | `sumologic.auditLogPath` | Define the path to the [Kubernetes Audit Log](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) | `/mnt/log/kube-apiserver-audit.log` |
 | `image.name` | The image repository and name to pull from | `sumologic/fluentd-kubernetes-sumologic` |
-| `image.tag` | The image tag to pull | `latest` |
+| `image.tag` | The image tag to pull | `v1.6` |
 | `imagePullPolicy` | Image pull policy | `IfNotPresent` |
 | `persistence.enabled` | Boolean value, used to turn on or off fluentd position file persistence, on nodes | `false` |
 | `persistence.hostPath` | The path, on each node, to a directory for fluentd pos files. You must create the directory on each node first. | `/var/run/fluentd-pos` |

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -64,9 +64,11 @@ The following tables lists the configurable parameters of the sumologic-fluentd 
 | `updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.6) | `OnDelete` |
 | `sumologic.collectorUrl` | An HTTP collector in SumoLogic that the container can send logs to via HTTP | `Nil` You must provide your own |
 | `sumologic.fluentdSource` | The fluentd input source, `file` or `systemd` | `file` |
+| `sumologic.fluentdUserConfigDir` | A directory of user-defined fluentd configuration files, which must be in the `*.conf` directory in the container | `/fluentd/conf.d/user` |
 | `sumologic.flushInterval` | How frequently to push logs to sumo, in seconds | `5` |
 | `sumologic.numThreads` | The number of http threads sending data to sumo | `1` |
 | `sumologic.sourceName` | Set the sumo `_sourceName` | `%{namespace}.%{pod}.%{container}` |
+| `sumologic.sourceHost` | Set the sumo `_sourceHost` | `Nil` |
 | `sumologic.sourceCategory` | Set the sumo `_sourceCategory` | `%{namespace}/%{pod_name}` |
 | `sumologic.sourceCategoryPrefix` | Define a prefix, for `_sourceCategory` | `Nil` |
 | `sumologic.sourceCategoryReplaceDash` | Used to replace `-` with another character | `/` |
@@ -82,6 +84,10 @@ The following tables lists the configurable parameters of the sumologic-fluentd 
 | `sumologic.excludeUnitRegex` | All matching systemd units will not be sent to sumo | `Nil` |
 | `sumologic.fluentdOpt` | Additional command line options, sent to fluentd | `Nil` |
 | `sumologic.verifySsl` | Verify SumoLogic HTTPS certificates | `true` |
+| `sumologic.multilineStartRegexp` | The regular expression for the `concat` plugin to use when merging multi-line messages | `/^\w{3} \d{1,2}, \d{4}/`, i.e. Julian dates |
+| `sumologic.readFromHead` | Start to read the logs from the head of file, not bottom. Only applies to containers log files. See in_tail doc for more information | `true` |
+| `sumologic.concatSeparator` | The character to use to delimit lines within the final concatenated message. Most multi-line messages contain a newline at the end of each line | `Nil` |
+| `sumologic.auditLogPath` | Define the path to the [Kubernetes Audit Log](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) | `/mnt/log/kube-apiserver-audit.log` |
 | `image.name` | The image repository and name to pull from | `sumologic/fluentd-kubernetes-sumologic` |
 | `image.tag` | The image tag to pull | `latest` |
 | `imagePullPolicy` | Image pull policy | `IfNotPresent` |

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -86,7 +86,7 @@ spec:
             - name: LOG_FORMAT
               value: {{ quote .Values.sumologic.logFormat }}
             {{- end }}
-            {{- if .Values.sumologic.kubernetesMeta }}
+            {{- if quote .Values.sumologic.kubernetesMeta }}
             - name: KUBERNETES_META
               value: {{ quote .Values.sumologic.kubernetesMeta }}
             {{- end }}
@@ -126,7 +126,7 @@ spec:
             - name: FLUENTD_OPT
               value: {{ quote .Values.sumologic.fluentdOpt }}
             {{- end }}
-            {{- if .Values.sumologic.verifySsl }}
+            {{- if quote .Values.sumologic.verifySsl }}
             - name: VERIFY_SSL
               value: {{ quote .Values.sumologic.verifySsl }}
             {{- end }}
@@ -134,7 +134,7 @@ spec:
             - name: MULTILINE_START_REGEXP
               value: {{ quote .Values.sumologic.multilineStartRegexp }}
             {{- end }}
-            {{- if .Values.sumologic.readFromHead }}
+            {{- if quote .Values.sumologic.readFromHead }}
             - name: READ_FROM_HEAD
               value: {{ quote .Values.sumologic.readFromHead }}
             {{- end }}

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -50,6 +50,10 @@ spec:
                   key: collector-url
             - name: FLUENTD_SOURCE
               value: {{ quote .Values.sumologic.fluentdSource }}
+            {{- if .Values.sumologic.fluentdUserConfigDir }}
+            - name: FLUENTD_USER_CONFIG_DIR
+              value: {{ quote .Values.sumologic.fluentdUserConfigDir }}
+            {{- end }}
             {{- if .Values.sumologic.flushInterval }}
             - name: FLUSH_INTERVAL
               value: {{ quote .Values.sumologic.flushInterval }}
@@ -61,6 +65,10 @@ spec:
             {{- if .Values.sumologic.sourceName }}
             - name: SOURCE_NAME
               value: {{ quote .Values.sumologic.sourceName }}
+            {{- end }}
+            {{- if .Values.sumologic.sourceHost }}
+            - name: SOURCE_HOST
+              value: {{ quote .Values.sumologic.sourceHost }}
             {{- end }}
             {{- if .Values.sumologic.sourceCategory }}
             - name: SOURCE_CATEGORY
@@ -121,6 +129,22 @@ spec:
             {{- if .Values.sumologic.verifySsl }}
             - name: VERIFY_SSL
               value: {{ quote .Values.sumologic.verifySsl }}
+            {{- end }}
+            {{- if .Values.sumologic.multilineStartRegexp }}
+            - name: MULTILINE_START_REGEXP
+              value: {{ quote .Values.sumologic.multilineStartRegexp }}
+            {{- end }}
+            {{- if .Values.sumologic.readFromHead }}
+            - name: READ_FROM_HEAD
+              value: {{ quote .Values.sumologic.readFromHead }}
+            {{- end }}
+            {{- if .Values.sumologic.concatSeparator }}
+            - name: CONCAT_SEPARATOR
+              value: {{ quote .Values.sumologic.concatSeparator }}
+            {{- end }}
+            {{- if .Values.sumologic.auditLogPath }}
+            - name: AUDIT_LOG_PATH
+              value: {{ quote .Values.sumologic.auditLogPath }}
             {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       volumes:

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for sumologic-fluentd.
 image:
   name: sumologic/fluentd-kubernetes-sumologic
-  tag: v1.4
+  tag: v1.6
   pullPolicy: IfNotPresent
 
 ## Annotations to add to the DaemonSet's Pods

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -58,7 +58,7 @@ sumologic:
   ## Include or exclude Kubernetes metadata such as namespace and pod_name if
   ## using json log format. (default true)
   kubernetesMeta: true
-  
+
   ## A ruby regex for containers. All matching containers will be excluded
   ## from Sumo Logic. The logs will still be sent to FluentD
   ## ref: http://rubular.com/
@@ -87,20 +87,20 @@ sumologic:
   ## ref: http://rubular.com/
   excludePodRegex: ""
 
-  ## A ruby regex for systemd units. All matching facilities will be excluded from 
+  ## A ruby regex for systemd units. All matching facilities will be excluded from
   ## Sumo Logic. The logs will still be sent to FluentD
   ## ref: http://rubular.com/
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
   excludeFacilityRegex: ""
-  
+
   ## A ruby regex for syslog priorities, which are integers represented as
-  ## strings. All matching priorities will be excluded from 
+  ## strings. All matching priorities will be excluded from
   ## Sumo Logic. The logs will still be sent to FluentD
   ## ref: http://rubular.com/
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
   excludePriorityRegex: ""
 
-  ## A ruby regex for systemd units. All matching hosts will be excluded from 
+  ## A ruby regex for systemd units. All matching hosts will be excluded from
   ## Sumo Logic. The logs will still be sent to FluentD
   ## ref: http://rubular.com/
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
@@ -150,4 +150,3 @@ rbac:
 
   ## Ignored if rbac.create is true
   serviceAccountName: default
-

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -26,6 +26,10 @@ sumologic:
   ## The source of fluentd logs, either file or systemd
   fluentdSource: file
 
+  ## A directory of user-defined fluentd configuration files, which must be in the "*.conf" directory
+  ## in the container (Default "/fluentd/conf.d/user")
+  fluentdUserConfigDir: ""
+
   ## How frequently to push logs to SumoLogic (default 5s)
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
   # flushInterval: 5
@@ -35,6 +39,9 @@ sumologic:
 
   ## Set the _sourceName metadata field in SumoLogic. (Default "%{namespace}.%{pod}.%{container}")
   sourceName: ""
+
+  ## Set the _sourceHost metadata field in SumoLogic. (Default Nil)
+  sourceHost: ""
 
   ## Set the _sourceCategory metadata field in SumoLogic. (Default "%{namespace}/%{pod_name}")
   sourceCategory: ""
@@ -102,6 +109,25 @@ sumologic:
   ## Fluentd command line options
   ## ref: http://docs.fluentd.org/v0.12/articles/command-line-option
   fluentdOpt: ""
+
+  ## Verify SumoLogic HTTPS certificates (Default true)
+  verifySsl: true
+
+  ## The regular expression for the "concat" plugin to use when merging multi-line messages
+  ## (Default "/^\w{3} \d{1,2}, \d{4}/", i.e. Julian dates)
+  multilineStartRegexp: ""
+
+  ## Start to read the logs from the head of file, not bottom.
+  ## Only applies to containers log files. See in_tail doc for more information (Default true)
+  readFromHead: true
+
+  ## The character to use to delimit lines within the final concatenated message.
+  ## Most multi-line messages contain a newline at the end of each line (Default Nil)
+  concatSeparator: ""
+
+  ## Define the path to the Kubernetes Audit Log (Default "/mnt/log/kube-apiserver-audit.log")
+  ## ref: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/
+  auditLogPath: ""
 
 ## By default, the daemonset will store position files, for logs tailed, in an
 ## emptyDir. If you have a directory, on the host, to store pos files, specify


### PR DESCRIPTION
@frankreno

Brings the Sumologic-Fluentd chart daemonset environment variables up to date with the image's capabilities (see a6ab82e), and adds the default values to `values.yaml` (see b40feae).

ENV variables added:
- `FLUENTD_USER_CONFIG_DIR`
- `SOURCE_HOST`
- `MULTILINE_START_REGEXP`
- `READ_FROM_HEAD`
- `CONCAT_SEPARATOR`
- `AUDIT_LOG_PATH`

Also updates the default image version to `1.6` (see e01123c), and fixes a bug where any boolean environment variables could not be set to `false` via command line (see b2fdbff).


