### PR TITLE
[Stable/mongodb] Allow to configure readiness and liveness probes for MongoDB chart

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 0.4.25
+version: 0.4.26
 appVersion: 3.7.1
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -43,19 +43,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the MongoDB chart and their default values.
 
-|         Parameter          |             Description             |                         Default                          |
-|----------------------------|-------------------------------------|----------------------------------------------------------|
-| `image`                    | MongoDB image                       | `bitnami/mongodb:{VERSION}`                              |
-| `imagePullPolicy`          | Image pull policy                   | `Always` if `imageTag` is `latest`, else `IfNotPresent`. |
-| `mongodbRootPassword`      | MongoDB admin password              | `random alhpanumeric string (10)`                                                    |
-| `mongodbUsername`          | MongoDB custom user                 | `nil`                                                    |
-| `mongodbPassword`          | MongoDB custom user password        | `random alhpanumeric string (10)`                                                    |
-| `mongodbDatabase`          | Database to create                  | `nil`                                                    |
-| `serviceType`              | Kubernetes Service type             | `ClusterIP`                                              |
-| `persistence.enabled`      | Use a PVC to persist data           | `true`                                                   |
-| `persistence.storageClass` | Storage class of backing PVC        | `nil` (uses alpha storage class annotation)              |
-| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite | `ReadWriteOnce`                                          |
-| `persistence.size`         | Size of data volume                 | `8Gi`                                                    |
+|         Parameter                   |             Description                    |                         Default                          |
+|----------------------------         |-------------------------------------       |----------------------------------------------------------|
+| `image`                             | MongoDB image                              | `bitnami/mongodb:{VERSION}`                              |
+| `imagePullPolicy`                   | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`. |
+| `mongodbRootPassword`               | MongoDB admin password                     | `random alhpanumeric string (10)`                        |
+| `mongodbUsername`                   | MongoDB custom user                        | `nil`                                                    |
+| `mongodbPassword`                   | MongoDB custom user password               | `random alhpanumeric string (10)`                        |
+| `mongodbDatabase`                   | Database to create                         | `nil`                                                    |
+| `serviceType`                       | Kubernetes Service type                    | `ClusterIP`                                              |
+| `persistence.enabled`               | Use a PVC to persist data                  | `true`                                                   |
+| `persistence.storageClass`          | Storage class of backing PVC               | `nil` (uses alpha storage class annotation)              |
+| `persistence.accessMode`            | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                          |
+| `persistence.size`                  | Size of data volume                        | `8Gi`                                                    |
+| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated   | 30                                                       |
+| `livenessProbe.periodSeconds`       | How often to perform the probe             | 10                                                       |
+| `livenessProbe.timeoutSeconds`      | When the probe times out                   | 5                                                        |
+| `livenessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.     |  1 |
+| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.       |  6 |
+| `readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated                                                        |  5 |
+| `readinessProbe.periodSeconds`      | How often to perform the probe                                                                   | 10 |
+| `readinessProbe.timeoutSeconds`     | When the probe times out                                                                         |  5 |
+| `readinessProbe.successThreshold`   | Minimum consecutive successes for the probe to be considered successful after having failed.     |  1 |
+| `readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe to be considered failed after having succeeded.       |  6 |
 
 The above parameters map to the env variables defined in [bitnami/mongodb](http://github.com/bitnami/bitnami-docker-mongodb). For more information please refer to the [bitnami/mongodb](http://github.com/bitnami/bitnami-docker-mongodb) image documentation.
 

--- a/stable/mongodb/templates/deployment.yaml
+++ b/stable/mongodb/templates/deployment.yaml
@@ -41,16 +41,14 @@ spec:
             - mongo
             - --eval
             - "db.adminCommand('ping')"
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
+{{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
           exec:
             command:
             - mongo
             - --eval
             - "db.adminCommand('ping')"
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
+{{ toYaml .Values.readinessProbe | indent 10 }}
         volumeMounts:
         - name: data
           mountPath: /bitnami/mongodb

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -52,3 +52,18 @@ resources:
   requests:
     memory: 256Mi
     cpu: 100m
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1


### PR DESCRIPTION
This PR adds support to the MongoDB chart to configure the liveness and readiness probes.
