### PR TITLE
Fix typos in hadoop

### DIFF
--- a/stable/hadoop/Chart.yaml
+++ b/stable/hadoop/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: The Apache Hadoop software library is a framework that allows for the distributed processing of large data sets across clusters of computers using simple programming models.
 name: hadoop
-version: 1.0.1
+version: 1.0.2
 appVersion: 2.7.3
 home: https://hadoop.apache.org/
 sources:

--- a/stable/hadoop/README.md
+++ b/stable/hadoop/README.md
@@ -41,7 +41,7 @@ The following tables lists the configurable parameters of the Hadoop chart and t
 | ------------------------------------------------- | -------------------------------                                                    | ---------------------------------------------------------------- |
 | `image`                                           | Hadoop image ([source](https://github.com/Comcast/kube-yarn/tree/master/image))    | `danisla/hadoop:{VERSION}`                                       |
 | `imagePullPolicy`                                 | Pull policy for the images                                                         | `IfNotPresent`                                                   |
-| `hadoopVersion`                                   | Version of hadoop libaries being used                                              | `{VERSION}`                                                      |
+| `hadoopVersion`                                   | Version of hadoop libraries being used                                              | `{VERSION}`                                                      |
 | `antiAffinity`                                    | Pod antiaffinity, `hard` or `soft`                                                 | `hard`                                                           |
 | `hdfs.nameNode.podMinAvailable`                   | PDB for HDFS NameNode                                                              | `1`                                                              |
 | `hdfs.nameNode.resources`                         | resources for the HDFS NameNode                                                    | `requests:memory=256Mi,cpu=10m,limits:memory=2048Mi,cpu=1000m`   |

--- a/stable/hadoop/tools/calc_resources.sh
+++ b/stable/hadoop/tools/calc_resources.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Calculates cluster resources given a percentage based on what is currently allocatable.
-# Related issue to programatic resource query: https://github.com/kubernetes/kubernetes/issues/27404
+# Related issue to programmatic resource query: https://github.com/kubernetes/kubernetes/issues/27404
 
 TARGET_PCT=$1
 

--- a/stable/hadoop/values.yaml
+++ b/stable/hadoop/values.yaml
@@ -69,11 +69,11 @@ persistence:
   nameNode:
     enabled: false
     storageClass: "-"
-    accessMode: ReadWriteOnce 
+    accessMode: ReadWriteOnce
     size: 50Gi
 
   dataNode:
     enabled: false
     storageClass: "-"
-    accessMode: ReadWriteOnce 
+    accessMode: ReadWriteOnce
     size: 200Gi


### PR DESCRIPTION
And also fixed `trailing spaces` and `no new line character at the end of file` error in file `values.yaml` using the new ci.