### PR TITLE
[incubator/kafka] Add tolerations for the kafka pods

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.4.1
+version: 0.4.2
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -64,6 +64,7 @@ following configurable parameters:
 | `logSubPath`                   | Subpath under `persistence.mountPath` where kafka logs will be placed.                                          | `logs`                                                     |
 | `schedulerName`                | Name of Kubernetes scheduler (other than the default)                                                           | `nil`                                                      |
 | `affinity`                     | Pod scheduling preferences                                                                                      | `{}`                                                       |
+| `tolerations`                  | List of node tolerations for the pods. https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/  | `[]`                                                       |
 | `external.enabled`             | If True, exposes Kafka brokers via NodePort (PLAINTEXT by default)                                              | `false`                                                    |
 | `external.servicePort`         | TCP port configured at external services (one per pod) to relay from NodePort to the external listener port.    | '19092'                                                    |
 | `external.firstListenerPort`   | TCP port which is added pod index number to arrive at the port used for NodePort and external listener port.    | '31090'                                                    |

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -41,6 +41,10 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
     {{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -51,6 +51,16 @@ affinity: {}
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
+# Tolerations for nodes that have taints on them.
+# Useful if you want to dedicate nodes to just run kafka
+# https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+# tolerations:
+# - key: "key"
+#   operator: "Equal"
+#   value: "value"
+#   effect: "NoSchedule"
+
 ## External access.
 ##
 external:


### PR DESCRIPTION
**What this PR does / why we need it**:

Lets you set tolerations for the kafka pods. This is useful if you want to run kafka on dedicated nodes. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
