### PR TITLE
[incubator/kafka] Set liveness probe to use jps and readiness to tcpSocket

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.4.6
+version: 0.4.7
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -59,17 +59,16 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         livenessProbe:
-          tcpSocket:
-            port: 9092
+          exec:
+            command:
+              - sh
+              - -ec
+              - /usr/bin/jps | /bin/grep -q SupportedKafka
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
-          exec:
-            command:
-              - kafka-topics
-              - --zookeeper
-              - {{ template "zookeeper.url" . }}
-              - --list
+          tcpSocket:
+            port: kafka
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
Use 'jps' for the Liveness probe, and tcpSocket check for Readiness.

This fixes an issue whereby a long broker startup causes the liveness probe to fail, e.g. when it's fixing corrupted indexes.

Fixes https://github.com/kubernetes/charts/issues/2682 and possibly https://github.com/kubernetes/charts/issues/3697 .  @benbarclay 