### PR TITLE
[stable/percona-xtradb-cluster] add helm tests

### DIFF
--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 name: percona-xtradb-cluster
-version: 0.0.2
+version: 0.1.0
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/README.md
+++ b/stable/percona-xtradb-cluster/README.md
@@ -56,6 +56,7 @@ The following tables lists the configurable parameters of the Percona chart and 
 | `image.tag`                 | `percona-xtradb-cluster` image tag.                 | `percona/percona-xtradb-cluster` |
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent` |
 | `replicas`                 | Number of pods to join the Percona XtraDB Cluster   | 3                                         |
+| `allowRootFrom`            | Remote hosts to allow root access, set to `127.0.0.1` to disable remote root  | `%` |
 | `mysqlRootPassword`        | Password for the `root` user.      | `not-a-secure-password`                                                      |
 | `xtraBackupPassword`       | Password for the `xtrabackup` user. | `replicate-my-data` |
 | `mysqlUser`                | Username of new user to create.    | `nil`                                                      |

--- a/stable/percona-xtradb-cluster/files/functions.sh
+++ b/stable/percona-xtradb-cluster/files/functions.sh
@@ -56,9 +56,10 @@ if [ ! -e "$DATADIR/mysql" ]; then
     -- What's done in this file shouldn't be replicated
     --  or products like mysql-fabric won't work
     SET @@SESSION.SQL_LOG_BIN=0;
-    CREATE USER 'root'@'127.0.0.1' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-    GRANT ALL ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION ;
+    CREATE USER 'root'@'${ALLOW_ROOT_FROM}' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+    GRANT ALL ON *.* TO 'root'@'${ALLOW_ROOT_FROM}' WITH GRANT OPTION ;
     ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+    GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
     CREATE USER 'xtrabackup'@'localhost' IDENTIFIED BY '$XTRABACKUP_PASSWORD';
     GRANT RELOAD,PROCESS,LOCK TABLES,REPLICATION CLIENT ON *.* TO 'xtrabackup'@'localhost';
     GRANT REPLICATION CLIENT ON *.* TO monitor@'%' IDENTIFIED BY 'monitor';

--- a/stable/percona-xtradb-cluster/templates/statefulset.yaml
+++ b/stable/percona-xtradb-cluster/templates/statefulset.yaml
@@ -67,6 +67,8 @@ spec:
           value: {{ default "" .Values.mysqlUser | quote }}
         - name: MYSQL_DATABASE
           value: {{ default "" .Values.mysqlDatabase | quote }}
+        - name: ALLOW_ROOT_FROM
+          value: {{ .Values.allowRootFrom | quote }}
         - name: CLUSTER_NAME
           value: {{ template "percona-xtradb-cluster.fullname" . }}
         - name: K8S_SERVICE_NAME

--- a/stable/percona-xtradb-cluster/templates/tests/pxc-test-cm.yaml
+++ b/stable/percona-xtradb-cluster/templates/tests/pxc-test-cm.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "percona-xtradb-cluster.fullname" . }}-tests
+data:
+  run.sh: |-
+    echo "Testing Percona XtraDB Cluster"
+    creds="-uroot -p${MYSQL_ROOT_PASSWORD} -h {{ template "percona-xtradb-cluster.fullname" . }}"
+    echo "==> basic mysql ping"
+    mysqladmin $creds ping
+    [[ $? != "0" ]] && exit $?
+    echo "==> test basic query"
+    mysql $creds -e "select now() \G"
+    [[ $? != "0" ]] && exit $?
+    echo "==> checking if cluster is ready"
+    mysql $creds -e "SHOW GLOBAL STATUS LIKE 'wsrep_ready' \G" | grep Value | awk '{ print $2}' | grep ON
+    [[ $? != "0" ]] && exit $?
+    echo "==> checking if cluster size matches replica count"
+    cluster_size=$(mysql $creds -e "SHOW GLOBAL STATUS LIKE 'wsrep_cluster_size' \G" | grep Value | awk '{ print $2}')
+    [[ $? != "0" ]] && exit $?
+    [[ "${cluster_size}" == "{{ .Values.replicas }}" ]] || exit 1
+    echo "SUCCESS"
+    exit 0

--- a/stable/percona-xtradb-cluster/templates/tests/pxc-test.yaml
+++ b/stable/percona-xtradb-cluster/templates/tests/pxc-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: pxc-test
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+    command: ["bash", "/tests/run.sh"]
+    env:
+    - name: MYSQL_ROOT_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ template "percona-xtradb-cluster.fullname" . }}
+          key: mysql-root-password
+    volumeMounts:
+    - mountPath: /tests
+      name: tests
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "percona-xtradb-cluster.fullname" . }}-tests
+  restartPolicy: Never

--- a/stable/percona-xtradb-cluster/values.yaml
+++ b/stable/percona-xtradb-cluster/values.yaml
@@ -31,6 +31,10 @@ replicas: 3
 ##
 # mysqlDatabase: test
 
+## hosts to allow root user access from
+# set to "127.0.0.1" to deny remote root.
+allowRootFrom: "%"
+
 ## Persist data to a persitent volume
 persistence:
   enabled: false


### PR DESCRIPTION
Add basic mysql/pxc state tests for `helm test` usage.

Added configurable hosts to allow remote root mysql access from.

