### PR TITLE
[incubator/patroni] updates etcd dependency to latest version 0.3.6

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.5
+version: 0.5.1
 appVersion: 1.2-p17
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/requirements.lock
+++ b/incubator/patroni/requirements.lock
@@ -1,14 +1,9 @@
 dependencies:
 - name: etcd
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  tags: null
-  version: 0.2.1
-- condition: ""
-  enabled: false
-  import-values: null
-  name: zookeeper
+  version: 0.3.6
+- name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  tags: null
   version: 0.2.2
-digest: sha256:eb2ad7cb8f0f4dbf1e6b9a79e3a408a814240a4579d77f4b35b87029b8b04b2c
-generated: 2017-10-23T12:09:56.47159975+01:00
+digest: sha256:af5cb9f406a215c54c5b34cfa19091f80ef73a453ee53017767eab5c319e9f51
+generated: 2018-01-22T14:04:57.901835+01:00

--- a/incubator/patroni/requirements.yaml
+++ b/incubator/patroni/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: etcd
-  version: 0.2.1
+  version: 0.3.6
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: Etcd.DeployChart
 - name: zookeeper


### PR DESCRIPTION
Change class: **minor/patch** (it neither adds features, nor fixes bugs; but keeps etcd up-to-date)

Updates the etcd in `requirements.yaml` from `0.2.2` to latest `0.3.6`. This version bump doesn't affect patroni, as far as I can tell (especially because etcd itself remains version `2.2.5`). But the etcd chart fixes some k8s deprecations.

**Testing**
* `helm lint` is fine
* `helm install --name=tester .` is fine

**Note**
The `helm dep up` also removed some lines from `requirements.lock`; I don't think this is bad - but I would like to have a double check on this :)

Kind regards
Tony