### PR TITLE
[stable/kong] Enables non-ssl deploys

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.12.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -54,6 +54,7 @@ and their default values.
 | image.tag                         | Kong image version                                                     | `0.11.2`              |
 | image.pullPolicy                  | Image pull policy                                                      | `IfNotPresent`        |
 | replicaCount                      | Kong instance count                                                    | `1`                   |
+| admin.useTLS                      | Determines if Kong admin is configured to respond on secure TCP port   | `true`                  |
 | admin.http.servicePort            | TCP port on which the Kong admin service is exposed                    | `8001`                |
 | admin.https.servicePort           | Secure TCP port on which the Kong admin service is exposed             | `8444`                |
 | admin.http.containerPort          | TCP port on which Kong app listens for admin traffic                   | `8001`                |
@@ -61,6 +62,7 @@ and their default values.
 | admin.nodePort                    | Node port when service type is `NodePort`                              | `32444`               |
 | admin.type                        | k8s service type, Options: NodePort, ClusterIP, LoadBalancer           | `NodePort`            |
 | admin.loadBalancerIP              | Will reuse an existing ingress static IP for the admin service         | `null`                |
+| proxy.useTLS                      | Determines if Kong proxy is configured to respond on secure TCP port   | `true`                  |
 | proxy.http.servicePort            | TCP port on which the Kong proxy service is exposed                    | `8000`                |
 | proxy.https.servicePort           | Secure TCP port on which the Kong Proxy Service is exposed             | `8443`                |
 | proxy.http.containerPort          | TCP port on which the Kong app listens for Proxy traffic               | `8000`                |

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -1,8 +1,8 @@
 1. Kong Admin can be accessed inside the cluster using:
      DNS={{ template "kong.fullname" . }}-admin.{{ .Release.Namespace }}.svc.cluster.local
-   {{- if .Values.admin.https }}
+   {{- if .Values.admin.useTLS }}
      PORT={{ .Values.admin.https.servicePort }}
-   {{- else if .Values.admin.http }}
+   {{- else }}
      PORT={{ .Values.admin.http.servicePort }}
    {{- end }}
 
@@ -19,11 +19,11 @@ To connect from outside the K8s cluster:
    {{- else if contains "ClusterIP" .Values.admin.type }}
      HOST=127.0.0.1
 
-     {{- if .Values.admin.https }}
+     {{- if .Values.admin.useTLS }}
      # Execute the following commands to route the connection to Admin SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl port-forward $POD_NAME {{ .Values.admin.https.servicePort }}:{{ .Values.admin.https.servicePort }}
-     {{- else if .Values.admin.http }}
+     {{- else }}
      # Execute the following commands to route the connection to Admin port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl port-forward $POD_NAME {{ .Values.admin.http.servicePort }}:{{ .Values.admin.http.servicePort }}
@@ -33,9 +33,9 @@ To connect from outside the K8s cluster:
 
 2. Kong Proxy can be accessed inside the cluster using:
      DNS={{ template "kong.fullname" . }}-proxy.{{ .Release.Namespace }}.svc.cluster.local
-   {{- if .Values.proxy.https }}
+   {{- if .Values.proxy.useTLS }}
      PORT={{ .Values.proxy.https.servicePort }}
-   {{- else if .Values.proxy.http }}
+   {{- else }}
      PORT={{ .Values.proxy.http.servicePort }}
    {{- end }}
 
@@ -52,11 +52,11 @@ To connect from outside the K8s cluster:
    {{- else if contains "ClusterIP" .Values.proxy.type }}
      HOST=127.0.0.1
 
-     {{- if .Values.proxy.https }}
+     {{- if .Values.proxy.useTLS }}
      # Execute the following commands to route the connection to proxy SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl port-forward $POD_NAME {{ .Values.proxy.https.servicePort }}:{{ .Values.proxy.https.servicePort }}
-     {{- else if .Values.proxy.http }}
+     {{- else }}
      # Execute the following commands to route the connection to proxy port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl port-forward $POD_NAME {{ .Values.proxy.http.servicePort }}:{{ .Values.proxy.http.servicePort }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -64,20 +64,20 @@ spec:
           value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
         ports:
