### PR TITLE
[stable/prestashop] Disable check the cookie IP address

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 0.5.3
+version: 0.5.4
 appVersion: 1.7.2
 description: A popular open source ecommerce solution. Professional tools are easily
   accessible to increase online sales including instant guest checkout, abandoned

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - name: {{ template "prestashop.fullname" . }}
         image: "{{ .Values.image }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
         - name: MARIADB_HOST
           value: {{ template "prestashop.mariadb.fullname" . }}
@@ -31,31 +31,33 @@ spec:
         - name: PRESTASHOP_HOST
           value: {{ include "prestashop.host" . | quote }}
         - name: PRESTASHOP_USERNAME
-          value: {{ default "" .Values.prestashopUsername | quote }}
+          value: {{ .Values.prestashopUsername | quote }}
         - name: PRESTASHOP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "prestashop.fullname" . }}
               key: prestashop-password
         - name: PRESTASHOP_EMAIL
-          value: {{ default "" .Values.prestashopEmail | quote }}
+          value: {{ .Values.prestashopEmail | quote }}
         - name: PRESTASHOP_FIRST_NAME
-          value: {{ default "" .Values.prestashopFirstName | quote }}
+          value: {{ .Values.prestashopFirstName | quote }}
         - name: PRESTASHOP_LAST_NAME
-          value: {{ default "" .Values.prestashopLastName | quote }}
+          value: {{ .Values.prestashopLastName | quote }}
+        - name: PRESTASHOP_COOKIE_CHECK_IP
+          value: "no"
         - name: SMTP_HOST
-          value: {{ default "" .Values.smtpHost | quote }}
+          value: {{ .Values.smtpHost | quote }}
         - name: SMTP_PORT
-          value: {{ default "" .Values.smtpPort | quote }}
+          value: {{ .Values.smtpPort | quote }}
         - name: SMTP_USER
-          value: {{ default "" .Values.smtpUser | quote }}
+          value: {{ .Values.smtpUser | quote }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "prestashop.fullname" . }}
               key: smtp-password
         - name: SMTP_PROTOCOL
-          value: {{ default "" .Values.smtpProtocol | quote }}
+          value: {{ .Values.smtpProtocol | quote }}
         ports:
         - name: http
           containerPort: 80

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami PrestaShop image version
 ## ref: https://hub.docker.com/r/bitnami/prestashop/tags/
 ##
-image: bitnami/prestashop:1.7.2-4-r0
+image: bitnami/prestashop:1.7.2-4-r1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
This PR set the `PRESTASHOP_COOKIE_CHECK_IP` env var to `no` as there is an issue where the user is automatically logged out while it is navigating in the administration panel.