### PR TITLE
[stable/kong] Added support for service annotations

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.12.1

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-admin
   annotations:
-    {{- range $key, $value := .Values.proxy.annotations }}
+    {{- range $key, $value := .Values.admin.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
   labels:

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-admin
+  annotations:
+    {{- range $key, $value := .Values.proxy.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
   labels:
     app: {{ template "kong.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-proxy
+  annotations:
+    {{- range $key, $value := .Values.proxy.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
   labels:
     app: {{ template "kong.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -8,6 +8,11 @@ image:
 
 # Specify Kong admin and proxy services configurations
 admin:
+  # If you want to specify annotations for the admin service, uncomment the following
+  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  annotations: {}
+  #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+
   # HTTPS traffic on the admin port
   https:
     servicePort: 8444
@@ -19,6 +24,11 @@ admin:
   type: NodePort
   nodePort: 32444
 proxy:
+  # If you want to specify annotations for the proxy service, uncomment the following
+  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  annotations: {}
+  #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+
   # HTTPS traffic on the proxy port
   https:
     servicePort: 8443


### PR DESCRIPTION
This is a fairly simple change, to add support for annotations on the admin and proxy services for Kong.  Defaults to no annotations in `values.yaml`, with commented out examples provided.
