### PR TITLE
Influxdb: Support graphite templates

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 0.8.0
+version: 0.8.1
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:
 - influxdb

--- a/stable/influxdb/templates/config.yaml
+++ b/stable/influxdb/templates/config.yaml
@@ -84,7 +84,7 @@ data:
       unix-socket-enabled = {{ .Values.config.http.unix_socket_enabled }}
       bind-socket = "{{ .Values.config.http.bind_socket }}"
     
-    # TODO: allow multiple graphite listeners with templates
+    # TODO: allow multiple graphite listeners
     
     [[graphite]]
       enabled = {{ .Values.config.graphite.enabled }}
@@ -98,6 +98,13 @@ data:
       consistency-level = "{{ .Values.config.graphite.consistency_level }}"
       separator = "{{ .Values.config.graphite.separator }}"
       udp-read-buffer = {{ .Values.config.graphite.udp_read_buffer | int64 }}
+      {{- if .Values.config.graphite.templates }}
+      templates = [
+        {{- range .Values.config.graphite.templates }}
+          {{ quote . }},
+        {{- end }}
+      ]
+      {{- end }}
     
     # TODO: allow multiple collectd listeners with templates
 

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -167,6 +167,9 @@ config:
     consistency_level: one
     separator: .
     udp_read_buffer: 0
+    # Uncomment to define graphite templates
+    #templates:
+    #  - "graphite.metric.*.*.* measurement.run"
   collectd:
     enabled: false
     bind_address: 25826

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -168,8 +168,8 @@ config:
     separator: .
     udp_read_buffer: 0
     # Uncomment to define graphite templates
-    #templates:
-    #  - "graphite.metric.*.*.* measurement.run"
+    # templates:
+    #   - "graphite.metric.*.*.* measurement.run"
   collectd:
     enabled: false
     bind_address: 25826


### PR DESCRIPTION
Small change to allow defining templates for the graphite -> influxdb bridge (see https://github.com/influxdata/influxdb/blob/master/services/graphite/README.md for details)