### PR TITLE
[stable/kube2iam] Bump to version 0.9.0

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.6.1
+version: 0.7.0
 description: Provide IAM credentials to pods based on annotations.
 keywords:
 - kube2iam

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -11,7 +11,7 @@ host:
 
 image:
   repository: jtblin/kube2iam
-  tag: 0.7.0
+  tag: 0.9.0
   pullPolicy: IfNotPresent
 
 # AWS Access keys to inject as environment variables


### PR DESCRIPTION
This updates kube2iam to version 0.9.0

cc the maintainers @jmcarp, @icereval, and @mgoodness 