### PR TITLE
[stable/fluent-bit] Allow mounting any file from the config map

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.2.8
+version: 0.2.9
 appVersion: 0.12.11
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -26,8 +26,7 @@ spec:
           mountPath: /var/lib/docker/containers
           readOnly: true
         - name: config
-          mountPath: /fluent-bit/etc/fluent-bit.conf
-          subPath: fluent-bit.conf
+          mountPath: /fluent-bit/etc/
 {{ if .Values.on_minikube }}
         - name: mnt
           mountPath: /mnt


### PR DESCRIPTION
This is just a wild idea and solution for the following problem: certain output plugins require files to be mounted (certificates, private keys, etc). Until now from the config map only the config file got mounted. With this change any file in the config map.

I'm open to suggestions (separate configmap, separate secret, config option in values file, etc) as I'm not really fond of this idea TBH.

/cc @kfox1111 @edsiper