### PR TITLE
[incubator][chartmuseum] Allow NodePort to be specified

### DIFF
--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 0.3.2
+version: 0.3.3
 appVersion: 0.2.8
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/incubator/chartmuseum/templates/service.yaml
+++ b/incubator/chartmuseum/templates/service.yaml
@@ -14,7 +14,11 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - port: {{ .Values.service.externalPort }}
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{.Values.service.nodePort}}
+{{- else }}
     targetPort: {{ .Values.service.internalPort }}
+{{- end }}
     protocol: TCP
     name: {{ .Release.Name }}
   selector:

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -55,7 +55,7 @@ service:
   type: ClusterIP
   externalPort: 8080
   internalPort: 8080
-  nodePort: 
+  nodePort:
   annotations: {}
 
 resources:

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -55,8 +55,9 @@ service:
   type: ClusterIP
   externalPort: 8080
   internalPort: 8080
+  nodePort: 
   annotations: {}
-    # foo.io/bar: "true"
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
This change allows the nodeport used for the service to be specified if required

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
