### PR TITLE
Fix CI failures and orphaned releases

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -41,7 +41,7 @@ function cleanup {
 
       # Before reporting the logs from all pods provide a helm status for
       # the release
-      helm status ${CURRENT_RELEASE}
+      helm status ${CURRENT_RELEASE} || true
 
       # List all logs for all containers in all pods for the namespace which was
       # created for this PR test run
@@ -54,7 +54,7 @@ function cleanup {
             containers=`kubectl get pods --show-all -o jsonpath="{.spec.containers[*].name}" --namespace ${NAMESPACE} $line`
             for cname in ${containers}; do
                 echo "---Logs from container $cname in pod $line:---"
-                kubectl logs --namespace ${NAMESPACE} -c ${cname} ${line}
+                kubectl logs --namespace ${NAMESPACE} -c ${cname} ${line} || true
                 echo "---End of logs for container $cname in pod $line---\n"
             done
 

--- a/test/verify-release.sh
+++ b/test/verify-release.sh
@@ -64,6 +64,9 @@ while (("$POD_RETRY_COUNT" < "$RETRY")); do
         exit 0
       fi
     done
+  else
+    echo "INFO: Waiting for pods to enter running state"
+    sleep "$RETRY_DELAY"
   fi
 done
 


### PR DESCRIPTION
The commits here fix two things:

* The CI system has cases where helm delete and namespace cleanup are skipped if there is an error getting logs on a pod. This causes the pod logs to always return true and avoid a premature exit before cleanup is run
* When pods are not yet in a running state there is no delay before rechecking. This is causing timeouts to happen waiting for pods.