### PR TITLE
[incubator/jaeger] Allow globally and individual overrides for names of components

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.0
+version: 0.3.1
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -20,16 +20,19 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "jaeger.fullname" -}}
-{{- $name := default "jaeger" .Values.nameOverride -}}
-{{- if .Values.nameComponentOverride }}
-{{- printf "%s" .Values.nameComponentOverride | trunc 63 | trimSuffix "-" -}}
-{{- else if eq .Chart.Name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -39,8 +42,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "jaeger.query.name" -}}
 {{- $nameGlobalOverride := printf "%s" (include "jaeger.fullname" .) -}}
-{{- if .Values.query.nameOverride -}}
-{{- printf "%s" .Values.query.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.query.fullnameOverride -}}
+{{- printf "%s" .Values.query.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" $nameGlobalOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -52,8 +55,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "jaeger.agent.name" -}}
 {{- $nameGlobalOverride := printf "%s" (include "jaeger.fullname" .) -}}
-{{- if .Values.agent.nameOverride -}}
-{{- printf "%s" .Values.agent.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.agent.fullnameOverride -}}
+{{- printf "%s" .Values.agent.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" $nameGlobalOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -65,8 +68,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "jaeger.collector.name" -}}
 {{- $nameGlobalOverride := printf "%s" (include "jaeger.fullname" .) -}}
-{{- if .Values.collector.nameOverride -}}
-{{- printf "%s" .Values.collector.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.collector.fullnameOverride -}}
+{{- printf "%s" .Values.collector.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" $nameGlobalOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -55,7 +55,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "cassandra.host" -}}
 {{- if .Values.provisionDataStore.cassandra -}}
+{{- if .Values.storage.cassandra.nameOverride }}
+{{- printf "%s" .Values.storage.cassandra.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- else }}
 {{- .Values.storage.cassandra.host }}
 {{- end -}}
@@ -64,8 +68,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "cassandra.contact_points" -}}
 {{- $port := .Values.storage.cassandra.port | toString }}
 {{- if .Values.provisionDataStore.cassandra -}}
+{{- if .Values.storage.cassandra.nameOverride }}
+{{- $host := printf "%s" .Values.storage.cassandra.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s:%s" $host $port }}
+{{- else }}
 {{- $host := printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
 {{- printf "%s:%s" $host $port }}
+{{- end -}}
 {{- else }}
 {{- printf "%s:%s" .Values.storage.cassandra.host $port }}
 {{- end -}}
@@ -78,8 +87,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "elasticsearch.client.url" -}}
 {{- $port := .Values.storage.elasticsearch.port | toString -}}
 {{- if .Values.provisionDataStore.elasticsearch -}}
+{{- if .Values.storage.elasticsearch.nameOverride }}
+{{- $host := printf "%s" .Values.storage.elasticsearch.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme $host $port }}
+{{- else }}
 {{- $host := printf "%s-%s-%s" .Release.Name "elasticsearch" "client" | trunc 63 | trimSuffix "-" -}}
 {{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme $host $port }}
+{{- end -}}
 {{- else }}
 {{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme .Values.storage.elasticsearch.host $port }}
 {{- end -}}

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: {{ template "jaeger.fullname" . }}-agent
+  name: {{ template "jaeger.agent.name" . }}-agent
   labels:
     app: {{ template "jaeger.name" . }}
     jaeger-infra: agent-daemonset
@@ -29,7 +29,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}
       containers:
-      - name: {{ template "jaeger.fullname" . }}-agent
+      - name: {{ template "jaeger.agent.name" . }}-agent
         image: {{ .Values.agent.image }}:{{ .Values.agent.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         env:

--- a/incubator/jaeger/templates/agent-svc.yaml
+++ b/incubator/jaeger/templates/agent-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "jaeger.agent.service.name" . }}-agent
+  name: {{ template "jaeger.agent.name" . }}-agent
   labels:
     app: {{ template "jaeger.name" . }}
     jaeger-infra: agent-service

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "jaeger.fullname" . }}-collector
+  name: {{ template "jaeger.collector.name" . }}-collector
   labels:
     app: {{ template "jaeger.name" . }}
     jaeger-infra: collector-deployment
@@ -32,7 +32,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.collector.nodeSelector | indent 8 }}
       containers:
-      - name: {{ template "jaeger.fullname" . }}-collector
+      - name: {{ template "jaeger.collector.name" . }}-collector
         image: {{ .Values.collector.image }}:{{ .Values.collector.tag }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         env:

--- a/incubator/jaeger/templates/collector-svc.yaml
+++ b/incubator/jaeger/templates/collector-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "jaeger.fullname" . }}-collector
+  name: {{ template "jaeger.collector.name" . }}-collector
   labels:
     app: {{ template "jaeger.name" . }}
     jaeger-infra: collector-service

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "jaeger.query.fullname" . }}
+  name: {{ template "jaeger.query.name" . }}-query
   labels:
     app: {{ template "jaeger.name" . }}
     jaeger-infra: query-deployment
