### PR TITLE
External-dns improve azure support

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.4.4
-appVersion: 0.4.5
+version: 0.4.5
+appVersion: 0.4.8
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
 - https://github.com/kubernetes-incubator/external-dns

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: ClusterRole
 metadata:
   labels: {{ include "external-dns.labels" . | indent 4 }}

--- a/stable/external-dns/templates/clusterrolebinding.yaml
+++ b/stable/external-dns/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
 kind: ClusterRoleBinding
 metadata:
   labels: {{ include "external-dns.labels" . | indent 4 }}

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -42,7 +42,14 @@ spec:
           {{- if .Values.aws.zoneType }}
             - --aws-zone-type={{ .Values.aws.zoneType }}
           {{- end }}
+          volumeMounts:
+          {{- if eq .Values.provider "azure" }}
+          - name: azure-config-file
+            mountPath: /etc/kubernetes/azure.json
+            readOnly: true
+          {{- end }}
           env:
+        {{- if eq .Values.provider "aws" }}
         {{- if and .Values.aws.secretKey .Values.aws.accessKey }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
@@ -68,6 +75,7 @@ spec:
           - name: CF_API_EMAIL
             value: "{{ .Values.cloudflare.email }}"
         {{- end }}
+        {{- end }}
         {{- $root := . -}}
         {{- range $key, $value := .Values.extraEnv }}
           - name: {{ $key }}
@@ -86,6 +94,13 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         {{- end }}
+      volumes:
+      {{- if eq .Values.provider "azure" }}
+      - name: azure-config-file
+        hostPath:
+          path: /etc/kubernetes/azure.json
+          type: File
+      {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -1,7 +1,7 @@
 ## Details about the image to be pulled.
 image:
   name: registry.opensource.zalan.do/teapot/external-dns
-  tag: v0.4.5
+  tag: v0.4.8
 
   pullPolicy: IfNotPresent
 

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -69,6 +69,8 @@ rbac:
   ## If true, create & use RBAC resources
   ##
   create: false
+  # Beginning with Kubernetes 1.8, the api is stable and v1 can be used.
+  apiVersion: v1beta
 
   ## Ignored if rbac.create is true
   ##

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -15,7 +15,7 @@ sources:
 publishInternalServices: false
 
 ## The DNS provider where the DNS records will be created (options: aws, google, inmemory, azure )
-provider: azure
+provider: aws
 
 # AWS Access keys to inject as environment variables
 aws:

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -15,7 +15,7 @@ sources:
 publishInternalServices: false
 
 ## The DNS provider where the DNS records will be created (options: aws, google, inmemory, azure )
-provider: aws
+provider: azure
 
 # AWS Access keys to inject as environment variables
 aws:


### PR DESCRIPTION
* Automatically mount the azure configuration as VolumeMount when using azure as provider.
* Bump external chart to latest stable version (0.4.8)
* Make RBAC api version configurable