### PR TITLE
[etcd-operator] ensure service account names match if creating rbac

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.6.3
+version: 0.7.0
 appVersion: 0.7.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.6.2
+version: 0.6.3
 appVersion: 0.7.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/templates/_helpers.tpl
+++ b/stable/etcd-operator/templates/_helpers.tpl
@@ -44,7 +44,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Create the name of the etcd-operator service account to use
 */}}
-{{- define "etcdOperator.serviceAccountName" -}}
+{{- define "etcd-operator.serviceAccountName" -}}
 {{- if .Values.serviceAccount.etcdOperatorServiceAccount.create -}}
     {{ default (include "etcd-operator.fullname" .) .Values.serviceAccount.etcdOperatorServiceAccount.name }}
 {{- else -}}
@@ -55,7 +55,7 @@ Create the name of the etcd-operator service account to use
 {{/*
 Create the name of the backup-operator service account to use 
 */}}
-{{- define "backupOperator.serviceAccountName" -}}
+{{- define "etcd-backup-operator.serviceAccountName" -}}
 {{- if .Values.serviceAccount.backupOperatorServiceAccount.create -}}
     {{ default (include "etcd-backup-operator.fullname" .) .Values.serviceAccount.backupOperatorServiceAccount.name }}
 {{- else -}}
@@ -66,7 +66,7 @@ Create the name of the backup-operator service account to use
 {{/*
 Create the name of the restore-operator service account to use 
 */}}
-{{- define "restoreOperator.serviceAccountName" -}}
+{{- define "etcd-restore-operator.serviceAccountName" -}}
 {{- if .Values.serviceAccount.restoreOperatorServiceAccount.create -}}
     {{ default (include "etcd-restore-operator.fullname" .) .Values.serviceAccount.restoreOperatorServiceAccount.name }}
 {{- else -}}

