### PR TITLE
Delete jobs using kubectl, not helm

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.6
+version: 0.1.7
 appVersion: 8.17
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -48,7 +48,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 > **Warning**: Jobs are not deleted automatically. They need to be manually deleted
 ```consule
-$ helm delete job/sentry-db-init job/sentry-user-create
+$ kubectl delete job/sentry-db-init job/sentry-user-create
 ```
 
 ## Configuration


### PR DESCRIPTION
The jobs should be deleted using `kubectl` not `helm`.
