### PR TITLE
[stable/consul] Add externalIPs parameter to the main service

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 1.3.2
+version: 1.3.3
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -46,6 +46,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | `SerfwanUdpPort`        | Container serf wan UDP listening port | `8302`                                                     |
 | `ServerPort`            | Container server listening port       | `8300`                                                     |
 | `ConsulDnsPort`         | Container dns listening port          | `8600`                                                     |
+| `ExternalIPs`           | External IP address for DNS, SerfWan, SerfLan | `[]`                                               |
 | `antiAffinity`          | Consul pod anti-affinity setting      | `hard`                                                     |
 | `maxUnavailable`        | Pod disruption Budget maxUnavailable  | `1`                                                        |
 | `ui.enabled`            | Enable Consul Web UI                  | `true`                                                    |

--- a/stable/consul/templates/consul-service-external.yaml
+++ b/stable/consul/templates/consul-service-external.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ExternalIPs }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "consul.fullname" . }}-external"
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Component }}"
+spec:
+  ports:
+  - name: http
+    port: {{ .Values.HttpPort }}
+  - name: rpc
+    port: {{ .Values.RpcPort }}
+  - name: serflan-tcp
+    protocol: "TCP"
+    port: {{ .Values.SerflanPort }}
+  - name: serflan-udp
+    protocol: "UDP"
+    port: {{ .Values.SerflanUdpPort }}
+  - name: serfwan-tcp
+    protocol: "TCP"
+    port: {{ .Values.SerfwanPort }}
+  - name: serfwan-udp
+    protocol: "UDP"
+    port: {{ .Values.SerfwanUdpPort }}
+  - name: server
+    port: {{.Values.ServerPort}}
+  - name: consuldns-tcp
+    port: {{.Values.ConsulDnsPort}}
+  - name: consuldns-udp
+    protocol: "UDP"
+    port: {{.Values.ConsulDnsPort}}
+  externalIPs:
+{{ toYaml .Values.ExternalIPs | indent 4 }}
+  selector:
+    component: "{{ .Release.Name }}-{{ .Values.Component }}"
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This change is aimed for environments that don't have dedicated load balancers (bare metal installations). We want Consul agents to be able to communicate with the Consul servers from outside of the Kubernetes cluster.