### PR TITLE
[stable/wordpress] removes unused `externalDatabase.rootPassword` param

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.8.7
+version: 0.8.8
 appVersion: 4.9.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -68,7 +68,6 @@ The following tables lists the configurable parameters of the WordPress chart an
 | `mariadb.mariadbUser`                | Database user to create                    | `bn_wordpress`                                             |
 | `mariadb.mariadbPassword`            | Password for the database                  | _random 10 character long alphanumeric string_             |
 | `externalDatabase.host`              | Host of the external database              | `localhost`                                                |
-| `externalDatabase.rootPassword`      | DB Root users password (schema creation)   | `nil`                                                    |
 | `externalDatabase.user`              | Existing username in the external db       | `bn_wordpress`                                             |
 | `externalDatabase.password`          | Password for the above username            | `nil`                                                      |
 | `externalDatabase.database`          | Name of the existing database              | `bitnami_wordpress`                                        |
@@ -123,10 +122,10 @@ Sometimes you may want to have Wordpress connect to an external database rather 
 
 ```console
 $ helm install stable/wordpress \
-    --set mariadb.enabled=false,externalDatabase.host=myexternalhost,externalDatabase.rootPassword=rootpassword,externalDatabase.user=myuser,externalDatabase.password=mypassword,externalDatabase.database=mydatabase,externalDatabase.port=3306
+    --set mariadb.enabled=false,externalDatabase.host=myexternalhost,externalDatabase.user=myuser,externalDatabase.password=mypassword,externalDatabase.database=mydatabase,externalDatabase.port=3306
 ```
-Note also if you disable MariaDB per above you MUST supply values for externalDatabase.rootPassword & externalDatabase.password.
 
+Note also if you disable MariaDB per above you MUST supply values for the `externalDatabase` connection.
 
 ## Ingress
 

--- a/stable/wordpress/templates/externaldb-secrets.yaml
+++ b/stable/wordpress/templates/externaldb-secrets.yaml
@@ -10,6 +10,5 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  db-root-password: {{ .Values.externalDatabase.rootPassword | b64enc | quote }}
   db-password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -62,7 +62,7 @@ externalDatabase:
   user: bn_wordpress
 
   ## Database password
-  # password:
+  password: ""
 
   ## Database name
   database: bitnami_wordpress

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -58,9 +58,6 @@ externalDatabase:
   ## Database host
   host: localhost
 
-  ## Database Root User (so wordpress can create the db schema etc)
-  # rootPassword:
-
   ## non-root Username for Wordpress Database
   user: bn_wordpress
 


### PR DESCRIPTION
*****************************************************************************************