### PR TITLE
[stable/etcd-operator] Fix bindings to cluster roles when rbac is ena…

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.6.2
+version: 0.6.3
 appVersion: 0.7.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/backup-operator-clusterrole-binding.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.rbac.backupOperatorServiceAccountName }}
+  name: {{ if .Values.rbac.create }}{{ template "etcd-backup-operator.fullname" . }}{{ else }}{{ .Values.rbac.backupOperatorServiceAccountName }}{{ end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/operator-clusterrole-binding.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.rbac.etcdOperatorServiceAccountName }}
+  name: {{ if .Values.rbac.create }}{{ template "etcd-operator.fullname" . }}{{ else }}{{ .Values.rbac.etcdOperatorServiceAccountName }}{{ end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
+++ b/stable/etcd-operator/templates/restore-operator-clusterrole-binding.yaml
@@ -11,7 +11,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.rbac.restoreOperatorServiceAccountName }}
+  name: {{ if .Values.rbac.create }}{{ template "etcd-restore-operator.fullname" . }}{{ else }}{{ .Values.rbac.restoreOperatorServiceAccountName }}{{ end }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Roles have always been bound to the default service account.

Now service account is selected depending on the value `rbac.create`, as in deployment template.