### PR TITLE
[stable/datadog] Independent toggles for APM

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.10.3
+version: 0.10.4
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
           {{- end }}
           name: dogstatsdport
           protocol: UDP
-        {{- if .Values.datadog.apmEnabled }}
+        {{- if or .Values.daemonset.apmEnabled .Values.datadog.apmEnabled }}
         - containerPort: 8126
           {{- if .Values.daemonset.useHostPort }}
           hostPort: 8126
@@ -68,7 +68,7 @@ spec:
           - name: TAGS
             value: {{ default "" .Values.datadog.tags | quote }}
           - name: DD_APM_ENABLED
-            value: {{ default "" .Values.datadog.apmEnabled | quote }}
+            value: {{ default "" (or .Values.daemonset.apmEnabled .Values.datadog.apmEnabled) | quote }}
           - name: KUBERNETES
             value: "yes"
 {{- if .Values.datadog.env }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - containerPort: 8125
           name: dogstatsdport
           protocol: UDP
-        {{- if .Values.datadog.apmEnabled }}
+        {{- if or .Values.deployment.apmEnabled .Values.datadog.apmEnabled }}
         - containerPort: 8126
           name: traceport
           protocol: TCP
@@ -49,7 +49,7 @@ spec:
           - name: TAGS
             value: {{ default "" .Values.datadog.tags | quote }}
           - name: DD_APM_ENABLED
-            value: {{ default "" .Values.datadog.apmEnabled | quote }}
+            value: {{ default "" (or .Values.deployment.apmEnabled .Values.datadog.apmEnabled) | quote }}
           - name: KUBERNETES
             value: "yes"
           {{- if .Values.datadog.collectEvents }}

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
   - port: 8125
     name: dogstatsdport
     protocol: UDP
-  {{- if .Values.datadog.apmEnabled }}
+  {{- if or .Values.deployment.apmEnabled .Values.datadog.apmEnabled }}
   - port: 8126
     name: traceport
     protocol: TCP

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -37,8 +37,10 @@ daemonset:
   ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   # updateStrategy: RollingUpdate
 
-  ## Un-comment this to enable APM and tracing for the daemon set only, on
-  ## ports 7777 and 8126
+  ## Un-comment this to enable APM and tracing for the daemon set
+  ## only, on ports 7777 and 8126. Note that if `datadog.apmEnabled:
+  ## true` is set, then setting `datadog.daemonset.apmEnabled: false`
+  ## will not override it.
   ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
   ##
   # apmEnabled: true
@@ -52,7 +54,9 @@ deployment:
   replicas: 1
 
   ## Un-comment this to enable APM and tracing for the deployment
-  ## only, on ports 7777 and 8126
+  ## only, on ports 7777 and 8126. Note that if `datadog.apmEnabled:
+  ## true` is set, then setting `datadog.deployment.apmEnabled: false`
+  ## will not override it.
   ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
   ##
   # apmEnabled: true

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -37,6 +37,12 @@ daemonset:
   ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   # updateStrategy: RollingUpdate
 
+  ## Un-comment this to enable APM and tracing for the daemon set only, on
+  ## ports 7777 and 8126
+  ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
+  ##
+  # apmEnabled: true
+
 # Apart from DaemonSet, deploy Datadog agent pods and related service for
 # applications that want to send custom metrics. Provides DogStasD service.
 #
@@ -44,6 +50,12 @@ daemonset:
 deployment:
   enabled: false
   replicas: 1
+
+  ## Un-comment this to enable APM and tracing for the deployment
+  ## only, on ports 7777 and 8126
+  ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
+  ##
+  # apmEnabled: true
 
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics


### PR DESCRIPTION
these changes enable users to enable APM for the daemonset and deployment independently by adding `datadog.daemonset.apmEnabled` and `datadog.deployment.apmEnabled`. `datadog.apmEnabled` has been retained for backwards compatibility.