### PR TITLE
[incubator/oauth-proxy] Fix documentation typo for clientID value

### DIFF
--- a/incubator/oauth-proxy/Chart.yaml
+++ b/incubator/oauth-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth-proxy
-version: 0.1.2
+version: 0.1.3
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/incubator/oauth-proxy/README.md
+++ b/incubator/oauth-proxy/README.md
@@ -42,7 +42,7 @@ The following tables lists the configurable parameters of the oauth-proxy chart 
 Parameter | Description | Default
 --- | --- | ---
 `affinity` | node/pod affinities | None
-`config.clientId` | oauth client ID | `""`
+`config.clientID` | oauth client ID | `""`
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'` | `""`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`


### PR DESCRIPTION
The README.md references the key clientId whilst the actual name used in values.yaml and the templates is clientID (caps "ID").