### PR TITLE
[stable/wordpress] Make liveness and readiness probes configurable

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.7.10
+version: 0.8.0
 appVersion: 4.9.1
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -113,9 +113,7 @@ spec:
             port: https
             scheme: HTTPS
           {{- end }}
-          initialDelaySeconds: 120
-          timeoutSeconds: 5
-          failureThreshold: 6
+{{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
           httpGet:
             path: /wp-login.php
@@ -125,9 +123,7 @@ spec:
             port: https
             scheme: HTTPS
           {{- end }}
-          initialDelaySeconds: 30
-          timeoutSeconds: 3
-          periodSeconds: 5
+{{ toYaml .Values.readinessProbe | indent 10 }}
         volumeMounts:
         - mountPath: /bitnami/apache
           name: wordpress-data

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -125,6 +125,21 @@ serviceType: LoadBalancer
 ## Allow health checks to be pointed at the https port
 healthcheckHttps: false
 
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
 ## Configure ingress resource that allow you to access the
 ## Wordpress instalation. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/


### PR DESCRIPTION
Depending on the platform and db options and a variety of associated factors (network latency, disk speed, etc.), initializing the database upon first WP startup _can_ take a lot longer than the 120 seconds previously hard-coded as the initial delay on the liveness probe. It seems it would be beneficial to make this value configurable, so this PR makes _all_ aspects of the liveness and readiness probes configurable (without changing the defaults).

fwiw, there are may other charts that could stand to receive the same treatment. I started here because this chart is of personal interest to me.

cc @prydonius @tompizmor 
  