### PR TITLE
[incubator/patroni] makes secretKeyRefs configurable

### DIFF
--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -1,0 +1,49 @@
+# Processes
+
+This document outlines processes and procedures for some common tasks in the charts repository.
+
+## Deprecating A Chart
+
+When a chart is no longer maintained it can be [deprecated](https://en.wikipedia.org/wiki/Deprecation). Once a chart is deprecated the expectation is the chart will see no further development. The chart and its versions will still be accessible, though tools such as [monocular](https://github.com/kubernetes-helm/monocular) and [Kubeapps Hub](https://hub.kubeapps.com/) will no longer list the chart.
+
+To deprecate a chart perform the following:
+
+1. Increment the chart `version` in the `Chart.yaml` file. This is required as all charts are immutable.
+1. Add a property to the `Chart.yaml` file of `deprecated: true` at the top level of the YAML structure.
+1. Above the deprecated property add a comment noting that the chart is deprecated and linking to the deprecation policy.
+1. Remove any maintainers from the chart as the chart is no longer maintained.
+1. Prefix the description with "DEPRECATED"
+1. Update READMEs and NOTES.txt to note that the chart is deprecated
+
+For example, A `Chart.yaml` could start like:
+
+```yaml
+name: foo
+# The foo chart is deprecated and no longer maintained. For details deprecation,
+# including how to un-deprecate a chart see the PROCESSES.md file.
+deprecated: true
+description: DEPRECATED foo bar baz qux...
+```
+
+## Un-deprecating A Chart
+
+When new maintainers are interested in bring a chart out of deprecation with
+new features or new support that can be an option. To un-deprecate a chart:
+
+1. Update the maintainers on the chart if any are listed. The previous maintainers should not be expected to maintain the chart unless they explicitly decide to do so.
+1. If there is an OWNERS file in the chart that should be updated with the new reviewers and  approvers.
+1. The deprecated property from the `Chart.yaml` file should be removed along with any associated comment.
+1. The chart `version` needs to be incremented accordingly. If the same functionality is kept the version can be a patch increase. Otherwise the minor or major version needs to be incremented. For more detail on changing the version number see the [semver specification](http://semver.org).
+
+## Promoting A Chart From Incubator To Stable
+
+When promoting a chart from incubator to stable there are several steps that need to be carried out.
+
+1. Prior to promoting the chart verify that it does not depend on any other incubator charts. Stable charts cannot depend on incubator charts.
+1. The chart should be copied, not moved, from the incubator directory to the stable directory.
+1. The chart in the incubator directory should be deprecated with the `deprecated: true` property being set and a comment noting that the chart has been promoted to stable. The chart version will, also, need to have the patch level of the `version` incremented.
+1. The version of the chart in the stable directory should be updated so that any documentation or other details points to stable rather than incubator. The chart `version` will, also, need to be incremented.
+
+## Reviewing A Pull Request
+
+There are two parts to reviewing a pull request in the process to do so and the guidelines to follow. Both of those are outlined in the [Review Guidelines](REVIEW_GUIDELINES.md).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 Use this repository to submit official Charts for Kubernetes Helm. Charts are curated application definitions for Kubernetes Helm. For more information about installing and using Helm, see its
 [README.md](https://github.com/kubernetes/helm/tree/master/README.md). To get a quick introduction to Charts see this [chart document](https://github.com/kubernetes/helm/blob/master/docs/charts.md).
 
+## Where to find us
+
+For general Helm Chart discussions join the Helm Charts (#charts) room in the [Kubernetes](http://slack.kubernetes.io/).
+
+For issues and support for Helm and Charts see [Support Channels](CONTRIBUTING.md#support-channels).
+
+
 ## How do I install these charts?
 
 Just `helm install stable/<chart>`. This is the default repository for Helm which is located at https://kubernetes-charts.storage.googleapis.com/ and is installed by default.

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -83,3 +83,20 @@ image:
 ## Compatibility
 
 We officially support compatibility with the current and the previous minor version of Kubernetes. Generated resources should use the latest possible API versions compatible with these versions. For extended backwards compatibility conditional logic based on capalilities may be used (see [built-in objects](https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/builtin_objects.md)).
+
+## Kubernetes Native Workloads.
+
+While reviewing Charts that contain workloads such as [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/), [Statefulset](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/), [Daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) and [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) the below points should be considered.  These are to be seen as best practices rather than strict enforcement.
+  
+1. Any workload that are stateless and long running (servers) in nature are to be created as deployments.  Deployments in turn creates replica sets.
+2. Unless there is a compelling reason replica sets or replication controllers are are to be avoided as workload types. 
+3. Workloads that are stateful in nature such as Databases, Key Value Store, Messages Queues, In-memory caches are to be created as StatefulSets
+4. It is recommended that Deployments and Statefulsets configure their workloads with a [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) for high availability.
+5. For workloads such as databases, KV store, etc., that replicates data it is recommended to configure interpod anti-affinity.
+6. It is recommended to have a default workload update strategy configured that is suitable for this chart
+7. Batch workloads are to be created using Jobs. 
+8. It is best to always create workload with latest supported [api version](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/) as older version are either depcicated or soon to be depreciated. 
+9. It is generally not advisable to provide hard [resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) to workloads and leave it configurable unless the workload requires such quantity bare minimum to function. 
+10. As much as possible complex pre-app setups are configured using [init contianers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/). 
+
+More [configuration](https://kubernetes.io/docs/concepts/configuration/overview/) best practises.  

--- a/incubator/elasticsearch/.helmignore
+++ b/incubator/elasticsearch/.helmignore
@@ -1,0 +1,3 @@
+.git
+# OWNERS file for Kubernetes
+OWNERS

--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.4.6
+version: 0.4.7
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/incubator/elasticsearch/OWNERS
+++ b/incubator/elasticsearch/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- simonswine
+- icereval
+reviewers:
+- simonswine
+- icereval

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.8.0
+appVersion: 1.0.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.2.4
+version: 0.3.0
 keywords:
   - jaeger
   - opentracing
@@ -15,3 +15,7 @@ sources:
 maintainers:
   - name: dvonthenen
     email: david.vonthenen@dell.com
+  - name: mikelorant
+    email: michael.lorant@fairfaxmedia.com.au
+  - name: pavelnikolov
+    email: pavel.nikolov@fairfaxmedia.com.au

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -4,11 +4,14 @@
 
 ## Introduction
 
-This chart adds all components required to run Jaeger as described in the [jaeger-kubernetes](https://github.com/jaegertracing/jaeger-kubernetes) GitHub page for a production-like deployment. The chart default will deploy a new Cassandra cluster, but also supports using an existing Cassandra cluster, deploying a new ElasticSearch cluster, or connecting to an existing ElasticSearch cluster. Once the back storage available, the chart will deploy jaeger-agent as a DaemonSet and deploy the jaeger-collector and jaeger-query components as standard individual deployments.
+This chart adds all components required to run Jaeger as described in the [jaeger-kubernetes](https://github.com/jaegertracing/jaeger-kubernetes) GitHub page for a production-like deployment. The chart default will deploy a new Cassandra cluster (using the [cassandra chart](https://github.com/kubernetes/charts/tree/master/incubator/cassandra)), but also supports using an existing Cassandra cluster, deploying a new ElasticSearch cluster (using the [elasticsearch chart](https://github.com/kubernetes/charts/tree/master/incubator/elasticsearch)), or connecting to an existing ElasticSearch cluster. Once the back storage available, the chart will deploy jaeger-agent as a DaemonSet and deploy the jaeger-collector and jaeger-query components as standard individual deployments.
 
 ## Prerequisites
 
 - Has been tested on Kubernetes 1.7+
+  - The `spark` cron job requires [K8s CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) support: 
+    > You need a working Kubernetes cluster at version >= 1.8 (for CronJob). For previous versions of cluster (< 1.8) you need to explicitly enable `batch/v2alpha1` API by passing `--runtime-config=batch/v2alpha1=true` to the API server ([see Turn on or off an API version for your cluster for more](https://kubernetes.io/docs/admin/cluster-management/#turn-on-or-off-an-api-version-for-your-cluster)).
+
 - The Cassandra chart calls out the following requirements (default) for a test environment (please see the important note in the installation section):
 ```
 resources:
@@ -83,10 +86,10 @@ helm install incubator/jaeger --name myrel --set cassandra.config.max_heap_size=
 
 ## Installing the Chart using an Existing Cassandra Cluster
 
-If you already have an existing running Cassandra cluster, you can configure the chart as follows to use it as your backing store (replace `cassandra` with whatever hostname the cluster has been configured with):
+If you already have an existing running Cassandra cluster, you can configure the chart as follows to use it as your backing store (make sure you replace `<HOST>`, `<PORT>`, etc with your values):
 
 ```bash
-helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=false --set cassandra.config.host=cassandra
+helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=false --set storage.cassandra.host=<HOST> --set storage.cassandra.port=<PORT> --set storage.cassandra.user=<USER> --set storage.cassandra.password=<PASSWORD> 
 ```
 
 > **Tip**: It is highly encouraged to run the Cassandra cluster with storage persistence.
@@ -96,7 +99,7 @@ helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags
 To install the chart with the release name `myrel` using a new ElasticSearch cluster instead of Cassandra (default), run the following command:
 
 ```bash
-$ helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=true
+$ helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=false  --set provisionDataStore.elasticsearch=true
 ```
 
 After a few minutes, you should see 2 ElasticSearch client nodes, 2 ElasticSearch data nodes, 3 ElasticSearch master nodes, a Jaeger DaemonSet, a Jaeger Collector, and a Jaeger Query (UI) pod deployed into your Kubernetes cluster.
@@ -105,13 +108,14 @@ After a few minutes, you should see 2 ElasticSearch client nodes, 2 ElasticSearc
 
 ## Installing the Chart using an Existing ElasticSearch Cluster
 
-If you already have an existing running ElasticSearch cluster, you can configure the chart as follows to use it as your backing store (replace `http://elasticsearch:9200` with whatever hostname the cluster has been configured with):
+If you already have an existing running ElasticSearch cluster, you can configure the chart as follows to use it as your backing store:
 
 ```bash
-helm install incubator/jaeger --name myrel --set tags.cassandra=false --set tags.elasticsearch=false --set elasticsearch.config.host=http://elasticsearch:9200
+helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=false --set provisionDataStore.elasticsearch=true --set storage.type=elasticsearch --set storage.elasticsearch.host=<HOST> --set storage.elasticsearch.port=<PORT> --set storage.elasticsearch.user=<USER> --set storage.elasticsearch.password=<password>
 ```
 
 > **Tip**: It is highly encouraged to run the ElasticSearch cluster with storage persistence.
+
 
 ## Uninstalling the Chart
 
@@ -129,54 +133,72 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the Jaeger chart and their default values.
 
-|             Parameter             |            Description             |                  Default               |
-|-----------------------------------|------------------------------------|----------------------------------------|
-| `cassandra.image.tag`             | The image tag/version              |  3.11                                  |
-| `cassandra.persistence.enabled`   | To enable storage persistence      |  false (Highly recommended to enable)  |
-| `cassandra.config.host`           | Existing Cassandra hostname        |  ""                                    |
-| `cassandra.config.cluster_name`   | Cluster name                       |  jaeger                                |
-| `cassandra.config.seed_size`      | Seed size                          |  1                                     |
-| `cassandra.config.dc_name`        | Datacenter name                    |  dc1                                   |
-| `cassandra.config.rack_name`      | Rack name                          |  rack1                                 |
-| `cassandra.config.endpoint_snitch`| Node discovery method              |  GossipingPropertyFileSnitch           |
-| `elasticsearch.config.host`       | Existing ElasticSearch hostname    |  ""                                    |
-| `elasticsearch.config.username`   | Existing ElasticSearch username    |  "elastic"                             |
-| `elasticsearch.config.password`   | Existing ElasticSearch password    |  "changeme"                            |
-| `schema.annotations`              | Annotations for the schema job     |  nil                                   |
-| `schema.image`                    | Image to setup cassandra schema    |  jaegertracing/jaeger-cassandra-schema |
-| `schema.tag`                      | Image tag/version                  |  0.6                                   |
-| `schema.pullPolicy`               | Schema image pullPolicy            |  IfNotPresent                          |
-| `schema.mode`                     | Schema mode (prod or test)         |  prod                                  |
-| `agent.annotationsPod`            | Annotations for Agent              |  nil                                   |
-| `agent.image`                     | Image for Jaeger Agent             |  jaegertracing/jaeger-agent            |
-| `agent.tag`                       | Image tag/version                  |  0.6                                   |
-| `agent.pullPolicy`                | Agent image pullPolicy             |  IfNotPresent                          |
-| `agent.cmdlineParams`             | Additional command line parameters |  nil                                   |
-| `agent.annotationsSvc`            | Annotations for Agent SVC          |  nil                                   |
-| `agent.zipkinThriftPort`          | zipkin.thrift over compact thrift  |  5775                                  |
-| `agent.compactPort`               | jaeger.thrift over compact thrift  |  6831                                  |
-| `agent.binaryPort`                | jaeger.thrift over binary thrift   |  6832                                  |
-| `collector.annotationsPod`        | Annotations for Collector          |  nil                                   |
-| `collector.image`                 | Image for jaeger collector         |  jaegertracing/jaeger-collector        |
-| `collector.tag`                   | Image tag/version                  |  0.6                                   |
-| `collector.pullPolicy`            | Collector image pullPolicy         |  IfNotPresent                          |
-| `collector.cmdlineParams`         | Additional command line parameters |  nil                                   |
-| `collector.annotationsSvc`        | Annotations for Collector SVC      |  nil                                   |
-| `collector.type`                  | Service type                       |  ClusterIP                             |
-| `collector.tchannelPort`          | Jaeger Agent port for thrift       |  14267                                 |
-| `collector.httpPort`              | Client port for HTTP thrift        |  14268                                 |
-| `collector.zipkinPort`            | Zipkin port for JSON/thrift HTTP   |  9411                                  |
-| `query.annotationsPod`            | Annotations for Query UI           |  nil                                   |
-| `query.image`                     | Image for Jaeger Query UI          |  jaegertracing/jaeger-query            |
-| `query.tag`                       | Image tag/version                  |  0.6                                   |
-| `query.pullPolicy`                | Query UI image pullPolicy          |  IfNotPresent                          |
-| `query.cmdlineParams`             | Additional command line parameters |  nil                                   |
-| `query.annotationsSvc`            | Annotations for Query SVC          |  nil                                   |
-| `query.type`                      | Service type                       |  ClusterIP                             |
-| `query.queryPort`                 | External accessible port           |  80                                    |
-| `query.targetPort`                | Internal Query UI port             |  16686                                 |
-| `ingress.enabled`                 | Allow external traffic access      |  false                                 |
-|-----------------------------------|------------------------------------|----------------------------------------|
+|             Parameter                    |            Description              |                  Default               |
+|------------------------------------------|-------------------------------------|----------------------------------------|
+| `agent.annotationsPod`                   | Annotations for Agent               |  nil                                   |
+| `agent.annotationsSvc`                   | Annotations for Agent SVC           |  nil                                   |
+| `agent.binaryPort`                       | jaeger.thrift over binary thrift    |  6832                                  |
+| `agent.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
+| `agent.compactPort`                      | jaeger.thrift over compact thrift   |  6831                                  |
+| `agent.image`                            | Image for Jaeger Agent              |  jaegertracing/jaeger-agent            |
+| `agent.pullPolicy`                       | Agent image pullPolicy              |  IfNotPresent                          |
+| `agent.tag`                              | Image tag/version                   |  0.6                                   |
+| `agent.zipkinThriftPort`                 | zipkin.thrift over compact thrift   |  5775                                  |
+| `cassandra.config.cluster_name`          | Cluster name                        |  jaeger                                |
+| `cassandra.config.dc_name`               | Datacenter name                     |  dc1                                   |
+| `cassandra.config.endpoint_snitch`       | Node discovery method               |  GossipingPropertyFileSnitch           |
+| `cassandra.config.rack_name`             | Rack name                           |  rack1                                 |
+| `cassandra.config.seed_size`             | Seed size                           |  1                                     |
+| `cassandra.image.tag`                    | The image tag/version               |  3.11                                  |
+| `cassandra.persistence.enabled`          | To enable storage persistence       |  false (Highly recommended to enable)  |
+| `collector.annotationsPod`               | Annotations for Collector           |  nil                                   |
+| `collector.annotationsSvc`               | Annotations for Collector SVC       |  nil                                   |
+| `collector.cmdlineParams`                | Additional command line parameters  |  nil                                   |
+| `collector.httpPort`                     | Client port for HTTP thrift         |  14268                                 |
+| `collector.image`                        | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
+| `collector.pullPolicy`                   | Collector image pullPolicy          |  IfNotPresent                          |
+| `collector.tag`                          | Image tag/version                   |  0.6                                   |
+| `collector.tchannelPort`                 | Jaeger Agent port for thrift        |  14267                                 |
+| `collector.type`                         | Service type                        |  ClusterIP                             |
+| `collector.zipkinPort`                   | Zipkin port for JSON/thrift HTTP    |  9411                                  |
+| `elasticsearch.cluster.name`             | Elasticsearch cluster name          |  "tracing"                             |
+| `elasticsearch.data.persistance.enabled` | To enable storage persistence       |  false (Highly recommended to enable)  |
+| `elasticsearch.image.tag`                | Elasticsearch image tag             |  "5.4"                                 |
+| `elasticsearch.rbac.create`              | To enable RBAC                      |  false                                 |
+| `hotrod.enabled`                         | Enables the Hotrod demo app         |  false                                 |
+| `provisionDataStore.cassandra`           | Provision Cassandra Data Store      |  true                                  |
+| `provisionDataStore.elasticsearch`       | Provision Elasticsearch Data Store  |  false                                 |
+| `query.annotationsPod`                   | Annotations for Query UI            |  nil                                   |
+| `query.annotationsSvc`                   | Annotations for Query SVC           |  nil                                   |
+| `query.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
+| `query.image`                            | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
+| `query.ingress.enabled`                  | Allow external traffic access       |  false                                 |
+| `query.pullPolicy`                       | Query UI image pullPolicy           |  IfNotPresent                          |
+| `query.queryPort`                        | External accessible port            |  80                                    |
+| `query.tag`                              | Image tag/version                   |  0.6                                   |
+| `query.targetPort`                       | Internal Query UI port              |  16686                                 |
+| `query.type`                             | Service type                        |  ClusterIP                             |
+| `schema.annotations`                     | Annotations for the schema job      |  nil                                   |
+| `schema.image`                           | Image to setup cassandra schema     |  jaegertracing/jaeger-cassandra-schema |
+| `schema.mode`                            | Schema mode (prod or test)          |  prod                                  |
+| `schema.pullPolicy`                      | Schema image pullPolicy             |  IfNotPresent                          |
+| `schema.tag`                             | Image tag/version                   |  0.6                                   |
+| `spark.enabled`                          | Enables the dependencies job        |  false                                 |
+| `spark.image`                            | Image for the dependencies job      |  jaegertracing/spark-dependencies      |
+| `spark.pullPolicy`                       | Image pull policy of the deps image |  Always                                |
+| `spark.schedule`                         | Schedule of the cron job            |  "49 23 * * *"                         |
+| `spark.tag`                              | Tag of the dependencies job image   |  latest                                |
+| `storage.cassandra.host`                 | Provisioned cassandra host          |  cassandra                             |
+| `storage.cassandra.password`             | Provisioned cassandra password      |  password                              |
+| `storage.cassandra.port`                 | Provisioned cassandra port          |  9042                                  |
+| `storage.cassandra.user`                 | Provisioned cassandra username      |  user                                  |
+| `storage.elasticsearch.host`             | Provisioned elasticsearch host      |  elasticsearch                         |
+| `storage.elasticsearch.password`         | Provisioned elasticsearch password  |  changeme                              |
+| `storage.elasticsearch.port`             | Provisioned elasticsearch port      |  9200                                  |
+| `storage.elasticsearch.scheme`           | Provisioned elasticsearch scheme    |  http                                  |
+| `storage.elasticsearch.user`             | Provisioned elasticsearch user      |  elastic                               |
+| `storage.type`                           | Storage type (ES or Cassandra)      |  cassandra                             |
+|------------------------------------------|-------------------------------------|----------------------------------------|
 
 For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
 
@@ -203,5 +225,13 @@ Override any required configuration options in the Cassandra chart that is requi
 Jaeger offers a multitude of [tags](https://hub.docker.com/u/jaegertracing/) for the various components used in this chart.
 
 ### Pending enhancements
-- Moving configurable parameters to use ConfigMap
-- Sidecar deployment support
+- [x] Use ConfigMap for configurable parameters
+- [x] Add the Hotrod example app
+- [x] Allow only some of the components to be installed
+- [x] Add support for the spark dependencies job (as a [k8s cronjob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)) 
+- [x] Use `provisionDataStore` key in the values.yaml file instead of `tags` to configure data store provisioning.
+- [x] Refactor chart to remove unnecessary quotes
+- [x] Remove the command overrides of the docker images and use [environment variables configuration](http://jaeger.readthedocs.io/en/latest/deployment/#configuration) instead
+- [x] Fix hard-coded replica count
+- [x] Collector service works both as `NodePort` and `ClusterIP` service types
+- [ ] Sidecar deployment support

--- a/incubator/jaeger/requirements.yaml
+++ b/incubator/jaeger/requirements.yaml
@@ -1,13 +1,9 @@
 dependencies:
-  - name: elasticsearch
-    version: 0.3.0
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-    condition: elasticsearch.enable
-    tags:
-      - elasticsearch
   - name: cassandra
-    version: 0.1.5
+    version: ^0.1.6
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-    condition: cassandra.enable
-    tags:
-      - cassandra
+    condition: provisionDataStore.cassandra
+  - name: elasticsearch
+    version: ^0.4.1
+    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    condition: provisionDataStore.elasticsearch

--- a/incubator/jaeger/templates/NOTES.txt
+++ b/incubator/jaeger/templates/NOTES.txt
@@ -15,7 +15,7 @@ You can log into the Jaeger Query UI here:
   echo http://$SERVICE_IP/
 {{- else if contains "ClusterIP"  .Values.query.service.type }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "jaeger.fullname" . }}-query" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }},component=query" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8080/
   kubectl port-forward $POD_NAME 8080:16686
 {{- end }}

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -1,4 +1,16 @@
 {{/* vim: set filetype=mustache: */}}
+
+{{/*
+Return the appropriate apiVersion for cronjob APIs.
+*/}}
+{{- define "cronjob.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "batch/v1beta1" -}}
+"batch/v1beta1"
+{{- else -}}
+"batch/v2alpha1"
+{{- end -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -19,6 +31,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{/*
 Create a fully qualified query name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -31,18 +44,56 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "cassandra.fullname" -}}
+{{- define "jaeger.agent.service.name" -}}
+{{- $name := default .Chart.Name .Values.agent.service.nameOverride -}}
+{{- if .Values.agent.service.nameOverride }}
+{{- printf "%s" .Values.agent.service.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "cassandra.host" -}}
+{{- if .Values.provisionDataStore.cassandra -}}
 {{- printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- .Values.storage.cassandra.host }}
+{{- end -}}
+{{- end -}}
+
+{{- define "cassandra.contact_points" -}}
+{{- $port := .Values.storage.cassandra.port | toString }}
+{{- if .Values.provisionDataStore.cassandra -}}
+{{- $host := printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s:%s" $host $port }}
+{{- else }}
+{{- printf "%s:%s" .Values.storage.cassandra.host $port }}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "elasticsearch.fullname" -}}
-{{- printf "%s-%s" .Release.Name "elasticsearch" | trunc 63 | trimSuffix "-" -}}
+{{- define "elasticsearch.client.url" -}}
+{{- $port := .Values.storage.elasticsearch.port | toString -}}
+{{- if .Values.provisionDataStore.elasticsearch -}}
+{{- $host := printf "%s-%s-%s" .Release.Name "elasticsearch" "client" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme $host $port }}
+{{- else }}
+{{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme .Values.storage.elasticsearch.host $port }}
+{{- end -}}
+{{- end -}}
+
+{{- define "jaeger.collector.host-port" -}}
+{{- if .Values.agent.collector.host }}
+{{- printf "%s:%s" .Values.agent.collector.host (default .Values.collector.service.tchannelPort .Values.agent.collector.port | toString) }}
+{{- else }}
+{{- printf "%s-collector:%s" (include "jaeger.fullname" .) (default .Values.collector.service.tchannelPort .Values.agent.collector.port | toString) }}
+{{- end -}}
+{{- end -}}
+
+{{- define "jaeger.hotrod.tracing.host" -}}
+{{- $host := printf "%s-agent" (include "jaeger.agent.service.name" .) -}}
+{{- default $host .Values.hotrod.tracing.host -}}
 {{- end -}}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -2,25 +2,25 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-agent"
+  name: {{ template "jaeger.fullname" . }}-agent
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: agent-daemonset
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "agent"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: agent
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.agent.annotations }}
   annotations:
-{{ toYaml .Values.agent.annotations | indent 6 }}
+{{ toYaml .Values.agent.annotations | indent 4 }}
 {{- end }}
 spec:
   template:
     metadata:
       labels:
-        app: "{{ template "jaeger.name" . }}"
-        component: "agent"
-        release: "{{ .Release.Name }}"
+        app: {{ template "jaeger.name" . }}
+        component: agent
+        release: {{ .Release.Name }}
         jaeger-infra: agent-instance
 {{- if .Values.agent.podLabels }}
 {{ toYaml .Values.agent.podLabels | indent 8 }}
@@ -29,22 +29,40 @@ spec:
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-agent"
-        image: "{{ .Values.agent.image }}:{{ .Values.agent.tag }}"
+      - name: {{ template "jaeger.fullname" . }}-agent
+        image: {{ .Values.agent.image }}:{{ .Values.agent.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
-        command:
-        - "/go/bin/agent-linux"
-        - "--collector.host-port={{ template "jaeger.fullname" . }}-collector:{{ .Values.collector.service.tchannelPort }}"
-{{- range $key, $value := .Values.agent.cmdlineParams }}
-        - "{{ $value }}"
-{{- end }}
+        env:
+        - name: COLLECTOR_HOST_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: collector.host-port
+        {{- range $key, $value := .Values.agent.cmdlineParams }}
+        - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
+          value: {{ $value }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.agent.service.zipkinThriftPort }}
           protocol: UDP
+          {{- if .Values.agent.daemonset.useHostPort }}
+          hostPort: {{ .Values.agent.service.zipkinThriftPort }}
+          {{- end }}
         - containerPort: {{ .Values.agent.service.compactPort }}
           protocol: UDP
+          {{- if .Values.agent.daemonset.useHostPort }}
+          hostPort: {{ .Values.agent.service.compactPort }}
+          {{- end }}
         - containerPort: {{ .Values.agent.service.binaryPort }}
           protocol: UDP
+          {{- if .Values.agent.daemonset.useHostPort }}
+          hostPort: {{ .Values.agent.service.binaryPort }}
+          {{- end }}
+        - containerPort: {{ .Values.agent.service.samplingPort }}
+          protocol: TCP
+          {{- if .Values.agent.daemonset.useHostPort }}
+          hostPort: {{ .Values.agent.service.samplingPort }}
+          {{- end }}
         resources:
 {{ toYaml .Values.agent.resources | indent 10 }}
 {{- end -}}

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -2,17 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-agent"
+  name: {{ template "jaeger.agent.service.name" . }}-agent
   labels:
-    app: "{{ template "jaeger.name" . }}"
-    jaeger-infra: {{ .Values.agent.name }}
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: agent-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "agent"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: agent
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.agent.service.annotations }}
   annotations:
-{{ toYaml .Values.agent.service.annotations | indent 6 }}
+{{ toYaml .Values.agent.service.annotations | indent 4 }}
 {{- end }}
 spec:
   ports:
@@ -28,10 +28,14 @@ spec:
     port: {{ .Values.agent.service.binaryPort }}
     protocol: UDP
     targetPort: {{ .Values.agent.service.binaryPort }}
-  clusterIP: None
+  - name: agent-sampling
+    port: {{ .Values.agent.service.samplingPort }}
+    protocol: TCP
+    targetPort: {{ .Values.agent.service.samplingPort }}
+  type: {{ .Values.agent.service.type }}
   selector:
-    app: "{{ template "jaeger.name" . }}"
-    component: "agent"
-    release: "{{ .Release.Name }}"
+    app: {{ template "jaeger.name" . }}
+    component: agent
+    release: {{ .Release.Name }}
     jaeger-infra: agent-instance
 {{- end -}}

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -1,81 +1,57 @@
-{{ if not (empty .Values.cassandra.config.host) }}
+{{- if .Values.collector.enabled -}}
+{{- if eq .Values.storage.type "cassandra" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+  name: {{ template "jaeger.fullname" . }}-cassandra-schema
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: cassandra-schema-job
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "cassandra-schema"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: cassandra-schema
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.schema.annotations }}
   annotations:
-{{ toYaml .Values.schema.annotations | indent 6 }}
+{{ toYaml .Values.schema.annotations | indent 4 }}
 {{- end }}
 spec:
   activeDeadlineSeconds: 120
   template:
     metadata:
-      name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
+      name: {{ template "jaeger.fullname" . }}-cassandra-schema
 {{- if .Values.schema.podLabels }}
       labels:
 {{ toYaml .Values.schema.podLabels | indent 8 }}
 {{- end }}
     spec:
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-        image: "{{ .Values.schema.image }}:{{ .Values.schema.tag }}"
+      - name: {{ template "jaeger.fullname" . }}-cassandra-schema
+        image: {{ .Values.schema.image }}:{{ .Values.schema.tag }}
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
         env:
-          - name: CQLSH_HOST
-            value: "{{ .Values.cassandra.config.host }}"
-          - name: MODE
-            value: "{{ .Values.schema.mode }}"
-          - name: DATACENTER
-            value: "{{ .Values.cassandra.config.dc_name }}"
+        - name: CQLSH_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: cassandra.servers
+        - name: MODE
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: cassandra.schema.mode
+        - name: DATACENTER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: cassandra.datacenter.name
+        - name: CASSANDRA_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "jaeger.fullname" . }}
+              key: cassandra.port
         resources:
 {{ toYaml .Values.schema.resources | indent 10 }}
       restartPolicy: OnFailure
-{{ else if .Values.tags.cassandra }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-  labels:
-    app: "{{ template "jaeger.name" . }}"
-    jaeger-infra: cassandra-schema-job
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "cassandra-schema"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
-{{- if .Values.schema.annotations }}
-  annotations:
-{{ toYaml .Values.schema.annotations | indent 6 }}
-{{- end }}
-spec:
-  activeDeadlineSeconds: 120
-  template:
-    metadata:
-      name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-{{- if .Values.schema.podLabels }}
-      labels:
-{{ toYaml .Values.schema.podLabels | indent 8 }}
-{{- end }}
-    spec:
-      containers:
-      - name: "{{ template "jaeger.fullname" . }}-cassandra-schema"
-        image: "{{ .Values.schema.image }}:{{ .Values.schema.tag }}"
-        imagePullPolicy: {{ .Values.schema.pullPolicy }}
-        env:
-          - name: CQLSH_HOST
-            value: "{{ template "cassandra.fullname" . }}"
-          - name: MODE
-            value: "{{ .Values.schema.mode }}"
-          - name: DATACENTER
-            value: "{{ .Values.cassandra.config.dc_name }}"
-        resources:
-{{ toYaml .Values.schema.resources | indent 10 }}
-      restartPolicy: OnFailure
-{{ end }}
+{{- end -}}
+{{- end -}}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -1,28 +1,29 @@
+{{- if .Values.collector.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-collector"
+  name: {{ template "jaeger.fullname" . }}-collector
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: collector-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "collector"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: collector
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.collector.annotations }}
   annotations:
-{{ toYaml .Values.collector.annotations | indent 6 }}
+{{ toYaml .Values.collector.annotations | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.collector.replicaCount }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: "{{ template "jaeger.name" . }}"
-        component: "collector"
-        release: "{{ .Release.Name }}"
+        app: {{ template "jaeger.name" . }}
+        component: collector
+        release: {{ .Release.Name }}
         jaeger-infra: collector-pod
 {{- if .Values.collector.podLabels }}
 {{ toYaml .Values.collector.podLabels | indent 8 }}
@@ -31,41 +32,76 @@ spec:
       nodeSelector:
 {{ toYaml .Values.collector.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.fullname" . }}-collector"
-        image: "{{ .Values.collector.image }}:{{ .Values.collector.tag }}"
+      - name: {{ template "jaeger.fullname" . }}-collector
+        image: {{ .Values.collector.image }}:{{ .Values.collector.tag }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
+        env:
+          - name: SPAN_STORAGE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: span-storage.type
+          {{- if eq .Values.storage.type "cassandra" }}
+          - name: CASSANDRA_SERVERS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.servers
+          - name: CASSANDRA_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.port
+          - name: CASSANDRA_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.keyspace
+          {{- end }}
+          {{- if eq .Values.storage.type "elasticsearch" }}
+          - name: ES_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.password
+          - name: ES_SERVER_URLS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.server-urls
+          - name: ES_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.username
+          {{- end }}
+          - name: COLLECTOR_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: collector.port
+          - name: COLLECTOR_HTTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: collector.http-port
+          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: collector.zipkin.http-port
         ports:
-        - containerPort: 14267
+        - containerPort: {{ .Values.collector.service.tchannelPort }}
           name: tchannel
           protocol: TCP
-        - containerPort: 14268
+        - containerPort: {{ .Values.collector.service.httpPort }}
           name: http
           protocol: TCP
-        - containerPort: 9411
+        - containerPort: {{ .Values.collector.service.zipkinPort }}
           name: zipkin
           protocol: TCP
         resources:
 {{ toYaml .Values.collector.resources | indent 10 }}
-        command:
-        - "/go/bin/collector-linux"
-{{ if not (empty .Values.elasticsearch.config.host) }}
-        - "--span-storage.type=elasticsearch"
-        - "--es.server-urls={{ .Values.elasticsearch.config.host }}"
-        - "--es.username={{ .Values.elasticsearch.config.username }}"
-        - "--es.password={{ .Values.elasticsearch.config.password }}"
-{{ else if .Values.tags.elasticsearch }}
-        - "--span-storage.type=elasticsearch"
-        - "--es.server-urls=http://{{ template "elasticsearch.fullname" . }}-client:9200"
-{{ else if not (empty .Values.cassandra.config.host) }}
-        - "--cassandra.servers={{ .Values.cassandra.config.host }}"
-        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-{{ else }}
-        - "--cassandra.servers={{ template "cassandra.fullname" . }}"
-        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-{{ end }}
-        - "--collector.zipkin.http-port={{ .Values.collector.service.zipkinPort }}"
-{{- range $key, $value := .Values.collector.cmdlineParams }}
-        - "{{ $value }}"
-{{- end }}
       dnsPolicy: {{ .Values.collector.dnsPolicy }}
       restartPolicy: Always
+{{- end -}}

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -1,35 +1,49 @@
+{{- if .Values.collector.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.fullname" . }}-collector"
+  name: {{ template "jaeger.fullname" . }}-collector
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: collector-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "collector"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: collector
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.collector.service.annotations }}
   annotations:
-{{ toYaml .Values.collector.service.annotations | indent 6 }}
+{{ toYaml .Values.collector.service.annotations | indent 4 }}
 {{- end }}
 spec:
   ports:
   - name: jaeger-collector-tchannel
     port: {{ .Values.collector.service.tchannelPort }}
     protocol: TCP
+    {{- if eq .Values.collector.service.type "NodePort" }}
+    nodePort: {{ .Values.collector.service.tchannelPort }}
+    {{- else }}
     targetPort: tchannel
+    {{- end }}
   - name: jaeger-collector-http
     port: {{ .Values.collector.service.httpPort }}
     protocol: TCP
+    {{- if eq .Values.collector.service.type "NodePort" }}
+    nodePort: {{ .Values.collector.service.httpPort }}
+    {{- else }}
     targetPort: http
+    {{- end }}
   - name: jaeger-collector-zipkin
     port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
+    {{- if eq .Values.collector.service.type "NodePort" }}
+    nodePort: {{ .Values.collector.service.zipkinPort }}
+    {{- else }}
     targetPort: zipkin
+    {{- end }}
   selector:
-    app: "{{ template "jaeger.name" . }}"
-    component: "collector"
-    release: "{{ .Release.Name }}"
+    app: {{ template "jaeger.name" . }}
+    component: collector
+    release: {{ .Release.Name }}
     jaeger-infra: collector-pod
   type: {{ .Values.collector.service.type }}
+{{- end -}}

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jaeger.fullname" . }}
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: common-configmap
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  cassandra.contact-points: {{ template "cassandra.contact_points" . }}
+  cassandra.datacenter.name: {{ .Values.cassandra.config.dc_name | quote }}
+  cassandra.keyspace: {{ printf "%s_%s" "jaeger_v1" .Values.cassandra.config.dc_name | quote }}
+  cassandra.port: {{ .Values.storage.cassandra.port | quote }}
+  cassandra.schema.mode: {{ .Values.schema.mode | quote }}
+  cassandra.servers: {{ template "cassandra.host" . }}
+  collector.host-port: {{ template "jaeger.collector.host-port" . }}
+  collector.http-port: {{ .Values.collector.service.httpPort | quote }}
+  collector.port: {{ .Values.collector.service.tchannelPort | quote }}
+  collector.zipkin.http-port: {{ .Values.collector.service.zipkinPort | quote }}
+  es.password: {{ .Values.storage.elasticsearch.password }}
+  es.server-urls: {{ template "elasticsearch.client.url" . }}
+  es.username: {{ .Values.storage.elasticsearch.user }}
+  hotrod.agent-host: {{ template "jaeger.hotrod.tracing.host" . }}
+  hotrod.agent-port: {{ .Values.hotrod.tracing.port | quote }}
+  span-storage.type: {{ .Values.storage.type | quote }}
+  query.health-check-http-port: {{ .Values.query.healthCheckPort | quote }}
+  query.port: {{ .Values.query.service.targetPort | quote }}
+  # Not implemented
+  # cassandra.archive.connections-per-host:
+  # cassandra.archive.keyspace:
+  # cassandra.archive.max-retry-attempts:
+  # cassandra.archive.password:
+  # cassandra.archive.port:
+  # cassandra.archive.proto-version:
+  # cassandra.archive.servers:
+  # cassandra.archive.socket-keep-alive:
+  # cassandra.archive.timeout:
+  # cassandra.archive.username:
+  # cassandra.connections-per-host:
+  # cassandra.max-retry-attempts:
+  # cassandra.password:
+  # cassandra.proto-version:
+  # cassandra.socket-keep-alive:
+  # cassandra.timeout:
+  # cassandra.username:
+  # collector.health-check-http-port:
+  # collector.num-workers:
+  # collector.queue-size:
+  # collector.write-cache-ttl:
+  # dependency-storage.data-frequency:
+  # discovery.min-peers:
+  # es.archive.max-span-age:
+  # es.archive.num-replicas:
+  # es.archive.num-shards:
+  # es.archive.password:
+  # es.archive.server-urls:
+  # es.archive.sniffer:
+  # es.archive.username:
+  # es.max-span-age:
+  # es.num-replicas:
+  # es.num-shards:
+  # es.sniffer:
+  # http-server.host-port:
+  # log-level:
+  # metrics-backend:
+  # metrics-http-route:
+  # processor.jaeger-binary.server-host-port:
+  # processor.jaeger-binary.server-max-packet-size:
+  # processor.jaeger-binary.server-queue-size:
+  # processor.jaeger-binary.workers:
+  # processor.jaeger-compact.server-host-port:
+  # processor.jaeger-compact.server-max-packet-size:
+  # processor.jaeger-compact.server-queue-size:
+  # processor.jaeger-compact.workers:
+  # processor.zipkin-compact.server-host-port:
+  # processor.zipkin-compact.server-max-packet-size:
+  # processor.zipkin-compact.server-queue-size:
+  # processor.zipkin-compact.workers:
+  # query.prefix:
+  # query.static-files:
+  # query.ui-config:

--- a/incubator/jaeger/templates/hotrod-deploy.yaml
+++ b/incubator/jaeger/templates/hotrod-deploy.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.hotrod.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "jaeger.fullname" . }}-hotrod
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: hotrod-deployment
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: hotrod
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.hotrod.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "jaeger.name" . }}
+        component: hotrod
+        release: {{ .Release.Name }}
+        jaeger-infra: hotrod-instance
+    spec:
+      containers:
+        - name: {{ template "jaeger.fullname" . }}-hotrod
+          image: {{ .Values.hotrod.image.repository }}:{{ .Values.hotrod.image.tag }}
+          imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
+          env:
+            - name: AGENT_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: hotrod.agent-host
+            - name: AGENT_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: hotrod.agent-port
+          ports:
+            - containerPort: {{ .Values.hotrod.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.hotrod.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.hotrod.service.internalPort }}
+          resources:
+{{ toYaml .Values.hotrod.resources | indent 12 }}
+    {{- if .Values.hotrod.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.hotrod.nodeSelector | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/incubator/jaeger/templates/hotrod-ing.yaml
+++ b/incubator/jaeger/templates/hotrod-ing.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.hotrod.enabled -}}
+{{- if .Values.hotrod.ingress.enabled -}}
+{{- $serviceName := include "jaeger.fullname" . -}}
+{{- $servicePort := .Values.hotrod.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "jaeger.fullname" . }}-hotrod
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: hotrod-ingress
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: hotrod
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.hotrod.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.hotrod.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.hotrod.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}-hotrod
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.hotrod.ingress.tls }}
+  tls:
+{{ toYaml .Values.hotrod.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/jaeger/templates/hotrod-svc.yaml
+++ b/incubator/jaeger/templates/hotrod-svc.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.hotrod.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jaeger.fullname" . }}-hotrod
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: hotrod-service
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: hotrod
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.hotrod.service.annotations }}
+  annotations:
+{{ toYaml .Values.hotrod.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.hotrod.service.type }}
+  ports:
+    - name: {{ .Values.hotrod.service.name }}
+      port: {{ .Values.hotrod.service.externalPort }}
+      protocol: TCP
+      targetPort: {{ .Values.hotrod.service.internalPort }}
+  selector:
+    app: {{ template "jaeger.name" . }}
+    component: hotrod
+    release: {{ .Release.Name }}
+    jaeger-infra: hotrod-instance
+{{- end -}}

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -1,28 +1,29 @@
+{{- if .Values.query.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: "{{ template "jaeger.query.fullname" . }}"
+  name: {{ template "jaeger.query.fullname" . }}
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: query-deployment
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "query"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: query
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.query.annotations }}
   annotations:
-{{ toYaml .Values.query.annotations | indent 6 }}
+{{ toYaml .Values.query.annotations | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.query.replicaCount }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: "{{ template "jaeger.name" . }}"
-        component: "query"
-        release: "{{ .Release.Name }}"
+        app: {{ template "jaeger.name" . }}
+        component: query
+        release: {{ .Release.Name }}
         jaeger-infra: query-pod
 {{- if .Values.query.podLabels }}
 {{ toYaml .Values.query.podLabels | indent 8 }}
@@ -31,40 +32,68 @@ spec:
       nodeSelector:
 {{ toYaml .Values.query.nodeSelector | indent 8 }}
       containers:
-      - name: "{{ template "jaeger.query.fullname" . }}"
-        image: "{{ .Values.query.image }}:{{ .Values.query.tag }}"
+      - name: {{ template "jaeger.query.fullname" . }}
+        image: {{ .Values.query.image }}:{{ .Values.query.tag }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
+        env:
+          - name: SPAN_STORAGE_TYPE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: span-storage.type
+          {{- if eq .Values.storage.type "cassandra" }}
+          - name: CASSANDRA_SERVERS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.servers
+          - name: CASSANDRA_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.port
+          - name: CASSANDRA_KEYSPACE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: cassandra.keyspace
+          {{- end }}
+          {{- if eq .Values.storage.type "elasticsearch" }}
+          - name: ES_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.password
+          - name: ES_SERVER_URLS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.server-urls
+          - name: ES_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: es.username
+          {{- end }}
+          - name: QUERY_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: query.port
+          - name: QUERY_HEALTH_CHECK_HTTP_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: query.health-check-http-port
         ports:
         - containerPort: {{ .Values.query.service.targetPort }}
           protocol: TCP
         resources:
 {{ toYaml .Values.query.resources | indent 10 }}
-        command:
-        - "/go/bin/query-linux"
-{{ if not (empty .Values.elasticsearch.config.host) }}
-        - "--span-storage.type=elasticsearch"
-        - "--es.server-urls={{ .Values.elasticsearch.config.host }}"
-        - "--es.username={{ .Values.elasticsearch.config.username }}"
-        - "--es.password={{ .Values.elasticsearch.config.password }}"
-{{ else if .Values.tags.elasticsearch }}
-        - "--span-storage.type=elasticsearch"
-        - "--es.server-urls=http://{{ template "elasticsearch.fullname" . }}-client:9200"
-{{ else if not (empty .Values.cassandra.config.host) }}
-        - "--cassandra.servers={{ .Values.cassandra.config.host }}"
-        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-{{ else }}
-        - "--cassandra.servers={{ template "cassandra.fullname" . }}"
-        - "--cassandra.keyspace=jaeger_v1_{{ .Values.cassandra.config.dc_name }}"
-{{ end }}
-        - "--query.static-files=/go/jaeger-ui/"
-        - "--query.port={{ .Values.query.service.targetPort }}"
-        - "--query.health-check-http-port={{ .Values.query.healthCheckPort }}"
-{{- range $key, $value := .Values.query.cmdlineParams }}
-        - "{{ $value }}"
-{{- end }}
         readinessProbe:
           httpGet:
-            path: "/"
+            path: /
             port: {{ .Values.query.healthCheckPort }}
       dnsPolicy: {{ .Values.query.dnsPolicy }}
       restartPolicy: Always
+{{- end -}}

--- a/incubator/jaeger/templates/query-ing.yaml
+++ b/incubator/jaeger/templates/query-ing.yaml
@@ -1,22 +1,24 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.query.ingress.enabled -}}
 {{- $serviceName := include "jaeger.query.fullname" . -}}
 {{- $servicePort := .Values.query.service.queryPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "jaeger.name" . }}
+  name: {{ template "jaeger.fullname" . }}-query
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: query-ingress
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    component: query
     heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  {{- if .Values.query.ingress.annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
+{{ toYaml .Values.query.ingress.annotations | indent 4 }}
+  {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.ingress.hosts }}
+    {{- range $host := .Values.query.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
@@ -25,8 +27,8 @@ spec:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
     {{- end -}}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.query.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
+{{ toYaml .Values.query.ingress.tls | indent 4 }}
   {{- end -}}
 {{- end -}}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -1,17 +1,18 @@
+{{- if .Values.query.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "jaeger.query.fullname" . }}"
+  name: {{ template "jaeger.query.fullname" . }}
   labels:
-    app: "{{ template "jaeger.name" . }}"
+    app: {{ template "jaeger.name" . }}
     jaeger-infra: query-service
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    component: "query"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    component: query
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 {{- if .Values.query.service.annotations }}
   annotations:
-{{ toYaml .Values.query.service.annotations | indent 6 }}
+{{ toYaml .Values.query.service.annotations | indent 4 }}
 {{- end }}
 spec:
   ports:
@@ -20,8 +21,9 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.query.service.targetPort }}
   selector:
-    app: "{{ template "jaeger.name" . }}"
-    component: "query"
-    release: "{{ .Release.Name }}"
+    app: {{ template "jaeger.name" . }}
+    component: query
+    release: {{ .Release.Name }}
     jaeger-infra: query-pod
   type: {{ .Values.query.service.type }}
+{{- end -}}

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.spark.enabled -}}
+{{- if or .Capabilities.APIVersions.Has "batch/v1beta1" .Capabilities.APIVersions.Has "batch/v2alpha1" -}}
+apiVersion: {{ template "cronjob.apiVersion" $ }}
+kind: CronJob
+metadata:
+  name: {{ template "jaeger.fullname" . }}-spark
+  labels:
+    app: {{ template "jaeger.name" . }}
+    jaeger-infra: spark-cronjob
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: spark
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.spark.annotations }}
+  annotations:
+{{ toYaml .Values.spark.annotations | indent 4 }}
+{{- end }}
+spec:
+  schedule: {{ .Values.spark.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ template "jaeger.name" . }}
+            component: spark
+            release: {{ .Release.Name }}
+            jaeger-infra: spark-instance
+            {{- if .Values.spark.podLabels }}
+            {{ toYaml .Values.spark.podLabels | indent 12 }}
+            {{- end }}
+        spec:
+          nodeSelector:
+            {{ toYaml .Values.spark.nodeSelector | indent 12 }}
+          containers:
+          - name: {{ template "jaeger.fullname" . }}-spark
+            image: {{ .Values.spark.image }}:{{ .Values.spark.tag }}
+            imagePullPolicy: {{ .Values.spark.pullPolicy }}
+            env:
+            - name: STORAGE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: span-storage.type
+            {{- if eq .Values.storage.type "cassandra" }}
+            - name: CASSANDRA_CONTACT_POINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: cassandra.contact-points
+            - name: CASSANDRA_KEYSPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: cassandra.keyspace
+              {{- end }}
+            {{- if eq .Values.storage.type "elasticsearch" }}
+            - name: ES_NODES
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: es.server-urls
+            - name: ES_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: es.password
+            - name: ES_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: es.username
+            {{- end }}
+            resources:
+            {{ toYaml .Values.spark.resources | indent 10 }}
+          restartPolicy: OnFailure
+{{- end -}}
+{{- end -}}

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -1,10 +1,27 @@
 # Default values for jaeger.
 # This is a YAML-formatted file.
+# Jaeger values are grouped by component. Cassandra values override subchart values
 
-# Begin: Override values on the Cassandra/ElasticSearch subchart to customize for Jaeger
-# This chart has been based on the Kubernetes integration found in the following repo:
-# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production/cassandra.yml
-# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production-elasticsearch/elasticsearch.yml
+provisionDataStore:
+  cassandra: true
+  elasticsearch: false
+
+storage:
+  # allowed values (cassandra, elasticsearch)
+  type: cassandra
+  cassandra:
+    host: cassandra
+    port: 9042
+    user: user
+    password: password
+  elasticsearch:
+    scheme: http
+    host: elasticsearch
+    port: 9200
+    user: elastic
+    password: changeme
+
+# Begin: Override values on the Cassandra subchart to customize for Jaeger
 cassandra:
   image:
     tag: 3.11
@@ -12,34 +29,23 @@ cassandra:
     # To enable persistence, please see the documentation for the Cassandra chart
     enabled: false
   config:
-    # Change the host value to point to an existing Cassandra instance
-    # Be sure to set both tags.cassandra and tags.elasticsearch to false
-    host: ""
     cluster_name: jaeger
     seed_size: 1
     dc_name: dc1
     rack_name: rack1
     endpoint_snitch: GossipingPropertyFileSnitch
-
-elasticsearch:
-  config:
-    # Change the host value to point to an existing ElasticSearch instance
-    # Be sure to set both tags.cassandra and tags.elasticsearch to false
-    host: ""
-    username: "elastic"
-    password: "changeme"
-# End: Override values on the Cassandra/ElasticSearch subchart to customize for Jaeger
+# End: Override values on the Cassandra subchart to customize for Jaeger
 
 # Begin: Default values for the various components of Jaeger
-tags:
-  # Chose which backing store to use. By default Cassandra is enabled.
-  cassandra: true
-  elasticsearch: false
-
+# This chart has been based on the Kubernetes integration found in the following repo:
+# https://github.com/jaegertracing/jaeger-kubernetes/blob/master/production/jaeger-production-template.yml
+#
+# This is the jaeger-cassandra-schema Job which sets up the Cassandra schema for
+# use by Jaeger
 schema:
   annotations: {}
   image: jaegertracing/jaeger-cassandra-schema
-  tag: 0.8
+  tag: 1.0.0
   pullPolicy: IfNotPresent
   # Acceptable values are test and prod. Default is for production use.
   mode: prod
@@ -53,21 +59,42 @@ schema:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+
+# Begin: Override values on the Elasticsearch subchart to customize for Jaeger
+elasticsearch:
+  image:
+    tag: "5.4"
+  cluster:
+    name: "tracing"
+  data:
+    persistance:
+      enabled: false
+  rbac:
+    create: false
+
 agent:
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-agent
-  tag: 0.8
+  tag: 1.0.0
   pullPolicy: IfNotPresent
+  collector:
+    host: null
+    port: null
   cmdlineParams: {}
+  daemonset:
+    useHostPort: false
   service:
     annotations: {}
+    type: ClusterIP
     # zipkinThriftPort :accept zipkin.thrift over compact thrift protocol
     zipkinThriftPort: 5775
     # compactPort: accept jaeger.thrift over compact thrift protocol
     compactPort: 6831
     # binaryPort: accept jaeger.thrift over binary thrift protocol
     binaryPort: 6832
+    # samplingPort: (HTTP) serve configs, sampling strategies
+    samplingPort: 5778
   resources: {}
     # limits:
     #   cpu: 500m
@@ -79,13 +106,16 @@ agent:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+
 collector:
+  enabled: true
   annotations: {}
   image: jaegertracing/jaeger-collector
-  tag: 0.8
+  tag: 1.0.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
+  replicaCount: 1
   service:
     annotations: {}
     type: ClusterIP
@@ -106,21 +136,57 @@ collector:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+
 query:
+  enabled: true
   annotations: {}
   image: jaegertracing/jaeger-query
-  tag: 0.8
+  tag: 1.0.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
   healthCheckPort: 16687
+  replicaCount: 1
   service:
     annotations: {}
-    type: NodePort
+    type: ClusterIP
     # queryPort: externally accessible port for UI and API
     queryPort: 80
     # targetPort: the internal port the UI and API are exposed on
     targetPort: 16686
+  ingress:
+    enabled: false
+    annotations: {}
+    # Used to create an Ingress record.
+    # hosts:
+    #   - chart-example.local
+    # annotations:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #    cpu: 256m
+    #    memory: 128Mi
+  nodeSelector: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+spark:
+  enabled: false
+  annotations: {}
+  image: jaegertracing/spark-dependencies
+  tag: latest
+  pullPolicy: Always
+  schedule: "49 23 * * *"
   resources: {}
     # limits:
     #   cpu: 500m
@@ -134,16 +200,43 @@ query:
   podLabels: {}
 # End: Default values for the various components of Jaeger
 
-ingress:
+hotrod:
   enabled: false
-  # Used to create an Ingress record.
-  # hosts:
-  #   - chart-example.local
-  # annotations:
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  # tls:
-    # Secrets must be manually created in the namespace.
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
+  replicaCount: 1
+  image:
+    repository: mikelorant/jaeger-hotrod
+    tag: latest
+    pullPolicy: Always
+  service:
+    annotations: {}
+    name: hotrod
+    type: ClusterIP
+    externalPort: 80
+    internalPort: 8080
+  ingress:
+    enabled: false
+    # Used to create Ingress record (should be used with service.type: ClusterIP).
+    hosts:
+      - chart-example.local
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  tracing:
+    host: null
+    port: 6831

--- a/incubator/oauth-proxy/Chart.yaml
+++ b/incubator/oauth-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth-proxy
-version: 0.1.4
+version: 0.1.5
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/incubator/oauth-proxy/README.md
+++ b/incubator/oauth-proxy/README.md
@@ -49,6 +49,7 @@ Parameter | Description | Default
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `a5huynh/oauth2_proxy`
 `image.tag` | Image tag | `2.2`
+`imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `ingress.enabled` | enable ingress | `false`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`

--- a/incubator/oauth-proxy/templates/deployment.yaml
+++ b/incubator/oauth-proxy/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             port: {{ .Values.service.internalPort }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
     {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/incubator/oauth-proxy/values.yaml
+++ b/incubator/oauth-proxy/values.yaml
@@ -13,6 +13,12 @@ image:
   tag: "2.2"
   pullPolicy: "IfNotPresent"
 
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# imagePullSecrets:
+  # - name: myRegistryKeySecretName
+
 extraArgs:
   email-domain: "*"
   upstream: "file:///dev/null"

--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.5
+version: 0.5.1
 appVersion: 1.2-p17
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.5
+version: 0.6.0
 appVersion: 1.2-p17
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.5.1
+version: 0.6.0
 appVersion: 1.2-p17
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -65,6 +65,7 @@ The following tables lists the configurable parameters of the patroni chart and 
 | `Credentials.Superuser` | password for the superuser          | `tea`                                               |
 | `Credentials.Admin`     | password for the admin user         | `cola`                                              |
 | `Credentials.Standby`   | password for the replication user   | `pinacolada`                                        |
+| `SecretKeyRefs`         | defines secret resources to env mapping | defaults to load `Credentials` from our own secret resource |
 | `Etcd.Enable`           | using etcd as DCS                   | `true`                                              |
 | `Etcd.DeployChart`      | deploy etcd chart                   | `true`                                              |
 | `Etcd.Host`             | host name of etcd cluster           | not used (Etcd.Discovery is used instead)           |

--- a/incubator/patroni/requirements.lock
+++ b/incubator/patroni/requirements.lock
@@ -1,14 +1,9 @@
 dependencies:
 - name: etcd
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  tags: null
-  version: 0.2.1
-- condition: ""
-  enabled: false
-  import-values: null
-  name: zookeeper
+  version: 0.3.6
+- name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  tags: null
   version: 0.2.2
-digest: sha256:eb2ad7cb8f0f4dbf1e6b9a79e3a408a814240a4579d77f4b35b87029b8b04b2c
-generated: 2017-10-23T12:09:56.47159975+01:00
+digest: sha256:af5cb9f406a215c54c5b34cfa19091f80ef73a453ee53017767eab5c319e9f51
+generated: 2018-01-22T14:04:57.901835+01:00

--- a/incubator/patroni/requirements.yaml
+++ b/incubator/patroni/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: etcd
-  version: 0.2.1
+  version: 0.3.6
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: Etcd.DeployChart
 - name: zookeeper

--- a/incubator/patroni/templates/NOTES.txt
+++ b/incubator/patroni/templates/NOTES.txt
@@ -1,24 +1,12 @@
 Patroni can be accessed via port 5432 on the following DNS name from within your cluster:
 {{ template "patroni.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
-To get your password for superuser or admin run:
 
-    # admin user password
-    PGPASSWORD_ADMIN=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "patroni.fullname" . }} -o jsonpath="{.data.password-admin}" | base64 --decode)
+To get your password for superuser run:
+    PGPASSWORD_SUPERUSER=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ default (include "patroni.fullname" .) .Values.SecretKeyRefs.PGPASSWORD_SUPERUSER.name | quote}} -o jsonpath={{ printf "{.data.%s}" .Values.SecretKeyRefs.PGPASSWORD_SUPERUSER.key | quote}} | base64 --decode)
 
-    # superuser password
-    PGPASSWORD_SUPERUSER=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "patroni.fullname" . }} -o jsonpath="{.data.password-superuser}" | base64 --decode)
 
-To connect to your database:
-
-1. Run a postgres pod and connect using the psql cli:
-    # login as admin
-    kubectl run -i --tty --rm psql --image=postgres \
-      --env "PGPASSWORD=$PGPASSWORD_ADMIN" \
-      --command -- psql -U admin \
-      -h {{ template "patroni.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
-
-    # login as superuser
+To connect to your database run a postgres pod and connect using the psql cli (login as superuser):
     kubectl run -i --tty --rm psql --image=postgres \
       --env "PGPASSWORD=$PGPASSWORD_SUPERUSER" \
       --command -- psql -U postgres \

--- a/incubator/patroni/templates/_helpers.tpl
+++ b/incubator/patroni/templates/_helpers.tpl
@@ -7,3 +7,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "patroni.fullname" -}}
 {{- printf "%s-%s" .Release.Name .Values.Name | trunc 63 -}}
 {{- end -}}
+
+{{/*
+    generates a yaml secretKeyRef env structure and expects the folowing structure as input (dict):
+    ```
+    SecretKeyRefs:
+        <container-env-var-name>:
+            name: <secret resource name> (optional, defaults to patroni.fullname as secret resource name)
+            key: <secret resource entry>
+    ```
+*/}}
+{{- define "patroni.secretKeyRefs" -}}
+{{- $global := . -}}
+{{- range $k, $v := .Values.SecretKeyRefs }}
+- name: {{ $k | upper | quote }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (include "patroni.fullname" $global) $v.name | quote }}
+      key: {{ $v.key | quote }}
+{{- end -}}
+{{- end -}}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -29,7 +29,7 @@ spec:
       - name: spilo
         image: "{{ .Values.Spilo.Image }}:{{ .Values.Spilo.Version }}"
         env:
-        {{- if $.Values.SecretKeyRefs }}
+        {{- if .Values.SecretKeyRefs }}
         {{- include "patroni.secretKeyRefs" . | indent 8 }}
         {{- end }}
         {{if .Values.Etcd.Enable }}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -29,21 +29,9 @@ spec:
       - name: spilo
         image: "{{ .Values.Spilo.Image }}:{{ .Values.Spilo.Version }}"
         env:
-        - name: PGPASSWORD_SUPERUSER
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
-              key: password-superuser
-        - name: PGPASSWORD_ADMIN
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
-              key: password-admin
-        - name: PGPASSWORD_STANDBY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
-              key: password-standby
+        {{- if $.Values.SecretKeyRefs }}
+        {{- include "patroni.secretKeyRefs" . | indent 8 }}
+        {{- end }}
         {{if .Values.Etcd.Enable }}
         {{if .Values.Etcd.DeployChart }}
         - name: ETCD_DISCOVERY_DOMAIN

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -36,8 +36,8 @@ Credentials:
 # ```
 # SecretKeyRefs:
 #   <container-env-var-name>:
-#     name: <secret resource name> (optional, defaults to patroni.fullname as secret resource name)
-#     key: <which secret resource entry should be used
+#     name: <secret resource name> (optional, defaults to patroni charts secret as resource name)
+#     key: <secret resource entry>
 # ```
 SecretKeyRefs:
   PGPASSWORD_SUPERUSER:

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -28,6 +28,25 @@ Credentials:
   Admin: cola
   Standby: pinacolada
 
+# Define where patroni should get its secrets from.
+# On default, it uses the generated secret by itself, but changing `SecretKeyRefs` allows you
+# to get the data from your own secret resource.
+#
+# Syntax:
+# ```
+# SecretKeyRefs:
+#   <container-env-var-name>:
+#     name: <secret resource name> (optional, defaults to patroni.fullname as secret resource name)
+#     key: <which secret resource entry should be used
+# ```
+SecretKeyRefs:
+  PGPASSWORD_SUPERUSER:
+    key: password-superuser
+  PGPASSWORD_ADMIN:
+    key: password-admin
+  PGPASSWORD_STANDBY:
+    key: password-standby
+
 ## Distribution Configuration stores. Please note that only one of the following stores should be selected.
 Etcd:
   Enable: true

--- a/incubator/webpagetest-server/Chart.yaml
+++ b/incubator/webpagetest-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-server
-version: 0.1.0
+version: 0.1.1
 home: https://www.webpagetest.org/
 icon: https://www.webpagetest.org/images/logo_wpt.png
 sources:

--- a/incubator/webpagetest-server/templates/agentIngress.yaml
+++ b/incubator/webpagetest-server/templates/agentIngress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.agentIngress.enabled -}}
-{{- $serviceName := include "fullname" . -}}
+{{- $serviceName := include "webpagetest.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $rejectSvcName := .Values.agentIngress.rejectServiceName -}}
 {{- $rejectSvcPort := .Values.agentIngress.rejectServicePort -}}

--- a/stable/aerospike/Chart.yaml
+++ b/stable/aerospike/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - aerospike
   - big-data
 home: http://aerospike.com
-version: 0.1.5
+version: 0.1.6
 icon: https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png
 sources:
 - https://github.com/aerospike/aerospike-server

--- a/stable/aerospike/README.md
+++ b/stable/aerospike/README.md
@@ -32,7 +32,7 @@ To install the chart with the release name `my-aerospike` using a dedicated name
 
 ```
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-$ helm install --name my-aerospike --namespace aerospike incubator/aerospike
+$ helm install --name my-aerospike --namespace aerospike stable/aerospike
 ```
 
 The chart can be customized using the following configurable parameters:
@@ -54,7 +54,7 @@ Specify parameters using `--set key=value[,key=value]` argument to `helm install
 Alternatively a YAML file that specifies the values for the parameters can be provided like this:
 
 ```bash
-$ helm install --name my-aerospike -f values.yaml incubator/aerospike
+$ helm install --name my-aerospike -f values.yaml stable/aerospike
 ```
 
 ### Conf files for Aerospike

--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,5 +1,5 @@
 name: anchore-engine
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.6
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/README.md
+++ b/stable/anchore-engine/README.md
@@ -15,6 +15,9 @@ The chart is split into three primary sections: GlobalConfig, CoreConfig, Worker
 the GlobalConfig is for configuration values that all components require, while the Core and Worker sections are
 tier-specific and allow customization for each role.
 
+NOTE: It is highly recommended to set a non-default password when deploying. The admin password is set to a default in the chart. To customize it use:
+ `--set globalConfig.users.admin.password=<pass>` or set it in the values.yaml locally.
+
 
 ### Core Role
 The core services provide the apis and state management for the system. Core services must be available within the cluster
@@ -35,18 +38,33 @@ Installing the Chart
 
 Deploying PostgreSQL as a dependency managed in the chart:
 
-`helm install .`
+`helm install stable/anchore-engine`
 
 
 Using and existing/external PostgreSQL service:
 
-`helm install --name <name> --set postgresql.enabled=False .`
+`helm install --name <name> --set postgresql.enabled=False stable/anchore-engine`
+
+
+This installs the chart in cluster-local mode. To expose the service outside the chart there are two options:
+1. Use a LoadBalancer service type by setting the `service.type=LoadBalancer` in the values.yaml or on CLI
+2. Use an ingress by setting `ingress.enabled=True` in the values.yaml or on CLI
+
 
 
 Configuration
 -------------
 
 While the configuration options of Anchore Engine are extensive, the options provided by the chart are:
+
+### Exposing the service outside the cluster:
+
+* Use ingress, which enables SSL termination at the LB:
+  * ingress.enabled=True (may require service.type=NodePort for some K8s installations e.g. GKE)
+
+* Use a LoadBalancer service type:
+  * service.type=LoadBalancer 
+
 
 ### Database
 
@@ -75,9 +93,14 @@ Adding Workers
 
 To set a specific number of workers once the service is running:
 
-`helm upgrade --set workerConfig.replicaCount=2`
+If using defaults from the chart:
+
+`helm upgrade --set workerConfig.replicaCount=2 <releasename> stable/anchore-engine`
+
+If customized values, use the local directory for the chart values:
+
+`helm upgrade --est workerConfig.replicaCount=2 <releasename> ./anchore-engine`
 
 To launch with more than one worker you can either modify values.yaml or run with:
 
-`helm install --set workerConfig.replicaCount=2 <chart location>`
-
+`helm install --set workerConfig.replicaCount=2 stable/anchore-engine`

--- a/stable/anchore-engine/templates/NOTES.txt
+++ b/stable/anchore-engine/templates/NOTES.txt
@@ -18,7 +18,7 @@ Using the service endpoint from within the cluster you can use:
 
 To verify the service is up and running, you can run container for the Anchore Engine CLI:
 
-    kubectl run -i --tty anchore-cli --restart=Never --image anchore/engine-cli --env ANCHORE_CLI_USER=admin --env ANCHORE_CLI_PASS=${ANCHORE_CLI_PASS} --env ANCHORE_CLI_URL=http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ports.api}}/v1/
+    kubectl run -i --tty anchore-cli --restart=Always --image anchore/engine-cli --env ANCHORE_CLI_USER=admin --env ANCHORE_CLI_PASS=${ANCHORE_CLI_PASS} --env ANCHORE_CLI_URL=http://{{ template "fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ports.api}}/v1/
 
 from within the container you can use 'anchore-cli' commands.
 

--- a/stable/anchore-engine/templates/core_configmap.yaml
+++ b/stable/anchore-engine/templates/core_configmap.yaml
@@ -60,9 +60,9 @@ data:
           email: {{ .Values.globalConfig.users.admin.email }}
           external_service_auths:
           {{ if not .Values.globalConfig.users.admin.anchoreIOCredentials.useAnonymous }}
-          anchoreio:
-            anchorecli:
-              auth: "${ANCHORE_IO_USER}:${ANCHORE_IO_PASSWORD}"
+            anchoreio:
+              anchorecli:
+                auth: "${ANCHORE_IO_USER}:${ANCHORE_IO_PASSWORD}"
           {{ end }}
           auto_policy_sync: {{ .Values.coreConfig.policyBundleSyncEnabled }}
 

--- a/stable/anchore-engine/templates/core_deployment.yaml
+++ b/stable/anchore-engine/templates/core_deployment.yaml
@@ -47,6 +47,16 @@ spec:
           value: {{ .Values.postgresql.postgresDatabase }}
         - name: ANCHORE_DB_HOST
           value: {{ template "postgres.fullname" . }}
+        - name: ANCHORE_IO_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: anchoreIOUser
+        - name: ANCHORE_IO_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: anchoreIOPassword
         - name: ANCHORE_DB_USER
           valueFrom:
             secretKeyRef:

--- a/stable/cert-manager/.helmignore
+++ b/stable/cert-manager/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,0 +1,15 @@
+name: cert-manager
+version: 0.2.1
+appVersion: 0.2.3
+description: A Helm chart for cert-manager
+home: https://github.com/jetstack/cert-manager
+keywords:
+  - cert-manager
+  - kube-lego
+  - letsencrypt
+  - tls
+sources:
+  - https://github.com/jetstack/cert-manager
+maintainers:
+  - name: munnerz
+    email: james@jetstack.io

--- a/stable/cert-manager/OWNERS
+++ b/stable/cert-manager/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- munnerz
+reviewers:
+- munnerz
+- unguiculus

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -1,0 +1,77 @@
+# cert-manager
+
+cert-manager is a Kubernetes addon to automate the management and issuance of
+TLS certificates from various issuing sources.
+
+It will ensure certificates are valid and up to date periodically, and attempt
+to renew certificates at an appropriate time before expiry.
+
+Changes to this chart are tested and version in the [upstream cert-manager repository](https://github.com/jetstack/cert-manager).
+Changes to this chart should be made as pull requests upstream, to be versioned and copied across to this repo.
+
+## TL;DR;
+
+```console
+$ helm install stable/cert-manager
+```
+
+## Introduction
+
+This chart creates a cert-manager deployment on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+- Kubernetes cluster with support for CustomResourceDefinition or ThirdPartyResource
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release .
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the cert-manager chart and their default values.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
+| `image.tag` | Image tag | `v0.2.3` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `replicaCount`  | Number of cert-manager replicas  | `1` |
+| `createCustomResource` | Create CRD/TPR with this release | `true` |
+| `extraArgs` | Optional flags for cert-manager | `[]` |
+| `rbac.create` | If `true`, create and use RBAC resources | `true`
+| `serviceAccount.create` | If `true`, create a new service account | `true`
+| `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
+| `resources` | CPU/memory resource requests/limits | `requests: {cpu: 10m, memory: 32Mi}` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `ingressShim.enabled` | Enable ingress-shim for automatic ingress integration | `true`|
+| `ingressShim.extraArgs` | Optional flags for ingress-shim | `[]` |
+| `ingressShim.resources` | CPU/memory resource requests/limits for ingress-shim | `requests: {cpu: 10m, memory: 32Mi}` |
+| `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
+| `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
+| `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml .
+```
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/cert-manager/templates/NOTES.txt
+++ b/stable/cert-manager/templates/NOTES.txt
@@ -1,0 +1,5 @@
+cert-manager has been deployed successfully!
+
+You may now go ahead and create issuers and certificates.
+
+See https://github.com/jetstack/cert-manager/blob/v0.2.3/docs/README.md

--- a/stable/cert-manager/templates/_helpers.tpl
+++ b/stable/cert-manager/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cert-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cert-manager.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $fullname := printf "%s-%s" $name .Release.Name -}}
+{{- default $fullname .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cert-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cert-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cert-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/cert-manager/templates/certificate-crd.yaml
+++ b/stable/cert-manager/templates/certificate-crd.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.createCustomResource -}}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1"  }}
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: certificate.certmanager.k8s.io
+description: "A specification for a cert-manager certificate"
+versions:
+  - name: v1alpha1
+{{- end -}}
+{{- end -}}

--- a/stable/cert-manager/templates/clusterissuer-crd.yaml
+++ b/stable/cert-manager/templates/clusterissuer-crd.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.createCustomResource -}}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+{{- end -}}
+{{- end -}}

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "cert-manager.fullname" . }}
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "cert-manager.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.extraArgs }}
+          args:
+{{ toYaml .Values.extraArgs | indent 12 }}
+        {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.ingressShim.enabled }}
+        - name: ingress-shim
+          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
+        {{- if .Values.ingressShim.extraArgs }}
+          args:
+{{ toYaml .Values.ingressShim.extraArgs | indent 12 }}
+        {{- end }}
+          resources:
+{{ toYaml .Values.ingressShim.resources | indent 12 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}

--- a/stable/cert-manager/templates/issuer-crd.yaml
+++ b/stable/cert-manager/templates/issuer-crd.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.createCustomResource -}}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: issuer.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+description: "A specification for a cert-manager issuer"
+versions:
+  - name: v1alpha1
+{{- end -}}
+{{- end -}}

--- a/stable/cert-manager/templates/rbac.yaml
+++ b/stable/cert-manager/templates/rbac.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "cert-manager.fullname" . }}
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "issuers", "clusterissuers"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["secrets", "events", "endpoints", "services", "pods"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "cert-manager.fullname" . }}
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "cert-manager.fullname" . }}
+subjects:
+  - name: {{ template "cert-manager.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end -}}

--- a/stable/cert-manager/templates/serviceaccount.yaml
+++ b/stable/cert-manager/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cert-manager.serviceAccountName" . }}
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -1,0 +1,55 @@
+# Default values for cert-manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+image:
+  repository: quay.io/jetstack/cert-manager-controller
+  tag: v0.2.3
+  pullPolicy: IfNotPresent
+
+createCustomResource: true
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+# Optional additional arguments
+extraArgs: []
+  # Use this flag to set a namespace that cert-manager will use to store
+  # supporting resources required for each ClusterIssuer (default is kube-system)
+  # - --cluster-resource-namespace=kube-system
+
+resources: {}
+  # requests:
+  #   cpu: 10m
+  #   memory: 32Mi
+
+nodeSelector: {}
+
+ingressShim:
+  enabled: true
+
+  # Optional additional arguments for ingress-shim
+  extraArgs: []
+
+  resources: {}
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
+
+  image:
+    repository: quay.io/jetstack/cert-manager-ingress-shim
+
+    # Defaults to image.tag.
+    # You should only change this if you know what you are doing!
+    # tag: v0.2.3
+
+    pullPolicy: IfNotPresent

--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.5.4
-appVersion: 1.1.3
+version: 0.6.2
+appVersion: 1.1.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -36,7 +36,7 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | ----------------------------- | ------------------------------------------ | -------------------------------------------- |
 | `Name`                        | Chart name                                 | `cockroachdb`                                |
 | `Image`                       | Container image name                       | `cockroachdb/cockroach`                      |
-| `ImageTag`                    | Container image tag                        | `v1.0`                                       |
+| `ImageTag`                    | Container image tag                        | `v1.1.4`                                     |
 | `ImagePullPolicy`             | Container pull policy                      | `Always`                                     |
 | `Replicas`                    | k8s statefulset replicas                   | `3`                                          |
 | `MaxUnavailable`              | k8s PodDisruptionBudget parameter          | `1`                                          |
@@ -46,7 +46,7 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | `Cpu`                         | Container requested cpu                    | `100m`                                       |
 | `Memory`                      | Container requested memory                 | `512Mi`                                      |
 | `Storage`                     | Persistent volume size                     | `1Gi`                                        |
-| `StorageClass`                | Persistent volume class                    | `anything`                                   |
+| `StorageClass`                | Persistent volume class                    | `null`                                       |
 | `CacheSize`                   | Size of CockroachDB's in-memory cache      | `25%`                                        |
 | `MaxSQLMemory`                | Max memory to use processing SQL queries   | `25%`                                        |
 | `ClusterDomain`               | Cluster's default DNS domain               | `cluster.local`                              |

--- a/stable/cockroachdb/templates/cluster-init.yaml
+++ b/stable/cockroachdb/templates/cluster-init.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-init"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+      - name: cluster-init
+        image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
+        imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
+        command:
+          - "/cockroach/cockroach"
+          - "init"
+          - "--insecure"
+          - "--host={{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-0.{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
+      restartPolicy: OnFailure

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -37,12 +37,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-{{ .Values.Component }}"
   annotations:
-    # This is needed to make the peer-finder work properly and to help avoid
-    # edge cases where instance 0 comes up after losing its data and needs to
-    # decide whether it should create a new cluster or try to join an existing
-    # one. If it creates a new cluster when it should have joined an existing
-    # one, we'd end up with two separate clusters listening at the same service
-    # endpoint, which would be very bad.
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
     prometheus.io/scrape: "true"
@@ -90,34 +84,6 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: "{{ .Release.Name }}-{{ .Values.Component }}"
     spec:
-      # Init containers are run only once in the lifetime of a pod, before
-      # it's started up for the first time. It has to exit successfully
-      # before the pod's main containers are allowed to start.
-      # This particular init container does a DNS lookup for other pods in
-      # the set to help determine whether or not a cluster already exists.
-      # If any other pods exist, it creates a file in the cockroach-data
-      # directory to pass that information along to the primary container that
-      # has to decide what command-line flags to use when starting CockroachDB.
-      # This only matters when a pod's persistent volume is empty - if it has
-      # data from a previous execution, that data will always be used.
-      # The cockroachdb/cockroach-k8s-init image is defined at
-      # github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/init
-      initContainers:
-      - name: bootstrap
-        image: "{{ .Values.BootstrapImage }}:{{ .Values.BootstrapImageTag }}"
-        imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
-        args:
-        - "-on-start=/on-start.sh"
-        - "-service={{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
-        - "-domain={{ .Values.ClusterDomain }}"
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        volumeMounts:
-        - name: datadir
-          mountPath: "/cockroach/cockroach-data"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -150,34 +116,25 @@ spec:
         command:
           - "/bin/bash"
           - "-ecx"
-          - |
             # The use of qualified `hostname -f` is crucial:
             # Other nodes aren't able to look up the unqualified hostname.
-            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0" "--cache" "{{ .Values.CacheSize }}" "--max-sql-memory" "{{ .Values.MaxSQLMemory }}")
-            # We only want to initialize a new cluster (by omitting the join flag)
-            # if we're sure that we're the first node (i.e. index 0) and that
-            # there aren't any other nodes running as part of the cluster that
-            # this is supposed to be a part of (which indicates that a cluster
-            # already exists and we should make sure not to create a new one).
-            # It's fine to run without --join on a restart if there aren't any
-            # other nodes.
-            if [ ! "$(hostname)" == "${STATEFULSET_NAME}-0" ] || \
-               [ -e "/cockroach/cockroach-data/cluster_exists_marker" ]
-            then
-              CRARGS+=("--join" "${STATEFULSET_NAME}-public")
-            fi
-            exec /cockroach/cockroach ${CRARGS[*]}
+          - "exec /cockroach/cockroach start --logtostderr --insecure --advertise-host $(hostname -f) --http-host 0.0.0.0 --cache {{ .Values.CacheSize }} --max-sql-memory {{ .Values.MaxSQLMemory }} --join ${STATEFULSET_NAME}-0.${STATEFULSET_NAME},${STATEFULSET_NAME}-1.${STATEFULSET_NAME},${STATEFULSET_NAME}-2.${STATEFULSET_NAME}"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: "{{ .Values.StorageClass }}"
     spec:
       accessModes:
         - "ReadWriteOnce"
+{{- if .Values.StorageClass }}
+{{- if (eq "-" .Values.StorageClass) }}
+      storageClassName: ""
+{{- else }}
+      storageClassName: "{{ .Values.StorageClass }}"
+{{- end }}
+{{- end }}
       resources:
         requests:
           storage: "{{ .Values.Storage }}"

--- a/stable/cockroachdb/templates/tests/client-test.yaml
+++ b/stable/cockroachdb/templates/tests/client-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-test"
+  annotations:
+    "helm.sh/hook": test-success
+{{- if and (.Values.NetworkPolicy.Enabled) (not .Values.NetworkPolicy.AllowExternal) }}
+  labels:
+    "{{.Release.Name}}-{{.Values.Component}}-client": true
+{{- end }}
+spec:
+  containers:
+  - name: "client-test"
+    image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
+    imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
+    command:
+      - "/cockroach/cockroach"
+      - "sql"
+      - "--insecure"
+      - "--host"
+      - "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-public.{{ .Release.Namespace }}"
+      - "--port"
+      - "{{ .Values.GrpcPort }}"
+      - "-e"
+      - "SHOW DATABASES;"
+  restartPolicy: Never

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -5,7 +5,7 @@
 
 Name: "cockroachdb"
 Image: "cockroachdb/cockroach"
-ImageTag: "v1.1.3"
+ImageTag: "v1.1.4"
 ImagePullPolicy: "Always"
 BootstrapImage: "cockroachdb/cockroach-k8s-init"
 BootstrapImageTag: "0.2"
@@ -19,7 +19,14 @@ Resources:
     cpu: "100m"
     memory: "512Mi"
 Storage: "1Gi"
-StorageClass: "anything"
+## Persistent Volume Storage Class for database data
+## If defined, storageClassName: <StorageClass>
+## If set to "-", storageClassName: "", which disables dynamic provisioning
+## If undefined or set to null, no storageClassName spec is
+##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+##   GKE, AWS & OpenStack)
+##
+StorageClass: null
 CacheSize: "25%"
 MaxSQLMemory: "25%"
 ClusterDomain: "cluster.local"

--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 1.1.3
+version: 1.1.4
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -263,7 +263,8 @@ spec:
               ${GOSSIP_KEY} \
             {{- end }}
               -client=0.0.0.0 \
-              -dns-port=${DNSPORT}
+              -dns-port=${DNSPORT} \
+              -http-port={{ .Values.HttpPort }}
       volumes:
       - name: gossip-key
         secret:

--- a/stable/consul/templates/test-config.yaml
+++ b/stable/consul/templates/test-config.yaml
@@ -6,11 +6,19 @@ data:
   run.sh: |-
     @test "Testing Consul cluster has quorum" {
       for i in {0..2}; do
-        if [ `kubectl exec {{ .Release.Name }}-consul-$i consul members --namespace={{ .Release.Namespace }} | grep server | wc -l` -ge "3" ]; then
-          echo "{{ .Release.Name }}-consul-$i OK. consul members returning at least 3 records."
-        else
-          echo "{{ .Release.Name }}-consul-$i ERROR. consul members returning less than 3 records."
-          exit 1
-        fi
+        for n in {1..30}; do
+          if [ `kubectl exec {{ .Release.Name }}-consul-$i consul members --namespace={{ .Release.Namespace }} | grep server | wc -l` -ge "3" ]; then
+            echo "{{ .Release.Name }}-consul-$i OK. consul members returning at least 3 records."
+            break
+          else
+            echo "{{ .Release.Name }}-consul-$i ERROR. consul members returning less than 3 records."
+          fi
+
+          if [ "$n" -ge "30" ]; then
+            echo "Failed $n times to get members from {{ .Release.Name }}-consul-$i"
+            exit 1
+          fi
+          sleep 10
+        done
       done
     }

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluent-bit
-version: 0.2.4
-appVersion: 0.12.7
+version: 0.2.5
+appVersion: 0.12.11
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
 - logging

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -5,7 +5,7 @@ on_minikube: false
 image:
   fluent_bit:
     repository: fluent/fluent-bit
-    tag: 0.12.7
+    tag: 0.12.11
   pullPolicy: Always
 
 backend:

--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 name: ghost
-version: 2.1.9
-appVersion: 1.20.2
+version: 2.1.10
+appVersion: 1.20.3
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world
 keywords:

--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,6 +1,6 @@
 name: ghost
-version: 2.1.8
-appVersion: 1.19.2
+version: 2.1.9
+appVersion: 1.20.2
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world
 keywords:

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Ghost image version
 ## ref: https://hub.docker.com/r/bitnami/ghost/tags/
 ##
-image: bitnami/ghost:1.20.2-r0
+image: bitnami/ghost:1.20.3-r0
 
 ## Busybox image used to configure volume permissions
 ##

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Ghost image version
 ## ref: https://hub.docker.com/r/bitnami/ghost/tags/
 ##
-image: bitnami/ghost:1.19.2-r1
+image: bitnami/ghost:1.20.2-r0
 
 ## Busybox image used to configure volume permissions
 ##

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.5.5
+version: 0.5.6
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/dashboards-config: {{ include (print $.Template.BasePath "/dashboards-configmap.yaml") . | sha256sum }}
       {{- range $key, $value := .Values.server.annotations }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       labels:
         app: {{ template "grafana.fullname" . }}

--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 0.8.0
+version: 0.8.1
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:
 - influxdb

--- a/stable/influxdb/templates/config.yaml
+++ b/stable/influxdb/templates/config.yaml
@@ -84,7 +84,7 @@ data:
       unix-socket-enabled = {{ .Values.config.http.unix_socket_enabled }}
       bind-socket = "{{ .Values.config.http.bind_socket }}"
     
-    # TODO: allow multiple graphite listeners with templates
+    # TODO: allow multiple graphite listeners
     
     [[graphite]]
       enabled = {{ .Values.config.graphite.enabled }}
@@ -98,6 +98,13 @@ data:
       consistency-level = "{{ .Values.config.graphite.consistency_level }}"
       separator = "{{ .Values.config.graphite.separator }}"
       udp-read-buffer = {{ .Values.config.graphite.udp_read_buffer | int64 }}
+      {{- if .Values.config.graphite.templates }}
+      templates = [
+        {{- range .Values.config.graphite.templates }}
+          {{ quote . }},
+        {{- end }}
+      ]
+      {{- end }}
     
     # TODO: allow multiple collectd listeners with templates
 

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -167,6 +167,9 @@ config:
     consistency_level: one
     separator: .
     udp_read_buffer: 0
+    # Uncomment to define graphite templates
+    # templates:
+    #   - "graphite.metric.*.*.* measurement.run"
   collectd:
     enabled: false
     bind_address: 25826

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.12.1
+version: 0.13.0
 appVersion: 2.73
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.12.0
+version: 0.12.1
 appVersion: 2.73
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -55,6 +55,9 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
+| `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
+| `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
+| `Master.Jobs`                     | Jenkins XML job configs              | Not set                                                                      |
 | `Master.InstallPlugins`           | List of Jenkins plugins to install   | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |
 | `Master.ScriptApproval`           | List of groovy functions to approve  | Not set                                                                      |
 | `Master.NodeSelector`             | Node labels for pod assignment       | `{}`                                                                         |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -156,6 +156,18 @@ data:
     mkdir -p /var/jenkins_home/init.groovy.d/;
     cp -n /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/
 {{- end }}
+{{- if .Values.Master.CredentialsXmlSecret }}
+    cp -n /var/jenkins_credentials/credentials.xml /var/jenkins_home;
+{{- end }}
+{{- if .Values.Master.SecretsFilesSecret }}
+    cp -n /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets;
+{{- end }}
+{{- if .Values.Master.Jobs }}
+    for job in $(ls /var/jenkins_jobs); do
+      mkdir -p /var/jenkins_home/jobs/$job
+      cp -n /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+    done
+{{- end }}
 {{- range $key, $val := .Values.Master.InitScripts }}
   init{{ $key }}.groovy: |-
 {{ $val | indent 4 }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -43,6 +43,7 @@ data:
                   {{- $key }}={{ $value }}
                   {{- $_ := set $local "first" false }}
                 {{- end }}</nodeSelector>
+                <nodeUsageMode>NORMAL</nodeUsageMode>
               <volumes>
 {{- range $index, $volume := .Values.Agent.volumes }}
                 <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -53,6 +53,24 @@ spec:
             -
               mountPath: /var/jenkins_config
               name: jenkins-config
+            {{- if .Values.Master.CredentialsXmlSecret }}
+            -
+              mountPath: /var/jenkins_credentials
+              name: jenkins-credentials
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.SecretsFilesSecret }}
+            -
+              mountPath: /var/jenkins_secrets
+              name: jenkins-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.Jobs }}
+            -
+              mountPath: /var/jenkins_jobs
+              name: jenkins-jobs
+              readOnly: true
+            {{- end }}
             -
               mountPath: /usr/share/jenkins/ref/plugins/
               name: plugin-dir
