### PR TITLE
[incubator/cassandra] Configurable UpdateStrategy and JVM Agent port

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.1.9
+version: 0.2.0
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing
   high availability with no single point of failure.

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -87,6 +87,7 @@ The following tables lists the configurable parameters of the Cassandra chart an
 | `config.heap_new_size`     | Initdb Arguments                                | `512M`                                                     |
 | `config.ports.cql`         | Initdb Arguments                                | `9042`                                                     |
 | `config.ports.thrift`      | Initdb Arguments                                | `9160`                                                     |
+| `config.ports.agent`       | The port of the JVM Agent (if any)              | `nil`                                                      |
 | `config.start_rpc`         | Initdb Arguments                                | `false`                                                    |
 | `persistence.enabled`      | Use a PVC to persist data                       | `true`                                                     |
 | `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
@@ -94,6 +95,7 @@ The following tables lists the configurable parameters of the Cassandra chart an
 | `persistence.size`         | Size of data volume                             | `10Gi`                                                     |
 | `resources`                | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
 | `service.type`             | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
+| `updateStrategy.type`      | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
 
 ## Scale cassandra
 When you want to change the cluster size of your cassandra, you can use the helm upgrade command.

--- a/incubator/cassandra/templates/cassandra-statefulset.yaml
+++ b/incubator/cassandra/templates/cassandra-statefulset.yaml
@@ -26,6 +26,11 @@ spec:
   - name: thrift
     port: {{ default 9160 .Values.config.ports.thrift }}
     targetPort: {{ default 9160 .Values.config.ports.thrift }}
+  {{- if .Values.config.ports.agent }}
+  - name: agent
+    port: {{ .Values.config.ports.agent }}
+    targetPort: {{ .Values.config.ports.agent }}
+  {{- end }}
   selector:
     app: {{ template "cassandra.fullname" . }}
 ---
@@ -41,6 +46,8 @@ metadata:
 spec:
   serviceName: {{ template "cassandra.fullname" . }}
   replicas: {{ .Values.config.cluster_size }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
   template:
     metadata:
       labels:
@@ -102,6 +109,10 @@ spec:
           containerPort: {{ default 9042 .Values.config.ports.cql }}
         - name: thrift
           containerPort: {{ default 9160 .Values.config.ports.thrift }}
+        {{- if .Values.config.ports.agent }}
+        - name: agent
+          containerPort: {{ .Values.config.ports.agent }}
+        {{- end }}
         volumeMounts:
         - name: data
           mountPath: /var/lib/cassandra

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -59,6 +59,8 @@ config:
   ports:
     cql: 9042
     thrift: 9160
+    # If a JVM Agent is in place
+    # agent: 61621
 
 ## Configure node selector. Edit code below for adding selector to pods
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -69,3 +71,6 @@ config:
 ## Additional pod labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
+
+updateStrategy:
+  type: OnDelete


### PR DESCRIPTION
An example of a JVM Agent would be the JMX Exporter to export metrics to Prometheus https://github.com/prometheus/jmx_exporter

As for the UpdateStrategy, it is useful to expose it as the default is `OnDelete` and not `RollingUpdate`