### PR TITLE
[stable/jenkins] Lower initial healthcheck delay

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.13.0
+version: 0.13.1
 appVersion: 2.73
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -36,7 +36,7 @@ Master:
   ContainerPort: 8080
   # Enable Kubernetes Liveness and Readiness Probes
   HealthProbes: true
-  HealthProbesTimeout: 120
+  HealthProbesTimeout: 60
   SlaveListenerPort: 50000
   LoadBalancerSourceRanges:
   - 0.0.0.0/0


### PR DESCRIPTION
The healthcheck initial delay was set to a high value and could be the cause of failing e2e tests. This sets it to a more reasonable setting based on what we have seen in practice.