### PR TITLE
Adds dnsPolicy as a controller option to values.yaml and places an ex…

### DIFF
--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -29,6 +29,7 @@ spec:
 {{ toYaml .Values.controller.podLabels | indent 8}}
         {{- end }}
     spec:
+      dnsPolicy: {{ .Values.controller.dnsPolicy | default "ClusterFirst" }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -30,6 +30,7 @@ spec:
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
     spec:
+      dnsPolicy: {{ .Values.controller.dnsPolicy | default "ClusterFirst" }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -17,6 +17,10 @@ controller:
   # is merged
   hostNetwork: false
 
+  # Optionally use this DNS Policy if you have 'hostNetwork: true'
+  # Without this, pods running with host network access will not be able to resolve names in K8S' internal DNS
+  #dnsPolicy: ClusterFirstWithHostNet
+
   ## Use host ports 80 and 443
   daemonset:
     useHostPort: false


### PR DESCRIPTION
Adds dnsPolicy as a controller option to values.yaml and places an explicit definition into the Pod templates for Deployments and DaemonSets.

Following up #3656 to propose the addition of dnsPolicy as an option in values.yaml. This should make installation of nginx-ingress-controller a bit more flexible in this matter.