### PR TITLE
Switched to environment variable arguments

### DIFF
--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark
-version: 0.1.4
+version: 0.1.5
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png

--- a/stable/spark/templates/spark-master-deployment.yaml
+++ b/stable/spark/templates/spark-master-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - name: {{ template "master-fullname" . }}
           image: "{{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}"
           command: ["/bin/sh","-c"]
-          args: ["echo $(hostname -i) {{ template "master-fullname" . }} >> /etc/hosts; /opt/spark/bin/spark-class org.apache.spark.deploy.master.Master --ip {{ template "master-fullname" . }} --port {{ .Values.Master.ServicePort }} --webui-port {{ .Values.WebUi.ContainerPort }}"]
+          args: ["echo $(hostname -i) {{ template "master-fullname" . }} >> /etc/hosts; /opt/spark/bin/spark-class org.apache.spark.deploy.master.Master"]
           ports:
             - containerPort: {{ .Values.Master.ContainerPort }}
             - containerPort: {{ .Values.WebUi.ContainerPort }}
@@ -70,3 +70,9 @@ spec:
           env:
           - name: SPARK_DAEMON_MEMORY
             value: {{ default "1g" .Values.Master.DaemonMemory | quote }}
+          - name: SPARK_MASTER_HOST
+            value: {{ template "master-fullname" . }}
+          - name: SPARK_MASTER_PORT
+            value: {{ .Values.Master.ServicePort | quote }}
+          - name: SPARK_MASTER_WEBUI_PORT
+            value: {{ .Values.WebUi.ContainerPort | quote }}

--- a/stable/spark/templates/spark-worker-deployment.yaml
+++ b/stable/spark/templates/spark-worker-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: {{ template "worker-fullname" . }}
           image: "{{ .Values.Worker.Image }}:{{ .Values.Worker.ImageTag }}"
-          command: ["/opt/spark/bin/spark-class", "org.apache.spark.deploy.worker.Worker", "spark://{{ template "master-fullname" . }}:{{ .Values.Master.ServicePort }}", "--webui-port", "{{ .Values.Worker.ContainerPort }}"]
+          command: ["/opt/spark/bin/spark-class", "org.apache.spark.deploy.worker.Worker", "spark://{{ template "master-fullname" . }}:{{ .Values.Master.ServicePort }}"]
           ports:
             - containerPort: {{ .Values.Worker.ContainerPort }}
           resources:
@@ -37,3 +37,5 @@ spec:
             value: {{ default "1g" .Values.Worker.DaemonMemory | quote }}
           - name: SPARK_WORKER_MEMORY
             value: {{ default "1g" .Values.Worker.ExecutorMemory | quote }}
+          - name: SPARK_WORKER_WEBUI_PORT
+            value: {{ .Values.WebUi.ContainerPort | quote }}

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -14,7 +14,7 @@ Master:
   ServicePort: 7077
   ContainerPort: 7077
   # Set Master JVM memory. Default 1g
-  #DaemonMemory: 1g
+  # DaemonMemory: 1g
 
 WebUi:
   Name: webui
@@ -31,9 +31,9 @@ Worker:
   Memory: "512Mi"
   ContainerPort: 8081
   # Set Worker JVM memory. Default 1g
-  #DaemonMemory: 1g
+  # DaemonMemory: 1g
   # Set how much total memory workers have to give executors
-  #ExecutorMemory: 1g
+  # ExecutorMemory: 1g
 
 Zeppelin:
   Name: zeppelin


### PR DESCRIPTION
Environment variables are evaluated before command-line arguments causing parsing of SPARK_MASTER_PORT to crash if left to the default value set by kubernetes.

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
