### PR TITLE
Adds dnsPolicy as an option to nginx-ingress-controller in values.yaml

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.9.2
+version: 0.9.3
 appVersion: 0.10.2
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.9.3
+version: 0.9.4
 appVersion: 0.10.2
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
 {{ toYaml .Values.controller.podLabels | indent 8}}
         {{- end }}
     spec:
-      dnsPolicy: {{ .Values.controller.dnsPolicy | default "ClusterFirst" }}
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -29,6 +29,7 @@ spec:
 {{ toYaml .Values.controller.podLabels | indent 8}}
         {{- end }}
     spec:
+      dnsPolicy: {{ .Values.controller.dnsPolicy | default "ClusterFirst" }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -30,6 +30,7 @@ spec:
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
     spec:
+      dnsPolicy: {{ .Values.controller.dnsPolicy | default "ClusterFirst" }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -30,7 +30,7 @@ spec:
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
     spec:
-      dnsPolicy: {{ .Values.controller.dnsPolicy | default "ClusterFirst" }}
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -17,9 +17,10 @@ controller:
   # is merged
   hostNetwork: false
 
-  # Optionally use this DNS Policy if you have 'hostNetwork: true'
-  # Without this, pods running with host network access will not be able to resolve names in K8S' internal DNS
-  # dnsPolicy: ClusterFirstWithHostNet
+  # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
+  # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
+  # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
+  dnsPolicy: ClusterFirst
 
   ## Use host ports 80 and 443
   daemonset:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -19,7 +19,7 @@ controller:
 
   # Optionally use this DNS Policy if you have 'hostNetwork: true'
   # Without this, pods running with host network access will not be able to resolve names in K8S' internal DNS
-  #dnsPolicy: ClusterFirstWithHostNet
+  # dnsPolicy: ClusterFirstWithHostNet
 
   ## Use host ports 80 and 443
   daemonset:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -17,6 +17,10 @@ controller:
   # is merged
   hostNetwork: false
 
+  # Optionally use this DNS Policy if you have 'hostNetwork: true'
+  # Without this, pods running with host network access will not be able to resolve names in K8S' internal DNS
+  #dnsPolicy: ClusterFirstWithHostNet
+
   ## Use host ports 80 and 443
   daemonset:
     useHostPort: false


### PR DESCRIPTION
Following up #3656, which proposes a new value in values.yaml to allow nginx controller to run with host network and still be able to resolve names inside the k8s cluster.