### PR TITLE
adding mandatory field server.host and Drone UI

### DIFF
--- a/incubator/drone/templates/NOTES.txt
+++ b/incubator/drone/templates/NOTES.txt
@@ -41,6 +41,8 @@ control provider:
 
     helm upgrade {{ .Release.Name }} \
       --reuse-values \
+      --set server.host="<scheme>://<hostname>" \
+      --set server.env.DRONE_OPEN="true" \ 
       --set server.env.DRONE_PROVIDER="github" \
       --set server.env.DRONE_GITHUB="true" \
       --set server.env.DRONE_ORGS="my-github-org" \


### PR DESCRIPTION
Without specifying `server.host` in the `<scheme>://<hostname>` format, pods fails because there is a validation for this in the DRONE code. This behavior is at least on Kubernetes 1.9.2 with Github.

Without having `DRONE_OPEN`, you cannot get inside the DRONE UI (you don't get authorized) and I don't really see any usage for it without this flag.