### PR TITLE
[stable/magento] Allow use of external database

### DIFF
--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -1,5 +1,5 @@
 name: magento
-version: 0.5.2
+version: 0.6.0
 appVersion: 2.2.2
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/OWNERS
+++ b/stable/magento/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- prydonius
+- tompizmor
+- sameersbn
+reviewers:
+- prydonius
+- tompizmor
+- sameersbn

--- a/stable/magento/README.md
+++ b/stable/magento/README.md
@@ -58,13 +58,23 @@ The following tables lists the configurable parameters of the Magento chart and 
 | `magentoLastName`                  | Magento Admin Last Name                  | `LastName`                                               |
 | `magentoMode`                      | Magento mode                             | `developer`                                              |
 | `magentoAdminUri`                  | Magento prefix to access Magento Admin   | `admin`                                                  |
+| `allowEmptyPassword`               | Allow DB blank passwords                 | `yes`                                                    |
+| `externalDatabase.host`            | Host of the external database            | `nil`                                                    |
+| `externalDatabase.port`            | Port of the external database            | `3306`                                                   |
+| `externalDatabase.user`            | Existing username in the external db     | `bn_magento`                                             |
+| `externalDatabase.password`        | Password for the above username          | `nil`                                                    |
+| `externalDatabase.database`        | Name of the existing databse             | `bitnami_magento`                                        |
+| `mariadb.enabled`                  | Use or not the mariadb chart             | `true`                                                   |
 | `mariadb.mariadbRootPassword`      | MariaDB admin password                   | `nil`                                                    |
+| `mariadb.mariadbDatabase`          | Database name to create                  | `bitnami_magento`                                        |
+| `mariadb.mariadbUser`              | Database user to create                  | `bn_magento`                                             |
+| `mariadb.mariadbPassword`          | Password for the database                | _random 10 character long alphanumeric string_           |
 | `serviceType`                      | Kubernetes Service type                  | `LoadBalancer`                                           |
 | `persistence.enabled`              | Enable persistence using PVC             | `true`                                                   |
-| `persistence.apache.storageClass`  | PVC Storage Class for Apache volume      | `nil`  (uses alpha storage annotation)                                              |
+| `persistence.apache.storageClass`  | PVC Storage Class for Apache volume      | `nil`  (uses alpha storage annotation)                   |
 | `persistence.apache.accessMode`    | PVC Access Mode for Apache volume        | `ReadWriteOnce`                                          |
 | `persistence.apache.size`          | PVC Storage Request for Apache volume    | `1Gi`                                                    |
