### PR TITLE
[stable/prometheus] use prefixURL in alertmanagers config

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.2.1
+version: 5.2.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -23,6 +23,9 @@ data:
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        {{- if $root.Values.alertmanager.prefixURL }}
+        path_prefix: {{ $root.Values.alertmanager.prefixURL }}
+        {{- end }}
         relabel_configs:
         - source_labels: [__meta_kubernetes_namespace]
           regex: {{ $root.Release.Namespace }}


### PR DESCRIPTION
When setting an alertmanager.prefixURL, I noticed that the server fails to talk to the alertmanager (a 404 is returned). Setting the path_prefix seems to avoid this.