### PR TITLE
[traefik] - updating to use the latest chart template fullname format

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.21.1
+version: 1.22.0
 appVersion: 1.5.2
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -85,6 +85,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 
 | Parameter                       | Description                                                          | Default                                   |
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
+| `fullnameOverride`              | Override the full resource names                                     | `{release-name}-traefik (or traefik if release-name is traefik`|
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
 | `imageTag`                      | The version of the official Traefik image to use                     | `1.5.2`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |

--- a/stable/traefik/templates/NOTES.txt
+++ b/stable/traefik/templates/NOTES.txt
@@ -5,11 +5,11 @@
 
      You can watch the status by running:
 
-         $ kubectl get svc {{ template "fullname" . }} --namespace {{ .Release.Namespace }} -w
+         $ kubectl get svc {{ template "traefik.fullname" . }} --namespace {{ .Release.Namespace }} -w
 
      Once 'EXTERNAL-IP' is no longer '<pending>':
 
-         $ kubectl describe svc {{ template "fullname" . }} --namespace {{ .Release.Namespace }} | grep Ingress | awk '{print $3}'
+         $ kubectl describe svc {{ template "traefik.fullname" . }} --namespace {{ .Release.Namespace }} | grep Ingress | awk '{print $3}'
 
 2. Configure DNS records corresponding to Kubernetes ingress resources to point to the load balancer IP/hostname found in step 1
 {{- end }}
@@ -22,7 +22,7 @@
 {{- else }}
 1. Traefik has been started. You can find out the port numbers being used by traefik by running:
 
-          $ kubectl describe svc {{ template "fullname" . }} --namespace {{ .Release.Namespace }}
+          $ kubectl describe svc {{ template "traefik.fullname" . }} --namespace {{ .Release.Namespace }}
 
 {{- end }}
 

--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -1,6 +1,14 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "traefik.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
@@ -21,7 +29,7 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create the block for the ProxyProtocol's Trusted IPs.
 */}}
-{{- define "trustedips" -}}
+{{- define "traefik.trustedips" -}}
          trustedIPs = [
 	   {{- range $idx, $ips := .Values.proxyProtocol.trustedIPs }}
 	     {{- if $idx }}, {{ end }}

--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -3,9 +3,19 @@
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- define "traefik.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/traefik/templates/acme-pvc.yaml
+++ b/stable/traefik/templates/acme-pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}-acme
+  name: {{ template "traefik.fullname" . }}-acme
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/acme-pvc.yaml
+++ b/stable/traefik/templates/acme-pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "traefik.fullname" . }}-acme
   labels:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "traefik.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -27,7 +27,7 @@ data:
       address = ":80"
       {{- if .Values.proxyProtocol.enabled }}
         [entryPoints.http.proxyProtocol]
-        {{ template "trustedips" . }}
+        {{ template "traefik.trustedips" . }}
       {{- end }}
       compress = {{ .Values.gzip.enabled }}
         {{- if .Values.ssl.enforced }}
@@ -40,7 +40,7 @@ data:
       address = ":443"
       {{- if .Values.proxyProtocol.enabled }}
         [entryPoints.https.proxyProtocol]
-        {{ template "trustedips" . }}
+        {{ template "traefik.trustedips" . }}
       {{- end }}
       compress = {{ .Values.gzip.enabled }}
         [entryPoints.https.tls]

--- a/stable/traefik/templates/dashboard-ingress.yaml
+++ b/stable/traefik/templates/dashboard-ingress.yaml
@@ -2,9 +2,9 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}-dashboard
+  name: {{ template "traefik.fullname" . }}-dashboard
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -25,6 +25,6 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ template "fullname" . }}-dashboard
+          serviceName: {{ template "traefik.fullname" . }}-dashboard
           servicePort: 80
 {{- end }}

--- a/stable/traefik/templates/dashboard-ingress.yaml
+++ b/stable/traefik/templates/dashboard-ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   labels:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/dashboard-service.yaml
+++ b/stable/traefik/templates/dashboard-service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-dashboard
+  name: {{ template "traefik.fullname" . }}-dashboard
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
   ports:
   - port: 80
     targetPort: 8080

