### PR TITLE
Add enable flag for security context

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 1.1.7
+version: 1.1.8
 appVersion: 4.0.6
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -69,6 +69,7 @@ The following tables lists the configurable parameters of the Redis chart and th
 | `networkPolicy.allowExternal` | Don't require client label for connections       | `true`                       |
 | `service.annotations`         | annotations for redis service                    | {}                           |
 | `service.loadBalancerIP`      | loadBalancerIP if service type is `LoadBalancer` | ``                           |
+| `securityContext.enabled`     | Enable security context                          | `true`                       |
 
 The above parameters map to the env variables defined in [bitnami/redis](http://github.com/bitnami/bitnami-docker-redis). For more information please refer to the [bitnami/redis](http://github.com/bitnami/bitnami-docker-redis) image documentation.
 

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.securityContext.isEnabled }}
+      {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -20,9 +20,11 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.securityContext.val }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.securityContext.val }}
+      {{- if .Values.securityContext.isEnabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -13,6 +13,7 @@ serviceType: ClusterIP
 
 ## Pod Security Context
 securityContext:
+  isEnabled: true
   fsGroup: 1001
   runAsUser: 1001
 

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -13,7 +13,7 @@ serviceType: ClusterIP
 
 ## Pod Security Context
 securityContext:
-  isEnabled: true
+  enabled: true
   fsGroup: 1001
   runAsUser: 1001
 


### PR DESCRIPTION
*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************

```
Sunils-MacBook-Pro:charts sunilganatra$ helm lint stable/redis
==> Linting stable/redis
Lint OK

1 chart(s) linted, no failures
```


```
Sunils-MacBook-Pro:charts sunilganatra$ helm package stable/redis
Successfully packaged chart and saved it to: /Users/sunilganatra/charts/redis-1.1.7.tgz
```

```
Sunils-MacBook-Pro:charts sunilganatra$ helm install --name redis-build-infra1 --namespace build-infra1 --set serviceType=NodePort --set image=bitnami/redis:3.2.9-r2 --set persistence.path=/bitnami/redis --set securityContext.isEnabled=false stable/redis
NAME:   redis-build-infra1
LAST DEPLOYED: Wed Jan 17 12:48:11 2018
NAMESPACE: build-infra1
STATUS: DEPLOYED

RESOURCES:
==> v1/PersistentVolumeClaim
NAME                      STATUS   VOLUME            CAPACITY  ACCESS MODES  STORAGECLASS  AGE
redis-build-infra1-redis  Pending  *******  2s

==> v1/Service
NAME                      TYPE      CLUSTER-IP     EXTERNAL-IP  PORT(S)         AGE
redis-build-infra1-redis  NodePort  172.21.53.229  <none>       6379:32634/TCP  2s

==> v1beta1/Deployment
NAME                      DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
redis-build-infra1-redis  1        1        1           0          2s

==> v1/Pod(related)
NAME                                       READY  STATUS   RESTARTS  AGE
redis-build-infra1-redis-659fd95df5-zcj7v  0/1    Pending  0         2s

==> v1/Secret
NAME                      TYPE    DATA  AGE
redis-build-infra1-redis  Opaque  1     2s


NOTES:
Redis can be accessed via port 6379 on the following DNS name from within your cluster:
redis-build-infra1-redis.build-infra1.svc.cluster.local
To get your password run:

    REDIS_PASSWORD=$(kubectl get secret --namespace build-infra1 redis-build-infra1-redis -o jsonpath="{.data.redis-password}" | base64 --decode)

To connect to your Redis server:

1. Run a Redis pod that you can use as a client:

   kubectl run --namespace build-infra1 redis-build-infra1-redis-client --rm --tty -i \
    --env REDIS_PASSWORD=$REDIS_PASSWORD \
   --image bitnami/redis:3.2.9-r2 -- bash

2. Connect using the Redis CLI:

  redis-cli -h redis-build-infra1-redis -a $REDIS_PASSWORD
```
