### PR TITLE
[incubator/jaeger] Adds ability to utilize a cloud providers firewall for services

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.13
+version: 0.3.14
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -137,8 +137,12 @@ The following table lists the configurable parameters of the Jaeger chart and th
 |------------------------------------------|-------------------------------------|----------------------------------------|
 | `agent.annotations`                      | Annotations for Agent               |  nil                                   |
 | `agent.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
+| `agent.service.annotations`              | Annotations for Agent SVC           |  nil                                   |
+| `agent.service.binaryPort`               | jaeger.thrift over binary thrift    |  6832                                  |
+| `agent.service.compactPort`              | jaeger.thrift over compact thrift   |  6831                                  |
 | `agent.image`                            | Image for Jaeger Agent              |  jaegertracing/jaeger-agent            |
 | `agent.pullPolicy`                       | Agent image pullPolicy              |  IfNotPresent                          |
+| `agent.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 | `agent.tag`                              | Image tag/version                   |  0.6                                   |
 | `agent.service.annotations`              | Annotations for Agent SVC           |  nil                                   |
 | `agent.service.binaryPort`               | jaeger.thrift over binary thrift    |  6832                                  |
@@ -151,12 +155,15 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `cassandra.config.seed_size`             | Seed size                           |  1                                     |
 | `cassandra.image.tag`                    | The image tag/version               |  3.11                                  |
 | `cassandra.persistence.enabled`          | To enable storage persistence       |  false (Highly recommended to enable)  |
-| `collector.annotations`                  | Annotations for Collector           |  nil                                   |
+| `collector.annotationsPod`               | Annotations for Collector           |  nil                                   |
 | `collector.cmdlineParams`                | Additional command line parameters  |  nil                                   |
+| `collector.service.httpPort`             | Client port for HTTP thrift         |  14268                                 |
+| `collector.service.annotations`          | Annotations for Collector SVC       |  nil                                   |
 | `collector.image`                        | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
 | `collector.pullPolicy`                   | Collector image pullPolicy          |  IfNotPresent                          |
 | `collector.service.annotations`          | Annotations for Collector SVC       |  nil                                   |
 | `collector.service.httpPort`             | Client port for HTTP thrift         |  14268                                 |
+| `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 | `collector.service.tchannelPort`         | Jaeger Agent port for thrift        |  14267                                 |
 | `collector.service.type`                 | Service type                        |  ClusterIP                             |
 | `collector.service.zipkinPort`           | Zipkin port for JSON/thrift HTTP    |  9411                                  |
@@ -166,14 +173,16 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `elasticsearch.image.tag`                | Elasticsearch image tag             |  "5.4"                                 |
 | `elasticsearch.rbac.create`              | To enable RBAC                      |  false                                 |
 | `hotrod.enabled`                         | Enables the Hotrod demo app         |  false                                 |
+| `hotrod.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 | `provisionDataStore.cassandra`           | Provision Cassandra Data Store      |  true                                  |
 | `provisionDataStore.elasticsearch`       | Provision Elasticsearch Data Store  |  false                                 |
 | `query.annotationsPod`                   | Annotations for Query UI            |  nil                                   |
-| `query.annotationsSvc`                   | Annotations for Query SVC           |  nil                                   |
+| `query.service.annotations`                   | Annotations for Query SVC           |  nil                                   |
 | `query.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
 | `query.image`                            | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
 | `query.ingress.enabled`                  | Allow external traffic access       |  false                                 |
 | `query.pullPolicy`                       | Query UI image pullPolicy           |  IfNotPresent                          |
+| `query.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 | `query.service.queryPort`                | External accessible port            |  80                                    |
 | `query.service.targetPort`               | Internal Query UI port              |  16686                                 |
 | `query.service.type`                     | Service type                        |  ClusterIP                             |
