### PR TITLE
[stable/prestashop] Update deprecated annotation - service.beta.kuber…

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 0.5.6
+version: 0.5.7
 appVersion: 1.7.3
 description: A popular open source ecommerce solution. Professional tools are easily
   accessible to increase online sales including instant guest checkout, abandoned

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -43,8 +43,6 @@ spec:
           value: {{ .Values.prestashopFirstName | quote }}
         - name: PRESTASHOP_LAST_NAME
           value: {{ .Values.prestashopLastName | quote }}
-        - name: PRESTASHOP_COOKIE_CHECK_IP
-          value: "no"
         - name: SMTP_HOST
           value: {{ .Values.smtpHost | quote }}
         - name: SMTP_PORT

--- a/stable/prestashop/templates/svc.yaml
+++ b/stable/prestashop/templates/svc.yaml
@@ -7,12 +7,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    service.beta.kubernetes.io/external-traffic: OnlyLocal
 spec:
   type: {{ .Values.serviceType }}
   {{- if eq .Values.serviceType "LoadBalancer" }}
   loadBalancerIP: {{ default "" .Values.prestashopLoadBalancerIP }}
+  externalTrafficPolicy: Local
   {{- end }}
   ports:
   - name: http


### PR DESCRIPTION
As stated [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip), the annotation `service.beta.kubernetes.io/external-traffic` has been deprecated in k8s 1.8.
Instead of using the annotation, now it is needed to set the `service.spec.externalTrafficPolicy` field to `Local`.

Without this customization, PrestaShop constantly will log out the user because the client IP is changing.