### PR TITLE
Sonarqube on AWS - PR-3239 update

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.3.5
+version: 0.3.6
 appVersion: 6.5
 keywords:
   - coverage

--- a/stable/sonarqube/templates/ingress.yaml
+++ b/stable/sonarqube/templates/ingress.yaml
@@ -20,6 +20,10 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
           - path: /*
             backend:
               serviceName: {{ $serviceName }}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -25,11 +25,11 @@ ingress:
   #     - chart-example.local
 
 readinessProbe:
-  initialDelaySeconds: 30
+  initialDelaySeconds: 120
   periodSeconds: 30
   failureThreshold: 6
 livenessProbe:
-  initialDelaySeconds: 30
+  initialDelaySeconds: 120
   periodSeconds: 30
 
 # Set extra env variables. Like proxy settings.


### PR DESCRIPTION
#3239 caused default backend 404 on AWS
'/' was assigned to default backend
`/*` was assigned to the sonarqube backend

This patch is to get both assigned to the same sonarqube backend
cc @jamatute @rjkernick
/assign @lachie83
