### PR TITLE
[incubator/oauth-proxy] Enabled custom oauth-proxy configuration file

### DIFF
--- a/incubator/oauth-proxy/Chart.yaml
+++ b/incubator/oauth-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth-proxy
-version: 0.1.6
+version: 0.1.7
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:

--- a/incubator/oauth-proxy/README.md
+++ b/incubator/oauth-proxy/README.md
@@ -45,6 +45,7 @@ Parameter | Description | Default
 `config.clientID` | oauth client ID | `""`
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'` | `""`
+`config.configFile` | custom [oauth_proxy.cfg](https://github.com/bitly/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `a5huynh/oauth2_proxy`

--- a/incubator/oauth-proxy/templates/configmap.yaml
+++ b/incubator/oauth-proxy/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.config.configFile }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "oauth-proxy.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth-proxy.fullname" . }}
+data:
+  oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}
+{{- end }}

--- a/incubator/oauth-proxy/templates/deployment.yaml
+++ b/incubator/oauth-proxy/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
           - --{{ $key }}
           {{- end }}
         {{- end }}
+        {{- if .Values.config.configFile }}
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        {{- end }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:
@@ -62,6 +65,16 @@ spec:
             port: {{ .Values.service.internalPort }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.config.configFile }}
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy
+          name: {{ template "oauth-proxy.fullname" . }}-configmap
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: {{ template "oauth-proxy.fullname" . }}
+        name: {{ template "oauth-proxy.fullname" . }}-configmap
+{{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/incubator/oauth-proxy/values.yaml
+++ b/incubator/oauth-proxy/values.yaml
@@ -7,6 +7,11 @@ config:
   # Create a new secret with the following command
   # python -c 'import os,base64; print base64.b64encode(os.urandom(16))'
   cookieSecret: "XXXXXXXXXX"
+  # Custom configuration file: oauth2_proxy.cfg
+  # configFile: |-
+  #   pass_basic_auth = false
+  #   pass_access_token = true
+  configFile: ""
 
 image:
   repository: "a5huynh/oauth2_proxy"


### PR DESCRIPTION

Added the ability to define a custom oauth-proxy.cfg file in the values.yaml.  Defining the config.configFile value will instruct the chart to create a configmap, mount the volume into the deployment pod spec, and launch the container image with the argument specifying the config file.

```
config:
  # Custom configuration file: oauth2_proxy.cfg
  # configFile: |-
  #   pass_basic_auth = false
  #   pass_access_token = true
  configFile: ""
```