### PR TITLE
[incubator/jaeger] Add parentheses around 'or' parameters to fix cron-job installation

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.6
+version: 0.3.7
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.spark.enabled -}}
-{{- if or .Capabilities.APIVersions.Has "batch/v1beta1" .Capabilities.APIVersions.Has "batch/v2alpha1" -}}
+{{- if or (.Capabilities.APIVersions.Has "batch/v1beta1") (.Capabilities.APIVersions.Has "batch/v2alpha1") -}}
 apiVersion: {{ template "cronjob.apiVersion" $ }}
 kind: CronJob
 metadata:


### PR DESCRIPTION
Without these parentheses, I wasn't able to install chart with `spark.enabled=true`.
