### PR TITLE
[stable/kube2iam] Add support for boolean flags via extraArgs

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.8.0
+version: 0.8.1
 description: Provide IAM credentials to pods based on annotations.
 keywords:
 - kube2iam

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -32,7 +32,11 @@ spec:
           {{- end }}
             - --iptables={{ .Values.host.iptables }}
           {{- range $key, $value := .Values.extraArgs }}
+            {{- if $value }}
             - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
           {{- end }}
           {{- if .Values.verbose }}
             - --verbose


### PR DESCRIPTION
This allows for use of the following kube2iam boolean flags:
```
--auto-discover-base-arn              Queries EC2 Metadata to determine the base ARN
--auto-discover-default-role          Queries EC2 Metadata to determine the default Iam Role and base ARN, cannot be used with --default-role, overwrites any previous setting for --base-role-arn
--insecure                            Kubernetes server should be accessed without verifying the TLS. Testing only
--iptables                            Add iptables rule (also requires --host-ip)
--namespace-restrictions              Enable namespace restrictions
--verbose                             Verbose 
```