### PR TITLE
stable/fluent-bit: Add Merge_JSON_Log support

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.12.11
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.2.6
+version: 0.2.7
 appVersion: 0.12.11
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -24,7 +24,9 @@ data:
     [FILTER]
         Name   kubernetes
         Match  kube.*
-
+{{- if .Values.filter.mergeJSONLog }}
+        Merge_JSON_Log   On
+{{- end }}
 {{ if eq .Values.backend.type "test" }}
     [OUTPUT]
         Name  file

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -40,6 +40,11 @@ tolerations: []
 ##
 nodeSelector: {}
 
+filter: {}
+# If true, check to see if the log field content is a JSON string map, if so,
+# it append the map fields as part of the log structure.
+#  mergeJSONLog: true
+
 ## Install Default RBAC roles and bindings
 rbac:
   ## If true, create & use RBAC resources


### PR DESCRIPTION
Add the ability for fluent-bit to merge log entry content if it's also a JSON string map. 

The feature remains off by default.

Closes #2322
