### PR TITLE
adding filebeat chart

### DIFF
--- a/stable/filebeat/.helmignore
+++ b/stable/filebeat/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+description: A Helm chart to collect Kubernetes logs with filebeat
+icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
+name: filebeat
+version: 0.1.0
+appVersion: 6.2.2
+sources:
+- https://www.elastic.co/guide/en/beats/filebeat/current/index.html
+maintainers:
+- name: rendhalver
+  email: pete.brown@powerhrg.com
+- name: sstarcher
+  email: shane.starcher@gmail.com

--- a/stable/filebeat/README.md
+++ b/stable/filebeat/README.md
@@ -1,0 +1,11 @@
+# Filebeat
+
+[filebeat](https://www.elastic.co/guide/en/beats/filebeat/current/index.html) is used to ship Kubernetes and host logs to multiple outputs.
+
+## Prerequisites
+
+- Kubernetes 1.9+
+
+## Note
+
+By default this chart only ships a single output to a file on the local system.  Users should set config.output.file.enabled=false and configure their own outputs as [documented](https://www.elastic.co/guide/en/beats/filebeat/current/configuring-output.html)

--- a/stable/filebeat/templates/NOTES.txt
+++ b/stable/filebeat/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that Filebeat has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "filebeat.name" . }},release={{ .Release.Name }}"

--- a/stable/filebeat/templates/_helpers.tpl
+++ b/stable/filebeat/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "filebeat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "filebeat.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "filebeat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "filebeat.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "filebeat.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/filebeat/templates/clusterrole.yaml
+++ b/stable/filebeat/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}   
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/stable/filebeat/templates/clusterrolebinding.yaml
+++ b/stable/filebeat/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "filebeat.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "filebeat.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/filebeat/templates/clusterrolebinding.yaml
+++ b/stable/filebeat/templates/clusterrolebinding.yaml
@@ -14,6 +14,6 @@ roleRef:
   name: {{ template "filebeat.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "filebeat.fullname" . }}
+  name: {{ template "filebeat.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -28,8 +28,6 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: 
-        - "-c"
-        - "/etc/filebeat.yml"
         - "-e"
         env:
         - name: POD_NAMESPACE
@@ -42,7 +40,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
         - name: filebeat-config
-          mountPath: /etc/filebeat.yml
+          mountPath: /usr/share/filebeat/filebeat.yml
           readOnly: true
           subPath: filebeat.yml
         - name: prospectors-config
@@ -64,7 +62,9 @@ spec:
         configMap:
           name: {{ template "filebeat.fullname" . }}-prospectors
       - name: data
-        emptyDir: {}
+        hostPath:
+          path: /var/lib/filebeat
+          type: DirectoryOrCreate    
       terminationGracePeriodSeconds: 60
       serviceAccountName: {{ template "filebeat.fullname" . }}
       tolerations:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
           path: /var/lib/filebeat
           type: DirectoryOrCreate    
       terminationGracePeriodSeconds: 60
-      serviceAccountName: {{ template "filebeat.fullname" . }}
+      serviceAccountName: {{ template "filebeat.serviceAccountName" . }}
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}   
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "filebeat.name" . }}
+      release: {{ .Release.Name }}
+  minReadySeconds: 10
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "filebeat.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: 
+        - "-c"
+        - "/etc/filebeat.yml"
+        - "-e"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          runAsUser: 0
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: filebeat-config
+          mountPath: /etc/filebeat.yml
+          readOnly: true
+          subPath: filebeat.yml
+        - name: prospectors-config
+          mountPath: /usr/share/filebeat/prospectors.d
+          readOnly: true
+        - name: data
+          mountPath: /usr/share/filebeat/data
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      volumes:
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: filebeat-config
+        secret:
+          secretName: {{ template "filebeat.fullname" . }}
+      - name: prospectors-config
+        configMap:
+          name: {{ template "filebeat.fullname" . }}-prospectors
+      - name: data
+        emptyDir: {}
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: {{ template "filebeat.fullname" . }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}

--- a/stable/filebeat/templates/prospectors-configmap.yaml
+++ b/stable/filebeat/templates/prospectors-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "filebeat.fullname" . }}-prospectors
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}   
+data:
+  kubernetes.yml: |-
+    - type: docker
+      containers.ids:
+      - "*"
+      processors:
+        - add_kubernetes_metadata:
+            in_cluster: true

--- a/stable/filebeat/templates/secret.yaml
+++ b/stable/filebeat/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "filebeat.fullname" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}   
+type: Opaque    
+data:
+  filebeat.yml: {{ toYaml .Values.config | indent 4 | b64enc }}

--- a/stable/filebeat/templates/serviceaccount.yaml
+++ b/stable/filebeat/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "filebeat.serviceAccountName" . }}
+  labels:
+    app: {{ template "filebeat.name" . }}
+    chart: {{ template "filebeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}   
+{{- end -}}

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -23,9 +23,9 @@ config:
     enabled: true
     paths:
     - /var/log/**
-    exclude_files: 
+    exclude_files:
     - '(\.[0-9]{1,})$'
-    - '.gz$'
+    - templates/clusterrolebinding.yaml'.gz$'
 
   output.file:
     path: "/usr/share/filebeat/data"

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -16,14 +16,16 @@ config:
       reload.enabled: false
 
   processors:
-    - add_cloud_metadata:
+  - add_cloud_metadata:
 
   filebeat.prospectors:
   - type: log
     enabled: true
     paths:
-      - /var/log/**
-    exclude_files: ['(\.[0-9]{1,})$', '.gz$']
+    - /var/log/**
+    exclude_files: 
+    - '(\.[0-9]{1,})$'
+    - '.gz$'
 
   output.file:
     path: "/usr/share/filebeat/data"

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -17,7 +17,7 @@ config:
 
   processors:
     - add_cloud_metadata:
-            
+
   filebeat.prospectors:
   - type: log
     enabled: true

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -1,0 +1,55 @@
+image:
+  repository: docker.elastic.co/beats/filebeat
+  tag: 6.2.2
+  pullPolicy: IfNotPresent
+
+config:
+  filebeat.config:
+    prospectors:
+      # Mounted `filebeat-prospectors` configmap:
+      path: ${path.config}/prospectors.d/*.yml
+      # Reload prospectors configs as they change:
+      reload.enabled: false
+    modules:
+      path: ${path.config}/modules.d/*.yml
+      # Reload module configs as they change:
+      reload.enabled: false
+
+  processors:
+    - add_cloud_metadata:
+            
+  filebeat.prospectors:
+  - type: log
+    enabled: true
+    paths:
+      - /var/log/**
+    exclude_files: ['(\.[0-9]{1,})$', '.gz$']
+
+  output.file:
+    path: "/usr/share/filebeat/data"
+    filename: filebeat
+    rotate_every_kb: 10000
+    number_of_files: 5
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 200Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 100Mi
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
This is an addition for adding a filebeat chart.  This work is a continuation of #3108.  I removed some of the assumptions and made it more generic to support other configuration options, such as redis.

Other updates were made to bring it more in-line with https://raw.githubusercontent.com/elastic/beats/master/deploy/kubernetes/filebeat-kubernetes.yaml
and additionally updated for Kubernetes 1.9 apis and general helm best practices.

@rendhalver and @unguiculus 
 