### PR TITLE
[incubator/drone] Makes agent + server affinities configurable

### DIFF
--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: http://docs.drone.io/logo.svg
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.8.2
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -34,10 +34,10 @@ The following tables lists the configurable parameters of the drone charts and t
 | Parameter                   | Description                                                                                   | Default                     |
 |-----------------------------|-----------------------------------------------------------------------------------------------|-----------------------------|
 | `images.server.repository`  | Drone **server** image                                                                        | `docker.io/drone/drone`     |
-| `images.server.tag`         | Drone **server** image tag                                                                    | `0.8.2`                     |
+| `images.server.tag`         | Drone **server** image tag                                                                    | `0.8.4`                     |
 | `images.server.pullPolicy`  | Drone **server** image pull policy                                                            | `IfNotPresent`              |
 | `images.agent.repository`   | Drone **agent** image                                                                         | `docker.io/drone/agent`     |
-| `images.agent.tag`          | Drone **agent** image tag                                                                     | `0.8.2`                     |
+| `images.agent.tag`          | Drone **agent** image tag                                                                     | `0.8.4`                     |
 | `images.agent.pullPolicy`   | Drone **agent** image pull policy                                                             | `IfNotPresent`              |
 | `images.dind.repository`    | Docker **dind** image                                                                         | `docker.io/library/docker`  |
 | `images.dind.tag`           | Docker **dind** image tag                                                                     | `17.12.0-ce-dind`           |
@@ -53,8 +53,10 @@ The following tables lists the configurable parameters of the drone charts and t
 | `server.host`               | Drone **server** hostname                                                                     | `(internal hostname)`       |
 | `server.env`                | Drone **server** environment variables                                                        | `(default values)`          |
 | `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
+| `server.afinity`            | Drone **server** scheduling preferences                                                       | `{}`                        |
 | `agent.env`                 | Drone **agent** environment variables                                                         | `(default values)`          |
 | `agent.resources`           | Drone **agent** pod resource requests & limits                                                | `{}`                        |
+| `agent.afinity`             | Drone **agent** scheduling preferences                                                        | `{}`                        |
 | `dind.driver`               | **DinD** storage driver                                                                       | `overlay2`                  |
 | `dind.resources`            | **DinD** pod resource requests & limits                                                       | `{}`                        |
 | `persistence.enabled`       | Use a PVC to persist data                                                                     | `true`                      |

--- a/incubator/drone/templates/deployment-agent.yaml
+++ b/incubator/drone/templates/deployment-agent.yaml
@@ -17,6 +17,10 @@ spec:
         release: "{{ .Release.Name }}"
         component: agent
     spec:
+{{- if .Values.agent.affinity }}
+      affinity:
+{{ toYaml .Values.agent.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: {{ template "drone.fullname" . }}-agent
         image: "{{ .Values.images.agent.repository }}:{{ .Values.images.agent.tag }}"

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -18,6 +18,10 @@ spec:
         release: "{{ .Release.Name }}"
         component: server
     spec:
+{{- if .Values.server.affinity }}
+      affinity:
+{{ toYaml .Values.server.affinity | indent 8 }}
+{{- end }}
       containers:
       - name: {{ template "drone.fullname" . }}-server
         image: "{{ .Values.images.server.repository }}:{{ .Values.images.server.tag }}"

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -6,7 +6,7 @@ images:
   ##
   server:
     repository: "docker.io/drone/drone"
-    tag: 0.8.2
+    tag: 0.8.4
     pullPolicy: IfNotPresent
 
   ## The official drone (agent) image, change tag to use a different version.
@@ -14,7 +14,7 @@ images:
   ##
   agent:
     repository: "docker.io/drone/agent"
-    tag: 0.8.2
+    tag: 0.8.4
     pullPolicy: IfNotPresent
 
   ## The official docker (dind) image, change tag to use a different version.
@@ -97,6 +97,11 @@ server:
   #    memory: 2Gi
   #    cpu: 1
 
+  ## Pod scheduling preferences.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
 agent:
   ## Drone agent configuration.
   ## Values in here get injected as environment variables.
@@ -114,6 +119,11 @@ agent:
   #  limits:
   #    memory: 2Gi
   #    cpu: 1
+
+  ## Pod scheduling preferences.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
 
 dind:
   ## Docker storage driver.


### PR DESCRIPTION
- Useful to specify anti-affinity between agents.
- Useful to restrict server to specific nodes for persistent storage.
- This PR also bumps default agent + server image tags to `0.8.4`.