### PR TITLE
fixes missing default port for docker feature

### DIFF
--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -41,7 +41,7 @@ ingress:
 docker:
   enabled: false
   # Used to enable a docker registry
-  # port: 5509
+  port: 5509
   # host: docker.local
 ## Persist data to a persitent volume
 persistence:


### PR DESCRIPTION

**Version of Helm and Kubernetes**:
```
helm version
Client: &version.Version{SemVer:"v2.7.2", GitCommit:"8478fb4fc723885b155c924d1c8c410b7a9444e6", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.7.2", GitCommit:"8478fb4fc723885b155c924d1c8c410b7a9444e6", GitTreeState:"clean"}
```
```
kubectl version
Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.1", GitCommit:"3a1c9449a956b6026f075fa3134ff92f7d55f812", GitTreeState:"clean", BuildDate:"2018-01-04T20:00:41Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"8", GitVersion:"v1.8.4", GitCommit:"9befc2b8928a9426501d3bf62f72849d5cbcd5a3", GitTreeState:"clean", BuildDate:"2017-11-20T05:17:43Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
```
**Which chart**:
`stable/sonatype-nexus`

**What happened**:
The current Chart will result in a failure if the docker feature is enabled without adding/enabling a port. The default value of the port isn't set so the resulting template will show `port: null`.

**What you expected to happen**:
The default port should be set, regardless of the enablement of the docker feature.

**How to reproduce it** (as minimally and precisely as possible):
```
my_values.yml
service:
  type: ClusterIP

docker:
  enabled: true
```

```
helm upgrade --debug --install sonatype-nexus --namespace default -f my_values.yml stable/sonatype-nexus
```
Results in:
```
[debug] Created tunnel using local port: '59534'

[debug] SERVER: "127.0.0.1:59534"

[debug] Fetched stable/sonatype-nexus to /Users/feffi/.helm/cache/archive/sonatype-nexus-0.1.6.tgz

Release "sonatype-nexus" does not exist. Installing it now.
[debug] CHART PATH: /Users/feffi/.helm/cache/archive/sonatype-nexus-0.1.6.tgz

Error: release sonatype-nexus failed: Service in version "v1" cannot be handled as a Service: v1.Service: Spec: v1.ServiceSpec: Ports: []v1.ServicePort: v1.ServicePort: Port: readUint32: unexpected character: �, parsing 316 ...","port":n... at {"apiVersion":"v1","kind":"Service","metadata":{"labels":{"app":"sonatype-nexus","chart":"sonatype-nexus-0.1.6","heritage":"Tiller","release":"sonatype-nexus"},"name":"sonatype-nexus-sonatype-nexus","namespace":"default"},"spec":{"ports":[{"name":"nexus","port":8081,"protocol":"TCP"},{"name":"nexus-docker","port":null,"protocol":"TCP"}],"selector":{"app":"sonatype-nexus","release":"sonatype-nexus"},"type":"ClusterIP"}}
```
**Anything else we need to know**:
A pull request for fixing this issue has been made: 