### PR TITLE
prometheus service annotations for elastisearch-exporter

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.0.2
 sources:
   - https://github.com/justwatchcom/elasticsearch_exporter

--- a/stable/elasticsearch-exporter/templates/service.yaml
+++ b/stable/elasticsearch-exporter/templates/service.yaml
@@ -7,10 +7,10 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.annotations }}
   annotations:
-    prometheus.io/scrape: "{{ .Values.service.scrape }}"
-    prometheus.io/port: "{{ .Values.service.httpPort }}"
-    prometheus.io/path: "{{ .Values.web.path }}"
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/elasticsearch-exporter/templates/service.yaml
+++ b/stable/elasticsearch-exporter/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     app: {{ template "elasticsearch-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+    prometheus.io/scrape: "{{ .Values.service.scrape }}"
+    prometheus.io/port: "{{ .Values.service.httpPort }}"
+    prometheus.io/path: "{{ .Values.web.path }}"
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -22,7 +22,7 @@ resources: {}
 service:
   type: ClusterIP
   httpPort: 9108
-  scrape: true
+  annotations: {}
 
 es:
   ## Address (host and port) of the Elasticsearch node we should connect to.

--- a/stable/elasticsearch-exporter/values.yaml
+++ b/stable/elasticsearch-exporter/values.yaml
@@ -22,6 +22,7 @@ resources: {}
 service:
   type: ClusterIP
   httpPort: 9108
+  scrape: true
 
 es:
   ## Address (host and port) of the Elasticsearch node we should connect to.


### PR DESCRIPTION
Adds annotations so that Prometheus running within Kubernetes will pick up the exposed metrics.