### PR TITLE
[stable/gcloud-sqlproxy] Fix certificate error.

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-sqlproxy
-version: 0.2.2
+version: 0.2.3
 description: Google Cloud SQL Proxy
 keywords:
 - google

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -30,17 +30,12 @@ spec:
         volumeMounts:
         - name: cloudsql-oauth-credentials
           mountPath: /secrets/cloudsql
-        - name: ssl-certs
-          mountPath: /etc/ssl/certs
         - name: cloudsql
           mountPath: /cloudsql
       volumes:
       - name: cloudsql-oauth-credentials
         secret:
           secretName: {{ template "gcloud-sqlproxy.fullname" . }}
-      - name: ssl-certs
-        hostPath:
-          path: /etc/ssl/certs
       - name: cloudsql
         emptyDir: {}
       nodeSelector:


### PR DESCRIPTION
This volume is no longer needed since 1.09 and actually causes errors:

https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/78
