### PR TITLE
[incubator/kafka] liveness and readiness probes as parameters

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.2.11
+version: 0.2.12
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -34,8 +34,8 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 9092
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
           exec:
             command:
@@ -43,8 +43,8 @@ spec:
               - --zookeeper
               - {{ template "zookeeper.url" . }}
               - --list
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         ports:
         - containerPort: 9092
           name: kafka

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -15,6 +15,18 @@ imageTag: "4.0.0"
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 imagePullPolicy: "IfNotPresent"
 
+livenessProbe:
+  ## Specify liveness probe initial delay
+  initialDelaySeconds: 30
+  ## Specify liveness probe timeout
+  timeoutSeconds: 5
+
+readinessProbe:
+  ## Specify readiness probe initial delay
+  initialDelaySeconds: 30
+  ## Specify readiness probe timeout
+  timeoutSeconds: 5
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 resources: {}


### PR DESCRIPTION
Guys, I have problems with starting kafka pods on my kubernetes cluster (running on bare metal).
```
Liveness probe failed: dial tcp 10.244.1.10:9092: getsockopt: connection refused
```
I decided to make liveness and readiness probes parameters configurable.