### PR TITLE
[stable/cert-manager] update with expanded docs. Remove creating TPR support.

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -6,30 +6,34 @@ TLS certificates from various issuing sources.
 It will ensure certificates are valid and up to date periodically, and attempt
 to renew certificates at an appropriate time before expiry.
 
-Changes to this chart are tested and version in the [upstream cert-manager repository](https://github.com/jetstack/cert-manager).
-Changes to this chart should be made as pull requests upstream, to be versioned and copied across to this repo.
-
-## TL;DR;
-
-```console
-$ helm install stable/cert-manager
-```
-
-## Introduction
-
-This chart creates a cert-manager deployment on a Kubernetes cluster using the Helm package manager.
-
 ## Prerequisites
 
-- Kubernetes cluster with support for CustomResourceDefinition or ThirdPartyResource
+- Kubernetes 1.7+
 
 ## Installing the Chart
+
+Full installation instructions, including details on how to configure extra
+functionality in cert-manager can be found in the [official deploying docs](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/deploying.md#addendum).
 
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release .
+$ helm install --name my-release stable/cert-manager
 ```
+
+In order to begin issuing certificates, you will need to set up a ClusterIssuer
+or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
+
+More information on the different types of issuers and how to configure them
+can be found in our documentation:
+
+https://github.com/jetstack/cert-manager/tree/master/docs/api-types/issuer
+
+For information on how to configure cert-manager to automatically provision
+Certificates for Ingress resources, take a look at the `ingress-shim`
+documentation:
+
+https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/ingress-shim.md
 
 > **Tip**: List all releases using `helm list`
 

--- a/stable/cert-manager/templates/NOTES.txt
+++ b/stable/cert-manager/templates/NOTES.txt
@@ -1,5 +1,15 @@
 cert-manager has been deployed successfully!
 
-You may now go ahead and create issuers and certificates.
+In order to begin issuing certificates, you will need to set up a ClusterIssuer
+or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 
-See https://github.com/jetstack/cert-manager/blob/v0.2.3/docs/README.md
+More information on the different types of issuers and how to configure them
+can be found in our documentation:
+
+https://github.com/jetstack/cert-manager/tree/v0.2.3/docs/api-types/issuer
+
+For information on how to configure cert-manager to automatically provision
+Certificates for Ingress resources, take a look at the `ingress-shim`
+documentation:
+
+https://github.com/jetstack/cert-manager/blob/v0.2.3/docs/user-guides/ingress-shim.md

--- a/stable/cert-manager/templates/certificate-crd.yaml
+++ b/stable/cert-manager/templates/certificate-crd.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -16,13 +15,4 @@ spec:
     kind: Certificate
     plural: certificates
   scope: Namespaced
-{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1"  }}
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  name: certificate.certmanager.k8s.io
-description: "A specification for a cert-manager certificate"
-versions:
-  - name: v1alpha1
-{{- end -}}
 {{- end -}}

--- a/stable/cert-manager/templates/clusterissuer-crd.yaml
+++ b/stable/cert-manager/templates/clusterissuer-crd.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -16,5 +15,4 @@ spec:
     kind: ClusterIssuer
     plural: clusterissuers
   scope: Cluster
-{{- end -}}
 {{- end -}}

--- a/stable/cert-manager/templates/issuer-crd.yaml
+++ b/stable/cert-manager/templates/issuer-crd.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -16,18 +15,4 @@ spec:
     kind: Issuer
     plural: issuers
   scope: Namespaced
-{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1" }}
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  name: issuer.certmanager.k8s.io
-  labels:
-    app: {{ template "cert-manager.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-description: "A specification for a cert-manager issuer"
-versions:
-  - name: v1alpha1
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
This PR:

* updates the cert-manager Helm chart with the latest changes from upstream
    * namely, removing support for creating TPRs on Kubernetes 1.6 - as it's not actually an operating mode configured nor tested in cert-manager
    * Also due to: https://github.com/kubernetes/helm/issues/3377 (more info: https://github.com/jetstack/cert-manager/pull/276)
* expands the README.md and NOTES.txt with additional post-installation information.

Fixes #3513
