### PR TITLE
Bumped helm release for e2e tests

### DIFF
--- a/test/helm-test-e2e.sh
+++ b/test/helm-test-e2e.sh
@@ -7,7 +7,7 @@ set -o xtrace
 
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.7.2-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.8.1-linux-amd64.tar.gz
 
 wget -q ${HELM_URL}/${HELM_TARBALL} -P ${WORKSPACE}
 tar xzfv ${WORKSPACE}/${HELM_TARBALL} -C ${WORKSPACE}


### PR DESCRIPTION
This is in the hope to resolve the `install --wait` issues with the Jenkins chart e2e tests.

https://k8s-testgrid.appspot.com/sig-apps#charts-gce&show-stale-tests=