### PR TITLE
[stable/rabbitmq-ha] Enable custom plugin configuration

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,13 +1,15 @@
 name: rabbitmq-ha
 apiVersion: v1
-appVersion: 3.7.0
-version: 0.1.1
+appVersion: 3.7.3
+version: 0.2.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:
 - rabbitmq
 - message queue
 - AMQP
+- MQTT
+- STOMP
 home: https://www.rabbitmq.com
 icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 sources:

--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.3
-version: 0.2.0
+version: 1.0.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -79,12 +79,20 @@ and their default values.
 | `rabbitmqEpmdPort`                 | EPMD port used for cross cluster replication                    | `4369`                                                   |
 | `rabbitmqErlangCookie`             | Erlang cookie                                                   | _random 32 character long alphanumeric string_           |
 | `rabbitmqHipeCompile`              | Precompile parts of RabbitMQ using HiPE                         | `false`                                                  |
+| `rabbitmqMQTTPlugin.config`        | MQTT configuration                                              | ``                                                       |
+| `rabbitmqMQTTPlugin.enabled`       | Enable MQTT plugin                                              | `false`                                                  |
 | `rabbitmqManagerPort`              | RabbitMQ Manager port                                           | `15672`                                                  |
 | `rabbitmqMemoryHighWatermark`      | Memory high watermark                                           | `256MB`                                                  |
 | `rabbitmqNodePort`                 | Node port                                                       | `5672`                                                   |
 | `rabbitmqPassword`                 | RabbitMQ application password                                   | _random 10 character long alphanumeric string_           |
+| `rabbitmqSTOMPPlugin.config`       | STOMP configuration                                             | ``                                                       |
+| `rabbitmqSTOMPPlugin.enabled`      | Enable STOMP plugin                                             | `false`                                                  |
 | `rabbitmqUsername`                 | RabbitMQ application username                                   | `guest`                                                  |
 | `rabbitmqVhost`                    | RabbitMQ application vhost                                      | `/`                                                      |
+| `rabbitmqWebMQTTPlugin.config`     | MQTT over websocket configuration                               | ``                                                       |
+| `rabbitmqWebMQTTPlugin.enabled`    | Enable MQTT over websocket plugin                               | `false`                                                  |
+| `rabbitmqWebSTOMPPlugin.config`    | STOMP over websocket configuration                              | ``                                                       |
+| `rabbitmqWebSTOMPPlugin.enabled`   | Enable STOMP over websocket plugin                              | `false`                                                  |
 | `rbac.create`                      | If true, create & use RBAC resources                            | `true`                                                   |
 | `rbac.serviceAccountName`          | Service account name to use (ignored if rbac.create=true)       | `default`                                                |
 | `replicaCount`                     | Number of replica                                               | `3`                                                      |
@@ -126,3 +134,39 @@ can be used to override the default configmap.yaml provided. It also allows for
 providing additional configuration files that will be mounted into
 `/etc/rabbitmq`. In the parent chart's values.yaml, set the value to true and
 provide the file `templates/configmap.yaml` for your use case.
