### PR TITLE
[stable/verdaccio] Set deployment strategy type to Recreate

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.1.2
+version: 0.1.3
 appVersion: 2.7.1
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png
 sources:

--- a/stable/verdaccio/templates/deployment.yaml
+++ b/stable/verdaccio/templates/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
   name: {{ template "verdaccio.fullname" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   template:
     metadata:
     {{- if .Values.podAnnotations }}


### PR DESCRIPTION
Fix issue related to persistent storage and Helm upgrade.
Set deployment strategy type to Recreate to prevent the application to be stuck during upgrade, waiting for the claim to be available.