### PR TITLE
[incubator/oauth-proxy] Add optional imagePullSecrets

### DIFF
--- a/incubator/oauth-proxy/Chart.yaml
+++ b/incubator/oauth-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth-proxy
-version: 0.1.4
+version: 0.1.5
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/incubator/oauth-proxy/README.md
+++ b/incubator/oauth-proxy/README.md
@@ -49,6 +49,7 @@ Parameter | Description | Default
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `a5huynh/oauth2_proxy`
 `image.tag` | Image tag | `2.2`
+`imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
 `ingress.enabled` | enable ingress | `false`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`

--- a/incubator/oauth-proxy/templates/deployment.yaml
+++ b/incubator/oauth-proxy/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             port: {{ .Values.service.internalPort }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
     {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/incubator/oauth-proxy/values.yaml
+++ b/incubator/oauth-proxy/values.yaml
@@ -13,6 +13,12 @@ image:
   tag: "2.2"
   pullPolicy: "IfNotPresent"
 
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# imagePullSecrets:
+  # - name: myRegistryKeySecretName
+
 extraArgs:
   email-domain: "*"
   upstream: "file:///dev/null"


### PR DESCRIPTION
This mirrors other charts usage of imagePullSecrets. This is particularly useful for Oauth Proxy because often users will prefer internal builds for security - it is also necessary to customize the templates.