### PR TITLE
[incubator/cassandra] Add pod anti-affinity

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.2.1
+version: 0.2.2
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing
   high availability with no single point of failure.

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -70,32 +70,34 @@ nodes:
 
 The following tables lists the configurable parameters of the Cassandra chart and their default values.
 
-| Parameter                  | Description                                     | Default                                                    |
-| -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
-| `image.repo`               | `cassandra` image repository                    | `cassandra`                                                |
-| `image.tag`                | `cassandra` image tag                           | `3`                                                        |
-| `image.pullPolicy`         | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `image.pullSecrets`        | Image pull secrets                              | `nil`                                                      |
-| `config.cluster_name`      | The name of the cluster.                        | `cassandra`                                                |
-| `config.cluster_size`      | The number of nodes in the cluster.             | `3`                                                        |
-| `config.seed_size`         | The number of seed nodes used to bootstrap new clients joining the cluster.                | `2`                                                        |
-| `config.num_tokens`        | Initdb Arguments                                | `256`                                                      |
-| `config.dc_name`           | Initdb Arguments                                | `DC1`                                                      |
-| `config.rack_name`         | Initdb Arguments                                | `RAC1`                                                     |
-| `config.endpoint_snitch`   | Initdb Arguments                                | `SimpleSnitch`                                             |
-| `config.max_heap_size`     | Initdb Arguments                                | `2048M`                                                    |
-| `config.heap_new_size`     | Initdb Arguments                                | `512M`                                                     |
-| `config.ports.cql`         | Initdb Arguments                                | `9042`                                                     |
-| `config.ports.thrift`      | Initdb Arguments                                | `9160`                                                     |
-| `config.ports.agent`       | The port of the JVM Agent (if any)              | `nil`                                                      |
-| `config.start_rpc`         | Initdb Arguments                                | `false`                                                    |
-| `persistence.enabled`      | Use a PVC to persist data                       | `true`                                                     |
-| `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
-| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
-| `persistence.size`         | Size of data volume                             | `10Gi`                                                     |
-| `resources`                | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
-| `service.type`             | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
-| `updateStrategy.type`      | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
+| Parameter                     | Description                                     | Default                                                    |
+| -----------------------       | ---------------------------------------------   | ---------------------------------------------------------- |
+| `image.repo`                  | `cassandra` image repository                    | `cassandra`                                                |
+| `image.tag`                   | `cassandra` image tag                           | `3`                                                        |
+| `image.pullPolicy`            | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `image.pullSecrets`           | Image pull secrets                              | `nil`                                                      |
+| `config.cluster_name`         | The name of the cluster.                        | `cassandra`                                                |
+| `config.cluster_size`         | The number of nodes in the cluster.             | `3`                                                        |
+| `config.seed_size`            | The number of seed nodes used to bootstrap new clients joining the cluster.                | `2`                                                        |
+| `config.num_tokens`           | Initdb Arguments                                | `256`                                                      |
+| `config.dc_name`              | Initdb Arguments                                | `DC1`                                                      |
+| `config.rack_name`            | Initdb Arguments                                | `RAC1`                                                     |
+| `config.endpoint_snitch`      | Initdb Arguments                                | `SimpleSnitch`                                             |
+| `config.max_heap_size`        | Initdb Arguments                                | `2048M`                                                    |
+| `config.heap_new_size`        | Initdb Arguments                                | `512M`                                                     |
+| `config.ports.cql`            | Initdb Arguments                                | `9042`                                                     |
+| `config.ports.thrift`         | Initdb Arguments                                | `9160`                                                     |
+| `config.ports.agent`          | The port of the JVM Agent (if any)              | `nil`                                                      |
+| `config.start_rpc`            | Initdb Arguments                                | `false`                                                    |
+| `persistence.enabled`         | Use a PVC to persist data                       | `true`                                                     |
+| `persistence.storageClass`    | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`      | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
+| `persistence.size`            | Size of data volume                             | `10Gi`                                                     |
+| `resources`                   | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
+| `service.type`                | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
+| `updateStrategy.type`         | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
+| `podAntiAffinity.enabled`     | Use pod anti-affinity                           | `false`                                                    |
+| `podAntiAffinity.topologyKey` | Topology key for pod anti-affinity              | `kubernetes.io/hostname`                                   |
 
 ## Scale cassandra
 When you want to change the cluster size of your cassandra, you can use the helm upgrade command.

--- a/incubator/cassandra/templates/cassandra-statefulset.yaml
+++ b/incubator/cassandra/templates/cassandra-statefulset.yaml
@@ -56,6 +56,18 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.podAntiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ template "cassandra.fullname" . }}
+            topologyKey: "{{ .Values.podAntiAffinity.topologyKey }}"
+{{- end }}
 {{- if .Values.selector }}
 {{ toYaml .Values.selector | indent 6 }}
 {{- end }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -62,6 +62,12 @@ config:
     # If a JVM Agent is in place
     # agent: 61621
 
+# Enable pod anti-affinity.
+# ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature
+podAntiAffinity:
+  enabled: false
+  topologyKey: "kubernetes.io/hostname"
+
 ## Configure node selector. Edit code below for adding selector to pods
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 # selector:


### PR DESCRIPTION
It seems to be important to runs Cassandra' pods which won't be co-located, especially in a production environment. In this PR is my proposal to add an option to use pod anti-affinity.