### PR TITLE
[incubator/drone] Startup & metadata fixes

### DIFF
--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: http://docs.drone.io/logo.svg
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.8.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -43,7 +43,6 @@ The following tables lists the configurable parameters of the drone charts and t
 | `images.dind.tag`           | Docker **dind** image tag                                                                     | `17.12.0-ce-dind`           |
 | `images.dind.pullPolicy`    | Docker **dind** image pull policy                                                             | `IfNotPresent`              |
 | `service.httpPort`          | Drone's Web GUI HTTP port                                                                     | `80`                        |
-| `service.httpPort`          | Drone's Web GUI HTTP port                                                                     | `80`                        |
 | `service.nodePort`          | If `service.type` is `NodePort` and this is non-empty, sets the http node port of the service | `32015`                     |
 | `service.type`              | Service type (ClusterIP, NodePort or LoadBalancer)                                            | `ClusterIP`                 |
 | `ingress.enabled`           | Enables Ingress for Drone                                                                     | `false`                     |

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -50,7 +50,7 @@ The following tables lists the configurable parameters of the drone charts and t
 | `ingress.annotations`       | Ingress annotations                                                                           | `{}`                        |
 | `ingress.hosts`             | Ingress accepted hostnames                                                                    | `nil`                       |
 | `ingress.tls`               | Ingress TLS configuration                                                                     | `[]`                        |
-| `server.host`               | Drone **server** hostname                                                                     | `(internal hostname)`       |
+| `server.host`               | Drone **server** scheme and hostname                                                          | `(internal hostname)`       |
 | `server.env`                | Drone **server** environment variables                                                        | `(default values)`          |
 | `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
 | `server.afinity`            | Drone **server** scheduling preferences                                                       | `{}`                        |

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -36,7 +36,7 @@ spec:
                 key: secret
           - name: DRONE_HOST
           {{- if hasKey .Values.server "host" }}
-            value: "http://{{ .Values.server.host }}"
+            value: "{{ .Values.server.host }}"
           {{- else }}
             value: "http://{{ template "drone.fullname" . }}"
           {{- end }}

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -36,9 +36,9 @@ spec:
                 key: secret
           - name: DRONE_HOST
           {{- if hasKey .Values.server "host" }}
-            value: {{ .Values.server.host }}
+            value: "http://{{ .Values.server.host }}"
           {{- else }}
-            value: {{ template "drone.fullname" . }}
+            value: "http://{{ template "drone.fullname" . }}"
           {{- end }}
           {{ range $key, $value := .Values.server.env }}
           - name: {{ $key }}

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -63,6 +63,7 @@ ingress:
 
 server:
   ## If not set, it will be autofilled with the cluster host.
+  ## Should include a scheme
   ##
   # host: "https://drone.domain.io"
 

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -63,7 +63,7 @@ ingress:
 
 server:
   ## If not set, it will be autofilled with the cluster host.
-  ## Should include a scheme
+  ## Host must be in "<scheme>://<hostname>" format.
   ##
   # host: "https://drone.domain.io"
 

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -1,4 +1,4 @@
-appVersion: "0.8.2"
+appVersion: "0.8.4"
 
 images:
   ## The official drone (server) image, change tag to use a different version.


### PR DESCRIPTION
The main fix is the first commit which allows drone to actually start. Without it, drone refuses to run because of [this](https://github.com/drone/drone/commit/453f415cc493e358c5cf0a7050e271059c51c072) commit, which was included in version 0.8.4.