### PR TITLE
[incubator/kube-spot-termination-notice-handler] Fix missing CLUSTER variable for Slack

### DIFF
--- a/incubator/kube-spot-termination-notice-handler/Chart.yaml
+++ b/incubator/kube-spot-termination-notice-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Watch and action AWS spot termination events
 name: kube-spot-termination-notice-handler
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/egeland/kube-spot-termination-notice-handler
 source:
   - https://hub.docker.com/r/egeland/kube-spot-termination-notice-handler/

--- a/incubator/kube-spot-termination-notice-handler/README.md
+++ b/incubator/kube-spot-termination-notice-handler/README.md
@@ -26,5 +26,6 @@ You may set these options in your values file:
 
 * `slackUrl` - optional - put a slack webhook URL here to get messaged when a termination notice is received.
 
-* `pollInterval` - how often to query the EC2 metadata for termination notices. Defaults to every `5` seconds.
+* `clusterName` - optional - when slack is configured use this cluster name for reports
 
+* `pollInterval` - how often to query the EC2 metadata for termination notices. Defaults to every `5` seconds.

--- a/incubator/kube-spot-termination-notice-handler/templates/daemonset.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/daemonset.yaml
@@ -29,6 +29,8 @@ spec:
             {{- end }}
             - name: POLL_INTERVAL
               value: {{ .Values.pollInterval | quote }}
+            - name: CLUSTER
+              value: {{ .Values.clusterName | quote }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/incubator/kube-spot-termination-notice-handler/values.yaml
+++ b/incubator/kube-spot-termination-notice-handler/values.yaml
@@ -9,8 +9,11 @@ image:
 # Poll the metadata every pollInterval seconds for termination events:
 pollInterval: 5
 
-## Send notifications to a Slack webhook URL - replace with your own value and uncomment:
+# Send notifications to a Slack webhook URL - replace with your own value and uncomment:
 # slackUrl: https://hooks.slack.com/services/EXAMPLE123/EXAMPLE123/example1234567
+
+# Set the cluster name to be reported in a Slack message
+# clusterName: test
 
 # Silence logspout by default - set to true to enable logs arriving in logspout
 enableLogspout: false


### PR DESCRIPTION
This fixes the following warning:
`Environment variable CLUSTER has no name set. You can set this to get it reported in the Slack message.`

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
