### PR TITLE
[incubator/patroni] Removed obsolete admin password option

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.6
+version: 0.6.2
 appVersion: 1.3-p4
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -63,7 +63,6 @@ The following tables lists the configurable parameters of the patroni chart and 
 | `Resources.Cpu`         | container requested cpu             | `100m`                                              |
 | `Resources.Memory`      | container requested memory          | `512Mi`                                             |
 | `Credentials.Superuser` | password for the superuser          | `tea`                                               |
-| `Credentials.Admin`     | password for the admin user         | `cola`                                              |
 | `Credentials.Standby`   | password for the replication user   | `pinacolada`                                        |
 | `Etcd.Enable`           | using etcd as DCS                   | `true`                                              |
 | `Etcd.DeployChart`      | deploy etcd chart                   | `true`                                              |

--- a/incubator/patroni/templates/NOTES.txt
+++ b/incubator/patroni/templates/NOTES.txt
@@ -1,10 +1,7 @@
 Patroni can be accessed via port 5432 on the following DNS name from within your cluster:
 {{ template "patroni.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
-To get your password for superuser or admin run:
-
-    # admin user password
-    PGPASSWORD_ADMIN=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "patroni.fullname" . }} -o jsonpath="{.data.password-admin}" | base64 --decode)
+To get your password for superuser run:
 
     # superuser password
     PGPASSWORD_SUPERUSER=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "patroni.fullname" . }} -o jsonpath="{.data.password-superuser}" | base64 --decode)
@@ -12,12 +9,6 @@ To get your password for superuser or admin run:
 To connect to your database:
 
 1. Run a postgres pod and connect using the psql cli:
-    # login as admin
-    kubectl run -i --tty --rm psql --image=postgres \
-      --env "PGPASSWORD=$PGPASSWORD_ADMIN" \
-      --command -- psql -U admin \
-      -h {{ template "patroni.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
-
     # login as superuser
     kubectl run -i --tty --rm psql --image=postgres \
       --env "PGPASSWORD=$PGPASSWORD_SUPERUSER" \

--- a/incubator/patroni/templates/sec-patroni.yaml
+++ b/incubator/patroni/templates/sec-patroni.yaml
@@ -10,5 +10,4 @@ metadata:
 type: Opaque
 data:
   password-superuser: {{ .Values.Credentials.Superuser | b64enc }}
-  password-admin: {{ .Values.Credentials.Admin | b64enc }}
   password-standby: {{ .Values.Credentials.Standby | b64enc }}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -35,11 +35,6 @@ spec:
             secretKeyRef:
               name: {{ template "patroni.fullname" . }}
               key: password-superuser
-        - name: PGPASSWORD_ADMIN
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "patroni.fullname" . }}
-              key: password-admin
         - name: PGPASSWORD_STANDBY
           valueFrom:
             secretKeyRef:

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -25,7 +25,6 @@ Resources:
 # * more information: https://github.com/zalando/patroni/blob/master/docs/SETTINGS.rst#postgresql
 Credentials:
   Superuser: tea
-  Admin: cola
   Standby: pinacolada
 
 ## Distribution Configuration stores. Please note that only one of the following stores should be selected.


### PR DESCRIPTION
:warning: ~~**https://github.com/kubernetes/charts/pull/3953 should go first**~~ :warning: 

There is no Spilo release available based upon PostgreSQL 9.6 with a working admin configuration option (https://github.com/zalando/spilo/pull/189).

Remove the option to not confuse any chart users.

I will create an additional PR with a new minor version to re-add the option based upon a PostgreSQL 10 image. Will also deal with the lack of best practices in this PR.