### PR TITLE
[stable/mongodb] Support existing volume claim

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 0.4.22
+version: 0.4.23
 appVersion: 3.6.1
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/deployment.yaml
+++ b/stable/mongodb/templates/deployment.yaml
@@ -60,7 +60,8 @@ spec:
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "mongodb.fullname" . }}
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
+
       {{- else }}
         emptyDir: {}
       {{- end -}}

--- a/stable/mongodb/templates/pvc.yaml
+++ b/stable/mongodb/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -29,6 +29,11 @@ serviceType: ClusterIP
 ##
 persistence:
   enabled: true
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
   ## mongodb data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Add support for using an existing volume claim for stable/mongodb chart. This PR is based upon the work in #2984 for the stable/openvpn chart.