### PR TITLE
[stable/redis] add `volumeMount` `subPath` feature.

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 1.1.7
+version: 1.1.8
 appVersion: 4.0.6
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -53,6 +53,7 @@ The following tables lists the configurable parameters of the Redis chart and th
 | `args`                        | Redis command-line args                          | []                           |
 | `persistence.enabled`         | Use a PVC to persist data                        | `true`                       |
 | `persistence.path`            | Path to mount the volume at, to use other images | `/bitnami`                   |
+| `persistence.subPath`         | Subdirectory of the volume to mount at           | `""`                        |
 | `persistence.existingClaim`   | Use an existing PVC to persist data              | `nil`                        |
 | `persistence.storageClass`    | Storage class of backing PVC                     | `generic`                    |
 | `persistence.accessMode`      | Use volume as ReadOnly or ReadWrite              | `ReadWriteOnce`              |

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
         volumeMounts:
         - name: redis-data
           mountPath: {{ .Values.persistence.path }}
+          subPath: {{ .Values.persistence.subPath }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -44,6 +44,9 @@ persistence:
   ## Redis images.
   path: /bitnami
 
+  ## The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services.
+  supPath: ""
+
   ## A manually managed Persistent Volume and Claim
   ## Requires persistence.enabled: true
   ## If defined, PVC must be created manually before volume will be bound

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -44,6 +44,9 @@ persistence:
   ## Redis images.
   path: /bitnami
 
+  ## The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services.
+  subPath: ""
+
   ## A manually managed Persistent Volume and Claim
   ## Requires persistence.enabled: true
   ## If defined, PVC must be created manually before volume will be bound


### PR DESCRIPTION
Ability to use subdirectories in PV. Helps with Dev under minikube and cases when one PV for multiple services is used.
