### PR TITLE
[stable/kube-state-metrics] allow for nodeSelector to be configured

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.5.1
+version: 0.5.2
 appVersion: 1.1.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -21,6 +21,7 @@ $ helm install stable/kube-state-metrics
 | `prometheusScrape`                  | Whether or not enable prom scrape                       | True                                        |
 | `rbac.create`                       | If true, create & use RBAC resources                    | False                                       |
 | `rbac.serviceAccountName`           | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
+| `nodeSelector`                      | Node labels for pod assignment	                        | {}                                     |
 | `podAnnotations`                    | Annotations to be added to the pod                      | {}                                     |
 | `resources`                         | kube-state-metrics resource requests and limits         | {}                                          |
 | `collectors.daemonsets`             | Enable the daemonsets collector.                        | true                                        |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -74,3 +74,8 @@ spec:
           timeoutSeconds: 5
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -16,6 +16,10 @@ rbac:
   # Ignored if rbac.create is true
   serviceAccountName: default
 
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
 # Annotations to be added to the pod
 podAnnotations: {}
 


### PR DESCRIPTION
Allow for a nodeSelector to be applied to the kube-state-metrics pod.