### PR TITLE
[stable/prometheus] Allow set securityContext for node exporter pods

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.1.6
+version: 5.1.7
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.1.5
+version: 5.1.6
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.2.1
+version: 5.2.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -167,6 +167,7 @@ Parameter | Description | Default
 `nodeExporter.podAnnotations` | annotations to be added to node-exporter pods | `{}`
 `nodeExporter.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `nodeExporter.resources` | node-exporter resource requests and limits (YAML) | `{}`
+`nodeExporter.securityContext` | securityContext for containers in pod | `{}`
 `nodeExporter.serviceAccountName` | service account name for node-exporter to use (ignored if rbac.create=true) | `default`
 `nodeExporter.service.annotations` | annotations for node-exporter service | `{prometheus.io/scrape: "true"}`
 `nodeExporter.service.clusterIP` | internal node-exporter cluster service IP | `None`

--- a/stable/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/prometheus/templates/node-exporter-daemonset.yaml
@@ -68,6 +68,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeExporter.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.nodeExporter.securityContext }}
+      securityContext:
+{{ toYaml .Values.nodeExporter.securityContext | indent 8 }}
+    {{- end }}
       volumes:
         - name: proc
           hostPath:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -341,6 +341,11 @@ nodeExporter:
     #   cpu: 100m
     #   memory: 30Mi
 
+  ## Security context to be added to node-exporter pods
+  ##
+  securityContext: {}
+    # runAsUser: 0
+
   service:
     annotations:
       prometheus.io/scrape: "true"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -561,7 +561,7 @@ pushgateway:
 
     ## pushgateway Ingress annotations
     ##
-    annotations:
+    annotations: {}
     #   kubernetes.io/ingress.class: nginx
     #   kubernetes.io/tls-acme: 'true'
 


### PR DESCRIPTION
This PR allow set securityContext for node exporter pods. For example:
```
securityContext:
      runAsUser: 0
```
which allow node exporter run as root user (maybe useful for a fix permissions issue, for filesystem stat collector when we mount root fs of a node into pod)