### PR TITLE
Improvements to CockroachDB chart

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.6.0
+version: 0.6.1
 appVersion: 1.1.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.5.4
-appVersion: 1.1.3
+version: 0.5.5
+appVersion: 1.1.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.5.5
+version: 0.6.0
 appVersion: 1.1.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.6.1
+version: 0.6.2
 appVersion: 1.1.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -46,7 +46,7 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | `Cpu`                         | Container requested cpu                    | `100m`                                       |
 | `Memory`                      | Container requested memory                 | `512Mi`                                      |
 | `Storage`                     | Persistent volume size                     | `1Gi`                                        |
-| `StorageClass`                | Persistent volume class                    | `anything`                                   |
+| `StorageClass`                | Persistent volume class                    | `null`                                       |
 | `CacheSize`                   | Size of CockroachDB's in-memory cache      | `25%`                                        |
 | `MaxSQLMemory`                | Max memory to use processing SQL queries   | `25%`                                        |
 | `ClusterDomain`               | Cluster's default DNS domain               | `cluster.local`                              |

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -36,7 +36,7 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | ----------------------------- | ------------------------------------------ | -------------------------------------------- |
 | `Name`                        | Chart name                                 | `cockroachdb`                                |
 | `Image`                       | Container image name                       | `cockroachdb/cockroach`                      |
-| `ImageTag`                    | Container image tag                        | `v1.0`                                       |
+| `ImageTag`                    | Container image tag                        | `v1.1.4`                                     |
 | `ImagePullPolicy`             | Container pull policy                      | `Always`                                     |
 | `Replicas`                    | k8s statefulset replicas                   | `3`                                          |
 | `MaxUnavailable`              | k8s PodDisruptionBudget parameter          | `1`                                          |

--- a/stable/cockroachdb/templates/cluster-init.yaml
+++ b/stable/cockroachdb/templates/cluster-init.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-init"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+      - name: cluster-init
+        image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
+        imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
+        command:
+          - "/cockroach/cockroach"
+          - "init"
+          - "--insecure"
+          - "--host={{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-0.{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
+      restartPolicy: OnFailure

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -37,12 +37,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-{{ .Values.Component }}"
   annotations:
-    # This is needed to make the peer-finder work properly and to help avoid
-    # edge cases where instance 0 comes up after losing its data and needs to
-    # decide whether it should create a new cluster or try to join an existing
-    # one. If it creates a new cluster when it should have joined an existing
-    # one, we'd end up with two separate clusters listening at the same service
-    # endpoint, which would be very bad.
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
     prometheus.io/scrape: "true"
@@ -90,34 +84,6 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: "{{ .Release.Name }}-{{ .Values.Component }}"
     spec:
-      # Init containers are run only once in the lifetime of a pod, before
-      # it's started up for the first time. It has to exit successfully
-      # before the pod's main containers are allowed to start.
-      # This particular init container does a DNS lookup for other pods in
-      # the set to help determine whether or not a cluster already exists.
-      # If any other pods exist, it creates a file in the cockroach-data
-      # directory to pass that information along to the primary container that
-      # has to decide what command-line flags to use when starting CockroachDB.
-      # This only matters when a pod's persistent volume is empty - if it has
-      # data from a previous execution, that data will always be used.
-      # The cockroachdb/cockroach-k8s-init image is defined at
-      # github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/init
-      initContainers:
-      - name: bootstrap
-        image: "{{ .Values.BootstrapImage }}:{{ .Values.BootstrapImageTag }}"
-        imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
-        args:
-        - "-on-start=/on-start.sh"
-        - "-service={{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
-        - "-domain={{ .Values.ClusterDomain }}"
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        volumeMounts:
-        - name: datadir
-          mountPath: "/cockroach/cockroach-data"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -150,23 +116,9 @@ spec:
         command:
           - "/bin/bash"
           - "-ecx"
-          - |
             # The use of qualified `hostname -f` is crucial:
             # Other nodes aren't able to look up the unqualified hostname.
