### PR TITLE
[datadog] mount auto_conf in the right folder for alpine images

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.10.5
+version: 0.10.6
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.10.4
+version: 0.10.5
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -104,7 +104,11 @@ spec:
           {{- end }}
           {{- if .Values.datadog.autoconf }}
           - name: autoconf
+            {{- if hasSuffix "-alpine" .Values.image.tag }}
+            mountPath: /opt/datadog-agent/agent/conf.d/auto_conf
+            {{- else }}
             mountPath: /etc/dd-agent/conf.d/auto_conf
+            {{- end }}
             readOnly: true
           {{- end }}
 {{- if .Values.datadog.volumeMounts }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -89,7 +89,11 @@ spec:
           {{- end }}
           {{- if .Values.datadog.autoconf }}
           - name: autoconf
+            {{- if hasSuffix "-alpine" .Values.image.tag }}
+            mountPath: /opt/datadog-agent/agent/conf.d/auto_conf
+            {{- else }}
             mountPath: /etc/dd-agent/conf.d/auto_conf
+            {{- end }}
             readOnly: true
           {{- end }}
 {{- if .Values.datadog.volumeMounts }}


### PR DESCRIPTION
Update the daemonset and deployment templates to account for alpine variants looking for auto_conf templates in the `/opt/datadog-agent/agent/conf.d/auto_conf` folder instead of the standard `/etc/dd-agent/conf.d/auto_conf`.

If you run a custom image, you need to name your tags `xyz-alpine` for that logic to kick in.