### PR TITLE
[stable/nginx-ingress] Use semverCompare for checking nginx-ingress image tag

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.8.26
+version: 0.8.27
 appVersion: 0.9.0-beta.15
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -40,16 +40,16 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-          {{- if and (semverCompare ">=0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
-          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}
-          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
-          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -40,16 +40,16 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+          {{- if and (semverCompare ">=0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -41,16 +41,16 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-          {{- if and (semverCompare ">=0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
-          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}
-          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
-          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -41,16 +41,16 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-          {{- if and (contains "0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+          {{- if and (semverCompare ">=0.9" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
-          {{- if (contains "0.9" .Values.controller.image.tag) }}
+          {{- if (semverCompare ">=0.9" .Values.controller.image.tag) }}
             - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
             - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}


### PR DESCRIPTION
The current flag checks for the `nginx-ingress` chart use the `contains` method to check for the value `0.9` in `.Values.controller.image.tag`. With a [0.10.0](https://github.com/kubernetes/ingress-nginx/projects/13) on the map, this check would no longer be sufficient and invalid flags would be passed to the executable.

This PR uses `semverCompare` to check that the `controller.image.tag` is greater than `0.9` for these conditionals.

Fixes #3410 