### PR TITLE
Bugfix: wordpress ingress: always delegate to service's HTTP port

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.8.2
+version: 0.8.3
 appVersion: 4.9.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/ingress.yaml
+++ b/stable/wordpress/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
         - path: {{ default "/" .path }}
           backend:
             serviceName: {{ template "fullname" $ }}
-            servicePort: {{ if .tls }}443{{ else }}80{{end}}
+            servicePort: 80
 {{- if .tls }}
   tls:
   - hosts:


### PR DESCRIPTION
In the current master, if you enable TLS in the ingress, it'll delegate to the service's https port (443), which in turn delegates to the pod's https port, where Wordpress wants to speak TLS (Bitnami's Wordpress image can terminate TLS internally). Since the ingress itself already terminates TLS, it'll end up trying to talk plain http to the pod's https port, resulting in

> Bad Request
> Your browser sent a request that this server could not understand.
> Reason: You're speaking plain HTTP to an SSL-enabled server port.
> Instead use the HTTPS scheme to access this URL, please.

This PR fixes this.