### PR TITLE
[incubator/patroni] RBAC role and rolebinding

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,7 +1,7 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.5.1
-appVersion: 1.2-p17
+version: 0.6
+appVersion: 1.3-p4
 home: https://github.com/zalando/patroni
 sources:
 - https://github.com/zalando/patroni

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -86,6 +86,7 @@ The following tables lists the configurable parameters of the patroni chart and 
 | `persistentVolume.size` | Persistent Volume size | `2Gi` |
 | `persistentVolume.storageClass` | Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default` |
 | `persistentVolume.subPath` | Subdirectory of Persistent Volume to mount | `""` |
+| `Rbac.Create` | create role and rolebindings for default service account | `false` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -86,7 +86,9 @@ The following tables lists the configurable parameters of the patroni chart and 
 | `persistentVolume.size` | Persistent Volume size | `2Gi` |
 | `persistentVolume.storageClass` | Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default` |
 | `persistentVolume.subPath` | Subdirectory of Persistent Volume to mount | `""` |
-| `rbac.create` | create role and rolebindings for default service account | `false` |
+| `rbac.create` | create required role and rolebindings | `true` |
+| `serviceAccount.create` | If true, create a new service account	| `true`
+| `serviceAccount.name` | Service account to be used. If not set and serviceAccount.create is `true`, a name is generated using the fullname template | ``  
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -86,7 +86,7 @@ The following tables lists the configurable parameters of the patroni chart and 
 | `persistentVolume.size` | Persistent Volume size | `2Gi` |
 | `persistentVolume.storageClass` | Persistent Volume Storage Class | `volume.alpha.kubernetes.io/storage-class: default` |
 | `persistentVolume.subPath` | Subdirectory of Persistent Volume to mount | `""` |
-| `Rbac.Create` | create role and rolebindings for default service account | `false` |
+| `rbac.create` | create role and rolebindings for default service account | `false` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/patroni/templates/_helpers.tpl
+++ b/incubator/patroni/templates/_helpers.tpl
@@ -7,3 +7,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "patroni.fullname" -}}
 {{- printf "%s-%s" .Release.Name .Values.Name | trunc 63 -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "patroni.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "patroni.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/patroni/templates/role-patroni.yaml
+++ b/incubator/patroni/templates/role-patroni.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.Rbac.Create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "patroni.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Component }}"
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints", "pods"]
+    verbs: ["patch"]
+{{- end }}

--- a/incubator/patroni/templates/role-patroni.yaml
+++ b/incubator/patroni/templates/role-patroni.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.Rbac.Create }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/incubator/patroni/templates/rolebinding-patroni.yaml
+++ b/incubator/patroni/templates/rolebinding-patroni.yaml
@@ -10,7 +10,7 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Component }}"
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: {{ template "patroni.serviceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/incubator/patroni/templates/rolebinding-patroni.yaml
+++ b/incubator/patroni/templates/rolebinding-patroni.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.Rbac.Create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "patroni.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Component }}"
+subjects:
+  - kind: ServiceAccount
+    name: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "patroni.fullname" . }}
+{{- end }}

--- a/incubator/patroni/templates/rolebinding-patroni.yaml
+++ b/incubator/patroni/templates/rolebinding-patroni.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.Rbac.Create }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:

--- a/incubator/patroni/templates/serviceaccount-patroni.yaml
+++ b/incubator/patroni/templates/serviceaccount-patroni.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "patroni.serviceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{.Release.Name}}-{{.Values.Component}}"
+{{- end }}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -25,6 +25,7 @@ spec:
           {{ $key }}: {{ $value | quote }}
         {{ end }}
       {{ end }}
+      serviceAccountName: {{ template "patroni.serviceAccountName" . }}
       containers:
       - name: spilo
         image: "{{ .Values.Spilo.Image }}:{{ .Values.Spilo.Version }}"

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -62,4 +62,12 @@ persistentVolume:
     - ReadWriteOnce
 
 rbac:
+  # Specifies whether RBAC resources should be created
   create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -61,5 +61,5 @@ persistentVolume:
   accessModes:
     - ReadWriteOnce
 
-Rbac:
-  Create: false
+rbac:
+  create: true

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -7,7 +7,7 @@ ImagePullPolicy: IfNotPresent
 Spilo:
   # this image was built from https://github.com/zalando/spilo/tree/master/postgres-appliance
   Image: registry.opensource.zalan.do/acid/spilo-9.6
-  Version: 1.2-p17
+  Version: 1.3-p4
 
 # How many postgres containers to spawn
 Replicas: 5
@@ -60,3 +60,6 @@ persistentVolume:
   annotations: {}
   accessModes:
     - ReadWriteOnce
+
+Rbac:
+  Create: false


### PR DESCRIPTION
```
2018-02-27 12:28:55,455 WARNING: Unable to change spilo-role label: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"release-name-patroni-0\" is forbidden: User \"system:serviceaccount:namespace:default\" cannot patch pods in the namespace \"namespace\": Unknown user \"system:serviceaccount:namespace:default\"","reason":"Forbidden","details":{"name":"release-name-patroni-0","kind":"pods"},"code":403}
```

The current chart does not create a role and rolebinding for the user while Patroni/Spilo needs permissions to patch pods and endpoints on a tightened RBAC enabled cluster.

This PR gives the user the ability to automatically create the required serviceaccount, role and rolebinding by setting the `rbac.create` / `serviceAccount.create` value to `true`.

I also updated the image version to `1.3-p4` as there are no breaking changes and it fixes [replication issues with Wal-E](https://github.com/zalando/patroni/issues/583#issuecomment-353359448).