### PR TITLE
datadog: support the agent6 in the helm chart

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.10.9
+version: 0.10.10
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/clusterrole.yaml
+++ b/stable/datadog/templates/clusterrole.yaml
@@ -28,22 +28,35 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: [""]
   resources:
-    - "namespaces" #
-    - "events"     # Cluster events + kube_service cache invalidation
-    - "services"   # kube_service tag
+    - "namespaces"
+    - "events"              # Cluster events + kube_service cache invalidation
+    - "componentstatuses"   # ServiceCheck apiserver in the agent6
+    - "services"            # kube_service tag agent5
+    - "endpoints"           # kube_service tag agent6
     - "nodes"
     - "pods"
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
 {{- if .Values.datadog.leaderElection }}
 - apiGroups: [""]
   resources:
     - "configmaps"
-  resourceNames: ["datadog-leader-elector"]
+  resourceNames:
+    - "datadog-leader-elector"  # agent5
+    - "datadogtoken"            # agent6
+    - "datadog-leader-election" # agent6
   verbs: ["get", "delete", "update"]
-- apiGroups: [""]
+- apiGroups:
+    - ""
   resources:
     - "configmaps"
   verbs: ["create"]
 {{- end }}
+- apiGroups:
+  - ""
+  resources: # Kubelet connectivity
+  - "nodes/metrics"
+  - "nodes/spec"
+  - "nodes/proxy"
+  verbs: ["get"]
 {{- end -}}
 

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -58,7 +58,9 @@ spec:
             value: {{ .Values.datadog.logLevel | quote }}
           {{- end }}
           {{- if .Values.datadog.nonLocalTraffic }}
-          - name: NON_LOCAL_TRAFFIC
+          - name: NON_LOCAL_TRAFFIC # agent5
+            value: {{ .Values.datadog.nonLocalTraffic | quote }}
+          - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC # agent6
             value: {{ .Values.datadog.nonLocalTraffic | quote }}
           {{- end }}
           {{- if .Values.datadog.tags }}
@@ -69,16 +71,31 @@ spec:
           - name: DD_APM_ENABLED
             value: {{ .Values.datadog.apmEnabled | quote }}
           {{- end }}
-          - name: KUBERNETES_LEADER_CANDIDATE
+          - name: KUBERNETES_LEADER_CANDIDATE # agent5
+            value: {{ .Values.datadog.leaderElection | quote}}
+          - name: DD_LEADER_ELECTION  # agent6
             value: {{ .Values.datadog.leaderElection | quote}}
           {{- if .Values.datadog.leaderElection }}
-          - name: KUBERNETES_LEADER_LEASE_DURATION
+          - name: KUBERNETES_LEADER_LEASE_DURATION # agent5
             value: {{ default "600" .Values.datadog.leaderLeaseDuration | quote }}
+          - name: DD_LEADER_LEASE_DURATION # agent6
+            value: {{ default "60" .Values.datadog.leaderLeaseDuration | quote }}
           {{- end }}
-          - name: SD_BACKEND
+          {{- if .Values.datadog.collectEvents }}
+          - name: DD_COLLECT_KUBERNETES_EVENTS # agent6
+            value: {{.Values.datadog.collectEvents | quote}}
+          {{- end }}
+          - name: SD_BACKEND  # agent5
             value: docker
           - name: KUBERNETES
             value: "yes"
+          {{- if (semverCompare ">=1" .Capabilities.KubeVersion.Major) and (semverCompare ">=7" .Capabilities.KubeVersion.Minor) }}
+          - name: DD_KUBERNETES_KUBELET_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          {{- end }}
+
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -1,10 +1,10 @@
 # Default values for datadog.
 image:
   # This chart is compatible with different images, please choose one
-  repository: datadog/docker-dd-agent  # Agent5
-  # repository: datadog/agent          # Agent6 (beta)
-  # repository: datadog/dogstatsd      # Standalone DogStatsD6 (beta)
-  tag: latest
+  repository: datadog/agent               # Agent6
+  # repository: datadog/dogstatsd         # Standalone DogStatsD6
+  # repository: datadog/docker-dd-agent   # Agent5
+  tag: 6.0.0  # Use 6.0.0-jmx to enable jmx fetch collection
   pullPolicy: IfNotPresent
 
 # NB! Normally you need to keep Datadog DaemonSet enabled!


### PR DESCRIPTION
### What does this PR do?

This PR changes the datadog chart to run the datadog/agent in Kubernetes.