### PR TITLE
Remove "\n" after command in "clone-mysql"

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysqlha
-version: 0.1.0
+version: 0.1.1
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:
   - mysql

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
     spec:
-      initContainers: 
+      initContainers:
       - name: clone-mysql
         image: {{ .Values.xtraBackupImage }}
         command:
@@ -32,7 +32,7 @@ spec:
             # Clone data from previous peer.
             ncat --recv-only {{ template "fullname" . }}-$(($ordinal-1)).{{ template "fullname" . }} 3307 | xbstream -x -C /var/lib/mysql
             # Prepare the backup.
-            xtrabackup --prepare --user=${MYSQL_REPLICATION_USER} --password=${MYSQL_REPLICATION_PASSWORD} --target-dir=/var/lib/mysql\n
+            xtrabackup --prepare --user=${MYSQL_REPLICATION_USER} --password=${MYSQL_REPLICATION_PASSWORD} --target-dir=/var/lib/mysql
         env:
         - name: MYSQL_REPLICATION_USER
           value: {{ .Values.mysqlha.mysqlReplicationUser }}
@@ -236,7 +236,7 @@ spec:
         volume.alpha.kubernetes.io/storage-class: {{ .Values.persistence.storageClass }}
         {{- end }}
     spec:
-      accessModes: 
+      accessModes:
       - {{ .Values.persistence.accessMode | quote }}
       resources:
         requests:


### PR DESCRIPTION
I try to use "incubator/mysqlha" but I found error from statefulset that show "/var/lib/mysqld not found"

So, after removing "\n" from the command everything works fine.