### PR TITLE
[stable/pachyderm] Bump chart to 0.1.4

### DIFF
--- a/stable/pachyderm/Chart.yaml
+++ b/stable/pachyderm/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - reproducibility
   - distributed
   - processing
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.6.6
 home: "https://pachyderm.io"
 sources:

--- a/stable/pachyderm/Chart.yaml
+++ b/stable/pachyderm/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - distributed
   - processing
 version: 0.1.4
-appVersion: 1.6.6
+appVersion: 1.6.7
 home: "https://pachyderm.io"
 sources:
   - "https://github.com/pachyderm/pachyderm"

--- a/stable/pachyderm/README.md
+++ b/stable/pachyderm/README.md
@@ -20,6 +20,7 @@ The following table lists the configurable parameters of `pachd` and their defau
 | Parameter                | Description           | Default           |
 |--------------------------|-----------------------|-------------------|
 | `pachd.image.repository` | Container image name  | `pachyderm/pachd` |
+| `pachd.pfsCache`         | File System cache size| `0G`              |
 | `*.image.tag`            | Container image tag   | `<latest version>`|
 | `*.image.pullPolicy`     | Image pull policy     | `Always`          |
 | `*.worker.repository`    | Worker image name     | `pachyderm/worker`|
@@ -126,7 +127,7 @@ Accessing the pachd service
 In order to use Pachyderm, please login through ssh to the master node and install the Pachyderm client:
 
 ```console
-$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.6/pachctl_1.6.6_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
+$ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/download/v1.6.7/pachctl_1.6.7_amd64.deb && sudo dpkg -i /tmp/pachctl.deb
 ```
 
 Please note that the client version should correspond with the pachd service version. For more information please consult: http://pachyderm.readthedocs.io/en/latest/index.html. Also, if you have your kubernetes client properly configured to talk with your remote cluster, you can simply install `pachctl` on your local machine and execute: `pachctl -k '-n=<namespace>' port-forward &`.

--- a/stable/pachyderm/templates/pachd_deployment.yaml
+++ b/stable/pachyderm/templates/pachd_deployment.yaml
@@ -81,7 +81,7 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: BLOCK_CACHE_BYTES
-          value: 0G
+          value: '{{ .Values.pachd.pfsCache }}'
         - name: IAM_ROLE
         - name: PACHYDERM_AUTHENTICATION_DISABLED_FOR_TESTING
           value: 'false'

--- a/stable/pachyderm/values.yaml
+++ b/stable/pachyderm/values.yaml
@@ -37,14 +37,16 @@ microsoft:
 ## Set default image settings, resource requests and number of replicas of pachd
 pachd:
  replicaCount: 1
+ ## Size of pachd's in-memory cache for PFS files. Size is specified in bytes, with allowed SI suffixes (M, K, G, Mi, Ki, Gi, etc).
+ pfsCache: 0G
  ## For available images please check: https://hub.docker.com/r/pachyderm/pachd/tags/
  image:
   repository: pachyderm/pachd
-  tag: 1.6.6
+  tag: 1.6.7
   pullPolicy: Always
  worker:
   repository: pachyderm/worker
-  tag: 1.6.6
+  tag: 1.6.7
  resources:
   ## For non-local deployments, 1 cpu and 2G of memory requests are recommended
   requests:


### PR DESCRIPTION
This PR is to update the pachyderm version used in the chart and to add an option to set the size of the PFS cache.