### PR TITLE
[Prometheus] Updated cAdvisor endpoint

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.3.1
+version: 5.2.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.1.2
+version: 5.2.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -718,7 +718,7 @@ serverFiles:
 
         kubernetes_sd_configs:
           - role: node
-          
+
         # This configuration will work only on kubelet 1.7.3+
         # As the scrape endpoints for cAdvisor have changed
         # if you are using older version you need to change the replacement to

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -719,6 +719,11 @@ serverFiles:
         kubernetes_sd_configs:
           - role: node
           
+        # This configuration will work only on kubelet 1.7.3+
+        # As the scrape endpoints for cAdvisor have changed
+        # if you are using older version you need to change the replacement to
+        # replacement: /api/v1/nodes/${1}:4194/proxy/metrics
+        # more info here https://github.com/coreos/prometheus-operator/issues/633
         relabel_configs:
           - action: labelmap
             regex: __meta_kubernetes_node_label_(.+)

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -718,7 +718,7 @@ serverFiles:
 
         kubernetes_sd_configs:
           - role: node
-
+          
         relabel_configs:
           - action: labelmap
             regex: __meta_kubernetes_node_label_(.+)
@@ -727,7 +727,7 @@ serverFiles:
           - source_labels: [__meta_kubernetes_node_name]
             regex: (.+)
             target_label: __metrics_path__
-            replacement: /api/v1/nodes/${1}:4194/proxy/metrics
+            replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 
       # Scrape config for service endpoints.
       #


### PR DESCRIPTION
Updated cadvisor scape endpoint so that it is compatible with Kubernetes 1.7.3+
Also added comment how to edit default values.yaml in order to be able to scrape cAdvisor metrics in older clusters
See more here https://github.com/prometheus/prometheus/issues/3181#issuecomment-329927699

This change is backwards incompatible.