### PR TITLE
Add initialDelaySeconds and periodSeconds to Logstash livenessProbe, update image

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.4.0
+version: 0.5.0
 appVersion: 6.2.1
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -4,7 +4,7 @@ icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt
 home: https://www.elastic.co/products/logstash
 name: logstash
 version: 0.4.0
-appVersion: 6.0.0
+appVersion: 6.2.1
 sources:
 - https://www.docker.elastic.co
 - https://www.elastic.co/guide/en/logstash/current/index.html

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -31,28 +31,29 @@ chart and deletes the release.
 
 The following tables lists the configurable parameters of the drone charts and their default values.
 
-|              Parameter              |                    Description                     |                     Default                      |
-| ----------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| `replicaCount`                      | Number of replicas                                 | `1`                                              |
-| `nodeSelector`                      | Node selectors                                     | `{}`                                             |
-| `livenessProbe.initialDelaySeconds` | initialDelaySeconds of Pod livenessProbe           | `60`                                             |
-| `livenessProbe.periodSeconds`       | periodSeconds of Pod livenessProbe                 | `20`                                             |
-| `nodeSelector`                      | Node selectors                                     | `{}`                                             |
-| `image.repository`                  | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
-| `image.tag`                         | Container image tag                                | `6.2.1`                                          |
-| `image.pullPolicy`                  | Container image pull policy                        | `IfNotPresent`                                   |
-| `service.type`                      | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
-| `service.internalPort`              | Logstash internal port                             | `1514`                                           |
-| `service.ports`                     | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
-| `ingress.enabled`                   | Enables Ingress                                    | `false`                                          |
-| `ingress.annotations`               | Ingress annotations                                | `{}`                                             |
-| `ingress.hosts`                     | Ingress accepted hostnames                         | `[]`                                             |
-| `ingress.tls`                       | Ingress TLS configuration                          | `nil`                                            |
-| `resources`                         | Pod resource requests & limits                     | `{}`                                             |
-| `elasticsearch.host`                | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
-| `elasticsearch.port`                | ElasticSearch port                                 | `9200`                                           |
-| `configData`                        | Extra logstash config                              | `{}`                                             |
-| `patterns`                          | Logstash patterns configuration                    | `nil`                                            |
-| `inputs`                            | Logstash inputs configuration                      | `(basic)`                                        |
-| `filters`                           | Logstash filters configuration                     | `nil`                                            |
-| `outputs`                           | Logstash outputs configuration                     | `(basic)`                                        |
+|              Parameter               |                    Description                     |                     Default                      |
+| -----------------------------------  | -------------------------------------------------- | ------------------------------------------------ |
+| `replicaCount`                       | Number of replicas                                 | `1`                                              |
+| `nodeSelector`                       | Node selectors                                     | `{}`                                             |
+| `livenessProbe.initialDelaySeconds`  | initialDelaySeconds of Pod livenessProbe           | `60`                                             |
+| `livenessProbe.periodSeconds`        | periodSeconds of Pod livenessProbe                 | `20`                                             |
+| `readinessProbe.initialDelaySeconds` | initialDelaySeconds of Pod readinessProbe          | `60`                                             |
+| `nodeSelector`                       | Node selectors                                     | `{}`                                             |
+| `image.repository`                   | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
+| `image.tag`                          | Container image tag                                | `6.2.1`                                          |
+| `image.pullPolicy`                   | Container image pull policy                        | `IfNotPresent`                                   |
+| `service.type`                       | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
+| `service.internalPort`               | Logstash internal port                             | `1514`                                           |
+| `service.ports`                      | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
+| `ingress.enabled`                    | Enables Ingress                                    | `false`                                          |
+| `ingress.annotations`                | Ingress annotations                                | `{}`                                             |
+| `ingress.hosts`                      | Ingress accepted hostnames                         | `[]`                                             |
+| `ingress.tls`                        | Ingress TLS configuration                          | `nil`                                            |
+| `resources`                          | Pod resource requests & limits                     | `{}`                                             |
+| `elasticsearch.host`                 | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
+| `elasticsearch.port`                 | ElasticSearch port                                 | `9200`                                           |
+| `configData`                         | Extra logstash config                              | `{}`                                             |
+| `patterns`                           | Logstash patterns configuration                    | `nil`                                            |
+| `inputs`                             | Logstash inputs configuration                      | `(basic)`                                        |
+| `filters`                            | Logstash filters configuration                     | `nil`                                            |
+| `outputs`                            | Logstash outputs configuration                     | `(basic)`                                        |

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -39,7 +39,7 @@ The following tables lists the configurable parameters of the drone charts and t
 | `livenessProbe.periodSeconds`       | periodSeconds of Pod livenessProbe                 | `20`                                             |
 | `nodeSelector`                      | Node selectors                                     | `{}`                                             |
 | `image.repository`                  | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
