### PR TITLE
[stable/traefik] Fix version info

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.20.0
-appVersion: 1.5.1
+version: 1.21.1
+appVersion: 1.5.2
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -86,7 +86,7 @@ The following tables lists the configurable parameters of the Traefik chart and 
 | Parameter                       | Description                                                          | Default                                   |
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
-| `imageTag`                      | The version of the official Traefik image to use                     | `1.4.5`                                  |
+| `imageTag`                      | The version of the official Traefik image to use                     | `1.5.2`                                  |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
 | `loadBalancerSourceRanges`      | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 ## Default values for Traefik
 image: traefik
-imageTag: v1.5.2
+imageTag: 1.5.2
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
 loadBalancerIP:


### PR DESCRIPTION
* This fixes the version info in Chart.yaml, values.yaml and README.md.
* Bump chart version to 1.21.1.

NOTE: the chart version has been bumped to 1.21.1, lined up to be merged AFTER https://github.com/kubernetes/charts/pull/3872 has been merged.