### PR TITLE
Add FluentD DaemonSet Chart

### DIFF
--- a/stable/fluentd-ds/.helmignore
+++ b/stable/fluentd-ds/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/fluentd-ds/Chart.yaml
+++ b/stable/fluentd-ds/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+description: A Fluentd Elasticsearch Helm chart for Kubernetes.
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+name: fluentd-ds
+version: 0.1.0
+appVersion: 0.12
+sources:
+- https://quay.io/repository/coreos/fluentd-kubernetes
+- https://github.com/coreos/fluentd-kubernetes-daemonset
+- https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+maintainers:
+- name: rendhalver
+  email: pete.brown@powerhrg.com

--- a/stable/fluentd-ds/templates/NOTES.txt
+++ b/stable/fluentd-ds/templates/NOTES.txt
@@ -1,0 +1,6 @@
+To verify that Fluentd Elasticsearch has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get all -l "app={{ template "fluentd-ds.name" . }},release={{ .Release.Name }}"
+
+THIS APPLICATION CAPTURES ALL CONSOLE OUTPUT AND FORWARDS IT TO Elasticsearch. Anything that might be identifying,
+including things like IP addresses, container images, and object names will NOT be anonymized.

--- a/stable/fluentd-ds/templates/_helpers.tpl
+++ b/stable/fluentd-ds/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd-ds.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fluentd-ds.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/fluentd-ds/templates/clusterrole.yaml
+++ b/stable/fluentd-ds/templates/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "fluentd-ds.fullname" . }}
+  labels:
+    app: {{ template "fluentd-ds.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  verbs: ["get", "list", "watch"]

--- a/stable/fluentd-ds/templates/clusterrolebinding.yaml
+++ b/stable/fluentd-ds/templates/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fluentd-ds.fullname" . }}
+  labels:
+    app: {{ template "fluentd-ds.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fluentd-ds.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd-ds.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/stable/fluentd-ds/templates/configmap.yaml
+++ b/stable/fluentd-ds/templates/configmap.yaml
@@ -40,12 +40,14 @@ data:
 
 {{- if .Values.config.kubernetes.enabled }}
     # Kubernetes
-    @include kubernetes.conf
+    @include kubernetes-input.conf
+    @include kubernetes-filter.conf
 {{- end }}
 
 {{- if .Values.config.systemd.enabled }}
     # SystemD
-    @include systemd.conf
+    @include systemd-input.conf
+    @include systemd-filter.conf
 {{- end }}
 
 {{- if .Values.config.apiserverAudit.enabled }}

--- a/stable/fluentd-ds/templates/configmap.yaml
+++ b/stable/fluentd-ds/templates/configmap.yaml
@@ -1,0 +1,214 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fluentd-ds.fullname" . }}
+  labels:
+    app: {{ template "fluentd-ds.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+data:
+  fluentd.conf: |
+    # Prevent fluentd from handling records containing its own logs. Otherwise
+    # it can lead to an infinite loop, when error in sending one message generates
+    # another message which also fails to be sent and so on.
+    <match fluent.**>
+      type null
+    </match>
+
+    # Used for health checking
+    <source>
+      @type http
+      port 9880
+      bind 0.0.0.0
+    </source>
+
+    # Emits internal metrics to every minute, and also exposes them on port
+    # 24220. Useful for determining if an output plugin is retryring/erroring,
+    # or determining the buffer queue length.
+    <source>
+      @type monitor_agent
+      bind 0.0.0.0
+      port 24220
+      tag fluentd.monitor.metrics
+    </source>
+
+{{- if .Values.config.prometheus.enabled }}
+    # Prometheus
+    @include prometheus.conf
+{{- end }}
+
+{{- if .Values.config.kubernetes.enabled }}
+    # Kubernetes
+    @include kubernetes.conf
+{{- end }}
+
+{{- if .Values.config.systemd.enabled }}
+    # SystemD
+    @include systemd.conf
+{{- end }}
+
+{{- if .Values.config.apiserverAudit.enabled }}
+    # API server
+    @include apiserver-audit-input.conf
+{{- end }}
+
+    # include extra config
+    @include extra.conf
+
+    # Send to storage
+    @include output.conf
+
+  prometheus.conf: |
+    # input plugin that is required to expose metrics by other prometheus
+    # plugins, such as the prometheus_monitor input below.
+    <source>
+      @type prometheus
+      bind 0.0.0.0
+      port 24231
+      metrics_path /metrics
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent and exposes them
+    # as prometheus metrics
+    <source>
+      @type prometheus_monitor
+      # update the metrics every 5 seconds
+      interval 5
+    </source>
+
+    <source>
+      @type prometheus_output_monitor
+      interval 5
+    </source>
+
+    <source>
+      @type prometheus_tail_monitor
+      interval 5
+    </source>
+
+  systemd-input.conf: |
+    <source>
+      @type systemd
+      pos_file /var/log/fluentd-journald-systemd.pos
+      read_from_head true
+      strip_underscores true
+      tag systemd
+    </source>
+
+  systemd-filter.conf: |
+    <match systemd>
+      @type rewrite_tag_filter
+      rewriterule1 SYSTEMD_UNIT   ^(.+).service$  systemd.$1
+      rewriterule2 SYSTEMD_UNIT   !^(.+).service$ systemd.unmatched
+    </match>
+
+    <filter systemd.kubelet>
+      type parser
+      format kubernetes
+      reserve_data true
+      key_name MESSAGE
+      suppress_parse_error_log true
+    </filter>
+
+    <filter systemd.docker>
+      type parser
+      format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      reserve_data true
+      key_name MESSAGE
+      suppress_parse_error_log true
+    </filter>
+
+    # Filter filter ssh logs since it's mostly bots trying to login
+    <filter systemd.**>
+      @type grep
+      <exclude>
+          key SYSTEMD_UNIT
+          pattern (sshd@.*\.service)
+      </exclude>
+      # exclude1 SYSTEMD_UNIT (sshd@.*\.service)
+    </filter>
+
+  kubernetes-input.conf: |
+    # Capture Kubernetes pod logs
+    # The kubelet creates symlinks that capture the pod name, namespace,
+    # container name & Docker container ID to the docker logs for pods in the
+    # /var/log/containers directory on the host.
+    <source>
+      type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      time_format %Y-%m-%dT%H:%M:%S.%NZ
+      tag kubernetes.*
+      format json
+      read_from_head true
+    </source>
+
+  kubernetes-filter.conf: |
+    # Query the API for extra metadata.
+    <filter kubernetes.**>
+      type kubernetes_metadata
+      # If the logs begin with '{' and end with '}' then it's JSON so merge
+      # the JSON log field into the log event
+      merge_json_log true
+      preserve_json_log true
+    </filter>
+
+    # rewrite_tag_filter does not support nested fields like
+    # kubernetes.container_name, so this exists to flatten the fields
+    # so we can use them in our rewrite_tag_filter
+    <filter kubernetes.**>
+      @type record_transformer
+      enable_ruby true
+      <record>
+        kubernetes_namespace_container_name ${record["kubernetes"]["namespace_name"]}.${record["kubernetes"]["container_name"]}
+      </record>
+    </filter>
+
+    # retag based on the container name of the log message
+    <match kubernetes.**>
+      @type rewrite_tag_filter
+      rewriterule1 kubernetes_namespace_container_name  ^(.+)$ kube.$1
+    </match>
+
+    # Remove the unnecessary field as the information is already available on
+    # other fields.
+    <filter kube.**>
+      @type record_transformer
+      remove_keys kubernetes_namespace_container_name
+    </filter>
+
+    <filter kube.kube-system.**>
+      type parser
+      format kubernetes
+      reserve_data true
+      key_name log
+      suppress_parse_error_log true
+    </filter>
+
+  apiserver-audit-input.conf: |
+    # Example:
+    # 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
+    # 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
+    <source>
+      type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\S+\s+AUDIT:/
+      # Fields must be explicitly captured by name to be parsed into the record.
+      # Fields may not always be present, and order may change, so this just looks
+      # for a list of key="\"quoted\" value" pairs separated by spaces.
+      # Unknown fields are ignored.
+      # Note: We can't separate query/response lines as format1/format2 because
+      #       they don't always come one after the other for a given query.
+      format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
+      time_format %FT%T.%L%Z
+      path /var/log/kubernetes/kube-apiserver-audit.log
+      pos_file /var/log/kube-apiserver-audit.log.pos
+      tag kube-apiserver-audit
+    </source>
+
+{{- range $key, $value := .Values.configMaps }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}

--- a/stable/fluentd-ds/templates/daemonset.yaml
+++ b/stable/fluentd-ds/templates/daemonset.yaml
@@ -1,0 +1,78 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fluentd-ds.fullname" . }}
+  labels:
+    app: {{ template "fluentd-ds.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    k8s-app: fluentd
+    component: logging-agent
+spec:
+  minReadySeconds: 10
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["fluentd", "-c", "/fluentd/etc/fluentd.conf", "-p", "/fluentd/plugins"]
+        env:
+          - name: OUTPUT_HOST
+            value: {{ .Values.output.host | quote }}
+          - name: OUTPUT_PORT
+            value: {{ .Values.output.port | quote }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - name: prom-metrics
+          containerPort: 24231
+          protocol: TCP
+        - name: monitor-agent
+          containerPort: 24220
+          protocol: TCP
+        - name: http-input
+          containerPort: 9880
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            # Use percent encoding for query param.
+            # The value is {"log": "health check"}.
+            # the endpoint itself results in a new fluentd
+            # tag 'fluentd.pod-healthcheck'
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluentd-config
+          mountPath: /fluentd/etc
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluentd-config
+        configMap:
+          name: {{ template "fluentd-ds.fullname" . }}
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: {{ template "fluentd-ds.fullname" . }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/stable/fluentd-ds/templates/daemonset.yaml
+++ b/stable/fluentd-ds/templates/daemonset.yaml
@@ -19,7 +19,15 @@ spec:
     metadata:
       labels:
         k8s-app: fluentd
+      annotations:
+        checksum/config: {{ include (print $.Chart.Name "/templates/" $.Chart.Name "-configmap.yaml") . | sha256sum }}
     spec:
+{{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $pullSecret := .Values.image.pullSecrets }}
+        - name: {{ $pullSecret }}
+      {{- end }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/fluentd-ds/templates/service.yaml
+++ b/stable/fluentd-ds/templates/service.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.config.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fluentd-ds.fullname" . }}
+  labels:
+    app: {{ template "fluentd-ds.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    k8s-app: fluentd
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    # - port: {{ .Values.service.externalPort }}
+    #   targetPort: {{ .Values.service.internalPort }}
+    #   protocol: TCP
+    #   name: {{ .Values.service.name }}
+    # Exposes Prometheus metrics
+    - name: prometheus-metrics
+      port: 24231
+      targetPort: prom-metrics
+      protocol: TCP
+    # Can be accessed using "kubectl proxy" at:
+    # http://127.0.0.1:8001/api/v1/proxy/namespaces/kube-system/services/fluentd:monitor-agent/api/plugins.json
+    - name: monitor-agent
+      port: 24220
+      targetPort: monitor-agent
+      protocol: TCP
+  selector:
+    k8s-app: fluentd
+    app: {{ template "fluentd-ds.name" . }}
+    release: {{ .Release.Name }}
+
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    k8s-app: fluentd
+  ports:
+  # Exposes Prometheus metrics
+  - name: prometheus-metrics
+    port: 24231
+    targetPort: prom-metrics
+    protocol: TCP
+  # Can be accessed using "kubectl proxy" at:
+  # http://127.0.0.1:8001/api/v1/proxy/namespaces/kube-system/services/fluentd:monitor-agent/api/plugins.json
+  - name: monitor-agent
+    port: 24220
+    targetPort: monitor-agent
+    protocol: TCP
+{{- end }}

--- a/stable/fluentd-ds/templates/serviceaccount.yaml
+++ b/stable/fluentd-ds/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fluentd-ds.fullname" . }}
+  labels:
+    app: {{ template "fluentd-ds.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}

--- a/stable/fluentd-ds/values.yaml
+++ b/stable/fluentd-ds/values.yaml
@@ -1,0 +1,125 @@
+# Default values for fluentd-ds.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: quay.io/coreos/fluentd-kubernetes
+  tag: v0.12-debian-elasticsearch
+  pullPolicy: IfNotPresent
+
+config:
+  systemd:
+    enabled: true
+  prometheus:
+    enabled: false
+  kubernetes:
+    enabled: true
+  apiserverAudit:
+    enabled: true
+
+output:
+  host: elasticsearch-client.default.svc.cluster.local
+  port: 9200
+
+service:
+  type: ClusterIP
+  metrics:
+    name: prometheus-metrics
+    port: 24231
+  agent:
+    port: 24220
+
+configMaps:
+  output.conf: |
+    <match **>
+      type elasticsearch
+      log_level info
+      include_tag_key true
+      # Replace with the host/port to your Elasticsearch cluster.
+      host "#{ENV['OUTPUT_HOST']}"
+      port "#{ENV['OUTPUT_PORT']}"
+      scheme http
+      ssl_verify false
+
+      logstash_format true
+      index_name logstash-
+      template_file /fluentd/etc/elasticsearch-template-es6x.json
+      template_name elasticsearch-template-es6x.json
+
+      buffer_chunk_limit 2M
+      buffer_queue_limit 32
+      flush_interval 10s
+      max_retry_wait 30
+      disable_retry_limit
+      num_threads 8
+    </match>
+  elasticsearch-template-es6x.json: |
+    {
+      "template" : "logstash-*",
+      "version" : 60001,
+      "settings" : {
+        "index.refresh_interval" : "5s"
+      },
+      "mappings" : {
+        "_default_" : {
+          "dynamic_templates" : [ {
+            "message_field" : {
+              "path_match" : "message",
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "text",
+                "norms" : false
+              }
+            }
+          }, {
+            "string_fields" : {
+              "match" : "*",
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "text", "norms" : false,
+                "fields" : {
+                  "keyword" : { "type": "keyword", "ignore_above": 256 }
+                }
+              }
+            }
+          } ],
+          "properties" : {
+            "@timestamp": { "type": "date"},
+            "@version": { "type": "keyword"},
+            "geoip"  : {
+              "dynamic": true,
+              "properties" : {
+                "ip": { "type": "ip" },
+                "location" : { "type" : "geo_point" },
+                "latitude" : { "type" : "half_float" },
+                "longitude" : { "type" : "half_float" }
+              }
+            }
+          }
+        }
+      }
+    }
+  extra.conf: |
+    # Example filter that adds an extra field "cluster_name" to all log
+    # messages:
+    # <filter **>
+    #   @type record_transformer
+    #   <record>
+    #     cluster_name "your_cluster_name"
+    #   </record>
+    # </filter>
+    #<system>
+    # equal to -qq option
+    #    log_level debug
+    #</system>
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 500m
+  #  memory: 200Mi
+  # requests:
+  #  cpu: 500m
+  #  memory: 200Mi

--- a/stable/fluentd-ds/values.yaml
+++ b/stable/fluentd-ds/values.yaml
@@ -5,7 +5,9 @@ image:
   repository: quay.io/coreos/fluentd-kubernetes
   tag: v0.12-debian-elasticsearch
   pullPolicy: IfNotPresent
-
+  # pullSecrets:
+  #   - secret1
+  #   - secret2
 config:
   systemd:
     enabled: true
@@ -41,7 +43,6 @@ configMaps:
       ssl_verify false
 
       logstash_format true
-      index_name logstash-
       template_file /fluentd/etc/elasticsearch-template-es6x.json
       template_name elasticsearch-template-es6x.json
 


### PR DESCRIPTION
Sets up a FluentD DaemonSet to gather and send container logs to a logging service
Elasticsearch is setup as the default but that is easily changable

This is a rewrite of #3232 to make it more configurable for multiple logging sources.

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
