### PR TITLE
Changes for prometheus ingress RBAC.

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.1.5
+version: 5.1.6
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
       - services
       - endpoints
       - pods
+      - ingresses
     verbs:
       - get
       - list
@@ -28,6 +29,15 @@ rules:
       - configmaps
     verbs:
       - get
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
   - nonResourceURLs:
       - "/metrics"
     verbs:


### PR DESCRIPTION
Prometheus has scraping for ingress as an option https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml#L211 which is missing in the RBAC. 