### PR TITLE
[stable/ghost] Update Ghost chart to use latest released version of the ghost image

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 2.1.12
+version: 2.1.13
 appVersion: 1.21.3
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami Ghost image version
 ## ref: https://hub.docker.com/r/bitnami/ghost/tags/
 ##
-image: bitnami/ghost:1.21.3-r3
+image: bitnami/ghost:1.21.3-r2
 
 ## Busybox image used to configure volume permissions
 ##


### PR DESCRIPTION
Because of a mistake, the ghost chart was updated to use a non-released version of the ghost docker image. This PR fix it.