### PR TITLE
[vault] support using custom name for vault service

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.9.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "vault.fullname" . }}
+  name: {{ .Values.service.name | default ( include "vault.fullname" . ) }}
   labels:
     app: {{ template "vault.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
This PR will simply add the ability to use the .Values.service.name value (that already exists) as the name of the vault service that gets created. This simply enables the ability to use that custom name instead of the fullname of the release and avoids having a double-up that looks like `vault-vault.default.svc.cluster.local`  if you're specifying a release name of `vault`.