### PR TITLE
[stable/cluster-autoscaler] Enable Autodiscovery

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.4.2
+version: 0.5.0
 appVersion: 1.1.0
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -1,23 +1,8 @@
 # cluster-autoscaler
 
-[The cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) scales worker nodes within an AWS autoscaling group or Spotinst Elastigroup.
+[The cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) scales worker nodes within an AWS autoscaling group (ASG) or Spotinst Elastigroup.
 
 ## TL;DR:
-
-## Helm < 2.5
-
-```console
-$ helm install stable/cluster-autoscaler --name my-release -f values.yaml
-```
-Where `values.yaml` contains:
-
-```
-autoscalingGroups:
-  - name: your-scaling-group-name
-    maxSize: 10
-    minSize: 1
-```
-## Helm >= 2.5
 
 ```console
 $ helm install stable/cluster-autoscaler --name my-release --set "autoscalingGroups[0].name=your-asg-name,autoscalingGroups[0].maxSize=10,autoscalingGroups[0].minSize=1"
@@ -25,66 +10,61 @@ $ helm install stable/cluster-autoscaler --name my-release --set "autoscalingGro
 
 ## Introduction
 
-This chart bootstraps an cluster-autoscaler deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a cluster-autoscaler deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
-  - Kubernetes 1.3+ with Beta APIs enabled
+
+  - Kubernetes 1.8+
+> [older versions](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases) may work by overriding the `image`. Cluster-autoscaler internally simulates the scheduler and bugs between mismatched versions may be subtle.
 
 ## Installing the Chart
 
-In order for the chart to configure the cluster-autoscaler properly during the installation process, you must provide some minimal configuration which can't rely on defaults. This includes at least one element in the `autoscalingGroups` array and its three values: `name`, `minSize` and `maxSize`. If you are using Helm < 2.5 these parameters cannot be passed to helm using the `--set` parameter, so you must supply these using a `values.yaml` file such as:
+**By default, no deployment is created and nothing will autoscale**.
 
-```
-autoscalingGroups:
-  - name: your-scaling-group-name
-    maxSize: 10
-    minSize: 1
-```
+You must provide some minimal configuration, either to specify instance groups or enable auto-discovery. It is not recommended to do both.
+
+Either:
+  - set `autoDiscovery.clusterName` and tag your autoscaling groups appropriately (`--cloud-provider=aws` only) **or**
+  - set at least one ASG as an element in the `autoscalingGroups` array with its three values: `name`, `minSize` and `maxSize`.
 
 To install the chart with the release name `my-release`:
 
-## Helm < 2.5
+### Using auto-discovery of tagged instance groups
+
+Auto-discovery finds ASGs tags as below and automatically manages them based on the min and max size specified in the ASG. `cloudProvider=aws` only.
+
+1) tag the ASGs with _key_ `k8s.io/cluster-autoscaler/enabled` and _key_ `kubernetes.io/cluster/<YOUR CLUSTER NAME>`
+1) verify the [IAM Permissions](#IAM)
+1) set `autoDiscovery.clusterName=<YOUR CLUSTER NAME>`
 
 ```console
