### PR TITLE
[stable/external-dns]: Specify Google Cloud DNS credentials.json via kubernetes secret

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.4.9
+version: 0.5.0
 appVersion: 0.4.8
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -34,7 +34,7 @@ The following tables lists the configurable parameters of the external-dns chart
 | `extraArgs`                        | Optional object of extra args, as `name`: `value` pairs. Where the name is the command line arg to external-dns.           | `{}`                                               |
 | `extraEnv`                         | Optional object of extra environment variables, as `name`: `value` pairs.                                                  | `{}`                                               |
 | `google.project`                   | When using the Google provider, specify the Google project (required when provider=google).                                | `""`                                               |
-| `google.serviceAccountSecret`      | When using the Google provider, optionally specify the secret which contains credentials.json if necessary.                    | `""`
+| `google.serviceAccountSecret`      | When using the Google provider, optionally specify the secret which contains credentials.json if necessary.                    | `""`|
 | `image.name`                       | Container image name (Including repository name if not `hub.docker.com`).                                                  | `registry.opensource.zalan.do/teapot/external-dns` |
 | `image.pullPolicy`                 | Container pull policy.                                                                                                     | `IfNotPresent`                                     |
 | `image.tag`                        | Container image tag.                                                                                                       | `v0.4.5`                                           |

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -34,6 +34,7 @@ The following tables lists the configurable parameters of the external-dns chart
 | `extraArgs`                        | Optional object of extra args, as `name`: `value` pairs. Where the name is the command line arg to external-dns.           | `{}`                                               |
 | `extraEnv`                         | Optional object of extra environment variables, as `name`: `value` pairs.                                                  | `{}`                                               |
 | `google.project`                   | When using the Google provider, specify the Google project (required when provider=google).                                | `""`                                               |
+| `google.serviceAccountSecret`      | When using the Google provider, optionally specify the secret which contains credentials.json if necessary.                    | `""`
 | `image.name`                       | Container image name (Including repository name if not `hub.docker.com`).                                                  | `registry.opensource.zalan.do/teapot/external-dns` |
 | `image.pullPolicy`                 | Container pull policy.                                                                                                     | `IfNotPresent`                                     |
 | `image.tag`                        | Container image tag.                                                                                                       | `v0.4.5`                                           |

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -55,12 +55,20 @@ spec:
             - --google-project={{ .Values.google.project }}
           {{- end }}
           volumeMounts:
+          {{- if .Values.google.serviceAccountSecret }}
+          - name: google-service-account
+            mountPath: /etc/secrets/service-account/
+          {{- end}}
           {{- if eq .Values.provider "azure" }}
           - name: azure-config-file
             mountPath: /etc/kubernetes/azure.json
             readOnly: true
           {{- end }}
           env:
+        {{- if .Values.google.serviceAccountSecret }}
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/secrets/service-account/credentials.json
+        {{- end }}
         {{- if eq .Values.provider "aws" }}
         {{- if and .Values.aws.secretKey .Values.aws.accessKey }}
           - name: AWS_ACCESS_KEY_ID
@@ -107,6 +115,11 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
         {{- end }}
       volumes:
+      {{- if .Values.google.serviceAccountSecret }}
+      - name: google-service-account
+        secret:
+          secretName: "{{.Values.google.serviceAccountSecret}}"
+      {{- end}}
       {{- if eq .Values.provider "azure" }}
       - name: azure-config-file
         hostPath:

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -32,6 +32,7 @@ cloudflare:
 # When using the Google provider, specify the Google project (required when provider=google)
 google:
   project: ""
+  serviceAccountSecret: ""
 
 ## Limit possible target zones by domain suffixes (optional)
 domainFilters: []


### PR DESCRIPTION
This Pull Request adds the ability to specify a secret which contains the credentials.json used to authenticate against the Google Cloud DNS service for external-dns.