### PR TITLE
Optionally adds liveness and readiness probes to jenkins

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.11.0
+version: 0.11.1
 appVersion: 2.73
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -44,6 +44,8 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.ServiceType`              | k8s service type                     | `LoadBalancer`                                                               |
 | `Master.ServicePort`              | k8s service port                     | `8080`                                                                       |
 | `Master.NodePort`                 | k8s node port                        | Not set                                                                      |
+| `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `false`                                                                  |
+| `Master.HealthProbesTimeout`      | Set the timeout for the liveness and readiness probes | `120`                                                       |
 | `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
 | `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -44,7 +44,7 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.ServiceType`              | k8s service type                     | `LoadBalancer`                                                               |
 | `Master.ServicePort`              | k8s service port                     | `8080`                                                                       |
 | `Master.NodePort`                 | k8s node port                        | Not set                                                                      |
-| `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `false`                                                                  |
+| `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `true`                                                                   |
 | `Master.HealthProbesTimeout`      | Set the timeout for the liveness and readiness probes | `120`                                                       |
 | `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -97,12 +97,12 @@ spec:
             httpGet:
               path: /login
               port: http
-            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout | default 120 }}
+            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout }}
           readinessProbe:
             httpGet:
               path: /login
               port: http
-            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout | default 120 }}
+            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout }}
 {{- end }}
           resources:
             requests:

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -92,6 +92,18 @@ spec:
             - containerPort: {{ .Values.Master.JMXPort }}
               name: jmx
             {{- end }}
+{{- if .Values.Master.HealthProbes }}
+          livenessProbe:
+            httpGet:
+              path: /login
+              port: http
+            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout | default 120 }}
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: http
+            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout | default 120 }}
+{{- end }}
           resources:
             requests:
               cpu: "{{ .Values.Master.Cpu }}"

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -34,6 +34,8 @@ Master:
   # HostName: jenkins.cluster.local
   # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
+  # Enable Kubernetes Liveness and Readiness Probes
+  HealthProbes: false
   SlaveListenerPort: 50000
   LoadBalancerSourceRanges:
   - 0.0.0.0/0

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -35,7 +35,8 @@ Master:
   # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
   # Enable Kubernetes Liveness and Readiness Probes
-  HealthProbes: false
+  HealthProbes: true
+  HealthProbesTimeout: 120
   SlaveListenerPort: 50000
   LoadBalancerSourceRanges:
   - 0.0.0.0/0


### PR DESCRIPTION
* Jenkins takes awhile to start the very first time, so we need to wait a bit before the first check
  * A value of 120 seconds seemed just right, but flexibility provided just in case it is not
* Setting the healthcheck endpoint to `/login` as that is what returns an HTTP200 when jenkins is alive
* This assists in addressing #772
