### PR TITLE
added fluentd-elasticsearch

### DIFF
--- a/incubator/fluentd-elasticsearch/Chart.yaml
+++ b/incubator/fluentd-elasticsearch/Chart.yaml
@@ -1,0 +1,18 @@
+name: fluentd-elasticsearch
+version: 0.0.1
+appVersion: 0.0.1
+description: A Fluentd Helm chart for Kubernetes with Elasticsearch output
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- elasticsearch
+- multiline
+- detect-exceptions
+- logging
+sources:
+- https://github.com/kubernetes/charts
+- https://github.com/fluent/fluentd-kubernetes-daemonset
+maintainers:
+- name: monotek
+  email: monotek23@gmail.com
+engine: gotpl

--- a/incubator/fluentd-elasticsearch/Chart.yaml
+++ b/incubator/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 0.0.1
+version: 0.1.0
 appVersion: 2.0.4
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png

--- a/incubator/fluentd-elasticsearch/Chart.yaml
+++ b/incubator/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluentd-elasticsearch
 version: 0.0.1
-appVersion: 0.0.1
+appVersion: 2.0.3
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 keywords:
@@ -10,8 +10,10 @@ keywords:
 - detect-exceptions
 - logging
 sources:
-- https://github.com/kubernetes/charts
+- https://github.com/kubernetes/charts/incubator/fluentd-elasticsearch
 - https://github.com/fluent/fluentd-kubernetes-daemonset
+- https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions
+- https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/fluentd-elasticsearch/fluentd-es-image
 maintainers:
 - name: monotek
   email: monotek23@gmail.com

--- a/incubator/fluentd-elasticsearch/Chart.yaml
+++ b/incubator/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluentd-elasticsearch
 version: 0.0.1
-appVersion: 2.0.3
+appVersion: 2.0.4
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 keywords:

