### PR TITLE
[stable/rethinkdb] Support rbac

### DIFF
--- a/stable/rethinkdb/Chart.yaml
+++ b/stable/rethinkdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: rethinkdb
 description: The open-source database for the realtime web
-version: 0.1.0
+version: 0.1.1
 keywords:
 - rethinkdb
 - database

--- a/stable/rethinkdb/templates/_helpers.tpl
+++ b/stable/rethinkdb/templates/_helpers.tpl
@@ -14,3 +14,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rethinkdb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rethinkdb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "rethinkdb.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/rethinkdb/templates/auth/clusterrole.yaml
+++ b/stable/rethinkdb/templates/auth/clusterrole.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: {{ template "rethinkdb.fullname" . }}
+  labels:
+    app: {{ template "rethinkdb.name" . }}
+    chart: {{ template "rethinkdb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/stable/rethinkdb/templates/auth/clusterrole.yaml
+++ b/stable/rethinkdb/templates/auth/clusterrole.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "rethinkdb.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/stable/rethinkdb/templates/auth/clusterrolebinding.yaml
+++ b/stable/rethinkdb/templates/auth/clusterrolebinding.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "rethinkdb.fullname" . }}
+  labels:
+    app: {{ template "rethinkdb.name" . }}
+    chart: {{ template "rethinkdb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/rethinkdb/templates/auth/clusterrolebinding.yaml
+++ b/stable/rethinkdb/templates/auth/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "rethinkdb.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "rethinkdb.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "rethinkdb.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/rethinkdb/templates/auth/clusterrolebinding.yaml
+++ b/stable/rethinkdb/templates/auth/clusterrolebinding.yaml
@@ -9,6 +9,6 @@ roleRef:
   name: {{ template "rethinkdb.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "rethinkdb.fullname" . }}
+    name: {{ template "rethinkdb.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/rethinkdb/templates/auth/serviceaccount.yaml
+++ b/stable/rethinkdb/templates/auth/serviceaccount.yaml
@@ -1,6 +1,11 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "rethinkdb.fullname" . }}
+  name: {{ template "rethinkdb.serviceAccountName" . }}
+  labels:
+    app: {{ template "rethinkdb.name" . }}
+    chart: {{ template "rethinkdb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 {{- end -}}

--- a/stable/rethinkdb/templates/auth/serviceaccount.yaml
+++ b/stable/rethinkdb/templates/auth/serviceaccount.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "rethinkdb.fullname" . }}
+{{- end -}}

--- a/stable/rethinkdb/templates/rethinkdb-admin-service.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-admin-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ template "rethinkdb.fullname" . }}-admin"
   labels:
     app: "{{ template "rethinkdb.name" . }}-admin"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "rethinkdb.chart" . }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 spec:

--- a/stable/rethinkdb/templates/rethinkdb-cluster-service.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-cluster-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ template "rethinkdb.fullname" . }}-cluster"
   labels:
     app: "{{ template "rethinkdb.name" . }}-cluster"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "rethinkdb.chart" . }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
   annotations:

--- a/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
@@ -23,7 +23,7 @@ spec:
 {{ toYaml .Values.cluster.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "rethinkdb.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ template "rethinkdb.serviceAccountName" . }}
       containers:
         - name: {{ template "rethinkdb.name" . }}-cluster
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
@@ -23,6 +23,7 @@ spec:
 {{ toYaml .Values.cluster.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "rethinkdb.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ template "rethinkdb.name" . }}-cluster
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-cluster-stateful-set.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ template "rethinkdb.fullname" . }}-cluster"
   labels:
     app: "{{ template "rethinkdb.name" . }}-cluster"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "rethinkdb.chart" . }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 spec:
@@ -17,7 +17,7 @@ spec:
         app: "{{ template "rethinkdb.name" . }}-cluster"
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ template "rethinkdb.chart" . }}
       annotations:
       {{- if .Values.cluster.podAnnotations }}
 {{ toYaml .Values.cluster.podAnnotations | indent 8 }}

--- a/stable/rethinkdb/templates/rethinkdb-cluster-storage-class.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-cluster-storage-class.yaml
@@ -8,7 +8,7 @@ kind: StorageClass
 metadata:
   labels:
     app: "{{ template "rethinkdb.name" . }}-cluster"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "rethinkdb.chart" . }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
   name: {{ template "rethinkdb.fullname" . }}

--- a/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
@@ -22,7 +22,7 @@ spec:
 {{ toYaml .Values.proxy.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "rethinkdb.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ template "rethinkdb.serviceAccountName" . }}
       containers:
         - name: {{ template "rethinkdb.name" . }}-proxy
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
@@ -22,6 +22,7 @@ spec:
 {{ toYaml .Values.proxy.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "rethinkdb.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ template "rethinkdb.name" . }}-proxy
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-proxy-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "{{ template "rethinkdb.fullname" . }}-proxy"
   labels:
     app: "{{ template "rethinkdb.name" . }}-proxy"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "rethinkdb.chart" . }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
 spec:
@@ -16,7 +16,7 @@ spec:
         app: {{ template "rethinkdb.name" . }}-proxy
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ template "rethinkdb.chart" . }}
       annotations:
       {{- if .Values.proxy.podAnnotations }}
 {{ toYaml .Values.proxy.podAnnotations | indent 8 }}

--- a/stable/rethinkdb/templates/rethinkdb-proxy-service.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-proxy-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "rethinkdb.fullname" . }}-proxy
   labels:
     app: {{ template "rethinkdb.name" . }}-proxy
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    chart: {{ template "rethinkdb.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:

--- a/stable/rethinkdb/templates/rethinkdb-secrets.yaml
+++ b/stable/rethinkdb/templates/rethinkdb-secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "rethinkdb.fullname" . }}
   labels:
     app: {{ template "rethinkdb.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "rethinkdb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/rethinkdb/values.yaml
+++ b/stable/rethinkdb/values.yaml
@@ -75,5 +75,12 @@ ports:
 rethinkdbPassword: rethinkdb
 
 rbac:
-  create: false
-  serviceAccountName: default
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:

--- a/stable/rethinkdb/values.yaml
+++ b/stable/rethinkdb/values.yaml
@@ -73,3 +73,7 @@ ports:
 
 # RethinkDB Admin Password
 rethinkdbPassword: rethinkdb
+
+rbac:
+  create: false
+  serviceAccountName: default

--- a/stable/rethinkdb/values.yaml
+++ b/stable/rethinkdb/values.yaml
@@ -25,7 +25,7 @@ cluster:
   persistentVolume:
     enabled: true
     # If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-    #storageClass: fast
+    # storageClass: fast
     accessModes:
       - ReadWriteOnce
     size: 1Gi
@@ -68,8 +68,8 @@ proxy:
 # RethinkDB Ports
 ports:
   cluster: 29015
-  driver:  28015
-  admin:   8080
+  driver: 28015
+  admin: 8080
 
 # RethinkDB Admin Password
 rethinkdbPassword: rethinkdb


### PR DESCRIPTION
Uses default ServiceAccount by default or creates a new one with permissions to get/list/watch endpoints since the init.sh script requires this to find other rethinkdb instances