### PR TITLE
[incubator/vault] Add Kubernetes auth backend to Vault

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.4.2
-appVersion: 0.9.0
+version: 0.4.3
+appVersion: 0.9.6
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -70,3 +70,16 @@ $ kubectl port-forward vault-pod 8200
 $ export VAULT_ADDR=http://127.0.0.1:8200
 $ vault status
 ```
+
+Try the Kubernetes authentication backend:
+
+```console
+export VAULT_ADDR=http://vault-service:8200
+
+# With the CLI
+vault write auth/kubernetes/login role=demo jwt=@/var/run/secrets/kubernetes.io/serviceaccount/token
+
+# Or with cURL
+curl -s $VAULT_ADDR/v1/auth/kubernetes/login -d \
+"{ \"jwt\": \"$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\", \"role\": \"default\" }" | jq
+ ```

--- a/incubator/vault/templates/clusterrolebinding.yaml
+++ b/incubator/vault/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.vault.kubernetesAuth -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vault.fullname" . }}
+  labels:
+    app: {{ template "vault.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -24,6 +24,26 @@ spec:
         {{- else }}
         command: ["vault", "server", "-config", "/vault/config/config.json"]
         {{- end }}
+        {{- if .Values.vault.kubernetesAuth }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - "/bin/sh"
+              - "-c"
+              - sleep 5
+                && vault auth-enable kubernetes
+                && vault write auth/kubernetes/config token_reviewer_jwt=@/var/run/secrets/kubernetes.io/serviceaccount/token kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt kubernetes_host=https://${KUBERNETES_SERVICE_HOST}
+                {{- range .Values.vault.policies }}
+                && vault write sys/policy/{{ .name }} rules='{{ .rules }}'
+                {{- end }}
+                {{- range .Values.vault.roles }}
+                && vault write auth/kubernetes/role/{{ .name }} bound_service_account_names={{ .bound_service_account_names }} bound_service_account_namespaces={{ .bound_service_account_namespaces }} policies={{ .policies }} ttl={{ .ttl }}
+                {{- end }}
+        {{- end }}
+        env:
+          - name: VAULT_ADDR
+            value: http://[::]:8200
         ports:
         - containerPort: {{ .Values.service.port }}
         livenessProbe:
@@ -52,6 +72,7 @@ spec:
       affinity:
 {{ tpl .Values.affinity . | indent 8 }}
       {{- end }}
+      serviceAccountName: {{ template "vault.fullname" . }}
       volumes:
         - name: vault-config
           configMap:

--- a/incubator/vault/templates/serviceaccount.yaml
+++ b/incubator/vault/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "vault.fullname" . }}
+  labels:
+    app: {{ template "vault.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: vault
-  tag: 0.9.0
+  tag: 0.9.1
   pullPolicy: IfNotPresent
 service:
   name: vault
@@ -62,6 +62,29 @@ vault:
   customSecrets: []
     # - secretName: vault-tls
     #   mountPath: /vault/tls
+  # Only used to enable the Kubernetes auth backend that can be used to authenticate
+  # with Vault using a Kubernetes Service Account Token. When in set to false, policies
+  # and roles is not used to configure Vault.
+  kubernetesAuth: true
+  # Allows creating policies in Vault which can be used later on in roles
+  # for the Kubernetes based authentication.
+  # See https://www.vaultproject.io/docs/concepts/policies.html for more information.
+  policies:
+    - name: allow_secrets
+      rules: path "secret/*" {
+              capabilities = ["create", "read", "update", "delete", "list"]
+             }
+  # Allows creating roles in Vault which can be used later on for the Kubernetes based
+  # authentication.
+  # See https://www.vaultproject.io/docs/auth/kubernetes.html#creating-a-role for
+  # more information.
+  roles:
+    # Allow every pod in the default namespace to use the secret kv store
+    - name: default
+      bound_service_account_names: default
+      bound_service_account_namespaces: default
+      policies: allow_secrets
+      ttl: 1h
   config:
     # A YAML representation of a final vault config.json file.
     # See https://www.vaultproject.io/docs/configuration/ for more information.


### PR DESCRIPTION
This change basically enables and configures the Kubernetes Auth Backend in Vault. See https://www.vaultproject.io/docs/auth/kubernetes.html