### PR TITLE
[stable/kube-lego] kube-lego is in maintenance mode, in favor of cert-manager

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,15 +1,12 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.3.0
+version: 0.1.13
+# The kube-lego chart is deprecated and no longer maintained.
+deprecated: true
 keywords:
 - kube-lego
 - letsencrypt
 sources:
 - https://github.com/jetstack/kube-lego/tree/master/examples/nginx
-maintainers:
-  - name: jackzampolin
-    email: jack.zampolin@gmail.com
-  - name: mgoodness
-    email: mgoodness@gmail.com
 engine: gotpl

--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.1.13
+version: 0.4.0
 # The kube-lego chart is deprecated and no longer maintained.
 deprecated: true
 keywords:

--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: Automatically requests certificates from Let's Encrypt
+description: DEPRECATED Automatically requests certificates from Let's Encrypt
 name: kube-lego
 version: 0.4.0
 # The kube-lego chart is deprecated and no longer maintained.

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -6,7 +6,7 @@
 >
 >  kube-lego is in maintenance mode only. There is no plan to support any new
 >  features. The latest Kubernetes release that kube-lego officially supports
->  is **1.8**.  The officially endorsed successor is **[cert-manager](https://github.com/jetstack/cert-manager/)**.
+>  is **1.8**.  The officially endorsed successor is **[cert-manager](https://hub.kubeapps.com/charts/stable/cert-manager)**.
 >
 >  If you are a current user of kube-lego, you can find a migration guide [here](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/migrating-from-kube-lego.md).
 >

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -2,6 +2,16 @@
 
 [kube-lego](https://github.com/jetstack/kube-lego) automatically requests certificates for Kubernetes Ingress resources from Let's Encrypt.
 
+>  :warning:
+>
+>  kube-lego is in maintenance mode only. There is no plan to support any new
+>  features. The latest Kubernetes release that kube-lego officially supports
+>  is **1.8**.  The officially endorsed successor is **[cert-manager](https://github.com/jetstack/cert-manager/)**.
+>
+>  If you are a current user of kube-lego, you can find a migration guide [here](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/migrating-from-kube-lego.md).
+>
+>  :warning:
+
 ## TL;DR;
 
 ```console

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -30,8 +30,9 @@ This chart bootstraps a kube-lego deployment on a [Kubernetes](http://kubernetes
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/kube-lego
+$ helm install --name my-release stable/kube-lego --set config.LEGO_EMAIL=my@email.tld
 ```
+**NOTE:** `config.LEGO_EMAIL` is required
 
 The command deploys kube-lego on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 

--- a/stable/kube-lego/templates/NOTES.txt
+++ b/stable/kube-lego/templates/NOTES.txt
@@ -1,5 +1,10 @@
 This chart installs kube-lego to generate TLS certs for Ingresses.
 
+NOTE:
+> kube-lego is in maintenance mode only. There is no plan to support any new
+>  features. The officially endorsed successor is cert-manager
+>  https://hub.kubeapps.com/charts/stable/cert-manager
+
 EXAMPLE INGRESS YAML:
 
 apiVersion: extensions/v1beta1

--- a/stable/kube-lego/templates/deployment.yaml
+++ b/stable/kube-lego/templates/deployment.yaml
@@ -33,7 +33,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-          # {{ required "config.LEGO_EMAIL is a required field" .Values.config.LEGO_EMAIL }}
           {{- range $key, $value := .Values.config }}
             - name: "{{ $key }}"
               value: "{{ $value }}"

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -5,7 +5,7 @@ config:
   ## Email address to use for registration with Let's Encrypt
   ##
   # LEGO_EMAIL: my@email.tld
-  LEGO_EMAIL: foo@example.com
+  LEGO_EMAIL:
 
   ## Let's Encrypt API endpoint
   ## Production: https://acme-v01.api.letsencrypt.org/directory

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -4,8 +4,7 @@
 config:
   ## Email address to use for registration with Let's Encrypt
   ##
-  # LEGO_EMAIL: my@email.tld
-  LEGO_EMAIL:
+  LEGO_EMAIL: foo@example.com
 
   ## Let's Encrypt API endpoint
   ## Production: https://acme-v01.api.letsencrypt.org/directory


### PR DESCRIPTION
[adding note to documentation to reflect note in parent repo: https://github.com/jetstack/kube-lego]