### PR TITLE
[vault] allow for custom cluster ip

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.9.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }} 
+  {{- end }}
   ports:
   - port: {{ .Values.service.port }}
     protocol: TCP

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -10,6 +10,7 @@ service:
   name: vault
   type: ClusterIP
   port: 8200
+  # clusterIP: None
   # annotations:
   #   cloud.google.com/load-balancer-type: "Internal"
 ingress:


### PR DESCRIPTION
This PR provides the ability to specify your own cluster IP value when using the ClusterIP service type. This is helpful in situations where you wish to provide a headless service for your deployment.