### PR TITLE
[stable/efs-provisioner] Chart for efs-provisioner, a Kubernetes external-storage provisioner

### DIFF
--- a/stable/efs-provisioner/.helmignore
+++ b/stable/efs-provisioner/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/efs-provisioner/Chart.yaml
+++ b/stable/efs-provisioner/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: efs-provisioner
+description: A Helm chart for the AWS EFS external storage provisioner
+version: 0.1.1
+appVersion: v0.1.2
+home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
+sources:
+ - https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
+ - https://github.com/mirror/busybox
+maintainers:
+ - name: whereisaaron
+   email: aaron@roydhouse.com

--- a/stable/efs-provisioner/README.md
+++ b/stable/efs-provisioner/README.md
@@ -1,0 +1,106 @@
+# Helm chart for 'efs-provisioner'
+
+The Kubernetes project provides an AWS [EFS provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs) 
+that is used to fulfill PersistentVolumeClaims with EFS PersistentVolumes.
+
+"The efs-provisioner allows you to mount EFS storage as PersistentVolumes in kubernetes. 
+It consists of a container that has access to an AWS EFS resource. The container reads 
+a configmap which contains the EFS filesystem ID, the AWS region and the name you want 
+to use for your efs-provisioner. This name will be used later when you create a storage class."
+
+This chart deploys the EFS Provisioner and a StorageClass for EFS volumes (optionally as the default).
+
+The EFS external storage provisioner runs in a Kubernetes cluster and will create persistent volumes
+in response to the PersistentVolumeClaim resources being created. These persistent volumes can then be
+mounted on containers.
+
+  https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+
+The persisent volumes are created as folders with in an AWS EFS filesystem.
+
+  https://aws.amazon.com/efs/
+
+## Prequisites
+
+You must create the EFS file system and end points yourself first.
+
+  https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html
+
+The end points must be accessible to the cluster and the cluster nodes must have
+permission to mount EFS file systems.
+
+## Configuring
+
+At a minimum you must the supply the EFS file system ID and the AWS region
+
+```
+helm install stable/efs-provisioner --set efsFileSystemId=fs-12345678 --set awsRegion=us-east-2
+```
+
+All the values documented below and by `helm inspect values`.
+
+```
+helm inspect values stable/efs-provisioner
+```
+
+```
+#
+# Default values for EFS provisioner service
+# https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
+#
+
+## Deploy environment label, e.g. dev, test, prod
+##
+global:
+  deployEnv: dev
+
+## Containers
+##
+replicaCount: 1
+revisionHistoryLimit: 10
+image:
+  repository: quay.io/external_storage/efs-provisioner
+  tag: latest
+  pullPolicy: IfNotPresent
+
+busyboxImage:
+  repository: gcr.io/google_containers/busybox
+  tag: 1.27
+  pullPolicy: IfNotPresent
+
+## Configure provisioner
+## https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs#deployment
+##
+efsProvisioner:
+  efsFileSystemId: fs-12345678
+  awsRegion: us-east-2
+  path: /example-pv
+  provisionerName: example.com/aws-efs
+  storageClass:
+    name: efs
+    isDefault: false
+    gidAllocate:
+      enabled: true
+      gidMin: 40000
+      gidMax: 50000
+    reclaimPolicy: Delete
+
+## Enable RBAC
+## Leave serviceAccountName blank for the default name
+##
+rbac:
+  create: true
+  serviceAccountName: ""
+
+## Configure resources
+##
+resources: {}
+  # To specify resources, uncomment the following lines, adjust them as necessary,
+  # and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 200m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+```

