### PR TITLE
[incubator/drone] Added data persistence

### DIFF
--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,8 +1,8 @@
 name: drone
 home: https://drone.io/
-version: 0.1.0
-appVersion: 0.8.1
-description: Drone CI
+version: 0.1.1
+appVersion: 0.8.2
+description: Drone is a Continuous Delivery system built on container technology
 keywords:
 - continuous-delivery
 - continuous-deployment

--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,5 +1,6 @@
 name: drone
 home: https://drone.io/
+icon: http://docs.drone.io/logo.svg
 version: 0.1.1
 appVersion: 0.8.2
 description: Drone is a Continuous Delivery system built on container technology

--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: http://docs.drone.io/logo.svg
-version: 0.1.1
+version: 0.2.0
 appVersion: 0.8.2
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -31,24 +31,33 @@ chart and deletes the release.
 
 The following tables lists the configurable parameters of the drone charts and their default values.
 
-| Parameter               | Description                                                                                   | Default                 |
-|-------------------------|-----------------------------------------------------------------------------------------------|-------------------------|
-| `image.repository`      | Drone **server** image                                                                        | `docker.io/drone/drone` |
-| `image.tag`             | Drone **server** image tag                                                                    | `0.8.1`                 |
-| `image.pullPolicy`      | Drone **server** image pull policy                                                            | `IfNotPresent`          |
-| `agentImage.repository` | Drone **agent** image                                                                         | `docker.io/drone/agent` |
-| `agentImage.tag`        | Drone **agent** image tag                                                                     | `0.8.1`                 |
-| `agentImage.pullPolicy` | Drone **agent** image pull policy                                                             | `IfNotPresent`          |
-| `service.httpPort`      | Drone's Web GUI HTTP port                                                                     | `80`                    |
-| `service.nodePort`      | If `service.type` is `NodePort` and this is non-empty, sets the http node port of the service | `32015`                 |
-| `service.type`          | Service type (ClusterIP, NodePort or LoadBalancer)                                            | `ClusterIP`             |
-| `ingress.enabled`       | Enables Ingress for Drone                                                                     | `false`                 |
-| `ingress.annotations`   | Ingress annotations                                                                           | `{}`                    |
-| `ingress.hosts`         | Ingress accepted hostnames                                                                    | `nil`                   |
-| `ingress.tls`           | Ingress TLS configuration                                                                     | `[]`                    |
-| `server.host`           | Drone **server** hostname                                                                     | `(internal hostname)`   |
-| `server.env`            | Drone **server** environment variables                                                        | `(default values)`      |
-| `server.resources`      | Drone **server** pod resource requests & limits                                               | `{}`                    |
-| `agent.env`             | Drone **agent** environment variables                                                         | `(default values)`      |
-| `agent.resources`       | Drone **agent** pod resource requests & limits                                                | `{}`                    |
-| `sharedSecret`         | Drone server and agent shared secret                                                          | `(random value)`        |
+| Parameter                   | Description                                                                                   | Default                     |
+|-----------------------------|-----------------------------------------------------------------------------------------------|-----------------------------|
+| `images.server.repository`  | Drone **server** image                                                                        | `docker.io/drone/drone`     |
+| `images.server.tag`         | Drone **server** image tag                                                                    | `0.8.2`                     |
+| `images.server.pullPolicy`  | Drone **server** image pull policy                                                            | `IfNotPresent`              |
+| `images.agent.repository`   | Drone **agent** image                                                                         | `docker.io/drone/agent`     |
+| `images.agent.tag`          | Drone **agent** image tag                                                                     | `0.8.2`                     |
+| `images.agent.pullPolicy`   | Drone **agent** image pull policy                                                             | `IfNotPresent`              |
+| `images.dind.repository`    | Docker **dind** image                                                                         | `docker.io/library/docker`  |
+| `images.dind.tag`           | Docker **dind** image tag                                                                     | `17.12.0-ce-dind`           |
+| `images.dind.pullPolicy`    | Docker **dind** image pull policy                                                             | `IfNotPresent`              |
+| `service.httpPort`          | Drone's Web GUI HTTP port                                                                     | `80`                        |
+| `service.httpPort`          | Drone's Web GUI HTTP port                                                                     | `80`                        |
+| `service.nodePort`          | If `service.type` is `NodePort` and this is non-empty, sets the http node port of the service | `32015`                     |
+| `service.type`              | Service type (ClusterIP, NodePort or LoadBalancer)                                            | `ClusterIP`                 |
+| `ingress.enabled`           | Enables Ingress for Drone                                                                     | `false`                     |
+| `ingress.annotations`       | Ingress annotations                                                                           | `{}`                        |
+| `ingress.hosts`             | Ingress accepted hostnames                                                                    | `nil`                       |
+| `ingress.tls`               | Ingress TLS configuration                                                                     | `[]`                        |
+| `server.host`               | Drone **server** hostname                                                                     | `(internal hostname)`       |
+| `server.env`                | Drone **server** environment variables                                                        | `(default values)`          |
+| `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
+| `agent.env`                 | Drone **agent** environment variables                                                         | `(default values)`          |
+| `agent.resources`           | Drone **agent** pod resource requests & limits                                                | `{}`                        |
+| `persistence.enabled`       | Use a PVC to persist data                                                                     | `true`                      |
+| `persistence.existingClaim` | Use an existing PVC to persist data                                                           | `nil`                       |
+| `persistence.storageClass`  | Storage class of backing PVC                                                                  | `nil`                       |
+| `persistence.accessMode`    | Use volume as ReadOnly or ReadWrite                                                           | `ReadWriteOnce`             |
+| `persistence.size`          | Size of data volume                                                                           | `1Gi`                       |
+| `sharedSecret`              | Drone server and agent shared secret                                                          | `(random value)`            |

--- a/incubator/drone/templates/deployment-agent.yaml
+++ b/incubator/drone/templates/deployment-agent.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       containers:
       - name: {{ template "drone.fullname" . }}-agent
-        image: "{{ .Values.agentImage.repository }}:{{ .Values.agentImage.tag }}"
-        imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
+        image: "{{ .Values.images.agent.repository }}:{{ .Values.images.agent.tag }}"
+        imagePullPolicy: {{ .Values.images.agent.pullPolicy }}
         env:
           - name: DRONE_SERVER
             value: {{ template "drone.fullname" . }}:9000
@@ -38,7 +38,8 @@ spec:
         resources:
 {{ toYaml .Values.agent.resources | indent 10 }}
       - name: {{ template "drone.fullname" . }}-dind
-        image: docker:17.05.0-ce-dind
+        image: "{{ .Values.images.dind.repository }}:{{ .Values.images.dind.tag }}"
+        imagePullPolicy: {{ .Values.images.dind.pullPolicy }}
         env:
         - name: DOCKER_DRIVER
           value: overlay

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -20,8 +20,8 @@ spec:
     spec:
       containers:
       - name: {{ template "drone.fullname" . }}-server
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ .Values.images.server.repository }}:{{ .Values.images.server.tag }}"
+        imagePullPolicy: {{ .Values.images.server.pullPolicy }}
         env:
           - name: DRONE_SECRET
             valueFrom:

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -51,4 +51,15 @@ spec:
             port: http
         resources:
 {{ toYaml .Values.server.resources | indent 10 }}
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/drone
+      volumes:
+      - name: data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "drone.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}
 {{ end }}

--- a/incubator/drone/templates/pvc.yaml
+++ b/incubator/drone/templates/pvc.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "drone.fullname" . }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -1,23 +1,29 @@
-appVersion: "0.8.1"
+appVersion: "0.8.2"
 
-## The official drone image, change tag to use a different version.
-## https://hub.docker.com/r/drone/drone/tags/
-##
-image:
-  repository: "docker.io/drone/drone"
-  tag: "0.8.1"
-  pullPolicy: "IfNotPresent"
+images:
+  ## The official drone (server) image, change tag to use a different version.
+  ## ref: https://hub.docker.com/r/drone/drone/tags/
+  ##
+  server:
+    repository: "docker.io/drone/drone"
+    tag: 0.8.2
+    pullPolicy: IfNotPresent
 
-## Since version 8.x drone splitted agent and server into two
-## different images.
-##
-## NOTE: Older versions of drone are **not** supported.
-## https://hub.docker.com/r/drone/agent/tags/
-##
-agentImage:
-  repository: "docker.io/drone/agent"
-  tag: "0.8.1"
-  pullPolicy: "IfNotPresent"
+  ## The official drone (agent) image, change tag to use a different version.
+  ## ref: https://hub.docker.com/r/drone/agent/tags/
+  ##
+  agent:
+    repository: "docker.io/drone/agent"
+    tag: 0.8.2
+    pullPolicy: IfNotPresent
+
+  ## The official docker (dind) image, change tag to use a different version.
+  ## ref: https://hub.docker.com/r/library/docker/tags/
+  ##
+  dind:
+    repository: "docker.io/library/docker"
+    tag: 17.12.0-ce-dind
+    pullPolicy: IfNotPresent
 
 service:
   httpPort: 80

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -68,12 +68,12 @@ server:
 
   ## Drone server configuration.
   ## Values in here get injected as environment variables.
-  ## http://readme.drone.io/admin/installation-reference
+  ## ref: http://readme.drone.io/admin/installation-reference
   ##
   env:
     DRONE_DEBUG: "false"
     DRONE_DATABASE_DRIVER: "sqlite3"
-    DRONE_DATABASE_DATASOURCE: "drone.sqlite"
+    DRONE_DATABASE_DATASOURCE: "/var/lib/drone/drone.sqlite"
 
     ## Drone requires some environment variables to bootstrap the
     ## git service or it won't start up.
@@ -100,7 +100,7 @@ server:
 agent:
   ## Drone agent configuration.
   ## Values in here get injected as environment variables.
-  ## http://readme.drone.io/admin/installation-reference
+  ## ref: http://readme.drone.io/admin/installation-reference
   ##
   env:
     DRONE_DEBUG: "false"
@@ -114,6 +114,28 @@ agent:
   #  limits:
   #    memory: 2Gi
   #    cpu: 1
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
+  ## rabbitmq data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 1Gi
 
 ## Uncomment this if you want to set a specific shared secret between
 ## the agents and servers, otherwise this will be auto-generated.


### PR DESCRIPTION
- [x] **Added data persistence to the chart**
- [x] Updated drone to version 0.8.2
- [x] Updated docker (dind) to version 17.12.0-ce
- [x] Better management of images (see values.yaml)
- [x] Updated README according to the new values
- [x] Added icon to the chart & better description

Once the current version of the chart is verified, drone should be ready to be moved in **stable/drone**.
NOTE: This chart has already been tested with persistence enabled.