### PR TITLE
[stable/redis] Allow customization of securityContext fsGroup/runAsUser fields

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 1.1.4
+version: 1.1.5
 appVersion: 4.0.6
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
       {{- end }}
     spec:
       securityContext:
-        runAsUser: 1001
-        fsGroup: 1001
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -11,6 +11,11 @@ imagePullPolicy: IfNotPresent
 ## Kubernetes service type
 serviceType: ClusterIP
 
+## Pod Security Context
+securityContext:
+  fsGroup: 1001
+  runAsUser: 1001
+
 ## Use password authentication
 usePassword: true
 


### PR DESCRIPTION
I use the [official repository](https://hub.docker.com/r/library/redis/) for Redis which creates a user with different UID/GID than the one currently used on the deployment manifest. This leads to permission errors when writing the RDB file to disk and service unavailability.

This pull request adds new values options for customizing the `pod.spec.securityContext.fsGroup` and `pod.spec.securityContext.runAsUser`, keeping the default the current value.