-$ helm install stable/cluster-autoscaler --name my-release -f values.yaml
+$ helm install stable/cluster-autoscaler --name my-release --set autoDiscovery.clusterName=<CLUSTER NAME>
 ```
 
-## Helm >= 2.5
+The [auto-discovery](#auto-discovery) section provides more details and examples
+
+### Specifying groups manually
+
+Without autodiscovery, specify an array of elements each containing ASG name, min size, max size. The sizes specified here will be applied to the ASG, assuming IAM permissions are correctly configured.
+
+1) verify the [IAM Permissions](#IAM Permissions)
+1) Either provide a yaml file setting `autoscalingGroups` (see values.yaml) or use `--set` e.g.:
 
 ```console
 $ helm install stable/cluster-autoscaler --name my-release --set "autoscalingGroups[0].name=your-asg-name,autoscalingGroups[0].maxSize=10,autoscalingGroups[0].minSize=1"
 ```
 
-The command deploys cluster-autoscaler on the Kubernetes cluster using the supplied configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
-
-> **Tip**: List all releases using `helm list`
-
-## Verifying Installation
-
-The chart will succeed even if the three required parameters are not supplied. To verify the cluster-autoscaler is configured properly find a pod that the deployment created and describe it. It must have a `--nodes` argument supplied to the `./cluster-autoscaler` app under `Command`. For example (all other values are omitted for brevity):
-
-```
-Containers:
-  cluster-autoscaler:
-    Command:
-      ./cluster-autoscaler
-      --cloud-provider=aws
-      --nodes=1:10:your-scaling-group-name
-      --scale-down-delay=10m
-      --skip-nodes-with-local-storage=false
-      --skip-nodes-with-system-pods=true
-      --v=4
-```
-
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment:
+To uninstall `my-release`:
 
 ```console
 $ helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+> **Tip**: List all releases using `helm list` or start clean with `helm delete --purge my-release`
 
 ## Configuration
 
@@ -93,14 +73,15 @@ The following tables lists the configurable parameters of the cluster-autoscaler
 Parameter | Description | Default
 --- | --- | ---
 `affinity` | node/pod affinities | None
-`autoscalingGroups[].name` | autoscaling group name | None. You *must* supply at least one.
-`autoscalingGroups[].maxSize` | maximum autoscaling group size | None. You *must* supply at least one.
-`autoscalingGroups[].minSize` | minimum autoscaling group size | None. You *must* supply at least one.
+`autoDiscovery.clusterName` | enable autodiscovery for name in ASG tag (only `cloudProvider=aws`)| `""` **required unless autoscalingGroups[] provided**
+`autoscalingGroups[].name` | autoscaling group name | None. Required unless `autoDiscovery.enabled=true`
+`autoscalingGroups[].maxSize` | maximum autoscaling group size | None. Required unless `autoDiscovery.enabled=true`
+`autoscalingGroups[].minSize` | minimum autoscaling group size | None. Required unless `autoDiscovery.enabled=true`
 `awsRegion` | AWS region (required if `cloudProvider=aws`) | `us-east-1`
 `sslCertPath` | Path on the host where ssl ca cert exists | `/etc/ssl/certs/ca-certificates.crt`
 `cloudProvider` | `aws` or `spotinst` are currently supported | `aws`
 `image.repository` | Image (used if `cloudProvider=aws`) | `k8s.gcr.io/cluster-autoscaler`
-`image.tag` | Image tag (used if `cloudProvider=aws`) | `v0.6.0`
+`image.tag` | Image tag (used if `cloudProvider=aws`) | `v1.1.0`
 `image.pullPolicy` | Image pull policy (used if `cloudProvider=aws`) | `IfNotPresent`
 `extraArgs` | additional container arguments | `{}`
 `nodeSelector` | node labels for pod assignment | `{}`
@@ -124,17 +105,16 @@ Parameter | Description | Default
 `tolerations` | List of node taints to tolerate (requires Kubernetes >= 1.6) | `[]`
 
 
-Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section.
-
-
-You can also specify any non-array parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section or by using the `--set key=value[,key=value]` argument to `helm install`. For example, to change the region and [expander](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders):
 
 ```console
 $ helm install stable/cluster-autoscaler --name my-release \
+    --set extraArgs.expander=most-pods \
     --set awsRegion=us-west-1
 ```
 
-## IAM Permissions
+## IAM
+
 The worker running the cluster autoscaler will need access to certain resources and actions:
 
 ```
@@ -146,6 +126,8 @@ The worker running the cluster autoscaler will need access to certain resources 
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
+                "autoscaling:DescribeTags",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:TerminateInstanceInAutoScalingGroup"
             ],
@@ -154,4 +136,79 @@ The worker running the cluster autoscaler will need access to certain resources 
     ]
 }
 ```
