### PR TITLE
[stable/nginx-ingress] ConfigMap expects strings as values

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.11.1
+version: 0.11.2
 appVersion: 0.11.0
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -13,6 +13,6 @@ data:
 {{- if .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
 {{- end }}
-{{- if .Values.controller.config }}
-{{ toYaml .Values.controller.config | indent 2 }}
-{{- end }}
+  {{- if .Values.controller.config }}{{ range $key, $value := .Values.controller.config }}
+  {{ $key | quote }}: {{ $value | quote }}
+  {{- end }}{{ end }}


### PR DESCRIPTION
This fixes helm install  --set controller.config.enable-modsecurity=true