### PR TITLE
fix: typo daemonset.useHostPort for nginx-ingress

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.11.0
+version: 0.11.1
 appVersion: 0.11.0
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -98,13 +98,13 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-              {{- if .Values.controller.daemonset.useHostPorts }}
+              {{- if .Values.controller.daemonset.useHostPort }}
               hostPort: 80
               {{- end }}
             - name: https
               containerPort: 443
               protocol: TCP
-              {{- if .Values.controller.daemonset.useHostPorts }}
+              {{- if .Values.controller.daemonset.useHostPort }}
               hostPort: 443
               {{- end }}
           {{- if .Values.controller.stats.enabled }}


### PR DESCRIPTION
There is a typo in `daemonset.useHostPorts` which suppose to be `daemonset.useHostPort`

This fixes https://github.com/kubernetes/charts/issues/3837