+
+Example of using RabbitMQ definition to setup users, permissions or policies:
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-release-rabbitmq-ha
+data:
+  enabled_plugins: |
+    [
+      rabbitmq_consistent_hash_exchange,
+      rabbitmq_federation,
+      rabbitmq_federation_management,
+      rabbitmq_management,
+      rabbitmq_peer_discovery_k8s,
+      rabbitmq_shovel,
+      rabbitmq_shovel_management
+    ].
+  rabbitmq.conf: |
+    # ....
+    management.load_definitions = /etc/rabbitmq/definitions.json
+  definitions.json: |
+    {
+      "permissions": [],
+      "users": [],
+      "policies: []
+    }
+```
+
+Then, install the chart with the above configuration:
+
+```
+$ helm install --name my-release --set customConfigMap=true stable/rabbitmq-ha
+```
+

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -94,7 +94,8 @@ and their default values.
 | `rabbitmqWebSTOMPPlugin.config`    | STOMP over websocket configuration                              | ``                                                       |
 | `rabbitmqWebSTOMPPlugin.enabled`   | Enable STOMP over websocket plugin                              | `false`                                                  |
 | `rbac.create`                      | If true, create & use RBAC resources                            | `true`                                                   |
-| `rbac.serviceAccountName`          | Service account name to use (ignored if rbac.create=true)       | `default`                                                |
+| `serviceAccount.create`            | Create service account                                          | `true`                                                   |
+| `serviceAccount.name`              | Service account name to use                                     | _name of the release_                                    |
 | `replicaCount`                     | Number of replica                                               | `3`                                                      |
 | `resources`                        | CPU/Memory resource requests/limits                             | `{}`                                                     |
 | `service.annotations`              | Annotations to add to service                                   | `none`                                                   |

--- a/stable/rabbitmq-ha/templates/_helpers.tpl
+++ b/stable/rabbitmq-ha/templates/_helpers.tpl
@@ -14,3 +14,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rabbitmq-ha.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "rabbitmq-ha.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -10,7 +10,35 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   enabled_plugins: |
-    [rabbitmq_consistent_hash_exchange,rabbitmq_federation,rabbitmq_federation_management,rabbitmq_management,rabbitmq_mqtt,rabbitmq_peer_discovery_k8s,rabbitmq_shovel,rabbitmq_shovel_management,rabbitmq_stomp,rabbitmq_web_stomp].
+    [
+      {{- if .Values.rabbitmqLDAPPlugin.enabled }}
+      rabbitmq_auth_backend_ldap,
+      {{- end }}
+
+      {{- if .Values.rabbitmqMQTTPlugin.enabled }}
+      rabbitmq_mqtt,
+      {{- end }}
+
+      {{- if .Values.rabbitmqWebMQTTPlugin.enabled }}
+      rabbitmq_web_mqtt,
+      {{- end }}
+
+      {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
+      rabbitmq_stomp,
+      {{- end }}
+
+      {{- if .Values.rabbitmqWebSTOMPPlugin.enabled }}
+      rabbitmq_web_stomp,
+      {{- end }}
+
+      rabbitmq_consistent_hash_exchange,
+      rabbitmq_federation,
+      rabbitmq_federation_management,
+      rabbitmq_management,
+      rabbitmq_peer_discovery_k8s,
+      rabbitmq_shovel,
+      rabbitmq_shovel_management
+    ].
 
   rabbitmq.conf: |
     ## RabbitMQ configuration
@@ -30,4 +58,29 @@ data:
 
     ## Memory-based Flow Control threshold
     vm_memory_high_watermark.absolute = {{ .Values.rabbitmqMemoryHighWatermark }}
+
+    ## LDAP Plugin
+    {{- if .Values.rabbitmqLDAPPlugin.enabled }}
+{{ .Values.rabbitmqLDAPPlugin.config | indent 4 }}
+    {{- end }}
+
+    ## MQTT Plugin
+    {{- if .Values.rabbitmqMQTTPlugin.enabled }}
+{{ .Values.rabbitmqMQTTPlugin.config | indent 4 }}
+    {{- end }}
+
+    ## Web MQTT Plugin
+    {{- if .Values.rabbitmqWebMQTTPlugin.enabled }}
+{{ .Values.rabbitmqWebMQTTPlugin.config | indent 4 }}
+    {{- end }}
+
+    ## STOMP Plugin
+    {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
+{{ .Values.rabbitmqSTOMPPlugin.config | indent 4 }}
+    {{- end }}
+
+    ## Web STOMP Plugin
+    {{- if .Values.rabbitmqWebSTOMPPlugin.enabled }}
+{{ .Values.rabbitmqWebSTOMPPlugin.config | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -37,6 +37,38 @@ spec:
       protocol: TCP
       port: {{ .Values.rabbitmqEpmdPort }}
       targetPort: epmd
+    {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
+    - name: stomp-tcp
+      protocol: TCP
+      port: 1883
+      targetPort: stomp-tcp
+    - name: stomp-ssl
+      protocol: TCP
+      port: 8883
+      targetPort: stomp-ssl
+    {{- end }}
+    {{- if .Values.rabbitmqWebSTOMPPlugin.enabled }}
+    - name: stomp-ws
+      protocol: TCP
+      port: 15674
+      targetPort: stomp-ws
+    {{- end }}
+    {{- if .Values.rabbitmqMQTTPlugin.enabled }}
+    - name: mqtt-tcp
+      protocol: TCP
+      port: 61613
+      targetPort: mqtt-tcp
+    - name: mqtt-ssl
+      protocol: TCP
+      port: 61614
+      targetPort: mqtt-ssl
+    {{- end }}
+    {{- if .Values.rabbitmqWebMQTTPlugin.enabled }}
+    - name: mqtt-ws
+      protocol: TCP
+      port: 15675
+      targetPort: mqtt-ws
+    {{- end }}
   selector:
     app: {{ template "rabbitmq-ha.name" . }}
     release: {{ .Release.Name }}

--- a/stable/rabbitmq-ha/templates/serviceaccount.yaml
+++ b/stable/rabbitmq-ha/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,5 +7,5 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  name: {{ template "rabbitmq-ha.fullname" . }}
+  name: {{ template "rabbitmq-ha.serviceAccountName" . }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: {{ template "rabbitmq-ha.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        {{- if not .Values.customConfigMap }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "rabbitmq-ha.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
@@ -34,6 +38,32 @@ spec:
             - name: http
               protocol: TCP
               containerPort: 15672
+            {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
+            - name: stomp-tcp
+              protocol: TCP
+              containerPort: 61613
+            - name: stomp-ssl
+              protocol: TCP
+              containerPort: 61614
+            {{- end }}
+            {{- if .Values.rabbitmqWebSTOMPPlugin.enabled }}
+            - name: stomp-ws
+              protocol: TCP
+              containerPort: 15674
+            {{- end }}
+            {{- if .Values.rabbitmqMQTTPlugin.enabled }}
+            - name: mqtt-tcp
+              protocol: TCP
+              containerPort: 1883
+            - name: mqtt-ssl
+              protocol: TCP
+              containerPort: 8883
+            {{- end }}
+            {{- if .Values.rabbitmqWebMQTTPlugin.enabled }}
+            - name: mqtt-ws
+              protocol: TCP
+              containerPort: 15675
+            {{- end }}
           livenessProbe:
             exec:
               command:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "rabbitmq-ha.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ template "rabbitmq-ha.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -178,5 +178,12 @@ customConfigMap: false
 rbac:
   create: true
 
-  # Defines the serviceAccountName to use when `rbac.create=false`
-  serviceAccountName: default
+## Service Account
+## Ref: https://kubernetes.io/docs/admin/service-accounts-admin/
+##
+serviceAccount:
+  create: true
+
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  # name:

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -36,6 +36,65 @@ rabbitmqManagerPort: 15672
 ## of a few minutes delay at startup.
 rabbitmqHipeCompile: false
 
+## LDAP Plugin
+## Ref: http://www.rabbitmq.com/ldap.html
+rabbitmqLDAPPlugin:
+  enabled: false
+
+  ## LDAP configuration:
+  config: |
+    # auth_backends.1 = ldap
+    # auth_ldap.servers.1  = my-ldap-server
+    # auth_ldap.user_dn_pattern = cn=${username},ou=People,dc=example,dc=com
+    # auth_ldap.use_ssl    = false
+    # auth_ldap.port       = 389
+    # auth_ldap.log        = false
+
+## MQTT Plugin
+## Ref: http://www.rabbitmq.com/mqtt.html
+rabbitmqMQTTPlugin:
+  enabled: false
+
+  ## MQTT configuration:
+  config: |
+    # mqtt.default_user     = guest
+    # mqtt.default_pass     = guest
+    # mqtt.allow_anonymous  = true
+
+## Web MQTT Plugin
+## Ref: http://www.rabbitmq.com/web-mqtt.html
+rabbitmqWebMQTTPlugin:
+  enabled: false
+
+  ## Web MQTT configuration:
+  config: |
+    # web_mqtt.ssl.port       = 12345
+    # web_mqtt.ssl.backlog    = 1024
+    # web_mqtt.ssl.certfile   = path/to/certs/client/cert.pem
+    # web_mqtt.ssl.keyfile    = path/to/certs/client/key.pem
+    # web_mqtt.ssl.cacertfile = path/to/certs/testca/cacert.pem
+    # web_mqtt.ssl.password   = changeme
+
+## STOMP Plugin
+## Ref: http://www.rabbitmq.com/stomp.html
+rabbitmqSTOMPPlugin:
+  enabled: false
+
+  ## STOMP configuration:
+  config: |
+    # stomp.default_user = guest
+    # stomp.default_pass = guest
+
+## Web STOMP Plugin
+## Ref: http://www.rabbitmq.com/web-stomp.html
+rabbitmqWebSTOMPPlugin:
+  enabled: false
+
+  ## Web STOMP configuration:
+  config: |
+    # web_stomp.ws_frame = binary
+    # web_stomp.cowboy_opts.max_keepalive = 10
+
 ## Number of replicas
 replicaCount: 3
 


### PR DESCRIPTION
- MQTT, STOMP and LDAP plugin can now be enabled from the command line
- add example of custom config
- follow new [RBAC best practices](https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/rbac.md)

close https://github.com/kubernetes/charts/issues/3653 and https://github.com/kubernetes/charts/issues/3706