--- a/incubator/fluentd-elasticsearch/README.md
+++ b/incubator/fluentd-elasticsearch/README.md
@@ -21,7 +21,6 @@ This chart bootstraps a [Fluentd](https://www.fluentd.org/) deployment on a [Kub
 To install the chart with the release name `my-release`:
 
 ```console
-$ # edit secrets/aws_access_key_id and secrets/aws_access_key_id with the key/password of a AWS user with a policy to access  elasticsearch
 $ helm install --name my-release incubator/fluentd-elasticsearch
 ```
 

--- a/incubator/fluentd-elasticsearch/README.md
+++ b/incubator/fluentd-elasticsearch/README.md
@@ -1,0 +1,66 @@
+# Fluentd Elasticsearch
+
+* Installs [Fluentd](https://www.fluentd.org/) log forwarder.
+
+## TL;DR;
+
+```console
+$ helm install incubator/fluentd-elasticsearch
+```
+
+## Introduction
+
+This chart bootstraps a [Fluentd](https://www.fluentd.org/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ # edit secrets/aws_access_key_id and secrets/aws_access_key_id with the key/password of a AWS user with a policy to access  elasticsearch
+$ helm install --name my-release incubator/fluentd-elasticsearch
+```
+
+The command deploys Fluentd elasticsearch on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Fluentd elasticsearch chart and their default values.
+
+| Parameter                       | Description                                | Default                                                    |
+| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| `image`                         | Image                                      | `gcr.io/google-containers/fluentd-elasticsearch`           |
+| `imageTag`                      | Image tag                                  | `v2.0.3                                                    |
+| `imagePullPolicy`               | Image pull policy                          | `Always` if `imageTag` is `imagePullPolicy`                |
+| `resources.limits.cpu`          | CPU limit                                  | `100m`                                                     |
+| `resources.limits.memory`       | Memory limit                               | `500Mi`                                                    |
+| `resources.requests.cpu`        | CPU request                                | `100m`                                                     |
+| `resources.requests.memory`     | Memory request                             | `200Mi`                                                    |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+    incubator/fluentd-elasticsearch
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml incubator/fluentd-elasticsearch
+```

--- a/incubator/fluentd-elasticsearch/templates/NOTES.txt
+++ b/incubator/fluentd-elasticsearch/templates/NOTES.txt
@@ -1,0 +1,6 @@
+To verify that Fluentd elasticsearch  has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "fluentd-elasticsearch .name" . }},release={{ .Release.Name }}"
+
+THIS APPLICATION CAPTURES ALL CONSOLE OUTPUT AND FORWARDS IT TO elasticsearch . Anything that might be identifying,
+including things like IP addresses, container images, and object names will NOT be anonymized.

--- a/incubator/fluentd-elasticsearch/templates/NOTES.txt
+++ b/incubator/fluentd-elasticsearch/templates/NOTES.txt
@@ -1,6 +1,6 @@
-To verify that Fluentd elasticsearch  has started, run:
+To verify that Fluentd has started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "fluentd-elasticsearch .name" . }},release={{ .Release.Name }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "fluentd-elasticsearch.name" . }},release={{ .Release.Name }}"
 
 THIS APPLICATION CAPTURES ALL CONSOLE OUTPUT AND FORWARDS IT TO elasticsearch . Anything that might be identifying,
 including things like IP addresses, container images, and object names will NOT be anonymized.

--- a/incubator/fluentd-elasticsearch/templates/_helpers.tpl
+++ b/incubator/fluentd-elasticsearch/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd-elasticsearch .name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fluentd-elasticsearch .fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- end -}}

--- a/incubator/fluentd-elasticsearch/templates/_helpers.tpl
+++ b/incubator/fluentd-elasticsearch/templates/_helpers.tpl
@@ -2,15 +2,15 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "fluentd-elasticsearch .name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 24 -}}
+{{- define "fluentd-elasticsearch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fluentd-elasticsearch .fullname" -}}
+{{- define "fluentd-elasticsearch.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/incubator/fluentd-elasticsearch/templates/clusterrole.yaml
+++ b/incubator/fluentd-elasticsearch/templates/clusterrole.yaml
@@ -2,11 +2,14 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
-    k8s-app: {{ template "fluentd-elasticsearch .fullname" . }}
+    app: {{ template "fluentd-elasticsearch.name" . }}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 rules:
 - apiGroups:
   - ""

--- a/incubator/fluentd-elasticsearch/templates/clusterrole.yaml
+++ b/incubator/fluentd-elasticsearch/templates/clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  labels:
+    k8s-app: {{ template "fluentd-elasticsearch .fullname" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  - "pods"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+{{- end -}}

--- a/incubator/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/incubator/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  labels:
+    k8s-app: {{ template "fluentd-elasticsearch .fullname" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  apiGroup: ""
+{{- end -}}

--- a/incubator/fluentd-elasticsearch/templates/clusterrolebinding.yaml
+++ b/incubator/fluentd-elasticsearch/templates/clusterrolebinding.yaml
@@ -2,17 +2,21 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
-    k8s-app: {{ template "fluentd-elasticsearch .fullname" . }}
+    app: {{ template "fluentd-elasticsearch.name" . }}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
   apiGroup: ""
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
   apiGroup: ""
 {{- end -}}

--- a/incubator/fluentd-elasticsearch/templates/configmap.yaml
+++ b/incubator/fluentd-elasticsearch/templates/configmap.yaml
@@ -1,13 +1,19 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
-    app: {{ template "fluentd-elasticsearch .name" . }}
+    app: {{ template "fluentd-elasticsearch.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
+    addonmanager.kubernetes.io/mode: Reconcile
 data:
+  system.conf: |-
+    <system>
+      root_dir /tmp/fluentd-buffers/
+    </system>
+
   containers.input.conf: |-
     # This configuration file for Fluentd / td-agent is used
     # to watch changes to Docker log files. The kubelet creates symlinks that
@@ -108,26 +114,19 @@ data:
     # CRI Log Example:
     # 2016-02-17T00:04:05.931087621Z stdout F [info:2016-02-16T16:04:05.930-08:00] Some log text here
     <source>
+      @id fluentd-containers.log
       @type tail
       path /var/log/containers/*.log
-      pos_file /var/log/es-containers.log.pos
+      pos_file /var/log/fluentd-containers.log.pos
       time_format %Y-%m-%dT%H:%M:%S.%NZ
       tag raw.kubernetes.*
+      format json
       read_from_head true
-      format multi_format
-      <pattern>
-        format json
-        time_key time
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
-      </pattern>
-      <pattern>
-        format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
-        time_format %Y-%m-%dT%H:%M:%S.%N%:z
-      </pattern>
     </source>
 
     # Detect exceptions in the log output and forward them as one log entry.
     <match raw.kubernetes.**>
+      @id raw.kubernetes
       @type detect_exceptions
       remove_tag_prefix raw
       message log
@@ -136,25 +135,28 @@ data:
       max_bytes 500000
       max_lines 1000
     </match>
+
   system.input.conf: |-
     # Example:
     # 2015-12-21 23:17:22,066 [salt.state       ][INFO    ] Completed state [net.ipv4.ip_forward] at time 23:17:22.066081
     <source>
+      @id minion
       @type tail
       format /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
       time_format %Y-%m-%d %H:%M:%S
       path /var/log/salt/minion
-      pos_file /var/log/es-salt.pos
+      pos_file /var/log/salt.pos
       tag salt
     </source>
 
     # Example:
     # Dec 21 23:17:22 gke-foo-1-1-4b5cbd14-node-4eoj startupscript: Finished running startup script /var/run/google.startup.script
     <source>
+      @id startupscript.log
       @type tail
       format syslog
       path /var/log/startupscript.log
-      pos_file /var/log/es-startupscript.log.pos
+      pos_file /var/log/startupscript.log.pos
       tag startupscript
     </source>
 
@@ -162,22 +164,24 @@ data:
     # time="2016-02-04T06:51:03.053580605Z" level=info msg="GET /containers/json"
     # time="2016-02-04T07:53:57.505612354Z" level=error msg="HTTP Error" err="No such image: -f" statusCode=404
     <source>
+      @id docker.log
       @type tail
       format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
       path /var/log/docker.log
-      pos_file /var/log/es-docker.log.pos
+      pos_file /var/log/docker.log.pos
       tag docker
     </source>
 
     # Example:
     # 2016/02/04 06:52:38 filePurge: successfully removed file /var/etcd/data/member/wal/00000000000006d0-00000000010a23d1.wal
     <source>
+      @id etcd.log
       @type tail
       # Not parsing this, because it doesn't have anything particularly useful to
       # parse out of it (like severities).
       format none
       path /var/log/etcd.log
-      pos_file /var/log/es-etcd.log.pos
+      pos_file /var/log/etcd.log.pos
       tag etcd
     </source>
 
@@ -188,6 +192,7 @@ data:
     # Example:
     # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]
     <source>
+      @id kubelet.log
       @type tail
       format multiline
       multiline_flush_interval 5s
@@ -195,13 +200,14 @@ data:
       format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
       time_format %m%d %H:%M:%S.%N
       path /var/log/kubelet.log
-      pos_file /var/log/es-kubelet.log.pos
+      pos_file /var/log/kubelet.log.pos
       tag kubelet
     </source>
 
     # Example:
     # I1118 21:26:53.975789       6 proxier.go:1096] Port "nodePort for kube-system/default-http-backend:http" (:31429/tcp) was open before and is still needed
     <source>
+      @id kube-proxy.log
       @type tail
       format multiline
       multiline_flush_interval 5s
@@ -209,13 +215,14 @@ data:
       format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
       time_format %m%d %H:%M:%S.%N
       path /var/log/kube-proxy.log
-      pos_file /var/log/es-kube-proxy.log.pos
+      pos_file /var/log/kube-proxy.log.pos
       tag kube-proxy
     </source>
 
     # Example:
     # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
     <source>
+      @id kube-apiserver.log
       @type tail
       format multiline
       multiline_flush_interval 5s
@@ -223,13 +230,14 @@ data:
       format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
       time_format %m%d %H:%M:%S.%N
       path /var/log/kube-apiserver.log
-      pos_file /var/log/es-kube-apiserver.log.pos
+      pos_file /var/log/kube-apiserver.log.pos
       tag kube-apiserver
     </source>
 
     # Example:
     # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
     <source>
+      @id kube-controller-manager.log
       @type tail
       format multiline
       multiline_flush_interval 5s
@@ -237,13 +245,14 @@ data:
       format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
       time_format %m%d %H:%M:%S.%N
       path /var/log/kube-controller-manager.log
-      pos_file /var/log/es-kube-controller-manager.log.pos
+      pos_file /var/log/kube-controller-manager.log.pos
       tag kube-controller-manager
     </source>
 
     # Example:
     # W0204 06:49:18.239674       7 reflector.go:245] pkg/scheduler/factory/factory.go:193: watch of *api.Service ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [2578313/2577886]) [2579312]
     <source>
+      @id kube-scheduler.log
       @type tail
       format multiline
       multiline_flush_interval 5s
@@ -251,13 +260,14 @@ data:
       format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
       time_format %m%d %H:%M:%S.%N
       path /var/log/kube-scheduler.log
-      pos_file /var/log/es-kube-scheduler.log.pos
+      pos_file /var/log/kube-scheduler.log.pos
       tag kube-scheduler
     </source>
 
     # Example:
     # I1104 10:36:20.242766       5 rescheduler.go:73] Running Rescheduler
     <source>
+      @id rescheduler.log
       @type tail
       format multiline
       multiline_flush_interval 5s
@@ -265,13 +275,14 @@ data:
       format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
       time_format %m%d %H:%M:%S.%N
       path /var/log/rescheduler.log
-      pos_file /var/log/es-rescheduler.log.pos
+      pos_file /var/log/rescheduler.log.pos
       tag rescheduler
     </source>
 
     # Example:
     # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
     <source>
+      @id glbc.log
       @type tail
       format multiline
       multiline_flush_interval 5s
@@ -279,13 +290,14 @@ data:
       format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
       time_format %m%d %H:%M:%S.%N
       path /var/log/glbc.log
-      pos_file /var/log/es-glbc.log.pos
+      pos_file /var/log/glbc.log.pos
       tag glbc
     </source>
 
     # Example:
     # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
     <source>
+      @id cluster-autoscaler.log
       @type tail
       format multiline
       multiline_flush_interval 5s
@@ -293,39 +305,54 @@ data:
       format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
       time_format %m%d %H:%M:%S.%N
       path /var/log/cluster-autoscaler.log
-      pos_file /var/log/es-cluster-autoscaler.log.pos
+      pos_file /var/log/cluster-autoscaler.log.pos
       tag cluster-autoscaler
     </source>
 
     # Logs from systemd-journal for interesting services.
     <source>
+      @id journald-docker
       @type systemd
       filters [{ "_SYSTEMD_UNIT": "docker.service" }]
-      pos_file /var/log/journald-docker.pos
+      #pos_file /var/log/journald-docker.pos
+      <storage>
+        @type local
+        persistent true
+      </storage>
       read_from_head true
       tag docker
     </source>
 
     <source>
+      @id journald-kubelet
       @type systemd
       filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
-      pos_file /var/log/journald-kubelet.pos
+      <storage>
+        @type local
+        persistent true
+      </storage>
       read_from_head true
       tag kubelet
     </source>
 
     <source>
+      @id journald-node-problem-detector
       @type systemd
       filters [{ "_SYSTEMD_UNIT": "node-problem-detector.service" }]
-      pos_file /var/log/journald-node-problem-detector.pos
+      <storage>
+        @type local
+        persistent true
+      </storage>
       read_from_head true
       tag node-problem-detector
     </source>
+
   forward.input.conf: |-
     # Takes the messages sent over TCP
     <source>
       @type forward
     </source>
+
   monitoring.conf: |-
     # Prometheus Exporter Plugin
     # input plugin that exports metrics
@@ -360,6 +387,7 @@ data:
         host ${hostname}
       </labels>
     </source>
+
   output.conf: |-
     # Enriches records with Kubernetes metadata
     <filter kubernetes.**>
@@ -367,20 +395,24 @@ data:
     </filter>
 
     <match **>
-       @type elasticsearch
-       log_level info
-       include_tag_key true
-       host {{ .Values.elasticsearch.host }}
-       port {{ .Values.elasticsearch.port }}
-       logstash_format true
-       # Set the chunk limits.
-       buffer_chunk_limit {{ .Values.elasticsearch.buffer_chunk_limit }}
-       buffer_queue_limit {{ .Values.elasticsearch.buffer_queue_limit }}
-       flush_interval 5s
-       # Never wait longer than 5 minutes between retries.
-       max_retry_wait 30
-       # Disable the limit on the number of retries (retry forever).
-       disable_retry_limit
-       # Use multiple threads for processing.
-       num_threads 2
+      @id elasticsearch
+      @type elasticsearch
+      @log_level info
+      include_tag_key true
+      host {{ .Values.elasticsearch.host }}
+      port {{ .Values.elasticsearch.port }}
+      logstash_format true
+      <buffer>
+        @type file
+        path /var/log/fluentd-buffers/kubernetes.system.buffer
+        flush_mode interval
+        retry_type exponential_backoff
+        flush_thread_count 2
+        flush_interval 5s
+        retry_forever
+        retry_max_interval 30
+        chunk_limit_size {{ .Values.elasticsearch.buffer_chunk_limit }}
+        queue_limit_length {{ .Values.elasticsearch.buffer_queue_limit }}
+        overflow_action block
+      </buffer>
     </match>

--- a/incubator/fluentd-elasticsearch/templates/configmap.yaml
+++ b/incubator/fluentd-elasticsearch/templates/configmap.yaml
@@ -1,0 +1,386 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  labels:
+    app: {{ template "fluentd-elasticsearch .name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+data:
+  containers.input.conf: |-
+    # This configuration file for Fluentd / td-agent is used
+    # to watch changes to Docker log files. The kubelet creates symlinks that
+    # capture the pod name, namespace, container name & Docker container ID
+    # to the docker logs for pods in the /var/log/containers directory on the host.
+    # If running this fluentd configuration in a Docker container, the /var/log
+    # directory should be mounted in the container.
+    #
+    # These logs are then submitted to Elasticsearch which assumes the
+    # installation of the fluent-plugin-elasticsearch & the
+    # fluent-plugin-kubernetes_metadata_filter plugins.
+    # See https://github.com/uken/fluent-plugin-elasticsearch &
+    # https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter for
+    # more information about the plugins.
+    #
+    # Example
+    # =======
+    # A line in the Docker log file might look like this JSON:
+    #
+    # {"log":"2014/09/25 21:15:03 Got request with path wombat\n",
+    #  "stream":"stderr",
+    #   "time":"2014-09-25T21:15:03.499185026Z"}
+    #
+    # The time_format specification below makes sure we properly
+    # parse the time format produced by Docker. This will be
+    # submitted to Elasticsearch and should appear like:
+    # $ curl 'http://elasticsearch-logging:9200/_search?pretty'
+    # ...
+    # {
+    #      "_index" : "logstash-2014.09.25",
+    #      "_type" : "fluentd",
+    #      "_id" : "VBrbor2QTuGpsQyTCdfzqA",
+    #      "_score" : 1.0,
+    #      "_source":{"log":"2014/09/25 22:45:50 Got request with path wombat\n",
+    #                 "stream":"stderr","tag":"docker.container.all",
+    #                 "@timestamp":"2014-09-25T22:45:50+00:00"}
+    #    },
+    # ...
+    #
+    # The Kubernetes fluentd plugin is used to write the Kubernetes metadata to the log
+    # record & add labels to the log record if properly configured. This enables users
+    # to filter & search logs on any metadata.
+    # For example a Docker container's logs might be in the directory:
+    #
+    #  /var/lib/docker/containers/997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b
+    #
+    # and in the file:
+    #
+    #  997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b-json.log
+    #
+    # where 997599971ee6... is the Docker ID of the running container.
+    # The Kubernetes kubelet makes a symbolic link to this file on the host machine
+    # in the /var/log/containers directory which includes the pod name and the Kubernetes
+    # container name:
+    #
+    #    synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log
+    #    ->
+    #    /var/lib/docker/containers/997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b/997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b-json.log
+    #
+    # The /var/log directory on the host is mapped to the /var/log directory in the container
+    # running this instance of Fluentd and we end up collecting the file:
+    #
+    #   /var/log/containers/synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log
+    #
+    # This results in the tag:
+    #
+    #  var.log.containers.synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log
+    #
+    # The Kubernetes fluentd plugin is used to extract the namespace, pod name & container name
+    # which are added to the log message as a kubernetes field object & the Docker container ID
+    # is also added under the docker field object.
+    # The final tag is:
+    #
+    #   kubernetes.var.log.containers.synthetic-logger-0.25lps-pod_default_synth-lgr-997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b.log
+    #
+    # And the final log record look like:
+    #
+    # {
+    #   "log":"2014/09/25 21:15:03 Got request with path wombat\n",
+    #   "stream":"stderr",
+    #   "time":"2014-09-25T21:15:03.499185026Z",
+    #   "kubernetes": {
+    #     "namespace": "default",
+    #     "pod_name": "synthetic-logger-0.25lps-pod",
+    #     "container_name": "synth-lgr"
+    #   },
+    #   "docker": {
+    #     "container_id": "997599971ee6366d4a5920d25b79286ad45ff37a74494f262e3bc98d909d0a7b"
+    #   }
+    # }
+    #
+    # This makes it easier for users to search for logs by pod name or by
+    # the name of the Kubernetes container regardless of how many times the
+    # Kubernetes pod has been restarted (resulting in a several Docker container IDs).
+
+    # Json Log Example:
+    # {"log":"[info:2016-02-16T16:04:05.930-08:00] Some log text here\n","stream":"stdout","time":"2016-02-17T00:04:05.931087621Z"}
+    # CRI Log Example:
+    # 2016-02-17T00:04:05.931087621Z stdout F [info:2016-02-16T16:04:05.930-08:00] Some log text here
+    <source>
+      @type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/es-containers.log.pos
+      time_format %Y-%m-%dT%H:%M:%S.%NZ
+      tag raw.kubernetes.*
+      read_from_head true
+      format multi_format
+      <pattern>
+        format json
+        time_key time
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </pattern>
+      <pattern>
+        format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+        time_format %Y-%m-%dT%H:%M:%S.%N%:z
+      </pattern>
+    </source>
+
+    # Detect exceptions in the log output and forward them as one log entry.
+    <match raw.kubernetes.**>
+      @type detect_exceptions
+      remove_tag_prefix raw
+      message log
+      stream stream
+      multiline_flush_interval 5
+      max_bytes 500000
+      max_lines 1000
+    </match>
+  system.input.conf: |-
+    # Example:
+    # 2015-12-21 23:17:22,066 [salt.state       ][INFO    ] Completed state [net.ipv4.ip_forward] at time 23:17:22.066081
+    <source>
+      @type tail
+      format /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
+      time_format %Y-%m-%d %H:%M:%S
+      path /var/log/salt/minion
+      pos_file /var/log/es-salt.pos
+      tag salt
+    </source>
+
+    # Example:
+    # Dec 21 23:17:22 gke-foo-1-1-4b5cbd14-node-4eoj startupscript: Finished running startup script /var/run/google.startup.script
+    <source>
+      @type tail
+      format syslog
+      path /var/log/startupscript.log
+      pos_file /var/log/es-startupscript.log.pos
+      tag startupscript
+    </source>
+
+    # Examples:
+    # time="2016-02-04T06:51:03.053580605Z" level=info msg="GET /containers/json"
+    # time="2016-02-04T07:53:57.505612354Z" level=error msg="HTTP Error" err="No such image: -f" statusCode=404
+    <source>
+      @type tail
+      format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      path /var/log/docker.log
+      pos_file /var/log/es-docker.log.pos
+      tag docker
+    </source>
+
+    # Example:
+    # 2016/02/04 06:52:38 filePurge: successfully removed file /var/etcd/data/member/wal/00000000000006d0-00000000010a23d1.wal
+    <source>
+      @type tail
+      # Not parsing this, because it doesn't have anything particularly useful to
+      # parse out of it (like severities).
+      format none
+      path /var/log/etcd.log
+      pos_file /var/log/es-etcd.log.pos
+      tag etcd
+    </source>
+
+    # Multi-line parsing is required for all the kube logs because very large log
+    # statements, such as those that include entire object bodies, get split into
+    # multiple lines by glog.
+
+    # Example:
+    # I0204 07:32:30.020537    3368 server.go:1048] POST /stats/container/: (13.972191ms) 200 [[Go-http-client/1.1] 10.244.1.3:40537]
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kubelet.log
+      pos_file /var/log/es-kubelet.log.pos
+      tag kubelet
+    </source>
+
+    # Example:
+    # I1118 21:26:53.975789       6 proxier.go:1096] Port "nodePort for kube-system/default-http-backend:http" (:31429/tcp) was open before and is still needed
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kube-proxy.log
+      pos_file /var/log/es-kube-proxy.log.pos
+      tag kube-proxy
+    </source>
+
+    # Example:
+    # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kube-apiserver.log
+      pos_file /var/log/es-kube-apiserver.log.pos
+      tag kube-apiserver
+    </source>
+
+    # Example:
+    # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kube-controller-manager.log
+      pos_file /var/log/es-kube-controller-manager.log.pos
+      tag kube-controller-manager
+    </source>
+
+    # Example:
+    # W0204 06:49:18.239674       7 reflector.go:245] pkg/scheduler/factory/factory.go:193: watch of *api.Service ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [2578313/2577886]) [2579312]
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/kube-scheduler.log
+      pos_file /var/log/es-kube-scheduler.log.pos
+      tag kube-scheduler
+    </source>
+
+    # Example:
+    # I1104 10:36:20.242766       5 rescheduler.go:73] Running Rescheduler
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/rescheduler.log
+      pos_file /var/log/es-rescheduler.log.pos
+      tag rescheduler
+    </source>
+
+    # Example:
+    # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/glbc.log
+      pos_file /var/log/es-glbc.log.pos
+      tag glbc
+    </source>
+
+    # Example:
+    # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
+    <source>
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\w\d{4}/
+      format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+      time_format %m%d %H:%M:%S.%N
+      path /var/log/cluster-autoscaler.log
+      pos_file /var/log/es-cluster-autoscaler.log.pos
+      tag cluster-autoscaler
+    </source>
+
+    # Logs from systemd-journal for interesting services.
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+      pos_file /var/log/journald-docker.pos
+      read_from_head true
+      tag docker
+    </source>
+
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
+      pos_file /var/log/journald-kubelet.pos
+      read_from_head true
+      tag kubelet
+    </source>
+
+    <source>
+      @type systemd
+      filters [{ "_SYSTEMD_UNIT": "node-problem-detector.service" }]
+      pos_file /var/log/journald-node-problem-detector.pos
+      read_from_head true
+      tag node-problem-detector
+    </source>
+  forward.input.conf: |-
+    # Takes the messages sent over TCP
+    <source>
+      @type forward
+    </source>
+  monitoring.conf: |-
+    # Prometheus Exporter Plugin
+    # input plugin that exports metrics
+    <source>
+      @type prometheus
+    </source>
+
+    <source>
+      @type monitor_agent
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+      @type prometheus_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # input plugin that collects metrics for output plugin
+    <source>
+      @type prometheus_output_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # input plugin that collects metrics for in_tail plugin
+    <source>
+      @type prometheus_tail_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+  output.conf: |-
+    # Enriches records with Kubernetes metadata
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+    </filter>
+
+    <match **>
+       @type elasticsearch
+       log_level info
+       include_tag_key true
+       host {{ .Values.elasticsearch.host }}
+       port {{ .Values.elasticsearch.port }}
+       logstash_format true
+       # Set the chunk limits.
+       buffer_chunk_limit {{ .Values.elasticsearch.buffer_chunk_limit }}
+       buffer_queue_limit {{ .Values.elasticsearch.buffer_queue_limit }}
+       flush_interval 5s
+       # Never wait longer than 5 minutes between retries.
+       max_retry_wait 30
+       # Disable the limit on the number of retries (retry forever).
+       disable_retry_limit
+       # Use multiple threads for processing.
+       num_threads 2
+    </match>

--- a/incubator/fluentd-elasticsearch/templates/configmap.yaml
+++ b/incubator/fluentd-elasticsearch/templates/configmap.yaml
@@ -388,34 +388,10 @@ data:
       </labels>
     </source>
 
-  output.conf: |-
-    # Enriches records with Kubernetes metadata
-    <filter kubernetes.**>
-      @type kubernetes_metadata
-    </filter>
-
-    <match **>
-      @id elasticsearch
-      @type elasticsearch
-      @log_level info
-      include_tag_key true
-      host {{ .Values.elasticsearch.host }}
-      port {{ .Values.elasticsearch.port }}
-      logstash_format true
-      <buffer>
-        @type file
-        path /var/log/fluentd-buffers/kubernetes.system.buffer
-        flush_mode interval
-        retry_type exponential_backoff
-        flush_thread_count 2
-        flush_interval 5s
-        retry_forever
-        retry_max_interval 30
-        chunk_limit_size {{ .Values.elasticsearch.buffer_chunk_limit }}
-        queue_limit_length {{ .Values.elasticsearch.buffer_queue_limit }}
-        overflow_action block
-      </buffer>
-    </match>
+{{- range $key, $value := .Values.configMaps }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}
 
 {{ if .Values.fluentdcustomconfig }}
   custom.conf: {{ toYaml .Values.fluentdcustomconfig | indent 2 }}

--- a/incubator/fluentd-elasticsearch/templates/configmap.yaml
+++ b/incubator/fluentd-elasticsearch/templates/configmap.yaml
@@ -416,3 +416,7 @@ data:
         overflow_action block
       </buffer>
     </match>
+
+{{ if .Values.fluentdcustomconfig }}
+  custom.conf: {{ toYaml .Values.fluentdcustomconfig | indent 2 }}
+{{ end }}

--- a/incubator/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/incubator/fluentd-elasticsearch/templates/daemonset.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
-  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
-    app: {{ template "fluentd-elasticsearch .fullname" . }}
+    app: {{ template "fluentd-elasticsearch.fullname" . }}
     version: {{ .Values.imageTag }}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -13,15 +13,17 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "fluentd-elasticsearch .fullname" . }}
+      app: {{ template "fluentd-elasticsearch.fullname" . }}
       version: {{ .Values.imageTag }}
       chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       heritage: "{{ .Release.Service }}"
-      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:
-        app: {{ template "fluentd-elasticsearch .fullname" . }}
+        app: {{ template "fluentd-elasticsearch.fullname" . }}
+        version: {{ .Values.imageTag }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        heritage: "{{ .Release.Service }}"
         kubernetes.io/cluster-service: "true"
         version: {{ .Values.imageTag }}
       # This annotation ensures that fluentd does not get evicted if the node
@@ -30,9 +32,9 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      serviceAccountName: {{ template "fluentd-elasticsearch .fullname" . }}
+      serviceAccountName: {{ template "fluentd-elasticsearch.fullname" . }}
       containers:
-      - name: {{ template "fluentd-elasticsearch .fullname" . }}
+      - name: {{ template "fluentd-elasticsearch.fullname" . }}
         image:  "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
@@ -49,10 +51,8 @@ spec:
         - name: libsystemddir
           mountPath: /host/lib
           readOnly: true
-        - name: config-volume-{{ template "fluentd-elasticsearch .fullname" . }}
+        - name: config-volume-{{ template "fluentd-elasticsearch.fullname" . }}
           mountPath: /etc/fluent/config.d
-      nodeSelector:
-        beta.kubernetes.io/fluentd-ds-ready: "true"
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog
@@ -65,6 +65,6 @@ spec:
       - name: libsystemddir
         hostPath:
           path: /usr/lib64
-      - name: config-volume-{{ template "fluentd-elasticsearch .fullname" . }}
+      - name: config-volume-{{ template "fluentd-elasticsearch.fullname" . }}
         configMap:
-          name: {{ template "fluentd-elasticsearch .fullname" . }}-{{.Chart.Version}}
+          name: {{ template "fluentd-elasticsearch.fullname" . }}

--- a/incubator/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/incubator/fluentd-elasticsearch/templates/daemonset.yaml
@@ -41,6 +41,14 @@ spec:
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q
+        - name: OUTPUT_HOST
+          value: {{ .Values.elasticsearch.host | quote }}
+        - name: OUTPUT_PORT
+          value: {{ .Values.elasticsearch.port | quote }}
+        - name: OUTPUT_BUFFER_CHUNK_LIMIT
+          value: {{ .Values.elasticsearch.buffer_chunk_limit | quote }}
+        - name: OUTPUT_BUFFER_QUEUE_LIMIT
+          value: {{ .Values.elasticsearch.buffer_queue_limit | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/incubator/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/incubator/fluentd-elasticsearch/templates/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
       # Note that this does not guarantee admission on the nodes (#40573).
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        checksum/config: {{ include (print $.Chart.Name "/templates/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "fluentd-elasticsearch.fullname" . }}
       containers:

--- a/incubator/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/incubator/fluentd-elasticsearch/templates/daemonset.yaml
@@ -68,3 +68,7 @@ spec:
       - name: config-volume-{{ template "fluentd-elasticsearch.fullname" . }}
         configMap:
           name: {{ template "fluentd-elasticsearch.fullname" . }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}

--- a/incubator/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/incubator/fluentd-elasticsearch/templates/daemonset.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  labels:
+    app: {{ template "fluentd-elasticsearch .fullname" . }}
+    version: {{ .Values.imageTag }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "fluentd-elasticsearch .fullname" . }}
+      version: {{ .Values.imageTag }}
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      heritage: "{{ .Release.Service }}"
+      release: "{{ .Release.Name }}"
+  template:
+    metadata:
+      labels:
+        app: {{ template "fluentd-elasticsearch .fullname" . }}
+        kubernetes.io/cluster-service: "true"
+        version: {{ .Values.imageTag }}
+      # This annotation ensures that fluentd does not get evicted if the node
+      # supports critical pod annotation based priority scheme.
+      # Note that this does not guarantee admission on the nodes (#40573).
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: {{ template "fluentd-elasticsearch .fullname" . }}
+      containers:
+      - name: {{ template "fluentd-elasticsearch .fullname" . }}
+        image:  "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+        env:
+        - name: FLUENTD_ARGS
+          value: --no-supervisor -q
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: libsystemddir
+          mountPath: /host/lib
+          readOnly: true
+        - name: config-volume-{{ template "fluentd-elasticsearch .fullname" . }}
+          mountPath: /etc/fluent/config.d
+      nodeSelector:
+        beta.kubernetes.io/fluentd-ds-ready: "true"
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      # It is needed to copy systemd library to decompress journals
+      - name: libsystemddir
+        hostPath:
+          path: /usr/lib64
+      - name: config-volume-{{ template "fluentd-elasticsearch .fullname" . }}
+        configMap:
+          name: {{ template "fluentd-elasticsearch .fullname" . }}-{{.Chart.Version}}

--- a/incubator/fluentd-elasticsearch/templates/service-account.yaml
+++ b/incubator/fluentd-elasticsearch/templates/service-account.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  labels:
+    k8s-app: {{ template "fluentd-elasticsearch .fullname" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+{{- end -}}

--- a/incubator/fluentd-elasticsearch/templates/service-account.yaml
+++ b/incubator/fluentd-elasticsearch/templates/service-account.yaml
@@ -1,10 +1,11 @@
-{{- if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "fluentd-elasticsearch .fullname" . }}
+  name: {{ template "fluentd-elasticsearch.fullname" . }}
   labels:
-    k8s-app: {{ template "fluentd-elasticsearch .fullname" . }}
+    app: {{ template "fluentd-elasticsearch.name" . }}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-{{- end -}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}

--- a/incubator/fluentd-elasticsearch/values.yaml
+++ b/incubator/fluentd-elasticsearch/values.yaml
@@ -17,6 +17,12 @@ resources:
     cpu: 100m
     memory: 200Mi
 
+## Add tolerations if specified
+# tolerations:
+#   - key: node-role.kubernetes.io/master
+#     operator: Exists
+#     effect: NoSchedule
+
 elasticsearch:
   host: 'elasticsearch-client'
   port: 9200

--- a/incubator/fluentd-elasticsearch/values.yaml
+++ b/incubator/fluentd-elasticsearch/values.yaml
@@ -1,5 +1,5 @@
 image: gcr.io/google-containers/fluentd-elasticsearch
-imageTag: v2.0.3
+imageTag: v2.0.4
 
 ## Specify an imagePullPolicy (Required)
 ## It's recommended to change this to 'Always' if the image tag is 'latest'

--- a/incubator/fluentd-elasticsearch/values.yaml
+++ b/incubator/fluentd-elasticsearch/values.yaml
@@ -25,3 +25,6 @@ elasticsearch:
 
 rbac:
   create: true
+
+fluentdcustomconfig: |
+  # add fluentd custom configs here

--- a/incubator/fluentd-elasticsearch/values.yaml
+++ b/incubator/fluentd-elasticsearch/values.yaml
@@ -26,5 +26,5 @@ elasticsearch:
 rbac:
   create: true
 
-fluentdcustomconfig: |
-  # add fluentd custom configs here
+# fluentdcustomconfig: |
+#   # add fluentd custom configs here

--- a/incubator/fluentd-elasticsearch/values.yaml
+++ b/incubator/fluentd-elasticsearch/values.yaml
@@ -18,10 +18,10 @@ resources:
     memory: 200Mi
 
 elasticsearch:
-  host: 'http://elasticsearch-client'
+  host: 'elasticsearch-client'
   port: 9200
   buffer_chunk_limit: 2M
   buffer_queue_limit: 8
 
 rbac:
-  create: false
+  create: true

--- a/incubator/fluentd-elasticsearch/values.yaml
+++ b/incubator/fluentd-elasticsearch/values.yaml
@@ -32,5 +32,35 @@ elasticsearch:
 rbac:
   create: true
 
+configMaps:
+  output.conf: |
+    # Enriches records with Kubernetes metadata
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+    </filter>
+
+    <match **>
+      @id elasticsearch
+      @type elasticsearch
+      @log_level info
+      include_tag_key true
+      host "#{ENV['OUTPUT_HOST']}"
+      port "#{ENV['OUTPUT_PORT']}"
+      logstash_format true
+      <buffer>
+        @type file
+        path /var/log/fluentd-buffers/kubernetes.system.buffer
+        flush_mode interval
+        retry_type exponential_backoff
+        flush_thread_count 2
+        flush_interval 5s
+        retry_forever
+        retry_max_interval 30
+        chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
+        queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
+        overflow_action block
+      </buffer>
+    </match>
+
 # fluentdcustomconfig: |
 #   # add fluentd custom configs here

--- a/incubator/fluentd-elasticsearch/values.yaml
+++ b/incubator/fluentd-elasticsearch/values.yaml
@@ -1,0 +1,27 @@
+image: gcr.io/google-containers/fluentd-elasticsearch
+imageTag: v2.0.3
+
+## Specify an imagePullPolicy (Required)
+## It's recommended to change this to 'Always' if the image tag is 'latest'
+## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+imagePullPolicy: IfNotPresent
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  limits:
+    cpu: 100m
+    memory: 500Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+
+elasticsearch:
+  host: 'http://elasticsearch-client'
+  port: 9200
+  buffer_chunk_limit: 2M
+  buffer_queue_limit: 8
+
+rbac:
+  create: false


### PR DESCRIPTION
This pr adds a fluentd chart wich exports to elasticsearch using the kubernetes metadata and googles dectect-exeptions plugin to have proper multiline logging for java stacktraces and so on.

Currently i use an own fluentd 1.1.0 dockerimage from: https://hub.docker.com/r/monotek/docker-fluentd-elasticsearch/

I'll added another pull request (https://github.com/kubernetes/kubernetes/pull/58525) to the Kubernetes repo to update the original image in: https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/fluentd-elasticsearch

It already got the detect-exeptions plugin with: https://github.com/kubernetes/kubernetes/pull/58063 so it only needs the fluentd 1.1.0 update.