### PR TITLE
[stable/datadog] update chart to support agent6 beta

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.10.3
+version: 0.10.4
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -122,7 +122,7 @@ datadog:
           port: 6379
 ```
 
-### leader election
+### Leader election
 
 The Datadog Agent supports built in leader election option for the Kubernetes event collector As of 5.17.
 
@@ -137,3 +137,11 @@ The `datadog.leaderLeaseDuration` is the duration for which a leader stays elect
 
 
 Make sure the `rbac.create` is enable as well to ensure the feature to work properly.
+
+### Agent6 beta
+
+The new major version of the agent is currently in beta, and this chart allows you to use it by setting a different `image.repository`.
+See `values.yaml` for supported values. Please note that not all features are available yet.
+
+Please refer to [the agent6 image documentation](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent) and
+[the agent6 general documentation](https://github.com/DataDog/datadog-agent/tree/master/docs) for more information.

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -1,10 +1,6 @@
 dependencies:
-- condition: ""
-  enabled: false
-  import-values: null
-  name: kube-state-metrics
+- name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  tags: null
-  version: 0.3.1
-digest: sha256:4a48468276205a7a903e1ec28396687d531c05b1d3f09bfdb76f79367a98a9db
-generated: 2017-11-20T15:02:45.275419301+09:00
+  version: 0.5.2
+digest: sha256:1ddb31e4190813e77fb94cc23eb004e8599cc87047f40c96cdf16ac0b497a1d3
+generated: 2018-01-18T12:48:33.521366+01:00

--- a/stable/datadog/requirements.yaml
+++ b/stable/datadog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
-    version: 0.3.1
+    version: ~0.5.2
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: kubeStateMetrics.enabled

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -48,27 +48,35 @@ spec:
           protocol: TCP
         {{- end }}
         env:
-          - name: API_KEY
+          - name: DD_API_KEY
             valueFrom:
               secretKeyRef:
                 name: {{ template "datadog.fullname" . }}
                 key: api-key
-          - name: LOG_LEVEL
+          {{- if .Values.datadog.logLevel }}
+          - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}
-          - name: SD_BACKEND
-            value: docker
+          {{- end }}
+          {{- if .Values.datadog.nonLocalTraffic }}
+          - name: NON_LOCAL_TRAFFIC
+            value: {{ .Values.datadog.nonLocalTraffic | quote }}
+          {{- end }}
+          {{- if .Values.datadog.tags }}
+          - name: DD_TAGS
+            value: {{ .Values.datadog.tags | quote }}
+          {{- end }}
+          {{- if .Values.datadog.apmEnabled }}
+          - name: DD_APM_ENABLED
+            value: {{ .Values.datadog.apmEnabled | quote }}
+          {{- end }}
           - name: KUBERNETES_LEADER_CANDIDATE
             value: {{ .Values.datadog.leaderElection | quote}}
           {{- if .Values.datadog.leaderElection }}
           - name: KUBERNETES_LEADER_LEASE_DURATION
             value: {{ default "600" .Values.datadog.leaderLeaseDuration | quote }}
           {{- end }}
-          - name: NON_LOCAL_TRAFFIC
-            value: {{ default "" .Values.datadog.nonLocalTraffic | quote }}
-          - name: TAGS
-            value: {{ default "" .Values.datadog.tags | quote }}
-          - name: DD_APM_ENABLED
-            value: {{ default "" .Values.datadog.apmEnabled | quote }}
+          - name: SD_BACKEND
+            value: docker
           - name: KUBERNETES
             value: "yes"
 {{- if .Values.datadog.env }}
@@ -84,15 +92,21 @@ spec:
           - name: cgroups
             mountPath: /host/sys/fs/cgroup
             readOnly: true
+          {{- if .Values.datadog.confd }}
           - name: confd
             mountPath: /conf.d
             readOnly: true
-          - name: autoconf
-            mountPath: /etc/dd-agent/conf.d/auto_conf
-            readOnly: true
+          {{- end }}
+          {{- if .Values.datadog.checksd }}
           - name: checksd
             mountPath: /checks.d
             readOnly: true
+          {{- end }}
+          {{- if .Values.datadog.autoconf }}
+          - name: autoconf
+            mountPath: /etc/dd-agent/conf.d/auto_conf
+            readOnly: true
+          {{- end }}
 {{- if .Values.datadog.volumeMounts }}
 {{ toYaml .Values.datadog.volumeMounts | indent 10 }}
 {{- end }}
@@ -106,15 +120,21 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        {{- if .Values.datadog.confd }}
         - name: confd
           configMap:
             name: {{ template "datadog.confd.fullname" . }}
+        {{- end }}
+        {{- if .Values.datadog.checksd }}
         - name: checksd
           configMap:
             name: {{ template "datadog.checksd.fullname" . }}
+        {{- end }}
+        {{- if .Values.datadog.autoconf }}
         - name: autoconf
           configMap:
             name: {{ template "datadog.autoconf.fullname" . }}
+        {{- end }}
 {{- if .Values.datadog.volumes }}
 {{ toYaml .Values.datadog.volumes | indent 8 }}
 {{- end }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.datadog.resources | indent 12 }}
         ports:
         - containerPort: 8125
           {{- if .Values.daemonset.useHostPort }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.datadog.resources | indent 12 }}
         ports:
         - containerPort: 8125
           name: dogstatsdport

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -35,21 +35,29 @@ spec:
           protocol: TCP
         {{- end }}
         env:
-          - name: API_KEY
+          - name: DD_API_KEY
             valueFrom:
               secretKeyRef:
                 name: {{ template "datadog.fullname" . }}
                 key: api-key
-          - name: LOG_LEVEL
+          {{- if .Values.datadog.logLevel }}
+          - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}
+          {{- end }}
+          {{- if .Values.datadog.nonLocalTraffic }}
+          - name: NON_LOCAL_TRAFFIC
+            value: {{ .Values.datadog.nonLocalTraffic | quote }}
+          {{- end }}
+          {{- if .Values.datadog.tags }}
+          - name: DD_TAGS
+            value: {{ .Values.datadog.tags | quote }}
+          {{- end }}
+          {{- if .Values.datadog.apmEnabled }}
+          - name: DD_APM_ENABLED
+            value: {{ .Values.datadog.apmEnabled | quote }}
+          {{- end }}
           - name: SD_BACKEND
             value: docker
-          - name: NON_LOCAL_TRAFFIC
-            value: {{ default "" .Values.datadog.nonLocalTraffic | quote }}
-          - name: TAGS
-            value: {{ default "" .Values.datadog.tags | quote }}
-          - name: DD_APM_ENABLED
-            value: {{ default "" .Values.datadog.apmEnabled | quote }}
           - name: KUBERNETES
             value: "yes"
           {{- if .Values.datadog.collectEvents }}
@@ -62,21 +70,28 @@ spec:
         volumeMounts:
           - name: dockersocket
             mountPath: /var/run/docker.sock
+            readOnly: true
           - name: procdir
             mountPath: /host/proc
             readOnly: true
           - name: cgroups
             mountPath: /host/sys/fs/cgroup
             readOnly: true
+          {{- if .Values.datadog.confd }}
           - name: confd
             mountPath: /conf.d
             readOnly: true
-          - name: autoconf
-            mountPath: /etc/dd-agent/conf.d/auto_conf
-            readOnly: true
+          {{- end }}
+          {{- if .Values.datadog.checksd }}
           - name: checksd
             mountPath: /checks.d
             readOnly: true
+          {{- end }}
+          {{- if .Values.datadog.autoconf }}
+          - name: autoconf
+            mountPath: /etc/dd-agent/conf.d/auto_conf
+            readOnly: true
+          {{- end }}
 {{- if .Values.datadog.volumeMounts }}
 {{ toYaml .Values.datadog.volumeMounts | indent 10 }}
 {{- end }}
@@ -90,15 +105,21 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
+        {{- if .Values.datadog.confd }}
         - name: confd
           configMap:
             name: {{ template "datadog.confd.fullname" . }}
+        {{- end }}
+        {{- if .Values.datadog.checksd }}
         - name: checksd
           configMap:
             name: {{ template "datadog.checksd.fullname" . }}
+        {{- end }}
+        {{- if .Values.datadog.autoconf }}
         - name: autoconf
           configMap:
             name: {{ template "datadog.autoconf.fullname" . }}
+        {{- end }}
 {{- if .Values.datadog.volumes }}
 {{ toYaml .Values.datadog.volumes | indent 8 }}
 {{- end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -1,9 +1,9 @@
 # Default values for datadog.
 image:
   # This chart is compatible with different images, please choose one
-  repository: datadog/docker-dd-agent # Agent5
-  # repository: datadog/agent # Agent6 (beta)
-  # repository: datadog/dogstatsd # Standalone DogStatsD6 (beta)
+  repository: datadog/docker-dd-agent  # Agent5
+  # repository: datadog/agent          # Agent6 (beta)
+  # repository: datadog/dogstatsd      # Standalone DogStatsD6 (beta)
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -1,6 +1,9 @@
 # Default values for datadog.
 image:
-  repository: datadog/docker-dd-agent
+  # This chart is compatible with different images, please choose one
+  repository: datadog/docker-dd-agent # Agent5
+  # repository: datadog/agent # Agent6 (beta)
+  # repository: datadog/dogstatsd # Standalone DogStatsD6 (beta)
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -118,13 +121,13 @@ datadog:
   ## Each key will become a file in /conf.d/auto_conf
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
   ##
-  autoconf:
-    kubernetes_state.yaml: |-
-      docker_images:
-        - kube-state-metrics
-      init_config:
-      instances:
-        - kube_state_url: http://%%host%%:%%port%%/metrics
+  # autoconf:
+  #   kubernetes_state.yaml: |-
+  #     docker_images:
+  #       - kube-state-metrics
+  #     init_config:
+  #     instances:
+  #       - kube_state_url: http://%%host%%:%%port%%/metrics
 
   ## Provide additonal service definitions
   ## Each key will become a file in /conf.d


### PR DESCRIPTION
- upgrade kube-state-metrics dependency
- use `DD_` prefixed envvars when supported by agent5
- add commented lines for using agent6 beta images instead of agent5
- cleanup pod specs: remove empty envvars and volumes
- update readme

Except for the updated k-s-m, this PR should not affect current agent5 deployments, but allows agent6 beta users to deploy with this chart.

Also, added a fix for #2930, as we didn't refer to the right variable name for resource limits.