### PR TITLE
[incubator/jaeger] Improve the Jaeger chart

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.8.0
+appVersion: 1.0.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.2.4
+version: 0.3.0
 keywords:
   - jaeger
   - opentracing
@@ -15,3 +15,7 @@ sources:
 maintainers:
   - name: dvonthenen
     email: david.vonthenen@dell.com
+  - name: mikelorant
+    email: michael.lorant@fairfaxmedia.com.au
+  - name: pavelnikolov
+    email: pavel.nikolov@fairfaxmedia.com.au

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -4,11 +4,14 @@
 
 ## Introduction
 
-This chart adds all components required to run Jaeger as described in the [jaeger-kubernetes](https://github.com/jaegertracing/jaeger-kubernetes) GitHub page for a production-like deployment. The chart default will deploy a new Cassandra cluster, but also supports using an existing Cassandra cluster, deploying a new ElasticSearch cluster, or connecting to an existing ElasticSearch cluster. Once the back storage available, the chart will deploy jaeger-agent as a DaemonSet and deploy the jaeger-collector and jaeger-query components as standard individual deployments.
+This chart adds all components required to run Jaeger as described in the [jaeger-kubernetes](https://github.com/jaegertracing/jaeger-kubernetes) GitHub page for a production-like deployment. The chart default will deploy a new Cassandra cluster (using the [cassandra chart](https://github.com/kubernetes/charts/tree/master/incubator/cassandra)), but also supports using an existing Cassandra cluster, deploying a new ElasticSearch cluster (using the [elasticsearch chart](https://github.com/kubernetes/charts/tree/master/incubator/elasticsearch)), or connecting to an existing ElasticSearch cluster. Once the back storage available, the chart will deploy jaeger-agent as a DaemonSet and deploy the jaeger-collector and jaeger-query components as standard individual deployments.
 
 ## Prerequisites
 
 - Has been tested on Kubernetes 1.7+
+  - The `spark` cron job requires [K8s CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) support: 
+    > You need a working Kubernetes cluster at version >= 1.8 (for CronJob). For previous versions of cluster (< 1.8) you need to explicitly enable `batch/v2alpha1` API by passing `--runtime-config=batch/v2alpha1=true` to the API server ([see Turn on or off an API version for your cluster for more](https://kubernetes.io/docs/admin/cluster-management/#turn-on-or-off-an-api-version-for-your-cluster)).
+
 - The Cassandra chart calls out the following requirements (default) for a test environment (please see the important note in the installation section):
 ```
 resources:
@@ -83,10 +86,10 @@ helm install incubator/jaeger --name myrel --set cassandra.config.max_heap_size=
 
 ## Installing the Chart using an Existing Cassandra Cluster
 
-If you already have an existing running Cassandra cluster, you can configure the chart as follows to use it as your backing store (replace `cassandra` with whatever hostname the cluster has been configured with):
+If you already have an existing running Cassandra cluster, you can configure the chart as follows to use it as your backing store (make sure you replace `<HOST>`, `<PORT>`, etc with your values):
 
 ```bash
-helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=false --set cassandra.config.host=cassandra
+helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=false --set storage.cassandra.host=<HOST> --set storage.cassandra.port=<PORT> --set storage.cassandra.user=<USER> --set storage.cassandra.password=<PASSWORD> 
 ```
 
 > **Tip**: It is highly encouraged to run the Cassandra cluster with storage persistence.
@@ -96,7 +99,7 @@ helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags
 To install the chart with the release name `myrel` using a new ElasticSearch cluster instead of Cassandra (default), run the following command:
 
 ```bash
-$ helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=true
+$ helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=false  --set provisionDataStore.elasticsearch=true
 ```
 
 After a few minutes, you should see 2 ElasticSearch client nodes, 2 ElasticSearch data nodes, 3 ElasticSearch master nodes, a Jaeger DaemonSet, a Jaeger Collector, and a Jaeger Query (UI) pod deployed into your Kubernetes cluster.
@@ -105,13 +108,14 @@ After a few minutes, you should see 2 ElasticSearch client nodes, 2 ElasticSearc
 
 ## Installing the Chart using an Existing ElasticSearch Cluster
 
-If you already have an existing running ElasticSearch cluster, you can configure the chart as follows to use it as your backing store (replace `http://elasticsearch:9200` with whatever hostname the cluster has been configured with):
+If you already have an existing running ElasticSearch cluster, you can configure the chart as follows to use it as your backing store:
 
 ```bash
-helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=false --set elasticsearch.config.host=http://elasticsearch:9200
+helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=false --set provisionDataStore.elasticsearch=true --set storage.type=elasticsearch --set storage.elasticsearch.host=<HOST> --set storage.elasticsearch.port=<PORT> --set storage.elasticsearch.user=<USER> --set storage.elasticsearch.password=<password>
 ```
 
 > **Tip**: It is highly encouraged to run the ElasticSearch cluster with storage persistence.
+
 
 ## Uninstalling the Chart
 
@@ -129,54 +133,58 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Jaeger chart and their default values.
 
-|             Parameter             |            Description             |                  Default               |
-|-----------------------------------|------------------------------------|----------------------------------------|
-| `cassandra.image.tag`             | The image tag/version              |  3.11                                  |
-| `cassandra.persistence.enabled`   | To enable storage persistence      |  false (Highly recommended to enable)  |
-| `cassandra.config.host`           | Existing Cassandra hostname        |  ""                                    |
-| `cassandra.config.cluster_name`   | Cluster name                       |  jaeger                                |
-| `cassandra.config.seed_size`      | Seed size                          |  1                                     |
-| `cassandra.config.dc_name`        | Datacenter name                    |  dc1                                   |
-| `cassandra.config.rack_name`      | Rack name                          |  rack1                                 |
-| `cassandra.config.endpoint_snitch`| Node discovery method              |  GossipingPropertyFileSnitch           |
-| `elasticsearch.config.host`       | Existing ElasticSearch hostname    |  ""                                    |
-| `elasticsearch.config.username`   | Existing ElasticSearch username    |  "elastic"                             |
-| `elasticsearch.config.password`   | Existing ElasticSearch password    |  "changeme"                            |
-| `schema.annotations`              | Annotations for the schema job     |  nil                                   |
-| `schema.image`                    | Image to setup cassandra schema    |  jaegertracing/jaeger-cassandra-schema |
-| `schema.tag`                      | Image tag/version                  |  0.6                                   |
-| `schema.pullPolicy`               | Schema image pullPolicy            |  IfNotPresent                          |
-| `schema.mode`                     | Schema mode (prod or test)         |  prod                                  |
-| `agent.annotationsPod`            | Annotations for Agent              |  nil                                   |
-| `agent.image`                     | Image for Jaeger Agent             |  jaegertracing/jaeger-agent            |
-| `agent.tag`                       | Image tag/version                  |  0.6                                   |
-| `agent.pullPolicy`                | Agent image pullPolicy             |  IfNotPresent                          |
-| `agent.cmdlineParams`             | Additional command line parameters |  nil                                   |
-| `agent.annotationsSvc`            | Annotations for Agent SVC          |  nil                                   |
-| `agent.zipkinThriftPort`          | zipkin.thrift over compact thrift  |  5775                                  |
-| `agent.compactPort`               | jaeger.thrift over compact thrift  |  6831                                  |
-| `agent.binaryPort`                | jaeger.thrift over binary thrift   |  6832                                  |
-| `collector.annotationsPod`        | Annotations for Collector          |  nil                                   |
-| `collector.image`                 | Image for jaeger collector         |  jaegertracing/jaeger-collector        |
-| `collector.tag`                   | Image tag/version                  |  0.6                                   |
-| `collector.pullPolicy`            | Collector image pullPolicy         |  IfNotPresent                          |
-| `collector.cmdlineParams`         | Additional command line parameters |  nil                                   |
-| `collector.annotationsSvc`        | Annotations for Collector SVC      |  nil                                   |
-| `collector.type`                  | Service type                       |  ClusterIP                             |
-| `collector.tchannelPort`          | Jaeger Agent port for thrift       |  14267                                 |
-| `collector.httpPort`              | Client port for HTTP thrift        |  14268                                 |
-| `collector.zipkinPort`            | Zipkin port for JSON/thrift HTTP   |  9411                                  |
-| `query.annotationsPod`            | Annotations for Query UI           |  nil                                   |
-| `query.image`                     | Image for Jaeger Query UI          |  jaegertracing/jaeger-query            |
-| `query.tag`                       | Image tag/version                  |  0.6                                   |
-| `query.pullPolicy`                | Query UI image pullPolicy          |  IfNotPresent                          |
-| `query.cmdlineParams`             | Additional command line parameters |  nil                                   |
-| `query.annotationsSvc`            | Annotations for Query SVC          |  nil                                   |
-| `query.type`                      | Service type                       |  ClusterIP                             |
-| `query.queryPort`                 | External accessible port           |  80                                    |
-| `query.targetPort`                | Internal Query UI port             |  16686                                 |
-| `ingress.enabled`                 | Allow external traffic access      |  false                                 |
-|-----------------------------------|------------------------------------|----------------------------------------|
+|             Parameter              |            Description              |                  Default               |
+|------------------------------------|-------------------------------------|----------------------------------------|
+| `provisionDataStore.cassandra`     | Provision Cassandra Data Store      |  true                                  |
+| `provisionDataStore.elasticsearch` | Provision Elasticsearch Data Store  |  false                                 |
+| `agent.annotationsPod`             | Annotations for Agent               |  nil                                   |
+| `agent.annotationsSvc`             | Annotations for Agent SVC           |  nil                                   |
+| `agent.binaryPort`                 | jaeger.thrift over binary thrift    |  6832                                  |
+| `agent.cmdlineParams`              | Additional command line parameters  |  nil                                   |
+| `agent.compactPort`                | jaeger.thrift over compact thrift   |  6831                                  |
+| `agent.image`                      | Image for Jaeger Agent              |  jaegertracing/jaeger-agent            |
+| `agent.pullPolicy`                 | Agent image pullPolicy              |  IfNotPresent                          |
+| `agent.tag`                        | Image tag/version                   |  0.6                                   |
+| `agent.zipkinThriftPort`           | zipkin.thrift over compact thrift   |  5775                                  |
+| `cassandra.config.cluster_name`    | Cluster name                        |  jaeger                                |
+| `cassandra.config.dc_name`         | Datacenter name                     |  dc1                                   |
+| `cassandra.config.endpoint_snitch` | Node discovery method               |  GossipingPropertyFileSnitch           |
+| `cassandra.config.rack_name`       | Rack name                           |  rack1                                 |
+| `cassandra.config.seed_size`       | Seed size                           |  1                                     |
+| `cassandra.image.tag`              | The image tag/version               |  3.11                                  |
+| `cassandra.persistence.enabled`    | To enable storage persistence       |  false (Highly recommended to enable)  |
+| `collector.annotationsPod`         | Annotations for Collector           |  nil                                   |
+| `collector.annotationsSvc`         | Annotations for Collector SVC       |  nil                                   |
+| `collector.cmdlineParams`          | Additional command line parameters  |  nil                                   |
+| `collector.httpPort`               | Client port for HTTP thrift         |  14268                                 |
+| `collector.image`                  | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
+| `collector.pullPolicy`             | Collector image pullPolicy          |  IfNotPresent                          |
+| `collector.tag`                    | Image tag/version                   |  0.6                                   |
+| `collector.tchannelPort`           | Jaeger Agent port for thrift        |  14267                                 |
+| `collector.type`                   | Service type                        |  ClusterIP                             |
+| `collector.zipkinPort`             | Zipkin port for JSON/thrift HTTP    |  9411                                  |
+| `hotrod.enabled`                   | Enables the Hotrod demo app         |  false                                 |
+| `spark.enabled`                    | Enables the dependencies job        |  false                                 |
+| `spark.image`                      | Image for the dependencies job      |  jaegertracing/spark-dependencies      |
+| `spark.tag`                        | Tag of the dependencies job image   |  latest                                |
+| `spark.pullPolicy`                 | Image pull policy of the deps image |  Always                                |
+| `spark.schedule`                   | Schedule of the cron job            |  "*/12 * * * *"                        |
+| `query.annotationsPod`             | Annotations for Query UI            |  nil                                   |
+| `query.annotationsSvc`             | Annotations for Query SVC           |  nil                                   |
+| `query.cmdlineParams`              | Additional command line parameters  |  nil                                   |
+| `query.image`                      | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
+| `query.ingress.enabled`            | Allow external traffic access       |  false                                 |
+| `query.pullPolicy`                 | Query UI image pullPolicy           |  IfNotPresent                          |
+| `query.queryPort`                  | External accessible port            |  80                                    |
+| `query.tag`                        | Image tag/version                   |  0.6                                   |
+| `query.targetPort`                 | Internal Query UI port              |  16686                                 |
+| `query.type`                       | Service type                        |  ClusterIP                             |
+| `schema.annotations`               | Annotations for the schema job      |  nil                                   |
+| `schema.image`                     | Image to setup cassandra schema     |  jaegertracing/jaeger-cassandra-schema |
+| `schema.mode`                      | Schema mode (prod or test)          |  prod                                  |
+| `schema.pullPolicy`                | Schema image pullPolicy             |  IfNotPresent                          |
+| `schema.tag`                       | Image tag/version                   |  0.6                                   |
+|------------------------------------|-------------------------------------|----------------------------------------|
 
 For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
 
@@ -203,5 +211,13 @@ Override any required configuration options in the Cassandra chart that is requi
 Jaeger offers a multitude of [tags](https://hub.docker.com/u/jaegertracing/) for the various components used in this chart.
 
 ### Pending enhancements
-- Moving configurable parameters to use ConfigMap
-- Sidecar deployment support
+- [x] Use ConfigMap for configurable parameters
+- [x] Add the Hotrod example app
+- [x] Allow only some of the components to be installed
+- [x] Add support for the spark dependencies job (as a [k8s cronjob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)) 
+- [x] Use `provisionDataStore` key in the values.yaml file instead of `tags` to configure data store provisioning.
+- [x] Refactor chart to remove unnecessary quotes
+- [x] Remove the command overrides of the docker images and use [environment variables configuration](http://jaeger.readthedocs.io/en/latest/deployment/#configuration) instead
+- [x] Fix hard-coded replica count
+- [x] Collector service works both as `NodePort` and `ClusterIP` service types
+- [ ] Sidecar deployment support

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -133,58 +133,72 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Jaeger chart and their default values.
 
-|             Parameter              |            Description              |                  Default               |
-|------------------------------------|-------------------------------------|----------------------------------------|
-| `provisionDataStore.cassandra`     | Provision Cassandra Data Store      |  true                                  |
-| `provisionDataStore.elasticsearch` | Provision Elasticsearch Data Store  |  false                                 |
-| `agent.annotationsPod`             | Annotations for Agent               |  nil                                   |
-| `agent.annotationsSvc`             | Annotations for Agent SVC           |  nil                                   |
-| `agent.binaryPort`                 | jaeger.thrift over binary thrift    |  6832                                  |
-| `agent.cmdlineParams`              | Additional command line parameters  |  nil                                   |
-| `agent.compactPort`                | jaeger.thrift over compact thrift   |  6831                                  |
-| `agent.image`                      | Image for Jaeger Agent              |  jaegertracing/jaeger-agent            |
-| `agent.pullPolicy`                 | Agent image pullPolicy              |  IfNotPresent                          |
-| `agent.tag`                        | Image tag/version                   |  0.6                                   |
-| `agent.zipkinThriftPort`           | zipkin.thrift over compact thrift   |  5775                                  |
-| `cassandra.config.cluster_name`    | Cluster name                        |  jaeger                                |
-| `cassandra.config.dc_name`         | Datacenter name                     |  dc1                                   |
-| `cassandra.config.endpoint_snitch` | Node discovery method               |  GossipingPropertyFileSnitch           |
-| `cassandra.config.rack_name`       | Rack name                           |  rack1                                 |
-| `cassandra.config.seed_size`       | Seed size                           |  1                                     |
-| `cassandra.image.tag`              | The image tag/version               |  3.11                                  |
-| `cassandra.persistence.enabled`    | To enable storage persistence       |  false (Highly recommended to enable)  |
-| `collector.annotationsPod`         | Annotations for Collector           |  nil                                   |
-| `collector.annotationsSvc`         | Annotations for Collector SVC       |  nil                                   |
-| `collector.cmdlineParams`          | Additional command line parameters  |  nil                                   |
-| `collector.httpPort`               | Client port for HTTP thrift         |  14268                                 |
-| `collector.image`                  | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
-| `collector.pullPolicy`             | Collector image pullPolicy          |  IfNotPresent                          |
-| `collector.tag`                    | Image tag/version                   |  0.6                                   |
-| `collector.tchannelPort`           | Jaeger Agent port for thrift        |  14267                                 |
-| `collector.type`                   | Service type                        |  ClusterIP                             |
-| `collector.zipkinPort`             | Zipkin port for JSON/thrift HTTP    |  9411                                  |
-| `hotrod.enabled`                   | Enables the Hotrod demo app         |  false                                 |
-| `spark.enabled`                    | Enables the dependencies job        |  false                                 |
-| `spark.image`                      | Image for the dependencies job      |  jaegertracing/spark-dependencies      |
-| `spark.tag`                        | Tag of the dependencies job image   |  latest                                |
-| `spark.pullPolicy`                 | Image pull policy of the deps image |  Always                                |
-| `spark.schedule`                   | Schedule of the cron job            |  "*/12 * * * *"                        |
-| `query.annotationsPod`             | Annotations for Query UI            |  nil                                   |
-| `query.annotationsSvc`             | Annotations for Query SVC           |  nil                                   |
-| `query.cmdlineParams`              | Additional command line parameters  |  nil                                   |
-| `query.image`                      | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
-| `query.ingress.enabled`            | Allow external traffic access       |  false                                 |
-| `query.pullPolicy`                 | Query UI image pullPolicy           |  IfNotPresent                          |
-| `query.queryPort`                  | External accessible port            |  80                                    |
-| `query.tag`                        | Image tag/version                   |  0.6                                   |
-| `query.targetPort`                 | Internal Query UI port              |  16686                                 |
-| `query.type`                       | Service type                        |  ClusterIP                             |
-| `schema.annotations`               | Annotations for the schema job      |  nil                                   |
-| `schema.image`                     | Image to setup cassandra schema     |  jaegertracing/jaeger-cassandra-schema |
-| `schema.mode`                      | Schema mode (prod or test)          |  prod                                  |
-| `schema.pullPolicy`                | Schema image pullPolicy             |  IfNotPresent                          |
-| `schema.tag`                       | Image tag/version                   |  0.6                                   |
-|------------------------------------|-------------------------------------|----------------------------------------|
+|             Parameter                    |            Description              |                  Default               |
+|------------------------------------------|-------------------------------------|----------------------------------------|
+| `agent.annotationsPod`                   | Annotations for Agent               |  nil                                   |
+| `agent.annotationsSvc`                   | Annotations for Agent SVC           |  nil                                   |
+| `agent.binaryPort`                       | jaeger.thrift over binary thrift    |  6832                                  |
+| `agent.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
+| `agent.compactPort`                      | jaeger.thrift over compact thrift   |  6831                                  |
+| `agent.image`                            | Image for Jaeger Agent              |  jaegertracing/jaeger-agent            |
+| `agent.pullPolicy`                       | Agent image pullPolicy              |  IfNotPresent                          |
+| `agent.tag`                              | Image tag/version                   |  0.6                                   |
+| `agent.zipkinThriftPort`                 | zipkin.thrift over compact thrift   |  5775                                  |
+| `cassandra.config.cluster_name`          | Cluster name                        |  jaeger                                |
+| `cassandra.config.dc_name`               | Datacenter name                     |  dc1                                   |
+| `cassandra.config.endpoint_snitch`       | Node discovery method               |  GossipingPropertyFileSnitch           |
+| `cassandra.config.rack_name`             | Rack name                           |  rack1                                 |
+| `cassandra.config.seed_size`             | Seed size                           |  1                                     |
+| `cassandra.image.tag`                    | The image tag/version               |  3.11                                  |
+| `cassandra.persistence.enabled`          | To enable storage persistence       |  false (Highly recommended to enable)  |
+| `collector.annotationsPod`               | Annotations for Collector           |  nil                                   |
+| `collector.annotationsSvc`               | Annotations for Collector SVC       |  nil                                   |
+| `collector.cmdlineParams`                | Additional command line parameters  |  nil                                   |
+| `collector.httpPort`                     | Client port for HTTP thrift         |  14268                                 |
+| `collector.image`                        | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
+| `collector.pullPolicy`                   | Collector image pullPolicy          |  IfNotPresent                          |
+| `collector.tag`                          | Image tag/version                   |  0.6                                   |
+| `collector.tchannelPort`                 | Jaeger Agent port for thrift        |  14267                                 |
+| `collector.type`                         | Service type                        |  ClusterIP                             |
+| `collector.zipkinPort`                   | Zipkin port for JSON/thrift HTTP    |  9411                                  |
+| `elasticsearch.cluster.name`             | Elasticsearch cluster name          |  "tracing"                             |
+| `elasticsearch.data.persistance.enabled` | To enable storage persistence       |  false (Highly recommended to enable)  |
+| `elasticsearch.image.tag`                | Elasticsearch image tag             |  "5.4"                                 |
+| `elasticsearch.rbac.create`              | To enable RBAC                      |  false                                 |
+| `hotrod.enabled`                         | Enables the Hotrod demo app         |  false                                 |
+| `provisionDataStore.cassandra`           | Provision Cassandra Data Store      |  true                                  |
+| `provisionDataStore.elasticsearch`       | Provision Elasticsearch Data Store  |  false                                 |
+| `query.annotationsPod`                   | Annotations for Query UI            |  nil                                   |
+| `query.annotationsSvc`                   | Annotations for Query SVC           |  nil                                   |
+| `query.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
+| `query.image`                            | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
+| `query.ingress.enabled`                  | Allow external traffic access       |  false                                 |
+| `query.pullPolicy`                       | Query UI image pullPolicy           |  IfNotPresent                          |
+| `query.queryPort`                        | External accessible port            |  80                                    |
+| `query.tag`                              | Image tag/version                   |  0.6                                   |
+| `query.targetPort`                       | Internal Query UI port              |  16686                                 |
+| `query.type`                             | Service type                        |  ClusterIP                             |
+| `schema.annotations`                     | Annotations for the schema job      |  nil                                   |
+| `schema.image`                           | Image to setup cassandra schema     |  jaegertracing/jaeger-cassandra-schema |
+| `schema.mode`                            | Schema mode (prod or test)          |  prod                                  |
+| `schema.pullPolicy`                      | Schema image pullPolicy             |  IfNotPresent                          |
+| `schema.tag`                             | Image tag/version                   |  0.6                                   |
+| `spark.enabled`                          | Enables the dependencies job        |  false                                 |
+| `spark.image`                            | Image for the dependencies job      |  jaegertracing/spark-dependencies      |
+| `spark.pullPolicy`                       | Image pull policy of the deps image |  Always                                |
+| `spark.schedule`                         | Schedule of the cron job            |  "49 23 * * *"                         |
+| `spark.tag`                              | Tag of the dependencies job image   |  latest                                |
+| `storage.cassandra.host`                 | Provisioned cassandra host          |  cassandra                             |
+| `storage.cassandra.password`             | Provisioned cassandra password      |  password                              |
+| `storage.cassandra.port`                 | Provisioned cassandra port          |  9042                                  |
+| `storage.cassandra.user`                 | Provisioned cassandra username      |  user                                  |
+| `storage.elasticsearch.host`             | Provisioned elasticsearch host      |  elasticsearch                         |
+| `storage.elasticsearch.password`         | Provisioned elasticsearch password  |  changeme                              |
+| `storage.elasticsearch.port`             | Provisioned elasticsearch port      |  9200                                  |
+| `storage.elasticsearch.scheme`           | Provisioned elasticsearch scheme    |  http                                  |
+| `storage.elasticsearch.user`             | Provisioned elasticsearch user      |  elastic                               |
+| `storage.type`                           | Storage type (ES or Cassandra)      |  cassandra                             |
+|------------------------------------------|-------------------------------------|----------------------------------------|
 
 For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
 

--- a/incubator/jaeger/requirements.yaml
+++ b/incubator/jaeger/requirements.yaml
@@ -1,13 +1,9 @@
 dependencies:
-  - name: elasticsearch
-    version: 0.3.0
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-    condition: elasticsearch.enable
-    tags:
-      - elasticsearch
   - name: cassandra
-    version: 0.1.5
+    version: ^0.1.6
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-    condition: cassandra.enable
-    tags:
-      - cassandra
+    condition: provisionDataStore.cassandra
+  - name: elasticsearch
+    version: ^0.4.1
+    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    condition: provisionDataStore.elasticsearch

--- a/incubator/jaeger/templates/NOTES.txt
+++ b/incubator/jaeger/templates/NOTES.txt
@@ -15,7 +15,7 @@ You can log into the Jaeger Query UI here:
   echo http://$SERVICE_IP/
 {{- else if contains "ClusterIP"  .Values.query.service.type }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "jaeger.fullname" . }}-query" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }},component=query" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8080/
   kubectl port-forward $POD_NAME 8080:16686
 {{- end }}

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 Return the appropriate apiVersion for cronjob APIs.
 */}}
 {{- define "cronjob.apiVersion" -}}
-{{- if ge .Capabilities.KubeVersion.Minor "8" -}}
+{{- if .Capabilities.APIVersions.Has "batch/v1beta1" -}}
 "batch/v1beta1"
 {{- else -}}
 "batch/v2alpha1"

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -53,18 +53,22 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "cassandra.fullname" -}}
+{{- define "cassandra.host" -}}
+{{- if .Values.provisionDataStore.cassandra -}}
 {{- printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- .Values.storage.cassandra.host }}
+{{- end -}}
 {{- end -}}
 
 {{- define "cassandra.contact_points" -}}
-{{- $host := printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
 {{- $port := .Values.storage.cassandra.port | toString }}
+{{- if .Values.provisionDataStore.cassandra -}}
+{{- $host := printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
 {{- printf "%s:%s" $host $port }}
+{{- else }}
+{{- printf "%s:%s" .Values.storage.cassandra.host $port }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -1,4 +1,16 @@
 {{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return the appropriate apiVersion for cronjob APIs.
+*/}}
+{{- define "cronjob.apiVersion" -}}
+{{- if ge .Capabilities.KubeVersion.Minor "8" -}}
+"batch/v1beta1"
+{{- else -}}
+"batch/v2alpha1"
+{{- end -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -19,6 +31,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{/*
 Create a fully qualified query name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -31,6 +44,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "jaeger.agent.service.name" -}}
+{{- $name := default .Chart.Name .Values.agent.service.nameOverride -}}
+{{- if .Values.agent.service.nameOverride }}
+{{- printf "%s" .Values.agent.service.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -39,10 +61,35 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "cassandra.contact_points" -}}
+{{- $host := printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
+{{- $port := .Values.storage.cassandra.port | toString }}
+{{- printf "%s:%s" $host $port }}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "elasticsearch.fullname" -}}
-{{- printf "%s-%s" .Release.Name "elasticsearch" | trunc 63 | trimSuffix "-" -}}
+{{- define "elasticsearch.client.url" -}}
+{{- $port := .Values.storage.elasticsearch.port | toString -}}
+{{- if .Values.provisionDataStore.elasticsearch -}}
+{{- $host := printf "%s-%s-%s" .Release.Name "elasticsearch" "client" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme $host $port }}
+{{- else }}
+{{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme .Values.storage.elasticsearch.host $port }}
+{{- end -}}
+{{- end -}}
+
+{{- define "jaeger.collector.host-port" -}}
+{{- if .Values.agent.collector.host }}
+{{- printf "%s:%s" .Values.agent.collector.host (default .Values.collector.service.tchannelPort .Values.agent.collector.port | toString) }}
+{{- else }}
+{{- printf "%s-collector:%s" (include "jaeger.fullname" .) (default .Values.collector.service.tchannelPort .Values.agent.collector.port | toString) }}
+{{- end -}}
+{{- end -}}
+
+{{- define "jaeger.hotrod.tracing.host" -}}
+{{- $host := printf "%s-agent" (include "jaeger.agent.service.name" .) -}}
+{{- default $host .Values.hotrod.tracing.host -}}
 {{- end -}}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -2,25 +2,25 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-agent"
+  name: {{ template "jaeger.fullname" . }}-agent
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: agent-daemonset
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "agent"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: agent
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.agent.annotations }}
   annotations:
-{{ toYaml .Values.agent.annotations | indent 6 }}
+{{ toYaml .Values.agent.annotations | indent 4 }}
 {{- end }}
 spec:
   template:
     metadata:
       labels:
-        app: "{{ template "jaeger.name" . }}"
-        component: "agent"
-        release: "{{ .Release.Name }}"
+        app: {{ template "jaeger.name" . }}
+        component: agent
+        release: {{ .Release.Name }}
         jaeger-infra: agent-instance
 {{- if .Values.agent.podLabels }}
 {{ toYaml .Values.agent.podLabels | indent 8 }}
@@ -29,22 +29,40 @@ spec:
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-agent"
-        image: "{{ .Values.agent.image }}:{{ .Values.agent.tag }}"
+      - name: {{ template "jaeger.fullname" . }}-agent
+        image: {{ .Values.agent.image }}:{{ .Values.agent.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
-        command:
-        - "/go/bin/agent-linux"
-        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.collector.service.tchannelPort }}"
-{{- range $key, $value := .Values.agent.cmdlineParams }}
-        - "{{ $value }}"
-{{- end }}
+        env:
+        - name: COLLECTOR_HOST_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: collector.host-port
+        {{- range $key, $value := .Values.agent.cmdlineParams }}
+        - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
+          value: {{ $value }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.agent.service.zipkinThriftPort }}
           protocol: UDP
+          {{- if .Values.agent.daemonset.useHostPort }}
+          hostPort: {{ .Values.agent.service.zipkinThriftPort }}
+          {{- end }}
         - containerPort: {{ .Values.agent.service.compactPort }}
           protocol: UDP
+          {{- if .Values.agent.daemonset.useHostPort }}
+          hostPort: {{ .Values.agent.service.compactPort }}
+          {{- end }}
         - containerPort: {{ .Values.agent.service.binaryPort }}
           protocol: UDP
+          {{- if .Values.agent.daemonset.useHostPort }}
+          hostPort: {{ .Values.agent.service.binaryPort }}
+          {{- end }}
+        - containerPort: {{ .Values.agent.service.samplingPort }}
+          protocol: TCP
+          {{- if .Values.agent.daemonset.useHostPort }}
+          hostPort: {{ .Values.agent.service.samplingPort }}
+          {{- end }}
         resources:
 {{ toYaml .Values.agent.resources | indent 10 }}
 {{- end -}}

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -2,17 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-agent"
+  name: {{ template "jaeger.agent.service.name" . }}-agent
   labels:
-    app: "{{ template "jaeger.name" . }}"
-    jaeger-infra: {{ .Values.agent.name }}
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: agent-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "agent"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: agent
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.agent.service.annotations }}
   annotations:
-{{ toYaml .Values.agent.service.annotations | indent 6 }}
+{{ toYaml .Values.agent.service.annotations | indent 4 }}
 {{- end }}
 spec:
   ports:
@@ -28,10 +28,14 @@ spec:
     port: {{ .Values.agent.service.binaryPort }}
     protocol: UDP
     targetPort: {{ .Values.agent.service.binaryPort }}
-  clusterIP: None
+  - name: agent-sampling
+    port: {{ .Values.agent.service.samplingPort }}
+    protocol: TCP
+    targetPort: {{ .Values.agent.service.samplingPort }}
+  type: {{ .Values.agent.service.type }}
   selector:
-    app: "{{ template "jaeger.name" . }}"
-    component: "agent"
-    release: "{{ .Release.Name }}"
+    app: {{ template "jaeger.name" . }}
+    component: agent
+    release: {{ .Release.Name }}
     jaeger-infra: agent-instance
 {{- end -}}

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -1,81 +1,52 @@
-{{ if not (empty .Values.cassandra.config.host) }}
+{{- if .Values.collector.enabled -}}
+{{- if eq .Values.storage.type "cassandra" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+  name: {{ template "jaeger.fullname" . }}-cassandra-schema
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: cassandra-schema-job
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "cassandra-schema"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: cassandra-schema
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.schema.annotations }}
   annotations:
-{{ toYaml .Values.schema.annotations | indent 6 }}
+{{ toYaml .Values.schema.annotations | indent 4 }}
 {{- end }}
 spec:
   activeDeadlineSeconds: 120
   template:
     metadata:
-      name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+      name: {{ template "jaeger.fullname" . }}-cassandra-schema
 {{- if .Values.schema.podLabels }}
       labels:
 {{ toYaml .Values.schema.podLabels | indent 8 }}
 {{- end }}
     spec:
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-        image: "{{ .Values.schema.image }}:{{ .Values.schema.tag }}"
+      - name: {{ template "jaeger.fullname" . }}-cassandra-schema
+        image: {{ .Values.schema.image }}:{{ .Values.schema.tag }}
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
         env:
-          - name: CQLSH_HOST
-            value: "{{ .Values.cassandra.config.host }}"
-          - name: MODE
-            value: "{{ .Values.schema.mode }}"
-          - name: DATACENTER
-            value: "{{ .Values.cassandra.config.dc_name }}"
+        - name: CQLSH_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: cassandra.servers
+        - name: MODE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: cassandra.schema.mode
+        - name: DATACENTER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: cassandra.datacenter.name
         resources:
 {{ toYaml .Values.schema.resources | indent 10 }}
       restartPolicy: OnFailure
-{{ else if .Values.tags.cassandra }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-  labels:
-    app: "{{ template "jaeger.name" . }}"
-    jaeger-infra: cassandra-schema-job
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "cassandra-schema"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-{{- if .Values.schema.annotations }}
-  annotations:
-{{ toYaml .Values.schema.annotations | indent 6 }}
-{{- end }}
-spec:
-  activeDeadlineSeconds: 120
-  template:
-    metadata:
-      name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-{{- if .Values.schema.podLabels }}
-      labels:
-{{ toYaml .Values.schema.podLabels | indent 8 }}
-{{- end }}
-    spec:
-      containers:
-      - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-        image: "{{ .Values.schema.image }}:{{ .Values.schema.tag }}"
-        imagePullPolicy: {{ .Values.schema.pullPolicy }}
-        env:
-          - name: CQLSH_HOST
-            value: "{{ template "cassandra.fullname" . }}"
-          - name: MODE
-            value: "{{ .Values.schema.mode }}"
-          - name: DATACENTER
-            value: "{{ .Values.cassandra.config.dc_name }}"
-        resources:
-{{ toYaml .Values.schema.resources | indent 10 }}
-      restartPolicy: OnFailure
-{{ end }}
+{{- end -}}
+{{- end -}}

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -45,6 +45,11 @@ spec:
             configMapKeyRef:
               name: {{ template "jaeger.fullname" . }}
               key: cassandra.datacenter.name
+        - name: CASSANDRA_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: cassandra.port
         resources:
 {{ toYaml .Values.schema.resources | indent 10 }}
       restartPolicy: OnFailure

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -1,28 +1,29 @@
+{{- if .Values.collector.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-collector"
+  name: {{ template "jaeger.fullname" . }}-collector
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: collector-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "collector"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: collector
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.collector.annotations }}
   annotations:
-{{ toYaml .Values.collector.annotations | indent 6 }}
+{{ toYaml .Values.collector.annotations | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.collector.replicaCount }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: "{{ template "jaeger.name" . }}"
-        component: "collector"
-        release: "{{ .Release.Name }}"
+        app: {{ template "jaeger.name" . }}
+        component: collector
+        release: {{ .Release.Name }}
         jaeger-infra: collector-pod
 {{- if .Values.collector.podLabels }}
 {{ toYaml .Values.collector.podLabels | indent 8 }}
@@ -31,41 +32,61 @@ spec:
       nodeSelector:
 {{ toYaml .Values.collector.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-collector"
-        image: "{{ .Values.collector.image }}:{{ .Values.collector.tag }}"
+      - name: {{ template "jaeger.fullname" . }}-collector
+        image: {{ .Values.collector.image }}:{{ .Values.collector.tag }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
+        env:
+          - name: SPAN_STORAGE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: span-storage.type
+          {{- if eq .Values.storage.type "cassandra" }}
+          - name: CASSANDRA_SERVERS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.servers
+          - name: CASSANDRA_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.keyspace
+          {{- end }}
+          {{- if eq .Values.storage.type "elasticsearch" }}
+          - name: ES_SERVER_URLS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.server-urls
+          {{- end }}
+          - name: COLLECTOR_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: collector.port
+          - name: COLLECTOR_HTTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: collector.http-port
+          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: collector.zipkin.http-port
         ports:
-        - containerPort: 14267
+        - containerPort: {{ .Values.collector.service.tchannelPort }}
           name: tchannel
           protocol: TCP
-        - containerPort: 14268
+        - containerPort: {{ .Values.collector.service.httpPort }}
           name: http
           protocol: TCP
-        - containerPort: 9411
+        - containerPort: {{ .Values.collector.service.zipkinPort }}
           name: zipkin
           protocol: TCP
         resources:
 {{ toYaml .Values.collector.resources | indent 10 }}
-        command:
-        - "/go/bin/collector-linux"
-{{ if not (empty .Values.elasticsearch.config.host) }}
-        - "--span-storage.type=elasticsearch"
-        - "--es.server-urls={{ .Values.elasticsearch.config.host }}"
-        - "--es.username={{ .Values.elasticsearch.config.username }}"
-        - "--es.password={{ .Values.elasticsearch.config.password }}"
-{{ else if .Values.tags.elasticsearch }}
-        - "--span-storage.type=elasticsearch"
-        - "--es.server-urls=http://{{ template "elasticsearch.fullname" . }}-client:9200"
-{{ else if not (empty .Values.cassandra.config.host) }}
-        - "--cassandra.servers={{ .Values.cassandra.config.host }}"
-        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-{{ else }}
-        - "--cassandra.servers={{ template "cassandra.fullname" . }}"
-        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-{{ end }}
-        - "--collector.zipkin.http-port={{ .Values.collector.service.zipkinPort }}"
-{{- range $key, $value := .Values.collector.cmdlineParams }}
-        - "{{ $value }}"
-{{- end }}
       dnsPolicy: {{ .Values.collector.dnsPolicy }}
       restartPolicy: Always
+{{- end -}}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -47,6 +47,11 @@ spec:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: cassandra.servers
+          - name: CASSANDRA_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.port
           - name: CASSANDRA_KEYSPACE
             valueFrom:
               configMapKeyRef:

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -54,11 +54,21 @@ spec:
                 key: cassandra.keyspace
           {{- end }}
           {{- if eq .Values.storage.type "elasticsearch" }}
+          - name: ES_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.password
           - name: ES_SERVER_URLS
             valueFrom:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: es.server-urls
+          - name: ES_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.username
           {{- end }}
           - name: COLLECTOR_PORT
             valueFrom:

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -1,35 +1,49 @@
+{{- if .Values.collector.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-collector"
+  name: {{ template "jaeger.fullname" . }}-collector
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: collector-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "collector"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: collector
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.collector.service.annotations }}
   annotations:
-{{ toYaml .Values.collector.service.annotations | indent 6 }}
+{{ toYaml .Values.collector.service.annotations | indent 4 }}
 {{- end }}
 spec:
   ports:
   - name: jaeger-collector-tchannel
     port: {{ .Values.collector.service.tchannelPort }}
     protocol: TCP
+    {{- if eq .Values.collector.service.type "NodePort" }}
+    nodePort: {{ .Values.collector.service.tchannelPort }}
+    {{- else }}
     targetPort: tchannel
+    {{- end }}
   - name: jaeger-collector-http
     port: {{ .Values.collector.service.httpPort }}
     protocol: TCP
+    {{- if eq .Values.collector.service.type "NodePort" }}
+    nodePort: {{ .Values.collector.service.httpPort }}
+    {{- else }}
     targetPort: http
+    {{- end }}
   - name: jaeger-collector-zipkin
     port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
+    {{- if eq .Values.collector.service.type "NodePort" }}
+    nodePort: {{ .Values.collector.service.zipkinPort }}
+    {{- else }}
     targetPort: zipkin
+    {{- end }}
   selector:
-    app: "{{ template "jaeger.name" . }}"
-    component: "collector"
-    release: "{{ .Release.Name }}"
+    app: {{ template "jaeger.name" . }}
+    component: collector
+    release: {{ .Release.Name }}
     jaeger-infra: collector-pod
   type: {{ .Values.collector.service.type }}
+{{- end -}}

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -18,7 +18,9 @@ data:
   collector.http-port: {{ .Values.collector.service.httpPort | quote }}
   collector.port: {{ .Values.collector.service.tchannelPort | quote }}
   collector.zipkin.http-port: {{ .Values.collector.service.zipkinPort | quote }}
+  es.password: {{ .Values.storage.elasticsearch.password }}
   es.server-urls: {{ template "elasticsearch.client.url" . }}
+  es.username: {{ .Values.storage.elasticsearch.user }}
   hotrod.agent-host: {{ template "jaeger.hotrod.tracing.host" . }}
   hotrod.agent-port: {{ .Values.hotrod.tracing.port | quote }}
   span-storage.type: {{ .Values.storage.type | quote }}
@@ -59,9 +61,7 @@ data:
   # es.max-span-age:
   # es.num-replicas:
   # es.num-shards:
-  # es.password:
   # es.sniffer:
-  # es.username:
   # http-server.host-port:
   # log-level:
   # metrics-backend:

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jaeger.fullname" . }}
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: common-configmap
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  cassandra.contact-points: {{ template "cassandra.contact_points" . }}
+  cassandra.datacenter.name: {{ .Values.cassandra.config.dc_name | quote }}
+  cassandra.keyspace: {{ printf "%s_%s" "jaeger_v1" .Values.cassandra.config.dc_name | quote }}
+  cassandra.schema.mode: {{ .Values.schema.mode | quote }}
+  cassandra.servers: {{ template "cassandra.fullname" . }}
+  collector.host-port: {{ template "jaeger.collector.host-port" . }}
+  collector.http-port: {{ .Values.collector.service.httpPort | quote }}
+  collector.port: {{ .Values.collector.service.tchannelPort | quote }}
+  collector.zipkin.http-port: {{ .Values.collector.service.zipkinPort | quote }}
+  es.server-urls: {{ template "elasticsearch.client.url" . }}
+  hotrod.agent-host: {{ template "jaeger.hotrod.tracing.host" . }}
+  hotrod.agent-port: {{ .Values.hotrod.tracing.port | quote }}
+  span-storage.type: {{ .Values.storage.type | quote }}
+  query.health-check-http-port: {{ .Values.query.healthCheckPort | quote }}
+  query.port: {{ .Values.query.service.targetPort | quote }}
+  # Not implemented
+  # cassandra.archive.connections-per-host:
+  # cassandra.archive.keyspace:
+  # cassandra.archive.max-retry-attempts:
+  # cassandra.archive.password:
+  # cassandra.archive.port:
+  # cassandra.archive.proto-version:
+  # cassandra.archive.servers:
+  # cassandra.archive.socket-keep-alive:
+  # cassandra.archive.timeout:
+  # cassandra.archive.username:
+  # cassandra.connections-per-host:
+  # cassandra.max-retry-attempts:
+  # cassandra.password:
+  # cassandra.port:
+  # cassandra.proto-version:
+  # cassandra.socket-keep-alive:
+  # cassandra.timeout:
+  # cassandra.username:
+  # collector.health-check-http-port:
+  # collector.num-workers:
+  # collector.queue-size:
+  # collector.write-cache-ttl:
+  # dependency-storage.data-frequency:
+  # discovery.min-peers:
+  # es.archive.max-span-age:
+  # es.archive.num-replicas:
+  # es.archive.num-shards:
+  # es.archive.password:
+  # es.archive.server-urls:
+  # es.archive.sniffer:
+  # es.archive.username:
+  # es.max-span-age:
+  # es.num-replicas:
+  # es.num-shards:
+  # es.password:
+  # es.sniffer:
+  # es.username:
+  # http-server.host-port:
+  # log-level:
+  # metrics-backend:
+  # metrics-http-route:
+  # processor.jaeger-binary.server-host-port:
+  # processor.jaeger-binary.server-max-packet-size:
+  # processor.jaeger-binary.server-queue-size:
+  # processor.jaeger-binary.workers:
+  # processor.jaeger-compact.server-host-port:
+  # processor.jaeger-compact.server-max-packet-size:
+  # processor.jaeger-compact.server-queue-size:
+  # processor.jaeger-compact.workers:
+  # processor.zipkin-compact.server-host-port:
+  # processor.zipkin-compact.server-max-packet-size:
+  # processor.zipkin-compact.server-queue-size:
+  # processor.zipkin-compact.workers:
+  # query.prefix:
+  # query.static-files:
+  # query.ui-config:

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -12,8 +12,9 @@ data:
   cassandra.contact-points: {{ template "cassandra.contact_points" . }}
   cassandra.datacenter.name: {{ .Values.cassandra.config.dc_name | quote }}
   cassandra.keyspace: {{ printf "%s_%s" "jaeger_v1" .Values.cassandra.config.dc_name | quote }}
+  cassandra.port: {{ .Values.storage.cassandra.port | quote }}
   cassandra.schema.mode: {{ .Values.schema.mode | quote }}
-  cassandra.servers: {{ template "cassandra.fullname" . }}
+  cassandra.servers: {{ template "cassandra.host" . }}
   collector.host-port: {{ template "jaeger.collector.host-port" . }}
   collector.http-port: {{ .Values.collector.service.httpPort | quote }}
   collector.port: {{ .Values.collector.service.tchannelPort | quote }}
@@ -40,7 +41,6 @@ data:
   # cassandra.connections-per-host:
   # cassandra.max-retry-attempts:
   # cassandra.password:
-  # cassandra.port:
   # cassandra.proto-version:
   # cassandra.socket-keep-alive:
   # cassandra.timeout:

--- a/incubator/jaeger/templates/hotrod-deploy.yaml
+++ b/incubator/jaeger/templates/hotrod-deploy.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.hotrod.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "jaeger.fullname" . }}-hotrod
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: hotrod-deployment
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: hotrod
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.hotrod.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "jaeger.name" . }}
+        component: hotrod
+        release: {{ .Release.Name }}
+        jaeger-infra: hotrod-instance
+    spec:
+      containers:
+        - name: {{ template "jaeger.fullname" . }}-hotrod
+          image: {{ .Values.hotrod.image.repository }}:{{ .Values.hotrod.image.tag }}
+          imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
+          env:
+            - name: AGENT_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: hotrod.agent-host
+            - name: AGENT_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: hotrod.agent-port
+          ports:
+            - containerPort: {{ .Values.hotrod.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.hotrod.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.hotrod.service.internalPort }}
+          resources:
+{{ toYaml .Values.hotrod.resources | indent 12 }}
+    {{- if .Values.hotrod.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hotrod.nodeSelector | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/incubator/jaeger/templates/hotrod-ing.yaml
+++ b/incubator/jaeger/templates/hotrod-ing.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.hotrod.enabled -}}
+{{- if .Values.hotrod.ingress.enabled -}}
+{{- $serviceName := include "jaeger.fullname" . -}}
+{{- $servicePort := .Values.hotrod.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "jaeger.fullname" . }}-hotrod
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: hotrod-ingress
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: hotrod
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.hotrod.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.hotrod.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.hotrod.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}-hotrod
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.hotrod.ingress.tls }}
+  tls:
+{{ toYaml .Values.hotrod.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/jaeger/templates/hotrod-svc.yaml
+++ b/incubator/jaeger/templates/hotrod-svc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.hotrod.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jaeger.fullname" . }}-hotrod
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: hotrod-service
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: hotrod
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.hotrod.service.annotations }}
+  annotations:
+{{ toYaml .Values.hotrod.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.hotrod.service.type }}
+  ports:
+    - name: {{ .Values.hotrod.service.name }}
+      port: {{ .Values.hotrod.service.externalPort }}
+      protocol: TCP
+      targetPort: {{ .Values.hotrod.service.internalPort }}
+  selector:
+    app: {{ template "jaeger.name" . }}
+    component: hotrod
+    release: {{ .Release.Name }}
+    jaeger-infra: hotrod-instance
+{{- end -}}

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -54,11 +54,21 @@ spec:
                 key: cassandra.keyspace
           {{- end }}
           {{- if eq .Values.storage.type "elasticsearch" }}
+          - name: ES_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.password
           - name: ES_SERVER_URLS
             valueFrom:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: es.server-urls
+          - name: ES_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.username
           {{- end }}
           - name: QUERY_PORT
             valueFrom:

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -47,6 +47,11 @@ spec:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: cassandra.servers
+          - name: CASSANDRA_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.port
           - name: CASSANDRA_KEYSPACE
             valueFrom:
               configMapKeyRef:

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -1,28 +1,29 @@
+{{- if .Values.query.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "{{ template "jaeger.query.fullname" . }}"
+  name: {{ template "jaeger.query.fullname" . }}
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: query-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "query"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: query
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.query.annotations }}
   annotations:
-{{ toYaml .Values.query.annotations | indent 6 }}
+{{ toYaml .Values.query.annotations | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.query.replicaCount }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: "{{ template "jaeger.name" . }}"
-        component: "query"
-        release: "{{ .Release.Name }}"
+        app: {{ template "jaeger.name" . }}
+        component: query
+        release: {{ .Release.Name }}
         jaeger-infra: query-pod
 {{- if .Values.query.podLabels }}
 {{ toYaml .Values.query.podLabels | indent 8 }}
@@ -31,40 +32,53 @@ spec:
       nodeSelector:
 {{ toYaml .Values.query.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.query.fullname" . }}"
-        image: "{{ .Values.query.image }}:{{ .Values.query.tag }}"
+      - name: {{ template "jaeger.query.fullname" . }}
+        image: {{ .Values.query.image }}:{{ .Values.query.tag }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
+        env:
+          - name: SPAN_STORAGE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: span-storage.type
+          {{- if eq .Values.storage.type "cassandra" }}
+          - name: CASSANDRA_SERVERS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.servers
+          - name: CASSANDRA_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.keyspace
+          {{- end }}
+          {{- if eq .Values.storage.type "elasticsearch" }}
+          - name: ES_SERVER_URLS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.server-urls
+          {{- end }}
+          - name: QUERY_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: query.port
+          - name: QUERY_HEALTH_CHECK_HTTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: query.health-check-http-port
         ports:
         - containerPort: {{ .Values.query.service.targetPort }}
           protocol: TCP
         resources:
 {{ toYaml .Values.query.resources | indent 10 }}
-        command:
-        - "/go/bin/query-linux"
-{{ if not (empty .Values.elasticsearch.config.host) }}
-        - "--span-storage.type=elasticsearch"
-        - "--es.server-urls={{ .Values.elasticsearch.config.host }}"
-        - "--es.username={{ .Values.elasticsearch.config.username }}"
-        - "--es.password={{ .Values.elasticsearch.config.password }}"
-{{ else if .Values.tags.elasticsearch }}
-        - "--span-storage.type=elasticsearch"
-        - "--es.server-urls=http://{{ template "elasticsearch.fullname" . }}-client:9200"
-{{ else if not (empty .Values.cassandra.config.host) }}
-        - "--cassandra.servers={{ .Values.cassandra.config.host }}"
-        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-{{ else }}
-        - "--cassandra.servers={{ template "cassandra.fullname" . }}"
-        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-{{ end }}
-        - "--query.static-files=/go/jaeger-ui/"
-        - "--query.port={{ .Values.query.service.targetPort }}"
-        - "--query.health-check-http-port={{ .Values.query.healthCheckPort }}"
-{{- range $key, $value := .Values.query.cmdlineParams }}
-        - "{{ $value }}"
-{{- end }}
         readinessProbe:
           httpGet:
-            path: "/"
+            path: /
             port: {{ .Values.query.healthCheckPort }}
       dnsPolicy: {{ .Values.query.dnsPolicy }}
       restartPolicy: Always
+{{- end -}}

--- a/incubator/jaeger/templates/query-ing.yaml
+++ b/incubator/jaeger/templates/query-ing.yaml
@@ -1,22 +1,24 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.query.ingress.enabled -}}
 {{- $serviceName := include "jaeger.query.fullname" . -}}
 {{- $servicePort := .Values.query.service.queryPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "jaeger.name" . }}
+  name: {{ template "jaeger.fullname" . }}-query
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: query-ingress
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    component: query
     heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  {{- if .Values.query.ingress.annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
+{{ toYaml .Values.query.ingress.annotations | indent 4 }}
+  {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.ingress.hosts }}
+    {{- range $host := .Values.query.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
@@ -25,8 +27,8 @@ spec:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
     {{- end -}}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.query.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+{{ toYaml .Values.query.ingress.tls | indent 4 }}
   {{- end -}}
 {{- end -}}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -1,17 +1,18 @@
+{{- if .Values.query.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.query.fullname" . }}"
+  name: {{ template "jaeger.query.fullname" . }}
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: query-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "query"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: query
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.query.service.annotations }}
   annotations:
-{{ toYaml .Values.query.service.annotations | indent 6 }}
+{{ toYaml .Values.query.service.annotations | indent 4 }}
 {{- end }}
 spec:
   ports:
@@ -20,8 +21,9 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.query.service.targetPort }}
   selector:
-    app: "{{ template "jaeger.name" . }}"
-    component: "query"
-    release: "{{ .Release.Name }}"
+    app: {{ template "jaeger.name" . }}
+    component: query
+    release: {{ .Release.Name }}
     jaeger-infra: query-pod
   type: {{ .Values.query.service.type }}
+{{- end -}}

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.spark.enabled -}}
+{{- if or .Capabilities.APIVersions.Has "batch/v1beta1" .Capabilities.APIVersions.Has "batch/v2alpha1" -}}
 apiVersion: {{ template "cronjob.apiVersion" $ }}
 kind: CronJob
 metadata:
@@ -73,4 +74,5 @@ spec:
             resources:
             {{ toYaml .Values.spark.resources | indent 10 }}
           restartPolicy: OnFailure
+{{- end -}}
 {{- end -}}

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.spark.enabled -}}
+apiVersion: {{ template "cronjob.apiVersion" $ }}
+kind: CronJob
+metadata:
+  name: {{ template "jaeger.fullname" . }}-spark
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: spark-cronjob
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: spark
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.spark.annotations }}
+  annotations:
+{{ toYaml .Values.spark.annotations | indent 4 }}
+{{- end }}
+spec:
+  schedule: {{ .Values.spark.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ template "jaeger.name" . }}
+            component: spark
+            release: {{ .Release.Name }}
+            jaeger-infra: spark-instance
+            {{- if .Values.spark.podLabels }}
+            {{ toYaml .Values.spark.podLabels | indent 12 }}
+            {{- end }}
+        spec:
+          nodeSelector:
+            {{ toYaml .Values.spark.nodeSelector | indent 12 }}
+          containers:
+          - name: {{ template "jaeger.fullname" . }}-spark
+            image: {{ .Values.spark.image }}:{{ .Values.spark.tag }}
+            imagePullPolicy: {{ .Values.spark.pullPolicy }}
+            env:
+            - name: STORAGE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: span-storage.type
+            {{- if eq .Values.storage.type "cassandra" }}
+            - name: CASSANDRA_CONTACT_POINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: cassandra.contact-points
+            - name: CASSANDRA_KEYSPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: cassandra.keyspace
+              {{- end }}
+            {{- if eq .Values.storage.type "elasticsearch" }}
+            - name: ES_NODES
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: es.server-urls
+            {{- end }}
+            resources:
+            {{ toYaml .Values.spark.resources | indent 10 }}
+          restartPolicy: OnFailure
+{{- end -}}

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -59,6 +59,16 @@ spec:
                 configMapKeyRef:
                   name: {{ template "jaeger.fullname" . }}
                   key: es.server-urls
+            - name: ES_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: es.password
+            - name: ES_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: es.username
             {{- end }}
             resources:
             {{ toYaml .Values.spark.resources | indent 10 }}

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -187,7 +187,7 @@ spark:
   image: jaegertracing/spark-dependencies
   tag: latest
   pullPolicy: Always
-  schedule: "*/12 * * * *"
+  schedule: "49 23 * * *"
   resources: {}
     # limits:
     #   cpu: 500m

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -115,7 +115,6 @@ collector:
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
-  useNodePort: false
   replicaCount: 1
   service:
     annotations: {}

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -1,10 +1,27 @@
 # Default values for jaeger.
 # This is a YAML-formatted file.
+# Jaeger values are grouped by component. Cassandra values override subchart values
 
-# Begin: Override values on the Cassandra/ElasticSearch subchart to customize for Jaeger
-# This chart has been based on the Kubernetes integration found in the following repo:
-# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production/cassandra.yml
-# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production-elasticsearch/elasticsearch.yml
+provisionDataStore:
+  cassandra: true
+  elasticsearch: false
+
+storage:
+  # allowed values (cassandra, elasticsearch)
+  type: cassandra
+  cassandra:
+    host: cassandra
+    port: 9042
+    user: user
+    password: password
+  elasticsearch:
+    scheme: http
+    host: elasticsearch
+    port: 9200
+    user: user
+    password: password
+
+# Begin: Override values on the Cassandra subchart to customize for Jaeger
 cassandra:
   image:
     tag: 3.11
@@ -12,34 +29,23 @@ cassandra:
     # To enable persistence, please see the documentation for the Cassandra chart
     enabled: false
   config:
-    # Change the host value to point to an existing Cassandra instance
-    # Be sure to set both tags.cassandra and tags.elasticsearch to false
-    host: ""
     cluster_name: jaeger
     seed_size: 1
     dc_name: dc1
     rack_name: rack1
     endpoint_snitch: GossipingPropertyFileSnitch
-
-elasticsearch:
-  config:
-    # Change the host value to point to an existing ElasticSearch instance
-    # Be sure to set both tags.cassandra and tags.elasticsearch to false
-    host: ""
-    username: "elastic"
-    password: "changeme"
-# End: Override values on the Cassandra/ElasticSearch subchart to customize for Jaeger
+# End: Override values on the Cassandra subchart to customize for Jaeger
 
 # Begin: Default values for the various components of Jaeger
-tags:
-  # Chose which backing store to use. By default Cassandra is enabled.
-  cassandra: true
-  elasticsearch: false
-
+# This chart has been based on the Kubernetes integration found in the following repo:
+# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production/jaeger-production-template.yml
+#
+# This is the jaeger-cassandra-schema Job which sets up the Cassandra schema for
+# use by Jaeger
 schema:
   annotations: {}
   image: jaegertracing/jaeger-cassandra-schema
-  tag: 0.8
+  tag: 1.0.0
   pullPolicy: IfNotPresent
   # Acceptable values are test and prod. Default is for production use.
   mode: prod
@@ -53,21 +59,42 @@ schema:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+
+# Begin: Override values on the Elasticsearch subchart to customize for Jaeger
+elasticsearch:
+  image:
+    tag: "5.4"
+  cluster:
+    name: "tracing"
+  data:
+    persistance:
+      enabled: false
+  rbac:
+    create: false
+
 agent:
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-agent
-  tag: 0.8
+  tag: 1.0.0
   pullPolicy: IfNotPresent
+  collector:
+    host: null
+    port: null
   cmdlineParams: {}
+  daemonset:
+    useHostPort: false
   service:
     annotations: {}
+    type: ClusterIP
     # zipkinThriftPort :accept zipkin.thrift over compact thrift protocol
     zipkinThriftPort: 5775
     # compactPort: accept jaeger.thrift over compact thrift protocol
     compactPort: 6831
     # binaryPort: accept jaeger.thrift over binary thrift protocol
     binaryPort: 6832
+    # samplingPort: (HTTP) serve configs, sampling strategies
+    samplingPort: 5778
   resources: {}
     # limits:
     #   cpu: 500m
@@ -79,13 +106,17 @@ agent:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+
 collector:
+  enabled: true
   annotations: {}
   image: jaegertracing/jaeger-collector
-  tag: 0.8
+  tag: 1.0.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
+  useNodePort: false
+  replicaCount: 1
   service:
     annotations: {}
     type: ClusterIP
@@ -106,21 +137,57 @@ collector:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+
 query:
+  enabled: true
   annotations: {}
   image: jaegertracing/jaeger-query
-  tag: 0.8
+  tag: 1.0.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
   healthCheckPort: 16687
+  replicaCount: 1
   service:
     annotations: {}
-    type: NodePort
+    type: ClusterIP
     # queryPort: externally accessible port for UI and API
     queryPort: 80
     # targetPort: the internal port the UI and API are exposed on
     targetPort: 16686
+  ingress:
+    enabled: false
+    annotations: {}
+    # Used to create an Ingress record.
+    # hosts:
+    #   - chart-example.local
+    # annotations:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #    cpu: 256m
+    #    memory: 128Mi
+  nodeSelector: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+spark:
+  enabled: false
+  annotations: {}
+  image: jaegertracing/spark-dependencies
+  tag: latest
+  pullPolicy: Always
+  schedule: "*/12 * * * *"
   resources: {}
     # limits:
     #   cpu: 500m
@@ -134,16 +201,43 @@ query:
   podLabels: {}
 # End: Default values for the various components of Jaeger
 
-ingress:
+hotrod:
   enabled: false
-  # Used to create an Ingress record.
-  # hosts:
-  #   - chart-example.local
-  # annotations:
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  # tls:
-    # Secrets must be manually created in the namespace.
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
+  replicaCount: 1
+  image:
+    repository: mikelorant/jaeger-hotrod
+    tag: latest
+    pullPolicy: Always
+  service:
+    annotations: {}
+    name: hotrod
+    type: ClusterIP
+    externalPort: 80
+    internalPort: 8080
+  ingress:
+    enabled: false
+    # Used to create Ingress record (should be used with service.type: ClusterIP).
+    hosts:
+      - chart-example.local
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  tracing:
+    host: null
+    port: 6831

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -18,8 +18,8 @@ storage:
     scheme: http
     host: elasticsearch
     port: 9200
-    user: user
-    password: password
+    user: elastic
+    password: changeme
 
 # Begin: Override values on the Cassandra subchart to customize for Jaeger
 cassandra:


### PR DESCRIPTION
This PR adds the following improvements to the *Jaeger* chart:
* Use ConfigMap for configurable parameters
* Add the Hotrod example app
* Allow only some of the components to be installed
* Add support for the spark dependencies job (as a [k8s cronjob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)) 
* Use `provisionDataStore` key in the `values.yaml` file instead of `tags` to configure data store provisioning
* Refactor chart to remove unnecessary quotes
* Remove the command overrides of the docker images and use [environment variables configuration](http://jaeger.readthedocs.io/en/latest/deployment/#configuration) instead
* Fix hard-coded replica count
* Collector service works both as `NodePort` and `ClusterIP` service types