### PR TITLE
[stable/suitecrm] Update deprecated annotation - service.beta.kuberne…

### DIFF
--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: suitecrm
-version: 0.3.7
+version: 0.3.8
 appVersion: 7.9.12
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/templates/svc.yaml
+++ b/stable/suitecrm/templates/svc.yaml
@@ -7,12 +7,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    service.beta.kubernetes.io/external-traffic: OnlyLocal
 spec:
   type: {{ .Values.serviceType }}
   {{- if eq .Values.serviceType "LoadBalancer" }}
   loadBalancerIP: {{ .Values.suitecrmLoadBalancerIP }}
+  externalTrafficPolicy: Local
   {{- end }}
   ports:
   - name: http


### PR DESCRIPTION
As stated [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip), the `annotation service.beta.kubernetes.io/external-traffic` has been deprecated in k8s 1.8.
Instead of using the annotation, now it is needed to set the `service.spec.externalTrafficPolicy` field to `Local`.

Without this customization, SuiteCRM constantly will log out the user because the client IP is changing.