-        {{- if .Values.admin.https }}
+        {{- if .Values.admin.useTLS }}
         - name: admin-ssl
           containerPort: {{ .Values.admin.https.containerPort }}
           protocol: TCP
-        {{- else if .Values.admin.http }}
+        {{- else }}
         - name: admin
           containerPort: {{ .Values.admin.http.containerPort }}
           protocol: TCP
         {{ end }}
-        {{- if .Values.proxy.https }}
+        {{- if .Values.proxy.useTLS }}
         - name: proxy-ssl
           containerPort: {{ .Values.proxy.https.containerPort }}
           protocol: TCP
-        {{- else if .Values.proxy.http }}
+        {{- else }}
         - name: proxy
           containerPort: {{ .Values.proxy.http.containerPort }}
           protocol: TCP

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -18,10 +18,10 @@ spec:
   {{- end }}
   ports:
   - name: kong-admin
-  {{- if .Values.admin.https }}
+  {{- if .Values.admin.useTLS }}
     port: {{ .Values.admin.https.servicePort }}
     targetPort: {{ .Values.admin.https.containerPort }}
-  {{- else if .Values.admin.http }}
+  {{- else }}
     port: {{ .Values.admin.http.servicePort }}
     targetPort: {{ .Values.admin.http.containerPort }}
   {{- end }}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -18,10 +18,10 @@ spec:
   {{- end }}
   ports:
   - name: kong-proxy
-  {{- if .Values.proxy.https }}
+  {{- if .Values.proxy.useTLS }}
     port: {{ .Values.proxy.https.servicePort }}
     targetPort: {{ .Values.proxy.https.containerPort }}
-  {{- else if .Values.proxy.http }}
+  {{- else }}
     port: {{ .Values.proxy.http.servicePort }}
     targetPort: {{ .Values.proxy.http.containerPort }}
   {{- end }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -13,6 +13,7 @@ admin:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
+  useTLS: true
   # HTTPS traffic on the admin port
   https:
     servicePort: 8444
@@ -29,6 +30,7 @@ proxy:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
+  useTLS: true
   # HTTPS traffic on the proxy port
   https:
     servicePort: 8443
@@ -58,6 +60,7 @@ resources: {}
   #  memory: 128Mi
 
 # readinessProbe for Kong pods
+# you will need to change the port and scheme when admin.useTLS is false
 readinessProbe:
   httpGet:
     path: "/status"
@@ -70,6 +73,7 @@ readinessProbe:
   failureThreshold: 5
 
 # livenessProbe for Kong pods
+# you will need to change the port and scheme when admin.useTLS is false
 livenessProbe:
   httpGet:
     path: "/status"

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -13,11 +13,13 @@ admin:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  useTLS: true
   # HTTPS traffic on the admin port
+  # Port 8444 over HTTPS is the default for the admin port
+  useTLS: true
   https:
     servicePort: 8444
     containerPort: 8444
+  # HTTP Port 8001 is used for the admin port when admin.useTLS is false
   http:
     servicePort: 8001
     containerPort: 8001
@@ -30,11 +32,13 @@ proxy:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  useTLS: true
   # HTTPS traffic on the proxy port
+  # Port 8443 over HTTPS is the default for the proxy port
+  useTLS: true
   https:
     servicePort: 8443
     containerPort: 8443
+  # HTTP Port 8000 is used for the proxy port when proxy.useTLS is false
   http:
     servicePort: 8000
     containerPort: 8000


### PR DESCRIPTION
Just setting admin.https (or proxy.https) to false or null causes a variety of other issues (warnings & deploy errors) in the chart so...
- adds new config parameters (admin.useTLS & proxy.useTLS)
- switches out `if .Values.admin.https` for `if .Values.admin.useTLS`
- switches out `if .Values.proxy.https` for `if .Values.proxy.useTLS`

The default behaviour of the chart is unchanged by this PR.  It still defaults to HTTPS.  It's just possible  to configure the services to run over HTTP now.
*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************