### PR TITLE
Bump Kapacitor

### DIFF
--- a/stable/kapacitor/Chart.yaml
+++ b/stable/kapacitor/Chart.yaml
@@ -1,5 +1,5 @@
 name: kapacitor
-version: 0.4.0
+version: 0.5.0
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.
 keywords:

--- a/stable/kapacitor/values.yaml
+++ b/stable/kapacitor/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: "kapacitor"
-  tag: "1.2"
+  tag: "1.4-alpine"
   pullPolicy: "IfNotPresent"
 
 ## Specify a service type, defaults to NodePort
@@ -51,7 +51,7 @@ resources:
 # or, at your terminal, with
 #
 # helm install --name kapacitor-rls --set influxURL=http://influxurl.com,envVars.KAPACITOR_SLACK_ENABLED=true,envVars.KAPACITOR_SLACK_URL="http://slack.com/xxxxx/xxxxx/xxxx/xxxxxxx" stable/kapacitor
-    
+
 ## Set the URL of InfluxDB instance to create subscription on
 ## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/
 ##


### PR DESCRIPTION
/assign @mattfarina

This PR switch Kapacitor to alpine to maintain the same base image
(alpine) across all the tick stack.

It also switches to docker.io for the same reason.
