### PR TITLE
Allow specifying Service annotations

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.3.2
+version: 0.4.0
 appVersion: v0.27.2
 maintainers:
 - name: pmint93

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -71,6 +71,7 @@ The following tables lists the configurable parameters of the Metabase chart and
 | service.type           | ClusterIP, NodePort, or LoadBalancer                       | ClusterIP         |
 | service.externalPort   | Service external port                                      | 80                |
 | service.internalPort   | Service internal port, should be the same as `listen.port` | 3000              |
+| service.annotations    | Service annotations                                        | {}                |
 | ingress.enabled        | Enable ingress controller resource                         | false             |
 | ingress.hosts          | Ingress resource hostnames                                 | null              |
 | ingress.annotations    | Ingress annotations configuration                          | null              |

--- a/stable/metabase/templates/service.yaml
+++ b/stable/metabase/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.metabase.service.annotations }}
+  annotations:
+{{ toYaml .Values.metabase.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/metabase/templates/service.yaml
+++ b/stable/metabase/templates/service.yaml
@@ -7,9 +7,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.metabase.service.annotations }}
+{{- if .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.metabase.service.annotations | indent 4 }}
+{{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -52,6 +52,9 @@ service:
   type: ClusterIP
   externalPort: 80
   internalPort: 3000
+  annotations:
+    # Used to add custom annotations to the Service.
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
 ingress:
   enabled: false
   # Used to create Ingress record (should used with service.type: ClusterIP).


### PR DESCRIPTION
I had a need to create internal AWS loadbalancers for Metabase, a feature supported by Kubernetes which needs to be configured through Service annotations.

In this PR I have added support for specifying custom annotations which need to be placed on the Service.

An example values.yaml file:

```
service:
  type: LoadBalancer
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-internal: '0.0.0.0/0'
```

This will place the annotation on the loadbalancer which will result in an internal ELB instead of the default external one.