### PR TITLE
[incubator/jaeger] bump image tag to 1.1.0

### DIFF
--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -45,7 +45,7 @@ cassandra:
 schema:
   annotations: {}
   image: jaegertracing/jaeger-cassandra-schema
-  tag: 1.0.0
+  tag: 1.1.0
   pullPolicy: IfNotPresent
   # Acceptable values are test and prod. Default is for production use.
   mode: prod
@@ -76,7 +76,7 @@ agent:
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-agent
-  tag: 1.0.0
+  tag: 1.1.0
   pullPolicy: IfNotPresent
   collector:
     host: null
@@ -111,7 +111,7 @@ collector:
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-collector
-  tag: 1.0.0
+  tag: 1.1.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
@@ -141,7 +141,7 @@ query:
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-query
-  tag: 1.0.0
+  tag: 1.1.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}


### PR DESCRIPTION
Use the latest release of jaeger.
