### PR TITLE
[stable/quassel]: Ensure references to postgres dependancy are correct (alternative)

### DIFF
--- a/stable/quassel/Chart.yaml
+++ b/stable/quassel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.12.4
 description: Quassel IRC is a modern, cross-platform, distributed IRC client.
 name: quassel
-version: 0.2.2
+version: 0.2.3
 icon: https://avatars3.githubusercontent.com/u/2965670
 home: https://quassel-irc.org/
 maintainers:

--- a/stable/quassel/templates/_helpers.tpl
+++ b/stable/quassel/templates/_helpers.tpl
@@ -30,3 +30,11 @@ Create chart name and version as used by the chart label.
 {{- define "quassel.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified app name for the postgres requirement.
+*/}}
+{{- define "quassel.postgresql.fullname" -}}
+{{- $postgresContext := dict "Values" .Values.postgresql "Release" .Release "Chart" (dict "Name" "postgresql") -}}
+{{ template "postgresql.fullname" $postgresContext }}
+{{- end -}}

--- a/stable/quassel/templates/deployment.yaml
+++ b/stable/quassel/templates/deployment.yaml
@@ -42,13 +42,13 @@ spec:
               value: {{ .Values.gid | quote }}
 {{- if .Values.postgresql.enabled }}
             - name: POSTGRESQL_HOST
-              value: {{ template "quassel.fullname" . }}-postgresql
+              value: {{ template "quassel.postgresql.fullname" . }}
             - name: POSTGRESQL_PORT
               value: "3306"
             - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "quassel.fullname" . }}-postgresql
+                  name: {{ template "quassel.postgresql.fullname" . }}
                   key: postgres-password
 {{- end }}
           volumeMounts:


### PR DESCRIPTION
When the postgresql dependancy is enabled with the latest verison of the
postgresql chart, the names we expected in this chart no longer line up.

We create a local quassel.postgresql.fullname template in this chart. This
template will defer to the postgresql.fullname template, passing in a
context which lines up with the postgresql.fullname templates
expectations.

---

This is an alternative implementation of https://github.com/kubernetes/charts/pull/3971