### PR TITLE
Make the strategy configurable

### DIFF
--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 0.3.5
+version: 0.3.6
 appVersion: 0.3.1
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -9,9 +9,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
+{{ toYaml .Values.stategy | indent 4 }}
   revisionHistoryLimit: 10
   template:
     metadata:

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-{{ toYaml .Values.stategy | indent 4 }}
+{{ toYaml .Values.strategy | indent 4 }}
   revisionHistoryLimit: 10
   template:
     metadata:

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -1,4 +1,8 @@
 replicaCount: 1
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
 image:
   repository: chartmuseum/chartmuseum
   tag: v0.3.1


### PR DESCRIPTION
This is important if you're using the chart with STORAGE=local
together with a persistent volume claim. In this case the default of
RollingUpdate will cause problems during deployments as the new pod
will be stuck in ContainerCreating while it waits for the pvc to
become available.
