### PR TITLE
[stable/phabricator] Add preamble and ingress support

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,5 +1,5 @@
 name: phabricator
-version: 0.5.6
+version: 0.5.7
 appVersion: 2017.52.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,5 +1,5 @@
 name: phabricator
-version: 0.5.7
+version: 0.5.8
 appVersion: 2018.2.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/templates/deployment.yaml
+++ b/stable/phabricator/templates/deployment.yaml
@@ -88,6 +88,11 @@ spec:
           mountPath: /bitnami/phabricator
         - name: apache-data
           mountPath: /bitnami/apache
+        {{- if .Values.phabricatorPreamble }}
+        - name: phabricator-preamble
+          mountPath: /opt/bitnami/phabricator/support/preamble.php
+          subPath: preamble.php
+        {{- end }}
       volumes:
       - name: phabricator-data
       {{- if .Values.persistence.enabled }}
@@ -102,5 +107,10 @@ spec:
           claimName: {{ template "phabricator.fullname" . }}-apache
       {{- else }}
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.phabricatorPreamble }}
+      - name: phabricator-preamble
+        configMap:
+          name: {{ template "phabricator.fullname" . }}
       {{- end }}
 {{- end -}}

--- a/stable/phabricator/templates/ingress.yaml
+++ b/stable/phabricator/templates/ingress.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "phabricator.fullname" . }}
+  labels:
+    app: {{ template "phabricator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  {{- if .Values.ingress.labels }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  annotations:
+  {{- if .Values.ingress.annotations }}
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  rules:
+  - host: {{ .Values.phabricatorHost }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "phabricator.fullname" . }}
+          servicePort: 80
+{{- end }}

--- a/stable/phabricator/templates/preamble.yaml
+++ b/stable/phabricator/templates/preamble.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.phabricatorPreamble }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  preamble.php: {{ .Values.phabricatorPreamble  | quote }}
+{{- end}}

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -45,6 +45,11 @@ phabricatorFirstName: First Name
 ##
 phabricatorLastName: Last Name
 
+## Preamble
+## ref: https://secure.phabricator.com/book/phabricator/article/configuring_preamble/
+##
+phabricatorPreamble:
+
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-phabricator/#smtp-configuration
 ##
@@ -80,7 +85,7 @@ mariadb:
     size: 8Gi
 
 ## Kubernetes configuration
-## For minikube, set this to NodePort, elsewhere use LoadBalancer
+## For minikube, or if using the Ingress controller, set this to NodePort, elsewhere use LoadBalancer
 ##
 serviceType: LoadBalancer
 
@@ -111,6 +116,11 @@ persistence:
     # storageClass: "-"
     accessMode: ReadWriteOnce
     size: 8Gi
+
+ingress:
+  enabled: false
+  annotations: {}
+  labels: {}
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
This adds [preamble support](https://secure.phabricator.com/book/phabricator/article/configuring_preamble/) (useful when running behind a loadbalancer) as well as ingress support to the phabricator chart.

Confirmed working on GKE.