### PR TITLE
[stable/spinnaker] Allow use of passwordFile and use serviceAccount for credentials

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.3.12
+version: 0.3.13
 appVersion: 1.1.0
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/configmap/spinnaker-config.yaml
+++ b/stable/spinnaker/templates/configmap/spinnaker-config.yaml
@@ -236,6 +236,7 @@ data:
       enabled: true
       accounts:
         - name: local
+          serviceAccount: true
           dockerRegistries:
             {{- range $index, $account := .Values.accounts }}
             - accountName: {{ $account.name }}


### PR DESCRIPTION
Fix 1: Includes passwordFile setting when the password **isn't** set rather than is set.
Fix 2: I am running release-1.5.x with the [clouddriver patch required for using service accounts](https://github.com/spinnaker/clouddriver/pull/2178) but this chart didn't have the serviceAccount flag correctly set. This fixes that so when the versions are upgraded it will not be an issue. 