--- a/stable/efs-provisioner/templates/NOTES.txt
+++ b/stable/efs-provisioner/templates/NOTES.txt
@@ -1,0 +1,15 @@
+You can provision an EFS-backed persistent volume with a persistent volume claim like below:
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: my-efs-vol-1
+  annotations:
+    volume.beta.kubernetes.io/storage-class: {{ .Values.efsProvisioner.storageClass.name }}
+spec:
+  storageClassName: {{ .Values.efsProvisioner.storageClass.name }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi

--- a/stable/efs-provisioner/templates/_helpers.tpl
+++ b/stable/efs-provisioner/templates/_helpers.tpl
@@ -1,0 +1,39 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "efs-provisioner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "efs-provisioner.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified chart name.
+*/}}
+{{- define "efs-provisioner.chartname" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "efs-provisioner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "efs-provisioner.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/efs-provisioner/templates/clusterrole.yaml
+++ b/stable/efs-provisioner/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "efs-provisioner.fullname" . }}
+  labels:
+    app: {{ template "efs-provisioner.name" . }}
+    env: {{ .Values.global.deployEnv }}
+    chart: {{ template "efs-provisioner.chartname" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+{{- end }}

--- a/stable/efs-provisioner/templates/clusterrolebinding.yaml
+++ b/stable/efs-provisioner/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "efs-provisioner.fullname" . }}
+  labels:
+    app: {{ template "efs-provisioner.name" . }}
+    env: {{ .Values.global.deployEnv }}
+    chart: {{ template "efs-provisioner.chartname" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "efs-provisioner.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "efs-provisioner.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/stable/efs-provisioner/templates/deployment.yaml
+++ b/stable/efs-provisioner/templates/deployment.yaml
@@ -1,0 +1,56 @@
+kind: Deployment
+apiVersion: apps/v1beta2
+metadata:
+  name: {{ template "efs-provisioner.fullname" . }}
+  labels:
+    app: {{ template "efs-provisioner.name" . }}
+    env: {{ .Values.global.deployEnv }}
+    chart: {{ template "efs-provisioner.chartname" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "efs-provisioner.name" . }}
+      release: "{{ .Release.Name }}"
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ template "efs-provisioner.name" . }}
+        release: "{{ .Release.Name }}"
+    spec:
+      serviceAccount: {{ template "efs-provisioner.serviceAccountName" . }}
+      containers:
+      - name: {{ template "efs-provisioner.fullname" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: FILE_SYSTEM_ID
+          value: {{ .Values.efsProvisioner.efsFileSystemId }}
+        - name: AWS_REGION
+          value: {{ .Values.efsProvisioner.awsRegion }}
+        - name: PROVISIONER_NAME
+          value: {{ .Values.efsProvisioner.provisionerName }}
+        volumeMounts:
+        - name: pv-volume
+          subPath: {{ (trimPrefix "/" .Values.efsProvisioner.path) }}
+          mountPath: /persistentvolumes
+      {{- if ne .Values.efsProvisioner.path "/" }}
+      initContainers:
+      - name: "init-path"
+        image: {{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag}}
+        imagePullPolicy: {{ .Values.busyboxImage.pullPolicy }}
+        command: [ "sh", "-c", "mkdir -p /efs-vol-root/{{ (trimPrefix "/" .Values.efsProvisioner.path) }}" ]
+        volumeMounts:
+        - name: pv-volume
+          mountPath: /efs-vol-root
+      {{- end }}
+      volumes:
+      - name: pv-volume
+        nfs:
+          server: {{ .Values.efsProvisioner.efsFileSystemId }}.efs.{{ .Values.efsProvisioner.awsRegion }}.amazonaws.com
+          path: /

--- a/stable/efs-provisioner/templates/serviceaccount.yaml
+++ b/stable/efs-provisioner/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "efs-provisioner.serviceAccountName" . }}
+  labels:
+    app: {{ template "efs-provisioner.name" . }}
+    env: {{ .Values.global.deployEnv }}
+    chart: {{ template "efs-provisioner.chartname" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/stable/efs-provisioner/templates/storageclass.yaml
+++ b/stable/efs-provisioner/templates/storageclass.yaml
@@ -1,0 +1,26 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: {{ .Values.efsProvisioner.storageClass.name }}
+  labels:
+    app: {{ template "efs-provisioner.name" . }}
+    env: {{ .Values.global.deployEnv }}
+    chart: {{ template "efs-provisioner.chartname" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- if .Values.efsProvisioner.storageClass.isDefault }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+provisioner: {{ .Values.efsProvisioner.provisionerName }}
+parameters:
+{{- if .Values.efsProvisioner.storageClass.gidAllocate.enabled }}
+{{- with .Values.efsProvisioner.storageClass.gidAllocate }}
+  gidAllocate: "true"
+  gidMin: "{{ .gidMin }}"
+  gidMax: "{{ .gidMax }}"
+{{- end }}
+{{- else }}
+  gidAllocate: "false"
+{{- end }}
+reclaimPolicy: {{ .Values.efsProvisioner.storageClass.reclaimPolicy }}

--- a/stable/efs-provisioner/values.yaml
+++ b/stable/efs-provisioner/values.yaml
@@ -1,0 +1,67 @@
+#
+# Default values for EFS provisioner service
+# https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
+#
+
+## Deploy environment label, e.g. dev, test, prod
+##
+global:
+  deployEnv: dev
+
+## Containers
+##
+replicaCount: 1
+revisionHistoryLimit: 10
+image:
+  repository: quay.io/external_storage/efs-provisioner
+  tag: v0.1.2
+  pullPolicy: IfNotPresent
+
+busyboxImage:
+  repository: gcr.io/google_containers/busybox
+  tag: 1.27
+  pullPolicy: IfNotPresent
+
+## Configure provisioner
+## https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs#deployment
+##
+efsProvisioner:
+  efsFileSystemId: fs-12345678
+  awsRegion: us-east-2
+  path: /example-pv
+  provisionerName: example.com/aws-efs
+  storageClass:
+    name: efs
+    isDefault: false
+    gidAllocate:
+      enabled: true
+      gidMin: 40000
+      gidMax: 50000
+    reclaimPolicy: Delete
+
+## Enable RBAC
+##
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+## Create or use ServiceAccount
+##
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+## Configure resources
+##
+resources: {}
+  # To specify resources, uncomment the following lines, adjust them as necessary,
+  # and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 200m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi


### PR DESCRIPTION
This chart deploys the EFS external storage provisioner, which is a Kubernetes incubator project:

  https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs

The chart follows the deployment manifests recommended by the `efs-provisioner` authors and I believe follows the best practices from the Helm documentation, and chart technical requirements.

The is no `appversion` in the `Chart.yaml`. As this is deploying a incubator project the authors' manifests recommend deploying 'latest', and 'latest' is not semVer compliant :-)

To test this you need a Kubernetes 1.8+ cluster running on AWS with and EFS file system available.