### PR TITLE
[stable/gcloud-sqlproxy] Allow specifying more than one instance.

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-sqlproxy
-version: 0.2.3
+version: 0.3.0
 description: Google Cloud SQL Proxy
 keywords:
 - google

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -21,11 +21,15 @@ You need to enable Cloud SQL Administration API and create a service account for
 
 ## Installing the Chart
 
-Install from remote URL with the release name `pg-sqlproxy` into namespace `sqlproxy`, set GCP service account and SQL instance and port:
+Install from remote URL with the release name `pg-sqlproxy` into namespace `sqlproxy`, set GCP service account and SQL instances and ports:
 
 ```console
 $ helm upgrade pg-sqlproxy stable/gcloud-sqlproxy --namespace sqlproxy \
-  --set serviceAccountKey="$(cat service-account.json | base64)",cloudsql.instance="PROJECT:REGION:INSTANCE",cloudsql.port="5432" -i
+    --set serviceAccountKey="$(cat service-account.json | base64)" \
+    --set cloudsql.instances[0].instance=INSTANCE \
+    --set cloudsql.instances[0].project=PROJECT \
+    --set cloudsql.instances[0].region=REGION \
+    --set cloudsql.instances[0].port=5432 -i
 ```
 
 Replace Postgres/MySQL host with: if access is from the same namespace with `pg-sqlproxy-gcloud-sqlproxy` or if it is from a different namespace with `pg-sqlproxy-gcloud-sqlproxy.sqlproxy`, the rest database connections settings do not have to be changed.
@@ -55,8 +59,7 @@ The following tables lists the configurable parameters of the Drupal chart and t
 | `imagePullPolicy`                 | Image pull policy                      | `IfNotPresent`                                            |
 | `replicasCount`                   | Replicas count                         | `1`                                                       |
 | `serviceAccountKey`               | Service account key JSON file          | Must be provided and base64 encoded                       |
-| `cloudsql.instance`               | PostgreSQL/MySQL instance name         | `project:region:instance` must be provided                |
-| `cloudsql.port`                   | PostgreSQL/MySQL instance port         | `5432`                                                    |
+| `cloudsql.instances`              | List of PostgreSQL/MySQL instances     | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided                |
 | `resources`                       | CPU/Memory resource requests/limits    | Memory: `100/150Mi`, CPU: `100/150m`                      |
 | `nodeSelector`                    | Node Selector                          |                                                           |
 

--- a/stable/gcloud-sqlproxy/templates/NOTES.txt
+++ b/stable/gcloud-sqlproxy/templates/NOTES.txt
@@ -9,30 +9,37 @@ All pods do not go to the running state if the GCP Service Account key was not p
 
 {{- end }}
 
-{{- if eq .Values.cloudsql.instance "PROJECT:REGION:INSTANCE" }}
+{{- if eq (index .Values.cloudsql.instances 0).instance "instance" }}
 
 ##############################################################################
-####   ERROR: You did not provide Google Cloud PROJECT:REGION:INSTANCE    ####
+####   ERROR: You did not provide Google Cloud instances.   ####
 ##############################################################################
 
-All pods do not go to the running state if the GCP `PROJECT:REGION:INSTANCE`
+All pods do not go to the running state if the instances
 settings were not provided.
 
 {{- end }}
 
-{{- if and .Values.serviceAccountKey (ne .Values.cloudsql.instance "PROJECT:REGION:INSTANCE") }}
+{{- if and .Values.serviceAccountKey (ne (index .Values.cloudsql.instances 0).instance "instance") }}
 
-The SQL server instance can be accessed via port {{ .Values.cloudsql.port }} on the
-following DNS name from within your cluster:
+The SQL server instances can be accessed via ports:
+{{- range .Values.cloudsql.instances }}
+  - {{ .port }} ({{ .instance }})
+{{- end }}
+on the following DNS name from within your cluster:
 - {{ template "gcloud-sqlproxy.fullname" . }}.{{ .Release.Namespace }}
 
 {{- else -}}
 
 This deployment will be incomplete until you provide GCP Service Account key
-and `PROJECT:REGION:INSTANCE` settings:
+and instances settings:
 
   helm upgrade {{ .Release.Name }} \
       --set serviceAccountKey="$(cat service-account.json | base64)" \
-      --set cloudsql.instance="PROJECT:REGION:INSTANCE" stable/gcloud-sqlproxy
+      --set cloudsql.instances[0].instance=INSTANCE \
+      --set cloudsql.instances[0].project=PROJECT \
+      --set cloudsql.instances[0].region=REGION \
+      --set cloudsql.instances[0].port=5432 \
+      stable/gcloud-sqlproxy
 
 {{- end }}

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccountKey (ne .Values.cloudsql.instance "PROJECT:REGION:INSTANCE") }}
+{{- if and .Values.serviceAccountKey (ne (index .Values.cloudsql.instances 0).instance "instance") }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -22,11 +22,15 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         command: ["/cloud_sql_proxy", "--dir=/cloudsql",
-                  "-instances={{ .Values.cloudsql.instance }}=tcp:0.0.0.0:{{ .Values.cloudsql.port }}",
+                  "-instances={{- range .Values.cloudsql.instances -}}
+                                {{ .project }}:{{ .region }}:{{ .instance }}=tcp:0.0.0.0:{{ .port }},
+                              {{- end }}",
                   "-credential_file=/secrets/cloudsql/credentials.json"]
         ports:
-        - name: sqlproxy
-          containerPort: {{ .Values.cloudsql.port }}
+        {{- range .Values.cloudsql.instances }}
+        - name: {{ .instance }}
+          containerPort: {{ .port }}
+        {{- end }}
         volumeMounts:
         - name: cloudsql-oauth-credentials
           mountPath: /secrets/cloudsql

--- a/stable/gcloud-sqlproxy/templates/svc.yaml
+++ b/stable/gcloud-sqlproxy/templates/svc.yaml
@@ -9,9 +9,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   ports:
-  - name: sqlproxy
+  {{- range .Values.cloudsql.instances }}
+  - name: {{ .instance }}
     protocol: TCP
-    port: {{ .Values.cloudsql.port }}
-    targetPort: sqlproxy
+    port: {{ .port }}
+    targetPort: {{ .instance }}
+  {{- end }}
   selector:
     app: {{ template "gcloud-sqlproxy.fullname" . }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -23,13 +23,16 @@ serviceAccountKey: ""
 ## SQL connection settings
 ##
 cloudsql:
-  ## PostgreSQL/MySQL instance:
+  ## PostgreSQL/MySQL instances:
   ## update with your GCP project, the region of your Cloud SQL instance
   ## and the name of your Cloud SQL instance
-  instance: "PROJECT:REGION:INSTANCE"
-
-  ## PostgreSQL port 5432 or MySQL port 3306, or other port you set for your SQL instance
-  port: 5432
+  ## PostgreSQL port 5432 or MySQL port 3306, or other port you set for your SQL instance.
+  ## Use different ports for different instances.
+  instances:
+  - instance: "instance"
+    project: "project"
+    region: "region"
+    port: 5432
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Useful when you want the proxy to serve multiple instances on different ports.

I'm bumping chart version to 0.3.0 as this is a breaking change.
