### PR TITLE
[stable/kong] Using ssl option to switch service between https/http

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.12.1

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -1,8 +1,8 @@
 1. Kong Admin can be accessed inside the cluster using:
      DNS={{ template "kong.fullname" . }}-admin.{{ .Release.Namespace }}.svc.cluster.local
-   {{- if .Values.admin.https }}
+   {{- if .Values.admin.ssl }}
      PORT={{ .Values.admin.https.servicePort }}
-   {{- else if .Values.admin.http }}
+   {{- else }}
      PORT={{ .Values.admin.http.servicePort }}
    {{- end }}
 
@@ -19,11 +19,11 @@ To connect from outside the K8s cluster:
    {{- else if contains "ClusterIP" .Values.admin.type }}
      HOST=127.0.0.1
 
-     {{- if .Values.admin.https }}
+     {{- if .Values.admin.ssl }}
      # Execute the following commands to route the connection to Admin SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl port-forward $POD_NAME {{ .Values.admin.https.servicePort }}:{{ .Values.admin.https.servicePort }}
-     {{- else if .Values.admin.http }}
+     {{- else }}
      # Execute the following commands to route the connection to Admin port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl port-forward $POD_NAME {{ .Values.admin.http.servicePort }}:{{ .Values.admin.http.servicePort }}
@@ -33,9 +33,9 @@ To connect from outside the K8s cluster:
 
 2. Kong Proxy can be accessed inside the cluster using:
      DNS={{ template "kong.fullname" . }}-proxy.{{ .Release.Namespace }}.svc.cluster.local
-   {{- if .Values.proxy.https }}
+   {{- if .Values.proxy.ssl }}
      PORT={{ .Values.proxy.https.servicePort }}
-   {{- else if .Values.proxy.http }}
+   {{- else }}
      PORT={{ .Values.proxy.http.servicePort }}
    {{- end }}
 
@@ -52,11 +52,11 @@ To connect from outside the K8s cluster:
    {{- else if contains "ClusterIP" .Values.proxy.type }}
      HOST=127.0.0.1
 
-     {{- if .Values.proxy.https }}
+     {{- if .Values.proxy.ssl }}
      # Execute the following commands to route the connection to proxy SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl port-forward $POD_NAME {{ .Values.proxy.https.servicePort }}:{{ .Values.proxy.https.servicePort }}
-     {{- else if .Values.proxy.http }}
+     {{- else }}
      # Execute the following commands to route the connection to proxy port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl port-forward $POD_NAME {{ .Values.proxy.http.servicePort }}:{{ .Values.proxy.http.servicePort }}

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -18,10 +18,10 @@ spec:
   {{- end }}
   ports:
   - name: kong-admin
-  {{- if .Values.admin.https }}
+  {{- if .Values.admin.ssl }}
     port: {{ .Values.admin.https.servicePort }}
     targetPort: {{ .Values.admin.https.containerPort }}
-  {{- else if .Values.admin.http }}
+  {{- else }}
     port: {{ .Values.admin.http.servicePort }}
     targetPort: {{ .Values.admin.http.containerPort }}
   {{- end }}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -18,10 +18,10 @@ spec:
   {{- end }}
   ports:
   - name: kong-proxy
-  {{- if .Values.proxy.https }}
+  {{- if .Values.proxy.ssl }}
     port: {{ .Values.proxy.https.servicePort }}
     targetPort: {{ .Values.proxy.https.containerPort }}
-  {{- else if .Values.proxy.http }}
+  {{- else }}
     port: {{ .Values.proxy.http.servicePort }}
     targetPort: {{ .Values.proxy.http.containerPort }}
   {{- end }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -14,6 +14,7 @@ admin:
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
   # HTTPS traffic on the admin port
+  ssl: true
   https:
     servicePort: 8444
     containerPort: 8444
@@ -30,6 +31,7 @@ proxy:
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
   # HTTPS traffic on the proxy port
+  ssl: true
   https:
     servicePort: 8443
     containerPort: 8443


### PR DESCRIPTION
I tried to use http ports in service without luck setting https: '' in my values.yaml but the deployment.yaml crashed with this message because it requires the info in it.

```
2018/03/09 15:47:40 warning: cannot overwrite table with non table for https (map[containerPort:8444 servicePort:8444])
Error: UPGRADE FAILED: render error in "kong/templates/deployment.yaml": template: kong/templates/deployment.yaml:34:48: executing "kong/templates/deployment.yaml" at <.Values.admin.https....>: can't evaluate field containerPort in type interface {}
```

So, to be able to use http in the services (for whatever reason anyone may have), I suggest in this PR to use an `ssl` boolean option.