### PR TITLE
[incubator/zookeeper] Allows alternate scheduler for zookeeper statefulset

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.4.6
+version: 0.4.7
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -106,6 +106,7 @@ Spreading allows you specify an anti-affinity between ZooKeeper servers in the e
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
+| `schedulerName` | Name of scheduler to use (other than the default). | `nil` |
 | `antiAffinity` | If present it must take the values 'hard' or 'soft'. 'hard' will cause the Kubernetes scheduler to not schedule the Pods on the same physical node under any circumstances 'soft' will cause the Kubernetes scheduler to make a best effort to not co-locate the Pods, but, if the only available resources are on the same node, the scheduler will co-locate them. | `hard` |
 
 ### Logging

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -18,6 +18,9 @@ spec:
         app: {{ include "zookeeper.name" . | quote }}
         release: {{ .Release.Name | quote }}
     spec:
+{{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+{{- end }}
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -34,6 +34,10 @@ security:
   runAsUser: 1000
   fsGroup: 1000
 
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
 
 # Affinities to add to the worker pods.
 # Useful if you prefer to run workers on non-spot instances, for example


### PR DESCRIPTION
Useful to define an alternate scheduler e.g. when running persistence via [Stork](https://github.com/libopenstorage/stork).