### PR TITLE
[stable/etcd-operator] deployment typos and add tolerations

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.7.2
+version: 0.7.3
 appVersion: 0.7.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -52,4 +52,4 @@ spec:
       tolerations:
 {{ toYaml .Values.backupOperator.tolerations | indent 8 }}
     {{- end }}
-{{- end}}
+{{- end }}

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         image: "{{ .Values.backupOperator.image.repository }}:{{ .Values.backupOperator.image.tag }}"
         imagePullPolicy: {{ .Values.backupOperator.image.pullPolicy }}
         command:
-         - etcd-backup-operator
+        - etcd-backup-operator
 {{- range $key, $value := .Values.backupOperator.commandArgs }}
         - "--{{ $key }}={{ $value }}"
 {{- end }}
@@ -47,5 +47,9 @@ spec:
     {{- if .Values.backupOperator.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.backupOperator.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.backupOperator.tolerations }}
+      tolerations:
+{{ toYaml .Values.backupOperator.tolerations | indent 8 }}
     {{- end }}
 {{- end}}

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         image: "{{ .Values.etcdOperator.image.repository }}:{{ .Values.etcdOperator.image.tag }}"
         imagePullPolicy: {{ .Values.etcdOperator.image.pullPolicy }}
         command:
-         - etcd-operator
+        - etcd-operator
 {{- range $key, $value := .Values.etcdOperator.commandArgs }}
         - "--{{ $key }}={{ $value }}"
 {{- end }}
@@ -47,5 +47,9 @@ spec:
     {{- if .Values.etcdOperator.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.etcdOperator.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.etcdOperator.tolerations }}
+      tolerations:
+{{ toYaml .Values.etcdOperator.tolerations | indent 8 }}
     {{- end }}
 {{- end }}

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       name: {{ template "etcd-restore-operator.fullname" . }}
       labels:
-        app: {{ template "etcd-restore-operator.fullname" . }}
+        app: {{ template "etcd-restore-operator.name" . }}
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "etcd-restore-operator.serviceAccountName" . }}
@@ -56,4 +56,4 @@ spec:
       tolerations:
 {{ toYaml .Values.restoreOperator.tolerations | indent 8 }}
     {{- end }}
-{{- end}}
+{{- end }}

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         ports:
         - containerPort: {{ .Values.restoreOperator.port }}
         command:
-         - etcd-restore-operator
+        - etcd-restore-operator
 {{- range $key, $value := .Values.restoreOperator.commandArgs }}
         - "--{{ $key }}={{ $value }}"
 {{- end }}
@@ -51,5 +51,9 @@ spec:
     {{- if .Values.restoreOperator.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.restoreOperator.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.restoreOperator.tolerations }}
+      tolerations:
+{{ toYaml .Values.restoreOperator.tolerations | indent 8 }}
     {{- end }}
 {{- end}}

--- a/stable/etcd-operator/templates/restore-operator-service.yaml
+++ b/stable/etcd-operator/templates/restore-operator-service.yaml
@@ -15,6 +15,6 @@ spec:
     name: http-etcd-restore-port
     port: {{ .Values.restoreOperator.port }}
   selector:
-    app: {{ template "etcd-restore-operator.fullname" . }}
+    app: {{ template "etcd-restore-operator.name" . }}
     release: {{ .Release.Name }}
-{{- end}}
+{{- end }}

--- a/stable/etcd-operator/templates/restore-operator-service.yaml
+++ b/stable/etcd-operator/templates/restore-operator-service.yaml
@@ -15,6 +15,6 @@ spec:
     name: http-etcd-restore-port
     port: {{ .Values.restoreOperator.port }}
   selector:
-    app: {{ template "etcd-restore-operator.name" . }}
+    app: {{ template "etcd-restore-operator.fullname" . }}
     release: {{ .Release.Name }}
 {{- end}}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
there are some typos in the deployments in latest. this pr fixes those and adds the option to add tolerations to deployments.
- the deployment yaml for all three operators has a typo: an extra space before `spec.containers[0].command[0]`
- the `app` label on restore operator pod is `{{ template "etcd-restore-operator.fullname" . }}`, but the selector on restore operator service is `{{ template "etcd-restore-operator.name" . }}`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
