### PR TITLE
[stable/grafana] Support Provisioner Configuration

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.8.5
+version: 0.8.6
 appVersion: 5.0.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -95,6 +95,14 @@ spec:
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
           volumeMounts:
+            {{- if .Values.provisioningDatasourcesFiles }}
+            - name: provisioning-volume 
+              mountPath: {{ default "/var/lib/grafana/provisioning" .Values.server.provisioningLocalPath }}/datasources
+            {{- end }}
+            {{- if .Values.provisioningDashboardsFiles }}
+            - name: provisioning-dashboards-volume 
+              mountPath: {{ default "/var/lib/grafana/provisioning" .Values.server.provisioningLocalPath }}/dashboards
+            {{- end }}
             - name: config-volume
               mountPath: {{ default "/etc/grafana" .Values.server.configLocalPath | quote }}
             - name: dashboard-volume
@@ -114,6 +122,16 @@ spec:
         - name: dashboard-volume-configmap
           configMap:
             name: {{ template "grafana.server.fullname" . }}-dashs
+        {{- if .Values.provisioningDatasourcesFiles }}
+        - name: provisioning-volume 
+          configMap:
+            name: {{ template "grafana.server.fullname" . }}-pdata
+        {{- end }}
+        {{- if .Values.provisioningDashboardsFiles }}
+        - name: provisioning-dashboards-volume
+          configMap:
+            name: {{ template "grafana.server.fullname" . }}-pdash
+        {{- end }}
         - name: storage-volume
       {{- if .Values.server.persistentVolume.enabled }}
           persistentVolumeClaim:

--- a/stable/grafana/templates/provisioning-dashboards-configmap.yaml
+++ b/stable/grafana/templates/provisioning-dashboards-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.provisioningDashboardsFiles -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "grafana.server.fullname" . }}-pdash
+data:
+{{ toYaml .Values.provisioningDashboardsFiles | indent 2 }}
+{{- end -}}

--- a/stable/grafana/templates/provisioning-datasources-configmap.yaml
+++ b/stable/grafana/templates/provisioning-datasources-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.provisioningDatasourcesFiles -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "grafana.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Values.server.name }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "grafana.server.fullname" . }}-pdata
+data:
+{{ toYaml .Values.provisioningDatasourcesFiles | indent 2 }}
+{{- end -}}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -189,6 +189,11 @@ server:
   ##
   # storageLocalPath: /var/lib/grafana/data
 
+  ## Grafana local provisioning path
+  ## Default: '/var/lib/grafana/provisioning'
+  ##
+  # provisioningLocalPath: /var/lib/grafana/provisioning
+
   ## Grafana Pod termination grace period
   ## Default: 300s (5m)
   ##
@@ -274,6 +279,7 @@ serverConfigFile:
     data = /var/lib/grafana/data
     logs = /var/log/grafana
     plugins = /var/lib/grafana/plugins
+    provisioning = /var/lib/grafana/provisioning
 
     [server]
     ;protocol = http
@@ -473,3 +479,14 @@ dashboardImports:
   ## Default: post-install,post-upgrade
   ##
   hook: post-install,post-upgrade
+  # restartPolicy: OnFailure
+
+
+## Grafana dashboard/datasource provisioner configuration
+##
+## If you'd like to use the provisioners to pull in dashboards from an external
+## source, add the configuration files below.
+##
+## See: http://docs.grafana.org/administration/provisioning/
+provisioningDashboardsFiles: {}
+provisioningDatasourcesFiles: {}


### PR DESCRIPTION
This PR extends the `stable/grafana` chart to allow for outside configuration of provisioners. 

With Grafana 5 it will be possible to manage datasources and dashboards using provisioners.  Adding a provisioner is done by adding one or more yaml configuration files in the `provisioning/datasources` and `provisioning/dashboards` directory. See also: http://docs.grafana.org/administration/provisioning/

For datasources the file can contain a list of datasources that will be added or updated during start-up. If the datasource already exists, Grafana will update it to match the configuration file. 

For dashboards the files contain the configuration for provisioning from external resources. It currently only support reading dashboards from file but more provisioners are in the works.

This functionality partly clashes with the jobs provided by this Helm chart. In order to support both Grafana 4/5 in the same chart, I think, it is a sensible approach to allow for both provisioning mechanisms. In the absence of more sophisticated provisioners (that allow the decoupling from Helm and dashboards) it is anyway required to load the dashboard from the filesystem and inject it using the existing mechanism.