### PR TITLE
[stable/postgres] command in notes to run postgres client pod should have `--restart=Never` flag set.

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.8.6
+version: 0.8.7
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -7,7 +7,7 @@ To get your user password run:
 
 To connect to your database run the following command (using the env variable from above):
 
-   kubectl run --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }}-client --rm --tty -i --image postgres \
+   kubectl run --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }}-client --restart=Never --rm --tty -i --image postgres \
    --env "PGPASSWORD=$PGPASSWORD" \{{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
    --labels="{{ template "postgresql.fullname" . }}-client=true" \{{- end }}
    --command -- psql -U {{ default "postgres" .Values.postgresUser }} \


### PR DESCRIPTION
Modify the printed command to connect to the postgresql server pod to use a `--restart=Never` so that the pod instantiated that hosts a `psql` client is not backed by a ReplicaSet.

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
