### PR TITLE
[stable/kubernetes-dashboard] Add `extraArgs` to `kubernetes-dashboard`

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.5.1
+version: 0.5.2
 appVersion: 1.8.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -42,7 +42,7 @@ The following tables lists the configurable parameters of the kubernetes-dashboa
 | `image.repository`     | Repository for container image     | `gcr.io/google_containers/kubernetes-dashboard-amd64`                    |
 | `image.tag`            | Image tag                          | `v1.8.1`                                                                 |
 | `image.pullPolicy`     | Image pull policy                  | `IfNotPresent`                                                           |
-| `extraArgs`            | Additional container arguments     | []                                                                       |
+| `extraArgs`            | Additional container arguments     | `{}`                                                                     |
 | `nodeSelector`         | node labels for pod assignment     | `{}`                                                                     |
 | `service.externalPort` | Dashboard internal port            | 80                                                                       |
 | `service.internalPort` | Dashboard external port            | 80                                                                       |

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -42,6 +42,7 @@ The following tables lists the configurable parameters of the kubernetes-dashboa
 | `image.repository`     | Repository for container image     | `gcr.io/google_containers/kubernetes-dashboard-amd64`                    |
 | `image.tag`            | Image tag                          | `v1.8.1`                                                                 |
 | `image.pullPolicy`     | Image pull policy                  | `IfNotPresent`                                                           |
+| `extraArgs`            | Additional container arguments     | []                                                                       |
 | `nodeSelector`         | node labels for pod assignment     | `{}`                                                                     |
 | `service.externalPort` | Dashboard internal port            | 80                                                                       |
 | `service.internalPort` | Dashboard external port            | 80                                                                       |

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        {{- range $key, $value := .Values.extraArgs }}
+          - --{{ $key }}={{ $value }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 9090

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -30,10 +30,10 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- if .Values.extraArgs }}
         args:
-        {{- range $key, $value := .Values.extraArgs }}
-          - --{{ $key }}={{ $value }}
-        {{- end }}
+{{ toYaml .Values.extraArgs | indent 10 }}
+{{- end }}
         ports:
         - name: http
           containerPort: 9090

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -14,6 +14,12 @@ labels: {}
 # kubernetes.io/cluster-service: "true"
 # kubernetes.io/name: "Kuberetes Dashboard"
 
+## Additional container arguments
+##
+# extraArgs:
+#   enable-insecure-login: true
+#   auto-generate-certificates: true
+
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##


### PR DESCRIPTION
Adds `extraArgs` to `stable/kubernetes-dashboard`.

## Use-case:
I'd like to add `--enable-insecure-login` because I get a certificate from `cert-manager` and set it on Ingress, and don't get the login view without it.