### PR TITLE
[stable/minio] Add persistence.existingClaim

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Distributed object storage server built for cloud applications and devops.
 name: minio
-version: 0.5.2
+version: 0.5.3
 keywords:
 - storage
 - object-storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -87,6 +87,7 @@ The following tables lists the configurable parameters of the Minio chart and th
 | `servicePort`              | Kubernetes port where service is exposed| `9000`                                              |
 | `persistence.enabled`      | Use persistent volume to store data | `true`                                                  |
 | `persistence.size`         | Size of persistent volume claim     | `10Gi`                                                  |
+| `persistence.existingClaim`| Use an existing PVC to persist data | `nil`                                                   |
 | `persistence.storageClass` | Type of persistent volume claim     | `generic`                                               |
 | `persistence.accessMode`   | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                                         |
 | `persistence.subPath`      | Mount a sub directory of the persistent volume if set | `""`                                  |
@@ -175,6 +176,19 @@ $ helm install --set persistence.enabled=false stable/minio
 ```
 
 > *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+Existing PersistentVolumeClaim
+------------------------------
+
+If a Persistent Volume Claim already exists, specify it during installation.
+
+1. Create the PersistentVolume
+1. Create the PersistentVolumeClaim
+1. Install the chart
+
+```bash
+$ helm install --set persistence.existingClaim=PVC_NAME stable/minio
+```
 
 NetworkPolicy
 -------------

--- a/stable/minio/templates/minio_deployment.yaml
+++ b/stable/minio/templates/minio_deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: export
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "minio.fullname" . }}
+            claimName: {{ .Values.persistence.existingClaim | default (include "minio.fullname" .) }}
         {{- else }}
           emptyDir: {}
         {{- end }}

--- a/stable/minio/templates/minio_pvc.yaml
+++ b/stable/minio/templates/minio_pvc.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.mode "standalone" "shared" }}
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -19,6 +19,7 @@ spec:
   storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/minio/templates/minio_pvc.yaml
+++ b/stable/minio/templates/minio_pvc.yaml
@@ -23,4 +23,3 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end }}

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -29,7 +29,7 @@ persistence:
   enabled: true
 
   ## A manually managed Persistent Volume and Claim
-  ## Requires persistence.enabled: true 
+  ## Requires persistence.enabled: true
   ## If defined, PVC must be created manually before volume will be bound
   # existingClaim:
 

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -28,6 +28,11 @@ replicas: 4
 persistence:
   enabled: true
 
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true 
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
   ## minio data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Adds an option to use manually created PV and PVC. Based on stable/redis chart.

We're using it in production to reuse NFS PV in a set of many similar Minio shared mode deployments, each reusing the same PV/PVC with a unique `persistence.subPath`.