### PR TITLE
Fix RBAC API Version

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.4.6
+version: 0.4.7
 appVersion: 0.4.8
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -78,7 +78,7 @@ rbac:
   ##
   create: false
   # Beginning with Kubernetes 1.8, the api is stable and v1 can be used.
-  apiVersion: v1beta
+  apiVersion: v1
 
   ## Ignored if rbac.create is true
   ##


### PR DESCRIPTION
This is a quick fix because `v1beta` is not a valid API version.
We should either use `v1` (>1.8) or `v1beta`.