### PR TITLE
[stable/grafana] Make docker image tag fixed (#2480)

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.5.3
+version: 0.5.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -31,7 +31,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Parameter                                 | Description                         | Default                                           |
 |-------------------------------------------|-------------------------------------|---------------------------------------------------|
-| `server.image`                            | Container image to run              | grafana/grafana:latest                            |
+| `server.image`                            | Container image to run              | grafana/grafana:4.6.3                             |
 | `server.adminUser`                        | Admin user username                 | admin                                             |
 | `server.adminPassword`                    | Admin user password                 | Randomly generated                                |
 | `server.persistentVolume.enabled`         | Create a volume to store data       | true                                              |

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -6,7 +6,7 @@ server:
 
   ## Grafana Docker image
   ##
-  image: "grafana/grafana:latest"
+  image: "grafana/grafana:4.6.3"
 
   extraEnv: {}
   nodeSelector: {}


### PR DESCRIPTION
The current Grafana chart is not immutable because it uses the grafana/grafana:latest image.

In my particular case, I need to be able to deploy Grafana one day and know that when I deploy it the next day, I will get the same version.  That way I can deploy to many environments over a period of multiple days.

This PR locks the image version to the current latest grafana/grafana:4.6.3

Of course, with this change, it becomes essential to make new versions of the chart when a new version of Grafana becomes available.  This is the approach taken by many charts.
