### PR TITLE
Add mesh peer to prometheus alert service

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.1.2
+version: 5.1.3
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/alertmanager-service.yaml
+++ b/stable/prometheus/templates/alertmanager-service.yaml
@@ -41,6 +41,12 @@ spec:
     {{- if .Values.alertmanager.service.nodePort }}
       nodePort: {{ .Values.alertmanager.service.nodePort }}
     {{- end }}
+{{- if .Values.alertmanager.service.enableMeshPeer }}
+    - name: meshpeer
+      port: 6783
+      protocol: TCP
+      targetPort: 6783
+{{- end }}
   selector:
     app: {{ template "prometheus.name" . }}
     component: "{{ .Values.alertmanager.name }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -143,6 +143,10 @@ alertmanager:
     annotations: {}
     labels: {}
     clusterIP: ""
+    
+    ## Enabling peer mesh service end points for enabling the HA alert manager
+    ## Ref: https://github.com/prometheus/alertmanager/blob/master/README.md
+    # enableMeshPeer : true
 
     ## List of IP addresses at which the alertmanager service is available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -143,7 +143,7 @@ alertmanager:
     annotations: {}
     labels: {}
     clusterIP: ""
-    
+
     ## Enabling peer mesh service end points for enabling the HA alert manager
     ## Ref: https://github.com/prometheus/alertmanager/blob/master/README.md
     # enableMeshPeer : true


### PR DESCRIPTION
To enable HA in Prometheus, the alerting service needs to expose port `6783` so that they could gossip with each other.

https://www.robustperception.io/high-availability-prometheus-alerting-and-notification/