### PR TITLE
[ stable/traefik] Allow usage of metrics without dashboard

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.16.0
+version: 1.17.0
 appVersion: 1.4.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -112,7 +112,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `acme.persistence.accessMode`   | `ReadWriteOnce` or `ReadOnly`                                        | `ReadWriteOnce`                           |
 | `acme.persistence.size`         | Minimum size of the volume requested                                 | `1Gi`                                     |
 | `dashboard.enabled`             | Whether to enable the Traefik dashboard                              | `false`                                   |
-| `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |               
+| `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |
 | `dashboard.service.annotations` | Annotations for the Traefik dashboard Service definition, specified as a map | None                |
 | `dashboard.ingress.annotations` | Annotations for the Traefik dashboard Ingress definition, specified as a map | None                |
 | `dashboard.ingress.labels`      | Labels for the Traefik dashboard Ingress definition, specified as a map      | None                              |
@@ -136,6 +136,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `metrics.statsd.enabled`        | Whether to enable pushing metrics to Statsd.                           | `false`                                   |
 | `metrics.statsd.address`        | Statsd host in the format <hostname>:<port>                          | `localhost:8125`                          |
 | `metrics.statsd.pushInterval`   | How often to push metrics to Statsd.                                 | `10s`                                     |
+| `deployment.podAnnotations`            | Annotations for the Traefik pod definition                    | None                                      |
 | `deployment.hostPort.httpEnabled`      | Whether to enable hostPort binding to host for http.          | `false`                                   |
 | `deployment.hostPort.httpsEnabled`     | Whether to enable hostPort binding to host for https.         | `false`                                   |
 | `deployment.hostPort.dashboardEnabled` | Whether to enable hostPort binding to host for dashboard.     | `false`                                   |

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -75,9 +75,11 @@ data:
     acmeLogging = true
     {{- end }}
     {{- end }}
-    {{- if .Values.dashboard.enabled }}
+    {{- if or .Values.dashboard.enabled .Values.metrics.prometheus.enabled .Values.metrics.statsd.enabled .Values.metrics.datadog.enabled }}
     [web]
     address = ":8080"
+    {{- end }}
+    {{- if .Values.dashboard.enabled }}
       {{- if .Values.dashboard.auth }}
       {{- if .Values.dashboard.auth.basic }}
       [web.auth.basic]

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -14,9 +14,13 @@ spec:
       app: {{ template "fullname" . }}
   template:
     metadata:
-      {{- if and (.Values.tolerations) (le .Capabilities.KubeVersion.Minor "5") }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if and (.Values.tolerations) (le .Capabilities.KubeVersion.Minor "5") }}
         scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'
+      {{- end }}
+      {{- range $key, $value := .Values.deployment.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       labels:
         app: {{ template "fullname" . }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -105,6 +105,8 @@ metrics:
     # address: localhost:8125
     # pushinterval: 10s
 deployment:
+  # podAnnotations:
+  #   key: value
   hostPort:
     httpEnabled: false
     httpsEnabled: false


### PR DESCRIPTION
These change fix an issue when one of the metrics is enabled but not the dashboard. Letting the configmap to be mis-configured and cause a CrashLoopBackOff.

It also add annotations to pod and checksum on the configmap following Charts best practices.