### PR TITLE
[stable/concourse] fixed incorrect values for gitlab auth secrets

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.0.0
+version: 1.0.2
 appVersion: 3.9.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -31,8 +31,8 @@ data:
   github-auth-client-secret: {{ template "concourse.secret.required" dict "key" "githubAuthClientSecret" "is" "concourse.githubAuth.enabled" "root" . }}
   {{- end }}
   {{- if .Values.concourse.gitlabAuth.enabled }}
-  github-auth-client-id: {{ template "concourse.secret.required" dict "key" "gitlabAuthClientId" "is" "concourse.gitlabAuth.enabled" "root" . }}
-  github-auth-client-secret: {{ template "concourse.secret.required" dict "key" "gitlabAuthClientSecret" "is" "concourse.gitlabAuth.enabled" "root" . }}
+  gitlab-auth-client-id: {{ template "concourse.secret.required" dict "key" "gitlabAuthClientId" "is" "concourse.gitlabAuth.enabled" "root" . }}
+  gitlab-auth-client-secret: {{ template "concourse.secret.required" dict "key" "gitlabAuthClientSecret" "is" "concourse.gitlabAuth.enabled" "root" . }}
   {{- end }}
   {{- if .Values.concourse.genericOauth.enabled }}
   generic-oauth-client-id: {{ template "concourse.secret.required" dict "key" "genericOauthClientId" "is" "concourse.genericOauth.enabled" "root" . }}


### PR DESCRIPTION
Pretty straighforward : github secrets were created instead of gitlab's.

Feel free to accept the PR or correct it in another PR.