### PR TITLE
[stable/aerospike] Add cmd and args options to Aerospike config

### DIFF
--- a/stable/aerospike/Chart.yaml
+++ b/stable/aerospike/Chart.yaml
@@ -5,10 +5,10 @@ keywords:
   - aerospike
   - big-data
 home: http://aerospike.com
-version: 0.1.6
+version: 0.1.7
 icon: https://s3-us-west-1.amazonaws.com/aerospike-fd/wp-content/uploads/2016/06/Aerospike_square_logo.png
 sources:
 - https://github.com/aerospike/aerospike-server
 maintainers:
-- name: kavehmzta
-  email: k.mousavizamani@travelaudience.com
+- name: kavehmz
+  email: kavehmz@gmail.com

--- a/stable/aerospike/README.md
+++ b/stable/aerospike/README.md
@@ -43,6 +43,8 @@ The chart can be customized using the following configurable parameters:
 | `image.tag`                     | Aerospike Container image tag                                   | `3.14.1.2`                   |
 | `image.pullPolicy`              | Aerospike Container pull policy                                 | `Always`                     |
 | `replicaCount`                  | Aerospike Brokers                                               | `1`                          |
+| `command`                       | Custom command (Docker Entrypoint)                              | `null`                       |
+| `args`                          | Custom args (Docker Cmd)                                        | `null`                       |
 | `persistentVolume`              | config of persistent volumes for storage-engine                 | `{}`                         |
 | `confFile`                      | config filename. This file should be included in the chart path | `aerospike.conf`             |
 | `resources`                     | resource requests and limits                                    | `{}`                         |

--- a/stable/aerospike/README.md
+++ b/stable/aerospike/README.md
@@ -43,8 +43,8 @@ The chart can be customized using the following configurable parameters:
 | `image.tag`                     | Aerospike Container image tag                                   | `3.14.1.2`                   |
 | `image.pullPolicy`              | Aerospike Container pull policy                                 | `Always`                     |
 | `replicaCount`                  | Aerospike Brokers                                               | `1`                          |
-| `command`                       | Custom command (Docker Entrypoint)                              | `null`                       |
-| `args`                          | Custom args (Docker Cmd)                                        | `null`                       |
+| `command`                       | Custom command (Docker Entrypoint)                              | `[]`                         |
+| `args`                          | Custom args (Docker Cmd)                                        | `[]`                         |
 | `persistentVolume`              | config of persistent volumes for storage-engine                 | `{}`                         |
 | `confFile`                      | config filename. This file should be included in the chart path | `aerospike.conf`             |
 | `resources`                     | resource requests and limits                                    | `{}`                         |

--- a/stable/aerospike/templates/statefulset.yaml
+++ b/stable/aerospike/templates/statefulset.yaml
@@ -21,6 +21,10 @@ spec:
       - name: {{ template "aerospike.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+{{ toYaml .Values.command | indent 10 }}
+        args:
+{{ toYaml .Values.args | indent 10 }}
         ports:
         - containerPort: 3000
           name: aero-clients

--- a/stable/aerospike/templates/statefulset.yaml
+++ b/stable/aerospike/templates/statefulset.yaml
@@ -21,10 +21,14 @@ spec:
       - name: {{ template "aerospike.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{ if .Values.command }}
         command:
 {{ toYaml .Values.command | indent 10 }}
+{{ end }}
+{{ if .Values.args }}
         args:
 {{ toYaml .Values.args | indent 10 }}
+{{ end }}
         ports:
         - containerPort: 3000
           name: aero-clients

--- a/stable/aerospike/values.yaml
+++ b/stable/aerospike/values.yaml
@@ -8,10 +8,10 @@ image:
   pullPolicy: IfNotPresent
 
 # pass custom command. This is equivalent of Entrypoint in docker
-# command:
+command: []
 
 # pass custom args. This is equivalent of Cmd in docker
-# args:
+args: []
 
 # Set as empty object {} if no volumes need to be created
 # See confFile below

--- a/stable/aerospike/values.yaml
+++ b/stable/aerospike/values.yaml
@@ -7,6 +7,12 @@ image:
   tag: 3.14.1.2
   pullPolicy: IfNotPresent
 
+# pass custom command. This is equivalent of Entrypoint in docker
+# command:
+
+# pass custom args. This is equivalent of Cmd in docker
+# args:
+
 # Set as empty object {} if no volumes need to be created
 # See confFile below
 persistentVolume: {}


### PR DESCRIPTION
* Add cmd and args to aerospike config. Having these, for example, we can modify /etc/aerospike/aerospike.conf for each pod now.
  This method helps to have custom settings on each pod and to have more dynamic setup.

* Changing the maintainer to my personal email.

* Bumbing the aerospike chart version to 0.1.7