+
+  - `DescribeTags` is required for autodiscovery.
+  - `DescribeLaunchconfigurations` is required to scale up an ASG from 0
+
 Unfortunately AWS does not support ARNs for autoscaling groups yet so you must use "*" as the resource. More information [here](http://docs.aws.amazon.com/autoscaling/latest/userguide/IAM.html#UsingWithAutoScaling_Actions).
+
+## Auto-discovery
+
+For auto-discovery of instances to work, they must be tagged with
+`k8s.io/cluster-autoscaler/enabled` and `kubernetes.io/cluster/<ClusterName>`
+
+The value of the tag does not matter, only the key.
+
+An example kops spec excerpt:
+
+```
+apiVersion: kops/v1alpha2
+kind: Cluster
+metadata:
+  name: my.cluster.internal
+spec:
+  additionalPolicies:
+    node: |
+      [
+        {"Effect":"Allow","Action":["autoscaling:DescribeAutoScalingGroups","autoscaling:DescribeAutoScalingInstances","autoscaling:DescribeLaunchConfigurations","autoscaling:DescribeTags","autoscaling:SetDesiredCapacity","autoscaling:TerminateInstanceInAutoScalingGroup"],"Resource":"*"}
+      ]
+      ...
+---
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: my.cluster.internal
+  name: my-instances
+spec:
+  cloudLabels:
+    k8s.io/cluster-autoscaler/enabled: ""
+    kubernetes.io/cluster/my.cluster.internal: owned
+  image: kope.io/k8s-1.8-debian-jessie-amd64-hvm-ebs-2018-01-14
+  machineType: r4.large
+  maxSize: 4
+  minSize: 0
+```
+
+In this example you would need to `--set autoDiscovery.clusterName=my.cluster.internal` when installing.
+
+It is not recommended to try to mix this with setting `autoscalingGroups`
+
+See [autoscaler AWS documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup) for a more discussion of the setup
+
+### Troubleshooting
+
+The chart will succeed even if the container arguments are incorrect. A few minutes after starting
+`kubectl logs -l "app=aws-cluster-autoscaler" --tail=50` should loop through something like
+
+```
+polling_autoscaler.go:111] Poll finished
+static_autoscaler.go:97] Starting main loop
+utils.go:435] No pod using affinity / antiaffinity found in cluster, disabling affinity predicate for this loop
+static_autoscaler.go:230] Filtering out schedulables
+```
+
+If not, find a pod that the deployment created and `describe` it, paying close attention to the arguments under `Command`. e.g.:
+
+```
+Containers:
+  cluster-autoscaler:
+    Command:
+      ./cluster-autoscaler
+      --cloud-provider=aws
+# if specifying ASGs manually
+      --nodes=1:10:your-scaling-group-name
+# if using autodiscovery
+      --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,kubernetes.io/cluster/<ClusterName>
+      --v=4
+```

--- a/stable/cluster-autoscaler/templates/NOTES.txt
+++ b/stable/cluster-autoscaler/templates/NOTES.txt
@@ -1,3 +1,18 @@
-To verify that aws-cluster-autoscaler has started, run:
+{{- if or .Values.autoDiscovery.clusterName .Values.autoscalingGroups -}}
+
+To verify that cluster-autoscaler has started, run:
 
   kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "cluster-autoscaler.name" . }},release={{ .Release.Name }}"
