### PR TITLE
[stable/mysql] The password values in values.yaml should be provided as base64

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.3.4
+version: 0.3.5
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.
 keywords:

--- a/stable/mysql/templates/secrets.yaml
+++ b/stable/mysql/templates/secrets.yaml
@@ -10,12 +10,12 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.mysqlRootPassword }}
-  mysql-root-password:  {{ .Values.mysqlRootPassword | b64enc | quote }}
+  mysql-root-password:  {{ .Values.mysqlRootPassword | quote }}
   {{ else }}
   mysql-root-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
   {{ if .Values.mysqlPassword }}
-  mysql-password:  {{ .Values.mysqlPassword | b64enc | quote }}
+  mysql-password:  {{ .Values.mysqlPassword | quote }}
   {{ else }}
   mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -4,12 +4,12 @@
 image: "mysql"
 imageTag: "5.7.14"
 
-## Specify password for root user
+## Specify base64 encoded password for root user
 ##
 ## Default: random 10 character string
 # mysqlRootPassword: testing
 
-## Create a database user
+## Create a database user with base64 encoded password
 ##
 # mysqlUser:
 # mysqlPassword:


### PR DESCRIPTION
If the user wants to provide its own passwords they should be base64 encoded in values.yaml file and not kept in clear text.