### PR TITLE
[stable/sumologic-fluentd] flushInterval changed to 5s

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.2.1
+version: 0.2.2
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -30,9 +30,9 @@ sumologic:
   ## in the container (Default "/fluentd/conf.d/user")
   fluentdUserConfigDir: ""
 
-  ## How frequently to push logs to SumoLogic (default 5s)
+  ## How frequently to push logs to SumoLogic (default 30s)
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
-  # flushInterval: 5
+  flushInterval: 5
 
   ## Increase number of http threads to Sumo. May be required in heavy logging clusters (default 1)
   # numThreads: 1


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

I believe this value was only commented out since it supposedly was the default. All docs claim the flush interval default is 5s, when it is in fact 30.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

See: https://github.com/SumoLogic/fluentd-kubernetes-sumologic/issues/45#issuecomment-363607875 and https://github.com/SumoLogic/fluentd-kubernetes-sumologic/blob/master/Dockerfile#L26