### PR TITLE
[chartmuseum] upgrade and add new env var for anonymous GET operation…

### DIFF
--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 0.3.1
-appVersion: 0.2.7
+version: 0.3.2
+appVersion: 0.2.8
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png
 maintainers:

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -35,6 +35,8 @@ env:
     ALLOW_OVERWRITE: false
     # absolute url for .tgzs in index.yaml
     CHART_URL:
+    # allow annonymous GET operations when auth is used
+    AUTH_ANONYMOUS_GET: false
   secret:
     # username for basic http authentication
     BASIC_AUTH_USER:


### PR DESCRIPTION
…s, when basic auth enabled

- Upgrades to the latest chartmuseum v0.2.8
- Include default value for a new env var `AUTH_ANONYMOUS_GET ` so it's disabled OOTB