### PR TITLE
[stable/nginx-ingress] Remove the defaultSSLCertificate option and document how to use extraArgs instead

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.23
+version: 0.8.24
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -22,11 +22,6 @@ controller:
   ##
   defaultBackendService: ""
 
-  ## Optionally specify the secret name for default SSL certificate
-  ## Must be <namespace>/<secret_name>
-  ##
-  defaultSSLCertificate: ""
-
   ## Election ID to use for status update
   ##
   electionID: ingress-controller-leader
@@ -54,6 +49,10 @@ controller:
     enabled: false
     namespace: ""   # defaults to .Release.Namespace
 
+  ## Additional command line arguments to pass to nginx-ingress-controller
+  ## E.g. to specify the default SSL certificate you can use
+  ## extraArgs:
+  ##   default-ssl-certificate: "<namespace>/<secret_name>"
   extraArgs: {}
 
   ## Additional environment variables to set


### PR DESCRIPTION
The default SSL certificate is an important deployment option for `nginx-ingress`. Without it a dummy certificate is used that leads to errors for end-users. By supplying your own wildcard, SAN, or SAN multi-wildcard certificate you can ensure even Ingress resources without explicit certificates work.

The chart maintainers have rejected implementing a default SSL certificate option (#3219, #2476, #1610, #1522) and recommend using the `extraArgs` option instead. This functions fine, but it not intuitive for the end user looking to configure the certificate, and requires some domain knowledge of the `nginx-ingress` binary's command line options.

The `defaultSSLCertificate` setting remains in the `values.yaml` file, but is not implemented. Charts users try to use the option and wonder why it doesn't work.

This PR addresses both issues. Removing the unimplemented `defaultSSLCertificate` from `values.yaml` and documenting for end-users how the can achieve the equivalent via the `extraArgs` option.