### PR TITLE
[WIP] Add annotations to logstash Deployment

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.3.1
+version: 0.3.2
 appVersion: 6.0.0
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -31,24 +31,26 @@ chart and deletes the release.
 
 The following tables lists the configurable parameters of the drone charts and their default values.
 
-| Parameter              | Description                                        | Default                                          |
-| ---------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| `replicaCount`         | Number of replicas                                 | `1`                                              |
-| `nodeSelector`         | Node selectors                                     | `{}`                                             |
-| `image.repository`     | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
-| `image.tag`            | Container image tag                                | `6.0.0`                                          |
-| `image.pullPolicy`     | Container image pull policy                        | `IfNotPresent`                                   |
-| `service.type`         | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                       |
-| `service.internalPort` | Logstash internal port                             | `1514`                                           |
-| `service.ports`        | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
-| `ingress.enabled`      | Enables Ingress                                    | `false`                                          |
-| `ingress.annotations`  | Ingress annotations                                | `{}`                                             |
-| `ingress.hosts`        | Ingress accepted hostnames                         | `[]`                                             |
-| `ingress.tls`          | Ingress TLS configuration                          | `nil`                                            |
-| `resources`            | Pod resource requests & limits                     | `{}`                                             |
-| `elasticsearch.host`   | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
-| `elasticsearch.port`   | ElasticSearch port                                 | `9200`                                           |
-| `patterns`             | Logstash patterns configuration                    | `nil`                                            |
-| `inputs`               | Logstash inputs configuration                      | `(basic)`                                        |
-| `filters`              | Logstash filters configuration                     | `nil`                                            |
-| `outputs`              | Logstash outputs configuration                     | `(basic)`                                        |
+| Parameter                | Description                                        | Default                                          |
+| ------------------------ | -------------------------------------------------- | ------------------------------------------------ |
+| `replicaCount`           | Number of replicas                                 | `1`                                              |
+| `configMapRestart`       | Whether to restart on ConfigMap changes            | `false`                                          |
+| `nodeSelector`           | Node selectors                                     | `{}`                                             |
+| `image.repository`       | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
+| `image.tag`              | Container image tag                                | `6.0.0`                                          |
+| `image.pullPolicy`       | Container image pull policy                        | `IfNotPresent`                                   |
+| `service.type`           | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
+| `service.internalPort`   | Logstash internal port                             | `1514`                                           |
+| `service.ports`          | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
+| `deployment.annotations` | Deployment annotations                             | `{}`                                             |
+| `ingress.enabled`        | Enables Ingress                                    | `false`                                          |
+| `ingress.annotations`    | Ingress annotations                                | `{}`                                             |
+| `ingress.hosts`          | Ingress accepted hostnames                         | `[]`                                             |
+| `ingress.tls`            | Ingress TLS configuration                          | `nil`                                            |
+| `resources`              | Pod resource requests & limits                     | `{}`                                             |
+| `elasticsearch.host`     | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
+| `elasticsearch.port`     | ElasticSearch port                                 | `9200`                                           |
+| `patterns`               | Logstash patterns configuration                    | `nil`                                            |
+| `inputs`                 | Logstash inputs configuration                      | `(basic)`                                        |
+| `filters`                | Logstash filters configuration                     | `nil`                                            |
+| `outputs`                | Logstash outputs configuration                     | `(basic)`                                        |

--- a/incubator/logstash/templates/deployment.yaml
+++ b/incubator/logstash/templates/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+{{- if .Values.configMapRestart }}
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end }}
+{{ toYaml .Values.deployment.annotations | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
-# whether to restart deployment on ConfigMap changes 
+# whether to restart deployment on ConfigMap changes
 configMapRestart: false
 nodeSelector: {}
 image:

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
+# whether to restart deployment on ConfigMap changes 
+configMapRestart: false
 nodeSelector: {}
 image:
   repository: docker.elastic.co/logstash/logstash-oss
@@ -20,6 +22,9 @@ service:
     - name: "filebeat-tcp"
       protocol: TCP
       containerPort: 5044
+
+deployment:
+  annotations:
 
 ingress:
   enabled: false


### PR DESCRIPTION
Add the ability to add annotations to the logstash Deployment.
Add the ability to restart the deployment when the ConfigMap changes using this method: https://github.com/kubernetes/helm/blob/master/docs/charts_tips_and_tricks.md#automatically-roll-deployments-when-configmaps-or-secrets-change

I am adding annotations to the deployment so we can setup logstash to wait for the elasticsearch service to be ready before it starts using k82-wait-for:
https://github.com/groundnuty/k8s-wait-for

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************