### PR TITLE
Allowing configurable sslCertPath for cluster autoscaler

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.4.1
+version: 0.4.2
 appVersion: 1.1.0
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -97,6 +97,7 @@ Parameter | Description | Default
 `autoscalingGroups[].maxSize` | maximum autoscaling group size | None. You *must* supply at least one.
 `autoscalingGroups[].minSize` | minimum autoscaling group size | None. You *must* supply at least one.
 `awsRegion` | AWS region (required if `cloudProvider=aws`) | `us-east-1`
+`sslCertPath` | Path on the host where ssl ca cert exists | `/etc/ssl/certs/ca-certificates.crt`
 `cloudProvider` | `aws` or `spotinst` are currently supported | `aws`
 `image.repository` | Image (used if `cloudProvider=aws`) | `k8s.gcr.io/cluster-autoscaler`
 `image.tag` | Image tag (used if `cloudProvider=aws`) | `v0.6.0`

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
             - name: ssl-certs
-              mountPath: /etc/ssl/certs/ca-certificates.crt
+              mountPath: {{ .Values.sslCertPath }}
               readOnly: true
     {{- if .Values.affinity }}
       affinity:
@@ -77,4 +77,4 @@ spec:
       volumes:
         - name: ssl-certs
           hostPath:
-            path: /etc/ssl/certs/ca-certificates.crt
+            path: {{ .Values.sslCertPath }}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -9,6 +9,8 @@ awsRegion: us-east-1
 # Currently only `aws` & `spotinst` are supported
 cloudProvider: aws
 
+sslCertPath: /etc/ssl/certs/ca-certificates.crt
+
 image:
   repository: k8s.gcr.io/cluster-autoscaler
   tag: v1.1.0


### PR DESCRIPTION
Allowing the chart to accept a different ssl-cert path. The default value remains the same. This is one way to make the chart work on Kubernetes clusters that are not running a `debian` or `cos` machine images.

I wasn't sure what to do about chart versioning so I didn't change it. 