### PR TITLE
Fixed svc name in grafana datasource job

### DIFF
--- a/stable/grafana/templates/job.yaml
+++ b/stable/grafana/templates/job.yaml
@@ -37,7 +37,7 @@ spec:
               name: {{ template "grafana.server.fullname" . }}
               key: grafana-admin-password
         args:
-          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/datasources"
+          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.server.fullname" . }}:{{ .Values.server.service.httpPort }}/api/datasources"
           - "--max-time"
           - "10"
           - "-H"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixed Grafana service URL for `set-datasource` job:
```
"http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/datasources"
```

If you run following command:
```
      helm upgrade grafana \
        stable/grafana \
        ...
```
job will search for `grafana-grafana` instead of `grafana`

```
$ kubectl logs grafana-set-datasource-rkdjr
\  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: grafana-grafana
```

**Which issue this PR fixes**:
none

**Special notes for your reviewer**:
none