### PR TITLE
Deprecate dask-distributed chart

### DIFF
--- a/stable/dask-distributed/Chart.yaml
+++ b/stable/dask-distributed/Chart.yaml
@@ -5,7 +5,4 @@ home: https://github.com/dask/distributed
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
 sources:
 - https://github.com/dask/distributed
-maintainers:
-- name: danielfrg
-  email: df.rodriguez143@gmail.com
 deprecated: true

--- a/stable/dask-distributed/Chart.yaml
+++ b/stable/dask-distributed/Chart.yaml
@@ -1,9 +1,9 @@
 name: dask-distributed
 # The dask-distributed chart is deprecated and no longer maintained.
-# For details on deprecation, including how to un-deprecate a chart, 
+# For details on deprecation, including how to un-deprecate a chart,
 # see the PROCESSES.md file.
 deprecated: true
-version: 3.0.0
+version: 2.0.1
 description: "DEPRECATED: Distributed computation in Python"
 home: https://github.com/dask/distributed
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200

--- a/stable/dask-distributed/Chart.yaml
+++ b/stable/dask-distributed/Chart.yaml
@@ -1,8 +1,11 @@
 name: dask-distributed
-version: 2.0.0
+# The dask-distributed chart is deprecated and no longer maintained.
+# For details on deprecation, including how to un-deprecate a chart, 
+# see the PROCESSES.md file.
+deprecated: true
+version: 3.0.0
 description: "DEPRECATED: Distributed computation in Python"
 home: https://github.com/dask/distributed
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
 sources:
 - https://github.com/dask/distributed
-deprecated: true

--- a/stable/dask-distributed/Chart.yaml
+++ b/stable/dask-distributed/Chart.yaml
@@ -1,6 +1,6 @@
 name: dask-distributed
 version: 2.0.0
-description: Distributed computation in Python
+description: "DEPRECATED: Distributed computation in Python"
 home: https://github.com/dask/distributed
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
 sources:
@@ -8,3 +8,4 @@ sources:
 maintainers:
 - name: danielfrg
   email: df.rodriguez143@gmail.com
+deprecated: true

--- a/stable/dask-distributed/README.md
+++ b/stable/dask-distributed/README.md
@@ -1,3 +1,10 @@
+# Deprecated
+
+This chart has been deprecated.
+
+See the chart in `stable/dask` instead.
+
+
 # Dask Distributed Helm Chart
 
 Dask Distributed allows distributed computation in Python the chart also includes a single user Jupyter Notebook.

--- a/stable/dask-distributed/templates/NOTES.txt
+++ b/stable/dask-distributed/templates/NOTES.txt
@@ -1,3 +1,7 @@
+##########################################################
+# This chart has been deprecated in favor of stable/dask #
+##########################################################
+
 1. Get the Dask Scheduler connection string by running this commands in the same shell:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available, until that the commands below will not work.  

--- a/stable/dask/templates/NOTES.txt
+++ b/stable/dask/templates/NOTES.txt
@@ -1,7 +1,3 @@
-##########################################################
-# This chart has been deprecated in favor of stable/dask #
-##########################################################
-
 Thank you for installing {{ .Chart.Name | upper }}, released at name: {{ .Release.Name }}.
 
 To learn more about the release, try:

--- a/stable/dask/templates/NOTES.txt
+++ b/stable/dask/templates/NOTES.txt
@@ -1,3 +1,7 @@
+##########################################################
+# This chart has been deprecated in favor of stable/dask #
+##########################################################
+
 Thank you for installing {{ .Chart.Name | upper }}, released at name: {{ .Release.Name }}.
 
 To learn more about the release, try:


### PR DESCRIPTION
Following on #2914 , this deprecates the old dask-distributed chart