### PR TITLE
Feature add dynamic spec statefulset of Concourse helm chart

### DIFF
--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -20,6 +20,9 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+{{- if .Values.worker.additionalSpec }}
+{{ toYaml .Values.worker.additionalSpec | indent 6 }}
+{{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "concourse.worker.fullname" . }}{{ else }}{{ .Values.rbac.workerServiceAccountName }}{{ end }}
       tolerations:
 {{ toYaml .Values.worker.tolerations | indent 8 }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -194,6 +194,7 @@ web:
       cpu: "100m"
       memory: "128Mi"
 
+
   ## Additional affinities to add to the web pods.
   ##
   # additionalAffinities:
@@ -322,6 +323,18 @@ worker:
   # annotations:
   #   iam.amazonaws.com/role: arn:aws:iam::123456789012:role/concourse
   #
+
+
+  # Additional settings to be added to statefulset template spec. Can be used for tolerations, node selectors etc.
+  # This way you can dedicate a complete node for a worker
+  #additionalSpec:
+  #  tolerations:
+  #  - key: "key"
+  #    operator: "Equal"
+  #    value: "value"
+  #    effect: "NoSchedule"
+  #  nodeSelector:
+  #      type: concourse
 
   ## Additional affinities to add to the worker pods.
   ## Useful if you prefer to run workers on non-spot instances, for example

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -194,7 +194,6 @@ web:
       cpu: "100m"
       memory: "128Mi"
 
-
   ## Additional affinities to add to the web pods.
   ##
   # additionalAffinities:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -325,16 +325,10 @@ worker:
   #
 
 
-  # Additional settings to be added to statefulset template spec. Can be used for tolerations, node selectors etc.
-  # This way you can dedicate a complete node for a worker
+  # Additional settings to be added to statefulset template spec. Can be used for for example node selector
   #additionalSpec:
-  #  tolerations:
-  #  - key: "key"
-  #    operator: "Equal"
-  #    value: "value"
-  #    effect: "NoSchedule"
   #  nodeSelector:
-  #      type: concourse
+  #    type: concourse
 
   ## Additional affinities to add to the worker pods.
   ## Useful if you prefer to run workers on non-spot instances, for example


### PR DESCRIPTION
*New feature*
Possibility to add custom settings to the pod spec of our StatefulSet for  the concourse worker. Previously the `values.yaml` solely supports features that are implemented in values. This adds more flexibility if the user wants to add more custom features to the pod spec. In our case, used for setting nodeSelector to our pods.
