### PR TITLE
[stable/consul] Clustering improvements

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 1.2.1
+version: 1.3.0
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -248,7 +248,10 @@ spec:
 
             PEERS=""
             for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
-                PEERS="${PEERS}${PEERS:+ } -retry-join $(ping -c 1 ${STATEFULSET_NAME}-${i}.${STATEFULSET_NAME}.${STATEFULSET_NAMESPACE}.svc | awk -F'[()]' '/PING/{print $2}')"
+              NEXT_PEER="$(ping -c 1 ${STATEFULSET_NAME}-${i}.${STATEFULSET_NAME}.${STATEFULSET_NAMESPACE}.svc | awk -F'[()]' '/PING/{print $2}')"
+              if [ "${NEXT_PEER}" != "${POD_IP}" ]; then
+                PEERS="${PEERS}${PEERS:+ } -retry-join ${STATEFULSET_NAME}-${i}.${STATEFULSET_NAME}.${STATEFULSET_NAMESPACE}.svc"
+              fi
             done
 
             exec /bin/consul agent \

--- a/stable/consul/templates/consul.yaml
+++ b/stable/consul/templates/consul.yaml
@@ -267,6 +267,7 @@ spec:
               -data-dir=/var/lib/consul \
               -server \
               -bootstrap-expect=${INITIAL_CLUSTER_SIZE} \
+              -disable-keyring-file \
               -bind=0.0.0.0 \
               -advertise=${IP} \
               ${PEERS} \


### PR DESCRIPTION
This avoids a few problems I experienced with new pods joining existing clusters, especially after a leader dies and is replaced.

The first is the issue essentially the one mentioned here: https://github.com/hashicorp/consul/issues/719#issuecomment-75183631
Because consul is saving the cluster key to the persistent volume, the replaced node can come up with the old key after a key rotation happens while it is gone. Using -disable-keyring-file keeps the key in memory and has the new pod re-acquire it from the remaining nodes like any new Pod would.

The second is this issue: https://github.com/hashicorp/consul/issues/2868
By excluding the current node from the list of nodes it should join, we avoid the problem of the node joining itself and using a mismatched key from the rest of the cluster which then prevents it from joining the remaining nodes.