### PR TITLE
Trivial fix to two missing namespace options

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.8.5
+version: 0.8.6
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -7,7 +7,7 @@ To get your user password run:
 
 To connect to your database run the following command (using the env variable from above):
 
-   kubectl run --namespace {{ .Release.Namespace }}{{ template "postgresql.fullname" . }}-client --rm --tty -i --image postgres \
+   kubectl run --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }}-client --rm --tty -i --image postgres \
    --env "PGPASSWORD=$PGPASSWORD" \{{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
    --labels="{{ template "postgresql.fullname" . }}-client=true" \{{- end }}
    --command -- psql -U {{ default "postgres" .Values.postgresUser }} \

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -7,7 +7,7 @@ To get your user password run:
 
 To connect to your database run the following command (using the env variable from above):
 
-   kubectl run {{ template "postgresql.fullname" . }}-client --rm --tty -i --image postgres \
+   kubectl run --namespace {{ .Release.Namespace }}{{ template "postgresql.fullname" . }}-client --rm --tty -i --image postgres \
    --env "PGPASSWORD=$PGPASSWORD" \{{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
    --labels="{{ template "postgresql.fullname" . }}-client=true" \{{- end }}
    --command -- psql -U {{ default "postgres" .Values.postgresUser }} \
@@ -30,6 +30,6 @@ To connect to your database directly from outside the K8s cluster:
 
      # Execute the following commands to route the connection:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "postgresql.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ default "5432" .Values.service.port }}:{{ default "5432" .Values.service.port }}
+     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ default "5432" .Values.service.port }}:{{ default "5432" .Values.service.port }}
 
    {{- end }}


### PR DESCRIPTION
I installed this chart from stable this evening, following the instructions from `NOTES.txt`. I noticed two of the commands are not namespaced, but they need to be if you install into a namespace other than `default`. This trivial PR fixes this in the `NOTES.txt` file.