-| `persistence.magento.storageClass` | PVC Storage Class for Magento volume     | `nil`  (uses alpha storage annotation)                                                |
+| `persistence.magento.storageClass` | PVC Storage Class for Magento volume     | `nil`  (uses alpha storage annotation)                   |
 | `persistence.magento.accessMode`   | PVC Access Mode for Magento volume       | `ReadWriteOnce`                                          |
 | `persistence.magento.size`         | PVC Storage Request for Magento volume   | `8Gi`                                                    |
 | `resources`                        | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`                             |

--- a/stable/magento/requirements.lock
+++ b/stable/magento/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.7.0
-digest: sha256:e1af13ac4ac21f67582006f12d2b4eb78a1a2a59b34338fac850f2bec0b08b41
-generated: 2017-08-09T22:52:51.270271603-04:00
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-01-11T14:11:57.269863+01:00

--- a/stable/magento/requirements.lock
+++ b/stable/magento/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
-generated: 2018-01-11T14:11:57.269863+01:00
+  version: 2.1.2
+digest: sha256:c8b7cfbae3b77525918ec3d38f8b0ce132c963707e7e59f3eaf5bc94347e66f1
+generated: 2018-01-15T11:40:57.489245+01:00

--- a/stable/magento/requirements.yaml
+++ b/stable/magento/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
+  version: 2.1.2
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/stable/magento/requirements.yaml
+++ b/stable/magento/requirements.yaml
@@ -1,4 +1,5 @@
 dependencies:
 - name: mariadb
   version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://kubernetes-charts.storage.googleapis.com/i
+  condition: mariadb.enabled

--- a/stable/magento/requirements.yaml
+++ b/stable/magento/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
   version: 0.7.0
-  repository: https://kubernetes-charts.storage.googleapis.com/i
+  repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/stable/magento/templates/NOTES.txt
+++ b/stable/magento/templates/NOTES.txt
@@ -1,4 +1,4 @@
-+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
 {{- if empty (include "magento.host" .) -}}
 ###############################################################################
@@ -29,8 +29,17 @@ host. To configure Magento with the URL of your service:
 
 2. Complete your Magento deployment by running:
 
-  helm upgrade {{ .Release.Name }} \
-    --set magentoHost=$APP_HOST,magentoPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }} stable/magento
+{{- if .Values.mariadb.enabled }}
+
+  helm upgrade {{ .Release.Name }} stable/magento \
+    --set magentoHost=$APP_HOST,magentoPassword=$APP_PASSWORD{{ if .Values.mariadb.mariadbRootPassword }},mariadb.mariadbRootPassword=$APP_DATABASE_PASSWORD{{ end }}
+{{- else }}
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/magento \
+    --set magentoPassword=$APP_PASSWORD,magentoHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.host) }},externalDatabase.host={{ .Values.externalDatabase.host }}{{- end }}{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }}
+{{- end }}
 
 {{- else -}}
 1. Get the Magento URL by running:
@@ -52,19 +61,34 @@ host. To configure Magento with the URL of your service:
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "magento.fullname" . }} -o jsonpath="{.data.magento-password}" | base64 --decode)
 {{- end }}
 
+{{- else -}}
 
- {{- else -}}
+########################################################################################
+### ERROR: You did not provide an external database host in your 'helm install' call ###
+########################################################################################
 
- ########################################################################################
- ### ERROR: You did not provide an external database host in your 'helm install' call ###
- ########################################################################################
-
- This deployment will be incomplete until you configure Magento with a resolvable database
- host. To configure Magento to use and external database host:
+This deployment will be incomplete until you configure Magento with a resolvable database
+host. To configure Magento to use and external database host:
 
 
- 1. Complete your Magento deployment by running:
+1. Complete your Magento deployment by running:
 
-   helm upgrade {{ .Release.Name }} --set magentoHost=YOUR_MAGENTO_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/magento
+{{- if contains "NodePort" .Values.serviceType }}
+  export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- else if contains "LoadBalancer" .Values.serviceType }}
 
- {{- end }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "magento.fullname" . }}'
+
+  export APP_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "magento.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+{{- else }}
+
+  export APP_HOST=127.0.0.1
+{{- end }}
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "magento.fullname" . }} -o jsonpath="{.data.magento-password}" | base64 --decode)
+
+  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
+
+  helm upgrade {{ .Release.Name }} stable/magento \
+    --set magentoPassword=$APP_PASSWORD,magentoHost=$APP_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST
+{{- end }}

--- a/stable/magento/templates/NOTES.txt
+++ b/stable/magento/templates/NOTES.txt
@@ -1,3 +1,5 @@
++{{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
+
 {{- if empty (include "magento.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
@@ -49,3 +51,20 @@ host. To configure Magento with the URL of your service:
   echo Username: {{ .Values.magentoUsername }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "magento.fullname" . }} -o jsonpath="{.data.magento-password}" | base64 --decode)
 {{- end }}
+
+
+ {{- else -}}
+
+ ########################################################################################
+ ### ERROR: You did not provide an external database host in your 'helm install' call ###
+ ########################################################################################
+
+ This deployment will be incomplete until you configure Magento with a resolvable database
+ host. To configure Magento to use and external database host:
+
+
+ 1. Complete your phpBB deployment by running:
+
+   helm upgrade {{ .Release.Name }} --set magentoHost=YOUR_MAGENTO_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/magento
+
+ {{- end }}

--- a/stable/magento/templates/NOTES.txt
+++ b/stable/magento/templates/NOTES.txt
@@ -63,7 +63,7 @@ host. To configure Magento with the URL of your service:
  host. To configure Magento to use and external database host:
 
 
- 1. Complete your phpBB deployment by running:
+ 1. Complete your Magento deployment by running:
 
    helm upgrade {{ .Release.Name }} --set magentoHost=YOUR_MAGENTO_HOST,serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/magento
 

--- a/stable/magento/templates/deployment.yaml
+++ b/stable/magento/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               name: {{ template "magento.mariadb.fullname" . }}
               key: mariadb-password
               {{- else }}
-              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              name: {{ template "magento.fullname" . }}-externaldb
               key: db-password
               {{- end }}
         - name: MAGENTO_HOST

--- a/stable/magento/templates/deployment.yaml
+++ b/stable/magento/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if include "magento.host" . -}}
+{{- if and (include "magento.host" .) (or .Values.mariadb.enabled .Values.externalDatabase.host) -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -17,36 +17,61 @@ spec:
       containers:
       - name: {{ template "magento.fullname" . }}
         image: "{{ .Values.image }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
         - name: MARIADB_HOST
+        {{- if .Values.mariadb.enabled }}
           value: {{ template "magento.mariadb.fullname" . }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.host | quote }}
+        {{- end }}
         - name: MARIADB_PORT_NUMBER
+        {{- if .Values.mariadb.enabled }}
           value: "3306"
-        - name: MARIADB_PASSWORD
+        {{- else }}
+          value: {{ .Values.externalDatabase.port | quote }}
+        {{- end }}
+        - name: MAGENTO_DATABASE_NAME
+        {{- if .Values.mariadb.enabled }}
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.database | quote }}
+        {{- end }}
+        - name: MAGENTO_DATABASE_USER
+        {{- if .Values.mariadb.enabled }}
+          value: {{ .Values.mariadb.mariadbUser | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.user | quote }}
+        {{- end }}
+        - name: MAGENTO_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.mariadb.enabled }}
               name: {{ template "magento.mariadb.fullname" . }}
-              key: mariadb-root-password
+              key: mariadb-password
+              {{- else }}
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+              {{- end }}
         - name: MAGENTO_HOST
           value: {{ include "magento.host" . | quote }}
         - name: MAGENTO_USERNAME
-          value: {{ default "" .Values.magentoUsername | quote }}
+          value: {{ .Values.magentoUsername | quote }}
         - name: MAGENTO_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "magento.fullname" . }}
               key: magento-password
         - name: MAGENTO_EMAIL
-          value: {{ default "" .Values.magentoEmail | quote }}
+          value: {{ .Values.magentoEmail | quote }}
         - name: MAGENTO_ADMINURI
-          value: {{ default "" .Values.magentoAdminUri | quote }}
+          value: {{ .Values.magentoAdminUri | quote }}
         - name: MAGENTO_FIRSTNAME
-          value: {{ default "" .Values.magentoFirstName | quote }}
+          value: {{ .Values.magentoFirstName | quote }}
         - name: MAGENTO_LASTNAME
-          value: {{ default "" .Values.magentoLastName | quote }}
+          value: {{ .Values.magentoLastName | quote }}
         - name: MAGENTO_MODE
-          value: {{ default "" .Values.magentoMode | quote }}
+          value: {{ .Values.magentoMode | quote }}
         ports:
         - name: http
           containerPort: 80

--- a/stable/magento/templates/externaldb-secrets.yaml
+++ b/stable/magento/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.mariadb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/magento/templates/externaldb-secrets.yaml
+++ b/stable/magento/templates/externaldb-secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
   labels:
-    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    app: {{ template "magento.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/magento/templates/externaldb-secrets.yaml
+++ b/stable/magento/templates/externaldb-secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  name: {{ template "magento.fullname" . }}-externaldb
   labels:
     app: {{ template "magento.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/magento/values.yaml
+++ b/stable/magento/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/bitnami/magento/tags/
 ##
 
-image: bitnami/magento:2.2.2-r0
+image: bitnami/magento:2.2.2-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -56,14 +56,57 @@ magentoLastName: LastName
 ##
 magentoMode: developer
 
+## Set to `yes` to allow the container to be started with blank passwords
+## ref: https://github.com/bitnami/bitnami-docker-magento#environment-variables
+allowEmptyPassword: "yes"
+
+##
+## External database configuration
+##
+externalDatabase:
+ ## Database host
+ host:
+
+ ## Database host
+ port: 3306
+
+ ## Database user
+ user: bn_magento
+
+ ## Database password
+ password:
+
+ ## Database name
+ database: bitnami_magento
+
+
 ##
 ## MariaDB chart configuration
 ##
 mariadb:
+  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  enabled: true
+
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
   ##
   # mariadbRootPassword:
+
+  ## Create a database
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ##
+  mariadbDatabase: bitnami_magento
+
+  ## Create a database user
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbUser: bn_magento
+
+  ## Password for mariadbUser
+  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ##
+  mariadbPassword: magento_db_password
+
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/stable/magento/values.yaml
+++ b/stable/magento/values.yaml
@@ -84,45 +84,45 @@ externalDatabase:
 ## MariaDB chart configuration
 ##
 mariadb:
-  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+ ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+ enabled: true
+
+ ## MariaDB admin password
+ ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
+ ##
+ # mariadbRootPassword:
+
+ ## Create a database
+ ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+ ##
+ mariadbDatabase: bitnami_magento
+
+ ## Create a database user
+ ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+ ##
+ mariadbUser: bn_magento
+
+ ## Password for mariadbUser
+ ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+ ##
+ mariadbPassword: magento_db_password
+
+
+ ## Enable persistence using Persistent Volume Claims
+ ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+ ##
+ persistence:
   enabled: true
-
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
+  ## mariadb data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
   ##
-  # mariadbRootPassword:
-
-  ## Create a database
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
-  ##
-  mariadbDatabase: bitnami_magento
-
-  ## Create a database user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
-  ##
-  mariadbUser: bn_magento
-
-  ## Password for mariadbUser
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
-  ##
-  mariadbPassword: magento_db_password
-
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  persistence:
-    enabled: true
-    ## mariadb data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    # storageClass: "-"
-    accessMode: ReadWriteOnce
-    size: 8Gi
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 8Gi
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
@@ -133,34 +133,34 @@ serviceType: LoadBalancer
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
-  enabled: true
-  apache:
-    ## apache data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    # storageClass: "-"
-    accessMode: ReadWriteOnce
-    size: 1Gi
-  magento:
-    ## magento data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    # storageClass: "-"
-    accessMode: ReadWriteOnce
-    size: 8Gi
+ enabled: true
+ apache:
+  ## apache data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 1Gi
+ magento:
+  ## magento data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 8Gi
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
 resources:
-  requests:
-    memory: 512Mi
-    cpu: 300m
+ requests:
+  memory: 512Mi
+  cpu: 300m


### PR DESCRIPTION
Since `bitnami/magento:2.2.2-r1` it is possible to configure Magento to use an already existing database.
This PR makes the required changes in the chart to create the database using the MariaDB chart and use it for Magento.