### PR TITLE
[stable/prometheus] update kube-state-metrics to v1.2.0 and fix rbac

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.0.2
+version: 5.1.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
@@ -52,11 +52,11 @@ rules:
     verbs:
       - list
       - watch
-	- apiGroups:
-			- autoscaling
-		resources:
-			- horizontalpodautoscalers
-		verbs:
-			- list
-			- watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
@@ -22,6 +22,8 @@ rules:
       - replicationcontrollers
       - limitranges
       - persistentvolumeclaims
+      - persistentvolumes
+      - endpoints
     verbs:
       - list
       - watch
@@ -50,4 +52,11 @@ rules:
     verbs:
       - list
       - watch
+	- apiGroups:
+			- autoscaling
+		resources:
+			- horizontalpodautoscalers
+		verbs:
+			- list
+			- watch
 {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -191,7 +191,7 @@ kubeStateMetrics:
   ##
   image:
     repository: k8s.gcr.io/kube-state-metrics
-    tag: v1.1.0
+    tag: v1.2.0
     pullPolicy: IfNotPresent
 
   ## kube-state-metrics container arguments


### PR DESCRIPTION
added `persistentvolumes`, `endpoints` and `horizontalpodautoscalers` to cluster role