@@ -120,6 +138,24 @@ spec:
               mountPath: /var/jenkins_config
               name: jenkins-config
               readOnly: true
+            {{- if .Values.Master.CredentialsXmlSecret }}
+            -
+              mountPath: /var/jenkins_credentials
+              name: jenkins-credentials
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.SecretsFilesSecret }}
+            -
+              mountPath: /var/jenkins_secrets
+              name: jenkins-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.Jobs }}
+            -
+              mountPath: /var/jenkins_jobs
+              name: jenkins-jobs
+              readOnly: true
+            {{- end }}
             -
               mountPath: /usr/share/jenkins/ref/plugins/
               name: plugin-dir
@@ -135,6 +171,21 @@ spec:
       - name: jenkins-config
         configMap:
           name: {{ template "jenkins.fullname" . }}
+      {{- if .Values.Master.CredentialsXmlSecret }}
+      - name: jenkins-credentials
+        secret:
+          secretName: {{ .Values.Master.CredentialsXmlSecret }}
+      {{- end }}
+      {{- if .Values.Master.SecretsFilesSecret }}
+      - name: jenkins-secrets
+        secret:
+          secretName: {{ .Values.Master.SecretsFilesSecret }}
+      {{- end }}
+      {{- if .Values.Master.Jobs }}
+      - name: jenkins-jobs
+        configMap:
+          name: {{ template "jenkins.fullname" . }}-jobs
+      {{- end }}
       - name: plugin-dir
         emptyDir: {}
       - name: secrets-dir

