### PR TITLE
CI should pull logs if test fails

### DIFF
--- a/test/helm-test/main.go
+++ b/test/helm-test/main.go
@@ -252,7 +252,11 @@ func doMain() int {
 		xmlWrap(fmt.Sprintf("Helm Test %s", path.Base(chartPath)), func() error {
 			o, execErr := output(exec.Command(helmPath, "test", rel))
 			if execErr != nil {
-				return fmt.Errorf("%s Command output: %s", execErr, string(o[:]))
+				l, logsErr := output(exec.Command(kubectlPath, "logs", rel, "--namespace", ns))
+				if logsErr != nil {
+					return fmt.Errorf("%s Command output: %s\n%s", execErr, string(o[:]), string(logsErr[:]))
+				}
+				return fmt.Errorf("%s Command output: %s\n%s", execErr, string(o[:]), string(l[:]))
 			}
 			return nil
 		})


### PR DESCRIPTION
Pull logs if a test fails (like Jenkins)
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-charts-gce/17407