### PR TITLE
[stable/memcached] fix the memcached chart's bug, when the AntiAffinity is soft

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 2.0.0
+version: 2.0.1
 description: Free & open source, high-performance, distributed memory object caching
   system.
 keywords:

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 5
             podAffinityTerm:
-            - topologyKey: "kubernetes.io/hostname"
+              topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchLabels:
                   app:  {{ template "memcached.fullname" . }}

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -10,15 +10,15 @@ image: memcached:1.4.36-alpine
 # imagePullPolicy:
 #
 
-##Replica count 
+## Replica count
 replicaCount: 3
 
-##Pod disruption budget minAvailable count
+## Pod disruption budget minAvailable count
 pdbMinAvailable: 3
 
 ## Select AnitAffinity as either hard or soft, default is hard
 AntiAffinity: "hard"
-  
+
 memcached:
   ## Various values that get set as command-line flags.
   ## ref: https://github.com/memcached/memcached/wiki/ConfiguringServer#commandline-arguments


### PR DESCRIPTION
when the AntiAffinity is soft,
the preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey should be a map , not a array.

@linki
  