### PR TITLE
[incubator/patroni] makes secretKeyRefs configureable

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.5.1
+version: 0.6.0
 appVersion: 1.2-p17
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -65,6 +65,7 @@ The following tables lists the configurable parameters of the patroni chart and 
 | `Credentials.Superuser` | password for the superuser          | `tea`                                               |
 | `Credentials.Admin`     | password for the admin user         | `cola`                                              |
 | `Credentials.Standby`   | password for the replication user   | `pinacolada`                                        |
+| `SecretKeyRefs`         | defines secret resources to env mapping | defaults to load `Credentials` from our own secret resource |
 | `Etcd.Enable`           | using etcd as DCS                   | `true`                                              |
 | `Etcd.DeployChart`      | deploy etcd chart                   | `true`                                              |
 | `Etcd.Host`             | host name of etcd cluster           | not used (Etcd.Discovery is used instead)           |

--- a/incubator/patroni/templates/NOTES.txt
+++ b/incubator/patroni/templates/NOTES.txt
@@ -1,24 +1,12 @@
 Patroni can be accessed via port 5432 on the following DNS name from within your cluster:
 {{ template "patroni.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
-To get your password for superuser or admin run:
 
-    # admin user password
-    PGPASSWORD_ADMIN=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "patroni.fullname" . }} -o jsonpath="{.data.password-admin}" | base64 --decode)
+To get your password for superuser run:
+    PGPASSWORD_SUPERUSER=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ default (include "patroni.fullname" .) .Values.SecretKeyRefs.PGPASSWORD_SUPERUSER.name | quote}} -o jsonpath={{ printf "{.data.%s}" .Values.SecretKeyRefs.PGPASSWORD_SUPERUSER.key | quote}} | base64 --decode)
 
-    # superuser password
-    PGPASSWORD_SUPERUSER=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "patroni.fullname" . }} -o jsonpath="{.data.password-superuser}" | base64 --decode)
 
-To connect to your database:
-
-1. Run a postgres pod and connect using the psql cli:
-    # login as admin
-    kubectl run -i --tty --rm psql --image=postgres \
-      --env "PGPASSWORD=$PGPASSWORD_ADMIN" \
-      --command -- psql -U admin \
-      -h {{ template "patroni.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
-
-    # login as superuser
+To connect to your database run a postgres pod and connect using the psql cli (login as superuser):
     kubectl run -i --tty --rm psql --image=postgres \
       --env "PGPASSWORD=$PGPASSWORD_SUPERUSER" \
       --command -- psql -U postgres \

--- a/incubator/patroni/templates/_helpers.tpl
+++ b/incubator/patroni/templates/_helpers.tpl
@@ -7,3 +7,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "patroni.fullname" -}}
 {{- printf "%s-%s" .Release.Name .Values.Name | trunc 63 -}}
 {{- end -}}
+
+{{/*
+    generates a yaml secretKeyRef env structure and expects the folowing structure as input (dict):
+    ```
+    SecretKeyRefs:
+        <container-env-var-name>:
+            name: <secret resource name> (optional, defaults to patroni.fullname as secret resource name)
+            key: <secret resource entry>
+    ```
+*/}}
+{{- define "patroni.secretKeyRefs" -}}
+{{- $global := . -}}
+{{- range $k, $v := .Values.SecretKeyRefs }}
+- name: {{ $k | upper | quote }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (include "patroni.fullname" $global) $v.name | quote }}
+      key: {{ $v.key | quote }}
+{{- end -}}
+{{- end -}}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -29,21 +29,9 @@ spec:
       - name: spilo
         image: "{{ .Values.Spilo.Image }}:{{ .Values.Spilo.Version }}"
         env:
-        - name: PGPASSWORD_SUPERUSER
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
-              key: password-superuser
-        - name: PGPASSWORD_ADMIN
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
-              key: password-admin
-        - name: PGPASSWORD_STANDBY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
-              key: password-standby
+        {{- if .Values.SecretKeyRefs }}
+        {{- include "patroni.secretKeyRefs" . | indent 8 }}
+        {{- end }}
         {{if .Values.Etcd.Enable }}
         {{if .Values.Etcd.DeployChart }}
         - name: ETCD_DISCOVERY_DOMAIN

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -28,6 +28,25 @@ Credentials:
   Admin: cola
   Standby: pinacolada
 
+# Define where patroni should get its secrets from.
+# On default, it uses the generated secret by itself, but changing `SecretKeyRefs` allows you
+# to get the data from your own secret resource.
+#
+# Syntax:
+# ```
+# SecretKeyRefs:
+#   <container-env-var-name>:
+#     name: <secret resource name> (optional, defaults to patroni charts secret as resource name)
+#     key: <secret resource entry>
+# ```
+SecretKeyRefs:
+  PGPASSWORD_SUPERUSER:
+    key: password-superuser
+  PGPASSWORD_ADMIN:
+    key: password-admin
+  PGPASSWORD_STANDBY:
+    key: password-standby
+
 ## Distribution Configuration stores. Please note that only one of the following stores should be selected.
 Etcd:
   Enable: true


### PR DESCRIPTION
Changeclass: minor - backward compatible

**WHY**
We are using the `patroni` chart by some other charts. In order to allow an out-of-the-box experience for our users, we need to control the generated secrets used by this chart, so we can generate random secrets and still can provide a nothing-needs-to-be-changed-on-default experience. As discussed in https://github.com/kubernetes/helm/issues/2196#issuecomment-293738730 I don't know a way to resolve secrets on template resolution time; so this is an idea I came up with to solve this until there is a better way.

**Behaviour**
This commit is non-disruptive to the userbase, as it defaults to
the current behaviour. I does not fix a bug, but instead extends the functionality.

**Testing**
* `helm lint` is fine
* `helm install --name tester .` is fine
* `helm template --name tester .` seems to be fine too

**Note**
I also fix a small issue in the `NOTES.txt` and removed the part of "login as admin". The admin user isn't able to login from remote; only the superuser is permitted.

I'm very interested in your feedback! Is this an acceptable approach to achieve the goal of getting secrets defined externally? How do you handle those kind of issues?

Kind regards and a happy weekend
Tony