### PR TITLE
Fix the Nginx service name shown in NOTES.txt

### DIFF
--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.0.0
+version: 7.0.1
 appVersion: 5.8.3
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/NOTES.txt
+++ b/stable/artifactory/templates/NOTES.txt
@@ -8,15 +8,15 @@ Congratulations. You have just deployed JFrog Artifactory Pro!
    {{- end }}
    
    {{- else if contains "NodePort" .Values.nginx.service.type }}
-   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "artifactory.nginx.name" . }})
+   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "artifactory.nginx.fullname" . }})
    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
    echo http://$NODE_IP:$NODE_PORT/
 
    {{- else if contains "LoadBalancer"  .Values.nginx.service.type }}
 
    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-         You can watch the status of the service by running 'kubectl get svc -w {{ template "artifactory.nginx.name" . }}'
-   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "artifactory.nginx.name" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+         You can watch the status of the service by running 'kubectl get svc -w {{ template "artifactory.nginx.fullname" . }}'
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "artifactory.nginx.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
    echo http://$SERVICE_IP/
 
    {{- else if contains "ClusterIP" .Values.nginx.service.type }}


### PR DESCRIPTION
This is a simple fix of the service name shown in NOTES.txt.

* This PR replaces https://github.com/kubernetes/charts/pull/3511, which I closed due to a technical error on my part.

@paulczar, @mattfarina - FYI.