### PR TITLE
[stable/concourse] Enable AWS SSM support for Credential Manager

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.0.2
+version: 1.0.3
 appVersion: 3.9.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -383,3 +383,33 @@ credentialManager:
     # pathPrefix:
 
 ```
+
+#### AWS Systems Manager Paramter Store (SSM)
+
+To use SSM, set `credentialManager.kubernetes.enabled` to false, and set `credentialManager.ssm.enabled` to true.
+
+For a given Concourse *team*, a pipeline will look for secrets in SSM using either `/concourse/{team}/{secret}` or `/concourse/{team}/{pipeline}/{secret}`; the patterns can be overridden using the `credentialManager.ssm.teamSecretTemplate` and `credentialManager.ssm.pipelineSecretTemplate` settings.
+
+Concourse requires AWS credentials which are able to read from SSM for this feature to function. Credentials can be set in the `secrets.awsSsm*` settings; if your cluster is running in a different AWS region, you may also need to set `credentialManager.ssm.region`.
+
+The minimum IAM policy you need to use SSM with Concourse is:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "kms:Decrypt",
+      "Resource": "<kms-key-arn>",
+      "Effect": "Allow"
+    },
+    {
+      "Action": "ssm:GetParameter*",
+      "Resource": "<...arn...>:parameter/concourse/*",
+      "Effect": "Allow"
+    }
+  ]
+}
+```
+
+Where `<kms-key-arn>` is the ARN of the KMS key used to encrypt the secrets in Paraemter Store, and the `<...arn...>` should be replaced with a correct ARN for your account and region's Parameter Store.

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -141,7 +141,11 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `credentialManager.kubernetes.enabled` | Enable Kubernetes Secrets Credential Manager | `true` |
 | `credentialManager.kubernetes.namespacePrefix` | Prefix for namespaces to look for secrets in | `.Release.Name-` |
 | `credentialManager.kubernetes.teams` | Teams to allow secret access when rbac is enabled | `["main"]` |
-| `credentialManager.vault.enabled` | Uuse Hashicorp Vault as a Credential Manager | `false` |
+| `credentialManager.ssm.enabled` | Use AWS SSM as a Credential Manager | `false` |
+| `credentialManager.ssm.region` | AWS Region to use for SSM | `nil` |
+| `credentialManager.ssm.pipelineSecretsTemplate` | Pipeline secrets template | `nil` |
+| `credentialManager.ssm.teamSecretsTemplate` | Team secrets template | `nil` |
+| `credentialManager.vault.enabled` | Use Hashicorp Vault as a Credential Manager | `false` |
 | `credentialManager.vault.url` | Vault Server URL | `nil` |
 | `credentialManager.vault.pathPrefix` | Vault path to namespace secrets | `/concourse` |
 | `credentialManager.vault.caCert` | CA public certificate when using self-signed TLS with Vault | `nil` |
@@ -158,6 +162,10 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `secrets.workerKeyPub` | Concourse Worker Public Key | *See [values.yaml](values.yaml)* |
 | `secrets.encryptionKey` | current encryption key | `nil` |
 | `secrets.oldEncryptionKey` | old encryption key, used for key rotation | `nil` |
+| `secrets.awsSsmAccessKey` | AWS Access Key ID for SSM access | `nil` |
+| `secrets.awsSsmSecretKey` | AWS Secret Access Key ID for SSM access | `nil` |
+| `secrets.awsSsmSessionToken` | AWS Session Token for SSM access | `nil` |
+
 | `secrets.basicAuthUsername` | Concourse Basic Authentication Username | `concourse` |
 | `secrets.basicAuthPassword` | Concourse Basic Authentication Password | `concourse` |
 | `secrets.githubAuthClientId` | Application client ID for GitHub OAuth | `nil` |

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -46,4 +46,11 @@ data:
   vault-client-cert: {{ default "" .Values.secrets.vaultClientCert | b64enc | quote }}
   vault-client-key: {{ default "" .Values.secrets.vaultClientKey | b64enc | quote }}
   {{- end }}
