### PR TITLE
Add SSL certificate support and AMPQS support

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.3
-version: 1.0.1
+version: 1.0.2
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,13 +1,14 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.3
-version: 1.0.0
+version: 1.0.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:
 - rabbitmq
 - message queue
 - AMQP
+- AMQPS
 - MQTT
 - STOMP
 home: https://www.rabbitmq.com

--- a/stable/rabbitmq-ha/templates/NOTES.txt
+++ b/stable/rabbitmq-ha/templates/NOTES.txt
@@ -14,11 +14,20 @@
 
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     export NODE_PORT_AMQP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "rabbitmq-ha.fullname" . }})
+    {{- if .Values.rabbitmqAmqpsSupport.enabled }}
+    export NODE_PORT_AMQPS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[4].nodePort}" services {{ template "rabbitmq-ha.fullname" . }})
+    {{- end }}
     export NODE_PORT_STATS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[3].nodePort}" services {{ template "rabbitmq-ha.fullname" . }})
 
   To Access the RabbitMQ AMQP port:
 
     echo amqp://$NODE_IP:$NODE_PORT_AMQP/
+
+{{- if .Values.rabbitmqAmqpsSupport.enabled }}
+  To Access the RabbitMQ AMQPS port:
+
+    echo amqps://$NODE_IP:$NODE_PORT_AMQPS/
+{{- end }}
 
   To Access the RabbitMQ Management interface:
 
@@ -30,10 +39,19 @@
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "rabbitmq-ha.name" . }}'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    {{- if .Values.rabbitmqAmqpsSupport.enabled }}
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[1].ip}')
+    {{- end }}
 
   To Access the RabbitMQ AMQP port:
 
     echo amqp://$SERVICE_IP:{{ .Values.rabbitmqNodePort }}/
+
+{{- if .Values.rabbitmqAmqpsSupport.enabled }}
+  To Access the RabbitMQ AMQPS port:
+
+    echo amqps://$SERVICE_IP:{{ .Values.rabbitmqAmqpsSupport.amqpsNodePort }}/
+{{- end }}
 
   To Access the RabbitMQ Management interface:
 
@@ -43,10 +61,19 @@
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "rabbitmq-ha.name" . }}" -o jsonpath="{.items[0].metadata.name}")
     kubectl port-forward $POD_NAME --namespace {{ .Release.Namespace }} {{ .Values.rabbitmqNodePort }}:{{ .Values.rabbitmqNodePort }} {{ .Values.rabbitmqManagerPort }}:{{ .Values.rabbitmqManagerPort }}
+    {{- if .Values.rabbitmqAmqpsSupport.enabled }}
+    kubectl port-forward $POD_NAME --namespace {{ .Release.Namespace }} {{ .Values.rabbitmqAmqpsSupport.amqpsNodePort }}:{{ .Values.rabbitmqAmqpsSupport.amqpsNodePort }} 
+    {{- end }}
 
   To Access the RabbitMQ AMQP port:
 
     echo amqp://127.0.0.1:{{ .Values.rabbitmqNodePort }}/
+
+{{- if .Values.rabbitmqAmqpsSupport.enabled }}
+  To Access the RabbitMQ AMQPS port:
+
+    echo amqps://127.0.0.1:{{ .Values.rabbitmqAmqpsSupport.amqpsNodePort }}/
+{{- end }}
 
   To Access the RabbitMQ Management interface:
 

--- a/stable/rabbitmq-ha/templates/NOTES.txt
+++ b/stable/rabbitmq-ha/templates/NOTES.txt
@@ -13,11 +13,11 @@
 {{- if contains "NodePort" .Values.service.type }}
 
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export NODE_PORT_AMQP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "rabbitmq-ha.fullname" . }})
+    export NODE_PORT_AMQP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name=="amqp")].nodePort}' services {{ template "rabbitmq-ha.fullname" . }})
     {{- if .Values.rabbitmqAmqpsSupport.enabled }}
-    export NODE_PORT_AMQPS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[4].nodePort}" services {{ template "rabbitmq-ha.fullname" . }})
+    export NODE_PORT_AMQPS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name=="amqps")].nodePort}' services {{ template "rabbitmq-ha.fullname" . }})
     {{- end }}
-    export NODE_PORT_STATS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[3].nodePort}" services {{ template "rabbitmq-ha.fullname" . }})
+    export NODE_PORT_STATS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}' services {{ template "rabbitmq-ha.fullname" . }})
 
   To Access the RabbitMQ AMQP port:
 

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -31,6 +31,10 @@ data:
       rabbitmq_web_stomp,
       {{- end }}
 
+      {{- if .Values.rabbitmqAuth.enabled }}
+      rabbitmq_auth_mechanism_ssl,
+      {{- end }}
+
       rabbitmq_consistent_hash_exchange,
       rabbitmq_federation,
       rabbitmq_federation_management,

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -43,6 +43,11 @@ data:
   rabbitmq.conf: |
     ## RabbitMQ configuration
     ## Ref: https://github.com/rabbitmq/rabbitmq-server/blob/master/docs/rabbitmq.conf.example
+    
+    ## Authentification
+    {{- if .Values.rabbitmqAuth.enabled }}
+{{ .Values.rabbitmqAuth.config | indent 4 }}
+    {{- end }}
 
     ## Clustering
     cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
