### PR TITLE
Remove clusterIP: None from master-svc.yaml

### DIFF
--- a/incubator/elasticsearch/templates/master-svc.yaml
+++ b/incubator/elasticsearch/templates/master-svc.yaml
@@ -9,7 +9,6 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "elasticsearch.master.fullname" . }}
 spec:
-  clusterIP: None
   ports:
     - port: 9300
       targetPort: transport


### PR DESCRIPTION
Why is this set to None? The master service needs a cluster IP during discovery of the minimum amount of master nodes. 