### PR TITLE
[spinnaker] Make Jenkins optional

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.3.13
+version: 0.3.14
 appVersion: 1.1.0
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/requirements.lock
+++ b/stable/spinnaker/requirements.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: jenkins
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.11.1
-digest: sha256:8035b2a0deff9dec733c243a02620b6229c909fce48d4136ffb18957d2495752
-generated: 2018-01-09T19:17:57.721455275-06:00
+digest: sha256:1c4189a19b9223fcd9f5c889a210d09b2443eb18b853a25691f9c3fad56ffc25
+generated: 2018-02-08T18:51:49.036721463-05:00

--- a/stable/spinnaker/requirements.lock
+++ b/stable/spinnaker/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.4.3
 - name: jenkins
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.11.1
-digest: sha256:1c4189a19b9223fcd9f5c889a210d09b2443eb18b853a25691f9c3fad56ffc25
-generated: 2018-02-08T18:51:49.036721463-05:00
+  version: 0.13.3
+digest: sha256:5cdbf5aa7fa2f1fab477b75cbe931bb053e261c4437413af3c8d8a39b119924c
+generated: 2018-02-25T13:11:01.017154568-08:00

--- a/stable/spinnaker/requirements.yaml
+++ b/stable/spinnaker/requirements.yaml
@@ -9,3 +9,4 @@ dependencies:
 - name: jenkins
   version: 0.11.1
   repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: jenkins.enabled

--- a/stable/spinnaker/requirements.yaml
+++ b/stable/spinnaker/requirements.yaml
@@ -7,6 +7,6 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: minio.enabled
 - name: jenkins
-  version: 0.11.1
+  version: 0.13.3
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: jenkins.enabled

--- a/stable/spinnaker/templates/configmap/_jenkins-config.tpl
+++ b/stable/spinnaker/templates/configmap/_jenkins-config.tpl
@@ -1,10 +1,10 @@
-{{ if .Values.jenkins.enabled -}}
+{{- define "override_config_map" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{.Release.Name}}-jenkins
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "jenkins.fullname" . }}
 data:
   config.xml: |-
     <?xml version='1.0' encoding='UTF-8'?>
@@ -29,10 +29,10 @@ data:
         <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@0.8">
           <name>kubernetes</name>
           <templates>
-{{- if .Values.jenkins.Agent.Enabled }}
+{{- if .Values.Agent.Enabled }}
             <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
               <name>jnlp</name>
-              <image>{{ .Values.jenkins.Agent.Image }}:{{ .Values.jenkins.Agent.ImageTag }}</image>
+              <image>{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}</image>
               <privileged>false</privileged>
               <alwaysPullImage>false</alwaysPullImage>
               <command></command>
@@ -42,15 +42,15 @@ data:
               <label></label>
               <nodeSelector>
                 {{- $local := dict "first" true }}
-                {{- range $key, $value := .Values.jenkins.Agent.NodeSelector }}
+                {{- range $key, $value := .Values.Agent.NodeSelector }}
                   {{- if not $local.first }},{{- end }}
                   {{- $key }}={{ $value }}
                   {{- $_ := set $local "first" false }}
                 {{- end }}</nodeSelector>
-              <resourceRequestCpu>{{ .Values.jenkins.Agent.Cpu }}</resourceRequestCpu>
-              <resourceRequestMemory>{{ .Values.jenkins.Agent.Memory }}</resourceRequestMemory>
-              <resourceLimitCpu>{{ .Values.jenkins.Agent.Cpu }}</resourceLimitCpu>
-              <resourceLimitMemory>{{ .Values.jenkins.Agent.Memory }}</resourceLimitMemory>
+              <resourceRequestCpu>{{ .Values.Agent.Cpu }}</resourceRequestCpu>
+              <resourceRequestMemory>{{ .Values.Agent.Memory }}</resourceRequestMemory>
+              <resourceLimitCpu>{{ .Values.Agent.Cpu }}</resourceLimitCpu>
+              <resourceLimitMemory>{{ .Values.Agent.Memory }}</resourceLimitMemory>
               <volumes>
                 <org.csanchez.jenkins.plugins.kubernetes.PodVolumes_-HostPathVolume>
                   <mountPath>/usr/bin/docker</mountPath>
@@ -98,24 +98,24 @@ data:
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
-{{- if .Values.jenkins.Master.InstallPlugins }}
+{{- if .Values.Master.InstallPlugins }}
     cp -n /var/jenkins_config/plugins.txt /var/jenkins_home;
     /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
 {{- end }}
-{{- if .Values.jenkins.Master.ScriptApproval }}
+{{- if .Values.Master.ScriptApproval }}
     cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
 {{- end }}
