### PR TITLE
[stable/etcd-operator] allow custom pod labels and annotations in etcd operator deploys

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.6.2
+version: 0.6.3
 appVersion: 0.7.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/README.md
+++ b/stable/etcd-operator/README.md
@@ -71,6 +71,8 @@ The following tables lists the configurable parameters of the etcd-operator char
 | `etcdOperator.resources.memory`                   | Memory limit per etcd-operator pod                                   | `128Mi`                                        |
 | `etcdOperator.nodeSelector`                       | Node labels for etcd operator pod assignment                         | `{}`                                           |
 | `etcdOperator.commandArgs`                        | Additional command arguments                                         | `{}`                                           |
+| `etcdOperator.podLabels`                          | Additional labels to be added to the etcd-operator pods              | `{}`                                           |
+| `etcdOperator.podAnnotations`                     | Additional annotations to be added to the etcd-operator pods         | `{}`                                           |
 | `backupOperator.name`                             | Backup operator name                                                 | `etcd-backup-operator`                         |
 | `backupOperator.replicaCount`                     | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
 | `backupOperator.image.repository`                 | Operator container image                                             | `quay.io/coreos/etcd-operator`                 |
@@ -83,6 +85,8 @@ The following tables lists the configurable parameters of the etcd-operator char
 | `backupOperator.spec.s3.awsSecret`                | Name of kubernetes secrete containing aws credentials                |                                                |
 | `backupOperator.nodeSelector`                     | Node labels for etcd operator pod assignment                         | `{}`                                           |
 | `backupOperator.commandArgs`                      | Additional command arguments                                         | `{}`                                           |
+| `backupOperator.podLabels`                        | Additional labels to be added to the etcd-backup-operator pods       | `{}`                                           |
+| `backupOperator.podAnnotations`                   | Additional annotations to be added to the etcd-backup-operator pods  | `{}`                                           |
 | `restoreOperator.name`                            | Restore operator name                                                | `etcd-backup-operator`                         |
 | `restoreOperator.replicaCount`                    | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
 | `restoreOperator.image.repository`                | Operator container image                                             | `quay.io/coreos/etcd-operator`                 |
@@ -94,6 +98,8 @@ The following tables lists the configurable parameters of the etcd-operator char
 | `restoreOperator.spec.s3.awsSecret`               | Name of kubernetes secrete containing aws credentials                |                                                |
 | `restoreOperator.nodeSelector`                    | Node labels for etcd operator pod assignment                         | `{}`                                           |
 | `restoreOperator.commandArgs`                     | Additional command arguments                                         | `{}`                                           |
+| `restoreOperator.podLabels`                      | Additional labels to be added to the etcd-restore-operator pods      | `{}`                                           |
+| `restoreOperator.podAnnotations`                 | Additional annotations to be added to the etcd-restore-operator pods | `{}`                                           |
 | `etcdCluster.name`                                | etcd cluster name                                                    | `etcd-cluster`                                 |
 | `etcdCluster.size`                                | etcd cluster size                                                    | `3`                                            |
 | `etcdCluster.version`                             | etcd cluster version                                                 | `3.2.10`                                       |

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -17,6 +17,13 @@ spec:
       labels:
         app: {{ template "etcd-backup-operator.fullname" . }}
         release: {{ .Release.Name }}
+{{- if .Values.backupOperator.podLabels }}
+{{ toYaml .Values.backupOperator.podLabels | indent 8 }}
+{{- end }}
+      annotations:
+{{- if .Values.backupOperator.podAnnotations }}
+{{ toYaml .Values.backupOperator.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "etcd-backup-operator.fullname" . }}{{ else }}{{ .Values.rbac.backupOperatorServiceAccountName }}{{ end }}
       containers:

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -17,6 +17,13 @@ spec:
       labels:
         app: {{ template "etcd-operator.fullname" . }}
         release: {{ .Release.Name }}
+{{- if .Values.etcdOperator.podLabels }}
+{{ toYaml .Values.etcdOperator.podLabels | indent 8 }}
+{{- end }}
+      annotations:
+{{- if .Values.etcdOperator.podAnnotations }}
+{{ toYaml .Values.etcdOperator.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "etcd-operator.fullname" . }}{{ else }}{{ .Values.rbac.etcdOperatorServiceAccountName }}{{ end }}
       containers:

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -17,6 +17,13 @@ spec:
       labels:
         app: {{ template "etcd-restore-operator.fullname" . }}
         release: {{ .Release.Name }}
+{{- if .Values.restoreOperator.podLabels }}
+{{ toYaml .Values.restoreOperator.podLabels | indent 8 }}
+{{- end }}
+      annotations:
+{{- if .Values.restoreOperator.podAnnotations }}
+{{ toYaml .Values.restoreOperator.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "etcd-restore-operator.fullname" . }}{{ else }}{{ .Values.rbac.restoreOperatorServiceAccountName }}{{ end }}
       containers:

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -45,6 +45,10 @@ etcdOperator:
   ## additional command arguments go here; will be translated to `--key=value` form
   ## e.g., analytics: true
   commandArgs: {}
+  ## extra labels to be added to the operator pods
+  podLabels: {}
+  ## extra annotations to be added to the operator pods
+  podAnnotations: {}
 
 # backup spec
 backupOperator:
@@ -68,6 +72,10 @@ backupOperator:
   ## additional command arguments go here; will be translated to `--key=value` form
   ## e.g., analytics: true
   commandArgs: {}
+  ## extra labels to be added to the backup operator pods
+  podLabels: {}
+  ## extra annotations to be added to the backup operator pods
+  podAnnotations: {}
 
 # restore spec
 restoreOperator:
@@ -93,6 +101,10 @@ restoreOperator:
   ## additional command arguments go here; will be translated to `--key=value` form
   ## e.g., analytics: true
   commandArgs: {}
+  ## extra labels to be added to the backup operator pods
+  podLabels: {}
+  ## extra annotations to be added to the backup operator pods
+  podAnnotations: {}
 
 ## etcd-cluster specific values
 etcdCluster:


### PR DESCRIPTION
This allows specifying additional pod labels on the etcd-operator deployments.