### PR TITLE
[stable/nginx-ingress] Make 'defaultSSLCertificate' actually work by adding to controller args when specified

### DIFF
--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -40,6 +40,9 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+          {{- if .Values.controller.defaultSSLCertificate }}
+            - --default-ssl-certificate={{ .Values.controller.defaultSSLCertificate }}
+          {{- end }}
           {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}


### PR DESCRIPTION
The [values.yaml includes a 'defaultSSLCertificate' option](https://github.com/kubernetes/charts/blob/master/stable/nginx-ingress/values.yaml#L25-L28). However the deployment template never actually checks or uses the value. This make it actually work as intended, by adding to controller args when specified.

```
  ## Optionally specify the secret name for default SSL certificate
  ## Must be <namespace>/<secret_name>
  ##
  defaultSSLCertificate: ""
```

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
