### PR TITLE
[stable/testlink] Fix default SMTP configuration

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 0.4.16
+version: 0.4.17
 appVersion: 1.9.16
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/templates/deployment.yaml
+++ b/stable/testlink/templates/deployment.yaml
@@ -40,15 +40,15 @@ spec:
         - name: TESTLINK_LANGUAGE
           value: {{ default "" .Values.testlinkLanguage | quote }}
         - name: SMTP_ENABLE
-          value: {{ default "" .Values.smtpEnable | quote }}
+          value: {{ .Values.smtpEnable | quote }}
         - name: SMTP_CONNECTION_MODE
-          value: {{ default "" .Values.smtpConnectionMode | quote }}
+          value: {{ .Values.smtpConnectionMode | quote }}
         - name: SMTP_HOST
-          value: {{ default "" .Values.smtpHost | quote }}
+          value: {{ .Values.smtpHost | quote }}
         - name: SMTP_PORT
-          value: {{ default "" .Values.smtpPort | quote }}
+          value: {{ .Values.smtpPort | quote }}
         - name: SMTP_USER
-          value: {{ default "" .Values.smtpUser | quote }}
+          value: {{ .Values.smtpUser | quote }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/testlink/values.yaml
+++ b/stable/testlink/values.yaml
@@ -33,12 +33,12 @@ testlinkLanguage: en_US
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-testlink#smtp-configuration
 ##
-# smtpEnable: true
-# smtpHost: smtp.example.com
-# smtpPort: 587
-# smtpUser: mailer@example.com
-# smtpPassword: mailerpassword
-# smtpConnectionMode: tls
+smtpEnable: false
+smtpHost:
+smtpPort:
+smtpUser:
+smtpPassword:
+smtpConnectionMode:
 
 ##
 ## MariaDB chart configuration


### PR DESCRIPTION
This PR fixes an issue with the testlink image when creating a new user. 

The issue is that SMTP was not properly configured. This change disable SMTP by default so the user is created (but the confirmation email is not sent)

If testlink is deployed with proper SMTP parameters the user is created and the confirmation email is sent.
