### PR TITLE
[stable/heapster] Match the label in deployment yaml

### DIFF
--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
-version: 0.2.6
+version: 0.2.7
 sources:
 - https://github.com/kubernetes/heapster
 - https://github.com/kubernetes/contrib/tree/master/addon-resizer

--- a/stable/heapster/templates/NOTES.txt
+++ b/stable/heapster/templates/NOTES.txt
@@ -1,14 +1,14 @@
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "heapster.service.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "heapster.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "heapster.service.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "heapster.service.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ template "heapster.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "heapster.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "heapster.service.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "heapster.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.externalPort }}
 {{- end }}


### PR DESCRIPTION
The instructions provided by `NOTES.txt` doesn't work because the label on the deployment doesn't match the label used in `NOTES.txt`. 

```
$ helm status eyewitness-lamb
LAST DEPLOYED: Thu Feb 22 15:23:44 2018
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME      TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)   AGE
heapster  ClusterIP  100.64.31.201  <none>       8082/TCP  1h

==> v1beta1/Deployment
NAME                      DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
eyewitness-lamb-heapster  1        1        1           1          1h

==> v1/Pod(related)
NAME                                       READY  STATUS   RESTARTS  AGE
eyewitness-lamb-heapster-66f796c55b-q86kh  2/2    Running  0         1h


NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace default -l "app=heapster" -o jsonpath="{.items[0].metadata.name}")
  kubectl --namespace default port-forward $POD_NAME 8082
```

And the output of the pod itself from kubectl -

```
$ kubectl describe pod eyewitness-lamb-heapster-66f796c55b-q86kh

Name:           eyewitness-lamb-heapster-66f796c55b-q86kh
Namespace:      default
Node:           ip-10-255-63-126.eu-central-1.compute.internal/10.255.63.126
Start Time:     Thu, 22 Feb 2018 15:23:45 +0100
Labels:         app=eyewitness-lamb-heapster
                pod-template-hash=2293527116
Annotations:    kubernetes.io/created-by={"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"default","name":"eyewitness-lamb-heapster-66f796c55b","uid":"fd44fde0-17db-11e8-a...
Status:         Running
IP:             100.102.116.133
Created By:     ReplicaSet/eyewitness-lamb-heapster-66f796c55b
Controlled By:  ReplicaSet/eyewitness-lamb-heapster-66f796c55b
```

So `NOTES.txt` looks for the label `app=heapster` but the pod has the label `app=eyewitness-lamb-heapster`. This was changed in https://github.com/kubernetes/charts/pull/2144.

I matched the `NOTES.txt` to match the label in `deployment.yaml` (though we could do it the other way round also).