@@ -32,7 +32,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.query.nodeSelector | indent 8 }}
       containers:
-      - name: {{ template "jaeger.query.fullname" . }}
+      - name: {{ template "jaeger.query.name" . }}-query
         image: {{ .Values.query.image }}:{{ .Values.query.tag }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         env:

--- a/incubator/jaeger/templates/query-ing.yaml
+++ b/incubator/jaeger/templates/query-ing.yaml
@@ -1,10 +1,9 @@
 {{- if .Values.query.ingress.enabled -}}
-{{- $serviceName := include "jaeger.query.fullname" . -}}
 {{- $servicePort := .Values.query.service.queryPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "jaeger.fullname" . }}-query
+  name: {{ template "jaeger.query.name" . }}-query
   labels:
     app: {{ template "jaeger.name" . }}
     jaeger-infra: query-ingress
@@ -24,7 +23,7 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: {{ $serviceName }}
+              serviceName: {{ template "jaeger.query.name" . }}-query
               servicePort: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.query.ingress.tls }}

--- a/incubator/jaeger/templates/query-svc.yaml
+++ b/incubator/jaeger/templates/query-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "jaeger.query.fullname" . }}
+  name: {{ template "jaeger.query.name" . }}-query
   labels:
     app: {{ template "jaeger.name" . }}
     jaeger-infra: query-service


### PR DESCRIPTION
This PR provides a consistent method for a given user to override the default names of components in the Jaeger chart. This is required in order for charts using Jaeger as a dependency to allow the Jaeger components have a consistent naming conventions for the parent charts components. Previously, there was some functionality to do name overrides only for select components, but this PR creates a consistent method for all components in Jaeger.

Currently, the default format all component names are prefixed with <release name>-<chart name>-<component being deployed>. As an example, if the helm release name is called myrel, the collector deployment is named myrel-jaeger-collector. This PR implements 2 methods of overriding the prefix (<release name>-<chart name>). The first is an option for globally changing the prefix for all components and the second is allowing the individual override of a single component. If both the global override and an individual override of a component is used, the individual component override takes precedence over the global. Please see examples below.

If --set fullnameOverride=mycomponents, the Jaeger components that get deployed will be named:
- mycomponents-collector
- mycomponents-query
- mycomponents-agent

If --set fullnameOverride=mycomponent and --set query.fullnameOverride=yourcomponents, the Jaeger components that get deployed will be named:
- mycomponents-collector
- yourcomponent-query
- mycomponents-agent

If --set collector.fullnameOverride=thiscomponent and the name of the release is called `myrel`, the Jaeger components that get deployed will be named:
- thiscomponent-collector
- myrel-jaeger-query
- myrel-jaeger-agent

These nameOverride options are  considered very advanced and should only be used by implementers of charts where Jaeger is a dependency chart OR for very advanced users. As such, the README will not be updated to reflect these options.

Tested on kubernetes 1.7 and 1.8 and also tested using Jaeger as a dependent chart to have consistent names with the parent chart.

**UPDATE:** to reflect the new variable fullnameOverride