### PR TITLE
[stable/cluster-autoscaler] Bump to version 1.1.0

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.3.1
-appVersion: 1.0.3
+version: 0.4.0
+appVersion: 1.1.0
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
 - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -83,4 +83,12 @@ rules:
     - watch
     - list
     - get
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - storageclasses
+    verbs:
+    - watch
+    - list
+    - get
 {{- end -}}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -11,7 +11,7 @@ cloudProvider: aws
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v1.0.3
+  tag: v1.1.0
   pullPolicy: IfNotPresent
 
 tolerations: []


### PR DESCRIPTION
This bumps the cluster autoscaler version to 1.1.0. It needs a new permission in order to watch storage classes.

cc the maintainer @mgoodness