### PR TITLE
[stable/mariadb]: Update chart templates

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 2.1.7
+version: 2.1.8
 appVersion: 10.1.31
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -9,8 +9,24 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "mariadb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mariadb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/mariadb/templates/configmap.yaml
+++ b/stable/mariadb/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
     app: {{ template "mariadb.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
     app: {{ template "mariadb.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/mariadb/templates/pvc.yaml
+++ b/stable/mariadb/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
     app: {{ template "mariadb.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/mariadb/templates/secrets.yaml
+++ b/stable/mariadb/templates/secrets.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
     app: {{ template "mariadb.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/mariadb/templates/svc.yaml
+++ b/stable/mariadb/templates/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
     app: {{ template "mariadb.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mariadb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:


### PR DESCRIPTION
Update the mariadb chart's templates to match those created by
`helm create`, and update chart labels to use the new mariadb.chart
template.