### PR TITLE
Fluent bit outputs

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.12.7
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluent-bit
-version: 0.2.5
-appVersion: 0.12.12
+version: 0.2.6
+appVersion: 0.12.11
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
 - logging

--- a/stable/fluent-bit/templates/NOTES.txt
+++ b/stable/fluent-bit/templates/NOTES.txt
@@ -6,4 +6,7 @@ It will forward all container logs to the svc named {{ .Values.backend.forward.h
 {{- else if eq .Values.backend.type "es" }}
 
 It will forward all container logs to the svc named {{ .Values.backend.es.host }} on port: {{ .Values.backend.es.port }}
+{{- else if eq .Values.backend.type "http" }}
+
+It will forward all container logs to the svc named {{ .Values.backend.http.host }} on port: {{ .Values.backend.http.port }}
 {{- end }}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -52,7 +52,7 @@ data:
         Host {{ .Values.backend.http.host }}
         Port {{ .Values.backend.http.port }}
         URI {{ .Values.backend.http.uri }}
-{{ if .Values.backend.http.proxy }}
+{{- if .Values.backend.http.proxy }}
         Proxy {{ .Values.backend.http.proxy }}
 {{- end }}
         Format {{ .Values.backend.http.format }}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -45,4 +45,15 @@ data:
         Port  {{ .Values.backend.es.port }}
         Logstash_Format On
         Retry_Limit False
+{{ else if eq .Values.backend.type "http" }}
+    [OUTPUT]
+        Name  http
+        Match *
+        Host {{ .Values.backend.http.host }}
+        Port {{ .Values.backend.http.port }}
+        URI {{ .Values.backend.http.uri }}
+{{ if .Values.backend.http.proxy }}
+        Proxy {{ .Values.backend.http.proxy }}
+{{- end }}
+        Format {{ .Values.backend.http.format }}
 {{- end }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -16,6 +16,16 @@ backend:
   es:
     host: elasticsearch
     port: 9200
+  ##
+  ## Ref: http://fluentbit.io/documentation/current/output/http.html
+  ##
+  http:
+    host: 127.0.0.1
+    port: 80
+    uri: "/"
+    ## Specify the data format to be used in the HTTP request body
+    ## Can be either 'msgpack' or 'json'
+    format: msgpack
 
 env: []
 


### PR DESCRIPTION
Adds `http` option to `backend.type` options with corresponding configuration