### PR TITLE
[stable/minio]: fix indentation of node selector labels of post-install-create…

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Distributed object storage server built for cloud applications and devops.
 name: minio
-version: 0.5.5
+version: 0.5.6
 keywords:
 - storage
 - object-storage

--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -21,7 +21,7 @@ spec:
       restartPolicy: OnFailure
 {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 4 }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}
       volumes:
         - name: minio-configuration


### PR DESCRIPTION
The nodeSelector in post-install-create-bucket-job.yaml was badly formatted due to wrong indentation. I  changed the indentation from 4 to 8 spaces. 