### PR TITLE
[stable/mysql] Prevent auto-generated passwords to change on helm upgrade

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.3.4
+version: 0.3.5
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.
 keywords:

--- a/stable/mysql/templates/secrets.yaml
+++ b/stable/mysql/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Release.IsInstall }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,3 +20,4 @@ data:
   {{ else }}
   mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
+{{ end }}

--- a/stable/mysql/templates/secrets.yaml
+++ b/stable/mysql/templates/secrets.yaml
@@ -1,4 +1,3 @@
-{{- if .Release.IsInstall }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed
 type: Opaque
 data:
   {{ if .Values.mysqlRootPassword }}
@@ -20,4 +22,3 @@ data:
   {{ else }}
   mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
-{{ end }}


### PR DESCRIPTION
Generating secrets is a probably better way to set up passwords. However, on Helm upgrade, the new secrets are generated each time. This pull request will only create secrets on install.

The other way of doing things is to have two separated secrets files, for auto-generated secrets and for one that user want to set manually. Autogenerated should never change once the chart is installed. 