### PR TITLE
[stable/kong] Add a chart for Kong

### DIFF
--- a/stable/kong/.helmignore
+++ b/stable/kong/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -11,4 +11,4 @@ name: kong
 sources:
 - https://github.com/Kong/kong
 version: 0.1.0
-appVersion: 0.11.2
+appVersion: 0.12.1

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: Kong is open-source API Gateway and Microservices Management Layer,
+  delivering high performance and reliability.
+engine: gotpl
+home: https://getkong.org/
+icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
+maintainers:
+- name: shashiranjan84
+  email: shashi@konghq.com
+name: kong
+sources:
+- https://github.com/Kong/kong
+version: 0.1.0
+appVersion: 0.11.2

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -16,7 +16,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
-- Kubernetes 1.6+ with Beta APIs enabled.
+- Kubernetes 1.8+ with Beta APIs enabled.
 - PV provisioner support in the underlying infrastructure if persistence
   is needed for Kong datastore.
 

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -1,0 +1,123 @@
+## Kong
+
+[Kong](https://getkong.org/) is an open-source API Gateway and Microservices
+Management Layer, delivering high performance and reliability.
+
+## TL;DR;
+
+```bash
+$ helm install stable/kong
+```
+
+## Introduction
+
+This chart bootstraps all the components needed to run Kong on a [Kubernetes](http://kubernetes.io)
+cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.6+ with Beta APIs enabled.
+- PV provisioner support in the underlying infrastructure if persistence
+  is needed for Kong datastore.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/kong
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the
+chart and deletes the release.
+
+## Configuration
+
+### General Configuration Parameters
+
+The following tables lists the configurable parameters of the Kong chart
+and their default values.
+
+| Parameter                         | Description                                                            | Default               |
+| ------------------------------    | --------------------------------------------------------------------   | -------------------   |
+| image.repository                  | Kong image                                                             | `kong`                |
+| image.tag                         | Kong image version                                                     | `0.11.2`              |
+| image.pullPolicy                  | Image pull policy                                                      | `IfNotPresent`        |
+| replicaCount                      | Kong instance count                                                    | `1`                   |
+| admin.http.servicePort            | TCP port on which the Kong admin service is exposed                    | `8001`                |
+| admin.https.servicePort           | Secure TCP port on which the Kong admin service is exposed             | `8444`                |
+| admin.http.containerPort          | TCP port on which Kong app listens for admin traffic                   | `8001`                |
+| admin.https.containerPort         | Secure TCP port on which Kong app listens for admin traffic            | `8444`                |
+| admin.nodePort                    | Node port when service type is `NodePort`                              | `32444`               |
+| admin.type                        | k8s service type, Options: NodePort, ClusterIP, LoadBalancer           | `NodePort`            |
+| admin.loadBalancerIP              | Will reuse an existing ingress static IP for the admin service         | `null`                |
+| proxy.http.servicePort            | TCP port on which the Kong proxy service is exposed                    | `8000`                |
+| proxy.https.servicePort           | Secure TCP port on which the Kong Proxy Service is exposed             | `8443`                |
+| proxy.http.containerPort          | TCP port on which the Kong app listens for Proxy traffic               | `8000`                |
+| proxy.https.containerPort         | Secure TCP port on which the Kong app listens for Proxy traffic        | `8443`                |
+| proxy.nodePort                    | Node port when service type is `NodePort`                              | `32443`               |
+| proxy.type                        | k8s service type. Options: NodePort, ClusterIP, LoadBalancer           | `NodePort`            |
+| proxy.loadBalancerIP              | To reuse an existing ingress static IP for the admin service           |                       |
+| env                               | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)               |
+| runMigrations                     | Run Kong migrations job                                                | `true`                |
+| readinessProbe                    | Kong readiness probe                                                   |                       |
+| livenessProbe                     | Kong liveness probe                                                    |                       |
+| affinity                          | Node/pod affinities                                                    |                       |
+| nodeSelector                      | Node labels for pod assignment                                         | `{}`                  |
+| podAnnotations                    | Annotations to add to each pod                                         | `{}`                  |
+| resources                         | Pod resource requests & limits                                         | `{}`                  |
+| tolerations                       | List of node taints to tolerate                                        | `[]`                  |
+
+### Kong-specific parameters
+
+Kong has a choice of either Postgres or Cassandra as a backend datatstore.
+This chart allows you to choose either of them with the `env.database`
+parameter.  Postgres is chosen by default.
+
+Additionally, this chart allows you to use your own database or spin up a new
+instance by using the `postgres.enabled` or `cassandra.enabled` parameters.
+Enabling both will create both databases in your cluster, but only one
+will be used by Kong based on the `env.database` parameter.
+Postgres is enabled by default.
+
+| Parameter                         | Description                                                            | Default               |
+| ------------------------------    | --------------------------------------------------------------------   | -------------------   |
+| cassandra.enabled                 | Spin up a new cassandra cluster for Kong                               | `false`               |
+| postgres.enabled                  | Spin up a new postgres instance for Kong                               | `true `               |
+| env.database                      | Choose either `postgres` or `cassandra`                                | `postgres`            |
+| env.pg_user                       | Postgres username                                                      | `kong`                |
+| env.pg_database                   | Postgres database name                                                 | `kong`                |
+| env.pg_password                   | Postgres database password (required if you are using your own database)| `kong`         |
+| env.pg_host                       | Postgres database host (required if you are using your own database)   | ``                    |
+| env.pg_port                       | Postgres database port                                                 | `5432`                |
+| env.cassandra_contact_points      | Cassandra contact points (required if you are using your own database) | ``                    |
+| env.cassandra_port                | Cassandra query port                                                   | `9042`                |
+| env.cassandra_keyspace            | Cassandra keyspace                                                     | `kong`                |
+| env.cassandra_repl_factor         | Replication factor for the Kong keyspace                               | `2`                   |
+
+For complete list of Kong configurations please check https://getkong.org/docs/0.11.x/configuration/.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install stable/kong --name my-release \
+  --set=image.tag=0.11.2,database.type=caasandra,cassandra.enabled=true
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install stable/kong --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/kong/requirements.lock
+++ b/stable/kong/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.8.5
+- name: cassandra
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 0.1.9
+digest: sha256:260f7cb6e0ada4190711d6bd8bff23a97bdcab3e1f0f2802270513644dd96172
+generated: 2017-12-25T22:52:53.50321-08:00

--- a/stable/kong/requirements.yaml
+++ b/stable/kong/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  version: ~0.8.3
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: postgresql.enabled
+- name: cassandra
+  version: ~0.1.6
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  condition: cassandra.enabled

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -1,0 +1,64 @@
+1. Kong Admin can be accessed inside the cluster using:
+     DNS={{ template "kong.fullname" . }}-admin.{{ .Release.Namespace }}.svc.cluster.local
+   {{- if .Values.admin.https }}
+     PORT={{ .Values.admin.https.servicePort }}
+   {{- else if .Values.admin.http }}
+     PORT={{ .Values.admin.http.servicePort }}
+   {{- end }}
+
+
+To connect from outside the K8s cluster:
+   {{- if contains "LoadBalancer" .Values.admin.type }}
+     HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.status.loadBalancer.ingress.ip}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "NodePort" .Values.admin.type }}
+     HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "ClusterIP" .Values.admin.type }}
+     HOST=127.0.0.1
+
+     {{- if .Values.admin.https }}
+     # Execute the following commands to route the connection to Admin SSL port:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ .Values.admin.https.servicePort }}:{{ .Values.admin.https.servicePort }}
+     {{- else if .Values.admin.http }}
+     # Execute the following commands to route the connection to Admin port:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ .Values.admin.http.servicePort }}:{{ .Values.admin.http.servicePort }}
+     {{- end }}
+   {{- end }}
+
+
+2. Kong Proxy can be accessed inside the cluster using:
+     DNS={{ template "kong.fullname" . }}-proxy.{{ .Release.Namespace }}.svc.cluster.local
+   {{- if .Values.proxy.https }}
+     PORT={{ .Values.proxy.https.servicePort }}
+   {{- else if .Values.proxy.http }}
+     PORT={{ .Values.proxy.http.servicePort }}
+   {{- end }}
+
+
+To connect from outside the K8s cluster:
+   {{- if contains "LoadBalancer" .Values.proxy.type }}
+     HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress.ip}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "NodePort" .Values.proxy.type }}
+     HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+     PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if contains "ClusterIP" .Values.proxy.type }}
+     HOST=127.0.0.1
+
+     {{- if .Values.proxy.https }}
+     # Execute the following commands to route the connection to proxy SSL port:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ .Values.proxy.https.servicePort }}:{{ .Values.proxy.https.servicePort }}
+     {{- else if .Values.proxy.http }}
+     # Execute the following commands to route the connection to proxy port:
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     kubectl port-forward $POD_NAME {{ .Values.proxy.http.servicePort }}:{{ .Values.proxy.http.servicePort }}
+     {{- end }}
+   {{- end }}

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "kong.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kong.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kong.postgresql.fullname" -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kong.cassandra.fullname" -}}
+{{- $name := default "cassandra" .Values.cassandra.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ template "kong.fullname" . }}"
+  labels:
+    app: "{{ template "kong.name" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app: "{{ template "kong.name" . }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: {{ template "kong.name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: KONG_NGINX_DAEMON
+          value: "off"
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        {{- range $key, $val := .Values.env }}
+        - name: KONG_{{ $key | upper}}
+          value: {{ $val | quote }}
+        {{- end}}
+        {{- if .Values.postgresql.enabled }}
+        - name: KONG_PG_HOST
+          value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "kong.postgresql.fullname" . }}
+              key: postgres-password
+        {{- end }}
+        {{- if .Values.cassandra.enabled }}
+        - name: KONG_CASSANDRA_CONTACT_POINTS
+          value: {{ template "kong.cassandra.fullname" . }}
+        {{- end }}
+        ports:
+        {{- if .Values.admin.https }}
+        - name: admin-ssl
+          containerPort: {{ .Values.admin.https.containerPort }}
+          protocol: TCP
+        {{- else if .Values.admin.http }}
+        - name: admin
+          containerPort: {{ .Values.admin.http.containerPort }}
+          protocol: TCP
+        {{ end }}
+        {{- if .Values.proxy.https }}
+        - name: proxy-ssl
+          containerPort: {{ .Values.proxy.https.containerPort }}
+          protocol: TCP
+        {{- else if .Values.proxy.http }}
+        - name: proxy
+          containerPort: {{ .Values.proxy.http.containerPort }}
+          protocol: TCP
+        {{- end }}
+        readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 10 }}
+        livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 10 }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "kong.name" . }}
   template:
     metadata:
     {{- if .Values.podAnnotations }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: "{{ template "kong.fullname" . }}"

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -28,6 +28,14 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: KONG_ADMIN_LISTEN
+          value: 0.0.0.0:{{ default 8001 .Values.admin.http.containerPort }}
+        - name: KONG_ADMIN_LISTEN_SSL
+          value: 0.0.0.0:{{ default 8444 .Values.admin.https.containerPort }}
+        - name: KONG_PROXY_LISTEN
+          value: 0.0.0.0:{{ default 8000 .Values.proxy.http.containerPort }}
+        - name: KONG_PROXY_LISTEN_SSL
+          value: 0.0.0.0:{{ default 8443 .Values.proxy.https.containerPort }}
         - name: KONG_NGINX_DAEMON
           value: "off"
         - name: KONG_PROXY_ACCESS_LOG

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "kong.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
     {{- if .Values.podAnnotations }}
@@ -19,8 +20,8 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: "{{ template "kong.name" . }}"
-        release: "{{ .Release.Name }}"
+        app: {{ template "kong.name" . }}
+        release: {{ .Release.Name }}
     spec:
       containers:
       - name: {{ template "kong.name" . }}

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -21,24 +21,24 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-          - name: KONG_NGINX_DAEMON
-            value: "off"
+        - name: KONG_NGINX_DAEMON
+          value: "off"
         {{- range $key, $val := .Values.env }}
-          - name: KONG_{{ $key | upper}}
-            value: {{ $val | quote }}
+        - name: KONG_{{ $key | upper}}
+          value: {{ $val | quote }}
         {{- end}}
         {{- if .Values.postgresql.enabled }}
-          - name: KONG_PG_HOST
-            value: {{ template "kong.postgresql.fullname" . }}
-          - name: KONG_PG_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "kong.postgresql.fullname" . }}
-                key: postgres-password
+        - name: KONG_PG_HOST
+          value: {{ template "kong.postgresql.fullname" . }}
+        - name: KONG_PG_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "kong.postgresql.fullname" . }}
+              key: postgres-password
         {{- end }}
         {{- if .Values.cassandra.enabled }}
