### PR TITLE
[stable/prometheus] Add ImagePullSecrets Option

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.4.0
+version: 5.4.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -97,7 +97,7 @@ Parameter | Description | Default
 `alertmanager.image.repository` | alertmanager container image repository | `prom/alertmanager`
 `alertmanager.image.tag` | alertmanager container image tag | `v0.13.0`
 `alertmanager.image.pullPolicy` | alertmanager container image pull policy | `IfNotPresent`
-`alertmanager.imagePullSecrets` | alertmanager container image pull Secrets | `IfNotPresent`
+`alertmanager.imagePullSecrets` | alertmanager container image pull Secrets | `[]`
 `alertmanager.prefixURL` | The prefix slug at which the server can be accessed | ``
 `alertmanager.baseURL` | The external url at which the server can be accessed | `/`
 `alertmanager.extraArgs` | Additional alertmanager container arguments | `{}`
@@ -205,7 +205,7 @@ Parameter | Description | Default
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
 `server.image.tag` | Prometheus server container image tag | `v2.1.0`
 `server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
-`server.imagePullSecrets` | Prometheus server container image pull Secrets | `IfNotPresent`
+`server.imagePullSecrets` | Prometheus server container image pull Secrets | `[]`
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``
 `server.baseURL` | The external url at which the server can be accessed | ``

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -97,6 +97,7 @@ Parameter | Description | Default
 `alertmanager.image.repository` | alertmanager container image repository | `prom/alertmanager`
 `alertmanager.image.tag` | alertmanager container image tag | `v0.13.0`
 `alertmanager.image.pullPolicy` | alertmanager container image pull policy | `IfNotPresent`
+`alertmanager.imagePullSecrets` | alertmanager container image pull Secrets | `IfNotPresent`
 `alertmanager.prefixURL` | The prefix slug at which the server can be accessed | ``
 `alertmanager.baseURL` | The external url at which the server can be accessed | `/`
 `alertmanager.extraArgs` | Additional alertmanager container arguments | `{}`
@@ -204,6 +205,7 @@ Parameter | Description | Default
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
 `server.image.tag` | Prometheus server container image tag | `v2.1.0`
 `server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
+`server.imagePullSecrets` | Prometheus server container image pull Secrets | `IfNotPresent`
 `server.extraArgs` | Additional Prometheus server container arguments | `{}`
 `server.prefixURL` | The prefix slug at which the server can be accessed | ``
 `server.baseURL` | The external url at which the server can be accessed | ``

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -27,6 +27,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "prometheus.alertmanager.fullname" . }}{{ else }}"{{ .Values.alertmanager.serviceAccountName }}"{{ end }}
+    {{- if .Values.alertmanager.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.alertmanager.imagePullSecrets | indent 8 }}
+    {{- end }}
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.alertmanager.name }}
           image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -26,6 +26,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "prometheus.server.fullname" . }}{{ else }}"{{ .Values.server.serviceAccountName }}"{{ end }}
+    {{- if .Values.alertmanager.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.alertmanager.imagePullSecrets | indent 8 }}
+    {{- end }}
       initContainers:
       - name: "{{ .Values.initChownData.name }}"
         image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -20,6 +20,11 @@ alertmanager:
     tag: v0.13.0
     pullPolicy: IfNotPresent
 
+  ## imagePullSecrets for pulling images
+  ##
+  imagePullSecrets: []
+    # - name: awsregistry
+
   ## Additional alertmanager container arguments
   ##
   extraArgs: {}
@@ -385,6 +390,11 @@ server:
     repository: prom/prometheus
     tag: v2.1.0
     pullPolicy: IfNotPresent
+
+  ## imagePullSecrets for pulling images
+  ##
+  imagePullSecrets: []
+    # - name: awsregistry
 
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug
   ## so that the various internal URLs are still able to access as they are in the default case.


### PR DESCRIPTION
*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
For Private registry for images, ImagePullSecrets is needed which is not an option right now. This patch provides that in alertmanager and server.