### PR TITLE
[stable/consul] Add nodeAffinity settings

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 1.1.3
+version: 1.2.0
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -136,6 +136,10 @@ spec:
         fsGroup: 1000
       {{- if eq .Values.antiAffinity "hard" }}
       affinity:
+        {{- if .Values.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml .Values.nodeAffinity | indent 10 }}
+        {{- end }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -147,6 +151,10 @@ spec:
             topologyKey: kubernetes.io/hostname
       {{- else if eq .Values.antiAffinity "soft" }}
       affinity:
+        {{- if .Values.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml .Values.nodeAffinity | indent 10 }}
+        {{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -51,6 +51,16 @@ EncryptGossip: true
 ## to set maxUnavailable to 1.
 maxUnavailable: 1
 
+## nodeAffinity settings
+# nodeAffinity:
+#   requiredDuringSchedulingIgnoredDuringExecution:
+#     nodeSelectorTerms:
+#     - matchExpressions:
+#       - key: cloud.google.com/gke-preemptible
+#         operator: NotIn
+#         values:
+#         - true
+
 ## Anti-Affinity setting. The default "hard" will use pod anti-affinity that is
 ## requiredDuringSchedulingIgnoredDuringExecution to ensure 2 services don't
 ## end up on the same node. Setting this to "soft" will use


### PR DESCRIPTION
Use case: I want to avoid running Consul on certain nodes, such
as preemptible nodes in a Google Kubernetes Engine node pool.

The current antiAffinity setting makes this pull request a bit hacky,
but this was the quickest way to simply get my functionality running.
I definitely wouldn't like to have it merged as it is right now ;)

Are you open to having the current affinity settings as a whole
be a bit more customizable? I imagine there might be other users
with this use case.