### PR TITLE
[stable/prometheus] allow to set extraArgs for kube-state-metrics

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.6.16
+version: 4.6.17
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -27,6 +27,10 @@ spec:
         - name: {{ template "prometheus.name" . }}-{{ .Values.kubeStateMetrics.name }}
           image: "{{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}"
           imagePullPolicy: "{{ .Values.kubeStateMetrics.image.pullPolicy }}"
+          args:
+          {{- range $key, $value := .Values.kubeStateMetrics.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -233,6 +233,10 @@ kubeStateMetrics:
     servicePort: 80
     type: ClusterIP
 
+  ## Additional kube-state-metrics container arguments
+  ##
+  extraArgs: {}
+
 nodeExporter:
   ## If false, node-exporter will not be installed
   ##


### PR DESCRIPTION
it should be possible to pass extra args to kube-state-metrics, i.e. to mitigate the kubernetes/kube-state-metrics#295 issue on GKE by setting the `collectors` arg to everything without `cronjobs`