### PR TITLE
[stable/elasticsearch-exporter] Add prometheus scraping annotations for elasticsearch exporter

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.0.2
 sources:
   - https://github.com/justwatchcom/elasticsearch_exporter

--- a/stable/elasticsearch-exporter/templates/service.yaml
+++ b/stable/elasticsearch-exporter/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.service.httpPort }}"
+    prometheus.io/path: "{{ .Values.web.path }}"
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Adds the prometheus scraping annotations, so prometheus will collect metrics.