### PR TITLE
[stable/docker-registry]: Add support for a predefined NodePort, and predefined PVC

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.6.2
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -25,25 +25,29 @@ $ helm install stable/docker-registry
 The following tables lists the configurable parameters of the vault chart and
 their default values.
 
-|       Parameter            |           Description                       |                         Default                     |
-|----------------------------|---------------------------------------------|-----------------------------------------------------|
-| `image.pullPolicy`         | Container pull policy                       | `IfNotPresent`                                      |
-| `image.repository`         | Container image to use                      | `registry`                                          |
-| `image.tag`                | Container image tag to deploy               | `2.6.2`                                             |
-| `persistence.accessMode`   | Access mode to use for PVC                  | `ReadWriteOnce`                                     |
-| `persistence.enabled`      | Whether to use a PVC for the Docker storage | `false`                                             |
-| `persistence.size`         | Amount of space to claim for PVC            | `10Gi`                                              |
-| `persistence.storageClass` | Storage Class to use for PVC                | `-`                                                 |
-| `replicaCount`             | k8s replicas                                | `1`                                                 |
-| `resources.limits.cpu`     | Container requested CPU                     | `nil`                                               |
-| `resources.limits.memory`  | Container requested memory                  | `nil`                                               |
-| `storage`                  | Storage system to use                       | `fileststem`                                        |
-| `tlsSecretName`            | Name of secret for TLS certs                | `nil`                                               |
-| `secrets.htpasswd`         | Htpasswd authentication                     | `nil`                                               |
-| `secrets.s3.accessKey`     | Access Key for S3 configuration             | `nil`                                               |
-| `secrets.s3.secretKey`     | Secret Key for S3 configuration             | `nil`                                               |
-| `haSharedSecret`           | Shared secret for Registry                  | `nil`                                               |
-| `configData`               | Configuration hash for docker               | `nil`                                               |
+| Parameter                   | Description                                                                              | Default         |
+|:----------------------------|:-----------------------------------------------------------------------------------------|:----------------|
+| `image.pullPolicy`          | Container pull policy                                                                    | `IfNotPresent`  |
+| `image.repository`          | Container image to use                                                                   | `registry`      |
+| `image.tag`                 | Container image tag to deploy                                                            | `2.6.2`         |
+| `persistence.accessMode`    | Access mode to use for PVC                                                               | `ReadWriteOnce` |
+| `persistence.enabled`       | Whether to use a PVC for the Docker storage                                              | `false`         |
+| `persistence.size`          | Amount of space to claim for PVC                                                         | `10Gi`          |
+| `persistence.storageClass`  | Storage Class to use for PVC                                                             | `-`             |
+| `persistence.existingClaim` | Name of an existing PVC to use for config                                                | `nil`           |
+| `service.port`              | TCP port on which the service is exposed                                                 | `5000`          |
+| `service.type`              | service type                                                                             | `ClusterIP`     |
+| `service.nodePort`          | if `service.type` is `NodePort` and this is non-empty, sets the node port of the service | `nil`           |
+| `replicaCount`              | k8s replicas                                                                             | `1`             |
+| `resources.limits.cpu`      | Container requested CPU                                                                  | `nil`           |
+| `resources.limits.memory`   | Container requested memory                                                               | `nil`           |
+| `storage`                   | Storage system to use                                                                    | `fileststem`    |
+| `tlsSecretName`             | Name of secret for TLS certs                                                             | `nil`           |
+| `secrets.htpasswd`          | Htpasswd authentication                                                                  | `nil`           |
+| `secrets.s3.accessKey`      | Access Key for S3 configuration                                                          | `nil`           |
+| `secrets.s3.secretKey`      | Secret Key for S3 configuration                                                          | `nil`           |
+| `haSharedSecret`            | Shared secret for Registry                                                               | `nil`           |
+| `configData`                | Configuration hash for docker                                                            | `nil`           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
         - name: data
       {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "docker-registry.fullname" . }}
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "docker-registry.fullname" . }}{{- end }}
       {{- else }}
           emptyDir: {}
       {{- end -}}

--- a/stable/docker-registry/templates/pvc.yaml
+++ b/stable/docker-registry/templates/pvc.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.persistence.enabled }}
+{{- if not .Values.persistence.existingClaim -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -22,3 +23,4 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end -}}

--- a/stable/docker-registry/templates/service.yaml
+++ b/stable/docker-registry/templates/service.yaml
@@ -18,6 +18,9 @@ spec:
       protocol: TCP
       name: {{ .Values.service.name }}
       targetPort: {{ .Values.service.port }}
+{{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{ .Values.service.nodePort }}
+{{- end }}
   selector:
     app: {{ template "docker-registry.name" . }}
     release: {{ .Release.Name }}

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -10,6 +10,7 @@ service:
   name: registry
   type: ClusterIP
   port: 5000
+  # nodePort:
   annotations: {}
   # foo.io/bar: "true"
 ingress:


### PR DESCRIPTION
Allow to specify a specific node port to use for the registry, as well as allow for
using a pre-created volume+volumeclaim.
