### PR TITLE
Add jetstack/cert-manager helm chart

### DIFF
--- a/stable/cert-manager/.helmignore
+++ b/stable/cert-manager/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -11,5 +11,5 @@ keywords:
 sources:
   - https://github.com/jetstack/cert-manager
 maintainers:
-  - name: James Munnelly
+  - name: munnerz
     email: james@jetstack.io

--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -10,3 +10,6 @@ keywords:
   - tls
 sources:
   - https://github.com/jetstack/cert-manager
+maintainers:
+  - name: James Munnelly
+    email: james@jetstack.io

--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,0 +1,12 @@
+name: cert-manager
+version: 0.2.1
+appVersion: 0.2.3
+description: A Helm chart for cert-manager
+home: https://github.com/jetstack/cert-manager
+keywords:
+  - cert-manager
+  - kube-lego
+  - letsencrypt
+  - tls
+sources:
+  - https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/OWNERS
+++ b/stable/cert-manager/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- munnerz
+reviewers:
+- munnerz
+- unguiculus

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -1,0 +1,74 @@
+# cert-manager
+
+cert-manager is a Kubernetes addon to automate the management and issuance of
+TLS certificates from various issuing sources.
+
+It will ensure certificates are valid and up to date periodically, and attempt
+to renew certificates at an appropriate time before expiry.
+
+## TL;DR;
+
+```console
+$ helm install .
+```
+
+## Introduction
+
+This chart creates a cert-manager deployment on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+- Kubernetes cluster with support for CustomResourceDefinition or ThirdPartyResource
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release .
+```
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables lists the configurable parameters of the cert-manager chart and their default values.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
+| `image.tag` | Image tag | `v0.2.3` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `replicaCount`  | Number of cert-manager replicas  | `1` |
+| `createCustomResource` | Create CRD/TPR with this release | `true` |
+| `extraArgs` | Optional flags for cert-manager | `[]` |
+| `rbac.create` | If `true`, create and use RBAC resources | `true`
+| `serviceAccount.create` | If `true`, create a new service account | `true`
+| `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
+| `resources` | CPU/memory resource requests/limits | `requests: {cpu: 10m, memory: 32Mi}` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `ingressShim.enabled` | Enable ingress-shim for automatic ingress integration | `true`|
+| `ingressShim.extraArgs` | Optional flags for ingress-shim | `[]` |
+| `ingressShim.resources` | CPU/memory resource requests/limits for ingress-shim | `requests: {cpu: 10m, memory: 32Mi}` |
+| `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
+| `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
+| `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml .
+```
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -6,10 +6,13 @@ TLS certificates from various issuing sources.
 It will ensure certificates are valid and up to date periodically, and attempt
 to renew certificates at an appropriate time before expiry.
 
