### PR TITLE
[ci] Fix regression in changed.sh

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -55,10 +55,10 @@ function cleanup {
             for cname in ${containers}; do
                 echo "---Logs from container $cname in pod $line:---"
                 kubectl logs --namespace ${NAMESPACE} -c ${cname} ${line}
-                printf "---End of logs for container $cname in pod $line---\n\n"
+                echo "---End of logs for container $cname in pod $line---\n"
             done
 
-            printf "===End of logs for pod $line===\n\n"
+            echo "===End of logs for pod $line===\n"
         fi
       done
 
@@ -121,7 +121,7 @@ for directory in ${CHANGED_FOLDERS}; do
     continue
   elif [ -d $directory ]; then
     CHART_NAME=`echo ${directory} | cut -d '/' -f2`
-    
+
     # A semver comparison is here as well as in the circleci tests. The circleci
     # tests provide almost immediate feedback to chart authors. This test is also
     # re-run right before the bot merges a PR so we can make sure the chart
@@ -143,7 +143,7 @@ for directory in ${CHANGED_FOLDERS}; do
       sleep $VERIFICATION_PAUSE
     fi
     helm delete --purge ${RELEASE_NAME}
-    
+
     # Setting the current release to none to avoid the cleanup and error
     # handling for a release that no longer exists.
     CURRENT_RELEASE=""


### PR DESCRIPTION
```
I0131 13:22:24.165] 2018-01-31T13:22:22.968+0000 I -        [conn303] end connection 127.0.0.1:59852 (6 connections now open)
W0131 13:22:24.165] + printf '---End of logs for container mongodb-replicaset in pod mongodb-5004-mongodb-replicaset-0---\n\n'
W0131 13:22:24.165] /src/test/changed.sh: line 58: printf: --: invalid option
W0131 13:22:24.166] printf: usage: printf [-v var] format [arguments]
W0131 13:22:24.166] Traceback (most recent call last):
W0131 13:22:24.166]   File "/workspace/./test-infra/jenkins/../scenarios/execute.py", line 50, in <module>
W0131 13:22:24.166]     main(ARGS.env, ARGS.cmd + ARGS.args)
W0131 13:22:24.167]   File "/workspace/./test-infra/jenkins/../scenarios/execute.py", line 41, in main
W0131 13:22:24.167]     check(*cmd)
W0131 13:22:24.167]   File "/workspace/./test-infra/jenkins/../scenarios/execute.py", line 30, in check
W0131 13:22:24.167]     subprocess.check_call(cmd)
W0131 13:22:24.167]   File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
W0131 13:22:24.168]     raise CalledProcessError(retcode, cmd)
W0131 13:22:24.168] subprocess.CalledProcessError: Command '('./test/e2e.sh',)' returned non-zero exit status 1
E0131 13:22:24.168] Command failed
I0131 13:22:24.168] process 601 exited with code 1 after 6.3m
E0131 13:22:24.168] FAIL: pull-charts-e2e
```

See https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/charts/3487/pull-charts-e2e/5004/