### PR TITLE
[stable/concourse] Add support for exposing prometheus metrics.

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.10.6
+version: 0.10.7
 appVersion: 3.6.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -296,11 +296,21 @@ spec:
                   key: vault-approle-secret-id
             {{- end }}
             {{- end }}
+            {{- if .Values.web.metrics.prometheus.enabled }}
+            - name: CONCOURSE_PROMETHEUS_BIND_IP
+              value: "0.0.0.0"
+            - name: CONCOURSE_PROMETHEUS_BIND_PORT
+              value: {{ .Values.web.metrics.prometheus.port | quote }}
+            {{- end }}
           ports:
             - name: atc
               containerPort: {{ .Values.concourse.atcPort }}
             - name: tsa
               containerPort: {{ .Values.concourse.tsaPort }}
+            {{- if .Values.web.metrics.prometheus.enabled }}
+            - name: prometheus
+              containerPort: {{ .Values.web.metrics.prometheus.port }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -370,6 +370,18 @@ web:
     #
     #
 
+  ## Metric Configuration
+  ## ref: https://concourse.ci/metrics.html
+  ##
+  metrics:
+
+    ## Enable the prometheus metrics?
+    ## Port is per https://github.com/prometheus/prometheus/wiki/Default-port-allocations
+    ##
+    prometheus:
+      enabled: false
+      port: 9391
+
 ## Configuration values for Concourse Worker components.
 ##
 worker:


### PR DESCRIPTION
In concourse, to expose prometheus metrics, need to set the env vars:
  CONCOURSE_PROMETHEUS_BIND_IP = 0.0.0.0
  CONCOURSE_PROMETHEUS_BIND_PORT = portnumber

This provides an HTTP endpoint to scrape the metrics.

Enabling metrics via the values.yaml is half the battle, still need to configure prometheus (potentially via service discovery and annotations) to scrape the data.
