### PR TITLE
jaeger: spark: Allow values file configuration of failed and successful CronJob history limits, with defaults

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.4
+version: 0.3.5
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -187,6 +187,8 @@ The following tables lists the configurable parameters of the Jaeger chart and t
 | `spark.image`                            | Image for the dependencies job      |  jaegertracing/spark-dependencies      |
 | `spark.pullPolicy`                       | Image pull policy of the deps image |  Always                                |
 | `spark.schedule`                         | Schedule of the cron job            |  "49 23 * * *"                         |
+| `spark.successfulJobsHistoryLimit`       | Cron job successfulJobsHistoryLimit |  5                                     |
+| `spark.failedJobsHistoryLimit`           | Cron job failedJobsHistoryLimit     |  5                                     |
 | `spark.tag`                              | Tag of the dependencies job image   |  latest                                |
 | `storage.cassandra.host`                 | Provisioned cassandra host          |  cassandra                             |
 | `storage.cassandra.password`             | Provisioned cassandra password      |  password                              |

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -17,8 +17,8 @@ metadata:
 {{- end }}
 spec:
   schedule: {{ .Values.spark.schedule | quote }}
-  successfulJobsHistoryLimit: {{ default 5 .Values.spark.successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ default 5 .Values.spark.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.spark.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.spark.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -17,6 +17,8 @@ metadata:
 {{- end }}
 spec:
   schedule: {{ .Values.spark.schedule | quote }}
+  successfulJobsHistoryLimit: {{ default 5 .Values.spark.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 5 .Values.spark.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -187,6 +187,8 @@ spark:
   tag: latest
   pullPolicy: Always
   schedule: "49 23 * * *"
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
   resources: {}
     # limits:
     #   cpu: 500m


### PR DESCRIPTION
For the Jaeger tracing Chart, make the Spark CronJob's successfulJobsHistoryLimit and failedJobsHistoryLimit configurable, with a default if not specified.

This was suggested by [Michael Lorant](https://github.com/mikelorant)