### PR TITLE
[stable/prometheus] Update default vaules.yaml on configmaps to reflect charts

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.4.1
+version: 5.4.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -663,8 +663,8 @@ alertmanagerFiles:
 ## Prometheus server ConfigMap entries
 ##
 serverFiles:
-  alerts: ""
-  rules: ""
+  alerts: {}
+  rules: {}
 
   prometheus.yml: |-
     rule_files:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -644,7 +644,7 @@ pushgateway:
 ## alertmanager ConfigMap entries
 ##
 alertmanagerFiles:
-  alertmanager.yml:
+  alertmanager.yml: |-
     global:
       # slack_api_url: ''
 
@@ -663,10 +663,10 @@ alertmanagerFiles:
 ## Prometheus server ConfigMap entries
 ##
 serverFiles:
-  alerts: {}
-  rules: {}
+  alerts: ""
+  rules: ""
 
-  prometheus.yml:
+  prometheus.yml: |-
     rule_files:
       - /etc/config/rules
       - /etc/config/alerts


### PR DESCRIPTION
Fixing configmaps error in default values.yaml. Aligning to how a `helm install` looks.

```
Release "prometheus" does not exist. Installing it now.
Error: release prometheus failed: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap: Data: ReadString: expects " or n, parsing 47 ...ger.yml":{... at {"apiVersion":"v1","data":{"alertmanager.yml":{"global":null,"receivers":[{"name":"default-receiver"}],"route":{"group_interval":"5m","group_wait":"10s","receiver":"default-receiver","repeat_interval":"3h"}}},"kind":"ConfigMap","metadata":{"labels":{"app":"prometheus","chart":"prometheus-4.6.13","component":"alertmanager","heritage":"Tiller","release":"prometheus"},"name":"prometheus-prometheus-alertmanager","namespace":"monitoring"}}
```