### PR TITLE
Adds Portus v2.3 chart to incubator

### DIFF
--- a/incubator/portus/.helmignore
+++ b/incubator/portus/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/portus/Chart.yaml
+++ b/incubator/portus/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+home: http://port.us.org
+description: A Portus Helm chart for Kubernetes. Portus is an authorization and user interface for the next generation of the Docker registry. 
+name: portus
+version: 0.1.0
+sources:
+  - https://github.com/kubic-project/caasp-services/tree/master/contrib/helm-charts/Portus
+maintainers:
+  - name: John Bonham
+    email: jbonham@suse.com

--- a/incubator/portus/Chart.yaml
+++ b/incubator/portus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 home: http://port.us.org
-description: A Portus Helm chart for Kubernetes. Portus is an authorization and user interface for the next generation of the Docker registry. 
+description: A Portus Helm chart for Kubernetes. Portus is an authorization and user interface for the next generation of the Docker registry.
 name: portus
 version: 0.1.0
 sources:

--- a/incubator/portus/README.md
+++ b/incubator/portus/README.md
@@ -1,0 +1,199 @@
+# Portus
+
+[Portus](http://port.us.org/) Portus is an open source authorization service and user interface for the next generation
+Docker Registry.
+
+## TL;DR;
+
+```console
+$ helm install incubator/portus
+```
+
+## Introduction
+
+This chart bootstraps a [Portus](http://port.us.org/) deployment on a [Kubernetes](http://kubernetes.io) cluster using
+the [Helm](https://helm.sh) package manager.
+
+It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which is
+required for bootstrapping a MariaDB deployment for the database requirements of the Portus application.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release incubator/portus
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes nearly all the Kubernetes components associated with the
+chart and deletes the release.
+
+## Portus TLS
+
+To run Portus securely you'll need an SSL key and certificate that cover the domain names that the Portus,
+Docker registry and Nginx services use. This chart does not use TLS by default, but it does support a TLS
+installation.
+
+To use TLS you must set `portus.tls.enabled` to true.
+
+You will need to generate an appropriate key and certificate if you would like to install the chart securely.
+
+If you would like to enable TLS for the Portus installation you will need to store your key in the value
+`portus.tls.key` and the certificate in the value `portus.tls.cert`
+
+## Configuration
+
+The following tables lists the configurable parameters of the portus chart and their default values.
+
+| Parameter                                         | Description                                | Default                                         |
+| ------------------------------------------------- | ------------------------------------------ | ----------------------------------------------- |
+| `portus.replicas`                                 | Portus deployment replica count            | ``                                              |
+| `portus.image.repository`                         | Portus image repository name               | `opensuse/portus`                               |
+| `portus.image.tag`                                | Portus image tag name                      | `2.3`                                           |
+| `portus.image.pullPolicy`                         | Portus image pull policy                   | `IfNotPresent`                                  |
+| `portus.service.port`                             | Portus service port                        | `3000`                                          |
+| `portus.resources.requests.memory`                | Portus memory resources                    | `512Mi`                                         |
+| `portus.resources.requests.cpu`                   | Portus cpu resources                       | `300m`                                          |
+| `portus.dbAdapter`                                | Database adapter Portus should use         | `mysql2`                                        |
+| `portus.dbHost`                                   | Name of host providing database            | ``                                              |
+| `portus.dbDatabase`                               | Name of database Portus will use           | ``                                              |
+| `portus.dbUsername`                               | Name of database user Portus will use      | ``                                              |
+| `portus.dbPassword`                               | Password to connect to database            | ``                                              |
+| `portus.password`                                 | Password used for background job user      | _random 10 character long alphanumeric string_  |
+| `portus.secretKeyBase`                            | Ruby on Rails secret app key               | _random 128 character long alphanumeric string_ |
+| `portus.config.email.from`                        | Email from address                         | `portus@example.com`                            |
+| `portus.config.email.name`                        | Email from name                            | `Portus`                                        |
+| `portus.config.email.reply_to`                    | Email reply-to                             | `no-reply@example.com`                          |
+| `portus.config.email.smtp.enabled`                | Enable SMTP email                          | `false`                                         |
+| `portus.config.email.smtp.address`                | SMTP address                               | `smtp.example.com`                              |
+| `portus.config.email.smtp.port`                   | SMTP config                                | `587`                                           |
+| `portus.config.email.smtp.domain`                 | SMTP port                                  | `example.com`                                   |
+| `portus.config.gravatar`                          | Use Gravatar                               | `true`                                          |
+| `portus.config.delete`                            | Allow repository deletion                  | `true`                                          |
+| `portus.config.first_user_admin`                  | Make initial user admin                    | `true`                                          |
+| `portus.config.signup`                            | Allow guests accounts                      | `true`                                          |
+| `portus.config.display_name`                      | Allow users to have display names          | `false`                                         |
+| `portus.config.user_permission.change_visibility` | Users can edit namespace visibility        | `true`                                          |
+| `portus.config.user_permission.create_team`       | Users can creat teams                      | `true`                                          |
+| `portus.config.user_permission.manage_team`       | Users can edit teams                       | `true`                                          |
+| `portus.config.user_permission.create_namespace`  | Users can create namespaces                | `true`                                          |
+| `portus.config.user_permission.manage_namespace`  | Users can edit namespaces                  | `true`                                          |
+| `portus.config.security.clair.server`             | Name of Clair server                       | ``                                              |
+| `portus.config.security.clair.health_port`        | Health port Clair is using                 | `6061`                                          |
+| `portus.config.security.zypper.server`            | Name of ZypperDocker server                | ``                                              |
+| `portus.config.anonymous_browsing`                | Allow anonymous repository browsing        | `true`                                          |
+| `portus.tls.enabled`                              | Determines if internal services use tls    | `false`                                         |
+| `portus.tls.key`                                  | SSL key for internal services              | ``                                              |
+| `portus.tls.cert`                                 | SSL certificate for internal services      | ``                                              |
+| `portus.background.enabled`                       | Run background Portus jobs                 | `true`                                          |
+| `portus.background.resources.requests.memory`     | Portus background process memory resources | `512Mi`                                         |
+| `portus.background.resources.requests.cpu`        | Portus background process cpu resources    | `300m`                                          |
+| `registry.replicas`                               | Docker registry deployment replica count   | `1`                                             |
+| `registry.mountPath`                              | Path uploaded images are stored at         | `/storage`                                      |
+| `registry.persistence.enabled`                    | Docker registry use persistent storage     | `true`                                          |
+| `registry.persistence.accessMode`                 | Docker registry persistence access mode    | `ReadWriteOnce`                                 |
+| `registry.persistence.capacity`                   | Docker registry persistence capacity       | `10Gi`                                          |
+| `registry.image.repository`                       | Docker registry image repository name      | `library/registry`                              |
+| `registry.image.tag`                              | Docker registry image tag name             | `latest`                                        |
+| `registry.image.pullPolicy`                       | Docker registry image pull policy          | `IfNotPresent`                                  |
+| `registry.service.port`                           | Docker registry API port                   | `5000`                                          |
+| `registry.service.debugPort`                      | Docker registry debug port                 | `5001`                                          |
+| `registry.resources.requests.memory`              | Registry deployment memory resources       | `512Mi`                                         |
+| `registry.resources.requests.cpu`                 | Registry deployment cpu resources          | `300m`                                          |
+| `nginx.replicas`                                  | Nginx deployment replica count             | `1`                                             |
+| `nginx.image.repository`                          | Nginx image repository name                | `library/nginx`                                 |
+| `nginx.image.tag`                                 | Nginx image tag name                       | `alpine`                                        |
+| `nginx.image.pullPolicy`                          | Nginx registry image pull policy           | `IfNotPresent`                                  |
+| `nginx.host`                                      | Domain name nginx proxy should use         | ``                                              |
+| `nginx.service.type`                              | Nginx service type                         | `ClusterIP`                                     |
+| `nginx.service.port`                              | Nginx internal port                        | `80`                                            |
+| `nginx.service.nodePort`                          | Nginx external port                        | ``                                              |
+| `nginx.ingress.enabled`                           | Determines if nginx proxy uses ingress     | `false`                                         |
+| `nginx.ingress.annotations`                       | Nginx ingress annotations                  | `{}`                                            |
+| `nginx.ingress.tls.enabled`                       | Determines if ingress uses TLS             | `[]`                                            |
+| `nginx.resources.requests.memory`                 | Nginx deployment memory resources          | `512Mi`                                         |
+| `nginx.resources.requests.cpu`                    | Nginx deployment cpu resources             | `300m`                                          |
+| `mariadb.enabled`                                 | Mariadb chart should be installed          | `true`                                          |
+| `mariadb.persistence.enabled`                     | Mariadb use persistent storage             | `false`                                         |
+| `mariadb.persistence.accessMode`                  | Mariadb persistence access mode            | `ReadWriteOnce`                                 |
+| `mariadb.persistence.size`                        | Mariadb persistence capacity               | `8Gi`                                           |
+| `mariadb.mariadbUser`                             | Mariadb user account name                  | `portus`                                        |
+| `mariadb.mariadbDatabase`                         | Mariadb database name                      | `portus`                                        |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release --set portus.replicas=2 incubator/portus
+```
+
+The above command will install Portus with a deployment set up to use two replicas.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
+chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml incubator/portus
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [Docker Registry](https://hub.docker.com/_/registry/) image stores the image data at the
+`.Values.registry.persistence.storagePath` path of the container.
+
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and
+minikube. See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Ingress
+
+This chart provides support for ingress resources. If you have an ingress controller installed on your cluster,
+such as [nginx-ingress](https://kubeapps.com/charts/stable/nginx-ingress) or [traefik](https://kubeapps.com/charts/stable/traefik)
+you can utilize the ingress controller to service your Portus application.
+
+To enable ingress set `nginx.ingress.enabled` to `true`.
+
+### Host
+The host set in `nginx.ingress.host` will be set as the host associated with the nginx proxy, which is the
+entrypoint into both the Portus application, and the Docker registry.
+
+### Annotations
+For annotations, please see
+[this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md).
+Not all annotations are supported by all ingress controllers, but this document does a good job of
+indicating which annotation is supported by many popular ingress controllers.
+
+### TLS Secrets
+If your cluster allows automatic creation/retrieval of TLS certificates
+(e.g. [kube-lego](https://github.com/jetstack/kube-lego)), please refer to the documentation for
+that mechanism.
+
+To manually configure TLS for ingress, first create/retrieve a key & certificate pair for the address you
+wish to protect. Then create a TLS secret in the namespace:
+
+```console
+kubectl create secret tls portus-tls --cert=path/to/tls.cert --key=path/to/tls.key
+```
+
+Include the secret's name, along with the desired hostnames, in the `nginx.ingress.tls`
+section of your custom `values.yaml` file.
+
+## MariaDB
+
+By default, this chart will use a MariaDB database deployed as a chart dependency. You can
+also bring your own MariaDB. To do so set `mariadb.enabled` to `false`, and set
+`portus.productionHost` to the address of the host providing the MariaDB that you would like
+to use, and `portus.productionPassword` to the password of the database you would like to use.

--- a/incubator/portus/requirements.lock
+++ b/incubator/portus/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mariadb
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.1
+digest: sha256:2aa62257cc5d38b171d80aed6b4052ebfd314a3043d07393f95bafb067263933
+generated: 2018-02-02T13:53:22.803733988-08:00

--- a/incubator/portus/requirements.yaml
+++ b/incubator/portus/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: mariadb 
+    version: 2.1.1 
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: mariadb.enabled

--- a/incubator/portus/templates/NOTES.txt
+++ b/incubator/portus/templates/NOTES.txt
@@ -1,0 +1,107 @@
+1. Get the Portus URL:
+
+  It may take a few moments for the Nginx proxy to find the Portus and Docker registry services, so you may get a 502 before connections are established.
+
+  {{- if .Values.nginx.ingress.enabled }}
+  You can access Portus, and the private Docker registry through:
+    {{- if .Values.nginx.ingress.tls.enabled }}
+    https://{{- .Values.nginx.host }}:{{- .Values.nginx.service.port }}
+    {{- else }}
+    http://{{- .Values.nginx.host }}:{{- .Values.nginx.service.port }}
+    {{- end }}
+
+  {{- else if eq "LoadBalancer" .Values.nginx.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "nginx.fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nginx.fullname" }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+  You can access Portus, and the private Docker registry through:
+    {{- if .Values.portus.tls.enabled }}
+    echo https://$SERVICE_IP:{{ .Values.nginx.service.port }}
+    {{- else }}
+    echo http://$SERVICE_IP:{{ .Values.nginx.service.port }}
+    {{- end }}
+
+  {{- else if and (eq "NodePort" .Values.nginx.service.type) .Values.nginx.service.nodePort }}
+  {{- if .Values.nginx.host }}
+  You can access Portus, and the private Docker registry through:
+    {{- if .Values.portus.tls.enabled }}
+    https://{{- .Values.nginx.host }}:{{- .Values.nginx.service.nodePort }}
+    {{- else }}
+    http://{{- .Values.nginx.host }}:{{- .Values.nginx.service.nodePort }}
+    {{- end }}
+  {{- else }}
+  You can access Portus through:
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+
+    {{- if .Values.portus.tls.enabled }}
+    https://$NODE_IP:{{- .Values.nginx.service.nodePort }}
+    {{- else }}
+    http://$NODE_IP:{{- .Values.nginx.service.nodePort }}
+    {{- end }}
+
+    The private Docker registry is not available from outside of the cluster. In order to have access to the registry from outside of the cluster "nginx.host" must be set. See instructions in the values file.
+  {{- end }}
+
+  {{- else }}
+  Portus is not accessible from outside of the cluster, with the current settings. Use an IngressController, LoadBalancer or NodePort to access Portus.
+  {{- end }}
+
+2. Create admin user account:
+
+  You will be prompted to create an account before you can use Portus.
+
+  {{- if .Values.portus.tls.enabled }}
+  Fill in whatever credentials you would like.
+  {{- else }}
+  In order to use the Docker registry without TLS you will need to setup the user with a specific name
+
+  Username:
+    Silly
+
+  You can set the email and password to whatever you would like.
+  {{- end }}
+
+3. Associate Portus with the private Docker registry:
+
+  After creating an admin account you will need to associate Portus with the installed instance of the Docker registry.
+
+  You can give the registry whatever name you would like, but must fill out the rest of the credentials according to these instructions.
+
+  Hostname:
+    {{ template "registry.fullname" . }}:{{ .Values.registry.service.port }}
+
+  {{- if .Values.portus.tls.enabled }}
+
+  Check "Use SSL"
+  {{- end }}
+
+  {{- if .Values.nginx.host }}
+
+  Click the button "Show Advanced"
+
+  External Registry Name:
+    {{- if .Values.nginx.ingress.enabled }}
+    {{- if .Values.nginx.ingress.tls.enabled }}
+    https://{{ .Values.nginx.host }}:{{ .Values.nginx.service.port }}
+    {{- else }}
+    http://{{ .Values.nginx.host }}:{{ .Values.nginx.service.port }}
+    {{- end }}
+
+    {{- else if and (eq "NodePort" .Values.nginx.service.type) .Values.portus.tls.enabled }}
+    https://{{ .Values.nginx.host }}:{{ .Values.nginx.service.nodePort }}
+
+    {{- else if eq "NodePort" .Values.nginx.service.type }}
+    http://{{ .Values.nginx.host }}:{{ .Values.nginx.service.nodePort }}
+
+    {{- else if eq "LoadBalancer" .Values.nginx.service.type }}
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "nginx.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+    {{- if .Values.portus.tls.enabled }}
+    echo https://$SERVICE_IP:{{ .Values.nginx.service.port }}
+    {{- else }}
+    echo http://$SERVICE_IP:{{ .Values.nginx.service.port }}
+    {{- end }}
+    {{- end }}
+  {{- end }}

--- a/incubator/portus/templates/_helpers.tpl
+++ b/incubator/portus/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "portus.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "registry.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "registry" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "nginx.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "nginx" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mariadb.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/portus/templates/nginx-configmap.yaml
+++ b/incubator/portus/templates/nginx-configmap.yaml
@@ -1,0 +1,214 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nginx.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  conf: |
+    # This file is largely based on the one written by @Djelibeybi in:
+    #      https://github.com/Djelibeybi/Portus-On-OracleLinux7/
+
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+      default_type  application/octet-stream;
+      charset       UTF-8;
+
+      # Some basic config.
+      server_tokens off;
+      sendfile      on;
+      tcp_nopush    on;
+      tcp_nodelay   on;
+
+      # On timeouts.
+      keepalive_timeout     65;
+      client_header_timeout 240;
+      client_body_timeout   240;
+      fastcgi_read_timeout  249;
+      reset_timedout_connection on;
+
+      ## Set a variable to help us decide if we need to add the
+      ## 'Docker-Distribution-Api-Version' header.
+      ## The registry always sets this header.
+      ## In the case of nginx performing auth, the header will be unset
+      ## since nginx is auth-ing before proxying.
+      map $upstream_http_docker_distribution_api_version $docker_distribution_api_version {
+        '' 'registry/2.0';
+      }
+
+      upstream {{ template "portus.fullname" . }} {
+        least_conn;
+        server {{ template "portus.fullname" . }}:{{ .Values.portus.service.port }} max_fails=3 fail_timeout=15s;
+      }
+
+      upstream {{ template "registry.fullname" . }}:{{ .Values.registry.service.port }} {
+        least_conn;
+        server {{ template "registry.fullname" . }}:{{ .Values.registry.service.port }} max_fails=3 fail_timeout=15s;
+      }
+
+      server {
+        server_name {{ template "nginx.fullname" . }}
+
+        {{- if .Values.portus.tls.enabled }}
+        listen {{ .Values.nginx.service.port }} ssl http2;
+
+        ##
+        # SSL
+
+        ssl on;
+
+        # Certificates
+        ssl_certificate /certificates/portus.crt;
+        ssl_certificate_key /certificates/portus.key;
+
+        # Enable session resumption to improve https performance
+        #
+        # http://vincent.bernat.im/en/blog/2011-ssl-session-reuse-rfc5077.html
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        # Enables server-side protection from BEAST attacks
+        # http://blog.ivanristic.com/2013/09/is-beast-still-a-threat.html
+        ssl_prefer_server_ciphers on;
+
+        # Disable SSLv3 (enabled by default since nginx 0.8.19)
+        # since it's less secure than TLS
+        # http://en.wikipedia.org/wiki/Secure_Sockets_Layer#SSL_3.0
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+        # Ciphers chosen for forward secrecy and compatibility.
+        #
+        # http://blog.ivanristic.com/2013/08/configuring-apache-nginx-and-openssl-for-forward-secrecy.html
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+        {{- else }}
+        listen {{ .Values.nginx.service.port }} http2;
+        {{- end }}
+
+        ##
+        # Docker-specific stuff.
+
+        proxy_set_header Host $http_host;   # required for Docker client sake
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+
+        # disable any limits to avoid HTTP 413 for large image uploads
+        client_max_body_size 0;
+
+        # required to avoid HTTP 411: see Issue #1486
+        # (https://github.com/docker/docker/issues/1486)
+        chunked_transfer_encoding on;
+
+        ##
+        # Custom headers.
+
+        # Adding HSTS[1] (HTTP Strict Transport Security) to avoid SSL stripping[2].
+        #
+        # [1] https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
+        # [2] https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+        # Don't allow the browser to render the page inside a frame or iframe
+        # and avoid Clickjacking. More in the following link:
+        #
+        # https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+        add_header X-Frame-Options DENY;
+
+        # Disable content-type sniffing on some browsers.
+        add_header X-Content-Type-Options nosniff;
+
+        # This header enables the Cross-site scripting (XSS) filter built into
+        # most recent web browsers. It's usually enabled by default anyway, so the
+        # role of this header is to re-enable the filter for this particular
+        # website if it was disabled by the user.
+        add_header X-XSS-Protection "1; mode=block";
+
+        # Add header for IE in compatibility mode.
+        add_header X-UA-Compatible "IE=edge";
+
+        # Redirect (most) requests to /v2/* to the Docker Registry
+        location /v2/ {
+          # Do not allow connections from docker 1.5 and earlier
+          # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
+          if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
+            return 404;
+          }
+
+          ## If $docker_distribution_api_version is empty, the header will not be added.
+          ## See the map directive above where this variable is defined.
+          add_header 'Docker-Distribution-Api-Version' $docker_distribution_api_version always;
+
+          {{- if .Values.portus.tls.enabled }}
+          proxy_pass https://{{ template "registry.fullname" . }}:{{ .Values.registry.service.port }};
+          {{- else }}
+          proxy_pass http://{{ template "registry.fullname" . }}:{{ .Values.registry.service.port }};
+          {{- end }}
+
+          proxy_set_header Host $http_host;   # required for docker client's sake
+          proxy_set_header X-Real-IP $remote_addr; # pass on real client's IP
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_read_timeout 900;
+          proxy_buffering on;
+        }
+
+        # Portus needs to handle /v2/token for authentication
+        location = /v2/token {
+          {{- if .Values.portus.tls.enabled }}
+          proxy_pass https://{{ template "portus.fullname" . }};
+          {{- else }}
+          proxy_pass http://{{ template "portus.fullname" . }};
+          {{- end }}
+
+          proxy_set_header Host $http_host;   # required for docker client's sake
+          proxy_set_header X-Real-IP $remote_addr; # pass on real client's IP
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_read_timeout 900;
+          proxy_buffering on;
+        }
+
+        # Portus needs to handle /v2/webhooks/events for notifications
+        location = /v2/webhooks/events {
+          {{- if .Values.portus.tls.enabled }}
+          proxy_pass https://{{ template "portus.fullname" . }};
+          {{- else }}
+          proxy_pass http://{{ template "portus.fullname" . }};
+          {{- end }}
+
+          proxy_set_header Host $http_host;   # required for docker client's sake
+          proxy_set_header X-Real-IP $remote_addr; # pass on real client's IP
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_read_timeout 900;
+          proxy_buffering on;
+        }
+
+        # Portus handles everything else for the UI
+        location / {
+          try_files $uri/index.html $uri.html $uri @{{ template "portus.fullname" . }};
+        }
+
+        location @{{ template "portus.fullname" . }} {
+          {{- if .Values.portus.tls.enabled }}
+          proxy_pass https://{{ template "portus.fullname" . }};
+          {{- else }}
+          proxy_pass http://{{ template "portus.fullname" . }};
+          {{- end }}
+
+          proxy_set_header Host $http_host;   # required for docker client's sake
+          proxy_set_header X-Real-IP $remote_addr; # pass on real client's IP
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_read_timeout 900;
+          proxy_buffering on;
+        }
+      }
+    }

--- a/incubator/portus/templates/nginx-deployment.yaml
+++ b/incubator/portus/templates/nginx-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "nginx.fullname" . }} 
+  labels:
+    name: {{ template "nginx.fullname" . }}
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.nginx.replicas }} 
+  selector:
+    matchLabels:
+      name: {{ template "nginx.fullname" . }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "nginx.fullname" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "nginx.fullname" . }}
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}" 
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }} 
+          resources:
+{{ toYaml .Values.nginx.resources | indent 12 }}
+          volumeMounts:
+            {{- if .Values.portus.tls.enabled }}
+            - name: certvol
+              mountPath: /certificates
+              readOnly: true
+            {{- end }}
+            - name: conf
+              mountPath: /etc/nginx
+          ports:
+            - containerPort: {{ .Values.nginx.service.port }}
+      volumes:
+        {{- if .Values.portus.tls.enabled }}
+        - name: certvol
+          secret:
+            secretName: {{ template "portus.fullname" . }}
+            items:
+            - key: key
+              path: portus.key
+            - key: cert
+              path: portus.crt
+        {{- end }}
+        - name: conf
+          configMap:
+            name: {{ template "nginx.fullname" . }}
+            items:
+            - key: conf
+              path: nginx.conf

--- a/incubator/portus/templates/nginx-ingress.yaml
+++ b/incubator/portus/templates/nginx-ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.nginx.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "nginx.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.nginx.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.nginx.host | quote }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ template "nginx.fullname" . }}
+              servicePort: {{ .Values.nginx.service.port }}
+  {{- if .Values.nginx.ingress.tls.enabled }}
+  tls:
+    - secretName: {{ .Values.nginx.ingress.tls.secretName | quote }}
+      hosts:
+        - {{ .Values.nginx.host | quote }}
+  {{- end }}
+{{- end }}

--- a/incubator/portus/templates/nginx-service.yaml
+++ b/incubator/portus/templates/nginx-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nginx.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    name: {{ template "nginx.fullname" . }}
+  type: {{ .Values.nginx.service.type }}
+  ports:
+    - name: portus
+      port: {{ .Values.nginx.service.port }}
+      {{- if and (eq "NodePort" .Values.nginx.service.type) .Values.nginx.service.nodePort }}
+      nodePort: {{ .Values.nginx.service.nodePort }}
+      {{- end }}

--- a/incubator/portus/templates/portus-configmap.yaml
+++ b/incubator/portus/templates/portus-configmap.yaml
@@ -1,0 +1,288 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "portus.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  config: |
+    # This file contains the default values for the configuration of this
+    # application. In order to change them, write your own config-local.yml file
+    # (it will be ignored by git). For more info, you can read the dedicated page
+    # here: http://port.us.org/docs/Configuring-Portus.html.
+
+    # Settings for the Portus mailer.
+    email:
+      from: {{ .Values.portus.config.email.from | quote }}
+      name: {{ .Values.portus.config.email.name | quote }}
+      reply_to: {{ .Values.portus.config.email.reply_to | quote }}
+
+      # If enabled, then SMTP will be used. Otherwise 'sendmail' will be used
+      # (defaults to: /usr/sbin/sendmail -i -t).
+      smtp:
+        enabled: {{ .Values.portus.config.email.smtp.enabled }}
+        address: {{ .Values.portus.config.email.smtp.address | quote }}
+        port: {{ .Values.portus.config.email.smtp.port }}
+        user_name: "username@example.com"
+        password: "password"
+        domain: {{ .Values.portus.config.email.smtp.domain | quote }}
+
+    # If enabled, then the profile picture will be picked from the Gravatar
+    # associated with each user. See: https://en.gravatar.com/
+    gravatar:
+      enabled: {{ .Values.portus.config.gravatar }}
+
+    # Allow admins and owners to delete images and tags. This feature should *only*
+    # be enabled if the version of the running registry is 2.4 or higher since
+    # it's the first version that supports garbage collection. That being said,
+    # Portus will only delete the manifests of the tags and administrators are
+    # supposed to be responsible for garbage collecting unreferenced blobs. This is
+    # because the registry 2.4 does not garbage collect automatically. For more
+    # information on garbage collection on the registry, read the documentation:
+    # https://github.com/docker/distribution/blob/master/docs/garbage-collection.md
+    # Also, you can read more in our documentation here:
+    # http://port.us.org/features/removing_images.html
+    delete:
+      enabled: {{ .Values.portus.config.delete }}
+
+    # LDAP support. If enabled, then only users of the specified LDAP server will
+    # be able to use Portus. Take a look at the documentation of LDAP support in our
+    # online docs: http://port.us.org/features/2_LDAP-support.html.
+    ldap:
+      enabled: false
+
+      hostname: "ldap_hostname"
+      port: 389
+
+      # Available options: "plain", "simple_tls" and "starttls". The default is
+      # "plain", the recommended is "starttls".
+      method: "plain"
+
+      # The base where users are located (e.g. "ou=users,dc=example,dc=com").
+      base: ""
+
+      # User filter (e.g. "mail=george*").
+      filter: ""
+
+      # The LDAP attribute where to search for username. The default is 'uid'.
+      uid: ""
+
+      # LDAP credentials used to search for a user.
+      authentication:
+        enabled: false
+        bind_dn: ""
+        password: ""
+
+      # Portus needs an email for each user, but there's no standard way to get
+      # that from LDAP servers. You can tell Portus how to get the email from users
+      # registered in the LDAP server with this configurable value. There are three
+      # possibilities:
+      #
+      #   - disabled: this is the default value. It means that Portus won't do a
+      #     thing when registering LDAP users (users will be redirected to their
+      #     profile page until they setup an email account).
+      #   - enabled where "attr" is empty: for this you need "ldap.base" to have
+      #     some value. In this case, the hostname will be guessed from the domain
+      #     component of the provided base string. For example, for the dn:
+      #     "ou=users,dc=example,dc=com", and a user name "user", the resulting
+      #     email is "user@example.com".
+      #   - enabled where "attr" is not empty: with this you specify the attribute
+      #     inside a LDIF record where the email is set.
+      #
+      # If something goes wrong when trying to guess the email, then it just falls
+      # back to the default behavior (empty email).
+      guess_email:
+        enabled: false
+        attr: ""
+
+    # OAuth support.
+    oauth:
+      # If enabled, users can authenticate with their Google Account.
+      # Callback url: <host>/users/auth/google_oauth2/callback
+      google_oauth2:
+        enabled: false
+        # Credentials. Details on https://developers.google.com/identity/protocols/OpenIDConnect
+        id: ""
+        secret: ""
+        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        domain: ""
+        options:
+          # G Suite domain. If set, then only members of the domain can sign in/up.
+          # If it's empty then any google users con sign in/up.
+          hd: ""
+
+      # OpenID authentication support. If enabled, then users can authenticate with OpenID/Connect
+      # Callback url: <host>/users/auth/open_id/callback
+      open_id:
+        enabled: false
+        # Optional. If identifier set then user redirect to the OpenID provider.
+        # If not, then user is asked for identifier before redirect.
+        # Example https://openid.stackexchange.com
+        identifier: ""
+        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        domain: ""
+
+      # Github authentication support.
+      # Callback url: <host>/users/auth/github/callback
+      github:
+        enabled: false
+        # Application credentials.
+        client_id: ""
+        client_secret: ""
+        # Only members of organization's team can sign in/up with Github.
+        organization: ""
+        team: ""
+        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        domain: ""
+
+      # Gitlab authentication support.
+      # Callback url: <host>/users/auth/gitlab/callback
+      gitlab:
+        enabled: false
+        application_id: ""
+        secret: ""
+        # Only member of the group can sign in/up with Gitlab.
+        group: ""
+        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        domain: ""
+        # The Gitlab server to be used. If empty, then https://gitlab.com is assumed.
+        server: ""
+
+      # Bitbucket authentication support. Need permission to read email.
+      # Callback url: <host>/users/auth/bitbucket/callback
+      bitbucket:
+        enabled: false
+        # Application credentials.
+        key: ""
+        secret: ""
+        # If a domain (e.g. mycompany.com) is set, then only signups with email from this domain are allowed.
+        domain: ""
+        options:
+          # Only members of team can sign in/up with Bitbucket. Need permission to read team membership.
+          team: ""
+
+    # Set first_user_admin to true if you want that the first user that signs up
+    # to be an admin.
+    #
+    # Set to false otherwise. Then you will need to run
+    #   rake portus:make_admin[USERNAME]
+    # in order to set the admin user
+    first_user_admin:
+      enabled: {{ .Values.portus.config.first_user_admin }}
+
+    # If enabled, then users can signup with the signup form. Otherwise, the admin
+    # is responsible of creating new users by either:
+    #   - Using the "portus:create_user" rake task.
+    #   - Using the form available in the admin panel.
+    # This is ignored if LDAP is enabled. Read more about this here:
+    # http://port.us.org/features/disabling_signup.html
+    signup:
+      enabled: {{ .Values.portus.config.signup }}
+
+    # By default require ssl to be enabled when running on production
+    check_ssl_usage:
+      enabled: {{ .Values.portus.tls.enabled }}
+
+    # Contains advanced options that tweak how Portus interacts with the
+    # Registry. Don't touch any of these values unless you *really* know what you
+    # are doing.
+    registry:
+      # Set the expiration time in minutes for the JWT Token that Portus uses to
+      # authenticate with the registry.
+      #
+      # Note that this is just a work-around on the fact that the registry does not
+      # try to get a new token again after the current one has expired. Once a
+      # solution is issued upstream, we can deprecate this option.
+      #
+      # See: https://github.com/SUSE/Portus/issues/510
+      jwt_expiration_time:
+        value: 5
+
+      # Set the pagination value for API calls that fetch data from the
+      # registry. You can read more about pagination in the registry here:
+      #   https://github.com/docker/distribution/blob/master/docs/spec/api.md#pagination
+      catalog_page:
+        value: 100
+
+      # Set the timeout in seconds for requests to the registry. Only change this
+      # value if you are *really* sure that you have an exceptionally slow
+      # connection to your private Docker registry.
+      timeout:
+        value: 2
+
+      # Set timeout in seconds for read response from registry.
+      read_timeout:
+        value: 120
+
+    # The FQDN of the machine where Portus is being deployed.
+    machine_fqdn:
+      value: {{ template "portus.fullname" . }}
+
+    # Allow users to have different display names on the web site. This will
+    # **not** be the username used by `docker login`. It defaults to false because
+    # it might confuse users that are not fully aware of it. You can read more about
+    # it here: http://port.us.org/features/display_name.html
+    display_name:
+      enabled: {{ .Values.portus.config.display_name }}
+
+    user_permission:
+      # Allow users to change the visibility or their personal namespace. If this is
+      # disabled, only an admin will be able to change this. It defaults to true.
+      change_visibility:
+        enabled: {{ .Values.portus.config.user_permission.change_visibility }}
+
+      # Allow users to create teams. If this is disabled only an admin will be able
+      # to do this. This defaults to true.
+      create_team:
+        enabled: {{ .Values.portus.config.user_permission.create_team }}
+
+      # Allow users to create/modify teams if they are an owner of it. If this is
+      # disabled only an admin will be able to do this. This defaults to true.
+      manage_team:
+        enabled: {{ .Values.portus.config.user_permission.manage_team }}
+
+      # Allow users to create namespaces. If this is disabled, only an admin will
+      # be able to do this. This defaults to true.
+      create_namespace:
+        enabled: {{ .Values.portus.config.user_permission.create_namespace }}
+
+      # Allow users to create/modify namespaces if they are an owner of it. If this
+      # is disabled, only an admin will be able to do this. This defaults to true.
+      manage_namespace:
+        enabled: {{ .Values.portus.config.user_permission.manage_namespace }}
+
+    # Security scanner support. Add the server location for each driver in order to
+    # enable it. If no drivers have been enabled, then this feature is skipped
+    # altogether. Enabling multiple drivers will simply aggregate the information
+    # provided by each driver.
+    security:
+      # CoreOS Clair support (https://github.com/coreos/clair). This is only
+      # guaranteed to work for v2.0.x releases of Clair.
+      clair:
+        server: {{ .Values.portus.config.security.clair.server | quote }}
+
+        # Port being used by Clair to report its status. Taking the default from
+        # Clair.
+        health_port: {{ .Values.portus.config.security.clair.health_port }}
+
+      # zypper-docker can be run as a server with its `serve` command. This backend
+      # fetches the information as given by zypper-docker. Note that this feature
+      # from zypper-docker is experimental and only available through another branch
+      # than master.
+      #
+      # NOTE: support for this is experimental since this functionality has not
+      # been merged into master yet in zypper-docker.
+      zypper:
+        server: {{ .Values.portus.config.security.zypper.server | quote }}
+
+      # This backend is only used for testing purposes, don't use it.
+      dummy:
+        server: ""
+
+    # Allow anonymous (non-logged-in) users to explore the images available in your
+    # Docker Registry. Only images on public namespaces will be shown.
+    anonymous_browsing:
+      enabled: {{ .Values.portus.config.anonymous_browsing }}

--- a/incubator/portus/templates/portus-deployment.yaml
+++ b/incubator/portus/templates/portus-deployment.yaml
@@ -1,0 +1,174 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "portus.fullname" . }} 
+  labels:
+    name: {{ template "portus.fullname" . }}
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.portus.replicas }}
+  selector:
+    matchLabels:
+      name: {{ template "portus.fullname" . }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "portus.fullname" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: "portus"
+          image: "{{ .Values.portus.image.repository }}:{{ .Values.portus.image.tag }}"
+          imagePullPolicy: {{ .Values.portus.image.pullPolicy }}
+          {{- if eq false .Values.portus.tls.enabled }}
+          command: ["/bin/bash"]
+          args: ["-c", "openssl genrsa -out /secrets/portus.key 3072;/init"]
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.portus.service.port }}
+          env:
+            - name: PORTUS_MACHINE_FQDN_VALUE
+              value: {{ template "portus.fullname" . }}
+            - name: PORTUS_DB_ADAPTER
+              value: {{ .Values.portus.dbAdapter }}
+            {{- if .Values.mariadb.enabled }}
+            - name: PORTUS_DB_HOST
+              value: {{ template "mariadb.fullname" . }}
+            - name: PORTUS_DB_DATABASE
+              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+            - name: PORTUS_DB_USERNAME
+              value: {{ .Values.mariadb.mariadbUser | quote }}
+            - name: PORTUS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.fullname" . }}
+                  key: mariadb-password
+            # - name: PORTUS_DB_PASSWORD
+            #   value: {{ .Values.mariadb.password }}
+            {{- else }}
+            - name: PORTUS_DB_HOST
+              value: {{ .Values.portus.dbHost }}
+            - name: PORTUS_DB_DATABASE
+              value: {{ .Values.portus.dbDatabase }}
+            - name: PORTUS_DB_USERNAME
+              value: {{ .Values.portus.dbUsername }}
+            - name: PORTUS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "portus.fullname" . }}  
+                  key: PORTUS_PRODUCTION_PASSWORD
+            {{- end }}
+            - name: PORTUS_KEY_PATH
+              value: "/secrets/portus.key"
+            {{- if .Values.portus.tls.enabled }}
+            - name: PORTUS_CERT_PATH
+              value: "/certificates/portus.crt"
+            - name: PORTUS_PUMA_TLS_KEY
+              value: "/secrets/portus.key"
+            - name: PORTUS_PUMA_TLS_CERT
+              value: "/certificates/portus.crt"
+            {{- end }}
+            - name: PORTUS_PUMA_HOST
+              value: {{ template "portus.fullname" . }} # :{{ .Values.portus.service.port }}
+            - name: RAILS_SERVE_STATIC_FILES
+              value: "true"
+            - name: PORTUS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "portus.fullname" . }}
+                  key: PORTUS_PASSWORD
+            - name: PORTUS_SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "portus.fullname" . }}
+                  key: PORTUS_SECRET_KEY_BASE
+          resources:
+{{ toYaml .Values.portus.resources | indent 12 }}
+          volumeMounts:
+            - name: secrets
+              mountPath: /secrets
+            - name: certificates
+              mountPath: /certificates
+            - name: config
+              mountPath: /srv/Portus/config/config-local.yml
+              subPath: etc/config-local.yml
+              readOnly: true
+        - name: "portus-background"
+          image: "{{ .Values.portus.image.repository }}:{{ .Values.portus.image.tag }}"
+          imagePullPolicy: {{ .Values.portus.image.pullPolicy }}
+          env:
+            - name: PORTUS_BACKGROUND
+              value: "true"
+            - name: PORTUS_DB_ADAPTER
+              value: {{ .Values.portus.dbAdapter | quote }}
+            {{- if .Values.mariadb.enabled }}
+            - name: PORTUS_DB_HOST
+              value: {{ template "mariadb.fullname" . }}
+            - name: PORTUS_DB_DATABASE
+              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+            - name: PORTUS_DB_USERNAME
+              value: {{ .Values.mariadb.mariadbUser | quote }}
+            - name: PORTUS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "mariadb.fullname" . }}
+                  key: mariadb-password
+            {{- else }}
+            - name: PORTUS_DB_HOST
+              value: {{ .Values.portus.dbHost }}
+            - name: PORTUS_DB_DATABASE
+              value: {{ .Values.portus.dbDatabase }}
+            - name: PORTUS_DB_USERNAME
+              value: {{ .Values.portus.dbUsername }}
+            - name: PORTUS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "portus.fullname" . }}
+                  key: PORTUS_PRODUCTION_PASSWORD
+            {{- end }}
+            - name: PORTUS_KEY_PATH
+              value: "/secrets/portus.key"
+            - name: PORTUS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "portus.fullname" . }}
+                  key: PORTUS_PASSWORD
+            - name: PORTUS_SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "portus.fullname" . }}
+                  key: PORTUS_SECRET_KEY_BASE
+          resources:
+{{ toYaml .Values.portus.background.resources | indent 12 }}
+          volumeMounts:
+            - name: secrets
+              mountPath: /secrets
+      volumes:
+        {{- if .Values.portus.tls.enabled }}
+        - name: secrets
+          secret:
+            secretName: {{ template "portus.fullname" . }}
+            items:
+              - key: key
+                path: portus.key
+        - name: certificates
+          secret:
+            secretName: {{ template "portus.fullname" . }}
+            items:
+              - key: cert
+                path: portus.crt
+        {{- else }}
+        - name: secrets
+          emptyDir: {}
+        - name: certificates
+          emptyDir: {}
+        {{- end }}
+        - name: config
+          configMap:
+            name: {{ template "portus.fullname" . }}
+            items:
+              - key: config
+                path: etc/config-local.yml

--- a/incubator/portus/templates/portus-secret.yaml
+++ b/incubator/portus/templates/portus-secret.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "portus.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.portus.password }}
+  PORTUS_PASSWORD: {{ .Values.portus.password | b64enc | quote }}
+  {{- else }}
+  PORTUS_PASSWORD: {{ randAlphaNum 10 | b64enc | quote }}
+  {{- end }}
+
+  {{- if .Values.portus.secretKeyBase }}
+  PORTUS_SECRET_KEY_BASE: {{ .Values.portus.secretKeyBase | b64enc | quote }}
+  {{- else }}
+  PORTUS_SECRET_KEY_BASE: {{ randAlphaNum 128 | b64enc | quote }}
+  {{- end }}
+
+  {{- if eq .Values.mariadb.enabled false }}
+  PORTUS_PRODUCTION_PASSWORD: {{ .Values.portus.productionPassword | b64enc | quote }}
+  {{- end }}
+
+  {{- if .Values.portus.tls.enabled }}
+  key: {{ .Values.portus.tls.key | b64enc | quote }}
+  cert: {{ .Values.portus.tls.cert | b64enc | quote }}
+  {{- end }}

--- a/incubator/portus/templates/portus-service.yaml
+++ b/incubator/portus/templates/portus-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "portus.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    name: {{ template "portus.fullname" . }}
+  ports:
+    - name: "{{ .Values.portus.service.name }}"
+      port: {{ .Values.portus.service.port }} 

--- a/incubator/portus/templates/registry-configmap.yaml
+++ b/incubator/portus/templates/registry-configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "registry.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- if .Values.portus.tls.enabled }}
+  REGISTRY_AUTH_TOKEN_REALM: {{ printf "https://%s:%s/v2/token" (.Values.nginx.host | default (printf "%s" (include "nginx.fullname" .))) .Values.nginx.port | quote }}
+  REGISTRY_AUTH_TOKEN_SERVICE: {{ printf "%s:%s" (include "registry.fullname" .) .Values.registry.service.port | quote }}
+  REGISTRY_AUTH_TOKEN_ISSUER: {{ template "portus.fullname" . }}
+  REGISTRY_HTTP_TLS_KEY: "/certificates/portus.key"
+  REGISTRY_HTTP_TLS_CERTIFICATE: "/certificates/portus.crt"
+  REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE: "/certificates/portus.crt"
+  {{- else }}
+  REGISTRY_AUTH_SILLY_REALM: {{ printf "http://%s:%s/v2/token" (.Values.nginx.host | default (printf "%s" (include "nginx.fullname" .))) (.Values.nginx.service.nodePort | default .Values.nginx.port) | quote }}
+  REGISTRY_AUTH_SILLY_SERVICE: {{ printf "%s:%s" (include "registry.fullname" .) .Values.registry.service.port | quote }}
+  {{- end }}
+
+  REGISTRY_NOTIFICATIONS_ENDPOINTS: >
+    - name: nginx
+      {{- if .Values.portus.tls.enabled }}
+      url: https://{{ template "nginx.fullname" . }}/v2/webhooks/events
+      {{- else }}
+      url: http://{{ template "nginx.fullname" . }}/v2/webhooks/events
+      {{- end }}
+      timeout: 2000ms
+      threshold: 5
+      backoff: 1s
+  config: |
+    version: 0.1
+    storage:
+      filesystem:
+        rootdirectory: {{ .Values.registry.mountPath }}
+      delete:
+        enabled: true
+    http:
+      addr: 0.0.0.0:{{ .Values.registry.service.port }}
+      debug:
+        addr: 0.0.0.0:{{ .Values.registry.service.debugPort }}

--- a/incubator/portus/templates/registry-deployment.yaml
+++ b/incubator/portus/templates/registry-deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "registry.fullname" . }} 
+  labels:
+    name: {{ template "registry.fullname" . }}
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.registry.replicas }} 
+  selector:
+    matchLabels:
+      name: {{ template "registry.fullname" . }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "registry.fullname" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ template "registry.fullname" . }}
+          image: "{{ .Values.registry.image.repository }}:{{ .Values.registry.image.tag }}" 
+          imagePullPolicy: {{ .Values.registry.image.pullPolicy }} 
+          {{- if .Values.portus.tls.enabled }}
+          command: ["/bin/sh"]
+          args: ["-c", "cp /certificates/portus.crt /usr/local/share/ca-certificates;update-ca-certificates;registry serve /etc/docker/registry/config.yml"]
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.registry.service.port }} 
+            - containerPort: {{ .Values.registry.service.debugPort }} 
+          env:
+            {{- if .Values.portus.tls.enabled }}
+            - name: REGISTRY_AUTH_TOKEN_REALM
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_AUTH_TOKEN_REALM
+            - name: REGISTRY_AUTH_TOKEN_SERVICE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_AUTH_TOKEN_SERVICE
+            - name: REGISTRY_AUTH_TOKEN_ISSUER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_AUTH_TOKEN_ISSUER
+            - name: REGISTRY_HTTP_TLS_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_HTTP_TLS_KEY
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_HTTP_TLS_CERTIFICATE
+            - name: REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE
+            {{- else }}
+            - name: REGISTRY_AUTH_SILLY_REALM
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_AUTH_SILLY_REALM
+            - name: REGISTRY_AUTH_SILLY_SERVICE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_AUTH_SILLY_SERVICE
+            {{- end }}
+            - name: REGISTRY_NOTIFICATIONS_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "registry.fullname" . }}
+                  key: REGISTRY_NOTIFICATIONS_ENDPOINTS
+          resources:
+{{ toYaml .Values.registry.resources | indent 12 }}
+          volumeMounts:
+            {{- if .Values.portus.tls.enabled }}
+            - name: certvol
+              mountPath: /certificates
+            {{- end }}
+            - name: config
+              mountPath: /etc/docker/registry
+              readOnly: true
+            - name: storage
+              mountPath: {{ .Values.registry.mountPath }}
+      volumes:
+        {{- if .Values.portus.tls.enabled }}
+        - name: certvol
+          secret:
+            secretName: {{ template "portus.fullname" . }}
+            items:
+            - key: key
+              path: portus.key
+            - key: cert
+              path: portus.crt
+        {{- end }}
+        - name: config
+          configMap:
+            name: {{ template "registry.fullname" . }}
+            items:
+              - key: config
+                path: config.yml
+        - name: storage
+          {{- if .Values.registry.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "registry.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/incubator/portus/templates/registry-persistent-volume-claim.yaml
+++ b/incubator/portus/templates/registry-persistent-volume-claim.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.registry.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "registry.fullname" . }}
+  labels:
+    storage: {{ template "registry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  accessModes:
+    - {{ .Values.registry.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.registry.persistence.size }}
+{{- end }}

--- a/incubator/portus/templates/registry-service.yaml
+++ b/incubator/portus/templates/registry-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "registry.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    name: {{ template "registry.fullname" . }}
+  ports:
+    - name: repo
+      port: {{ .Values.registry.service.port }} 
+    - name: debug
+      port: {{ .Values.registry.service.debugPort }} 

--- a/incubator/portus/values.yaml
+++ b/incubator/portus/values.yaml
@@ -1,0 +1,211 @@
+## Default values for Portus Helm Chart.
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
+
+## Default values for Portus
+##
+portus:
+  replicas: 1
+
+  ## Image configuration.
+  ##
+  image:
+    repository: "opensuse/portus"
+    tag: "2.3"
+    pullPolicy: "IfNotPresent"
+
+  ## Service configuration.
+  ##
+  service:
+    port: "3000"
+
+  ## Resource configuration.
+  ##
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "300m"
+
+  ## Portus database configuration.
+  dbAdapter: "mysql2"
+
+  ## only set db values if using existing database deployment
+  ##
+  # dbHost
+  # dbDatabase:
+  # dbUsername:
+  # dbPassword:
+
+  ## Defaults to a random 10-character alphanumeric string if not set
+  ##
+  # password:
+
+  ## Defaults to a random 128-character alphanumeric string if not set
+  ##
+  # secretKeyBase:
+
+  ## config
+  ##
+  config:
+    email:
+      from: "portus@example.com"
+      name: "Portus"
+      reply_to: "no-reply@example.com"
+      smtp:
+        enabled: false
+        address: "smtp.example.com"
+        port: 587
+        domain: "example.com"
+    gravatar: true  # If enabled, then the profile picture will be picked from the Gravatar
+    delete: true  # Allow admins and owners to delete images and tags
+    first_user_admin: true # First user signing up will be admin
+    signup: true  # If enabled, then users can signup with the signup form
+    display_name: false  # Allow users to have different display names on the web site
+    user_permission:
+      change_visibility: true  # Allow users to change the visibility or their personal namespace
+      create_team: true # Allow users to create teams
+      manage_team: true  # Allow users to create/modify teams if they are an owner of it
+      create_namespace: true # Allow users to create namespaces
+      manage_namespace: true  # Allow users to create/modify namespaces if they are an owner of it
+    security:
+      clair:
+        server: "" # This is only guaranteed to work for v2.0.x releases of Clair
+        health_port: 6061 # Port being used by Clair to report its status
+      zypper:
+        server: "" #  support for this is experimental since this functionality has not been merged into master yet in zypper-docker
+    anonymous_browsing: true # Allow anonymous (non-logged-in) users to explore the images available in your Docker Registry
+
+  ## TLS configuration
+  ## the internal host names of the portus, registry and nginx service must be covered by the key/cert in order for TLS to work properly
+  ##
+  tls:
+    enabled: false
+
+    ## must include key if using tls
+    ##
+    # key:
+
+    ## must include certificate if using tls
+    ##
+    # cert:
+
+  ## background processing
+  ##
+  background:
+    enabled: true
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "300m"
+
+## Default values for Docker Registry.
+##
+registry:
+  replicas: 1
+  mountPath: "/storage"
+
+  ## persistence configuration.
+  ##
+  persistence:
+    enabled: false
+    accessMode: "ReadWriteOnce"
+    size: "10Gi"
+
+  ## image configuration.
+  # #
+  image:
+    repository: "library/registry"
+    tag: "2.5.2"
+    pullPolicy: "IfNotPresent"
+
+  ## Service configuration.
+  ##
+  service:
+    port: "5000"
+    debugPort: "5001"
+
+  ## Resource configuration.
+  ##
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "300m"
+
+## Default values for Nginx.
+##
+nginx:
+  replicas: 1
+
+  ## image configuration.
+  ##
+  image:
+    repository: "library/nginx"
+    tag: "alpine"
+    pullPolicy: "IfNotPresent"
+
+  ## Service configuration.
+  ##
+  service:
+    ## Set to ClusterIP if using ingress, or NodePort if using minikube 
+    ##
+    type: "ClusterIP"
+
+    port: "80"
+    # nodePort:
+
+  ## in order to access the docker registry from outside of the cluster
+  ## if ingress is enabled set host to the domain you are using
+  ## if NodePort is being used set host to the ip address of a cluster node
+  ##
+  # host:
+
+  ## ingress configuration.
+  ##
+  ingress:
+    enabled: false
+
+    ## Anntations to be added to the web ingress
+    ##
+    # annotations:
+    #   kubernetes.io/ingress.class: "nginx"
+    #   nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    #   kubernetes.io/ingress.allow-http: "false"
+    #   ingress.kubernetes.io/ssl-passthrough: "true"
+
+    ## TLS configuration
+    ## the ingress host must be covered by the key/cert in order for TLS to work properly
+    ##
+    # tls:
+    #   enabled: false
+
+      ## Secrets containing SSL key and cert must be manually created in the namespace
+      ##
+      # secretName: "portus-tls"
+
+  ## Resource configuration.
+  ##
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "300m"
+
+## Default values for Mariadb.
+##
+mariadb:
+  ## Use Mariadb chart dependency
+  ## Set to false if using your own Mariadb
+  ##
+  enabled: true
+
+  ## persistence configuration.
+  ##
+  persistence:
+    enabled: false
+    accessMode: "ReadWriteOnce"
+    size: "8Gi"
+
+  ## Configuration values for Mariadb.
+  ##
+  mariadbUser: "portus"
+  mariadbDatabase: "portus"
+  mariadbPassword: "portus"

--- a/incubator/portus/values.yaml
+++ b/incubator/portus/values.yaml
@@ -58,22 +58,22 @@ portus:
         domain: "example.com"
     gravatar: true  # If enabled, then the profile picture will be picked from the Gravatar
     delete: true  # Allow admins and owners to delete images and tags
-    first_user_admin: true # First user signing up will be admin
+    first_user_admin: true  # First user signing up will be admin
     signup: true  # If enabled, then users can signup with the signup form
     display_name: false  # Allow users to have different display names on the web site
     user_permission:
       change_visibility: true  # Allow users to change the visibility or their personal namespace
-      create_team: true # Allow users to create teams
+      create_team: true  # Allow users to create teams
       manage_team: true  # Allow users to create/modify teams if they are an owner of it
-      create_namespace: true # Allow users to create namespaces
+      create_namespace: true  # Allow users to create namespaces
       manage_namespace: true  # Allow users to create/modify namespaces if they are an owner of it
     security:
       clair:
-        server: "" # This is only guaranteed to work for v2.0.x releases of Clair
-        health_port: 6061 # Port being used by Clair to report its status
+        server: ""  # This is only guaranteed to work for v2.0.x releases of Clair
+        health_port: 6061  # Port being used by Clair to report its status
       zypper:
-        server: "" #  support for this is experimental since this functionality has not been merged into master yet in zypper-docker
-    anonymous_browsing: true # Allow anonymous (non-logged-in) users to explore the images available in your Docker Registry
+        server: ""  #  support for this is experimental since this functionality has not been merged into master yet in zypper-docker
+    anonymous_browsing: true  # Allow anonymous (non-logged-in) users to explore the images available in your Docker Registry
 
   ## TLS configuration
   ## the internal host names of the portus, registry and nginx service must be covered by the key/cert in order for TLS to work properly
@@ -146,7 +146,7 @@ nginx:
   ## Service configuration.
   ##
   service:
-    ## Set to ClusterIP if using ingress, or NodePort if using minikube 
+    ## Set to ClusterIP if using ingress, or NodePort if using minikube
     ##
     type: "ClusterIP"
 


### PR DESCRIPTION
Portus is an open source authorization service and user interface for the next generation Docker Registry.

This chart uses the newest Portus release, v2.3, and optionally supports ingress, TLS, and persistent Mariadb and Docker Registry storage. The Portus application and the Docker Registry instance are configured to be accessible from a single entry point, set up through an NGINX reverse proxy.