### PR TITLE
Removing hardcoded secret name from newrelic-infrastructure

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.0.12
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
       volumes:
         - name: newrelic-config
           secret:
-            secretName: newrelic-config
+            secretName: {{ template "newrelic-infra.fullname" . }}-config
         - name: dev
           hostPath:
             path: /dev

--- a/stable/newrelic-infrastructure/templates/secret.yaml
+++ b/stable/newrelic-infrastructure/templates/secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels: {{ include "newrelic-infra.labels" . | indent 4 }}
-  name: newrelic-config
+  name: {{ template "newrelic-infra.fullname" . }}-config
 type: Opaque
 data:
   config: {{ ( printf "export NRIA_LICENSE_KEY=%s" .Values.licenseKey ) | b64enc }}


### PR DESCRIPTION
This PR removes the hardcoded secret name for the license key and instead uses the `{{ template "newrelic-infra.fullname" . }}-config` format.

If installing multiple copies of the DS into the same namespace (example: one for masters and one for nodes) it will fail since the secret already exists.