### PR TITLE
[stable/sonatype-nexus] Add annotation configuration in pvc

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 0.1.6
+version: 0.1.7
 appVersion: 3.5.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -43,18 +43,19 @@ The following tables lists the configurable parameters of the Nexus chart and th
 | ------------------------------------------  | ----------------------------------  | -------------------------------------------|
 | `image.tag`                                 | `nexus` image tag.                  | 3.5.1-02                                   |
 | `image.pullPolicy`                          | Image pull policy                   | `IfNotPresent`                             |
-| `nodeSelector`                              | node labels for pod assignment      | {}                                        |
+| `nodeSelector`                              | node labels for pod assignment      | {}                                         |
 | `ingress.enabled`                           | Flag for enabling ingress           | false                                      |
 | `persistence.enabled`                       | Create a volume to store data       | true                                       |
 | `persistence.size`                          | Size of persistent volume to claim  | 8Gi RW                                     |
 | `persistence.storageClass`                  | Type of persistent volume claim     | nil  (uses alpha storage class annotation) |
 | `persistence.accessMode`                    | ReadWriteOnce or ReadOnly           | ReadWriteOnce                              |
+| `persistence.annotations`                   | Persistent Volume annotations       | {}                                         |
 | `service.type`                              | Kubernetes Service type             | `LoadBalancer`                             |
 | `service.readinessProbe.initialDelaySeconds`| ReadinessProbe initial delay        | 30                                         |
 | `service.readinessProbe.periodSeconds`      | Seconds between polls               | 30                                         |
 | `service.readinessProbe.failureThreshold`   | Number of attempts before failure   | 6                                          |
 | `service.livenessProbe.initialDelaySeconds` | livenessProbe initial delay         | 30                                         |
-| `service.livenessProbe.periodSeconds`       | Seconds between polls               | 30                                         |                
+| `service.livenessProbe.periodSeconds`       | Seconds between polls               | 30                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/sonatype-nexus/templates/pvc.yaml
+++ b/stable/sonatype-nexus/templates/pvc.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -53,6 +53,8 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
+  # annotations:
+  #  "helm.sh/resource-policy": keep
   accessMode: ReadWriteOnce
   size: 8Gi
 resources: {}


### PR DESCRIPTION
I would like to keep a pvc object when I delete my release.
I use `"helm.sh/resource-policy": keep` in this case