### PR TITLE
Make it possible to add tolerations to fluentd-cw

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-cloudwatch
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.1.1
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -61,7 +61,7 @@ The following tables lists the configurable parameters of the Fluentd Cloudwatch
 | `logGroupName`                  | AWS Cloudwatch log group                   | `kubernetes`                                               |
 | `rbac.create`                   | If true, create & use RBAC resources       | `false`                                                    |
 | `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true) | `default`                                |
-| `tolerations`                   | Add tolerations                            | `nil`                                                      |
+| `tolerations`                   | Add tolerations                            | `[]`                                                       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -61,6 +61,7 @@ The following tables lists the configurable parameters of the Fluentd Cloudwatch
 | `logGroupName`                  | AWS Cloudwatch log group                   | `kubernetes`                                               |
 | `rbac.create`                   | If true, create & use RBAC resources       | `false`                                                    |
 | `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true) | `default`                                |
+| `tolerations`                   | Add tolerations                            | `nil`                                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -63,3 +63,7 @@ spec:
       - name: config-volume
         configMap:
           name: {{ template "fluentd-cloudwatch.fullname" . }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -20,6 +20,12 @@ resources:
 
 # hostNetwork: false
 
+## Add tolerations if specified
+# tolerations:
+#   - key: node-role.kubernetes.io/master
+#     operator: Exists
+#     effect: NoSchedule
+
 annotations: {}
 
 awsRegion: us-east-1

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -21,7 +21,7 @@ resources:
 # hostNetwork: false
 
 ## Add tolerations if specified
-# tolerations:
+tolerations: []
 #   - key: node-role.kubernetes.io/master
 #     operator: Exists
 #     effect: NoSchedule


### PR DESCRIPTION
This adds the possability to add tolerations to the fluentd-cloudwatch chart. This is handy if you also want to ship the logs from your master nodes.

This is mostly a copy from [fluentd-elasticsearch](https://github.com/kubernetes/charts/blob/master/incubator/fluentd-elasticsearch/templates/daemonset.yaml#L80-L83) that has the same behaviour. 
