### PR TITLE
[incubator/sentry-kubernetes] add missing clusterrole and clusterrolebinding

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.1.0
+version: 0.1.1
 sources:
 - https://github.com/getsentry/sentry-kubernetes
 keywords:

--- a/incubator/sentry-kubernetes/templates/clusterrole.yaml
+++ b/incubator/sentry-kubernetes/templates/clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
+  name: {{ template "sentry-kubernetes.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/incubator/sentry-kubernetes/templates/clusterrolebinding.yaml
+++ b/incubator/sentry-kubernetes/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels: {{ include "sentry-kubernetes.labels" . | indent 4 }}
+  name: {{ template "sentry-kubernetes.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "sentry-kubernetes.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "sentry-kubernetes.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/incubator/sentry-kubernetes/templates/clusterrolebinding.yaml
+++ b/incubator/sentry-kubernetes/templates/clusterrolebinding.yaml
@@ -10,6 +10,6 @@ roleRef:
   name: {{ template "sentry-kubernetes.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "sentry-kubernetes.fullname" . }}
+    name: {{ template "sentry-kubernetes.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -34,4 +34,4 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "sentry-kubernetes.serviceAccountName" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ template "sentry-kubernetes.serviceAccountName" . }}

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -34,4 +34,4 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if .Values.rbac.create }}{{ template "sentry-kubernetes.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "sentry-kubernetes.serviceAccountName" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}


### PR DESCRIPTION
This PR adds the missing clusterrole and clusterrolebinding needed for the sentry-kubernetes chart.

It was part of the original PR https://github.com/kubernetes/charts/pull/2708 but wasn't formatted right.
You can see more about it [here](https://github.com/getsentry/sentry-kubernetes/issues/4) about why you need the role and binding.