### PR TITLE
[icubator/fluentd-cloudwatch] fix the namespaces rbac permission

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-cloudwatch
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.1.1
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png

--- a/incubator/fluentd-cloudwatch/templates/clusterrole.yaml
+++ b/incubator/fluentd-cloudwatch/templates/clusterrole.yaml
@@ -10,6 +10,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups: [""]
-  resources: ["fluentd-cloudwatch.namespaces", "pods"]
+  resources: ["namespaces", "pods"]
   verbs: ["get", "list", "watch"]
 {{- end }}


### PR DESCRIPTION
Fixes the rbac permissions for fluentd-cloudwatch.

cc @jmcarp @icereval @kenden