### PR TITLE
[stable/postgresql] Use lo address instead of POD_IP in readiness & liveness probe

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.8.12
+version: 0.8.13
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready --host $POD_IP
+            - exec pg_isready --host 127.0.0.1
           initialDelaySeconds: 120
           timeoutSeconds: 5
           failureThreshold: 6
@@ -65,7 +65,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready --host $POD_IP
+            - exec pg_isready --host 127.0.0.1
           initialDelaySeconds: 5
           timeoutSeconds: 3
           periodSeconds: 5


### PR DESCRIPTION
This makes the liveness and readiness probes run pg_isready against localhost instead of the pod IP.

I'm trying to run PostgreSQL within a cluster with Istio enabled (with mTLS), which causes the Postgres chart to not work (as istio intercepts requests to the pods IP address).

Whilst it isn't this charts concern that Istio has shortcomings, I'm also not sure what value this really brings (aside from building a test for whether Postgres is listening on all addresses, I suppose).

It'd be great if this could be changed as it'd save me having to fork this whole chart for a 2 line change!