+
+{{- else -}}
+
+##############################################################################
+####   ERROR: You must specify values for either                          ####
+####   autoDiscovery.clusterName or autoscalingGroups[]                   ####
+##############################################################################
+
+The deployment and pod will not be created and the installation is not functional
+See README:
+  open https://github.com/kubernetes/charts/tree/master/stable/cluster-autoscaler
+
+{{- end -}}

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- if or .Values.autoDiscovery.clusterName .Values.autoscalingGroups }}
+{{/* one of the above is required */}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -35,8 +37,16 @@ spec:
             - ./cluster-autoscaler
             - --cloud-provider={{ .Values.cloudProvider }}
             - --namespace={{ .Release.Namespace }}
-          {{- range .Values.autoscalingGroups }}
+          {{- if .Values.autoscalingGroups }}
+            {{- range .Values.autoscalingGroups }}
             - --nodes={{ .minSize }}:{{ .maxSize }}:{{ .name }}
+            {{- end }}
+          {{- end }}
+          {{- if eq .Values.cloudProvider "aws" }}
+            {{- if .Values.autoDiscovery.clusterName }}
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,kubernetes.io/cluster/
+              {{- .Values.autoDiscovery.clusterName }}
+            {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
@@ -78,3 +88,4 @@ spec:
         - name: ssl-certs
           hostPath:
             path: {{ .Values.sslCertPath }}
+{{- end}}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -1,7 +1,7 @@
 autoDiscovery:
 # Only cloudProvider `aws` is supported by auto-discovery at this time
 # Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
-  clusterName: #cluster.local
+  clusterName:  # cluster.local
 
 autoscalingGroups: []
 # At least one element is required if not using autoDiscovery

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -1,7 +1,16 @@
+autoDiscovery:
+# Only cloudProvider `aws` is supported by auto-discovery at this time
+# Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
+  clusterName: #cluster.local
+
 autoscalingGroups: []
+# At least one element is required if not using autoDiscovery
   # - name: asg1
   #   maxSize: 1
-  #   minSize: 1
+  #   minSize: 2
+  # - name: asg2
+  #   maxSize: 1
+  #   minSize: 2
 
 # Required if cloudProvider=aws
 awsRegion: us-east-1
@@ -30,7 +39,6 @@ extraArgs: {}
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-##
 nodeSelector: {}
 
 podAnnotations: {}
@@ -71,7 +79,6 @@ service:
 spotinst:
   account: ""
   token: ""
-
   image:
     repository: spotinst/kubernetes-cluster-autoscaler
     tag: 0.6.0


### PR DESCRIPTION
## Background

Currently, autodiscovery is not exposed by the chart. Additionally, the pull-charts-e2e test fails because this chart does not provide enough defaults to start the pod.

## What's this do

- Uses upstream's default AWS ASG tags for autodiscovery of nodes. The user can then set `autoDiscovery.clusterName` to enable autodiscovery of tagged ASGs
- Expands on several use cases and cleans up the readme
- Adds an error if neither required value is provided, and doesn't create a deployment in this case (currently pod crashloops).

## How to review
Please see #3989 and #4077 for the major motivation.
Split into three commits, with 000978f833cc515c50dc69aafd733ed160e98de6 containing the logic changes.

## Alternatives considered
Providing a nonsense default ASG or enabling autoscaling by default would also get the pod started, but it will crashloop and the pull-charts-e2e test will fail.

## Related
supersedes #4079
closes #4077 
closes #2954 (actually fixed by #3248)
closes #3724
supersedes #3989 

### See also
[Pattern of not deploying and printing an error message in NOTES from GC SQL Proxy](https://github.com/kubernetes/charts/pull/826#pullrequestreview-33550759)
[Previous discussion about getting this chart to start](https://github.com/kubernetes/charts/issues/668)
[Why cluster name is not accessible](https://github.com/kubernetes/helm/issues/2055)
[The upstream recommended configuration for cluster-autoscaler autodiscovery tags](https://github.com/kubernetes/autoscaler/blob/591885da6b55e679ee99f443945debff01c565b8/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml#L140)
[The documentation for these tags](https://github.com/kubernetes/autoscaler/blob/5302c37d6d6e89a2eeac0c74b4afe6caadfa3340/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup)