### PR TITLE
[incubator/zookeeper] Makes zookeeper updateStrategy configurable

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.4.3
+version: 0.4.4
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -66,6 +66,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `servers` | The number of ZooKeeper servers. This should always be (1,3,5, or 7) | `3` |
+| `updateStrategy` | The ZooKeeper StatefulSet update strategy. | `{ type: "OnDelete" }` |
 | `minAvailable` | The minimum number of servers that must be available during evictions. This should in the interval `[(servers/2) + 1,(servers - 1)]`. | `servers-1` |
 | `resources.requests.cpu` | The amount of CPU to request. As ZooKeeper is not very CPU intensive, `2` is a good choice to start with for a production deployment. | `500m` |
 | `heap` | The amount of JVM heap that the ZooKeeper servers will use. As ZooKeeper stores all of its data in memory, this value should reflect the size of your working set. The JVM -Xms/-Xmx format is used. |`2G` |

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   serviceName: {{ template "zookeeper.fullname" . }}-headless
   replicas: {{ .Values.servers }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
   template:
     metadata:
       labels:

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -3,6 +3,8 @@
 # Declare name/value pairs to be passed into your templates.
 # name: value
 servers: 3
+updateStrategy:
+  type: "OnDelete"
 # minAvailable: 2
 resources:
   requests:


### PR DESCRIPTION
`RollingUpdate` useful so that `kubectl rollout status` works correctly. Partitioned updates useful for eg canary deploys.