### PR TITLE
[stable/elastalert] Updated image for Elasticsearch 6 support, and other minor chart adjustments

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -9,5 +9,6 @@ sources:
 maintainers:
   - name: pickledrick
     email: 9246508+pickledrick@users.noreply.github.com
-  - name: Jason Ertel
+  - name: jertel
+    email: jertel@codesim.com
 engine: gotpl

--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -4,7 +4,6 @@ version: 0.1.2
 appVersion: 0.1.29
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:
-- https://github.com/krizsan/elastalert-docker
 - https://github.com/jertel/elastalert-docker
 - https://github.com/Yelp/elastalert
 maintainers:

--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.1.1
-appVersion: 0.1.21
+version: 0.1.2
+appVersion: 0.1.29
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:
 - https://github.com/krizsan/elastalert-docker
@@ -9,4 +9,5 @@ sources:
 maintainers:
   - name: pickledrick
     email: 9246508+pickledrick@users.noreply.github.com
+  - name: Jason Ertel
 engine: gotpl

--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -5,6 +5,7 @@ appVersion: 0.1.29
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:
 - https://github.com/krizsan/elastalert-docker
+- https://github.com/jertel/elastalert-docker
 - https://github.com/Yelp/elastalert
 maintainers:
   - name: pickledrick

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -32,11 +32,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Parameter                 | Description                                         | Default                           |
 |---------------------------|-----------------------------------------------------|-----------------------------------|
-| `image.repository`        | docker image                                        | quay.io/pickledrick/elastalert    |
-| `image.tag`               | docker image tag                                    | latest                            |
+| `image.repository`        | docker image                                        | jertel/elastalert-docker    |
+| `image.tag`               | docker image tag                                    | 0.1.29                            |
 | `image.pullPolicy`        | image pull policy                                   | IfNotPresent                      |
 | `replicaCount`            | number of replicas to run                           | 1                                 |
 | `elasticsearch.host`      | elasticsearch endpoint to use                       | elasticsearch                     |
 | `elasticsearch.port`      | elasticsearch port to use                           | 80                                |
 | `resources`               |  Container resource requests and limits             | {}                                |
 | `rules`                   | Rule and alert configuration for Elastalert         | {} example shown in values.yaml   |
+| `runIntervalMins`         | Default interval between alert checks, in minutes   | 1                                 |
+| `bufferTimeMins`          | Default rule buffer time, in minutes                | 15                                |

--- a/stable/elastalert/templates/config.yaml
+++ b/stable/elastalert/templates/config.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "elastalert.fullname" . }}-config
@@ -12,42 +13,11 @@ data:
     rules_folder: /opt/rules
     scan_subdirectories: false
     run_every:
-      minutes: 1
+      minutes: {{ .Values.runIntervalMins }}
     buffer_time:
-      minutes: 15
+      minutes: {{ .Values.bufferTimeMins }}
     es_host: {{ .Values.elasticsearch.host }}
     es_port: {{ .Values.elasticsearch.port }}
     writeback_index: elastalert_status
     alert_time_limit:
       days: 2
-  elastalert_supervisord: |-
-    [unix_http_server]
-    file=/var/run/elastalert_supervisor.sock
-
-    [supervisord]
-    logfile=/opt/logs/elastalert_supervisord.log
-    logfile_maxbytes=1MB
-    logfile_backups=2
-    loglevel=debug
-    nodaemon=false
-    directory=%(here)s
-
-    [rpcinterface:supervisor]
-    supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
-
-    [supervisorctl]
-    serverurl=unix:///var/run/elastalert_supervisor.sock
-
-    [program:elastalert]
-    # running globally
-    command = elastalert --config /opt/config/elastalert_config.yaml --verbose
-    # (alternative) using virtualenv
-    # command=/path/to/venv/bin/elastalert --config /path/to/config.yaml --verbose
-    process_name=elastalert
-    autorestart=true
-    startsecs=15
-    stopsignal=INT
-    stopasgroup=true
-    killasgroup=true
-    stderr_logfile=/opt/logs/elastalert_stderr.log
-    stderr_logfile_maxbytes=5MB

--- a/stable/elastalert/templates/deployment.yaml
+++ b/stable/elastalert/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.elasticsearch.host }}
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -44,3 +45,4 @@ spec:
             items:
             - key: elastalert_config
               path: elastalert_config.yaml
+{{- end }}

--- a/stable/elastalert/templates/deployment.yaml
+++ b/stable/elastalert/templates/deployment.yaml
@@ -21,11 +21,6 @@ spec:
       - name: elastalert
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        env:
-        - name: ELASTICSEARCH_HOST
-          value: {{ .Values.elasticsearch.host }}
-        - name: ELASTICSEARCH_PORT
-          value: {{ .Values.elasticsearch.port | quote }}
         volumeMounts:
           - name: config
             mountPath: '/opt/config'
@@ -49,5 +44,3 @@ spec:
             items:
             - key: elastalert_config
               path: elastalert_config.yaml
-            - key: elastalert_supervisord
-              path: elastalert_supervisord.conf

--- a/stable/elastalert/templates/rules.yaml
+++ b/stable/elastalert/templates/rules.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "elastalert.fullname" . }}-rules

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -19,7 +19,7 @@ resources: {}
 
 elasticsearch:
   # elasticsearch endpoint e.g. (svc.namespace||svc)
-  host: elasticsearch
+  host: 
   # elasticsearch port
   port: 80
 

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -19,7 +19,7 @@ resources: {}
 
 elasticsearch:
   # elasticsearch endpoint e.g. (svc.namespace||svc)
-  host: 
+  host: ""
   # elasticsearch port
   port: 80
 

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -3,11 +3,17 @@ replicaCount: 1
 # number of helm release revisions to retain
 revisionHistoryLimit: 5
 
+# Default internal between alert checks against the elasticsearch datasource, in minutes
+runIntervalMins: 1
+
+# Default rule buffer duration, in minutes
+bufferTimeMins: 15
+
 image:
   # docker image
-  repository: quay.io/pickledrick/elastalert
+  repository: jertel/elastalert-docker
   # docker image tag
-  tag: stable
+  tag: 0.1.29
   pullPolicy: IfNotPresent
 resources: {}
 


### PR DESCRIPTION
Updated image for Elasticsearch 6 support, removed supervisord since k8s deployments provide that capability already, and added apiVersion to support helm upgrades

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
