### PR TITLE
Add annotations and service type to zookeeper

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
-*****************************************************************************************
-
+<!--
 Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
 make sure you are aware of our technical requirements and best practices:
 
@@ -14,8 +13,20 @@ our review guidelines:
 Following our best practices right from the start will accelerate the review process and
 help get your PR merged quicker.
 
-When updates to your PR are requested, please add new commits and do not squash the 
-history. This will make it easier to identify new changes. The PR will be squashed 
+When updates to your PR are requested, please add new commits and do not squash the
+history. This will make it easier to identify new changes. The PR will be squashed
 anyways when it is merged. Thanks.
 
-*****************************************************************************************
+For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
+
+Please make sure you test your changes before you push them. Once pushed, a CircleCI
+will run across your changes and do some initial checks and linting. These checks run
+very quickly. Please check the results. We would like these checks to pass before we
+even continue reviewing your changes.
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
+
+**Special notes for your reviewer**:

--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.5.1
+version: 0.5.3
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -46,7 +46,7 @@ statefulsets/myzk-zookeeper   3         3         2m
 
 1. `statefulsets/myzk-zookeeper` is the StatefulSet created by the chart.
 1. `po/myzk-zookeeper-<0|1|2>` are the Pods created by the StatefulSet. Each Pod has a single container running a ZooKeeper server.
-1. `svc/myzk-zookeeper-headless` is the Headless Server used to control the network domain of the ZooKeeper ensemble.
+1. `svc/myzk-zookeeper-headless` is the Headless Service used to control the network domain of the ZooKeeper ensemble.
 1. `svc/myzk-zookeeper` is a Service that can be used by clients to connect to an available ZooKeeper server.
 
 ## Configuration

--- a/incubator/zookeeper/templates/NOTES.txt
+++ b/incubator/zookeeper/templates/NOTES.txt
@@ -1,7 +1,8 @@
 Thank you for installing ZooKeeper on your Kubernetes cluster. More information
 about ZooKeeper can be found at https://zookeeper.apache.org/doc/current/
 
-1. ZooKeeper is not accessible outside of the Kubernetes cluster. Its purpose is
+1. ZooKeeper will be accessible outside of the Kubernetes cluster only if 
+appropriate annotations and service type were provided. Its purpose is
 to provide coordination for distributed systems running inside the cluster. As
 ZooKeeper uses a TCP based protocol with an internal wire format, you will
 probably want to use an existing client library for communication with the

--- a/incubator/zookeeper/templates/service-clients.yaml
+++ b/incubator/zookeeper/templates/service-clients.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}
+{{- if .Values.annotations }}
+  annotations: 
+{{ toYaml .Values.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ include "zookeeper.name" . | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -14,3 +18,7 @@ spec:
   selector:
     app: {{ include "zookeeper.name" . | quote }}
     release: {{ .Release.Name | quote }}
+{{- if .Values.serviceType }}
+  type: {{ .Values.serviceType }}
+{{- end }}
+

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -32,6 +32,14 @@ security:
   runAsUser: 1000
   fsGroup: 1000
 
+## Make zookeeper accessible outside of the kubernetes cluster
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+# annotations:
+#   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+# serviceType: LoadBalancer
+
+
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##

--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 1.3.2
+version: 1.3.3
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul-ingress.yaml
+++ b/stable/consul/templates/consul-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-{{ .Values.Component }}"
-  name: "{{ template "fullname" . }}-ui"
+  name: "{{ template "consul.fullname" . }}-ui"
 spec:
   rules:
   {{- range .Values.uiIngress.hosts }}

--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.7.1
+version: 0.7.2
 appVersion: 0.7.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.etcdOperator.replicaCount }}
   template:
     metadata:
       name: {{ template "etcd-operator.fullname" . }}

--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.9.1
+version: 0.9.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -90,7 +90,7 @@ $ helm install --name my-release \
     stable/postgresql
 ```
 
-The above command creates a PostgreSQL user named `root` with password `secretpassword`. Additionally it creates a database named `my-database`.
+The above command creates a PostgreSQL user named `my-user` with password `secretpassword`. Additionally it creates a database named `my-database`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 

--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 0.1.6
+version: 0.1.7
 appVersion: 3.5.1
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -43,18 +43,19 @@ The following tables lists the configurable parameters of the Nexus chart and th
 | ------------------------------------------  | ----------------------------------  | -------------------------------------------|
 | `image.tag`                                 | `nexus` image tag.                  | 3.5.1-02                                   |
 | `image.pullPolicy`                          | Image pull policy                   | `IfNotPresent`                             |
-| `nodeSelector`                              | node labels for pod assignment      | {}                                        |
+| `nodeSelector`                              | node labels for pod assignment      | {}                                         |
 | `ingress.enabled`                           | Flag for enabling ingress           | false                                      |
 | `persistence.enabled`                       | Create a volume to store data       | true                                       |
 | `persistence.size`                          | Size of persistent volume to claim  | 8Gi RW                                     |
 | `persistence.storageClass`                  | Type of persistent volume claim     | nil  (uses alpha storage class annotation) |
 | `persistence.accessMode`                    | ReadWriteOnce or ReadOnly           | ReadWriteOnce                              |
+| `persistence.annotations`                   | Persistent Volume annotations       | {}                                         |
 | `service.type`                              | Kubernetes Service type             | `LoadBalancer`                             |
 | `service.readinessProbe.initialDelaySeconds`| ReadinessProbe initial delay        | 30                                         |
 | `service.readinessProbe.periodSeconds`      | Seconds between polls               | 30                                         |
 | `service.readinessProbe.failureThreshold`   | Number of attempts before failure   | 6                                          |
 | `service.livenessProbe.initialDelaySeconds` | livenessProbe initial delay         | 30                                         |
-| `service.livenessProbe.periodSeconds`       | Seconds between polls               | 30                                         |                
+| `service.livenessProbe.periodSeconds`       | Seconds between polls               | 30                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/sonatype-nexus/templates/pvc.yaml
+++ b/stable/sonatype-nexus/templates/pvc.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -53,6 +53,8 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
+  # annotations:
+  #  "helm.sh/resource-policy": keep
   accessMode: ReadWriteOnce
   size: 8Gi
 resources: {}

--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: suitecrm
-version: 0.3.8
+version: 0.3.9
 appVersion: 7.9.12
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/values.yaml
+++ b/stable/suitecrm/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami SuiteCRM image version
 ## ref: https://hub.docker.com/r/bitnami/suitecrm/tags/
 ##
-image: bitnami/suitecrm:7.9.12-r1
+image: bitnami/suitecrm:7.9.12-r2
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.8.10
+version: 0.8.11
 appVersion: 4.9.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -1,7 +1,7 @@
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
 ##
-image: bitnami/wordpress:4.9.4-r4
+image: bitnami/wordpress:4.9.4-r5
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Enable the zookeeper service to be accessible from inside as well as outside the cluster if required.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Enables the zookeeper service to be accessible from inside as well as outside the cluster if required.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
