### PR TITLE
[incubator/logstash] add ability to add custom annotations and labels to the pod

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.4.0
+version: 0.4.1
 appVersion: 6.0.0
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -46,6 +46,8 @@ The following tables lists the configurable parameters of the drone charts and t
 | `ingress.hosts`        | Ingress accepted hostnames                         | `[]`                                             |
 | `ingress.tls`          | Ingress TLS configuration                          | `nil`                                            |
 | `resources`            | Pod resource requests & limits                     | `{}`                                             |
+| `podAnnotations`       | Pod annotations                                    | `{}`                                             |
+| `podLabels`            | Pod labels                                         | `{}`                                             |
 | `elasticsearch.host`   | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
 | `elasticsearch.port`   | ElasticSearch port                                 | `9200`                                           |
 | `configData`           | Extra logstash config                              | `{}`                                             |

--- a/incubator/logstash/templates/deployment.yaml
+++ b/incubator/logstash/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: {{ template "logstash.name" . }}
         release: {{ .Release.Name }}
       {{- if .Values.podLabels }}
-        # Allows custom annotations to be specified
+        # Allows custom labels to be specified
         {{- range $key, $val := .Values.podLabels }}
         {{ $key }}: {{ $val | quote }}
         {{- end }}

--- a/incubator/logstash/templates/deployment.yaml
+++ b/incubator/logstash/templates/deployment.yaml
@@ -14,6 +14,13 @@ spec:
       labels:
         app: {{ template "logstash.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+      {{- if .Values.podAnnotations }}
+        # Allows custom annotations to be specified
+        {{- range $key, $val := .Values.podAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/incubator/logstash/templates/deployment.yaml
+++ b/incubator/logstash/templates/deployment.yaml
@@ -14,6 +14,12 @@ spec:
       labels:
         app: {{ template "logstash.name" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+        # Allows custom annotations to be specified
+        {{- range $key, $val := .Values.podLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      {{- end }}
       annotations:
       {{- if .Values.podAnnotations }}
         # Allows custom annotations to be specified

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -24,6 +24,10 @@ service:
 # Extra config options
 configData: {}
 
+podAnnotations: {}
+  # Add custom annotations to pods
+  # iam.amazonaws.com/role: "example-role"
+
 ingress:
   enabled: false
   # Used to create an Ingress and Service record.

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -28,6 +28,11 @@ podAnnotations: {}
   # Add custom annotations to pods
   # iam.amazonaws.com/role: "example-role"
 
+podLabels: {}
+  # Add custom labels to pods
+  # team: "developers"
+  # service: "logstash"
+
 ingress:
   enabled: false
   # Used to create an Ingress and Service record.


### PR DESCRIPTION
We use pod annotations and labels for various things, like kube2iam roles and metrics, so it would be nice to not have to fork the chart to do these things.

One of the things we use pod annotations for is [kube2iam](https://github.com/jtblin/kube2iam).