-{{- if .Values.jenkins.Master.InitScripts }}
+{{- if .Values.Master.InitScripts }}
     mkdir -p /var/jenkins_home/init.groovy.d/;
     cp -n /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/
 {{- end }}
-{{- range $key, $val := .Values.jenkins.Master.InitScripts }}
+{{- range $key, $val := .Values.Master.InitScripts }}
   init{{ $key }}.groovy: |-
 {{ $val | indent 4}}
 {{- end }}
   plugins.txt: |-
-{{- if .Values.jenkins.Master.InstallPlugins }}
-{{- range $index, $val := .Values.jenkins.Master.InstallPlugins }}
+{{- if .Values.Master.InstallPlugins }}
+{{- range $index, $val := .Values.Master.InstallPlugins }}
 {{ $val | indent 4 }}
 {{- end }}
 {{- end }}

--- a/stable/spinnaker/templates/configmap/jenkins-config.yaml
+++ b/stable/spinnaker/templates/configmap/jenkins-config.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.jenkins.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -116,5 +117,6 @@ data:
 {{- if .Values.jenkins.Master.InstallPlugins }}
 {{- range $index, $val := .Values.jenkins.Master.InstallPlugins }}
 {{ $val | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/spinnaker/templates/configmap/jenkins-jobs.yaml
+++ b/stable/spinnaker/templates/configmap/jenkins-jobs.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.jenkins.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -190,3 +191,4 @@ data:
         <triggers/>
         <disabled>false</disabled>
       </flow-definition>
+{{- end }}

--- a/stable/spinnaker/templates/configmap/spinnaker-config.yaml
+++ b/stable/spinnaker/templates/configmap/spinnaker-config.yaml
@@ -420,7 +420,7 @@ data:
         #
         # Note that jenkins is not installed with Spinnaker so you must obtain this
         # on your own if you are interested.
-        enabled: true
+        enabled: {{ .Values.jenkins.enabled }}
         defaultMaster:
           name: default
           baseUrl: http://{{ .Release.Name }}-jenkins:8080/

--- a/stable/spinnaker/templates/configmap/test-config.yaml
+++ b/stable/spinnaker/templates/configmap/test-config.yaml
@@ -7,6 +7,8 @@ data:
     @test "Testing Spinnaker UI is accessible" {
       curl --retry 12 --retry-delay 10 {{ template "fullname" . }}-deck:9000
     }
+{{- if .Values.jenkins.enabled -}}
     @test "Testing Jenkins UI is accessible" {
       curl --retry 12 --retry-delay 10 {{.Release.Name}}-jenkins:8080/login
     }
+{{- end }}

--- a/stable/spinnaker/templates/configmap/test-config.yaml
+++ b/stable/spinnaker/templates/configmap/test-config.yaml
@@ -7,8 +7,3 @@ data:
     @test "Testing Spinnaker UI is accessible" {
       curl --retry 12 --retry-delay 10 {{ template "fullname" . }}-deck:9000
     }
-{{- if .Values.jenkins.enabled -}}
-    @test "Testing Jenkins UI is accessible" {
-      curl --retry 12 --retry-delay 10 {{.Release.Name}}-jenkins:8080/login
-    }
-{{- end }}

--- a/stable/spinnaker/templates/hooks/upload-build-image.yaml
+++ b/stable/spinnaker/templates/hooks/upload-build-image.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.jenkins.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -44,3 +45,4 @@ spec:
         volumeMounts:
         - name: jenkins-jobs
           mountPath: /jobs
+{{- end }}

--- a/stable/spinnaker/templates/hooks/upload-run-pipeline.yaml
+++ b/stable/spinnaker/templates/hooks/upload-run-pipeline.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.jenkins.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -44,3 +45,4 @@ spec:
         volumeMounts:
         - name: jenkins-jobs
           mountPath: /jobs
+{{- end }}

--- a/stable/spinnaker/templates/hooks/upload-run-script.yaml
+++ b/stable/spinnaker/templates/hooks/upload-run-script.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.jenkins.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -44,3 +45,4 @@ spec:
         volumeMounts:
         - name: jenkins-jobs
           mountPath: /jobs
+{{- end }}

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -111,6 +111,7 @@ gcs:
 # with Spinnaker, visit:
 #   https://www.spinnaker.io/setup/ci/jenkins/
 jenkins:
+  enabled: true
   Master:
     Cpu: "500m"
     Memory: "512Mi"


### PR DESCRIPTION
Some organizations may not use jenkins with Spinnaker. This PR proposes to make jenkins usage optional.

- Update jenkins dep
- Adds jenkins.enabled value
- Load requirements, hooks, and config maps if jenkins
enabled

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
