### PR TITLE
[incubator/gocd] Update install repository references to incubator

### DIFF
--- a/incubator/gocd/Chart.yaml
+++ b/incubator/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 0.2.0
+version: 0.2.1
 appVersion: 18.1.0
 description: A GoCD Helm chart for Kubernetes. GoCD is an Open source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.svg

--- a/incubator/gocd/README.md
+++ b/incubator/gocd/README.md
@@ -17,7 +17,7 @@ This chart bootstraps a single node GoCD server and a GoCD Agent deployment with
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/gocd
+$ helm install --name my-release incubator/gocd
 ```
 
 The command deploys GoCD on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -87,7 +87,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/gocd
+$ helm install --name my-release -f values.yaml incubator/gocd
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -139,7 +139,7 @@ a previously configured Persistent Volume Claim can be used.
 3. Install the chart
 
 ```
-$ helm install --name my-release --set server.persistence.godata.existingClaim=PVC_NAME stable/gocd
+$ helm install --name my-release --set server.persistence.godata.existingClaim=PVC_NAME incubator/gocd
 ```
 
 # License


### PR DESCRIPTION
This is a minimal change to fix installation instructions for the `incubator/gocd` chart.  A duplicate change has been made in #3711, so this can be safely closed if that PR is merged first.