### PR TITLE
[stable/kubernetes-dashboard] Harden Kubernetes Dashboard security setup to protect whole cluster

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 name: kubernetes-dashboard
-version: 0.5.3
-appVersion: 1.8.1
+version: 0.6.0
+appVersion: 1.8.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:
 - kubernetes

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -33,26 +33,33 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Access control
+It is critical for the Kubernetes custer to correctly setup access control of Kubernetes Dashboard. See this [guide](https://github.com/kubernetes/dashboard/wiki/Access-control) for best practises.
+
+It is highly recommended to use RBAC with minimal privileges needed for Dashboard to run.  
+
 ## Configuration
 
 The following tables lists the configurable parameters of the kubernetes-dashboard chart and their default values.
 
-| Parameter              | Description                        | Default                                                                  |
-|------------------------|------------------------------------|--------------------------------------------------------------------------|
-| `image.repository`     | Repository for container image     | `gcr.io/google_containers/kubernetes-dashboard-amd64`                    |
-| `image.tag`            | Image tag                          | `v1.8.1`                                                                 |
-| `image.pullPolicy`     | Image pull policy                  | `IfNotPresent`                                                           |
-| `extraArgs`            | Additional container arguments     | `[]`                                                                     |
-| `nodeSelector`         | node labels for pod assignment     | `{}`                                                                     |
-| `service.externalPort` | Dashboard internal port            | 80                                                                       |
-| `service.internalPort` | Dashboard external port            | 80                                                                       |
-| `ingress.annotations`  | Specify ingress class              | `kubernetes.io/ingress.class: nginx`                                     |
-| `ingress.enabled`      | Enable ingress controller resource | `false`                                                                  |
-| `ingress.hosts`        | Dashboard Hostnames                | `nil`                                                                    |
-| `ingress.tls`          | Ingress TLS configuration          | `[]`                                                                     |
-| `resources`            | Pod resource requests & limits     | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
-| `rbac.create`          | Create & use RBAC resources        | `false`                                                                  |
-| `rbac.serviceAccountName` |  ServiceAccount kubernetes-dashboard will use (ignored if rbac.create=true) | `default`        |
+| Parameter                 | Description                                                                             | Default                                                                  |
+|---------------------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `image.repository`        | Repository for container image                                                          | `k8s.gcr.io/kubernetes-dashboard-amd64`                                  |
+| `image.tag`               | Image tag                                                                               | `v1.8.3`                                                                 |
+| `image.pullPolicy`        | Image pull policy                                                                       | `IfNotPresent`                                                           |
+| `extraArgs`               | Additional container arguments                                                          | `[]`                                                                     |
+| `nodeSelector`            | node labels for pod assignment                                                          | `{}`                                                                     |
+| `tolerations`             | List of node taints to tolerate (requires Kubernetes >= 1.6)                            | `[]`                                                                     |
+| `service.externalPort`    | Dashboard internal port                                                                 | 443                                                                      |
+| `service.internalPort`    | Dashboard external port                                                                 | 443                                                                      |
+| `ingress.annotations`     | Specify ingress class                                                                   | `kubernetes.io/ingress.class: nginx`                                     |
+| `ingress.enabled`         | Enable ingress controller resource                                                      | `false`                                                                  |
+| `ingress.hosts`           | Dashboard Hostnames                                                                     | `nil`                                                                    |
+| `ingress.tls`             | Ingress TLS configuration                                                               | `[]`                                                                     |
+| `resources`               | Pod resource requests & limits                                                          | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
+| `rbac.create`             | Create & use RBAC resources                                                             | `false`                                                                  |
+| `rbac.clusterAdminRole`   | "cluster-admin" ClusterRole will be used for dashboard ServiceAccount (NOT RECOMMENDED) | `false`                                                                  |
+| `rbac.serviceAccountName` | ServiceAccount kubernetes-dashboard will use (ignored if rbac.create=true)              | `default`                                                                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -58,7 +58,7 @@ The following table lists the configurable parameters of the kubernetes-dashboar
 | `ingress.tls`             | Ingress TLS configuration                                                                                                   | `[]`                                                                     |
 | `resources`               | Pod resource requests & limits                                                                                              | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
 | `rbac.create`             | Create & use RBAC resources                                                                                                 | `true`                                                                   |
-| `rbac.clusterAdminRole`   | "cluster-admin" ClusterRole will be used for dashboard ServiceAccount ([NOT RECOMMENDED](#access-control)                   | `false`                                                                  |
+| `rbac.clusterAdminRole`   | "cluster-admin" ClusterRole will be used for dashboard ServiceAccount ([NOT RECOMMENDED](#access-control))                  | `false`                                                                  |
 | `serviceAccount.create`   | Whether a new service account name that the agent will use should be created.                                               | `true`                                                                   |
 | `serviceAccount.name`     | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template. |                                                                          |
 

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -42,24 +42,25 @@ It is highly recommended to use RBAC with minimal privileges needed for Dashboar
 
 The following table lists the configurable parameters of the kubernetes-dashboard chart and their default values.
 
-| Parameter                 | Description                                                                             | Default                                                                  |
-|---------------------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| `image.repository`        | Repository for container image                                                          | `k8s.gcr.io/kubernetes-dashboard-amd64`                                  |
-| `image.tag`               | Image tag                                                                               | `v1.8.3`                                                                 |
-| `image.pullPolicy`        | Image pull policy                                                                       | `IfNotPresent`                                                           |
-| `extraArgs`               | Additional container arguments                                                          | `[]`                                                                     |
-| `nodeSelector`            | node labels for pod assignment                                                          | `{}`                                                                     |
-| `tolerations`             | List of node taints to tolerate (requires Kubernetes >= 1.6)                            | `[]`                                                                     |
-| `service.externalPort`    | Dashboard internal port                                                                 | 443                                                                      |
-| `service.internalPort`    | Dashboard external port                                                                 | 443                                                                      |
-| `ingress.annotations`     | Specify ingress class                                                                   | `kubernetes.io/ingress.class: nginx`                                     |
-| `ingress.enabled`         | Enable ingress controller resource                                                      | `false`                                                                  |
-| `ingress.hosts`           | Dashboard Hostnames                                                                     | `nil`                                                                    |
-| `ingress.tls`             | Ingress TLS configuration                                                               | `[]`                                                                     |
-| `resources`               | Pod resource requests & limits                                                          | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
-| `rbac.create`             | Create & use RBAC resources                                                             | `false`                                                                  |
-| `rbac.clusterAdminRole`   | "cluster-admin" ClusterRole will be used for dashboard ServiceAccount (NOT RECOMMENDED) | `false`                                                                  |
-| `rbac.serviceAccountName` | ServiceAccount kubernetes-dashboard will use (ignored if rbac.create=true)              | `default`                                                                |
+| Parameter                 | Description                                                                                                                 | Default                                                                  |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `image.repository`        | Repository for container image                                                                                              | `k8s.gcr.io/kubernetes-dashboard-amd64`                                  |
+| `image.tag`               | Image tag                                                                                                                   | `v1.8.3`                                                                 |
+| `image.pullPolicy`        | Image pull policy                                                                                                           | `IfNotPresent`                                                           |
+| `extraArgs`               | Additional container arguments                                                                                              | `[]`                                                                     |
+| `nodeSelector`            | node labels for pod assignment                                                                                              | `{}`                                                                     |
+| `tolerations`             | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`                                                                     |
+| `service.externalPort`    | Dashboard internal port                                                                                                     | 443                                                                      |
+| `service.internalPort`    | Dashboard external port                                                                                                     | 443                                                                      |
+| `ingress.annotations`     | Specify ingress class                                                                                                       | `kubernetes.io/ingress.class: nginx`                                     |
+| `ingress.enabled`         | Enable ingress controller resource                                                                                          | `false`                                                                  |
+| `ingress.hosts`           | Dashboard Hostnames                                                                                                         | `nil`                                                                    |
+| `ingress.tls`             | Ingress TLS configuration                                                                                                   | `[]`                                                                     |
+| `resources`               | Pod resource requests & limits                                                                                              | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
+| `rbac.create`             | Create & use RBAC resources                                                                                                 | `true`                                                                   |
+| `rbac.clusterAdminRole`   | "cluster-admin" ClusterRole will be used for dashboard ServiceAccount (NOT RECOMMENDED)                                     | `false`                                                                  |
+| `serviceAccount.create`   | Whether a new service account name that the agent will use should be created.                                               | `true`                                                                   |
+| `serviceAccount.name`     | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template. |                                                                          |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -40,7 +40,7 @@ It is highly recommended to use RBAC with minimal privileges needed for Dashboar
 
 ## Configuration
 
-The following tables lists the configurable parameters of the kubernetes-dashboard chart and their default values.
+The following table lists the configurable parameters of the kubernetes-dashboard chart and their default values.
 
 | Parameter                 | Description                                                                             | Default                                                                  |
 |---------------------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------|

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -58,7 +58,7 @@ The following table lists the configurable parameters of the kubernetes-dashboar
 | `ingress.tls`             | Ingress TLS configuration                                                                                                   | `[]`                                                                     |
 | `resources`               | Pod resource requests & limits                                                                                              | `limits: {cpu: 100m, memory: 50Mi}, requests: {cpu: 100m, memory: 50Mi}` |
 | `rbac.create`             | Create & use RBAC resources                                                                                                 | `true`                                                                   |
-| `rbac.clusterAdminRole`   | "cluster-admin" ClusterRole will be used for dashboard ServiceAccount (NOT RECOMMENDED)                                     | `false`                                                                  |
+| `rbac.clusterAdminRole`   | "cluster-admin" ClusterRole will be used for dashboard ServiceAccount ([NOT RECOMMENDED](#access-control)                   | `false`                                                                  |
 | `serviceAccount.create`   | Whether a new service account name that the agent will use should be created.                                               | `true`                                                                   |
 | `serviceAccount.name`     | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template. |                                                                          |
 

--- a/stable/kubernetes-dashboard/templates/NOTES.txt
+++ b/stable/kubernetes-dashboard/templates/NOTES.txt
@@ -5,7 +5,7 @@
 {{- if .Values.ingress.enabled }}
 From outside the cluster, the server URL(s) are:
 {{- range .Values.ingress.hosts }}
-     http://{{ . }}
+     https://{{ . }}
 {{- end }}
 
 {{- else if contains "NodePort" .Values.service.type }}
@@ -13,7 +13,7 @@ From outside the cluster, the server URL(s) are:
 Get the Kubernetes Dashboard URL by running:
   export NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kubernetes-dashboard.fullname" . }})
   export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo https://$NODE_IP:$NODE_PORT/
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
@@ -22,11 +22,11 @@ Get the Kubernetes Dashboard URL by running:
 
 Get the Kubernetes Dashboard URL by running:
   export SERVICE_IP=$(kubectl get svc {{ template "kubernetes-dashboard.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/
+  echo https://$SERVICE_IP/
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
 Get the Kubernetes Dashboard URL by running:
   export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app={{ template "kubernetes-dashboard.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:9090/
+  echo https://127.0.0.1:9090/
   kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 9090:9090
 {{- end }}

--- a/stable/kubernetes-dashboard/templates/_helpers.tpl
+++ b/stable/kubernetes-dashboard/templates/_helpers.tpl
@@ -23,3 +23,21 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubernetes-dashboard.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubernetes-dashboard.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "kubernetes-dashboard.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     kubernetes.io/cluster-service: "true"
@@ -25,7 +25,7 @@ spec:
         release: {{ .Release.Name }}
         kubernetes.io/cluster-service: "true"
     spec:
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "kubernetes-dashboard.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ template "kubernetes-dashboard.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -30,27 +30,41 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.extraArgs }}
         args:
+          - --auto-generate-certificates
+{{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 10 }}
 {{- end }}
         ports:
-        - name: http
-          containerPort: 9090
+        - name: https
+          containerPort: 8443
           protocol: TCP
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+          # Create on-disk volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
-          failureThreshold: 3
           httpGet:
+            scheme: HTTPS
             path: /
-            port: 9090
-            scheme: HTTP
+            port: 8443
           initialDelaySeconds: 30
-          periodSeconds: 10
-          successThreshold: 1
           timeoutSeconds: 30
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: kubernetes-dashboard-certs
+        secret:
+          secretName: {{ template "kubernetes-dashboard.fullname" . }}
+      - name: tmp-volume
+        emptyDir: {}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}

--- a/stable/kubernetes-dashboard/templates/ingress.yaml
+++ b/stable/kubernetes-dashboard/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.ingress.annotations }}

--- a/stable/kubernetes-dashboard/templates/role.yaml
+++ b/stable/kubernetes-dashboard/templates/role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}

--- a/stable/kubernetes-dashboard/templates/role.yaml
+++ b/stable/kubernetes-dashboard/templates/role.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.rbac.create (not .Values.rbac.clusterAdminRole) }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: {{ template "kubernetes-dashboard.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  # Allow Dashboard to create 'kubernetes-dashboard-key-holder' secret.
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - create
+
+  # Allow Dashboard to create 'kubernetes-dashboard-settings' config map.
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - create
+
+  # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  resourceNames:
+    - kubernetes-dashboard-key-holder
+    - {{ template "kubernetes-dashboard.fullname" . }}
+  verbs:
+    - get
+    - update
+    - delete
+
+  # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  resourceNames:
+    - kubernetes-dashboard-settings
+  verbs:
+    - get
+    - update
+
+  # Allow Dashboard to get metrics from heapster.
+- apiGroups:
+    - ""
+  resources:
+    - services
+  resourceNames:
+    - heapster
+  verbs:
+    - proxy
+- apiGroups:
+    - ""
+  resources:
+    - services/proxy
+  resourceNames:
+    - heapster
+    - "http:heapster:"
+    - "https:heapster:"
+  verbs:
+    - get
+{{- end -}}

--- a/stable/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/stable/kubernetes-dashboard/templates/rolebinding.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.rbac.create }}
+
+{{- if .Values.rbac.clusterAdminRole }}
+# Cluster role binding for clusterAdminRole == true
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -16,4 +19,25 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kubernetes-dashboard.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- else -}}
+# Role binding for clusterAdminRole == false
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ template "kubernetes-dashboard.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubernetes-dashboard.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}

--- a/stable/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/stable/kubernetes-dashboard/templates/rolebinding.yaml
@@ -7,7 +7,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}
@@ -17,7 +17,7 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: {{ template "kubernetes-dashboard.fullname" . }}
+    name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- else -}}
 # Role binding for clusterAdminRole == false
@@ -26,7 +26,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}
@@ -37,7 +37,7 @@ roleRef:
   name: {{ template "kubernetes-dashboard.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "kubernetes-dashboard.fullname" . }}
+    name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}
 {{- end -}}

--- a/stable/kubernetes-dashboard/templates/secret.yaml
+++ b/stable/kubernetes-dashboard/templates/secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}

--- a/stable/kubernetes-dashboard/templates/secret.yaml
+++ b/stable/kubernetes-dashboard/templates/secret.yaml
@@ -1,6 +1,5 @@
-{{- if .Values.rbac.create }}
 apiVersion: v1
-kind: ServiceAccount
+kind: Secret
 metadata:
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
@@ -9,4 +8,4 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}
   namespace: {{ .Release.Namespace }}
-{{- end -}}
+type: Opaque

--- a/stable/kubernetes-dashboard/templates/serviceaccount.yaml
+++ b/stable/kubernetes-dashboard/templates/serviceaccount.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "kubernetes-dashboard.fullname" . }}
+  name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -19,7 +19,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - port: {{ .Values.service.externalPort }}
-    targetPort: http
+    targetPort: https
 {{- if hasKey .Values.service "nodePort" }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
   labels:
     app: {{ template "kubernetes-dashboard.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     kubernetes.io/cluster-service: "true"

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -5,7 +5,7 @@
 
 image:
   repository: k8s.gcr.io/kubernetes-dashboard-amd64
-  tag: v1.8.1
+  tag: v1.8.3
   pullPolicy: IfNotPresent
 
 ## Here labels can be added to the kubernets dashboard deployment
@@ -25,9 +25,16 @@ labels: {}
 ##
 nodeSelector: {}
 
+## List of node taints to tolerate (requires Kubernetes >= 1.6)
+tolerations: []
+#  - key: "key"
+#    operator: "Equal|Exists"
+#    value: "value"
+#    effect: "NoSchedule|PreferNoSchedule|NoExecute"
+
 service:
   type: ClusterIP
-  externalPort: 80
+  externalPort: 443
 
   ## This allows an overide of the heapster service name
   ## Default: {{ .Chart.Name }}
@@ -81,6 +88,10 @@ rbac:
   ## If true, create & use RBAC resources
   #
   create: false
+  ## If true, cluster-admin ClusterRole will be used for dashboard ServiceAccount (NOT RECOMMENDED)
+  ## If false, only minimal recommended role will be used.
+  #
+  clusterAdminRole: false
 
   ## Ignored if rbac.create is true
   #

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -85,14 +85,16 @@ ingress:
   #       - kubernetes-dashboard.domain.com
 
 rbac:
-  ## If true, create & use RBAC resources
-  #
-  create: false
-  ## If true, cluster-admin ClusterRole will be used for dashboard ServiceAccount (NOT RECOMMENDED)
-  ## If false, only minimal recommended role will be used.
-  #
+  # Specifies whether RBAC resources should be created
+  create: true
+
+  # Specifies whether cluster-admin ClusterRole will be used for dashboard
+  # ServiceAccount (NOT RECOMMENDED).
   clusterAdminRole: false
 
-  ## Ignored if rbac.create is true
-  #
-  serviceAccountName: default
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
In reaction to the [Tesla incident](https://blog.redlock.io/cryptojacking-tesla)...

Based on [Access control](https://github.com/kubernetes/dashboard/wiki/Access-control) best practises for Kubernetes Dashboard and great [talk](https://blog.heptio.com/on-securing-the-kubernetes-dashboard-16b09b1b7aca) from @jbeda:
- Use HTTPS by default
- Added minimal role for Kubernetes Dashboard (as default)
- Use cluster-admin role only if `rbac.clusterAdminRole` is `true` (not recommended)