### PR TITLE
Add annotations and service type to zookeeper

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 0.5.2
+version: 0.5.3
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif

--- a/incubator/zookeeper/templates/NOTES.txt
+++ b/incubator/zookeeper/templates/NOTES.txt
@@ -1,7 +1,8 @@
 Thank you for installing ZooKeeper on your Kubernetes cluster. More information
 about ZooKeeper can be found at https://zookeeper.apache.org/doc/current/
 
-1. ZooKeeper is not accessible outside of the Kubernetes cluster. Its purpose is
+1. ZooKeeper will be accessible outside of the Kubernetes cluster only if 
+appropriate annotations and service type were provided. Its purpose is
 to provide coordination for distributed systems running inside the cluster. As
 ZooKeeper uses a TCP based protocol with an internal wire format, you will
 probably want to use an existing client library for communication with the

--- a/incubator/zookeeper/templates/service-clients.yaml
+++ b/incubator/zookeeper/templates/service-clients.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zookeeper.fullname" . }}
+{{- if .Values.annotations }}
+  annotations: 
+{{ toYaml .Values.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ include "zookeeper.name" . | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -14,3 +18,7 @@ spec:
   selector:
     app: {{ include "zookeeper.name" . | quote }}
     release: {{ .Release.Name | quote }}
+{{- if .Values.serviceType }}
+  type: {{ .Values.serviceType }}
+{{- end }}
+

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -32,6 +32,14 @@ security:
   runAsUser: 1000
   fsGroup: 1000
 
+## Make zookeeper accessible outside of the kubernetes cluster
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+##
+# annotations:
+#   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+# serviceType: LoadBalancer
+
+
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##


### PR DESCRIPTION
Enable the zookeeper service to be accessible from inside as well as outside the cluster if required.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Enables the zookeeper service to be accessible from inside as well as outside the cluster if required.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
