### PR TITLE
[stable/grafana] Fix grafana url to same as deployment name

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.8.3
+version: 0.8.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/job.yaml
+++ b/stable/grafana/templates/job.yaml
@@ -37,7 +37,7 @@ spec:
               name: {{ template "grafana.server.fullname" . }}
               key: grafana-admin-password
         args:
-          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/datasources"
+          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.server.fullname" . }}:{{ .Values.server.service.httpPort }}/api/datasources"
           - "--max-time"
           - "10"
           - "-H"


### PR DESCRIPTION
After #4062 merged, some case (eg. release name contains chart name) are not working when using setdatasource job.

```
# kubectl logs grafana-set-datasource-db6xd -n kube-system
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: grafana-grafana
  ```

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
