### PR TITLE
[stable/postgresql] Add persistence.mountPath parameter

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.8.7
+version: 0.8.8
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -60,6 +60,7 @@ The following tables lists the configurable parameters of the PostgresSQL chart 
 | `persistence.annotations`  | Persistent Volume annotations                   | `{}`                                                       |
 | `persistence.size`         | Size of data volume                             | `8Gi`                                                      |
 | `persistence.subPath`      | Subdirectory of the volume to mount at          | `postgresql-db`                                            |
+| `persistence.mountPath`    | Mount path of data volume                       | `/var/lib/postgresql/data/pgdata`                          |
 | `resources`                | CPU/Memory resource requests/limits             | Memory: `256Mi`, CPU: `100m`                               |
 | `metrics.enabled`          | Start a side-car prometheus exporter            | `false`                                                    |
 | `metrics.image`            | Exporter image                                  | `wrouesnel/postgres_exporter`                              |

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: data
-          mountPath: /var/lib/postgresql/data/pgdata
+          mountPath: {{ .Values.persistence.mountPath }}
           subPath: {{ .Values.persistence.subPath }}
 {{- if .Values.metrics.enabled }}
       - name: metrics

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -51,6 +51,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
   subPath: "postgresql-db"
+  mountPath: /var/lib/postgresql/data/pgdata
 
   # annotations: {}
 


### PR DESCRIPTION
This allows to mount the volume in `/var/lib/postgresql/data` for example instead of `/var/lib/postgresql/data/pgdata`. This is mandatory if the user starting the `postgres` image is not the owner of `/var/lib/postgresql/data/pgdata` but only has write access to it.
    
With this patch, the entrypoint will create `/var/lib/postgresql/data` with the user that launched the container as owner and initdb will be happy.
