### PR TITLE
[incubator/jaeger] Fix render error when ingress enabled

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.1
+version: 0.3.2
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/templates/query-ing.yaml
+++ b/incubator/jaeger/templates/query-ing.yaml
@@ -23,7 +23,7 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: {{ template "jaeger.query.name" . }}-query
+              serviceName: {{ template "jaeger.query.name" $ }}-query
               servicePort: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.query.ingress.tls }}


### PR DESCRIPTION
There is a bug when ingress is enabled and hosts are set.
```bash
helm install incubator/jaeger \
  --set query.ingress.enabled=true \
  --set query.ingress.hosts={example.com}
```

The error looks like
```
Error: render error in "jaeger/templates/query-ing.yaml": 
  template: jaeger/templates/_helpers.tpl:44:40: 
  executing "jaeger.query.name" at <include "jaeger.full...>: 
  error calling include: 
    template: jaeger/templates/_helpers.tpl:27:14: 
    executing "jaeger.fullname" at <.Values.fullnameOver...>: 
    can't evaluate field Values in type string
```

Hotrod ingress is not affected.
