### PR TITLE
[incubator/zookeeper] Allows configurable nodeAffinity

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.4.2
+version: 0.4.3
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -106,6 +106,7 @@ Spreading allows you specify an anti-affinity between ZooKeeper servers in the e
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `antiAffinity` | If present it must take the values 'hard' or 'soft'. 'hard' will cause the Kubernetes scheduler to not schedule the Pods on the same physical node under any circumstances 'soft' will cause the Kubernetes scheduler to make a best effort to not co-locate the Pods, but, if the only available resources are on the same node, the scheduler will co-locate them. | `hard` |
+| `nodeAffinity` | Scheduler parameters for node selection. | `{}` |
 
 ### Logging
 In order to allow for the default installation to work well with the log rolling and retention policy of Kubernetes, all logs are written to stdout. This should also be compatible with logging integrations such as Google Cloud Logging and ELK.

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -16,8 +16,9 @@ spec:
         app: {{ include "zookeeper.name" . | quote }}
         release: {{ .Release.Name | quote }}
     spec:
-      {{- if eq .Values.antiAffinity "hard" }}
+      {{- if or .Values.antiAffinity .Values.nodeAffinity }}
       affinity:
+        {{- if eq .Values.antiAffinity "hard" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
@@ -25,8 +26,7 @@ spec:
                 matchLabels:
                   app: {{ include "zookeeper.name" . | quote }}
                   release: {{ .Release.Name | quote }}
-      {{- else if eq .Values.antiAffinity "soft" }}
-      affinity:
+        {{- else if eq .Values.antiAffinity "soft" }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 1
@@ -36,6 +36,11 @@ spec:
                   matchLabels:
                     app: {{ include "zookeeper.name" . | quote }}
                     release: {{ .Release.Name | quote }}
+        {{- end }}
+        {{- if .Values.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml .Values.nodeAffinity | indent 10 }}
+        {{- end }}
       {{- end }}
       containers:
       - name: {{ template "zookeeper.name" . }}-server

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -27,6 +27,7 @@ purgeHours: 1
 probeInitialDelaySeconds: 15
 probeTimeoutSeconds: 5
 antiAffinity: "hard"
+nodeAffinity: {}
 logLevel: "INFO"
 security:
   enabled: false


### PR DESCRIPTION
@lachie83 @kow3ns adding nodeAffinity because I want to run zookeeper backed by Portworx volumes, and Portworx only runs on a subset of my nodes.