### PR TITLE
[incubator/logstash] use logstash monitoring port as liveness and readiness check

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.5.1
+version: 0.6.0
 appVersion: 6.2.1
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -54,7 +54,7 @@ The following tables lists the configurable parameters of the drone charts and t
 | `podLabels`                          | Pod labels                                         | `{}`                                             |
 | `elasticsearch.host`                 | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
 | `elasticsearch.port`                 | ElasticSearch port                                 | `9200`                                           |
-| `configData`                         | Extra logstash config                              | `{}`                                             |
+| `configData`                         | logstash.yml settings file                         | `{}`                                             |
 | `patterns`                           | Logstash patterns configuration                    | `nil`                                            |
 | `inputs`                             | Logstash inputs configuration                      | `(basic)`                                        |
 | `filters`                            | Logstash filters configuration                     | `nil`                                            |

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -43,7 +43,7 @@ The following tables lists the configurable parameters of the drone charts and t
 | `image.tag`                          | Container image tag                                | `6.2.1`                                          |
 | `image.pullPolicy`                   | Container image pull policy                        | `IfNotPresent`                                   |
 | `service.type`                       | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
-| `service.internalPort`               | Logstash internal port                             | `1514`                                           |
+| `service.internalPort`               | Logstash monitoring port                           | `9600`                                           |
 | `service.ports`                      | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
 | `ingress.enabled`                    | Enables Ingress                                    | `false`                                          |
 | `ingress.annotations`                | Ingress annotations                                | `{}`                                             |

--- a/incubator/logstash/templates/configmap.yaml
+++ b/incubator/logstash/templates/configmap.yaml
@@ -11,6 +11,7 @@ metadata:
 data:
   logstash.yml: |-
     http.host: "0.0.0.0"
+    http.port: {{ .Values.service.internalPort }}
     path.config: /usr/share/logstash/pipeline
 {{- if .Values.configData }}
 {{ toYaml .Values.configData | indent 4 }}

--- a/incubator/logstash/templates/deployment.yaml
+++ b/incubator/logstash/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
               value: {{ .Values.elasticsearch.host | quote }}
             - name: ELASTICSEARCH_PORT
               value: {{ .Values.elasticsearch.port | quote }}
-            - name: SYSLOG_PORT
-              value: {{ .Values.service.internalPort | quote }}
           volumeMounts:
             - name: config
               mountPath: /usr/share/logstash/config/logstash.yml

--- a/incubator/logstash/templates/service.yaml
+++ b/incubator/logstash/templates/service.yaml
@@ -16,6 +16,11 @@ spec:
       protocol: {{ $port.protocol }}
       targetPort: {{ $port.containerPort }}
   {{- end }}
+    - name: "logstash-monitoring"
+      port: {{ .Values.service.internalPort }}
+      protocol: "TCP"
+      targetPort: {{ .Values.service.internalPort }}
+
   selector:
     app: {{ template "logstash.name" . }}
     release: {{ .Release.Name }}

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  internalPort: 1514
+  internalPort: 9600
   ports:
     - name: "syslog-tcp"
       protocol: TCP
@@ -81,7 +81,7 @@ inputs:
   main: |-
     input {
       tcp {
-        port => "${SYSLOG_PORT}"
+        port => "1514"
         type => syslog
       }
       udp {

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -9,7 +9,8 @@ image:
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  internalPort: 9600 # logstash monitoring port
+  # logstash monitoring port
+  internalPort: 9600
   ports:
     - name: "syslog-tcp"
       protocol: TCP

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -9,7 +9,7 @@ image:
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
-  internalPort: 9600
+  internalPort: 9600 # logstash monitoring port
   ports:
     - name: "syslog-tcp"
       protocol: TCP


### PR DESCRIPTION
Rather than requiring the user to open an input port for logstash (in case they use an input like rabbitmq or sqs), we should use the logstash monitoring port for liveness and readiness checks.

I bumped the chart version to 0.6.0 because if an end user has changed the logstash setting for `http.port` they will need to modify their values.yaml.

Logstash monitoring: https://www.elastic.co/guide/en/logstash/current/monitoring.html

I also updated the README to clarify the use of `configSettings`, which is actually the logstash settings, not configuration.

Settings file: https://www.elastic.co/guide/en/logstash/current/logstash-settings-file.html