### PR TITLE
Add a stable Helm chart for MetalLB.

### DIFF
--- a/stable/metallb/.helmignore
+++ b/stable/metallb/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 version: 0.1.0
 
 name: metallb
-appVersion: 0.4.0
+appVersion: 0.4.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
 home: https://metallb.universe.tf

--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+version: 0.1.0
+
+name: metallb
+appVersion: 0.4.0
+description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
+keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
+home: https://metallb.universe.tf
+icon: https://metallb.universe.tf/images/logo.png
+maintainers:
+- name: David Anderson
+  email: dave@natulte.net

--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -8,5 +8,5 @@ keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
 home: https://metallb.universe.tf
 icon: https://metallb.universe.tf/images/logo.png
 maintainers:
-- name: David Anderson
+- name: danderson
   email: dave@natulte.net

--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 version: 0.1.0
 
 name: metallb
-appVersion: 0.4.1
+appVersion: 0.4.3
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
 home: https://metallb.universe.tf

--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -1,0 +1,118 @@
+MetalLB
+-------
+
+MetalLB is a load-balancer implementation for bare
+metal [Kubernetes](https://kubernetes.io) clusters, using standard
+routing protocols.
+
+TL;DR;
+------
+
+```console
+$ helm install --name metallb stable/metallb
+```
+
+Introduction
+------------
+
+This chart bootstraps a [MetalLB](https://metallb.universe.tf)
+installation on a [Kubernetes](http://kubernetes.io) cluster using
+the [Helm](https://helm.sh) package manager. This chart provides an
+implementation for LoadBalancer Service objects.
+
+MetalLB is a cluster service, and as such can only be deployed as a
+cluster singleton. Running multiple installations of MetalLB in a
+single cluster is not supported.
+
+Prerequisites
+-------------
+
+-	Kubernetes 1.9+
+
+Installing the Chart
+--------------------
+
+The chart can be installed as follows:
+
+```console
+$ helm install --name metallb stable/metallb
+```
+
+The command deploys MetalLB on the Kubernetes cluster. This chart does
+not provide a default configuration, MetalLB will not act on your
+Kubernetes Services until you provide
+one. The [configuration](#configuration) section lists various ways to
+provide this configuration.
+
+Uninstalling the Chart
+----------------------
+
+To uninstall/delete the `metallb` deployment:
+
+```console
+$ helm delete metallb
+```
+
+The command removes all the Kubernetes components associated with the
+chart and deletes the release.
+
+Configuration
+-------------
+
+See `values.yaml` for configuration notes. Specify each parameter
+using the `--set key=value[,key=value]` argument to `helm
+install`. For example,
+
+```console
+$ helm install --name metallb \
+  --set rbac.create=false \
+    stable/metallb
+```
+
+The above command disables the use of RBAC rules.
+
+Alternatively, a YAML file that specifies the values for the above
+parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name metallb -f values.yaml stable/metallb
+```
+
+By default, this chart does not install a configuration for MetalLB,
+and simply warns you that you must
+follow
+[the configuration instructions on MetalLB's website](https://metallb.universe.tf/configuration/) to
+create an appropriate ConfigMap.
+
+For simple setups that only use
+MetalLB's [ARP mode](https://metallb.universe.tf/concepts/arp-ndp/),
+you can specify a single IP range using the `arpCIDR` parameter to
+have the chart install a working configuration for you:
+
+```console
+$ helm install --name metallb \
+  --set arpCIDR=192.168.16.240/30 \
+  stable/metallb
+```
+
+If you have a more complex configuration and want Helm to manage it
+for you, you can provide it in the `config` parameter. The
+configuration format
+is
+[documented on MetalLB's website](https://metallb.universe.tf/configuration/).
+
+```console
+$ cat values.yaml
+config:
+  peers:
+  - peer-address: 10.0.0.1
+    peer-asn: 64512
+    my-asn: 64512
+  address-pools:
+  - name: default
+    protocol: bgp
+    cidr:
+    - 198.51.100.0/24
+
+$ helm install --name metallb -f values.yaml stable/metallb
+```

--- a/stable/metallb/templates/NOTES.txt
+++ b/stable/metallb/templates/NOTES.txt
@@ -1,0 +1,14 @@
+
+MetalLB is now running in the cluster.
+{{ if .Values.arpCIDR -}}
+LoadBalancer Services in your cluster are now available on IPs
+within {{ .Values.arpCIDR }}. To see the IP assignments,
+try `kubectl get services`.
+{{- else if .Values.config }}
+LoadBalancer Services in your cluster are now available on the IPs you
+defined in MetalLB's configuration. To see IP assignments,
+try `kubectl get services`.
+{{- else }}
+WARNING: you did not provide a configuration for MetalLB. LoadBalancer
+services will not function until you provide a configuration.
+{{- end }}

--- a/stable/metallb/templates/_helpers.tpl
+++ b/stable/metallb/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metallb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metallb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metallb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/metallb/templates/_helpers.tpl
+++ b/stable/metallb/templates/_helpers.tpl
@@ -30,3 +30,25 @@ Create chart name and version as used by the chart label.
 {{- define "metallb.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "metallb.controllerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.controller.create -}}
+    {{ default (printf "%s-controller" (include "metallb.fullname" .)) .Values.serviceAccounts.controller.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.controller.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the speaker service account to use
+*/}}
+{{- define "metallb.speakerServiceAccountName" -}}
+{{- if .Values.serviceAccounts.speaker.create -}}
+    {{ default (printf "%s-speaker" (include "metallb.fullname" .)) .Values.serviceAccounts.speaker.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.speaker.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -12,7 +11,7 @@ metadata:
 data:
   config: |
 {{- if .Values.config }}
-{{ toYaml .Values.override_config | indent 4 }}
+{{ toYaml .Values.config | indent 4 }}
 {{- else }}
     address-pools:
     - name: default

--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -1,0 +1,18 @@
+{{- if (or .Values.config .Values.arpCIDR) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+{{- if .Values.config }}
+{{ toYaml .Values.override_config | indent 4 }}
+{{- else }}
+    address-pools:
+    - name: default
+      protocol: arp
+      cidr:
+      - {{ .Values.arpCIDR }}
+{{- end }}
+{{- end }}

--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -3,7 +3,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: metallb-system
-  name: config
+  name: {{ template "metallb.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 data:
   config: |
 {{- if .Values.config }}

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -1,8 +1,7 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
-  name: {{ template "metallb.fullname" . }}
+  name: {{ template "metallb.fullname" . }}-controller
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -41,8 +40,8 @@ spec:
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         args:
         - --port=7472
-        - --config-ns={{ .Release.Namespace | quote }}
-        - --config="{{ template "metallb.fullname" . }}"
+        - --config-ns={{ .Release.Namespace }}
+        - --config={{ template "metallb.fullname" . }}
         ports:
         - name: monitoring
           containerPort: 7472

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -30,9 +30,7 @@ spec:
         prometheus.io/port: "7472"
 {{- end }}
     spec:
-{{- if .Values.rbac.create }}
-      serviceAccountName: controller
-{{- end }}
+      serviceAccountName: {{ template "metallb.controllerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       securityContext:
         runAsNonRoot: true

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -9,9 +9,6 @@ metadata:
     chart: {{ template "metallb.chart" . }}
     app: {{ template "metallb.name" . }}
     component: controller
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "7472"
 spec:
   revisionHistoryLimit: 3
   selector:
@@ -27,6 +24,11 @@ spec:
         chart: {{ template "metallb.chart" . }}
         app: {{ template "metallb.name" . }}
         component: controller
+{{- if .Values.prometheus.scrapeAnnotations }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+{{- end }}
     spec:
 {{- if .Values.rbac.create }}
       serviceAccountName: controller

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   namespace: metallb-system
-  name: controller
+  name: {{ template "metallb.fullname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  namespace: metallb-system
+  name: controller
+  labels:
+    {{- if .Values.helmLabels }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- end }}
+    app: {{ template "metallb.name" . }}
+    component: controller
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "7472"
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: {{ template "metallb.name" . }}
+      component: controller
+      {{- if .Values.helmLabels }}
+      release: {{ .Release.Name | quote }}
+      {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- if .Values.helmLabels }}
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+        {{- end }}
+        app: {{ template "metallb.name" . }}
+        component: controller
+    spec:
+{{- if .Values.rbac.create }}
+      serviceAccountName: controller
+{{- end }}
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534 # nobody
+      containers:
+      - name: controller
+        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
+        imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+        args:
+        - --port=7472
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+{{ toYaml .Values.controller.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -4,11 +4,9 @@ metadata:
   namespace: metallb-system
   name: controller
   labels:
-    {{- if .Values.helmLabels }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
-    {{- end }}
     app: {{ template "metallb.name" . }}
     component: controller
   annotations:
@@ -20,17 +18,13 @@ spec:
     matchLabels:
       app: {{ template "metallb.name" . }}
       component: controller
-      {{- if .Values.helmLabels }}
       release: {{ .Release.Name | quote }}
-      {{- end }}
   template:
     metadata:
       labels:
-        {{- if .Values.helmLabels }}
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
         chart: {{ template "metallb.chart" . }}
-        {{- end }}
         app: {{ template "metallb.name" . }}
         component: controller
     spec:

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if .Values.helmLabels }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    chart: {{ template "metallb.chart" . }}
     {{- end }}
     app: {{ template "metallb.name" . }}
     component: controller
@@ -29,7 +29,7 @@ spec:
         {{- if .Values.helmLabels }}
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+        chart: {{ template "metallb.chart" . }}
         {{- end }}
         app: {{ template "metallb.name" . }}
         component: controller

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -41,6 +41,8 @@ spec:
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         args:
         - --port=7472
+        - --config-ns={{ .Release.Namespace | quote }}
+        - --config="{{ template "metallb.fullname" . }}"
         ports:
         - name: monitoring
           containerPort: 7472

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/namespace.yaml
+++ b/stable/metallb/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system

--- a/stable/metallb/templates/namespace.yaml
+++ b/stable/metallb/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: metallb-system

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.rbac.create -}}
+
+# Roles
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metallb-system:controller
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["services/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metallb-system:speaker
+rules:
+- apiGroups: [""]
+  resources: ["services", "endpoints", "nodes"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: metallb-system
+  name: leader-election
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  resourceNames: ["metallb-speaker"]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: metallb-system
+  name: config-watcher
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+
+## Service accounts
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: metallb-system
+  name: controller
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: metallb-system
+  name: speaker
+---
+
+## Role bindings
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-system:controller
+subjects:
+- kind: ServiceAccount
+  namespace: metallb-system
+  name: controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-system:speaker
+subjects:
+- kind: ServiceAccount
+  namespace: metallb-system
+  name: speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: metallb-system
+  name: config-watcher
+subjects:
+- kind: ServiceAccount
+  name: controller
+- kind: ServiceAccount
+  name: speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: config-watcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: metallb-system
+  name: leader-election
+subjects:
+- kind: ServiceAccount
+  name: speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election
+
+{{- end -}}

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -38,7 +38,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-leader-election
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -57,7 +56,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -85,8 +83,8 @@ metadata:
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.controllerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -103,8 +101,8 @@ metadata:
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.speakerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -113,7 +111,6 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -133,7 +130,6 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-leader-election
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -4,7 +4,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metallb-system:controller
+  name: {{ template "metallb.fullname" . }}:controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 rules:
 - apiGroups: [""]
   resources: ["services"]
@@ -19,7 +24,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metallb-system:speaker
+  name: {{ template "metallb.fullname" . }}:speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 rules:
 - apiGroups: [""]
   resources: ["services", "endpoints", "nodes"]
@@ -29,7 +39,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: metallb-system
-  name: leader-election
+  name: {{ template "metallb.fullname" . }}-leader-election
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 rules:
 - apiGroups: [""]
   resources: ["endpoints"]
@@ -43,7 +58,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: metallb-system
-  name: config-watcher
+  name: {{ template "metallb.fullname" . }}-config-watcher
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -57,7 +77,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metallb-system:controller
+  name: {{ template "metallb.fullname" . }}:controller
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
   namespace: metallb-system
@@ -65,12 +90,17 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metallb-system:controller
+  name: {{ template "metallb.fullname" . }}:controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metallb-system:speaker
+  name: {{ template "metallb.fullname" . }}:speaker
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
   namespace: metallb-system
@@ -78,13 +108,18 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metallb-system:speaker
+  name: {{ template "metallb.fullname" . }}:speaker
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: metallb-system
-  name: config-watcher
+  name: {{ template "metallb.fullname" . }}-config-watcher
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "metallb.controllerServiceAccountName" . }}
@@ -93,19 +128,23 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: config-watcher
+  name: {{ template "metallb.fullname" . }}-config-watcher
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: metallb-system
-  name: leader-election
+  name: {{ template "metallb.fullname" . }}-leader-election
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "metallb.speakerServiceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election
-
+  name: {{ template "metallb.fullname" . }}-leader-election
 {{- end -}}

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -53,20 +53,6 @@ rules:
   verbs: ["create"]
 ---
 
-## Service accounts
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  namespace: metallb-system
-  name: controller
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  namespace: metallb-system
-  name: speaker
----
-
 ## Role bindings
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -75,7 +61,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   namespace: metallb-system
-  name: controller
+  name: {{ template "metallb.controllerServiceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -88,7 +74,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   namespace: metallb-system
-  name: speaker
+  name: {{ template "metallb.speakerServiceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -101,9 +87,9 @@ metadata:
   name: config-watcher
 subjects:
 - kind: ServiceAccount
-  name: controller
+  name: {{ template "metallb.controllerServiceAccountName" . }}
 - kind: ServiceAccount
-  name: speaker
+  name: {{ template "metallb.speakerServiceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -116,7 +102,7 @@ metadata:
   name: leader-election
 subjects:
 - kind: ServiceAccount
-  name: speaker
+  name: {{ template "metallb.speakerServiceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -38,7 +38,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-leader-election
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -57,7 +57,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -85,7 +85,7 @@ metadata:
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.controllerServiceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -103,7 +103,7 @@ metadata:
     app: {{ template "metallb.name" . }}
 subjects:
 - kind: ServiceAccount
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.speakerServiceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -113,7 +113,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -133,7 +133,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}-leader-election
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/service-accounts.yaml
+++ b/stable/metallb/templates/service-accounts.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.controllerServiceAccountName" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -15,7 +14,6 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.speakerServiceAccountName" . }}
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/service-accounts.yaml
+++ b/stable/metallb/templates/service-accounts.yaml
@@ -4,6 +4,11 @@ kind: ServiceAccount
 metadata:
   namespace: metallb-system
   name: {{ template "metallb.controllerServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 {{- end }}
 ---
 {{- if .Values.serviceAccounts.speaker.create }}
@@ -12,4 +17,9 @@ kind: ServiceAccount
 metadata:
   namespace: metallb-system
   name: {{ template "metallb.speakerServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "metallb.chart" . }}
+    app: {{ template "metallb.name" . }}
 {{- end }}

--- a/stable/metallb/templates/service-accounts.yaml
+++ b/stable/metallb/templates/service-accounts.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccounts.controller.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: metallb-system
+  name: {{ template "metallb.controllerServiceAccountName" . }}
+{{- end }}
+---
+{{- if .Values.serviceAccounts.speaker.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: metallb-system
+  name: {{ template "metallb.speakerServiceAccountName" . }}
+{{- end }}

--- a/stable/metallb/templates/service-accounts.yaml
+++ b/stable/metallb/templates/service-accounts.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.controllerServiceAccountName" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -15,7 +15,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.speakerServiceAccountName" . }}
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -1,8 +1,7 @@
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
-  namespace: {{ .Release.Namespace | quote }}
-  name: {{ template "metallb.fullname" . }}
+  name: {{ template "metallb.fullname" . }}-speaker
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -38,8 +37,8 @@ spec:
         imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
         args:
         - --port=7472
-        - --config-ns={{ .Release.Namespace | quote }}
-        - --config="{{ template "metallb.fullname" . }}"
+        - --config-ns={{ .Release.Namespace }}
+        - --config={{ template "metallb.fullname" . }}
         env:
         - name: METALLB_NODE_IP
           valueFrom:

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -23,9 +23,11 @@ spec:
         chart: {{ template "metallb.chart" . }}
         app: {{ template "metallb.name" . }}
         component: speaker
+{{- if .Values.prometheus.scrapeAnnotations }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "7472"
+{{- end }}
     spec:
 {{- if .Values.rbac.create }}
       serviceAccountName: speaker

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -4,11 +4,9 @@ metadata:
   namespace: metallb-system
   name: speaker
   labels:
-    {{- if .Values.helmLabels }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "metallb.chart" . }}
-    {{- end }}
     app: {{ template "metallb.name" . }}
     component: speaker
 spec:
@@ -16,17 +14,13 @@ spec:
     matchLabels:
       app: {{ template "metallb.name" . }}
       component: speaker
-      {{- if .Values.helmLabels }}
       release: {{ .Release.Name | quote }}
-      {{- end }}
   template:
     metadata:
       labels:
-        {{- if .Values.helmLabels }}
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
         chart: {{ template "metallb.chart" . }}
-        {{- end }}
         app: {{ template "metallb.name" . }}
         component: speaker
       annotations:

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
-  namespace: metallb-system
+  namespace: {{ .Release.Namespace | quote }}
   name: {{ template "metallb.fullname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  namespace: metallb-system
+  name: speaker
+  labels:
+    {{- if .Values.helmLabels }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- end }}
+    app: {{ template "metallb.name" . }}
+    component: speaker
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "metallb.name" . }}
+      component: speaker
+      {{- if .Values.helmLabels }}
+      release: {{ .Release.Name | quote }}
+      {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- if .Values.helmLabels }}
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+        {{- end }}
+        app: {{ template "metallb.name" . }}
+        component: speaker
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7472"
+    spec:
+{{- if .Values.rbac.create }}
+      serviceAccountName: speaker
+{{- end }}
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: speaker
+        image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag }}
+        imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
+        args:
+        - --port=7472
+        env:
+        - name: METALLB_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: monitoring
+          containerPort: 7472
+        resources:
+{{ toYaml .Values.speaker.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - all
+            add:
+            - net_raw

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -29,9 +29,7 @@ spec:
         prometheus.io/port: "7472"
 {{- end }}
     spec:
-{{- if .Values.rbac.create }}
-      serviceAccountName: speaker
-{{- end }}
+      serviceAccountName: {{ template "metallb.speakerServiceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
       containers:

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   namespace: metallb-system
-  name: speaker
+  name: {{ template "metallb.fullname" . }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if .Values.helmLabels }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    chart: {{ template "metallb.chart" . }}
     {{- end }}
     app: {{ template "metallb.name" . }}
     component: speaker
@@ -25,7 +25,7 @@ spec:
         {{- if .Values.helmLabels }}
         heritage: {{ .Release.Service | quote }}
         release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+        chart: {{ template "metallb.chart" . }}
         {{- end }}
         app: {{ template "metallb.name" . }}
         component: speaker

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -38,6 +38,8 @@ spec:
         imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
         args:
         - --port=7472
+        - --config-ns={{ .Release.Namespace | quote }}
+        - --config="{{ template "metallb.fullname" . }}"
         env:
         - name: METALLB_NODE_IP
           valueFrom:

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -25,9 +25,9 @@ controller:
     tag: v0.4.0
     pullPolicy: IfNotPresent
   resources:
-    limits:
-      cpu: 100m
-      memory: 100Mi
+    #limits:
+      #cpu: 100m
+      #memory: 100Mi
 
 # controller contains configuration specific to the MetalLB speaker
 # daemonset.
@@ -37,9 +37,9 @@ speaker:
     tag: v0.4.0
     pullPolicy: IfNotPresent
   resources:
-    limits:
-      cpu: 100m
-      memory: 100Mi
+    #limits:
+      #cpu: 100m
+      #memory: 100Mi
 
 # helmLabels specifies whether to include Helm-specific labels in
 # manifests. This is used when generating the non-Helm manifest files

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -22,7 +22,7 @@ rbac:
 controller:
   image:
     repository: metallb/controller
-    tag: v0.4.0
+    tag: v0.4.1
     pullPolicy: IfNotPresent
   resources:
     #limits:
@@ -34,7 +34,7 @@ controller:
 speaker:
   image:
     repository: metallb/speaker
-    tag: v0.4.0
+    tag: v0.4.1
     pullPolicy: IfNotPresent
   resources:
     #limits:

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -6,9 +6,9 @@
 # https://metallb.universe.tf/configuration/ for available options.
 config:
 
-# load-balancers. When arpCIDR is specified instead of config, the
-# chart will install a trivial "quick start" MetalLB configuration
-# that uses ARP mode. Refer to https://metallb.universe.tf/ for more
+# When arpCIDR is specified instead of config, the chart will install
+# a trivial "quick start" MetalLB configuration that uses ARP
+# mode. Refer to https://metallb.universe.tf/ for more
 # information. For production configurations, use of the `config`
 # field is recommended instead of arpCIDR.
 arpCIDR:
@@ -27,6 +27,20 @@ prometheus:
   # monitoring configuration. If you use the Prometheus operator, this
   # can be left at false.
   scrapeAnnotations: false
+
+serviceAccounts:
+  controller:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.  If not set and create is
+    # true, a name is generated using the fullname template
+    name:
+  speaker:
+    # Specifies whether a ServiceAccount should be created
+    create: true
+    # The name of the ServiceAccount to use.  If not set and create is
+    # true, a name is generated using the fullname template
+    name:
 
 # controller contains configuration specific to the MetalLB cluster
 # controller.

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -1,0 +1,47 @@
+# Default values for metallb.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# config is the MetalLB configuration, in YAML format. Refer to
+# https://metallb.universe.tf/configuration/ for available options.
+config:
+
+# load-balancers. When arpCIDR is specified instead of config, the
+# chart will install a trivial "quick start" MetalLB configuration
+# that uses ARP mode. Refer to https://metallb.universe.tf/ for more
+# information. For production configurations, use of the `config`
+# field is recommended instead of arpCIDR.
+arpCIDR:
+
+rbac:
+  # create specifies whether to install and use RBAC rules.
+  create: true
+
+# controller contains configuration specific to the MetalLB cluster
+# controller.
+controller:
+  image:
+    repository: metallb/controller
+    tag: v0.4.0
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+
+# controller contains configuration specific to the MetalLB speaker
+# daemonset.
+speaker:
+  image:
+    repository: metallb/speaker
+    tag: v0.4.0
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+
+# helmLabels specifies whether to include Helm-specific labels in
+# manifests. This is used when generating the non-Helm manifest files
+# during MetalLB development, and should be left alone otherwise.
+helmLabels: true

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -17,6 +17,17 @@ rbac:
   # create specifies whether to install and use RBAC rules.
   create: true
 
+prometheus:
+  # scrape annotations specifies whether to add Prometheus metric
+  # auto-collection annotations to pods. See
+  # https://github.com/prometheus/prometheus/blob/release-2.1/documentation/examples/prometheus-kubernetes.yml
+  # for a corresponding Prometheus configuration.  Alternatively, you
+  # may want to use the Prometheus Operator
+  # (https://github.com/coreos/prometheus-operator) for more powerful
+  # monitoring configuration. If you use the Prometheus operator, this
+  # can be left at false.
+  scrapeAnnotations: false
+
 # controller contains configuration specific to the MetalLB cluster
 # controller.
 controller:

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -40,8 +40,3 @@ speaker:
     #limits:
       #cpu: 100m
       #memory: 100Mi
-
-# helmLabels specifies whether to include Helm-specific labels in
-# manifests. This is used when generating the non-Helm manifest files
-# during MetalLB development, and should be left alone otherwise.
-helmLabels: true

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -47,7 +47,7 @@ serviceAccounts:
 controller:
   image:
     repository: metallb/controller
-    tag: v0.4.1
+    tag: v0.4.3
     pullPolicy: IfNotPresent
   resources:
     #limits:
@@ -59,7 +59,7 @@ controller:
 speaker:
   image:
     repository: metallb/speaker
-    tag: v0.4.1
+    tag: v0.4.3
     pullPolicy: IfNotPresent
   resources:
     #limits:

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -50,9 +50,9 @@ controller:
     tag: v0.4.3
     pullPolicy: IfNotPresent
   resources:
-    #limits:
-      #cpu: 100m
-      #memory: 100Mi
+    # limits:
+      # cpu: 100m
+      # memory: 100Mi
 
 # controller contains configuration specific to the MetalLB speaker
 # daemonset.
@@ -62,6 +62,6 @@ speaker:
     tag: v0.4.3
     pullPolicy: IfNotPresent
   resources:
-    #limits:
-      #cpu: 100m
-      #memory: 100Mi
+    # limits:
+      # cpu: 100m
+      # memory: 100Mi


### PR DESCRIPTION
The chart installs MetalLB 0.4.0, which was just released.