+  {{- if .Values.credentialManager.ssm.enabled }}
+  aws-ssm-access-key: {{ default "" .Values.secrets.awsSsmAccessKey | b64enc | quote }}
+  aws-ssm-secret-key: {{ default "" .Values.secrets.awsSsmSecretKey | b64enc | quote }}
+  {{- if .Values.secrets.awsSsmSessionToken }}
+  aws-ssm-session-token: {{ .Values.secrets.awsSsmSessionToken | b64enc | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -32,6 +32,10 @@ spec:
             {{- if .Values.credentialManager.kubernetes.enabled }}
             - "--kubernetes-in-cluster"
             {{- end }}
+            {{- if .Values.credentialManager.ssm.enabled }}
+            - "--aws-ssm-region"
+            - "$(CONCOURSE_AWS_SSM_REGION)"
+            {{- end }}
           env:
             - name: CONCOURSE_TSA_HOST_KEY
               value: "/concourse-keys/host_key"
@@ -211,6 +215,37 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-approle-secret-id
+            {{- end }}
+            {{- end }}
+            {{- if .Values.credentialManager.ssm.enabled }}
+            - name: CONCOURSE_AWS_SSM_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: aws-ssm-access-key
+            - name: CONCOURSE_AWS_SSM_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: aws-ssm-secret-key
+            {{- if .Values.secrets.awsSsmSessionToken }}
+            - name: CONCOURSE_AWS_SSM_SESSION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: aws-ssm-session-token
+            {{- end }}
+            {{- if .Values.credentialManager.ssm.region }}
+            - name: CONCOURSE_AWS_SSM_REGION
+              value: {{ .Values.credentialManager.ssm.region | quote }}
+            {{- end }}
+            {{- if .Values.credentialManager.ssm.pipelineSecretTemplate }}
+            - name: CONCOURSE_AWS_SSM_PIPELINE_SECRET_TEMPLATE
+              value: {{ .Values.credentialManager.ssm.pipelineSecretTemplate | quote }}
+            {{- end }}
+            {{- if .Values.credentialManager.ssm.teamSecretTemplate }}
+            - name: CONCOURSE_AWS_SSM_TEAM_SECRET_TEMPLATE
+              value: {{ .Values.credentialManager.ssm.teamSecretTemplate | quote }}
             {{- end }}
             {{- end }}
             {{- if .Values.web.metrics.prometheus.enabled }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -457,6 +457,26 @@ credentialManager:
     teams:
       - main
 
+  ## Configuration for AWS SSM as the Credential Manager. Supported in Concourse 3.9.0.
+  ##
+  ssm:
+
+    ## Enable the use of AWS SSM.
+    ##
+    enabled: false
+
+    ## AWS region to use when reading from SSM
+    ##
+    # region:
+
+    ## pipeline-specific template for SSM parameters, defaults to: /concourse/{team}/{pipeline}/{secret}
+    ##
+    # pipelineSecretTemplate:
+
+    ## team-specific template for SSM parameters, defaults to: /concourse/{team}/{secret}
+    ##
+    # teamSecretTemplate: ''
+
   ## Configuration for Hashicorp Vault as the Credential Manager.
   ##
   vault:
@@ -611,6 +631,11 @@ secrets:
   ##
   # encryptionKey:
   # oldEncryptionKey:
+
+  ## Secrets for SSM AWS access
+  # awsSsmAccessKey:
+  # awsSsmSecretKey:
+  # awsSsmSessionToken:
 
   ## Secrets for Concourse basic auth
   ##


### PR DESCRIPTION
Allow enabling and configuring AWS SSM support for Concourse's Credential Manager.

This is still undocumented in the Concourse credentials docs, but was enabled in `3.9.0`. I've tested this and have successfully been able to pull a secret from SSM in my pipelines.

```yaml
jobs:
- name: test credentials
  plan:
  - task: echo
    config:
      platform: linux
      image_resource:
        type: docker-image
        source:
          repository: busybox
      params:
        secret: ((test-secret))
      run:
        path: echo
        args:
        - "the secret is: $secret"
```

<img width="1054" alt="screen shot 2018-03-03 at 9 50 03 pm" src="https://user-images.githubusercontent.com/10828/36933454-f386bb30-1f2c-11e8-91cc-cf3cf7cc6d07.png">

<img width="407" alt="screen shot 2018-03-03 at 9 48 20 pm" src="https://user-images.githubusercontent.com/10828/36933444-b1eb6950-1f2c-11e8-81b9-8bcd81cdb155.png">

I pieced everything together from:

  - [PR which initially merged SSM support into Concourse/atc](https://github.com/concourse/atc/pull/229)
  - [Open issue about missing SSM docs](https://github.com/concourse/concourse/issues/2003)
  - [ATC spec](https://github.com/concourse/concourse/blob/6649dd5912632bd3e600f0cc9025ac539ffd21bd/jobs/atc/spec)
