### PR TITLE
[stable/sematext-docker-agent] Add support for custom endpoints

### DIFF
--- a/stable/sematext-docker-agent/Chart.yaml
+++ b/stable/sematext-docker-agent/Chart.yaml
@@ -1,5 +1,5 @@
 name: sematext-docker-agent
-version: 0.1.2
+version: 0.1.3
 description: Sematext Docker Agent
 keywords:
 - alerts

--- a/stable/sematext-docker-agent/README.md
+++ b/stable/sematext-docker-agent/README.md
@@ -37,19 +37,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configuration parameters of the sematext-docker-agent chart and their default values.
 
-|             Parameter       |            Description             |                    Default                |
-|-----------------------------|------------------------------------|-------------------------------------------|
-| `sematext.spmToken`         | Sematext SPM token                 | `Nil` You must provide your SPM token     |
-| `sematext.logseneToken`     | Sematext Logsene token             | `Nil` You must provide your Logsene token |
-| `sematext.region`           | Sematext region                    | `US` Sematext US or EU region             |
-| `image.repository`          | The image repository               | `sematext/sematext-agent-docker`          |
-| `image.tag`                 | The image tag                      | `1.31.48`                                 |
-| `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
-| `resources.requests.cpu`    | CPU resource requests              | `Nil`                                     |
-| `resources.limits.cpu`      | CPU resource limits                | `Nil`                                     |
-| `resources.requests.memory` | Memory resource requests           | `Nil`                                     |
-| `resources.limits.memory`   | Memory resource limits             | `Nil`                                     |
-| `sematext.useHostNetwork`   | Use the host networking            | `true`                                    |
+|             Parameter         |            Description               |                    Default                |
+|-------------------------------|--------------------------------------|-------------------------------------------|
+| `sematext.spmToken`           | Sematext SPM token                   | `Nil` You must provide your SPM token     |
+| `sematext.logseneToken`       | Sematext Logsene token               | `Nil` You must provide your Logsene token |
+| `sematext.region`             | Sematext region                      | `US` Sematext US or EU region             |
+| `image.repository`            | The image repository                 | `sematext/sematext-agent-docker`          |
+| `image.tag`                   | The image tag                        | `1.31.48`                                 |
+| `image.pullPolicy`            | Image pull policy                    | `IfNotPresent`                            |
+| `resources.requests.cpu`      | CPU resource requests                | `Nil`                                     |
+| `resources.limits.cpu`        | CPU resource limits                  | `Nil`                                     |
+| `resources.requests.memory`   | Memory resource requests             | `Nil`                                     |
+| `resources.limits.memory`     | Memory resource limits               | `Nil`                                     |
+| `sematext.useHostNetwork`     | Use the host networking              | `true`                                    |
+| `sematext.url.spmReceiver`    | Custom endpoint for SPM receiver     | `Nil`                                     |
+| `sematext.url.logseneReceiver`| Custom endpoint for Logsene receiver | `Nil`                                     |
+| `sematext.url.eventsReceiver` | Custom endpoint for Events receiver  | `Nil`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/sematext-docker-agent/templates/configmap.yaml
+++ b/stable/sematext-docker-agent/templates/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sematext.fullname" . }}
+  labels:
+    app: {{ template "sematext.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+data:
+{{- if .Values.sematext.url }}
+  SPM_RECEIVER_URL: {{ default "" .Values.sematext.url.spmReceiver | quote }}
+  LOGSENE_RECEIVER_URL: {{ default "" .Values.sematext.url.logseneReceiver | quote }}
+  EVENTS_RECEIVER_URL: {{ default "" .Values.sematext.url.eventsReceiver | quote }}
+{{- else if eq .Values.sematext.region "EU" }}
+  SPM_RECEIVER_URL: "https://spm-receiver.eu.sematext.com/receiver/v1"
+  LOGSENE_RECEIVER_URL: "https://logsene-receiver.eu.sematext.com"
+  EVENTS_RECEIVER_URL: "https://event-receiver.eu.sematext.com"
+{{- else if eq .Values.sematext.region "US" }}
+  SPM_RECEIVER_URL: "https://spm-receiver.sematext.com/receiver/v1"
+  LOGSENE_RECEIVER_URL: "https://logsene-receiver.sematext.com"
+  EVENTS_RECEIVER_URL: "https://event-receiver.sematext.com"
+{{- end }}

--- a/stable/sematext-docker-agent/templates/daemonset.yaml
+++ b/stable/sematext-docker-agent/templates/daemonset.yaml
@@ -43,14 +43,9 @@ spec:
             secretKeyRef:
               name: {{ template "sematext.fullname" . }}
               key: logsene-token
-{{- if eq .Values.sematext.region "EU" }}
-        - name: SPM_RECEIVER_URL
-          value: "https://spm-receiver.eu.sematext.com/receiver/v1"
-        - name: LOGSENE_RECEIVER_URL
-          value: "https://logsene-receiver.eu.sematext.com"
-        - name: EVENTS_RECEIVER_URL
-          value: "https://event-receiver.eu.sematext.com"
-{{- end }}
+        - envFrom:
+          - configMapRef:
+              name: {{ template "sematext.fullname" . }}
         volumeMounts:
           - mountPath: /var/run/docker.sock
             name: docker-sock

--- a/stable/sematext-docker-agent/templates/daemonset.yaml
+++ b/stable/sematext-docker-agent/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
             secretKeyRef:
               name: {{ template "sematext.fullname" . }}
               key: logsene-token
-        - envFrom:
+        envFrom:
           - configMapRef:
               name: {{ template "sematext.fullname" . }}
         volumeMounts:

--- a/stable/sematext-docker-agent/values.yaml
+++ b/stable/sematext-docker-agent/values.yaml
@@ -15,6 +15,13 @@ sematext:
 
   useHostNetwork: true
   name: sematext-docker-agent
+
+  # Support for custom URLs
+  # url:
+  #   spmReceiver: http://spm-receiver:8080
+  #   logseneReceiver: http://logsene-receiver:8080
+  #   eventsReceiver: http://events-receiver:8080
+
   resources: {}
   #  requests:
   #    cpu: 500m


### PR DESCRIPTION
This chart has predefined endpoints where to send the data, but for on-premises deployments, they need to be changed.