### PR TITLE
Add Kubernetes audit INPUT

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluent-bit
-version: 0.2.10
-appVersion: 0.12.11
+version: 0.2.11
+appVersion: 0.12.14
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
 - logging

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -13,6 +13,19 @@ data:
         Log_Level    info
         Parsers_File parsers.conf
 
+{{- if .Values.audit.enable }}
+    [INPUT]
+        Name             tail
+        Path             {{ default "/var/log/kube-apiserver-audit.log" .Values.audit.filepath }}
+        DB               /var/log/audit.db
+        Tag              audit.*
+        Refresh_Interval 5
+        Mem_Buf_Limit    {{ default "35MB" .Values.audit.Mem_Buf_Limit }}
+        Buffer_Chunk_Size {{ default "2MB" .Values.audit.Buffer_Chunk_Size }}
+        Buffer_Max_Size   {{ default "10MB" .Values.audit.Buffer_Chunk_Size }}
+        Skip_Long_Lines  On
+{{- end }}
+
     [INPUT]
         Name             tail
         Path             /var/log/containers/*.log

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -5,7 +5,7 @@ on_minikube: false
 image:
   fluent_bit:
     repository: fluent/fluent-bit
-    tag: 0.12.11
+    tag: 0.12.14
   pullPolicy: Always
 
 backend:
@@ -66,6 +66,14 @@ tolerations: []
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
+
+audit:
+  enable: false
+  filepath: /var/log/kube-apiserver-audit.log
+  # Mem_Buf_Limit: 35MB
+  # Buffer_Chunk_Size: 2MB
+  # Buffer_Max_Size: 10MB
+
 
 filter: {}
 # If true, check to see if the log field content is a JSON string map, if so,


### PR DESCRIPTION
Add audit input as an option to avoid having to override configmap managed by helm.