### PR TITLE
Update readme to reflect move from incubator to stable for cockroachdb

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.6.3
-appVersion: 1.1.6
+version: 0.6.4
+appVersion: 1.1.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.6.2
+version: 0.6.3
 appVersion: 1.1.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -24,8 +24,7 @@ This chart will do the following:
 To install the chart with the release name `my-release`:
 
 ```shell
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-helm install --name my-release incubator/cockroachdb
+helm install --name my-release stable/cockroachdb
 ```
 
 ## Configuration
@@ -58,7 +57,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```shell
-helm install --name my-release -f values.yaml incubator/cockroachdb
+helm install --name my-release -f values.yaml stable/cockroachdb
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)


### PR DESCRIPTION
CockroachDB is now in stable. Updated the install section, and one more place referring to the incubator.

/cc @a-robinson Does this look ok?