### PR TITLE
[stable/prometheus] update prometheus.io/port regex

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.4.0
+version: 5.4.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -834,7 +834,7 @@ serverFiles:
           - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
             action: replace
             target_label: __address__
-            regex: (.+)(?::\d+);(\d+)
+            regex: ([^:]+)(?::\d+)?;(\d+)
             replacement: $1:$2
           - action: labelmap
             regex: __meta_kubernetes_service_label_(.+)
@@ -911,7 +911,7 @@ serverFiles:
             regex: (.+)
           - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             action: replace
-            regex: (.+):(?:\d+);(\d+)
+            regex: ([^:]+)(?::\d+)?;(\d+)
             replacement: ${1}:${2}
             target_label: __address__
           - action: labelmap

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -912,7 +912,7 @@ serverFiles:
           - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             action: replace
             regex: ([^:]+)(?::\d+)?;(\d+)
-            replacement: ${1}:${2}
+            replacement: $1:$2
             target_label: __address__
           - action: labelmap
             regex: __meta_kubernetes_pod_label_(.+)


### PR DESCRIPTION
Most of our pods have the "scrape" annotation set without actually setting the port. That usually works fine, and prometheus scrapes all the containerPorts in the pod without configuration.

Recently, I deployed a pod with multiple containers, but only 1 port to scrape metrics from, so I set the `prometheus.io/port` annotation. Prometheus didn't seem to listen to the annotation, and instead scraped port 80, as well as all the other containerPorts. After changing the regex for the port replace, only the specific port I set with the annotation was scraped.

I got the regex from here: https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml#L263

Honestly, I don't fully understand the implications of this change. Perhaps it's dumb, but it _does_ seem to fix my issue.