@@ -83,4 +88,10 @@ data:
     {{- if .Values.rabbitmqWebSTOMPPlugin.enabled }}
 {{ .Values.rabbitmqWebSTOMPPlugin.config | indent 4 }}
     {{- end }}
+
+    ## AMQPS support
+    {{- if .Values.rabbitmqAmqpsSupport.enabled }}
+{{ .Values.rabbitmqAmqpsSupport.config | indent 4 }}
+    {{- end }}
+
 {{- end }}

--- a/stable/rabbitmq-ha/templates/secret.yaml
+++ b/stable/rabbitmq-ha/templates/secret.yaml
@@ -19,3 +19,20 @@ data:
   {{ else }}
   rabbitmq-erlang-cookie: {{ randAlphaNum 32 | b64enc | quote }}
   {{ end }}
+{{- if .Values.rabbitmqCert.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rabbitmq-ha.fullname" . }}-cert
+  labels:
+    app: {{ template "rabbitmq-ha.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  cacert.pem: {{ .Values.rabbitmqCert.cacertfile | quote }}
+  cert.pem: {{ .Values.rabbitmqCert.certfile | quote }}
+  key.pem: {{ .Values.rabbitmqCert.keyfile | quote }}
+{{- end }}

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -69,6 +69,12 @@ spec:
       port: 15675
       targetPort: mqtt-ws
     {{- end }}
+    {{- if .Values.rabbitmqAmqpsSupport.enabled }}
+    - name: amqps
+      protocol: TCP
+      port: {{ .Values.rabbitmqAmqpsSupport.amqpsNodePort }}
+      targetPort: amqps
+    {{- end }}
   selector:
     app: {{ template "rabbitmq-ha.name" . }}
     release: {{ .Release.Name }}

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -64,6 +64,11 @@ spec:
               protocol: TCP
               containerPort: 15675
             {{- end }}
+            {{- if .Values.rabbitmqAmqpsSupport.enabled }}
+            - name: amqps
+              protocol: TCP
+              containerPort: 5671
+            {{- end }}
           livenessProbe:
             exec:
               command:
@@ -114,6 +119,10 @@ spec:
               mountPath: /var/lib/rabbitmq
             - name: config
               mountPath: /etc/rabbitmq
+            {{- if .Values.rabbitmqCert.enabled }}
+            - name: cert
+              mountPath: /etc/cert
+            {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
@@ -147,6 +156,12 @@ spec:
         - name: config
           configMap:
             name: {{ template "rabbitmq-ha.fullname" . }}
+        {{- if .Values.rabbitmqCert.enabled }}
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: {{ template "rabbitmq-ha.fullname" . }}-cert
+        {{- end }}
 {{- if .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -36,6 +36,25 @@ rabbitmqManagerPort: 15672
 ## of a few minutes delay at startup.
 rabbitmqHipeCompile: false
 
+## SSL certificates
+## Red: http://www.rabbitmq.com/ssl.html
+rabbitmqCert:
+  enabled: false
+
+  cacertfile: |
+  certfile: |
+  keyfile: |
+
+## Authentification mecanism
+## Ref: http://www.rabbitmq.com/authentication.html
+rabbitmqAuth:
+  enabled: false
+
+  config: |
+    # auth_mechanisms.1 = PLAIN
+    # auth_mechanisms.2 = AMQPLAIN
+    # auth_mechanisms.3 = EXTERNAL
+
 ## LDAP Plugin
 ## Ref: http://www.rabbitmq.com/ldap.html
 rabbitmqLDAPPlugin:
@@ -70,9 +89,9 @@ rabbitmqWebMQTTPlugin:
   config: |
     # web_mqtt.ssl.port       = 12345
     # web_mqtt.ssl.backlog    = 1024
-    # web_mqtt.ssl.certfile   = path/to/certs/client/cert.pem
-    # web_mqtt.ssl.keyfile    = path/to/certs/client/key.pem
-    # web_mqtt.ssl.cacertfile = path/to/certs/testca/cacert.pem
+    # web_mqtt.ssl.certfile   = /etc/cert/cacert.pem
+    # web_mqtt.ssl.keyfile    = /etc/cert/cert.pem
+    # web_mqtt.ssl.cacertfile = /etc/cert/key.pem
     # web_mqtt.ssl.password   = changeme
 
 ## STOMP Plugin
@@ -94,6 +113,23 @@ rabbitmqWebSTOMPPlugin:
   config: |
     # web_stomp.ws_frame = binary
     # web_stomp.cowboy_opts.max_keepalive = 10
+
+## AMQPS support
+## Ref: http://www.rabbitmq.com/ssl.html
+rabbitmqAmqpsSupport:
+  enabled: false
+
+  # NodePort
+  amqpsNodePort: 5671
+
+  # SSL configuration
+  config: |
+    # listeners.ssl.default             = 5671
+    # ssl_options.cacertfile            = /etc/cert/cacert.pem
+    # ssl_options.certfile              = /etc/cert/cert.pem
+    # ssl_options.keyfile               = /etc/cert/key.pem
+    # ssl_options.verify                = verify_peer
+    # ssl_options.fail_if_no_peer_cert  = false
 
 ## Number of replicas
 replicaCount: 3


### PR DESCRIPTION
Chart stable/rabbitmq-ha:
- I have added support for using SSL certificate and use AMPQS.
- I have changed the config of rabbitmqWebMQTTPlugin to be able to use the added certificate
- I have added the possibility to add RabbitMQ authentification in the configuration file