### PR TITLE
[stable/jenkins] Allow more configuration of Jenkins agent service

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.14.0
+version: 0.14.1
 appVersion: 2.73
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-agent-svc.yaml
+++ b/stable/jenkins/templates/jenkins-agent-svc.yaml
@@ -6,6 +6,10 @@ metadata:
     app: {{ template "jenkins.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+{{- if .Values.Master.SlaveListenerServiceAnnotations }}
+  annotations:
+{{ toYaml .Values.Master.SlaveListenerServiceAnnotations | indent 4 }}
+{{- end }}
 spec:
   ports:
     - port: {{ .Values.Master.SlaveListenerPort }}

--- a/stable/jenkins/templates/jenkins-agent-svc.yaml
+++ b/stable/jenkins/templates/jenkins-agent-svc.yaml
@@ -13,4 +13,4 @@ spec:
       name: slavelistener
   selector:
     component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
-  type: ClusterIP
+  type: {{ .Values.Master.SlaveListenerServiceType }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -46,6 +46,7 @@ Master:
   # Kubernetes service type for the JNLP slave service
   # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341
   SlaveListenerServiceType: ClusterIP
+  SlaveListenerServiceAnnotations: {}
   LoadBalancerSourceRanges:
   - 0.0.0.0/0
   # Optionally assign a known public LB IP

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -43,6 +43,9 @@ Master:
   HealthProbes: true
   HealthProbesTimeout: 60
   SlaveListenerPort: 50000
+  # Kubernetes service type for the JNLP slave service
+  # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341
+  SlaveListenerServiceType: ClusterIP
   LoadBalancerSourceRanges:
   - 0.0.0.0/0
   # Optionally assign a known public LB IP


### PR DESCRIPTION
We want to expose our Jenkins agent service as a `NodePort` so that non-Kubernetes managed agents can communicate with the master.

Setting this to `LoadBalancer` is a big security risk according to #1341 so I am open to suggestions if allowing this to be configured is a concern.