### PR TITLE
[stable/quassel]: Ensure references to postgres dependancy are correct

### DIFF
--- a/stable/quassel/Chart.yaml
+++ b/stable/quassel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.12.4
 description: Quassel IRC is a modern, cross-platform, distributed IRC client.
 name: quassel
-version: 0.2.2
+version: 0.2.3
 icon: https://avatars3.githubusercontent.com/u/2965670
 home: https://quassel-irc.org/
 maintainers:

--- a/stable/quassel/templates/_helpers.tpl
+++ b/stable/quassel/templates/_helpers.tpl
@@ -30,3 +30,19 @@ Create chart name and version as used by the chart label.
 {{- define "quassel.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified app name for the postgres requirement.
+*/}}
+{{- define "quassel.postgresql.fullname" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/quassel/templates/deployment.yaml
+++ b/stable/quassel/templates/deployment.yaml
@@ -42,13 +42,13 @@ spec:
               value: {{ .Values.gid | quote }}
 {{- if .Values.postgresql.enabled }}
             - name: POSTGRESQL_HOST
-              value: {{ template "quassel.fullname" . }}-postgresql
+              value: {{ template "quassel.postgresql.fullname" . }}
             - name: POSTGRESQL_PORT
               value: "3306"
             - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "quassel.fullname" . }}-postgresql
+                  name: {{ template "quassel.postgresql.fullname" . }}
                   key: postgres-password
 {{- end }}
           volumeMounts:


### PR DESCRIPTION
When the postgresql dependancy is enabled with the latest verison of the
postgresql chart, the names we expected in this chart no longer line up.

We duplicate the postgresql fullname template in this chart, with some
slight modifications (changing .Chart.Name references to the hardcoded
string "postgresql", and changing .Values -> .Values.postgresql).

---

I'm not sure that is the best way - duplicating the template and making minor changes seems likely to end badly. However, this seems to be a fairly common pattern within the charts in this repo - e.g. I see kong, odoo, gitlab-ee/ce, redmine, concourse all depend on postgresql, and all duplicate it's fullname template. Each of these will have to refresh their copy of the template once they update the postgresql chart to 0.8.13 or newer.

---

An alternative implementation of this fix has been pushed as https://github.com/kubernetes/charts/pull/3972