### PR TITLE
Use the correct service name when specifying the ingress backend

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.8.2
+version: 0.8.3
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/ingress.yaml
+++ b/stable/grafana/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $servicePort := .Values.server.service.httpPort -}}
 {{- $path := .Values.server.ingress.path -}}
+{{- $root := . }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -23,7 +24,7 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
+              serviceName: {{ template "grafana.server.fullname" $root }}
               servicePort: {{ $servicePort }}
             {{- if $path }}
             path: {{ $path }}


### PR DESCRIPTION
When utilizing the ingress generated by the chart, the serviceName used
by the ingress differs from the name used while generating the
Service.

This PR corrects that, by using the same template function in both
locations.

**What this PR does / why we need it**:

It currently creates an ingress that serves a 503

@zanhsieh 