-            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0" "--cache" "{{ .Values.CacheSize }}" "--max-sql-memory" "{{ .Values.MaxSQLMemory }}")
-            # We only want to initialize a new cluster (by omitting the join flag)
-            # if we're sure that we're the first node (i.e. index 0) and that
-            # there aren't any other nodes running as part of the cluster that
-            # this is supposed to be a part of (which indicates that a cluster
-            # already exists and we should make sure not to create a new one).
-            # It's fine to run without --join on a restart if there aren't any
-            # other nodes.
-            if [ ! "$(hostname)" == "${STATEFULSET_NAME}-0" ] || \
-               [ -e "/cockroach/cockroach-data/cluster_exists_marker" ]
-            then
-              CRARGS+=("--join" "${STATEFULSET_NAME}-public")
-            fi
-            exec /cockroach/cockroach ${CRARGS[*]}
+          - "exec /cockroach/cockroach start --logtostderr --insecure --advertise-host $(hostname -f) --http-host 0.0.0.0 --cache {{ .Values.CacheSize }} --max-sql-memory {{ .Values.MaxSQLMemory }} --join ${STATEFULSET_NAME}-0.${STATEFULSET_NAME},${STATEFULSET_NAME}-1.${STATEFULSET_NAME},${STATEFULSET_NAME}-2.${STATEFULSET_NAME}"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -125,11 +125,16 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: "{{ .Values.StorageClass }}"
     spec:
       accessModes:
         - "ReadWriteOnce"
+{{- if .Values.StorageClass }}
+{{- if (eq "-" .Values.StorageClass) }}
+      storageClassName: ""
+{{- else }}
+      storageClassName: "{{ .Values.StorageClass }}"
+{{- end }}
+{{- end }}
       resources:
         requests:
           storage: "{{ .Values.Storage }}"

--- a/stable/cockroachdb/templates/tests/client-test.yaml
+++ b/stable/cockroachdb/templates/tests/client-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-test"
+  annotations:
+    "helm.sh/hook": test-success
+{{- if and (.Values.NetworkPolicy.Enabled) (not .Values.NetworkPolicy.AllowExternal) }}
+  labels:
+    "{{.Release.Name}}-{{.Values.Component}}-client": true
+{{- end }}
+spec:
+  containers:
+  - name: "client-test"
+    image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"
+    imagePullPolicy: "{{ .Values.ImagePullPolicy }}"
+    command:
+      - "/cockroach/cockroach"
+      - "sql"
+      - "--insecure"
+      - "--host"
+      - "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-public.{{ .Release.Namespace }}"
+      - "--port"
+      - "{{ .Values.GrpcPort }}"
+      - "-e"
+      - "SHOW DATABASES;"
+  restartPolicy: Never

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -5,7 +5,7 @@
 
 Name: "cockroachdb"
 Image: "cockroachdb/cockroach"
-ImageTag: "v1.1.3"
+ImageTag: "v1.1.4"
 ImagePullPolicy: "Always"
 BootstrapImage: "cockroachdb/cockroach-k8s-init"
 BootstrapImageTag: "0.2"

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -19,7 +19,14 @@ Resources:
     cpu: "100m"
     memory: "512Mi"
 Storage: "1Gi"
-StorageClass: "anything"
+## Persistent Volume Storage Class for database data
+## If defined, storageClassName: <StorageClass>
+## If set to "-", storageClassName: "", which disables dynamic provisioning
+## If undefined or set to null, no storageClassName spec is
+##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+##   GKE, AWS & OpenStack)
+##
+StorageClass: null
 CacheSize: "25%"
 MaxSQLMemory: "25%"
 ClusterDomain: "cluster.local"


### PR DESCRIPTION
Bump the CockroachDB version to v1.1.4.

Switch from a more fragile peer-finder-based cluster initialization mechanism to using the built-in `cockroach init` command as a post-install hook.

Move from using the alpha `storageClass` annotation (which gets ignored by the latest release) to the actual `storageClass` field.

These changes have been already been in use by our non-helm Kubernetes configurations for a while now, so they're well tested.