### PR TITLE
[stable/consul] Parameterize domain option passed to consul (#4064)

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 1.3.1
+version: 1.3.2
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul-statefulset.yaml
+++ b/stable/consul/templates/consul-statefulset.yaml
@@ -153,6 +153,9 @@ spec:
             {{- if .Values.DatacenterName }}
               -datacenter {{ .Values.DatacenterName }} \
             {{- end }}
+            {{- if .Values.Domain }}
+              -domain={{ .Values.Domain }} \
+            {{- end }}
               -data-dir=/var/lib/consul \
               -server \
               -bootstrap-expect=${INITIAL_CLUSTER_SIZE} \

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -12,6 +12,11 @@ SerfwanPort: 8302
 SerfwanUdpPort: 8302
 ServerPort: 8300
 ConsulDnsPort: 8600
+
+## Specify the domain with which consul should run with
+## This will be passed as a -domain parameter
+Domain: consul
+
 ## Used as selector
 Component: "consul"
 Replicas: 3


### PR DESCRIPTION
This is for #4064 

### Changes

- Introduced a `Domain` value in `values.yaml` which is defaulted to `consul`.
- In `consul-statefulset.yaml`, use the `.Values.Domain` if present, and pass it as `-domain` parameter to consul agent.
- Bumped up patch version.