### PR TITLE
[incubator/patroni] Declare port name so service and endpoint bind correctly

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.6
+version: 0.6.1
 appVersion: 1.3-p4
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/templates/svc-patroni.yaml
+++ b/incubator/patroni/templates/svc-patroni.yaml
@@ -10,5 +10,6 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - port: 5432
+  - name: postgresql
+    port: 5432
     targetPort: 5432


### PR DESCRIPTION
The port that gets declared by Spilo for the endpoint has a [hardcoded](https://github.com/zalando/spilo/blob/8fcddb1a89043653d329e52c132551b1cdb67530/postgres-appliance/callback_role.py#L67) name `postgresql`.

The service definition this chart offers did not have this name, resulting in a mismatch between the endpoint and the service. Which resulted in Patroni not being exposed by the service.

This PR simply adds the name so Kubernetes can make the match.