### PR TITLE
[stable/cert-manager] Add podAnnotations

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -70,6 +70,7 @@ The following tables lists the configurable parameters of the cert-manager chart
 | `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
 | `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
 | `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
+| `podAnnotations` | Annotations to add to each pod | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: {{ template "cert-manager.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+      {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
       containers:

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -32,6 +32,8 @@ resources: {}
   #   cpu: 10m
   #   memory: 32Mi
 
+podAnnotations: {}
+
 nodeSelector: {}
 
 ingressShim:


### PR DESCRIPTION
This PR add podAnnotations value to the deployment resource.

This is useful if you want to use the Route53 provider together with Kube2Iam to allocate role:

```
annotations:
   "iam.amazonaws.com/role":"arn:aws:iam::<project id>:role/CertManagerRole"
```