### PR TITLE
Redis-ha ServiceAccount

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 2.0.0
+version: 2.0.1
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
 maintainers:

--- a/stable/redis-ha/README.md
+++ b/stable/redis-ha/README.md
@@ -66,6 +66,7 @@ The following tables lists the configurable parameters of the Redis chart and th
 | `resources.sentinel`             | CPU/Memory for sentinel node resource requests/limits | Memory: `200Mi`, CPU: `100m`                              |
 | `replicas.servers`               | Number of redis master/slave pods                     | 3                                                         |
 | `replicas.sentinels`             | Number of sentinel pods                               | 3                                                         |
+| `serviceAccountName`             | Service account which allows pod to set tags          | default                                                   |
 | `nodeSelector`                   | Node labels for pod assignment                        | {}                                                        |
 | `tolerations`                    | Toleration labels for pod assignment                  | []                                                        |
 | `servers.serviceType`            | Set to "LoadBalancer" to enable access from the VPC   | ClusterIP                                                 |

--- a/stable/redis-ha/templates/redis-sentinel-deployment.yaml
+++ b/stable/redis-ha/templates/redis-sentinel-deployment.yaml
@@ -11,6 +11,7 @@ spec:
         name: {{ template "fullname" . }}-sentinel
 {{ include "labels.standard" . | indent 8 }}
     spec:
+      serviceAccountName: {{ default "default" .Values.serviceAccountName }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/redis-ha/templates/redis-server-deployment.yaml
+++ b/stable/redis-ha/templates/redis-server-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         redis-node: "true"
 {{ include "labels.standard" . | indent 8 }}
     spec:
+      serviceAccountName: {{ default "default" .Values.serviceAccountName }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -15,6 +15,9 @@ resources:
     limits:
       memory: 200Mi
 
+# On GKE we need to set service account or change the default
+#serviceAccountName: redis
+
 ## Node labels and tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -15,8 +15,10 @@ resources:
     limits:
       memory: 200Mi
 
-# On GKE we need to set service account or change the default
-#serviceAccountName: redis
+## On GKE we need to set service account or change the default
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+## ref: https://kubernetes.io/docs/admin/service-accounts-admin/
+serviceAccountName: default
 
 ## Node labels and tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector


### PR DESCRIPTION
Adds option to set Kubernetes Service Account required on GKE deployments by default

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