+Changes to this chart are tested and version in the [upstream cert-manager repository](https://github.com/jetstack/cert-manager).
+Changes to this chart should be made as pull requests upstream, to be versioned and copied across to this repo.
+
 ## TL;DR;
 
 ```console
-$ helm install .
+$ helm install stable/cert-manager
 ```
 
 ## Introduction

--- a/stable/cert-manager/templates/NOTES.txt
+++ b/stable/cert-manager/templates/NOTES.txt
@@ -1,0 +1,5 @@
+cert-manager has been deployed successfully!
+
+You may now go ahead and create issuers and certificates.
+
+See https://github.com/jetstack/cert-manager/blob/master/docs/README.md

--- a/stable/cert-manager/templates/NOTES.txt
+++ b/stable/cert-manager/templates/NOTES.txt
@@ -2,4 +2,4 @@ cert-manager has been deployed successfully!
 
 You may now go ahead and create issuers and certificates.
 
-See https://github.com/jetstack/cert-manager/blob/master/docs/README.md
+See https://github.com/jetstack/cert-manager/blob/v0.2.3/docs/README.md

--- a/stable/cert-manager/templates/_helpers.tpl
+++ b/stable/cert-manager/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cert-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cert-manager.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $fullname := printf "%s-%s" $name .Release.Name -}}
+{{- default $fullname .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cert-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cert-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cert-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/cert-manager/templates/certificate-crd.yaml
+++ b/stable/cert-manager/templates/certificate-crd.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.createCustomResource -}}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Certificate
+    plural: certificates
+  scope: Namespaced
+{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1"  }}
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: certificate.certmanager.k8s.io
+description: "A specification for a cert-manager certificate"
+versions:
+  - name: v1alpha1
+{{- end -}}
+{{- end -}}

--- a/stable/cert-manager/templates/clusterissuer-crd.yaml
+++ b/stable/cert-manager/templates/clusterissuer-crd.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.createCustomResource -}}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+{{- end -}}
+{{- end -}}

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "cert-manager.fullname" . }}
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "cert-manager.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.extraArgs }}
+          args:
+{{ toYaml .Values.extraArgs | indent 12 }}
+        {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.ingressShim.enabled }}
+        - name: ingress-shim
+          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
+        {{- if .Values.ingressShim.extraArgs }}
+          args:
+{{ toYaml .Values.ingressShim.extraArgs | indent 12 }}
+        {{- end }}
+          resources:
+{{ toYaml .Values.ingressShim.resources | indent 12 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}

--- a/stable/cert-manager/templates/issuer-crd.yaml
+++ b/stable/cert-manager/templates/issuer-crd.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.createCustomResource -}}
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: issuer.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+description: "A specification for a cert-manager issuer"
+versions:
+  - name: v1alpha1
+{{- end -}}
+{{- end -}}

--- a/stable/cert-manager/templates/rbac.yaml
+++ b/stable/cert-manager/templates/rbac.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "cert-manager.fullname" . }}
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "issuers", "clusterissuers"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["secrets", "events", "endpoints", "services", "pods"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "cert-manager.fullname" . }}
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "cert-manager.fullname" . }}
+subjects:
+  - name: {{ template "cert-manager.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end -}}

--- a/stable/cert-manager/templates/serviceaccount.yaml
+++ b/stable/cert-manager/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cert-manager.serviceAccountName" . }}
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -27,10 +27,10 @@ extraArgs: []
   # supporting resources required for each ClusterIssuer (default is kube-system)
   # - --cluster-resource-namespace=kube-system
 
-resources:
-  requests:
-    cpu: 10m
-    memory: 32Mi
+resources: {}
+  # requests:
+  #   cpu: 10m
+  #   memory: 32Mi
 
 nodeSelector: {}
 
@@ -40,10 +40,10 @@ ingressShim:
   # Optional additional arguments for ingress-shim
   extraArgs: []
 
-  resources:
-    requests:
-      cpu: 10m
-      memory: 32Mi
+  resources: {}
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
 
   image:
     repository: quay.io/jetstack/cert-manager-ingress-shim

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -1,0 +1,55 @@
+# Default values for cert-manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+image:
+  repository: quay.io/jetstack/cert-manager-controller
+  tag: v0.2.3
+  pullPolicy: IfNotPresent
+
+createCustomResource: true
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+# Optional additional arguments
+extraArgs: []
+  # Use this flag to set a namespace that cert-manager will use to store
+  # supporting resources required for each ClusterIssuer (default is kube-system)
+  # - --cluster-resource-namespace=kube-system
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+nodeSelector: {}
+
+ingressShim:
+  enabled: true
+
+  # Optional additional arguments for ingress-shim
+  extraArgs: []
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+
+  image:
+    repository: quay.io/jetstack/cert-manager-ingress-shim
+
+    # Defaults to image.tag.
+    # You should only change this if you know what you are doing!
+    # tag: v0.2.3
+
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
After the work by @unguiculus to improve our helm chart for cert-manager to follow best practices, I'd like to submit it upstream to be a part of the stable Helm chart repository.

We use our Helm charts as part of e2e testing, so if possible it'd be ideal for changes to the chart to be made upstream in our own repo before rolling them out into kubernetes/charts. I'm looking at how this can be automated, or at least made easier. For the time being I think a client side script to generate PRs against `kubernetes/charts` for each tagged release will suffice.

I've added a notice in the README of this chart to reflect this, I hope that's okay, and I wonder if any other charts do a similar thing that I can borrow some wisdom from?