### PR TITLE
Add podManagementPolicy support to incubator/cassandra

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.2.1
+version: 0.2.2
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing
   high availability with no single point of failure.

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -95,6 +95,7 @@ The following tables lists the configurable parameters of the Cassandra chart an
 | `persistence.size`         | Size of data volume                             | `10Gi`                                                     |
 | `resources`                | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
 | `service.type`             | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
+| `podManagementPolicy`      | podManagementPolicy of the StatefulSet          | `OrderedReady`                                             |
 | `updateStrategy.type`      | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
 
 ## Scale cassandra

--- a/incubator/cassandra/templates/cassandra-statefulset.yaml
+++ b/incubator/cassandra/templates/cassandra-statefulset.yaml
@@ -46,6 +46,7 @@ metadata:
 spec:
   serviceName: {{ template "cassandra.fullname" . }}
   replicas: {{ .Values.config.cluster_size }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
   template:

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -72,5 +72,6 @@ config:
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
+podManagementPolicy: OrderedReady
 updateStrategy:
   type: OnDelete


### PR DESCRIPTION
This PR adds support for setting the `podManagementPolicy` of the cassandra `StatefulSet`.