### PR TITLE
add external-dns txt-prefix param to deployment and readme

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.4.8
+version: 0.4.9
 appVersion: 0.4.8
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the external-dns chart
 | `sources`                          | List of resource types to monitor, possible values are fake, service or ingress.                                           | `[service, ingress]`                               |
 | `tolerations`                      | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                               | `[]`                                               |
 | `txtOwnerId`                       | When using the TXT registry, a name that identifies this instance of ExternalDNS (optional)                                | `"default"`                                        |
+| `txtPrefix`                        | When using the TXT registry, a prefix for ownership records that avoids collision with CNAME entries (optional)            | `""`                                        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
           {{- if .Values.txtOwnerId }}
             - --txt-owner-id={{ .Values.txtOwnerId }}
           {{- end }}
+          {{- if .Values.txtPrefix }}
+            - --txt-prefix={{ .Values.txtPrefix }}
+          {{- end }}
           {{- if .Values.annotationFilter }}
             - --annotation-filter={{ .Values.annotationFilter }}
           {{- end }}


### PR DESCRIPTION
This PR adds the txt-prefix parameter to the external-dns chart to allow txt registries to prefix the owner entry. If using a txt registry and attempting to use a CNAME the --txt-prefix must be set to avoid conflicts.