### PR TITLE
[stable/sentry] Support external database

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.9
+version: 0.2.0
 appVersion: 8.17
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [Sentry](https://sentry.io/) deployment on a [Kubernetes
 
 It also packages the [PostgreSQL](https://github.com/kubernetes/charts/tree/master/stable/postgresql) and [Redis](https://github.com/kubernetes/charts/tree/master/stable/redis) which are required for Sentry.
 
-> **Warning**: This chart does not yet allow for you to specify your own database host or redis host.
+> **Warning**: This chart does not yet allow for you to specify your own redis host.
 
 ## Prerequisites
 
@@ -69,6 +69,11 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `email.password`                     | SMTP password                              | `nil`                                                      |
 | `email.use_tls`                      | SMTP TLS for security                      | `false`                                                    |
 | `email.enable_replies`               | Allow email replies                        | `false`                                                    |
+| `postgresql.enabled`                 | Enable PostgreSQL as a chart dependency    | `true`                                                     |
+| `externalDatabase.host`              | Host of the external database              | `nil`                                                      |
+| `externalDatabase.user`              | Existing username in the external db       | `sentry`                                                   |
+| `externalDatabase.password`          | Password for the above username            | `nil`                                                      |
+| `externalDatabase.database`          | Name of the existing database              | `nil`                                                      |
 | `service.type`                       | Kubernetes service type                    | `LoadBalancer`                                             |
 | `service.name`                       | Kubernetes service name                    | `sentry`                                                   |
 | `service.externalPort`               | Kubernetes external service port           | `9000`                                                     |

--- a/stable/sentry/requirements.lock
+++ b/stable/sentry/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.10.1
-digest: sha256:edf23e476cacd385037588df3226003e75fa5161f8c7556c370383bf9f9d1d71
-generated: 2017-09-29T15:01:25.29542-05:00
+digest: sha256:32729c6c49f772b92891fc5e75be2514a897bfe5332c6df2ba08110102c5d728
+generated: 2018-03-07T16:29:35.74472+08:00

--- a/stable/sentry/requirements.yaml
+++ b/stable/sentry/requirements.yaml
@@ -2,6 +2,7 @@ dependencies:
   - name: postgresql
     version: 0.8.3
     repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: postgresql.enabled
   - name: redis
     version: 0.10.1
     repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -30,16 +30,33 @@ spec:
               name: {{ template "fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresUser | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.user | quote }}
+        {{- end }}
         - name: SENTRY_DB_NAME
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresDatabase | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.database | quote }}
+        {{- end }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.postgresql.enabled }}
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
+              {{- else }}
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+              {{- end }}
         - name: SENTRY_POSTGRES_HOST
+        {{- if .Values.postgresql.enabled }}
           value: {{ template "postgresql.fullname" . }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.host | quote }}
+        {{- end }}
         - name: SENTRY_POSTGRES_PORT
           value: "5432"
         - name: SENTRY_REDIS_PASSWORD

--- a/stable/sentry/templates/externaldb-secrets.yaml
+++ b/stable/sentry/templates/externaldb-secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  labels:
+    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}
+{{- end }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -33,16 +33,33 @@ spec:
               name: {{ template "fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresUser | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.user | quote }}
+        {{- end }}
         - name: SENTRY_DB_NAME
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresDatabase | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.database | quote }}
+        {{- end }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.postgresql.enabled }}
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
+              {{- else }}
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+              {{- end }}
         - name: SENTRY_POSTGRES_HOST
+        {{- if .Values.postgresql.enabled }}
           value: {{ template "postgresql.fullname" . }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.host | quote }}
+        {{- end }}
         - name: SENTRY_POSTGRES_PORT
           value: "5432"
         - name: SENTRY_REDIS_PASSWORD

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -32,16 +32,33 @@ spec:
               name: {{ template "fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresUser | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.user | quote }}
+        {{- end }}
         - name: SENTRY_DB_NAME
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresDatabase | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.database | quote }}
+        {{- end }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.postgresql.enabled }}
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
+              {{- else }}
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+              {{- end }}
         - name: SENTRY_POSTGRES_HOST
+        {{- if .Values.postgresql.enabled }}
           value: {{ template "postgresql.fullname" . }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.host | quote }}
+        {{- end }}
         - name: SENTRY_POSTGRES_PORT
           value: "5432"
         - name: SENTRY_REDIS_PASSWORD

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -29,16 +29,33 @@ spec:
               name: {{ template "fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresUser | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.user | quote }}
+        {{- end }}
         - name: SENTRY_DB_NAME
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresDatabase | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.database | quote }}
+        {{- end }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.postgresql.enabled }}
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
+              {{- else }}
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+              {{- end }}
         - name: SENTRY_POSTGRES_HOST
+        {{- if .Values.postgresql.enabled }}
           value: {{ template "postgresql.fullname" . }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.host | quote }}
+        {{- end }}
         - name: SENTRY_POSTGRES_PORT
           value: "5432"
         - name: SENTRY_REDIS_PASSWORD

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -30,16 +30,33 @@ spec:
               name: {{ template "fullname" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresUser | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.user | quote }}
+        {{- end }}
         - name: SENTRY_DB_NAME
+        {{- if .Values.postgresql.enabled }}
           value: {{ default "sentry" .Values.postgresDatabase | quote }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.database | quote }}
+        {{- end }}
         - name: SENTRY_DB_PASSWORD
           valueFrom:
             secretKeyRef:
+              {{- if .Values.postgresql.enabled }}
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
+              {{- else }}
+              name: {{ printf "%s-%s" .Release.Name "externaldb" }}
+              key: db-password
+              {{- end }}
         - name: SENTRY_POSTGRES_HOST
+        {{- if .Values.postgresql.enabled }}
           value: {{ template "postgresql.fullname" . }}
+        {{- else }}
+          value: {{ .Values.externalDatabase.host | quote }}
+        {{- end }}
         - name: SENTRY_POSTGRES_PORT
           value: "5432"
         - name: SENTRY_REDIS_PASSWORD

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -112,7 +112,14 @@ ingress:
 
 # TODO: add support for plugins https://docs.sentry.io/server/plugins/
 
+externalDatabase:
+ host: 
+ user: sentry
+ password:
+ database:
+
 postgresql:
+  enabled: true
   postgresDatabase: sentry
   postgresUser: sentry
   imageTag: "9.5"
@@ -120,5 +127,6 @@ postgresql:
     enabled: true
 
 redis:
+  enabled: true
   persistence:
     enabled: true

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -113,10 +113,10 @@ ingress:
 # TODO: add support for plugins https://docs.sentry.io/server/plugins/
 
 externalDatabase:
- host: 
- user: sentry
- password:
- database:
+  host:
+  user: sentry
+  password:
+  database:
 
 postgresql:
   enabled: true


### PR DESCRIPTION
As titled, this pull request make it possible for users of Sentry chart to use external databases (e.g. CloudSQL)