### PR TITLE
Add toleration values to newrelic infra chart

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.12
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/README.md
+++ b/stable/newrelic-infrastructure/README.md
@@ -6,16 +6,16 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 
 ## Configuration
 
-| Parameter          | Description                                         | Default                    |
-| ------------------ | --------------------------------------------------- | -------------------------- |
-| `config`           | A `newrelic-infra.yml` file if you wish to provide. | ` `                 |
-| `image.name`       | The container to pull.                              | `newrelic/infrastructure`  |
-| `image.pullPolicy` | The pull policy.                                    | `IfNotPresent`             |
-| `image.tag`        | The version of the container to pull.               | `0.0.11`                   |
-| `licenseKey`       | The license key for your New Relic Account.         | ``                         |
-| `resources`        | Any resources you wish to assign to the pod.        | See Resources below        |
-| `verboseLog`       | Should the agent log verbosely. (Boolean)           | `false`                    |
-| `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |
+| Parameter          | Description                                                  | Default                    |
+| ------------------ | ------------------------------------------------------------ | -------------------------- |
+| `config`           | A `newrelic-infra.yml` file if you wish to provide.          | ` `                        |
+| `image.name`       | The container to pull.                                       | `newrelic/infrastructure`  |
+| `image.pullPolicy` | The pull policy.                                             | `IfNotPresent`             |
+| `image.tag`        | The version of the container to pull.                        | `0.0.11`                   |
+| `licenseKey`       | The license key for your New Relic Account.                  | ``                         |
+| `resources`        | Any resources you wish to assign to the pod.                 | See Resources below        |
+| `verboseLog`       | Should the agent log verbosely. (Boolean)                    | `false`                    |
+| `tolerations`      | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`                      |
 
 ## Resources
 

--- a/stable/newrelic-infrastructure/README.md
+++ b/stable/newrelic-infrastructure/README.md
@@ -15,6 +15,7 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 | `licenseKey`       | The license key for your New Relic Account.         | ``                         |
 | `resources`        | Any resources you wish to assign to the pod.        | See Resources below        |
 | `verboseLog`       | Should the agent log verbosely. (Boolean)           | `false`                    |
+| `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |
 
 ## Resources
 

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -84,8 +84,8 @@ spec:
             - key: newrelic-infra.yml
               path: newrelic-infra.yml
         {{- end }}
-      {{- if .Values.daemonset.tolerations }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.daemonset.tolerations | indent 8 }}
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
 {{- end }}

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -84,4 +84,8 @@ spec:
             - key: newrelic-infra.yml
               path: newrelic-infra.yml
         {{- end }}
+      {{- if .Values.daemonset.tolerations }}
+      tolerations:
+{{ toYaml .Values.daemonset.tolerations | indent 8 }}
+      {{- end }}
 {{- end }}

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -62,3 +62,6 @@ resources:
   #  service: login service
   #  team: alpha-team
   #
+
+daemonset:
+  tolerations: []

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -63,5 +63,4 @@ resources:
   #  team: alpha-team
   #
 
-daemonset:
-  tolerations: []
+tolerations: []


### PR DESCRIPTION
This PR adds custom `tolerations` configuration for the newrelic-infrastructure chart. In this way users of the chart may decide to schedule the daemonset on master / other nodes as need-be.
