### PR TITLE
[stable/kube2iam] Add liveness probe

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.7.0
+version: 0.8.0
 description: Provide IAM credentials to pods based on annotations.
 keywords:
 - kube2iam

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -55,7 +55,6 @@ Parameter | Description | Default
 `resources` | pod resource requests & limits | `{}`
 `updateStrategy` | Strategy for DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
 `verbose` | Enable verbose output | `false`
-`livenessProbeEnabled` | Enable liveness probe | `true`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -55,7 +55,7 @@ Parameter | Description | Default
 `resources` | pod resource requests & limits | `{}`
 `updateStrategy` | Strategy for DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
 `verbose` | Enable verbose output | `false`
-
+`livenessProbeEnabled` | Enable liveness probe | `true`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -37,6 +37,7 @@ spec:
           {{- if .Values.verbose }}
             - --verbose
           {{- end }}
+            - --app-port={{ .Values.host.port }}
           env:
             - name: HOST_IP
               valueFrom:

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -61,7 +61,6 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.host.port }}
-          {{- if .Values.livenessProbeEnabled }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -72,7 +71,6 @@ spec:
             successThreshold: 1
             failureThreshold: 3
             timeoutSeconds: 1
-          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         {{- if .Values.host.iptables }}

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -59,7 +59,19 @@ spec:
               value: {{ .Values.aws.region }}
           {{- end }}
           ports:
-            - containerPort: 8181
+            - containerPort: {{ .Values.host.port }}
+          {{- if .Values.livenessProbeEnabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.host.port }}
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: 1
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         {{- if .Values.host.iptables }}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -15,8 +15,6 @@ image:
   tag: 0.9.0
   pullPolicy: IfNotPresent
 
-livenessProbeEnabled: true
-
 # AWS Access keys to inject as environment variables
 aws:
   secret_key: ""

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -8,11 +8,14 @@ host:
   ip: $(HOST_IP)
   iptables: false
   interface: docker0
+  port: 8181
 
 image:
   repository: jtblin/kube2iam
   tag: 0.9.0
   pullPolicy: IfNotPresent
+
+livenessProbeEnabled: true
 
 # AWS Access keys to inject as environment variables
 aws:


### PR DESCRIPTION
Hey - I recently had a problem where kube2iam pods went unresponsive and ec2 metadata requests were left hanging - restarting the failed pods resolved the issue.

I'd like to get Kubernetes to do that for me so have added a liveness check to use the `/healthz` resource, introduced in https://github.com/jtblin/kube2iam/issues/26

Thanks for taking a look!