### PR TITLE
[stable/grafana] Improve importing dashboards.

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.8.1
+version: 0.8.2
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -56,3 +56,4 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.service.type`                     | ClusterIP, NodePort, or LoadBalancer| ClusterIP                                         |
 | `server.setDatasource.enabled`            | Creates grafana datasource with job | false                                             |
 | `server.extraEnv`                          | Extra environment variables to set in the server container. List of [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#envvar-v1-core) values | [] |
+| `dashboardImports.enabled`                | Creates grafana dashboards with job | false |

--- a/stable/grafana/templates/dashboards-import-job-configmap.yaml
+++ b/stable/grafana/templates/dashboards-import-job-configmap.yaml
@@ -11,15 +11,22 @@ metadata:
 data:
   init.sh: |
     #!/bin/sh
+    set -e
     cd /var/lib/grafana/import
     {{- range $name, $val := .Values.dashboardImports.dashboards }}
-      curl -o {{ $name }} {{ $val }}
+      wget -O {{ $name }} {{ $val }}
     {{- end }}
     for dashboard in $(ls); do
-      curl "http://${ADMIN_USER}:${ADMIN_PASSWORD}@{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/dashboards/db" \
-      --max-time 10 \
-      --header "Content-Type: application/json;charset=UTF-8" \
-      --data-binary "{ \"dashboard\":$(cat $dashboard), \"overwrite\":false }" ;
+      wget \
+      "http://{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/dashboards/db" \
+      --user=${ADMIN_USER} \
+      --password=${ADMIN_PASSWORD} \
+      --auth-no-challenge \
+      --content-on-error \
+      -O- \
+      --timeout=10 \
+      --header="Content-Type: application/json;charset=UTF-8" \
+      --post-data="{ \"dashboard\":$(cat $dashboard), \"overwrite\":true }" ;
     done;
 
 {{- end -}}

--- a/stable/grafana/templates/dashboards-import-job.yaml
+++ b/stable/grafana/templates/dashboards-import-job.yaml
@@ -2,6 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  annotations:
+    "helm.sh/hook": {{ .Values.dashboardImports.hook }}
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app: {{ template "grafana.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -10,6 +14,7 @@ metadata:
   name: {{ template "grafana.server.fullname" . }}-import-dashboards
 spec:
   activeDeadlineSeconds: {{ .Values.dashboardImports.activeDeadlineSeconds }}
+  backoffLimit: {{ .Values.dashboardImports.backoffLimit }}
   template:
     metadata:
       labels:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -439,14 +439,14 @@ dashboardImports:
   enabled: false
 
   ## How long should it take to commit failure
-  ## Default: 300
+  ## Default: 30
   ##
-  # activeDeadlineSeconds: 300
+  activeDeadlineSeconds: 30
 
   ## Docker image to run import process
-  ## Default: appropriate/curl:latest
+  ## Default: jgoclawski/wget:1.0
   ##
-  # image: appropriate/curl:latest
+  image: jgoclawski/wget:1.0
 
   ## Grafana dashboard files to import as ConfigMap entries
   # files: {}
@@ -461,6 +461,16 @@ dashboardImports:
   # dashboards: {}
 
   ## Specify the Job policy
-  ## Default: OnFailure
+  ## Default: Never
   ##
-  # restartPolicy: OnFailure
+  restartPolicy: Never
+
+  ## Specify Pod Backoff failure policy
+  ## Default: 1
+  ##
+  backoffLimit: 1
+
+  ## Specify when Helm should run the import job
+  ## Default: post-install,post-upgrade
+  ##
+  hook: post-install,post-upgrade


### PR DESCRIPTION
It's a follow-up for #3192. I had a few issues when using the import job, so here are a few improvements:

* allow overwriting existing dashboards
  - useful for updating dashboards
* correctly fail job on errors and print output
  - curl replaced with wget
* set limit for failures to 1
  - use backoffLimit rather than activeDeadlineSeconds
* delete job when it succeeds
  - Helm hooks added for Job
* make possible to run jon only once or on every update
* Update README
