### PR TITLE
Adding support for nodeSelector to newrelic-infrastructure

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.12
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/README.md
+++ b/stable/newrelic-infrastructure/README.md
@@ -15,6 +15,7 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 | `licenseKey`       | The license key for your New Relic Account.                  | ``                         |
 | `resources`        | Any resources you wish to assign to the pod.                 | See Resources below        |
 | `verboseLog`       | Should the agent log verbosely. (Boolean)                    | `false`                    |
+| `nodeSelector`     | Node label to use for scheduling                             | `nil`                      |
 | `tolerations`      | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`                      |
 
 ## Resources

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -84,6 +84,10 @@ spec:
             - key: newrelic-infra.yml
               path: newrelic-infra.yml
         {{- end }}
+      {{- if $.Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml $.Values.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -63,4 +63,8 @@ resources:
   #  team: alpha-team
   #
 
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
 tolerations: []


### PR DESCRIPTION
Adding nodeSelector support allows users to use targeted config files for custom attributes in newrelic. This makes distinguishing nodes much easier.