--- a/stable/etcd-operator/templates/_helpers.tpl
+++ b/stable/etcd-operator/templates/_helpers.tpl
@@ -40,3 +40,36 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.restoreOperator.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the etcd-operator service account to use
+*/}}
+{{- define "etcdOperator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.etcdOperatorServiceAccount.create -}}
+    {{ default (include "etcd-operator.fullname" .) .Values.serviceAccount.etcdOperatorServiceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.etcdOperatorServiceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the backup-operator service account to use 
+*/}}
+{{- define "backupOperator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.backupOperatorServiceAccount.create -}}
+    {{ default (include "etcd-backup-operator.fullname" .) .Values.serviceAccount.backupOperatorServiceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.backupOperatorServiceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the restore-operator service account to use 
+*/}}
+{{- define "restoreOperator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.restoreOperatorServiceAccount.create -}}
+    {{ default (include "etcd-restore-operator.fullname" .) .Values.serviceAccount.restoreOperatorServiceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.restoreOperatorServiceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "backupOperator.serviceAccountName" . }}
+  name: {{ template "etcd-backup-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
@@ -11,11 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-{{- if .Values.serviceAccount.backupOperatorServiceAccount.name }}
-  name: {{ .Values.serviceAccount.backupOperatorServiceAccount.name }}
-{{- else }}
-  name: {{ template "etcd-backup-operator.fullname" . }}
-{{- end }}
+  name: {{ template "backupOperator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
@@ -11,7 +11,11 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.rbac.backupOperatorServiceAccountName }}
   name: {{ .Values.rbac.backupOperatorServiceAccountName }}
+{{- else }}
+  name: {{ template "etcd-backup-operator.fullname" . }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
@@ -11,8 +11,8 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-{{- if .Values.rbac.backupOperatorServiceAccountName }}
-  name: {{ .Values.rbac.backupOperatorServiceAccountName }}
+{{- if .Values.serviceAccount.backupOperatorServiceAccount.name }}
+  name: {{ .Values.serviceAccount.backupOperatorServiceAccount.name }}
 {{- else }}
   name: {{ template "etcd-backup-operator.fullname" . }}
 {{- end }}

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -18,11 +18,7 @@ spec:
         app: {{ template "etcd-backup-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-    {{- if .Values.serviceAccount.backupOperatorServiceAccount.name }}
-      serviceAccountName: {{ .Values.serviceAccount.backupOperatorServiceAccount.name }}
-    {{- else }}
-      serviceAccountName: {{ template "etcd-backup-operator.fullname" . }}
-    {{- end }}
+      serviceAccountName: {{ template "backupOperator.serviceAccountName" . }}
       containers:
       - name: {{ .Values.backupOperator.name }}
         image: "{{ .Values.backupOperator.image.repository }}:{{ .Values.backupOperator.image.tag }}"

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -18,8 +18,8 @@ spec:
         app: {{ template "etcd-backup-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-    {{- if .Values.rbac.backupOperatorServiceAccountName }}
-      serviceAccountName: {{ .Values.rbac.backupOperatorServiceAccountName }}
+    {{- if .Values.serviceAccount.backupOperatorServiceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.backupOperatorServiceAccount.name }}
     {{- else }}
       serviceAccountName: {{ template "etcd-backup-operator.fullname" . }}
     {{- end }}

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -18,7 +18,11 @@ spec:
         app: {{ template "etcd-backup-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "etcd-backup-operator.fullname" . }}{{ else }}{{ .Values.rbac.backupOperatorServiceAccountName }}{{ end }}
+    {{- if .Values.rbac.backupOperatorServiceAccountName }}
+      serviceAccountName: {{ .Values.rbac.backupOperatorServiceAccountName }}
+    {{- else }}
+      serviceAccountName: {{ template "etcd-backup-operator.fullname" . }}
+    {{- end }}
       containers:
       - name: {{ .Values.backupOperator.name }}
         image: "{{ .Values.backupOperator.image.repository }}:{{ .Values.backupOperator.image.tag }}"

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: {{ template "etcd-backup-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "backupOperator.serviceAccountName" . }}
+      serviceAccountName: {{ template "etcd-backup-operator.serviceAccountName" . }}
       containers:
       - name: {{ .Values.backupOperator.name }}
         image: "{{ .Values.backupOperator.image.repository }}:{{ .Values.backupOperator.image.tag }}"

--- a/stable/etcd-operator/templates/backup-operator-service-account.yaml
+++ b/stable/etcd-operator/templates/backup-operator-service-account.yaml
@@ -3,7 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.rbac.backupOperatorServiceAccountName }}
+  name: {{ .Values.rbac.backupOperatorServiceAccountName }}
+{{- else }}
   name: {{ template "etcd-backup-operator.fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-backup-operator.name" . }}

--- a/stable/etcd-operator/templates/backup-operator-service-account.yaml
+++ b/stable/etcd-operator/templates/backup-operator-service-account.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "backupOperator.serviceAccountName" . }}
+  name: {{ template "etcd-backup-operator.serviceAccountName" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-backup-operator.name" . }}

--- a/stable/etcd-operator/templates/backup-operator-service-account.yaml
+++ b/stable/etcd-operator/templates/backup-operator-service-account.yaml
@@ -3,11 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.serviceAccount.backupOperatorServiceAccount.name }}
-  name: {{ .Values.serviceAccount.backupOperatorServiceAccount.name }}
-{{- else }}
-  name: {{ template "etcd-backup-operator.fullname" . }}
-{{- end }}
+  name: {{ template "backupOperator.serviceAccountName" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-backup-operator.name" . }}

--- a/stable/etcd-operator/templates/backup-operator-service-account.yaml
+++ b/stable/etcd-operator/templates/backup-operator-service-account.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.rbac.create .Values.deployments.backupOperator }}
+{{- if and .Values.serviceAccount.backupOperatorServiceAccount.create .Values.deployments.backupOperator }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.rbac.backupOperatorServiceAccountName }}
-  name: {{ .Values.rbac.backupOperatorServiceAccountName }}
+{{- if .Values.serviceAccount.backupOperatorServiceAccount.name }}
+  name: {{ .Values.serviceAccount.backupOperatorServiceAccount.name }}
 {{- else }}
   name: {{ template "etcd-backup-operator.fullname" . }}
 {{- end }}

--- a/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
@@ -11,11 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-{{- if .Values.serviceAccount.etcdOperatorServiceAccount.name }}
-  name: {{ .Values.serviceAccount.etcdOperatorServiceAccount.name }}
-{{- else }}
-  name: {{ template "etcd-operator.fullname" . }}
-{{- end }}
+  name: {{ template "etcdOperator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "etcdOperator.serviceAccountName" . }}
+  name: {{ template "etcd-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
@@ -11,7 +11,11 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.rbac.etcdOperatorServiceAccountName }}
   name: {{ .Values.rbac.etcdOperatorServiceAccountName }}
+{{- else }}
+  name: {{ template "etcd-operator.fullname" . }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
@@ -11,8 +11,8 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-{{- if .Values.rbac.etcdOperatorServiceAccountName }}
-  name: {{ .Values.rbac.etcdOperatorServiceAccountName }}
+{{- if .Values.serviceAccount.etcdOperatorServiceAccount.name }}
+  name: {{ .Values.serviceAccount.etcdOperatorServiceAccount.name }}
 {{- else }}
   name: {{ template "etcd-operator.fullname" . }}
 {{- end }}

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -18,7 +18,11 @@ spec:
         app: {{ template "etcd-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "etcd-operator.fullname" . }}{{ else }}{{ .Values.rbac.etcdOperatorServiceAccountName }}{{ end }}
+    {{- if .Values.rbac.etcdOperatorServiceAccountName }}
+      serviceAccountName: {{ .Values.rbac.etcdOperatorServiceAccountName }}
+    {{- else }}
+      serviceAccountName: {{ template "etcd-operator.fullname" . }}
+    {{- end }}
       containers:
       - name: {{ template "etcd-operator.fullname" . }}
         image: "{{ .Values.etcdOperator.image.repository }}:{{ .Values.etcdOperator.image.tag }}"

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -18,11 +18,7 @@ spec:
         app: {{ template "etcd-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-    {{- if .Values.serviceAccount.etcdOperatorServiceAccount.name }}
-      serviceAccountName: {{ .Values.serviceAccount.etcdOperatorServiceAccount.name }}
-    {{- else }}
-      serviceAccountName: {{ template "etcd-operator.fullname" . }}
-    {{- end }}
+      serviceAccountName: {{ template "etcdOperator.serviceAccountName" . }}
       containers:
       - name: {{ template "etcd-operator.fullname" . }}
         image: "{{ .Values.etcdOperator.image.repository }}:{{ .Values.etcdOperator.image.tag }}"

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: {{ template "etcd-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "etcdOperator.serviceAccountName" . }}
+      serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
       containers:
       - name: {{ template "etcd-operator.fullname" . }}
         image: "{{ .Values.etcdOperator.image.repository }}:{{ .Values.etcdOperator.image.tag }}"

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -18,8 +18,8 @@ spec:
         app: {{ template "etcd-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-    {{- if .Values.rbac.etcdOperatorServiceAccountName }}
-      serviceAccountName: {{ .Values.rbac.etcdOperatorServiceAccountName }}
+    {{- if .Values.serviceAccount.etcdOperatorServiceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.etcdOperatorServiceAccount.name }}
     {{- else }}
       serviceAccountName: {{ template "etcd-operator.fullname" . }}
     {{- end }}

--- a/stable/etcd-operator/templates/operator-service-account.yaml
+++ b/stable/etcd-operator/templates/operator-service-account.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.rbac.create .Values.deployments.etcdOperator }}
+{{- if and .Values.serviceAccount.etcdOperatorServiceAccount.create .Values.deployments.etcdOperator }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.rbac.etcdOperatorServiceAccountName }}
-  name: {{ .Values.rbac.etcdOperatorServiceAccountName }}
+{{- if .Values.serviceAccount.etcdOperatorServiceAccount.name }}
+  name: {{ .Values.serviceAccount.etcdOperatorServiceAccount.name }}
 {{- else }}
   name: {{ template "etcd-operator.fullname" . }}
 {{- end }}

--- a/stable/etcd-operator/templates/operator-service-account.yaml
+++ b/stable/etcd-operator/templates/operator-service-account.yaml
@@ -3,11 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.serviceAccount.etcdOperatorServiceAccount.name }}
-  name: {{ .Values.serviceAccount.etcdOperatorServiceAccount.name }}
-{{- else }}
-  name: {{ template "etcd-operator.fullname" . }}
-{{- end }}
+  name: {{ template "etcdOperator.serviceAccountName" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-operator.name" . }}

--- a/stable/etcd-operator/templates/operator-service-account.yaml
+++ b/stable/etcd-operator/templates/operator-service-account.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "etcdOperator.serviceAccountName" . }}
+  name: {{ template "etcd-operator.serviceAccountName" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-operator.name" . }}

--- a/stable/etcd-operator/templates/operator-service-account.yaml
+++ b/stable/etcd-operator/templates/operator-service-account.yaml
@@ -3,7 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.rbac.etcdOperatorServiceAccountName }}
+  name: {{ .Values.rbac.etcdOperatorServiceAccountName }}
+{{- else }}
   name: {{ template "etcd-operator.fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-operator.name" . }}

--- a/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
@@ -11,7 +11,11 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.rbac.restoreOperatorServiceAccountName }}
   name: {{ .Values.rbac.restoreOperatorServiceAccountName }}
+{{- else }}
+  name: {{ template "etcd-restore-operator.fullname" . }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
@@ -11,11 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-{{- if .Values.serviceAccount.restoreOperatorServiceAccount.name }}
-  name: {{ .Values.serviceAccount.restoreOperatorServiceAccount.name }}
-{{- else }}
-  name: {{ template "etcd-restore-operator.fullname" . }}
-{{- end }}
+  name: {{ template "restoreOperator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
@@ -11,8 +11,8 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-{{- if .Values.rbac.restoreOperatorServiceAccountName }}
-  name: {{ .Values.rbac.restoreOperatorServiceAccountName }}
+{{- if .Values.serviceAccount.restoreOperatorServiceAccount.name }}
+  name: {{ .Values.serviceAccount.restoreOperatorServiceAccount.name }}
 {{- else }}
   name: {{ template "etcd-restore-operator.fullname" . }}
 {{- end }}

--- a/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "restoreOperator.serviceAccountName" . }}
+  name: {{ template "etcd-restore-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: {{ template "etcd-restore-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ template "restoreOperator.serviceAccountName" . }}
+      serviceAccountName: {{ template "etcd-restore-operator.serviceAccountName" . }}
       containers:
       - name: {{ .Values.restoreOperator.name }}
         image: "{{ .Values.restoreOperator.image.repository }}:{{ .Values.restoreOperator.image.tag }}"

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -18,7 +18,11 @@ spec:
         app: {{ template "etcd-restore-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "etcd-restore-operator.fullname" . }}{{ else }}{{ .Values.rbac.restoreOperatorServiceAccountName }}{{ end }}
+    {{- if .Values.rbac.restoreOperatorServiceAccountName }}
+      serviceAccountName: {{ .Values.rbac.restoreOperatorServiceAccountName }}
+    {{- else }}
+      serviceAccountName: {{ template "etcd-restore-operator.fullname" . }}
+    {{- end }}
       containers:
       - name: {{ .Values.restoreOperator.name }}
         image: "{{ .Values.restoreOperator.image.repository }}:{{ .Values.restoreOperator.image.tag }}"

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -18,8 +18,8 @@ spec:
         app: {{ template "etcd-restore-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-    {{- if .Values.rbac.restoreOperatorServiceAccountName }}
-      serviceAccountName: {{ .Values.rbac.restoreOperatorServiceAccountName }}
+    {{- if .Values.serviceAccount.restoreOperatorServiceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.restoreOperatorServiceAccount.name }}
     {{- else }}
       serviceAccountName: {{ template "etcd-restore-operator.fullname" . }}
     {{- end }}

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -18,11 +18,7 @@ spec:
         app: {{ template "etcd-restore-operator.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-    {{- if .Values.serviceAccount.restoreOperatorServiceAccount.name }}
-      serviceAccountName: {{ .Values.serviceAccount.restoreOperatorServiceAccount.name }}
-    {{- else }}
-      serviceAccountName: {{ template "etcd-restore-operator.fullname" . }}
-    {{- end }}
+      serviceAccountName: {{ template "restoreOperator.serviceAccountName" . }}
       containers:
       - name: {{ .Values.restoreOperator.name }}
         image: "{{ .Values.restoreOperator.image.repository }}:{{ .Values.restoreOperator.image.tag }}"

--- a/stable/etcd-operator/templates/restore-operator-service-account.yaml
+++ b/stable/etcd-operator/templates/restore-operator-service-account.yaml
@@ -3,7 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.rbac.restoreOperatorServiceAccountName }}
+  name: {{ .Values.rbac.restoreOperatorServiceAccountName }}
+{{- else }}
   name: {{ template "etcd-restore-operator.fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-restore-operator.name" . }}

--- a/stable/etcd-operator/templates/restore-operator-service-account.yaml
+++ b/stable/etcd-operator/templates/restore-operator-service-account.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "restoreOperator.serviceAccountName" . }}
+  name: {{ template "etcd-restore-operator.serviceAccountName" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-restore-operator.name" . }}

--- a/stable/etcd-operator/templates/restore-operator-service-account.yaml
+++ b/stable/etcd-operator/templates/restore-operator-service-account.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.rbac.create .Values.deployments.restoreOperator }}
+{{- if and .Values.serviceAccount.restoreOperatorServiceAccount.create .Values.deployments.restoreOperator }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.rbac.restoreOperatorServiceAccountName }}
-  name: {{ .Values.rbac.restoreOperatorServiceAccountName }}
+{{- if .Values.serviceAccount.restoreOperatorServiceAccount.name }}
+  name: {{ .Values.serviceAccount.restoreOperatorServiceAccount.name }}
 {{- else }}
   name: {{ template "etcd-restore-operator.fullname" . }}
 {{- end }}

--- a/stable/etcd-operator/templates/restore-operator-service-account.yaml
+++ b/stable/etcd-operator/templates/restore-operator-service-account.yaml
@@ -3,11 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.serviceAccount.restoreOperatorServiceAccount.name }}
-  name: {{ .Values.serviceAccount.restoreOperatorServiceAccount.name }}
-{{- else }}
-  name: {{ template "etcd-restore-operator.fullname" . }}
-{{- end }}
+  name: {{ template "restoreOperator.serviceAccountName" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "etcd-restore-operator.name" . }}

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -10,14 +10,14 @@ rbac:
 ## Service account names and whether to create them
 serviceAccount:
   etcdOperatorServiceAccount:
-    name: etcd-operator-sa
     create: true
+    name:
   backupOperatorServiceAccount:
-    name: backup-operator-sa
     create: true
+    name:
   restoreOperatorServiceAccount:
-    name: restore-operator-sa
     create: true
+    name:
 
 # Select what to deploy
 deployments:

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -6,9 +6,18 @@
 rbac:
   create: true
   apiVersion: v1beta1
-  etcdOperatorServiceAccountName: etcd-operator-sa
-  backupOperatorServiceAccountName: backup-operator-sa
-  restoreOperatorServiceAccountName: restore-operator-sa
+
+## Service account names and whether to create them
+serviceAccount:
+  etcdOperatorServiceAccount:
+    name: etcd-operator-sa
+    create: true
+  backupOperatorServiceAccount:
+    name: backup-operator-sa
+    create: true
+  restoreOperatorServiceAccount:
+    name: restore-operator-sa
+    create: true
 
 # Select what to deploy
 deployments:

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -6,9 +6,9 @@
 rbac:
   create: true
   apiVersion: v1beta1
-  etcdOperatorServiceAccountName: default
-  backupOperatorServiceAccountName: default
-  restoreOperatorServiceAccountName: default
+  etcdOperatorServiceAccountName: etcd-operator-sa
+  backupOperatorServiceAccountName: backup-operator-sa
+  restoreOperatorServiceAccountName: restore-operator-sa
 
 # Select what to deploy
 deployments:


### PR DESCRIPTION
This PR is to fix a bug that I encountered with the etcd-operator and RBAC setup. The way the current defaults are configured, deploying with RBAC results in cluster role bindings not matching up with the generated names from the service account and the deployment. 

For example, if I deploy RBAC:
- the [deployment](https://github.com/kubernetes/charts/blob/master/stable/etcd-operator/templates/operator-deployment.yaml#L21) and [svc account](https://github.com/kubernetes/charts/blob/master/stable/etcd-operator/templates/operator-service-account.yaml#L6) would both receive the generated "fullname" of the install.
- the [CRB](https://github.com/kubernetes/charts/blob/master/stable/etcd-operator/templates/operator-clusterrole-binding.yaml#L14), however, receives the value for the default (like `etcdOperatorServiceAccountName`).

This PR basically fixes that behavior by adding checks to see if the `etcdOperatorServiceAccountName` values are already present. If so, it uses those as opposed to generating the "fullname" value. This has the added value of allowing for custom svc account names to be used while creating RBAC stuff during install.