--- a/stable/traefik/templates/dashboard-service.yaml
+++ b/stable/traefik/templates/dashboard-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "traefik.fullname" . }}-dashboard
   labels:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -16,7 +16,8 @@ metadata:
   {{- end }}
 spec:
   selector:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
+    release: {{ .Release.Name }}
   ports:
   - port: 80
     targetPort: 8080

--- a/stable/traefik/templates/default-cert-secret.yaml
+++ b/stable/traefik/templates/default-cert-secret.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}-default-cert
+  name: {{ template "traefik.fullname" . }}-default-cert
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/default-cert-secret.yaml
+++ b/stable/traefik/templates/default-cert-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "traefik.fullname" . }}-default-cert
   labels:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "traefik.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -11,7 +11,7 @@ spec:
   replicas: {{ default 1 .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ template "traefik.fullname" . }}
   template:
     metadata:
       annotations:
@@ -23,13 +23,13 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "traefik.fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
       {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccountName: {{ template "traefik.fullname" . }}
       {{- else }}
       serviceAccountName: default
       {{- end }}
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       containers:
       - image: {{ .Values.image }}:{{ .Values.imageTag }}
-        name: {{ template "fullname" . }}
+        name: {{ template "traefik.fullname" . }}
         resources:
           requests:
             cpu: "{{ .Values.cpuRequest }}"
@@ -70,7 +70,7 @@ spec:
           - name: {{ $k }}
             valueFrom:
               secretKeyRef:
-                name: {{ template "fullname" $ }}-dnsprovider-config
+                name: {{ template "traefik.fullname" $ }}-dnsprovider-config
                 key: {{ $k }}
         {{- end }}
         {{- end }}
@@ -114,17 +114,17 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "fullname" . }}
+          name: {{ template "traefik.fullname" . }}
       {{- if .Values.ssl.enabled }}
       - name: ssl
         secret:
-          secretName: {{ template "fullname" . }}-default-cert
+          secretName: {{ template "traefik.fullname" . }}-default-cert
       {{- end }}
       {{- if .Values.acme.enabled }}
       - name: acme
       {{- if .Values.acme.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}-acme
+          claimName: {{ template "traefik.fullname" . }}-acme
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -11,7 +11,8 @@ spec:
   replicas: {{ default 1 .Values.replicas }}
   selector:
     matchLabels:
-      app: {{ template "traefik.fullname" . }}
+      app: {{ template "traefik.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       annotations:
@@ -23,7 +24,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       labels:
-        app: {{ template "traefik.fullname" . }}
+        app: {{ template "traefik.name" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/dns-provider-secret.yaml
+++ b/stable/traefik/templates/dns-provider-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "traefik.fullname" . }}-dnsprovider-config
   labels:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/dns-provider-secret.yaml
+++ b/stable/traefik/templates/dns-provider-secret.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}-dnsprovider-config
+  name: {{ template "traefik.fullname" . }}-dnsprovider-config
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/traefik/templates/rbac.yaml
+++ b/stable/traefik/templates/rbac.yaml
@@ -2,12 +2,12 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "traefik.fullname" . }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "traefik.fullname" . }}
 rules:
   - apiGroups:
       - ""
@@ -32,13 +32,13 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "traefik.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "traefik.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "fullname" . }}
+  name: {{ template "traefik.fullname" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "traefik.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -30,7 +30,7 @@ spec:
     {{- end }}
   {{- end }}
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "traefik.fullname" . }}
   ports:
   - port: 80
     name: http

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "traefik.fullname" . }}
   labels:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -30,7 +30,8 @@ spec:
     {{- end }}
   {{- end }}
   selector:
-    app: {{ template "traefik.fullname" . }}
+    app: {{ template "traefik.name" . }}
+    release: {{ .Release.Name }}     
   ports:
   - port: 80
     name: http


### PR DESCRIPTION
Changes the fullname to use the namespaced traefik.fullname along with updating the template to use the latest fullname format.  If a user has the chart installed as the name `traefik` the service will change from `traefik-traefik` to now `traefik` if the release name is not `traefik` no change will be seen for the user.