### PR TITLE
[stable/concourse] Fix typo in Vault cert paths.

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.11.0
+version: 0.11.1
 appVersion: 3.8.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -275,11 +275,11 @@ spec:
                   key: vault-client-token
             {{- if .Values.credentialManager.vault.caCert }}
             - name: CONCOURSE_VAULT_CA_CERT
-              value: "/concourse-vault/ca.crt"
+              value: "/concourse-vault/ca.cert"
             {{- end }}
             {{- if .Values.credentialManager.vault.clientCert }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
-              value: "/concourse-vault/client.crt"
+              value: "/concourse-vault/client.cert"
             - name: CONCOURSE_VAULT_CLIENT_KEY
               value: "/concourse-vault/client.key"
             {{- end }}


### PR DESCRIPTION
The paths for certs in `/concourse-vault` were using the extension `crt` instead of the expected extension `cert` which caused the pod to fail with an error.