### PR TITLE
Add annotations to the Traefik Dashboard Service

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.15.2
+version: 1.16.0
 appVersion: 1.4.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -112,8 +112,9 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `acme.persistence.accessMode`   | `ReadWriteOnce` or `ReadOnly`                                        | `ReadWriteOnce`                           |
 | `acme.persistence.size`         | Minimum size of the volume requested                                 | `1Gi`                                     |
 | `dashboard.enabled`             | Whether to enable the Traefik dashboard                              | `false`                                   |
-| `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |
-| `dashboard.ingress.annotations` | Annotations for the Traefik dashboard Ingress definition, specified as a map | None                              |
+| `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |               
+| `dashboard.service.annotations` | Annotations for the Traefik dashboard Service definition, specified as a map | None                |
+| `dashboard.ingress.annotations` | Annotations for the Traefik dashboard Ingress definition, specified as a map | None                |
 | `dashboard.ingress.labels`      | Labels for the Traefik dashboard Ingress definition, specified as a map      | None                              |
 | `dashboard.auth.basic`          | Basic auth for the Traefik dashboard specified as a map, see Authentication section | unset by default; this means basic auth is disabled |
 | `dashboard.statistics.recentErrors` | Number of recent errors to show in the ‘Health’ tab              | None                                      |

--- a/stable/traefik/templates/dashboard-service.yaml
+++ b/stable/traefik/templates/dashboard-service.yaml
@@ -8,6 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.dashboard.service }}
+  {{- range $key, $value := .Values.dashboard.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   selector:
     app: {{ template "fullname" . }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -51,6 +51,9 @@ acme:
 dashboard:
   enabled: false
   domain: traefik.example.com
+  service:
+    # annotations:
+    #   key: value
   ingress:
     # annotations:
     #   key: value


### PR DESCRIPTION
Hi there 😄 

This PR adds the ability to add annotations to Traefik Dashboard's Service. This is useful when using tools like [external-dns](https://github.com/kubernetes-incubator/external-dns).

Thank you!
JH