--- a/stable/jenkins/templates/jobs.yaml
+++ b/stable/jenkins/templates/jobs.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.Master.Jobs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}-jobs
+data:
+{{ .Values.Master.Jobs | indent 2 }}
+{{- end -}}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -64,6 +64,16 @@ Master:
   InitScripts:
   #  - |
   #    print 'adding global pipeline libraries, register properties, bootstrap jobs...'
+  # Kubernetes secret that contains a 'credentials.xml' for Jenkins
+  # CredentialsXmlSecret: jenkins-credentials
+  # Kubernetes secret that contains files to be put in the Jenkins 'secrets' directory,
+  # useful to manage encryption keys used for credentials.xml for instance (such as
+  # master.key and hudson.util.Secret)
+  # SecretsFilesSecret: jenkins-secrets
+  # Jenkins XML job configs to provision
+  # Jobs: |-
+  #   test: |-
+  #     <<xml here>>
   CustomConfigMap: false
   # Node labels and tolerations for pod assignment
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector

--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.2.0
+version: 0.2.1
 appVersion: 6.0.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/templates/NOTES.txt
+++ b/stable/kibana/templates/NOTES.txt
@@ -1,3 +1,3 @@
-To verify that oauth-proxy has started, run:
+To verify that {{ template "kibana.fullname" . }} has started, run:
 
   kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "kibana.fullname" . }}"

