### PR TITLE
[stable/buildkite] Change name of Docker credentials in Pod

### DIFF
--- a/stable/buildkite/Chart.yaml
+++ b/stable/buildkite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Agent for Buildkite
 name: buildkite
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.0
 icon: https://github.com/buildkite/media/blob/master/marks/Buildkite%20-%20Mark%20-%20colour.png
 keywords:

--- a/stable/buildkite/templates/secret-registry.yaml
+++ b/stable/buildkite/templates/secret-registry.yaml
@@ -10,6 +10,6 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  .dockerconfigjson: |-
+  config.json: |-
     {{ .Values.registryCreds.dockerConfig }}
 {{- end }}

--- a/stable/buildkite/values.yaml
+++ b/stable/buildkite/values.yaml
@@ -19,7 +19,8 @@ agent:
 # Extra env vars to be passed
 # If you do want to xxtra env vars to pass to agent, uncomment the following
 # lines, adjust them as necessary.
-#extraEnv:
+#
+# extraEnv:
 #  - name: test1
 #    value: "test1"
 #  - name: test2


### PR DESCRIPTION
Since the Docker registry credentials are mounted at ~/.docker/, the file should be named appropriately so the credentials are picked up by the Docker client.
