### PR TITLE
[stable/redis] chart omits line continuation \ in the NOTES.txt

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 1.1.5
+version: 1.1.6
 appVersion: 4.0.6
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/NOTES.txt
+++ b/stable/redis/templates/NOTES.txt
@@ -12,7 +12,7 @@ To connect to your Redis server:
 1. Run a Redis pod that you can use as a client:
 
    kubectl run --namespace {{ .Release.Namespace }} {{ template "redis.fullname" . }}-client --rm --tty -i \
-   {{ if .Values.usePassword }} --env REDIS_PASSWORD=$REDIS_PASSWORD{{ end }}
+   {{ if .Values.usePassword }} --env REDIS_PASSWORD=$REDIS_PASSWORD \{{ end }}
    {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}--labels="{{ template "redis.fullname" . }}-client=true" \{{- end }}
    --image {{ .Values.image }} -- bash
 


### PR DESCRIPTION
When .values.usePassword is true (the out of the box default), the rendered NOTES.txt includes an example command which should span multiple lines, but since a \ is omitted, the command fails to execute without modification. 

Renders as: 
```
   kubectl run --namespace kyleschlosser ignorant-sasquatch-redis-client --rm --tty -i \
    --env REDIS_PASSWORD=$REDIS_PASSWORD
   --image bitnami/redis:4.0.6-r1 -- bash
```

Should be:
```
   kubectl run --namespace kyleschlosser ignorant-sasquatch-redis-client --rm --tty -i \
    --env REDIS_PASSWORD=$REDIS_PASSWORD \
   --image bitnami/redis:4.0.6-r1 -- bash
```