### PR TITLE
[stable/postgresql] makes secretKeyRefs configureable

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.10.0
+version: 0.11.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `postgresUser`             | Username of new user to create.                 | `postgres`                                                 |
 | `postgresPassword`         | Password for the new user.                      | random 10 characters                                       |
 | `usePasswordFile`          | Inject the password via file instead of env var | `false`                                                    |
+| `secretKeyRefs`            | defines secret resource for the postgres pw     | defaults to our own `postgresPassword` secret resource   |
 | `postgresDatabase`         | Name for new database to create.                | `postgres`                                                 |
 | `postgresInitdbArgs`       | Initdb Arguments                                | `nil`                                                      |
 | `schedulerName`            | Name of an alternate scheduler                  | `nil`                                                      |

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -3,7 +3,11 @@ PostgreSQL can be accessed via port 5432 on the following DNS name from within y
 
 To get your user password run:
 
-    PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }} -o jsonpath="{.data.postgres-password}" | base64 --decode; echo)
+{{- if .Values.usePasswordFile }}
+    PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "postgresql.fullname" . | quote}} -o jsonpath="{.data.postgres-password}" | base64 --decode; echo)
+{{- else }}
+    PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ default (include "postgresql.fullname" .) .Values.secretKeyRefs.POSTGRES_PASSWORD.name | quote}} -o jsonpath={{ printf "{.data.%s}" .Values.secretKeyRefs.POSTGRES_PASSWORD.key | quote}} | base64 --decode; echo)
+{{- end }}
 
 To connect to your database run the following command (using the env variable from above):
 

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -34,3 +34,23 @@ Return the appropriate apiVersion for networkpolicy.
 "networking.k8s.io/v1"
 {{- end -}}
 {{- end -}}
+
+{{/*
+    generates a yaml secretKeyRef env structure and expects the following structure as input (dict):
+    ```
+    secretKeyRefs:
+        <container-env-var-name>:
+            name: <secret resource name> (optional, defaults to postgresql.fullname as secret resource name)
+            key: <secret resource entry>
+    ```
+*/}}
+{{- define "postgresql.secretKeyRefs" -}}
+{{- $global := . -}}
+{{- range $k, $v := .Values.secretKeyRefs }}
+- name: {{ $k | upper | quote }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (include "postgresql.fullname" $global) $v.name | quote }}
+      key: {{ $v.key | quote }}
+{{- end -}}
+{{- end -}}

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -52,13 +52,8 @@ spec:
         {{- if .Values.usePasswordFile }}
         - name: POSTGRES_PASSWORD_FILE
           value: /conf/postgres-password
-        {{- else }}
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "postgresql.fullname" . }}
-              key: postgres-password
         {{- end }}
+        {{- include "postgresql.secretKeyRefs" . | indent 8 }}
         - name: POD_IP
           valueFrom: { fieldRef: { fieldPath: status.podIP } }
         ports:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -22,7 +22,23 @@ imageTag: "9.6.2"
 ## Default: random 10 character string
 # postgresPassword:
 
+# Define where postgresql should get its secrets from.
+# On default, it uses the generated secret by itself, but changing `secretKeyRefs` allows you
+# to get the data from your own secret resource.
+#
+# Syntax:
+# ```
+# secretKeyRefs:
+#   <container-env-var-name>:
+#     name: <secret resource name> (optional, defaults to postgresqls charts secret as resource name)
+#     key: <secret resource entry>
+# ```
+secretKeyRefs: {}
+#  POSTGRES_PASSWORD:
+#    key: postgres-password
+
 ## Inject postgresPassword via a volume mount instead of environment variable
+# Be aware, that you need to drop the above secretKeyRefs.POSTGRES_PASSWORD as well!
 usePasswordFile: false
 
 ## Create a database


### PR DESCRIPTION
Changeclass: minor - backward compatible

**WHY**
We are using the `postgresql` chart by some other charts. In order to allow an out-of-the-box experience for our users, we need to control the generated secrets used by this chart, so we can generate random secrets and still can provide a nothing-needs-to-be-changed-on-default experience. As discussed in https://github.com/kubernetes/helm/issues/2196#issuecomment-293738730 I don't know a way to resolve secrets on template resolution time; so this is an idea I came up with to solve this until there is a better way.

**Behaviour**
This commit is non-disruptive to the userbase, as it defaults to
the current behaviour. I does not fix a bug, but instead extends the functionality.

**Testing**
* `helm lint` is fine
* `helm install --name tester .` is fine (also checked the commands generated in NOTES.txt)
* `helm template --name tester .` seems to be fine too

I'm very interested in your feedback! Is this an acceptable approach to achieve the goal of getting secrets defined externally? How do you handle those kind of issues?

Kind regards
Tony

Related to https://github.com/kubernetes/charts/pull/3378