### PR TITLE
[stable/sugarcrm] Update deprecated annotation - service.beta.kuberne…

### DIFF
--- a/stable/sugarcrm/Chart.yaml
+++ b/stable/sugarcrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: sugarcrm
-version: 0.2.5
+version: 0.2.6
 appVersion: 6.5.26
 description: SugarCRM enables businesses to create extraordinary customer relationships with the most innovative and affordable CRM solution in the market.
 keywords:

--- a/stable/sugarcrm/templates/svc.yaml
+++ b/stable/sugarcrm/templates/svc.yaml
@@ -7,12 +7,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-    service.beta.kubernetes.io/external-traffic: OnlyLocal
 spec:
   type: {{ .Values.serviceType }}
   {{- if eq .Values.serviceType "LoadBalancer" }}
   loadBalancerIP: {{ .Values.sugarcrmLoadBalancerIP }}
+  externalTrafficPolicy: Local
   {{- end }}
   ports:
   - name: http


### PR DESCRIPTION
As stated [here](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip), the `annotation service.beta.kubernetes.io/external-traffic` has been deprecated in k8s 1.8.
Instead of using the annotation, now it is needed to set the `service.spec.externalTrafficPolicy` field to `Local`.

Without this customization, SugarCRM constantly will log out the user because the client IP is changing.
