### PR TITLE
[incubator/kubewatch] fix startup issues due to empty resourcesToWatch config

### DIFF
--- a/incubator/kubewatch/Chart.yaml
+++ b/incubator/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 0.2.0
+version: 0.2.1
 appVersion: v0.0.3
 description: Kubewatch notifies your slack rooms when changes to your cluster occur
 keywords:

--- a/incubator/kubewatch/README.md
+++ b/incubator/kubewatch/README.md
@@ -49,7 +49,15 @@ Parameter | Description | Default
 `rbac.create` | If true, create & use RBAC resources | `false`
 `rbac.serviceAccountName` | existing ServiceAccount to use (ignored if rbac.create=true) | `default`
 `replicaCount` | desired number of pods | `1`
-`resourcesToWatch` | list of resources which kubewatch should watch and notify slack | `{}`
+`resourcesToWatch` | list of resources which kubewatch should watch and notify slack | `{pod: true, deployment: true}`
+`resourcesToWatch.pod` | watch changes to [Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/) | `true`
+`resourcesToWatch.deployment` | watch changes to [Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) | `true`
+`resourcesToWatch.replicationcontroller` | watch changes to [ReplicationControllers](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/) | `false`
+`resourcesToWatch.replicaset` | watch changes to [ReplicaSets](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/) | `false`
+`resourcesToWatch.daemonset` | watch changes to [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) | `false`
+`resourcesToWatch.services` | watch changes to [Services](https://kubernetes.io/docs/concepts/services-networking/service/) | `false`
+`resourcesToWatch.job` | watch changes to [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) | `false`
+`resourcesToWatch.persistentvolume` | watch changes to [PersistentVolumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) | `false`
 `resources` | pod resource requests & limits | `{}`
 `slack.channel` | slack channel to notify | `""`
 `slack.token` | slack API token | `""`
@@ -69,3 +77,10 @@ $ helm install incubator/kubewatch --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Create a Slack bot
+
+Open [https://my.slack.com/services/new/bot](https://my.slack.com/services/new/bot) to create a new Slack bot.
+The API token can be found on the edit page (it starts with `xoxb-`).
+
+Invite the Bot to your channel by typing `/join @name_of_your_bot` in the Slack message area.

--- a/incubator/kubewatch/values.yaml
+++ b/incubator/kubewatch/values.yaml
@@ -2,18 +2,20 @@ slack:
   # Slack channel to notify
   channel: ""
 
-  # Slack bots token
-  # Ref: https://api.slack.com/docs/token-types#bot
+  # Slack bots token. Create using: https://my.slack.com/services/new/bot
+  # and invite the bot to your channel using: /join @botname
   token: ""
 
-# Resouces to watch
-resourcesToWatch: {}
-  # deployment: true
-  # replicationcontroller: true
-  # replicaset: true
-  # daemonset: true
-  # services: true
-  # pod: true
+# Resources to watch
+resourcesToWatch:
+  deployment: true
+  replicationcontroller: false
+  replicaset: false
+  daemonset: false
+  services: false
+  pod: true
+  job: false
+  persistentvolume: false
 
 image:
   repository: "tuna/kubewatch"


### PR DESCRIPTION
This PR fixes startup issues with the incubator/kubewatch chart. Currently the pod enters in a CrashLoopBackOff because resourcesToWatch is empty. This change provides a sane default configuration and makes it easier to users to discover the various settings for `resourcesToWatch`.