-          - name: KONG_CASSANDRA_CONTACT_POINTS
-            value: {{ template "kong.cassandra.fullname" . }}
+        - name: KONG_CASSANDRA_CONTACT_POINTS
+          value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
         command: [ "/bin/sh", "-c", "kong migrations up" ]
       restartPolicy: OnFailure

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.runMigrations }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kong.fullname" . }}-migrations
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  template:
+    metadata:
+      name: {{ template "kong.name" . }}-migrations
+      labels:
+        app: "{{ template "kong.name" . }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: {{ template "kong.name" . }}-migrations
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: KONG_NGINX_DAEMON
+            value: "off"
+        {{- range $key, $val := .Values.env }}
+          - name: KONG_{{ $key | upper}}
+            value: {{ $val | quote }}
+        {{- end}}
+        {{- if .Values.postgresql.enabled }}
+          - name: KONG_PG_HOST
+            value: {{ template "kong.postgresql.fullname" . }}
+          - name: KONG_PG_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "kong.postgresql.fullname" . }}
+                key: postgres-password
+        {{- end }}
+        {{- if .Values.cassandra.enabled }}
+          - name: KONG_CASSANDRA_CONTACT_POINTS
+            value: {{ template "kong.cassandra.fullname" . }}
+        {{- end }}
+        command: [ "/bin/sh", "-c", "kong migrations up" ]
+      restartPolicy: OnFailure
+{{- end }}

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-admin
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.admin.type }}
+  {{- if and (eq .Values.admin.type "LoadBalancer") .Values.admin.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - name: kong-admin
+  {{- if .Values.admin.https }}
+    port: {{ .Values.admin.https.servicePort }}
+    targetPort: {{ .Values.admin.https.containerPort }}
+  {{- else if .Values.admin.http }}
+    port: {{ .Values.admin.http.servicePort }}
+    targetPort: {{ .Values.admin.http.containerPort }}
+  {{- end }}
+  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.nodePort))) }}
+    nodePort: {{ .Values.admin.nodePort }}
+  {{- end }}
+    protocol: TCP
+  selector:
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-proxy
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.proxy.type }}
+  {{- if and (eq .Values.proxy.type "LoadBalancer") .Values.proxy.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.proxy.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - name: kong-proxy
+  {{- if .Values.proxy.https }}
+    port: {{ .Values.proxy.https.servicePort }}
+    targetPort: {{ .Values.proxy.https.containerPort }}
+  {{- else if .Values.proxy.http }}
+    port: {{ .Values.proxy.http.servicePort }}
+    targetPort: {{ .Values.proxy.http.containerPort }}
+  {{- end }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.nodePort))) }}
+    nodePort: {{ .Values.proxy.nodePort }}
+  {{- end }}
+    protocol: TCP
+  selector:
+    app: {{ template "kong.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -107,7 +107,6 @@ cassandra:
 postgresql:
   enabled: true
   postgresUser: kong
-  postgresPassword: kong
   postgresDatabase: kong
   persistence:
     enabled: false

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -1,0 +1,113 @@
+# Default values for kong.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: kong
+  tag: 0.11.2
+  pullPolicy: IfNotPresent
+
+# Specify Kong admin and proxy services configurations
+admin:
+  # HTTPS traffic on the admin port
+  https:
+    servicePort: 8444
+    containerPort: 8444
+  http:
+    servicePort: 8001
+    containerPort: 8001
+  # Kong admin service type
+  type: NodePort
+  nodePort: 32444
+proxy:
+  # HTTPS traffic on the proxy port
+  https:
+    servicePort: 8443
+    containerPort: 8443
+  http:
+    servicePort: 8000
+    containerPort: 8000
+  type: NodePort
+  nodePort: 32443
+
+# Set runMigrations to run Kong migrations
+runMigrations: true
+
+# Specify Kong configurations
+# Kong configurations guide https://getkong.org/docs/latest/configuration/
+env:
+  database: postgres
+
+# If you want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+# readinessProbe for Kong pods
+readinessProbe:
+  httpGet:
+    path: "/status"
+    port: admin-ssl
+    scheme: HTTPS
+  initialDelaySeconds: 300
+  timeoutSeconds: 60
+  periodSeconds: 60
+  successThreshold: 1
+  failureThreshold: 5
+
+# livenessProbe for Kong pods
+livenessProbe:
+  httpGet:
+    path: "/status"
+    port: admin-ssl
+    scheme: HTTPS
+  initialDelaySeconds: 300
+  timeoutSeconds: 60
+  periodSeconds: 60
+  successThreshold: 1
+  failureThreshold: 5
+
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+# Annotation to be added to Kong pods
+podAnnotations: {}
+
+# Kong pod count
+replicaCount: 1
+
+# Kong has a choice of either Postgres or Cassandra as a backend datatstore.
+# This chart allows you to choose either of them with the `database.type`
+# parameter.  Postgres is chosen by default.
+
+# Additionally, this chart allows you to use your own database or spin up a new
+# instance by using the `postgres.enabled` or `cassandra.enabled` parameters.
+# Enabling both will create both databases in your cluster, but only one
+# will be used by Kong based on the `env.database` parameter.
+# Postgres is enabled by default.
+
+# Cassandra chart configs
+cassandra:
+  enabled: false
+
+# PostgreSQL chart configs
+postgresql:
+  enabled: true
+  postgresUser: kong
+  postgresPassword: kong
+  postgresDatabase: kong
+  persistence:
+    enabled: false

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: kong
-  tag: 0.11.2
+  tag: 0.12.1
   pullPolicy: IfNotPresent
 
 # Specify Kong admin and proxy services configurations


### PR DESCRIPTION
- Chart deploys Kong and its backing datastore either Cassandra or
  PostgreSql(default)
- Uses official [Kong](https://hub.docker.com/_/kong/) Docker image

Note: Opening this new PR instead of #3031.