--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.3.0
-appVersion: v0.26.2
+version: 0.3.1
+appVersion: v0.27.2
 maintainers:
 - name: pmint93
   email: phamminhthanh69@gmail.com

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -46,7 +46,7 @@ The following tables lists the configurable parameters of the Metabase chart and
 |------------------------|------------------------------------------------------------|-------------------|
 | replicaCount           | desired number of controller pods                          | 1                 |
 | image.repository       | controller container image repository                      | metabase/metabase |
-| image.tag              | controller container image tag                             | v0.26.2           |
+| image.tag              | controller container image tag                             | v0.27.2           |
 | image.pullPolicy       | controller container image pull policy                     | IfNotPresent      |
 | listen.host            | Listening on a specific network host                       | 0.0.0.0           |
 | listen.port            | Listening on a specific network port                       | 3000              |
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the Metabase chart and
 | ssl.keyStorePassword   | The password for key Store                                 | null              |
 | database.type          | Backend database type                                      | h2                |
 | database.encryptionKey | Secret key for encrypt sensitive information into database | null              |
+| database.connectionURI | Database connection URI (alternative to the below settings)| null              |
 | database.host          | Database host                                              | null              |
 | database.port          | Database port                                              | null              |
 | database.dbname        | Database name                                              | null              |

--- a/stable/metabase/templates/database-secret.yaml
+++ b/stable/metabase/templates/database-secret.yaml
@@ -1,4 +1,3 @@
-{{- if ne (.Values.database.type | lower) "h2" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,6 +9,14 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
+  {{- if .Values.database.encryptionKey }}
+  encryptionKey: {{ .Values.database.encryptionKey | b64enc | quote }}
+  {{- end }}
+{{- if ne (.Values.database.type | lower) "h2" }}
+  {{- if .Values.database.connectionURI }}
+  connectionURI: {{ .Values.database.connectionURI | b64enc | quote }}
+  {{- else }}
   username: {{ .Values.database.username | b64enc | quote }}
   password: {{ .Values.database.password | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/stable/metabase/templates/deployment.yaml
+++ b/stable/metabase/templates/deployment.yaml
@@ -42,9 +42,21 @@ spec:
           {{- end }}
           - name: MB_DB_TYPE
             value: {{ .Values.database.type | lower }}
+          {{- if .Values.database.encryptionKey }}
           - name: MB_ENCRYPTION_SECRET_KEY
-            value: {{ .Values.database.encryptionKey | quote }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-database
+                key: encryptionKey
+          {{- end }}
           {{- if ne (.Values.database.type | lower) "h2" }}
+            {{- if .Values.database.connectionURI }}
+          - name: MB_DB_CONNECTION_URI
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "metabase.fullname" . }}-database
+                key: connectionURI
+            {{- else }}
           - name: MB_DB_HOST
             value: {{ .Values.database.host | quote }}
           - name: MB_DB_PORT
@@ -61,6 +73,7 @@ spec:
               secretKeyRef:
                 name: {{ template "metabase.fullname" . }}-database
                 key: password
+            {{- end }}
           {{- end }}
           - name: MB_PASSWORD_COMPLEXITY
             value: {{ .Values.password.complexity }}

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 image:
   repository: metabase/metabase
-  tag: v0.26.2
+  tag: v0.27.2
   pullPolicy: IfNotPresent
 
 # Config Jetty web server
@@ -31,6 +31,8 @@ database:
   # dbname:
   # username:
   # password:
+  ## Alternatively, use a connection URI for full configurability. Example for SSL enabled Postgres.
+  # connectionURI: postgres://user:password@host:port/database?ssl=true&sslmode=require&sslfactory=org.postgresql.ssl.NonValidatingFactory"
 
 password:
   # Changing Metabase password complexity:

--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,6 +1,6 @@
 name: moodle
-version: 0.4.2
-appVersion: 3.4.0
+version: 0.4.3
+appVersion: 3.4.1
 description: Moodle is a learning platform designed to provide educators, administrators
   and learners with a single robust, secure and integrated system to create personalised
   learning environments

--- a/stable/moodle/values.yaml
+++ b/stable/moodle/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Moodle` image version
 ## ref: https://hub.docker.com/r/bitnami/moodle/tags/
 ##
-image: bitnami/moodle:3.4.0-r1
+image: bitnami/moodle:3.4.1-r0
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,6 +1,6 @@
 name: phabricator
-version: 0.5.7
-appVersion: 2018.2.0
+version: 0.5.8
+appVersion: 2018.3.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:
 - phabricator

--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,5 +1,5 @@
 name: phabricator
-version: 0.5.8
+version: 0.5.9
 appVersion: 2018.3.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Phabricator image version
 ## ref: https://hub.docker.com/r/bitnami/phabricator/tags/
 ##
-image: bitnami/phabricator:2018.3.0-r0
+image: bitnami/phabricator:2018.3.0-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Phabricator image version
 ## ref: https://hub.docker.com/r/bitnami/phabricator/tags/
 ##
-image: bitnami/phabricator:2018.2.0-r0
+image: bitnami/phabricator:2018.3.0-r0
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.8.7
+version: 0.8.8
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -60,6 +60,7 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 | `persistence.annotations`  | Persistent Volume annotations                   | `{}`                                                       |
 | `persistence.size`         | Size of data volume                             | `8Gi`                                                      |
 | `persistence.subPath`      | Subdirectory of the volume to mount at          | `postgresql-db`                                            |
+| `persistence.mountPath`    | Mount path of data volume                       | `/var/lib/postgresql/data/pgdata`                          |
 | `resources`                | CPU/Memory resource requests/limits             | Memory: `256Mi`, CPU: `100m`                               |
 | `metrics.enabled`          | Start a side-car prometheus exporter            | `false`                                                    |
 | `metrics.image`            | Exporter image                                  | `wrouesnel/postgres_exporter`                              |

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: data
-          mountPath: /var/lib/postgresql/data/pgdata
+          mountPath: {{ .Values.persistence.mountPath }}
           subPath: {{ .Values.persistence.subPath }}
 {{- if .Values.metrics.enabled }}
       - name: metrics

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -51,6 +51,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
   subPath: "postgresql-db"
+  mountPath: /var/lib/postgresql/data/pgdata
 
   # annotations: {}
 

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.0.0
+version: 5.0.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.6.17
+version: 4.6.18
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 4.6.18
+version: 5.0.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -38,6 +38,54 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Prometheus 2.x
+
+Prometheus version 2.x has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/)
+
+Users of this chart will need to update their alerting rules to the new format before they can upgrade.
+
+## Upgrading from previous chart versions.
+
+As of version 5.0, this chart uses Prometheus 2.1. This version of prometheus introduces a new data format and is not compatible with prometheus 1.x. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
+
+### Example migration
+
+Assuming you have an existing release of the prometheus chart, named `prometheus-old`. In order to update to prometheus 2.1 while keeping your old data do the following:
+
+1. Update the `prometheus-old` release. Disable scraping and every component besides the prometheus server, similar to the configuration below:
+
+	```
+	alertmanager:
+	  enabled: false
+	alertmanagerFiles:
+	  alertmanager.yml: ""
+	kubeStateMetrics:
+	  enabled: false
+	nodeExporter:
+	  enabled: false
+	pushgateway:
+	  enabled: false
+	server:
+	  extraArgs:
+	    storage.local.retention: 720h
+	serverFiles:
+	  alerts: ""
+	  prometheus.yml: ""
+	  rules: ""
+	```
+	
+1. Deploy a new release of the chart with version 5.0+ using prometheus 2.x. In the values.yaml set the scrape config as usual, and also add the `prometheus-old` instance as a remote-read target.
+
+   ```
+	  prometheus.yml: |
+	    ...
+	    remote_read:
+	    - url: http://prometheus-old/api/v1/read
+	    ...
+   ```
+   
+   Old data will be available when you query the new prometheus instance. 
+
 ## Configuration
 
 The following tables lists the configurable parameters of the Prometheus chart and their default values.
@@ -47,10 +95,10 @@ Parameter | Description | Default
 `alertmanager.enabled` | If true, create alertmanager | `true`
 `alertmanager.name` | alertmanager container name | `alertmanager`
 `alertmanager.image.repository` | alertmanager container image repository | `prom/alertmanager`
-`alertmanager.image.tag` | alertmanager container image tag | `v0.5.1`
+`alertmanager.image.tag` | alertmanager container image tag | `v0.13.0`
 `alertmanager.image.pullPolicy` | alertmanager container image pull policy | `IfNotPresent`
 `alertmanager.prefixURL` | The prefix slug at which the server can be accessed | ``
-`alertmanager.baseURL` | The external url at which the server can be accessed | ``
+`alertmanager.baseURL` | The external url at which the server can be accessed | `/`
 `alertmanager.extraArgs` | Additional alertmanager container arguments | `{}`
 `alertmanager.configMapOverrideName` | Prometheus alertmanager ConfigMap override where full-name is `{{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName}}` and setting this value will prevent the default alertmanager ConfigMap from being generated | `""`
 `alertmanager.ingress.enabled` | If true, alertmanager Ingress will be created | `false`
@@ -86,7 +134,7 @@ Parameter | Description | Default
 `kubeStateMetrics.enabled` | If true, create kube-state-metrics | `true`
 `kubeStateMetrics.name` | kube-state-metrics container name | `kube-state-metrics`
 `kubeStateMetrics.image.repository` | kube-state-metrics container image repository| `k8s.gcr.io/kube-state-metrics`
-`kubeStateMetrics.image.tag` | kube-state-metrics container image tag | `v0.4.1`
+`kubeStateMetrics.image.tag` | kube-state-metrics container image tag | `v1.1.0`
 `kubeStateMetrics.image.pullPolicy` | kube-state-metrics container image pull policy | `IfNotPresent`
 `kubeStateMetrics.args` | kube-state-metrics container arguments | `{}`
 `kubeStateMetrics.nodeSelector` | node labels for kube-state-metrics pod assignment | `{}`
@@ -104,7 +152,7 @@ Parameter | Description | Default
 `nodeExporter.enabled` | If true, create node-exporter | `true`
 `nodeExporter.name` | node-exporter container name | `node-exporter`
 `nodeExporter.image.repository` | node-exporter container image repository| `prom/node-exporter`
-`nodeExporter.image.tag` | node-exporter container image tag | `v0.13.0`
+`nodeExporter.image.tag` | node-exporter container image tag | `v0.15.2`
 `nodeExporter.image.pullPolicy` | node-exporter container image pull policy | `IfNotPresent`
 `nodeExporter.extraArgs` | Additional node-exporter container arguments | `{}`
 `nodeExporter.extraHostPathMounts` | Additional node-exporter hostPath mounts | `[]`
@@ -144,9 +192,8 @@ Parameter | Description | Default
 `rbac.create` | If true, create & use RBAC resources | `false`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
-`server.image.tag` | Prometheus server container image tag | `v1.5.1`
+`server.image.tag` | Prometheus server container image tag | `v2.1.0`
 `server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
-`server.alertmanagerURL` | (optional) alertmanager URL; only used if alertmanager.enabled = false | `""`
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``
 `server.baseURL` | The external url at which the server can be accessed | ``
@@ -180,8 +227,8 @@ Parameter | Description | Default
 `server.service.type` | type of Prometheus server service to create | `ClusterIP`
 `server.terminationGracePeriodSeconds` | Prometheus server Pod termination grace period | `300`
 `server.retention` | (optional) Prometheus data retention | `""`
-`serverFiles.alerts` | Prometheus server alerts configuration | `""`
-`serverFiles.rules` | Prometheus server rules configuration | `""`
+`serverFiles.alerts` | Prometheus server alerts configuration | `{}`
+`serverFiles.rules` | Prometheus server rules configuration | `{}`
 `serverFiles.prometheus.yml` | Prometheus server scrape configuration | example configuration
 `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 

--- a/stable/prometheus/templates/NOTES.txt
+++ b/stable/prometheus/templates/NOTES.txt
@@ -91,7 +91,7 @@ Get the PushGateway URL by running these commands in the same shell:
   echo http://$SERVICE_IP:{{ .Values.pushgateway.service.servicePort }}
 {{- else if contains "ClusterIP"  .Values.pushgateway.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus.name" . }},component={{ .Values.pushgateway.name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9093
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9091
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -10,5 +10,33 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "prometheus.server.fullname" . }}
 data:
-{{ toYaml .Values.serverFiles | indent 2 }}
-{{- end }}
+{{- $root := . -}}
+{{- range $key, $value := .Values.serverFiles }}
+  {{ $key }}: |
+{{ toYaml $value | default "{}" | indent 4 }}
+{{- if eq $key "prometheus.yml" -}}
+{{- if $root.Values.alertmanager.enabled -}}
+    alerting:
+      alertmanagers:
+      - kubernetes_sd_configs:
+          - role: pod
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace]
+          regex: {{ $root.Release.Namespace }}
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_label_app]
+          regex: prometheus
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_label_component]
+          regex: alertmanager
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_container_port_number]
+          regex:
+          action: drop
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -71,7 +71,13 @@ spec:
             - containerPort: 9090
           readinessProbe:
             httpGet:
-              path: {{ .Values.server.prefixURL }}/status
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
               port: 9090
             initialDelaySeconds: 30
             timeoutSeconds: 30

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -26,6 +26,15 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "prometheus.server.fullname" . }}{{ else }}"{{ .Values.server.serviceAccountName }}"{{ end }}
+      initContainers:
+      - name: "init-chown-data"
+        image: "busybox"
+        # 65534 is the nobody user that prometheus uses.
+        command: ["chown", "-R", "65534:65534", "{{ .Values.server.persistentVolume.mountPath }}"]
+        volumeMounts:
+        - name: storage-volume
+          mountPath: {{ .Values.server.persistentVolume.mountPath }}
+          subPath: "{{ .Values.server.persistentVolume.subPath }}"
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.name }}
           image: "{{ .Values.configmapReload.image.repository }}:{{ .Values.configmapReload.image.tag }}"
@@ -44,16 +53,14 @@ spec:
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
-          {{- if or .Values.alertmanager.enabled .Values.server.alertmanagerURL }}
-            - --alertmanager.url={{- if .Values.alertmanager.enabled }}http://{{ template "prometheus.alertmanager.fullname" . }}:{{ .Values.alertmanager.service.servicePort }}{{ .Values.alertmanager.prefixURL }}{{- else }}{{ .Values.server.alertmanagerURL }}{{- end }}
-          {{- end }}
           {{- if .Values.server.retention }}
-            - --storage.local.retention={{ .Values.server.retention }}
+            - --storage.tsdb.retention={{ .Values.server.retention }}
           {{- end }}
             - --config.file=/etc/config/prometheus.yml
-            - --storage.local.path={{ .Values.server.persistentVolume.mountPath }}
+            - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
+            - --web.enable-lifecycle
           {{- range $key, $value := .Values.server.extraArgs }}
             - --{{ $key }}={{ $value }}
           {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -17,7 +17,7 @@ alertmanager:
   ##
   image:
     repository: prom/alertmanager
-    tag: v0.9.1
+    tag: v0.13.0
     pullPolicy: IfNotPresent
 
   ## Additional alertmanager container arguments
@@ -31,7 +31,7 @@ alertmanager:
 
   ## External URL which can access alertmanager
   ## Maybe same with Ingress host name
-  baseURL: ""
+  baseURL: "/"
 
   ## Additional alertmanager container environment variable
   ## For instance to add a http_proxy
@@ -191,7 +191,7 @@ kubeStateMetrics:
   ##
   image:
     repository: k8s.gcr.io/kube-state-metrics
-    tag: v1.1.0-rc.0
+    tag: v1.1.0
     pullPolicy: IfNotPresent
 
   ## kube-state-metrics container arguments
@@ -253,7 +253,7 @@ nodeExporter:
   ##
   image:
     repository: prom/node-exporter
-    tag: v0.15.0
+    tag: v0.15.2
     pullPolicy: IfNotPresent
 
   ## Custom Update Strategy
@@ -332,12 +332,8 @@ server:
   ##
   image:
     repository: prom/prometheus
-    tag: v1.8.1
+    tag: v2.1.0
     pullPolicy: IfNotPresent
-
-  ## (optional) alertmanager URL
-  ## only used if alertmanager.enabled = false
-  alertmanagerURL: ""
 
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug
   ## so that the various internal URLs are still able to access as they are in the default case.
@@ -598,10 +594,10 @@ alertmanagerFiles:
 ## Prometheus server ConfigMap entries
 ##
 serverFiles:
-  alerts: ""
-  rules: ""
+  alerts: {}
+  rules: {}
 
-  prometheus.yml: |-
+  prometheus.yml:
     rule_files:
       - /etc/config/rules
       - /etc/config/alerts

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,6 +1,6 @@
 name: redis
-version: 1.1.8
-appVersion: 4.0.6
+version: 1.1.9
+appVersion: 4.0.7
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:
 - redis

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 1.1.7
+version: 1.1.8
 appVersion: 4.0.6
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -69,6 +69,7 @@ The following tables lists the configurable parameters of the Redis chart and th
 | `networkPolicy.allowExternal` | Don't require client label for connections       | `true`                       |
 | `service.annotations`         | annotations for redis service                    | {}                           |
 | `service.loadBalancerIP`      | loadBalancerIP if service type is `LoadBalancer` | ``                           |
+| `securityContext.enabled`     | Enable security context                          | `true`                       |
 
 The above parameters map to the env variables defined in [bitnami/redis](http://github.com/bitnami/bitnami-docker-redis). For more information please refer to the [bitnami/redis](http://github.com/bitnami/bitnami-docker-redis) image documentation.
 

--- a/stable/redis/templates/deployment.yaml
+++ b/stable/redis/templates/deployment.yaml
@@ -20,9 +20,11 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Redis image version
 ## ref: https://hub.docker.com/r/bitnami/redis/tags/
 ##
-image: bitnami/redis:4.0.6-r1
+image: bitnami/redis:4.0.7-r0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -13,6 +13,7 @@ serviceType: ClusterIP
 
 ## Pod Security Context
 securityContext:
+  enabled: true
   fsGroup: 1001
   runAsUser: 1001
 

--- a/stable/sematext-docker-agent/.helmignore
+++ b/stable/sematext-docker-agent/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/sematext-docker-agent/Chart.yaml
+++ b/stable/sematext-docker-agent/Chart.yaml
@@ -1,0 +1,15 @@
+name: sematext-docker-agent
+version: 0.1.0
+description: Sematext Docker Agent
+keywords:
+- alerts
+- metrics
+- events
+- logs
+home: https://sematext.com/
+icon: https://sematext.com/wp-content/uploads/2017/06/cropped-sematext-logo-1.png
+sources:
+- https://github.com/sematext/sematext-agent-docker
+maintainers:
+- name: komljen
+  email: alen.komljen@live.com

--- a/stable/sematext-docker-agent/README.md
+++ b/stable/sematext-docker-agent/README.md
@@ -1,0 +1,66 @@
+# Sematext Docker Agent
+
+[Sematext](https://sematext.com/) Agent for Docker collects Metrics, Events, and Logs from the Docker API for SPM Docker Monitoring & Logsene / Hosted ELK Log Management.
+
+## Introduction
+
+This chart installs the Sematext Docker Agent to all nodes in your cluster via a `DaemonSet` resource.
+
+## Prerequisites
+
+- Kubernetes 1.2+
+
+## Installation
+
+To install the chart run the following command:
+
+```bash
+$ helm install --name release_name \
+    --set sematext.spmToken=YOUR_SPM_TOKEN,sematext.logseneToken=YOUR_LOGS_TOKEN stable/sematext
+```
+
+After a few minutes, you should see logs, metrics and events being reported in Sematext web UI.
+
+**NOTE:** If you want to use Sematext in EU region set the region as well `--set sematext.region=EU`.
+
+## Deleting
+
+To uninstall the chart delete `release_name` deployment:
+
+```bash
+$ helm delete release_name
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configuration parameters of the sematext-docker-agent chart and their default values.
+
+|             Parameter       |            Description             |                    Default                |
+|-----------------------------|------------------------------------|-------------------------------------------|
+| `sematext.spmToken`         | Sematext SPM token                 | `Nil` You must provide your SPM token     |
+| `sematext.logseneToken`     | Sematext Logsene token             | `Nil` You must provide your Logsene token |
+| `sematext.region`           | Sematext region                    | `US` Sematext US or EU region             |
+| `image.repository`          | The image repository               | `sematext/sematext-agent-docker`          |
+| `image.tag`                 | The image tag                      | `1.31.48`                                 |
+| `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
+| `resources.requests.cpu`    | CPU resource requests              | `Nil`                                     |
+| `resources.limits.cpu`      | CPU resource limits                | `Nil`                                     |
+| `resources.requests.memory` | Memory resource requests           | `Nil`                                     |
+| `resources.limits.memory`   | Memory resource limits             | `Nil`                                     |
+| `sematext.useHostNetwork`   | Use the host networking            | `true`                                    |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```bash
+$ helm install --name release_name \
+    --set sematext.spmToken=YOUR_SPM_TOKEN,sematext.region=EU \
+    stable/sematext
+```
+
+Alternatively, you can use a YAML file that specifies the values and it can be provided while installing the chart. For example:
+
+```bash
+$ helm install --name release_name -f custom_values.yaml stable/sematext
+```

--- a/stable/sematext-docker-agent/templates/NOTES.txt
+++ b/stable/sematext-docker-agent/templates/NOTES.txt
@@ -1,0 +1,51 @@
+{{- if and (not .Values.sematext.spmToken) (not .Values.sematext.logseneToken) -}}
+
+###############################################################################
+#           ERROR: Please provide spmToken and/or logseneToken!               #
+###############################################################################
+
+Depending on which region you want to use, create a monitoring and/or logs apps
+to get your tokens. Then, start the app with:
+
+helm install --name release_name \
+  --set sematext.spmToken=YOUR_SPM_TOKEN,sematext.region=US \
+  stable/sematext
+
+Or if you created both apps use:
+
+helm install --name release_name \
+  --set sematext.spmToken=YOUR_SPM_TOKEN,sematext.logseneToken=YOUR_LOGS_TOKEN,sematext.region=US \
+  stable/sematext
+
+Please check the README file for all available parameters.
+
+{{- else if not .Values.sematext.logseneToken -}}
+
+Missing logseneToken! You will only receive metrics and events.
+{{ if eq .Values.sematext.region "US" }}
+After a few minutes check your app at https://apps.sematext.com/ui/monitoring
+{{ else if eq .Values.sematext.region "EU" }}
+After a few minutes check your app at https://apps.eu.sematext.com/ui/monitoring
+{{ end }}
+
+{{- else if not .Values.sematext.spmToken -}}
+
+Missing spmToken! You will only receive logs.
+{{ if eq .Values.sematext.region "US" }}
+After a few minutes check your app at https://apps.sematext.com/ui/logs
+{{ else if eq .Values.sematext.region "EU" }}
+After a few minutes check your app at https://apps.eu.sematext.com/ui/logs
+{{ end }}
+
+{{- else -}}
+
+You are all set!
+{{ if eq .Values.sematext.region "US" }}
+After a few minutes check your metrics app at https://apps.sematext.com/ui/monitoring
+or logs at https://apps.sematext.com/ui/logs
+{{ else if eq .Values.sematext.region "EU" }}
+After a few minutes check your metrics app at https://apps.eu.sematext.com/ui/monitoring
+or logs at https://apps.eu.sematext.com/ui/logs
+{{ end }}
+
+{{- end -}}

--- a/stable/sematext-docker-agent/templates/_helpers.tpl
+++ b/stable/sematext-docker-agent/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sematext.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "sematext.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/sematext-docker-agent/templates/daemonset.yaml
+++ b/stable/sematext-docker-agent/templates/daemonset.yaml
@@ -1,0 +1,74 @@
+{{- if or (.Values.sematext.spmToken) (.Values.sematext.logseneToken) }}
+{{- if .Capabilities.APIVersions.Has "apps/v1beta2" }}
+apiVersion: apps/v1beta2
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: DaemonSet
+metadata:
+  name: {{ template "sematext.fullname" . }}
+  labels:
+    app: {{ template "sematext.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "sematext.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "sematext.name" . }}
+      name: {{ template "sematext.name" . }}
+    spec:
+      {{- if .Values.sematext.useHostNetwork }}
+      hostNetwork: {{ .Values.sematext.useHostNetwork }}
+      {{- end }}
+      dnsPolicy: "ClusterFirst"
+      restartPolicy: "Always"
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        resources:
+{{ toYaml .Values.sematext.resources | indent 10 }}
+        env:
+        - name: SPM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sematext.fullname" . }}
+              key: spm-token
+        - name: LOGSENE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "sematext.fullname" . }}
+              key: logsene-token
+{{- if eq .Values.sematext.region "EU" }}
+        - name: SPM_RECEIVER_URL
+          value: "https://spm-receiver.eu.sematext.com/receiver/v1"
+        - name: LOGSENE_RECEIVER_URL
+          value: "https://logsene-receiver.eu.sematext.com"
+        - name: EVENTS_RECEIVER_URL
+          value: "https://event-receiver.eu.sematext.com"
+{{- end }}
+        volumeMounts:
+          - mountPath: /var/run/docker.sock
+            name: docker-sock
+          - mountPath: /etc/localtime
+            name: localtime
+          - mountPath: /rootfs
+            name: rootfs
+            readOnly: true
+        securityContext:
+          privileged: true
+      volumes:
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+        - name: rootfs
+          hostPath:
+            path: /
+{{- end }}

--- a/stable/sematext-docker-agent/templates/secrets.yaml
+++ b/stable/sematext-docker-agent/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sematext.fullname" . }}
+  labels:
+    app: {{ template "sematext.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  spm-token: {{ default "" .Values.sematext.spmToken | b64enc | quote }}
+  logsene-token: {{ default "" .Values.sematext.logseneToken | b64enc | quote }}

--- a/stable/sematext-docker-agent/values.yaml
+++ b/stable/sematext-docker-agent/values.yaml
@@ -1,0 +1,24 @@
+image:
+  repository: sematext/sematext-agent-docker
+  # For all available tags check here https://hub.docker.com/r/sematext/sematext-agent-docker/tags/
+  tag: 1.31.48
+  pullPolicy: IfNotPresent
+
+sematext:
+  # You will need to Create and Set at least one token before starting this agent!
+
+  # spmToken:
+  # logseneToken:
+
+  # Depending on where you created your apps, choose US or EU region.
+  region: US
+
+  useHostNetwork: true
+  name: sematext-docker-agent
+  resources: {}
+  #  requests:
+  #    cpu: 500m
+  #    memory: 128Mi
+  #  limits:
+  #    cpu: 1000m
+  #    memory: 1024Mi

--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.3.4
+version: 0.3.5
 appVersion: 6.5
 keywords:
   - coverage

--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.3.3
+version: 0.3.4
 appVersion: 6.5
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -39,14 +39,15 @@ The following table lists the configurable parameters of the Sonarqube chart and
 
 | Parameter                                   | Description                         | Default                                    |
 | ------------------------------------------  | ----------------------------------  | -------------------------------------------|
-| `imageTag`                                  | `sonarqube` image tag.              | 6.5                                        |
-| `imagePullPolicy`                           | Image pull policy                   | `IfNotPresent`                             |
+| `image.tag`                                 | `sonarqube` image tag.              | 6.5                                        |
+| `image.pullPolicy`                          | Image pull policy                   | `IfNotPresent`                             |
 | `ingress.enabled`                           | Flag for enabling ingress           | false                                      |
 | `service.type`                              | Kubernetes service type             | `LoadBalancer`                             |
 | `persistence.enabled`                       | Flag for enabling persistent storage| false                                      |
 | `persistence.storageClass`                  | Storage class to be used            | "-"                                        |
 | `persistence.accessMode`                    | Volumes access mode to be set       | `ReadWriteOnce`                            |
-| `persistence.size`                          | Size of the volume                  | `10Gi`                                      |
+| `persistence.size`                          | Size of the volume                  | `10Gi`                                     |
+| `sonarProperties`                           | Custom `sonar.properties` file      | None                                       |
 | `postgresql.postgresUser`                   | Postgresql database user            | `sonarUser`                                |
 | `postgresql.postgresPassword`               | Postgresql database password        | `sonarPass`                                |
 | `postgresql.postgresDatabase`               | Postgresql database name            | `sonarDB`                                  |

--- a/stable/sonarqube/templates/ingress.yaml
+++ b/stable/sonarqube/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -67,6 +67,13 @@ persistence:
 plugins:
   install: []
 
+# A custom sonar.properties file can be provided using a multiline YAML string.
+# For example:
+# sonarProperties: |
+#   sonar.forceAuthentication=true
+#   sonar.security.realm=LDAP
+#   ldap.url=ldaps://organization.com
+
 ## Configuration values for the postgresql dependency
 ## ref: https://github.com/kubernetes/charts/blob/master/stable/postgressql/README.md
 ##

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark
-version: 0.1.9
+version: 0.1.10
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark
-version: 0.1.7
+version: 0.1.9
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png

--- a/stable/spark/README.md
+++ b/stable/spark/README.md
@@ -45,6 +45,7 @@ The following tables lists the configurable parameters of the Spark chart and th
 | `Master.ServicePort`    | k8s service port                   | `7077`                                                     |
 | `Master.ContainerPort`  | Container listening port           | `7077`                                                     |
 | `Master.DaemonMemory`   | Master JVM Xms and Xmx option      | `1g`                                                       |
+| `Master.ServiceType `   | Kubernetes Service type            | `LoadBalancer`                                             |
 
 ### Spark WebUi
 
@@ -75,16 +76,22 @@ The following tables lists the configurable parameters of the Spark chart and th
 
 ### Zeppelin
 
-|       Parameter         |           Description            |                         Default                          |
-|-------------------------|----------------------------------|----------------------------------------------------------|
-| `Zeppelin.Name`         | Zeppelin name                    | `zeppelin-controller`                                    |
-| `Zeppelin.Image`        | Container image name             | `apache/zeppelin`                                        |
-| `Zeppelin.ImageTag`     | Container image tag              | `0.7.3`                                                  |
-| `Zeppelin.Replicas`     | k8s deployment replicas          | `1`                                                      |
-| `Zeppelin.Component`    | k8s selector key                 | `zeppelin`                                               |
-| `Zeppelin.Cpu`          | container requested cpu          | `100m`                                                   |
-| `Zeppelin.ServicePort`  | k8s service port                 | `8080`                                                   |
-| `Zeppelin.ContainerPort`| Container listening port         | `8080`                                                   |
+|       Parameter                |           Description            |                         Default                          |
+|--------------------------------|----------------------------------|----------------------------------------------------------|
+| `Zeppelin.Name`                | Zeppelin name                    | `zeppelin-controller`                                    |
+| `Zeppelin.Image`               | Container image name             | `gcr.io/google_containers/zeppelin`                      |
+| `Zeppelin.ImageTag`            | Container image tag              | `v0.5.5_v2`                                              |
+| `Zeppelin.Replicas`            | k8s deployment replicas          | `1`                                                      |
+| `Zeppelin.Component`           | k8s selector key                 | `zeppelin`                                               |
+| `Zeppelin.Cpu`                 | container requested cpu          | `100m`                                                   |
+| `Zeppelin.ServicePort`         | k8s service port                 | `8080`                                                   |
+| `Zeppelin.ContainerPort`       | Container listening port         | `8080`                                                   |
+| `Zeppelin.Ingress.Enabled`     | if `true`, an ingress is created | `false`                                                  |
+| `Zeppelin.Ingress.Annotations` | annotations for the ingress      | `{}`                                                     |
+| `Zeppelin.Ingress.Path`        | the ingress path                 | `/`                                                      |
+| `Zeppelin.Ingress.Hosts`       | a list of ingress hosts          | `[zeppelin.example.com]`                                 |
+| `Zeppelin.Ingress.Tls`         | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
+| `Zeppelin.ServiceType `        | Kubernetes Service type          | `LoadBalancer`                                           |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/spark/README.md
+++ b/stable/spark/README.md
@@ -78,8 +78,8 @@ The following tables lists the configurable parameters of the Spark chart and th
 |       Parameter         |           Description            |                         Default                          |
 |-------------------------|----------------------------------|----------------------------------------------------------|
 | `Zeppelin.Name`         | Zeppelin name                    | `zeppelin-controller`                                    |
-| `Zeppelin.Image`        | Container image name             | `k8s.gcr.io/zeppelin`                      |
-| `Zeppelin.ImageTag`     | Container image tag              | `v0.5.5_v2`                                              |
+| `Zeppelin.Image`        | Container image name             | `apache/zeppelin`                                        |
+| `Zeppelin.ImageTag`     | Container image tag              | `0.7.3`                                                  |
 | `Zeppelin.Replicas`     | k8s deployment replicas          | `1`                                                      |
 | `Zeppelin.Component`    | k8s selector key                 | `zeppelin`                                               |
 | `Zeppelin.Cpu`          | container requested cpu          | `100m`                                                   |

--- a/stable/spark/templates/NOTES.txt
+++ b/stable/spark/templates/NOTES.txt
@@ -10,7 +10,6 @@
   
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
   You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "zeppelin-fullname" . }}'
-  
+
   export ZEPPELIN_SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "zeppelin-fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$ZEPPELIN_SERVICE_IP:{{ .Values.Zeppelin.ServicePort }}
-

--- a/stable/spark/templates/_helpers.tpl
+++ b/stable/spark/templates/_helpers.tpl
@@ -3,29 +3,29 @@
 Expand the name of the chart.
 */}}
 {{- define "name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create fully qualified names.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "master-fullname" -}}
 {{- $name := default .Chart.Name .Values.Master.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "webui-fullname" -}}
 {{- $name := default .Chart.Name .Values.WebUi.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "worker-fullname" -}}
 {{- $name := default .Chart.Name .Values.Worker.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "zeppelin-fullname" -}}
 {{- $name := default .Chart.Name .Values.Zeppelin.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/spark/templates/spark-master-deployment.yaml
+++ b/stable/spark/templates/spark-master-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       targetPort: {{ .Values.WebUi.ContainerPort }}
   selector:
     component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
-  type: "LoadBalancer"
+  type: {{ .Values.Master.ServiceType }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/stable/spark/templates/spark-zeppelin-deployment.yaml
+++ b/stable/spark/templates/spark-zeppelin-deployment.yaml
@@ -42,10 +42,11 @@ spec:
       containers:
         - name: {{ template "zeppelin-fullname" . }}
           image: "{{ .Values.Zeppelin.Image }}:{{ .Values.Zeppelin.ImageTag }}"
-          command: ["/bin/sh","-c"]
-          args: ["sed -i.bak s/spark-master:7077/{{ template "master-fullname" . }}:{{ .Values.Master.ServicePort }}/g /opt/zeppelin/conf/zeppelin-env.sh; /opt/zeppelin/bin/docker-zeppelin.sh"]
           ports:
             - containerPort: {{ .Values.Zeppelin.ContainerPort }}
           resources:
             requests:
               cpu: "{{ .Values.Zeppelin.Cpu }}"
+          env:
+            - name: SPARK_MASTER
+              value: "spark://{{ template "master-fullname" . }}:{{ .Values.Master.ServicePort }}"

--- a/stable/spark/templates/spark-zeppelin-deployment.yaml
+++ b/stable/spark/templates/spark-zeppelin-deployment.yaml
@@ -9,11 +9,12 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Zeppelin.Component }}"
 spec:
   ports:
-    - port: {{ .Values.Zeppelin.ServicePort }}
+    - name: http
+      port: {{ .Values.Zeppelin.ServicePort }}
       targetPort: {{ .Values.Zeppelin.ContainerPort }}
   selector:
     component: "{{ .Release.Name }}-{{ .Values.Zeppelin.Component }}"
-  type: "LoadBalancer"
+  type: {{ .Values.Zeppelin.ServiceType }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -44,6 +45,7 @@ spec:
           image: "{{ .Values.Zeppelin.Image }}:{{ .Values.Zeppelin.ImageTag }}"
           ports:
             - containerPort: {{ .Values.Zeppelin.ContainerPort }}
+              name: http
           resources:
             requests:
               cpu: "{{ .Values.Zeppelin.Cpu }}"

--- a/stable/spark/templates/spark-zeppelin-ingress.yaml
+++ b/stable/spark/templates/spark-zeppelin-ingress.yaml
@@ -1,0 +1,44 @@
+{{- $ingress := .Values.Zeppelin.Ingress -}}
+{{- $fullName := include "zeppelin-fullname" . -}}
+{{- if $ingress.Enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "zeppelin-fullname" . }}
+{{- if $ingress.Annotations }}
+  annotations:
+{{ toYaml $ingress.Annotations | indent 4 }}
+{{- end }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Zeppelin.Component }}"
+spec:
+{{- if $ingress.Tls }}
+  tls:
+  {{- range $ingress.Tls }}
+  - hosts:
+    {{- range .Hosts }}
+    - {{ . }}
+    {{- end }}
+    secretName: {{ .SecretName | default (printf "%s-tls" $fullName) }}
+{{- end }}
+{{- end }}
+  {{- if $ingress.Hosts }}
+  rules:
+  {{- range $ingress.Hosts }}
+  - host: {{ . }}
+    http:
+      paths:
+      - path: {{ $ingress.Path }}
+        backend:
+          serviceName: {{ $fullName }}
+          servicePort: http
+  {{- end }}
+{{- else }}
+  backend:
+    serviceName: {{ template "zeppelin-fullname" . }}
+    servicePort: http
+{{- end }}
+{{- end }}

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -37,8 +37,8 @@ Worker:
 
 Zeppelin:
   Name: zeppelin
-  Image: "k8s.gcr.io/zeppelin"
-  ImageTag: "v0.5.5_v2"
+  Image: "apache/zeppelin"
+  ImageTag: "0.7.3"
   Replicas: 1
   Component: "zeppelin"
   Cpu: "100m"

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -15,6 +15,7 @@ Master:
   ContainerPort: 7077
   # Set Master JVM memory. Default 1g
   # DaemonMemory: 1g
+  ServiceType: LoadBalancer
 
 WebUi:
   Name: webui
@@ -44,3 +45,22 @@ Zeppelin:
   Cpu: "100m"
   ServicePort: 8080
   ContainerPort: 8080
+  ServiceType: LoadBalancer
+  Ingress:
+    Enabled: false
+    Path: "/"
+    Tls: []
+  #    - Hosts:
+  #    SecretName: zeppelin
+  # Used to create an Ingress record.
+  # Hosts:
+  # - example.local
+  # Annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
+  # Tls:
+  #   Enabled: true
+  # Secrets must be manually created in the namespace.
+  #   SecretName: example-tls
+  #   Hosts:
+  #   - example.local

--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,6 +1,6 @@
 name: suitecrm
-version: 0.3.2
-appVersion: 7.9.8
+version: 0.3.3
+appVersion: 7.9.9
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:
 - suitecrm

--- a/stable/suitecrm/OWNERS
+++ b/stable/suitecrm/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- prydonius
+- tompizmor
+- sameersbn
+reviewers:
+- prydonius
+- tompizmor
+- sameersbn

--- a/stable/suitecrm/values.yaml
+++ b/stable/suitecrm/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami SuiteCRM image version
 ## ref: https://hub.docker.com/r/bitnami/suitecrm/tags/
 ##
-image: bitnami/suitecrm:7.9.8-r0
+image: bitnami/suitecrm:7.9.9-r0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/traefik/.helmignore
+++ b/stable/traefik/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.17.0
+version: 1.17.1
 appVersion: 1.4.6
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
@@ -13,7 +13,7 @@ sources:
 - https://github.com/containous/traefik
 - https://github.com/krancour/charts/tree/master/traefik
 maintainers:
-- name: Kent Rancourt
+- name: krancour
   email: kent.rancourt@microsoft.com
 engine: gotpl
 icon: http://traefik.io/traefik.logo.png

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.16.1
+version: 1.17.0
 appVersion: 1.4.6
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.16.0
-appVersion: 1.4.5
+version: 1.16.1
+appVersion: 1.4.6
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/OWNERS
+++ b/stable/traefik/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- krancour
+reviewers:
+- krancour

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -112,7 +112,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `acme.persistence.accessMode`   | `ReadWriteOnce` or `ReadOnly`                                        | `ReadWriteOnce`                           |
 | `acme.persistence.size`         | Minimum size of the volume requested                                 | `1Gi`                                     |
 | `dashboard.enabled`             | Whether to enable the Traefik dashboard                              | `false`                                   |
-| `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |               
+| `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |
 | `dashboard.service.annotations` | Annotations for the Traefik dashboard Service definition, specified as a map | None                |
 | `dashboard.ingress.annotations` | Annotations for the Traefik dashboard Ingress definition, specified as a map | None                |
 | `dashboard.ingress.labels`      | Labels for the Traefik dashboard Ingress definition, specified as a map      | None                              |
@@ -136,6 +136,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | `metrics.statsd.enabled`        | Whether to enable pushing metrics to Statsd.                           | `false`                                   |
 | `metrics.statsd.address`        | Statsd host in the format <hostname>:<port>                          | `localhost:8125`                          |
 | `metrics.statsd.pushInterval`   | How often to push metrics to Statsd.                                 | `10s`                                     |
+| `deployment.podAnnotations`            | Annotations for the Traefik pod definition                    | None                                      |
 | `deployment.hostPort.httpEnabled`      | Whether to enable hostPort binding to host for http.          | `false`                                   |
 | `deployment.hostPort.httpsEnabled`     | Whether to enable hostPort binding to host for https.         | `false`                                   |
 | `deployment.hostPort.dashboardEnabled` | Whether to enable hostPort binding to host for dashboard.     | `false`                                   |

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -75,9 +75,11 @@ data:
     acmeLogging = true
     {{- end }}
     {{- end }}
-    {{- if .Values.dashboard.enabled }}
+    {{- if or .Values.dashboard.enabled .Values.metrics.prometheus.enabled .Values.metrics.statsd.enabled .Values.metrics.datadog.enabled }}
     [web]
     address = ":8080"
+    {{- end }}
+    {{- if .Values.dashboard.enabled }}
       {{- if .Values.dashboard.auth }}
       {{- if .Values.dashboard.auth.basic }}
       [web.auth.basic]

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -14,9 +14,13 @@ spec:
       app: {{ template "fullname" . }}
   template:
     metadata:
-      {{- if and (.Values.tolerations) (le .Capabilities.KubeVersion.Minor "5") }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if and (.Values.tolerations) (le .Capabilities.KubeVersion.Minor "5") }}
         scheduler.alpha.kubernetes.io/tolerations: '{{ toJson .Values.tolerations }}'
+      {{- end }}
+      {{- range $key, $value := .Values.deployment.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       labels:
         app: {{ template "fullname" . }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -105,6 +105,8 @@ metrics:
     # address: localhost:8125
     # pushinterval: 10s
 deployment:
+  # podAnnotations:
+  #   key: value
   hostPort:
     httpEnabled: false
     httpsEnabled: false

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 ## Default values for Traefik
 image: traefik
-imageTag: 1.4.5
+imageTag: 1.4.6
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
 loadBalancerIP:

--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.1.3
-appVersion: 2.7.1
+version: 0.2.0
+appVersion: 2.7.3
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png
 sources:
 - http://www.verdaccio.org

--- a/stable/verdaccio/templates/NOTES.txt
+++ b/stable/verdaccio/templates/NOTES.txt
@@ -1,5 +1,14 @@
 1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
+{{- $tls := .Values.ingress.tls }}
+{{- if .Values.ingress.enabled }}
+  {{- range $host := .Values.ingress.hosts }}
+  {{- if $tls }}
+  https://{{ $host }}
+  {{- else }}
+  http://{{ $host }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "verdaccio.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT

--- a/stable/verdaccio/templates/configmap.yaml
+++ b/stable/verdaccio/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.customConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,58 +8,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  config.yaml: |
-    #
-    # This is the config file used for the docker images.
-    # It allows all users to do anything, so don't use it on production systems.
-    #
-    # Do not configure host and port under `listen` in this file
-    # as it will be ignored when using docker.
-    # see https://github.com/verdaccio/verdaccio/blob/master/wiki/docker.md#docker-and-custom-port-configuration
-    #
-    # Look here for more config file examples:
-    # https://github.com/verdaccio/verdaccio/tree/master/conf
-    #
-
-    # path to a directory with all packages
-    storage: /verdaccio/storage/data
-
-    auth:
-      htpasswd:
-        file: /verdaccio/storage/htpasswd
-        # Maximum amount of users allowed to register, defaults to "+infinity".
-        # You can set this to -1 to disable registration.
-        #max_users: 1000
-
-    # a list of other known repositories we can talk to
-    uplinks:
-      npmjs:
-        url: https://registry.npmjs.org/
-
-    packages:
-      '@*/*':
-        # scoped packages
-        access: $all
-        publish: $authenticated
-        proxy: npmjs
-
-      '**':
-        # allow all users (including non-authenticated users) to read and
-        # publish all packages
-        #
-        # you can specify usernames/groupnames (depending on your auth plugin)
-        # and three keywords: "$all", "$anonymous", "$authenticated"
-        access: $all
-
-        # allow all known users to publish packages
-        # (anyone can register by default, remember?)
-        publish: $authenticated
-
-        # if package is not available locally, proxy requests to 'npmjs' registry
-        proxy: npmjs
-
-    # log settings
-    logs:
-      - {type: stdout, format: pretty, level: http}
-      #- {type: file, path: verdaccio.log, level: info}
-{{- end }}
+  config.yaml: |-
+{{ .Values.configMap | indent 4 }}

--- a/stable/verdaccio/templates/deployment.yaml
+++ b/stable/verdaccio/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
     type: Recreate
   template:
     metadata:
-    {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
     {{- end }}
       labels:
@@ -31,10 +32,12 @@ spec:
             httpGet:
               path: /
               port: 4873
+            initialDelaySeconds: 5
           readinessProbe:
             httpGet:
               path: /
               port: 4873
+            initialDelaySeconds: 5
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/stable/verdaccio/templates/ingress.yaml
+++ b/stable/verdaccio/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled }}
+{{- $serviceName := include "verdaccio.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "verdaccio.fullname" . }}
+  labels:
+    app: {{ template "verdaccio.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end}}

--- a/stable/verdaccio/values.yaml
+++ b/stable/verdaccio/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: verdaccio/verdaccio
-  tag: 2.7.1
+  tag: 2.7.3
   pullPolicy: IfNotPresent
 
 service:
@@ -33,8 +33,70 @@ resources: {}
   #  cpu: 100m
   #  memory: 512Mi
 
-customConfigMap: false
+ingress:
+  enabled: false
+# hosts:
+#   - npm.blah.com
+# annotations:
+#   kubernetes.io/ingress.class: nginx
+# tls:
+#   - secretName: secret
+#     hosts:
+#       - npm.blah.com
 
+configMap: |
+  # This is the config file used for the docker images.
+  # It allows all users to do anything, so don't use it on production systems.
+  #
+  # Do not configure host and port under `listen` in this file
+  # as it will be ignored when using docker.
+  # see https://github.com/verdaccio/verdaccio/blob/master/wiki/docker.md#docker-and-custom-port-configuration
+  #
+  # Look here for more config file examples:
+  # https://github.com/verdaccio/verdaccio/tree/master/conf
+  #
+
+  # path to a directory with all packages
+  storage: /verdaccio/storage/data
+
+  auth:
+    htpasswd:
+      file: /verdaccio/storage/htpasswd
+      # Maximum amount of users allowed to register, defaults to "+infinity".
+      # You can set this to -1 to disable registration.
+      #max_users: 1000
+
+  # a list of other known repositories we can talk to
+  uplinks:
+    npmjs:
+      url: https://registry.npmjs.org/
+
+  packages:
+    '@*/*':
+      # scoped packages
+      access: $all
+      publish: $authenticated
+      proxy: npmjs
+
+    '**':
+      # allow all users (including non-authenticated users) to read and
+      # publish all packages
+      #
+      # you can specify usernames/groupnames (depending on your auth plugin)
+      # and three keywords: "$all", "$anonymous", "$authenticated"
+      access: $all
+
+      # allow all known users to publish packages
+      # (anyone can register by default, remember?)
+      publish: $authenticated
+
+      # if package is not available locally, proxy requests to 'npmjs' registry
+      proxy: npmjs
+
+  # log settings
+  logs:
+    - {type: stdout, format: pretty, level: http}
+    #- {type: file, path: verdaccio.log, level: info}
 persistence:
   enabled: true
   ## A manually managed Persistent Volume and Claim

--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.8.1
+version: 0.8.2
 appVersion: 4.9.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-image: bitnami/wordpress:4.9.2-r0
+image: bitnami/wordpress:4.9.2-r1
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Changeclass: minor - backward compatible

**WHY**
We are using the `patroni` chart by some other charts. In order to allow an out-of-the-box experience for our users, we need to control the generated secrets used by this chart, so we can generate random secrets and still can provide a nothing-needs-to-be-changed-on-default experience. As discussed in https://github.com/kubernetes/helm/issues/2196#issuecomment-293738730 I don't know a way to resolve secrets on template resolution time; so this is an idea I came up with to solve this until there is a better way.

**Behaviour**
This commit is non-disruptive to the userbase, as it defaults to
the current behaviour. I does not fix a bug, but instead extends the functionality.

**Testing**
* `helm lint` is fine
* `helm install --name tester .` is fine
* `helm template --name tester .` seems to be fine too

**Todo**
* fix `requirements.yaml` => don't know why they are failing in CI, haven't changed them and want feedback on this first, before running an `helm dep update`. (done in https://github.com/kubernetes/charts/pull/3399)

**Note**
I also fix a small issue in the `NOTES.txt` and removed the part of "login as admin". The admin user isn't able to login from remote; only the superuser is permitted.

I'm very interested in your feedback! Is this an acceptable approach to achieve the goal of getting secrets defined externally? How do you handle those kind of issues?

Kind regards and a happy weekend
Tony