### PR TITLE
[datadog] Too much whitespace stripping

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.10.4
+version: 0.10.5
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/serviceaccount.yaml
+++ b/stable/datadog/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 # You need to use that account for your dd-agent DaemonSet
-{{- if .Values.rbac.create -}}
+{{ if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
The double whitespace stripping is causing the api version to get concatenated with the comment above

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
