### PR TITLE
[stable/mariadb] use credentials in exec probes

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 2.1.8
+version: 2.1.9
 appVersion: 10.1.31
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/templates/configmap.yaml
+++ b/stable/mariadb/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
-    app: {{ template "mariadb.fullname" . }}
+    app: {{ template "mariadb.name" . }}
     chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -58,23 +58,17 @@ spec:
         livenessProbe:
           exec:
             command:
-            - mysqladmin
-            - ping
-          {{- if .Values.usePassword }}
-            - -uroot
-            - -p$MARIADB_ROOT_PASSWORD
-          {{- end }}
+            - bash
+            - -c
+            - mysqladmin ping{{ if .Values.usePassword }} -uroot -p$MARIADB_ROOT_PASSWORD{{ end }}
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
           exec:
             command:
-            - mysqladmin
-            - ping
-          {{- if .Values.usePassword }}
-            - -uroot
-            - -p$MARIADB_ROOT_PASSWORD
-          {{- end }}
+            - bash
+            - -c
+            - mysqladmin ping{{ if .Values.usePassword }} -uroot -p$MARIADB_ROOT_PASSWORD{{ end }}
           initialDelaySeconds: 5
           timeoutSeconds: 1
         resources:

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -60,6 +60,10 @@ spec:
             command:
             - mysqladmin
             - ping
+          {{- if .Values.usePassword }}
+            - -uroot
+            - -p$MARIADB_ROOT_PASSWORD
+          {{- end }}
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
@@ -67,6 +71,10 @@ spec:
             command:
             - mysqladmin
             - ping
+          {{- if .Values.usePassword }}
+            - -uroot
+            - -p$MARIADB_ROOT_PASSWORD
+          {{- end }}
           initialDelaySeconds: 5
           timeoutSeconds: 1
         resources:

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
-    app: {{ template "mariadb.fullname" . }}
+    app: {{ template "mariadb.name" . }}
     chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "mariadb.fullname" . }}
+        app: {{ template "mariadb.name" . }}
     spec:
       securityContext:
         runAsUser: 1001

--- a/stable/mariadb/templates/pvc.yaml
+++ b/stable/mariadb/templates/pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
-    app: {{ template "mariadb.fullname" . }}
+    app: {{ template "mariadb.name" . }}
     chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/mariadb/templates/secrets.yaml
+++ b/stable/mariadb/templates/secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
-    app: {{ template "mariadb.fullname" . }}
+    app: {{ template "mariadb.name" . }}
     chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/mariadb/templates/svc.yaml
+++ b/stable/mariadb/templates/svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
-    app: {{ template "mariadb.fullname" . }}
+    app: {{ template "mariadb.name" . }}
     chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -29,4 +29,4 @@ spec:
     targetPort: metrics
 {{- end }}
   selector:
-    app: {{ template "mariadb.fullname" . }}
+    app: {{ template "mariadb.name" . }}


### PR DESCRIPTION
The liveness and readiness probes don't use login credentials, if specified, and fill up the Access_denied_errors counter:

```
MariaDB [(none)]> SHOW GLOBAL STATUS like "%Access_denied_errors%";
+----------------------+--------+
| Variable_name        | Value  |
+----------------------+--------+
| Access_denied_errors | 107706 |
+----------------------+--------+
```

This PR will fix this. I had to wrap the command with bash to access the valueFrom env var (see https://github.com/kubernetes/kubernetes/pull/42273)

Furthermore, I refactored the app labels to match the [current best practices](https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/labels.md)