### PR TITLE
Update README.md with correct default value

### DIFF
--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.0.2
+version: 7.0.3
 appVersion: 5.8.4
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -120,7 +120,7 @@ The following tables lists the configurable parameters of the artifactory chart 
 | `ingress.hosts`             | Artifactory Ingress hostnames       | `[]` |
 | `ingress.tls`               | Artifactory Ingress TLS configuration (YAML) | `[]` |
 | `nginx.name` | Nginx name | `nginx`   |
-| `nginx.enabled` | Deploy nginx server | `false`   |
+| `nginx.enabled` | Deploy nginx server | `true`   |
 | `nginx.replicaCount` | Nginx replica count | `1`   |
 | `nginx.image.repository`    | Container image                   | `docker.bintray.io/jfrog/nginx-artifactory-pro`                |
 | `nginx.image.version`       | Container tag                     | `5.8.4`                                                |


### PR DESCRIPTION
The default value in the README.md for the nginx.enable was 'false' while in the values.yaml it is 'true'