-| `image.tag`                         | Container image tag                                | `6.0.0`                                          |
+| `image.tag`                         | Container image tag                                | `6.2.1`                                          |
 | `image.pullPolicy`                  | Container image pull policy                        | `IfNotPresent`                                   |
 | `service.type`                      | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
 | `service.internalPort`              | Logstash internal port                             | `1514`                                           |

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -31,25 +31,28 @@ chart and deletes the release.
 
 The following tables lists the configurable parameters of the drone charts and their default values.
 
-| Parameter              | Description                                        | Default                                          |
-| ---------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| `replicaCount`         | Number of replicas                                 | `1`                                              |
-| `nodeSelector`         | Node selectors                                     | `{}`                                             |
-| `image.repository`     | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
-| `image.tag`            | Container image tag                                | `6.0.0`                                          |
-| `image.pullPolicy`     | Container image pull policy                        | `IfNotPresent`                                   |
-| `service.type`         | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
-| `service.internalPort` | Logstash internal port                             | `1514`                                           |
-| `service.ports`        | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
-| `ingress.enabled`      | Enables Ingress                                    | `false`                                          |
-| `ingress.annotations`  | Ingress annotations                                | `{}`                                             |
-| `ingress.hosts`        | Ingress accepted hostnames                         | `[]`                                             |
-| `ingress.tls`          | Ingress TLS configuration                          | `nil`                                            |
-| `resources`            | Pod resource requests & limits                     | `{}`                                             |
-| `elasticsearch.host`   | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
-| `elasticsearch.port`   | ElasticSearch port                                 | `9200`                                           |
-| `configData`           | Extra logstash config                              | `{}`                                             |
-| `patterns`             | Logstash patterns configuration                    | `nil`                                            |
-| `inputs`               | Logstash inputs configuration                      | `(basic)`                                        |
-| `filters`              | Logstash filters configuration                     | `nil`                                            |
-| `outputs`              | Logstash outputs configuration                     | `(basic)`                                        |
+|              Parameter              |                    Description                     |                     Default                      |
+| ----------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| `replicaCount`                      | Number of replicas                                 | `1`                                              |
+| `nodeSelector`                      | Node selectors                                     | `{}`                                             |
+| `livenessProbe.initialDelaySeconds` | initialDelaySeconds of Pod livenessProbe           | `60`                                             |
+| `livenessProbe.periodSeconds`       | periodSeconds of Pod livenessProbe                 | `20`                                             |
+| `nodeSelector`                      | Node selectors                                     | `{}`                                             |
+| `image.repository`                  | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
+| `image.tag`                         | Container image tag                                | `6.0.0`                                          |
+| `image.pullPolicy`                  | Container image pull policy                        | `IfNotPresent`                                   |
+| `service.type`                      | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
+| `service.internalPort`              | Logstash internal port                             | `1514`                                           |
+| `service.ports`                     | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
+| `ingress.enabled`                   | Enables Ingress                                    | `false`                                          |
+| `ingress.annotations`               | Ingress annotations                                | `{}`                                             |
+| `ingress.hosts`                     | Ingress accepted hostnames                         | `[]`                                             |
+| `ingress.tls`                       | Ingress TLS configuration                          | `nil`                                            |
+| `resources`                         | Pod resource requests & limits                     | `{}`                                             |
+| `elasticsearch.host`                | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
+| `elasticsearch.port`                | ElasticSearch port                                 | `9200`                                           |
+| `configData`                        | Extra logstash config                              | `{}`                                             |
+| `patterns`                          | Logstash patterns configuration                    | `nil`                                            |
+| `inputs`                            | Logstash inputs configuration                      | `(basic)`                                        |
+| `filters`                           | Logstash filters configuration                     | `nil`                                            |
+| `outputs`                           | Logstash outputs configuration                     | `(basic)`                                        |

--- a/incubator/logstash/templates/deployment.yaml
+++ b/incubator/logstash/templates/deployment.yaml
@@ -27,12 +27,13 @@ spec:
     {{- end }}
           livenessProbe:
             tcpSocket:
-              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
               port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ .Values.elasticsearch.host | quote }}

--- a/incubator/logstash/templates/deployment.yaml
+++ b/incubator/logstash/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
     {{- end }}
           livenessProbe:
             tcpSocket:
+              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
               port: {{ .Values.service.internalPort }}
           readinessProbe:
             tcpSocket:

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 nodeSelector: {}
 image:
   repository: docker.elastic.co/logstash/logstash-oss
-  tag: 6.0.0
+  tag: 6.2.1
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -24,6 +24,10 @@ service:
 # Extra config options
 configData: {}
 
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 20
+
 ingress:
   enabled: false
   # Used to create an Ingress and Service record.

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -27,6 +27,8 @@ configData: {}
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 20
+readinessProbe:
+  initialDelaySeconds: 120
 
 ingress:
   enabled: false


### PR DESCRIPTION
This PR adds  initialDelaySeconds and periodSeconds to the livenessProbe of Logstash. Without the delay, the Logstash Pod would be restarted if not started in under 10 seconds. I also updated the image from 6.0.0 to the current 6.2.1.
