### PR TITLE
[stable/sumokube] enable customization of DaemonSet's UpdateStrategy

### DIFF
--- a/stable/sumokube/Chart.yaml
+++ b/stable/sumokube/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumokube
-version: 0.1.1
+version: 0.1.2
 description: Sumologic Log Collector
 keywords:
 - monitoring

--- a/stable/sumokube/README.md
+++ b/stable/sumokube/README.md
@@ -55,6 +55,7 @@ The following tables lists the configurable parameters of the Sumokube chart and
 | `resources.requests.memory` | Memory resource requests           | 128Mi                                      |
 | `resources.limits.memory`   | Memory resource limits             | 256Mi                                      |
 | `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6)            | []    |
+| `daemonset.updateStrategy`  | Strategy for applying template changes (requires Kubernetes >= 1.6)            | []    |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/sumokube/templates/daemonset.yaml
+++ b/stable/sumokube/templates/daemonset.yaml
@@ -63,4 +63,6 @@ spec:
           name: "{{ template "fullname" . }}-config-{{.Release.Time.Seconds }}"
       tolerations:
 {{ toYaml .Values.daemonset.tolerations | indent 8 }}
+  updateStrategy:
+    type: {{ default "OnDelete" .Values.daemonset.updateStrategy | quote }}
 {{ end }}

--- a/stable/sumokube/values.yaml
+++ b/stable/sumokube/values.yaml
@@ -32,4 +32,3 @@ resources:
 
 daemonset:
   tolerations: []
-


### PR DESCRIPTION
* defaults to `OnDelete`
* optionally can be set to `RollingUpdate`

https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/

I borrowed the implementation from Datadog:

https://github.com/kubernetes/charts/blob/5b68734e5713f835b70dc3f483b8485681d640ad/stable/datadog/templates/daemonset.yaml#L150-L151