### PR TITLE
[stable/kubernetes-dashboard] Fix `extraArgs` documentation

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.5.2
+version: 0.6.0
 appVersion: 1.8.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.6.0
+version: 0.5.3
 appVersion: 1.8.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -42,7 +42,7 @@ The following tables lists the configurable parameters of the kubernetes-dashboa
 | `image.repository`     | Repository for container image     | `gcr.io/google_containers/kubernetes-dashboard-amd64`                    |
 | `image.tag`            | Image tag                          | `v1.8.1`                                                                 |
 | `image.pullPolicy`     | Image pull policy                  | `IfNotPresent`                                                           |
-| `extraArgs`            | Additional container arguments     | `{}`                                                                     |
+| `extraArgs`            | Additional container arguments     | `[]`                                                                     |
 | `nodeSelector`         | node labels for pod assignment     | `{}`                                                                     |
 | `service.externalPort` | Dashboard internal port            | 80                                                                       |
 | `service.internalPort` | Dashboard external port            | 80                                                                       |

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -30,10 +30,12 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.extraArgs }}
+        {{- if .Values.extraArgs }}
         args:
-{{ toYaml .Values.extraArgs | indent 10 }}
-{{- end }}
+          {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+          {{- end }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 9090

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -30,12 +30,10 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.extraArgs }}
+{{- if .Values.extraArgs }}
         args:
-          {{- range $key, $value := .Values.extraArgs }}
-            - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
-          {{- end }}
-        {{- end }}
+{{ toYaml .Values.extraArgs | indent 10 }}
+{{- end }}
         ports:
         - name: http
           containerPort: 9090

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -17,8 +17,8 @@ labels: {}
 ## Additional container arguments
 ##
 # extraArgs:
-#   enable-insecure-login: true
-#   auto-generate-certificates: true
+#   - --enable-insecure-login
+#   - --system-banner="Welcome to Kubernetes"
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
I added `extraArgs` in #3587, but messed up either the documentation or the template.

The documentation has:
```yaml
extraArgs:
  enable-insecure-login: true
  auto-generate-certificates: true
```

but it needs to be configured like this to work currently:
```yaml
extraArgs:
  - --enable-insecure-login
  - --auto-generate-certificates=true
```

I changed the template to take an object instead of an array because it seems to be more popular in other charts, but can also do the opposite.