### PR TITLE
etcd-operator: add Alejandro Escobar as maintainer

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -12,3 +12,5 @@ maintainers:
   email: chance.zibolski@coreos.com
 - name: lachie83
   email: lachlan@deis.com
+- name: alejandroEsc
+  email: jaescobar.cell@gmail.com

--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.7.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png


### PR DESCRIPTION
Due to Alejandro's contribution to etcd-operator chart, his using/testing the chart at work, and his good will to maintain it, Alejandro has been referenced as the official active maintainer in etcd-operator:
https://github.com/coreos/etcd-operator/blob/master/doc/user/install_guide.md#installation-using-helm

It would be great to add Alejandro in the chart maintainer list to better coordinate and help with community issues further. Thanks!