### PR TITLE
[stable/concourse] Change Concourse links

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.0.3
+version: 1.0.4
 appVersion: 3.9.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
@@ -7,7 +7,7 @@ keywords:
 - ci
 - concourse
 - concourse.ci
-home: https://concourse.ci/
+home: https://concourse-ci.org/
 sources:
 - https://github.com/concourse/bin
 - https://github.com/kubernetes/charts

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -1,6 +1,6 @@
 # Concourse Helm Chart
 
-[Concourse](https://concourse.ci/) is a simple and scalable CI system.
+[Concourse](https://concourse-ci.org/) is a simple and scalable CI system.
 
 ## TL;DR;
 
@@ -10,7 +10,7 @@ $ helm install stable/concourse
 
 ## Introduction
 
-This chart bootstraps a [Concourse](https://concourse.ci/) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Concourse](https://concourse-ci.org/) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites Details
 
@@ -68,7 +68,7 @@ The following tables lists the configurable parameters of the Concourse chart an
 | Parameter               | Description                           | Default                                                    |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
 | `image` | Concourse image | `concourse/concourse` |
-| `imageTag` | Concourse image version | `3.8.0` |
+| `imageTag` | Concourse image version | `3.9.0` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
 | `concourse.externalURL` | URL used to reach any ATC from the outside world | `nil` |
 | `concourse.atcPort` | Concourse ATC listen port | `8080` |
@@ -165,7 +165,6 @@ The following tables lists the configurable parameters of the Concourse chart an
 | `secrets.awsSsmAccessKey` | AWS Access Key ID for SSM access | `nil` |
 | `secrets.awsSsmSecretKey` | AWS Secret Access Key ID for SSM access | `nil` |
 | `secrets.awsSsmSessionToken` | AWS Session Token for SSM access | `nil` |
-
 | `secrets.basicAuthUsername` | Concourse Basic Authentication Username | `concourse` |
 | `secrets.basicAuthPassword` | Concourse Basic Authentication Password | `concourse` |
 | `secrets.githubAuthClientId` | Application client ID for GitHub OAuth | `nil` |
@@ -313,7 +312,7 @@ The only way to completely avoid putting secrets in Helm is to bring your own Po
 
 ### Credential Management
 
-Pipelines ususally need credentials to do things. Concourse supports the use of a [Credential Manager](https://concourse.ci/creds.html) so your pipelines can contain references to secrets instead of the actual secret values. You can't use more than one credential manager at a time.
+Pipelines ususally need credentials to do things. Concourse supports the use of a [Credential Manager](https://concourse-ci.org/creds.html) so your pipelines can contain references to secrets instead of the actual secret values. You can't use more than one credential manager at a time.
 
 #### Kubernetes Secrets
 
@@ -365,7 +364,7 @@ To use Vault, set `credentialManager.kubernetes.enabled` to false, and set the f
 
 ```yaml
 ## Configuration values for the Credential Manager.
-## ref: https://concourse.ci/creds.html
+## ref: https://concourse-ci.org/creds.html
 ##
 credentialManager:
 

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -44,7 +44,7 @@
   Password: see basic-auth-password in secret {{ template "concourse.concourse.fullname" . }}
   {{ end }}
 {{- end }}
-* If this is your first time using Concourse, follow the tutorial at https://concourse.ci/hello-world.html
+* If this is your first time using Concourse, follow the tutorial at https://concourse-ci.org/hello-world.html
 {{- if contains "naive" .Values.concourse.baggageclaimDriver }}
 
 *******************

--- a/stable/concourse/templates/worker-svc.yaml
+++ b/stable/concourse/templates/worker-svc.yaml
@@ -14,7 +14,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ## We do NOT expose any port as workers will forward connections with the ATC through a TSA reverse-tunnel
-  ## ref: https://concourse.ci/architecture.html#architecture-worker
+  ## ref: https://concourse-ci.org/architecture.html#architecture-worker
   ##
   ports: []
   selector:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -21,17 +21,17 @@ imageTag: "3.9.0"
 imagePullPolicy: IfNotPresent
 
 ## Configuration values for Concourse.
-## ref: https://concourse.ci/setting-up.html
+## ref: https://concourse-ci.org/setting-up.html
 ##
 concourse:
 
   ## ATC listen port.
-  ## ref: https://concourse.ci/architecture.html
+  ## ref: https://concourse-ci.org/architecture.html
   ##
   atcPort: 8080
 
   ## TSA listen port.
-  ## ref: https://concourse.ci/architecture.html
+  ## ref: https://concourse-ci.org/architecture.html
   ##
   tsaPort: 2222
 
@@ -87,19 +87,19 @@ concourse:
   # insecureDockerRegistry:
 
   ## Enable encryption of pipeline configuration. Encryption keys can be set via secrets.
-  ## See https://concourse.ci/encryption.html
+  ## See https://concourse-ci.org/encryption.html
   ##
   encryption:
     enabled: false
 
   ## Enable basic auth for the "main" Concourse team.
-  ## See https://concourse.ci/teams.html#basic-auth
+  ## See https://concourse-ci.org/teams.html#basic-auth
   ##
   basicAuth:
     enabled: true
 
   ## Enable GitHub auth for the "main" Concourse team.
-  ## See https://concourse.ci/teams.html#github-auth
+  ## See https://concourse-ci.org/teams.html#github-auth
   ##
   githubAuth:
     enabled: false
@@ -150,7 +150,7 @@ concourse:
     # apiUrl:
 
   ## Enable generic OAuth for the "main" Concourse team.
-  ## See https://concourse.ci/teams.html#generic-oauth
+  ## See https://concourse-ci.org/teams.html#generic-oauth
   ##
   genericOauth:
     enabled: false
@@ -268,7 +268,7 @@ web:
     #
 
   ## Metric Configuration
-  ## ref: https://concourse.ci/metrics.html
+  ## ref: https://concourse-ci.org/metrics.html
   ##
   metrics:
 
@@ -352,7 +352,7 @@ worker:
   #    effect: "NoSchedule"
 
   ## Time to allow the pod to terminate before being forcefully terminated. This should provide time for
-  ## the worker to retire, i.e. drain its tasks. See https://concourse.ci/worker-internals.html for worker
+  ## the worker to retire, i.e. drain its tasks. See https://concourse-ci.org/worker-internals.html for worker
   ## lifecycle semantics.
   terminationGracePeriodSeconds: 60
 
@@ -435,7 +435,7 @@ postgresql:
     enabled: true
 
 ## Configuration values for using a Credential Manager. Only one can be enabled.
-## ref: https://concourse.ci/creds.html
+## ref: https://concourse-ci.org/creds.html
 ##
 credentialManager:
 
@@ -526,7 +526,7 @@ secrets:
   create: true
 
   ## Concourse Host Keys.
-  ## ref: https://concourse.ci/binaries.html#generating-keys
+  ## ref: https://concourse-ci.org/binaries.html#generating-keys
   ##
   hostKey: |-
     -----BEGIN RSA PRIVATE KEY-----
@@ -561,7 +561,7 @@ secrets:
     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse
 
   ## Concourse Session Signing Keys.
-  ## ref: https://concourse.ci/binaries.html#generating-keys
+  ## ref: https://concourse-ci.org/binaries.html#generating-keys
   ##
   sessionSigningKey: |-
     -----BEGIN RSA PRIVATE KEY-----
@@ -593,7 +593,7 @@ secrets:
     -----END RSA PRIVATE KEY-----
 
   ## Concourse Worker Keys.
-  ## ref: https://concourse.ci/binaries.html#generating-keys
+  ## ref: https://concourse-ci.org/binaries.html#generating-keys
   ##
   workerKey: |-
     -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
Concourse.ci was hijacked and the team has made the decision to move to
https://concourse-ci.org:

https://medium.com/concourse-ci/were-switchin-domains-5597dcd0b48b