### PR TITLE
Update doc for nginx-ingress about externalIPs and hostNetwork=true

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.9.2
+version: 0.9.3
 appVersion: 0.10.2
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -50,7 +50,7 @@ Parameter | Description | Default
 `controller.image.tag` | controller container image tag | `0.10.2`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.config` | nginx ConfigMap entries | none
-`controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace | false
+`controller.hostNetwork` | If the nginx deployment / daemonset should run on the host's network namespace. Do not set this when `controller.service.externalIPs` is set and `kube-proxy` is used as there will be a port-conflict for port `80` | false
 `controller.defaultBackendService` | default 404 backend service; required only if `defaultBackend.enabled = false` | `""`
 `controller.electionID` | election ID to use for the status update | `ingress-controller-leader`
 `controller.extraEnvs` | any additional environment variables to set in the pods | `{}`
@@ -70,7 +70,7 @@ Parameter | Description | Default
 `controller.publishService.enabled` | if true, the controller will set the endpoint records on the ingress objects to reflect those on the service | `false`
 `controller.publishService.pathOverride` | override of the default publish-service name | `""`
 `controller.service.clusterIP` | internal controller cluster service IP | `""`
-`controller.service.externalIPs` | controller service external IP addresses | `[]`
+`controller.service.externalIPs` | controller service external IP addresses. Do not set this when `controller.hostNetwork` is set to `true` and `kube-proxy` is used as there will be a port-conflict for port `80` | `[]`
 `controller.service.externalTrafficPolicy` | If `controller.service.type` is `NodePort` or `LoadBalancer`, set this to `Local` to enable [source IP preservation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport) | `"Cluster"`
 `controller.service.healthCheckNodePort` | If `controller.service.type` is `NodePort` or `LoadBalancer` and `controller.service.externalTrafficPolicy` is set to `Local`, set this to [the managed health-check port the kube-proxy will expose](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typenodeport). If blank, a random port in the `NodePort` range will be assigned | `""`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`


### PR DESCRIPTION
When `kube-proxy` is used, setting both `controller.service.externalIPs` and `controller.hostNetwork=true` for the `nginx-ingress` chart is an invalid configuration as `kube-proxy` also uses port `80` (nginx port) and causes a port-conflict for port `80` for nginx. Due to this issue, the nginx ingress controller pod goes to `CrashLoopBackOff` state:

```
$ kubectl get pods -o wide | grep my-nginx-ingress-controller
my-nginx-ingress-controller-5fb9b7c986-lfdln      0/1     CrashLoopBackOff   4      3m     10.10.97.46    node1-we2d86faeb2
```

Here is how `kube-proxy` uses port `80` which causes port-conflict for nginx:

```
admin@ node1-we2d86faeb2:~$ sudo lsof -i :80
COMMAND    PID USER   FD   TYPE  DEVICE SIZE/OFF NODE NAME
kube-prox 2215 root   12u  IPv4 3190900      0t0  TCP 10.10.97.200:http (LISTEN)

admin@ node1-we2d86faeb2:~$ sudo netstat -pan | grep :80
tcp        0      0 10.10.97.200:80         0.0.0.0:*               LISTEN      2215/kube-proxy
```

This PR updates the documentation for the `nginx-ingress` chart about this invalid configuration so that users know about it.

Full discussion with the nginx-ingress developer @aledbf is at https://github.com/kubernetes/ingress-nginx/issues/2062#issuecomment-364833575.