### PR TITLE
[stable/coredns] update to 1.0.6 and small improvements

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 name: coredns
-version: 0.8.0
-appVersion: 1.0.1
+version: 0.9.0
+appVersion: 1.0.6
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:
 - coredns

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         {{- end }}
         release: {{ .Release.Name | quote }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.isClusterService }}
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -25,8 +25,8 @@ spec:
   {{- else }}
     app: {{ template "coredns.fullname" . }}
   {{- end }}
-  {{- if .Values.isClusterService }}
-  clusterIP: {{ .Values.plugins.kubernetes.clusterIP }}
+  {{- if .Values.clusterIP }}
+  clusterIP: {{ .Values.clusterIP }}
   {{- end }}
   ports:
   {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "UDP") }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -29,6 +29,9 @@ isClusterService: true
 # serviceType specifies type of service to be created for this chart.
 serviceType: "ClusterIP"
 
+# cluster IP to use
+# clusterIP: ""
+
 # serviceProtocol specifies the protocol on which to expose the CoreDNS service.
 # Can be one of three options: "UDPNTCP" (default), "UDP" or "TCP"
 serviceProtocol: "UDPNTCP"

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: coredns/coredns
-  tag: "1.0.1"
+  tag: "1.0.6"
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
Updating the chart to latest stable version, 1.0.6.

Adding the functionality to roll the deployment upon config changes.

Moving ClusterIP configuration to outside the kubernetes plugin section, since it may be useful to configure even if running without the kubernetes plugin.