### PR TITLE
[stable/concourse] Fix substitutions - {} with () in args

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 0.11.4
+version: 0.11.5
 appVersion: 3.8.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -25,9 +25,9 @@ spec:
             {{- if .Values.credentialManager.enabled }}
             {{- if default "" .Values.credentialManager.vault.appRoleId }}
             - "--vault-auth-param"
-            - "role_id=${CONCOURSE_VAULT_APPROLE_ID}"
+            - "role_id=$(CONCOURSE_VAULT_APPROLE_ID)"
             - "--vault-auth-param"
-            - "secret_id=${CONCOURSE_VAULT_APPROLE_SECRET_ID}"
+            - "secret_id=$(CONCOURSE_VAULT_APPROLE_SECRET_ID)"
             {{- end }}
             {{- end }}
           env:


### PR DESCRIPTION
Fix wrong args being passed into web-deployment due to use of `${}` instead of `$()` while using vault
