### PR TITLE
[stable/cockroachdb] Add config for public service type

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.6.5
+version: 0.6.6
 appVersion: 1.1.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -51,6 +51,7 @@ The following tables lists the configurable parameters of the CockroachDB chart 
 | `ClusterDomain`               | Cluster's default DNS domain               | `cluster.local`                              |
 | `NetworkPolicy.Enabled`       | Enable NetworkPolicy                       | `false`                                      |
 | `NetworkPolicy.AllowExternal` | Don't require client label for connections | `true`                                       |
+| `Service.Type`                | Public service type                        | `ClusterIP`                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-{{ .Values.Component }}"
 spec:
+  type: {{ .Values.Service.type }}
   ports:
   # The main port, served by gRPC, serves Postgres-flavor SQL, internode
   # traffic and the cli.

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -31,3 +31,5 @@ ClusterDomain: "cluster.local"
 NetworkPolicy:
   Enabled: false
   AllowExternal: true
+Service:
+  type: ClusterIP


### PR DESCRIPTION
Would prefer not to `kubectl port-forward` on dev environments. Adding configuration for the public service's `type` let's me set it to something more convenient like `NodePort`.