### PR TITLE
Adding tolerance support to newrelic infrastructure

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.12
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -84,4 +84,7 @@ spec:
             - key: newrelic-infra.yml
               path: newrelic-infra.yml
         {{- end }}
+      tolerations:
+        tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -19,6 +19,10 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
 # If you wish to provide additional labels to apply to the pod(s), specify
 # them here
 # podLabels:


### PR DESCRIPTION
Simple addition of tolerations to the pod spec. Tolerations are helpful for this particular type of DaemonSet in order to monitor the health of all nodes.