### PR TITLE
Several changes in support of improved helm functionality

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 name: chaoskube
-version: 0.6.2
-appVersion: 0.6.1
+version: 0.7.1
+appVersion: 0.7.1
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube
 sources:

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -41,13 +41,16 @@ $ helm install stable/chaoskube --set dryRun=false
 |---------------------------|-----------------------------------------------------|-----------------------------------|
 | `name`                    | container name                                      | chaoskube                         |
 | `image`                   | docker image                                        | quay.io/linki/chaoskube           |
-| `imageTag`                | docker image tag                                    | v0.6.1                            |
+| `imageTag`                | docker image tag                                    | v0.7.1                            |
 | `replicas`                | number of replicas to run                           | 1                                 |
 | `interval`                | interval between pod terminations                   | 10m                               |
 | `labels`                  | label selector to filter pods by                    | "" (matches everything)           |
 | `annotations`             | annotation selector to filter pods by               | "" (matches everything)           |
 | `namespaces`              | namespace selector to filter pods by                | "" (all namespaces)               |
 | `dryRun`                  | don't kill pods, only log what would have been done | true                              |
+| `timezone`                | Set timezone for running actions (Optional)         | "" (UTC)                          |
+| `excludedWeekdays`        | Set Days of the Week to avoid actions (Optional)    | "" (Don't skip any days)          |
+| `excludedTimesOfDay`      | Set Time Range to avoid actions  (Optional)         | "" (Don't skip any time)          |
 | `resources.cpu`           | cpu resource requests and limits                    | 10m                               |
 | `resources.memory`        | memory resource requests and limits                 | 16Mi                              |
 | `rbac.create`             | create rbac service account and roles               | false                             |
@@ -65,4 +68,7 @@ $ helm install \
     - --interval=10m
     - --labels=app=foo,stage!=prod
     - --namespaces=!kube-system,!production
+    - --timezone=America/New_York
+    - --excludedWeekdays="Sat,Tue"
+    - --excludedTimesOfDay="12:00-18:00"
 ```

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -28,6 +28,15 @@ spec:
         {{- if not .Values.dryRun }}
         - --no-dry-run
         {{- end }}
+        {{- if .Values.excludedWeekdays }}
+        - --excluded-weekdays={{ .Values.excludedWeekdays }}
+        {{- end }}
+        {{- if .Values.excludedTimesOfDay }}
+        - --excluded-times-of-day={{ .Values.excludedTimesOfDay }}
+        {{- end }}
+        {{- if .Values.timezone }}
+        - --timezone={{ .Values.timezone }}
+        {{- end }}
         resources:
           requests:
             cpu: {{ .Values.resources.cpu }}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -5,7 +5,7 @@ name: chaoskube
 image: quay.io/linki/chaoskube
 
 # docker image tag
-imageTag: v0.6.1
+imageTag: v0.7.1
 
 # number of replicas to run
 replicas: 1
@@ -24,6 +24,15 @@ namespaces:
 
 # don't kill pods, only log what would have been done
 dryRun: true
+
+# Uncomment to set values for exempting specific week days from Chaoskube Actions
+# excludedWeekdays: Sat,Sun
+
+# Uncomment to set values for excluding specific times of day from Chaoskube Actions
+# excludedTimesOfDay: 22:00-08:00
+
+# Uncomment to set specific Timezone
+# timezone: America/New_York
 
 # resource requests and limits
 resources:


### PR DESCRIPTION
Hello! My first PR, hoping I'm doing this right.

The goal of this PR is to bring chaoskube's helm chart up to date with functionality inside chaoskube itself.  The maintainer included several bits of functionality that would go great in the chart.

1. Bring container to latest stable versioned release
2. Add timezone option setting
3. Add Day of Week/Time of Day exclusions
4. Update readme with new options and version bump

Confirmation of success:
```
[10:28:57] jsimmonds:chaoskube git:(chaoskube_extraargs) $ helm lint
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
```
```
[10:21:49] jsimmonds:chaoskube git:(chaoskube_extraargs) $ kubectl logs -f chaoskube-chaoskube-65fccff4d-xqgh4
time="2018-02-21T15:21:57Z" level=info msg="Targeting cluster at https://100.64.0.1:443"
time="2018-02-21T15:21:57Z" level=info msg="Using time zone: America/New_York (EST)"
time="2018-02-21T15:21:57Z" level=info msg="Excluding weekdays: [Saturday Sunday Wednesday Thursday]"
time="2018-02-21T15:21:57Z" level=info msg="Excluding times of day: [00:00-19:00]"
time="2018-02-21T15:21:57Z" level=info msg="This day of the week is excluded from chaos."
```
```
[10:22:15] jsimmonds:chaoskube git:(chaoskube_extraargs) $ kubectl describe pod chaoskube-chaoskube-65fccff4d-xqgh4
Name:           chaoskube-chaoskube-65fccff4d-xqgh4
Namespace:      default
Node:           ip-10-65-182-175.ec2.internal/10.65.182.175
Start Time:     Wed, 21 Feb 2018 10:21:43 -0500
Labels:         app=chaoskube-chaoskube
                chart=chaoskube-0.7.1
                heritage=Tiller
                pod-template-hash=219779908
                release=chaoskube
Annotations:    kubernetes.io/created-by={"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"chaoskube-chaoskube-65fccff4d","uid":"ec146515-171a-11e8-8a8e-0e...
Status:         Running
IP:             100.108.0.3
Controlled By:  ReplicaSet/chaoskube-chaoskube-65fccff4d
Containers:
  chaoskube:
    Container ID:  docker://420a6ac51a71455ba564143ebbed2c209828fdd39885c873b8d0eff80ede012e
    Image:         quay.io/linki/chaoskube:latest
    Image ID:      docker-pullable://quay.io/linki/chaoskube@sha256:fd88c6fa12da0ad62149ac6912db73d7106746673f409dde6d1375ff280b9b6f
    Port:          <none>
    Args:
      --interval=60m
      --labels=
      --annotations=
      --namespaces=
      --no-dry-run
      --excluded-weekdays=Sat,Sun,Wed,Thu
      --excluded-times-of-day=0:00-19:00
      --timezone=America/New_York
    State:          Running
      Started:      Wed, 21 Feb 2018 10:21:45 -0500
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     10m
      memory:  16Mi
    Requests:
      cpu:        10m
      memory:     16Mi
    Environment:  <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from chaoskube-chaoskube-token-72c5b (ro)
Conditions:
  Type           Status
  Initialized    True
  Ready          True
  PodScheduled   True
Volumes:
  chaoskube-chaoskube-token-72c5b:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  chaoskube-chaoskube-token-72c5b
    Optional:    false
QoS Class:       Guaranteed
Node-Selectors:  <none>
Tolerations:     node.alpha.kubernetes.io/notReady:NoExecute for 300s
                 node.alpha.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type    Reason                 Age   From                                    Message
  ----    ------                 ----  ----                                    -------
  Normal  Scheduled              44s   default-scheduler                       Successfully assigned chaoskube-chaoskube-65fccff4d-xqgh4 to ip-10-65-182-175.ec2.internal
  Normal  SuccessfulMountVolume  44s   kubelet, ip-10-65-182-175.ec2.internal  MountVolume.SetUp succeeded for volume "chaoskube-chaoskube-token-72c5b"
  Normal  Pulling                43s   kubelet, ip-10-65-182-175.ec2.internal  pulling image "quay.io/linki/chaoskube:latest"
  Normal  Pulled                 43s   kubelet, ip-10-65-182-175.ec2.internal  Successfully pulled image "quay.io/linki/chaoskube:latest"
  Normal  Created                43s   kubelet, ip-10-65-182-175.ec2.internal  Created container
  Normal  Started                42s   kubelet, ip-10-65-182-175.ec2.internal  Started container
```