@@ -201,7 +210,6 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.elasticsearch.user`             | Provisioned elasticsearch user      |  elastic                               |
 | `storage.elasticsearch.nodesWanOnly`     | Only access specified es host       |  false                                 |
 | `storage.type`                           | Storage type (ES or Cassandra)      |  cassandra                             |
-|------------------------------------------|-------------------------------------|----------------------------------------|
 
 For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
 

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -133,3 +133,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $host := printf "%s-agent" (include "jaeger.agent.name" .) -}}
 {{- default $host .Values.hotrod.tracing.host -}}
 {{- end -}}
+
+{{/*
+Configure list of IP CIDRs allowed access to load balancer (if supported)
+*/}}
+{{- define "loadBalancerSourceRanges" -}}
+{{- if .service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -38,10 +38,5 @@ spec:
     component: agent
     release: {{ .Release.Name }}
     jaeger-infra: agent-instance
-{{- if .Values.agent.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.agent.service.loadBalancerSourceRanges }}
-    - {{ $cidr }}
-  {{- end }}
-{{- end }}
+{{- template "loadBalancerSourceRanges" .Values.agent }}
 {{- end -}}

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -38,4 +38,10 @@ spec:
     component: agent
     release: {{ .Release.Name }}
     jaeger-infra: agent-instance
+{{- if .Values.agent.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.agent.service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
 {{- end -}}

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -46,4 +46,10 @@ spec:
     release: {{ .Release.Name }}
     jaeger-infra: collector-pod
   type: {{ .Values.collector.service.type }}
+{{- if .Values.collector.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.collector.service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
 {{- end -}}

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -46,10 +46,5 @@ spec:
     release: {{ .Release.Name }}
     jaeger-infra: collector-pod
   type: {{ .Values.collector.service.type }}
-{{- if .Values.collector.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.collector.service.loadBalancerSourceRanges }}
-    - {{ $cidr }}
-  {{- end }}
-{{- end }}
+{{- template "loadBalancerSourceRanges" .Values.collector }}
 {{- end -}}

--- a/incubator/jaeger/templates/hotrod-svc.yaml
+++ b/incubator/jaeger/templates/hotrod-svc.yaml
@@ -26,4 +26,10 @@ spec:
     component: hotrod
     release: {{ .Release.Name }}
     jaeger-infra: hotrod-instance
+{{- if .Values.hotrod.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.hotrod.service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
 {{- end -}}

--- a/incubator/jaeger/templates/hotrod-svc.yaml
+++ b/incubator/jaeger/templates/hotrod-svc.yaml
@@ -26,10 +26,5 @@ spec:
     component: hotrod
     release: {{ .Release.Name }}
     jaeger-infra: hotrod-instance
-{{- if .Values.hotrod.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.hotrod.service.loadBalancerSourceRanges }}
-    - {{ $cidr }}
-  {{- end }}
-{{- end }}
+{{- template "loadBalancerSourceRanges" .Values.hotrod }}
 {{- end -}}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -26,4 +26,10 @@ spec:
     release: {{ .Release.Name }}
     jaeger-infra: query-pod
   type: {{ .Values.query.service.type }}
+{{- if .Values.query.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.query.service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
 {{- end -}}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -26,10 +26,5 @@ spec:
     release: {{ .Release.Name }}
     jaeger-infra: query-pod
   type: {{ .Values.query.service.type }}
-{{- if .Values.query.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.query.service.loadBalancerSourceRanges }}
-    - {{ $cidr }}
-  {{- end }}
-{{- end }}
+{{- template "loadBalancerSourceRanges" .Values.query }}
 {{- end -}}

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -87,6 +87,9 @@ agent:
     useHostPort: false
   service:
     annotations: {}
+
+    # List of IP ranges that are allowed to access the load balancer (if supported)
+    loadBalancerSourceRanges: []
     type: ClusterIP
     # zipkinThriftPort :accept zipkin.thrift over compact thrift protocol
     zipkinThriftPort: 5775
@@ -119,6 +122,9 @@ collector:
   replicaCount: 1
   service:
     annotations: {}
+
+    # List of IP ranges that are allowed to access the load balancer (if supported)
+    loadBalancerSourceRanges: []
     type: ClusterIP
     # tchannelPort: used by jaeger-agent to send spans in jaeger.thrift format
     tchannelPort: 14267
@@ -151,6 +157,9 @@ query:
   service:
     annotations: {}
     type: ClusterIP
+
+    # List of IP ranges that are allowed to access the load balancer (if supported)
+    loadBalancerSourceRanges: []
     # queryPort: externally accessible port for UI and API
     queryPort: 80
     # targetPort: the internal port the UI and API are exposed on
@@ -214,6 +223,9 @@ hotrod:
     annotations: {}
     name: hotrod
     type: ClusterIP
+
+    # List of IP ranges that are allowed to access the load balancer (if supported)
+    loadBalancerSourceRanges: []
     externalPort: 80
     internalPort: 8080
   ingress:

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -87,7 +87,6 @@ agent:
     useHostPort: false
   service:
     annotations: {}
-
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -122,7 +122,6 @@ collector:
   replicaCount: 1
   service:
     annotations: {}
-
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
@@ -157,7 +156,6 @@ query:
   service:
     annotations: {}
     type: ClusterIP
-
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     # queryPort: externally accessible port for UI and API
@@ -223,7 +221,6 @@ hotrod:
     annotations: {}
     name: hotrod
     type: ClusterIP
-
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     externalPort: 80


### PR DESCRIPTION
* Adds declaration allowing the user to configure which IP CIDRs are
allowed to access a service via a cloud providers firewall
* An example configuration of `values.yaml` may look like this:
```
query:
  service:
    type: LoadBalancer
    loadBalancerSourceRanges:
      - "192.0.2.0/24"
      - "198.51.100.0/24"
```
* The above would configure a cloud provider's firewall with a ruleset
allowing only the configured IP ranges access to the query service
* This adds this declaration across the board for all services as it may
be valuable. One example, is to send metric data from applications that
do not reside in kubernetes
* This PR also updates the README to reflect other options for services
that have not been updated over time.