### PR TITLE
Add configuration for additional arguments

### DIFF
--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
 {{- if eq .Values.env.open.STORAGE "local" }}
         - --storage-local-rootdir=/storage
 {{- end }}
+        {{- if .Values.deployment.additionalArguments }}
+{{ toYaml .Values.deployment.additionalArguments | indent 8}}
+{{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
         livenessProbe:

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -44,6 +44,9 @@ deployment:
   ## Chartmuseum Deployment annotations
   annotations: {}
   #   name: value
+  ## Additional arguments for the chartmuseum deployment - see the image documentation for available options
+  additionalArguments: {}
+  # --allow-overwrite
 replica:
   ## Chartmuseum Replicas annotations
   annotations: {}

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -45,8 +45,8 @@ deployment:
   annotations: {}
   #   name: value
   ## Additional arguments for the chartmuseum deployment - see the image documentation for available options
-  additionalArguments: {}
-  # --allow-overwrite
+  additionalArguments:
+  # - --allow-overwrite
 replica:
   ## Chartmuseum Replicas annotations
   annotations: {}


### PR DESCRIPTION
Hi,
I added the additionalArguments to the deployment, to allow the user to set the commandline options documented at https://github.com/kubernetes-helm/chartmuseum.
Best regards,
Stefan



*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
