### PR TITLE
[stable/kube-state-metrics] Upgrade to 1.2.0, add new collectors

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.5.3
-appVersion: 1.1.0
+version: 0.6.0
+appVersion: 1.2.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -12,28 +12,32 @@ $ helm install stable/kube-state-metrics
 
 ## Configuration
 
-| Parameter                           | Description                                             | Default                                     |
-|-------------------------------------|---------------------------------------------------------|---------------------------------------------|
-| `image.repository`                  | The image repository to pull from                       | k8s.gcr.io/kube-state-metrics               |
-| `image.tag`                         | The image tag to pull from                              | <latest version>                                      |
-| `image.pullPolicy`                  | Image pull policy                                       | IfNotPresent                                |
-| `service.port`                      | The port of the container                               | 8080                                        |
-| `prometheusScrape`                  | Whether or not enable prom scrape                       | True                                        |
-| `rbac.create`                       | If true, create & use RBAC resources                    | False                                       |
-| `rbac.serviceAccountName`           | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
-| `nodeSelector`                      | Node labels for pod assignment	                        | {}                                     |
-| `podAnnotations`                    | Annotations to be added to the pod                      | {}                                     |
-| `resources`                         | kube-state-metrics resource requests and limits         | {}                                          |
-| `collectors.daemonsets`             | Enable the daemonsets collector.                        | true                                        |
-| `collectors.deployments`            | Enable the deployments collector.                       | true                                        |
-| `collectors.limitranges`            | Enable the limitranges collector.                       | true                                        |
-| `collectors.nodes`                  | Enable the nodes collector.                             | true                                        |
-| `collectors.pods`                   | Enable the pods collector.                              | true                                        |
-| `collectors.replicasets`            | Enable the replicasets collector.                       | true                                        |
-| `collectors.replicationcontrollers` | Enable the replicationcontrollers collector.            | true                                        |
-| `collectors.resourcequotas`         | Enable the resourcequotas collector.                    | true                                        |
-| `collectors.services`               | Enable the services collector.                          | true                                        |
-| `collectors.jobs`                   | Enable the jobs collector.                              | true                                        |
-| `collectors.cronjobs`               | Enable the cronjobs collector.                          | true                                        |
-| `collectors.statefulsets`           | Enable the statefulsets collector.                      | true                                        |
-| `collectors.persistentvolumeclaims` | Enable the persistentvolumeclaims collector.            | true                                        |
+| Parameter                             | Description                                             | Default                                     |
+|---------------------------------------|---------------------------------------------------------|---------------------------------------------|
+| `image.repository`                    | The image repository to pull from                       | k8s.gcr.io/kube-state-metrics               |
+| `image.tag`                           | The image tag to pull from                              | <latest version>                            |
+| `image.pullPolicy`                    | Image pull policy                                       | IfNotPresent                                |
+| `service.port`                        | The port of the container                               | 8080                                        |
+| `prometheusScrape`                    | Whether or not enable prom scrape                       | True                                        |
+| `rbac.create`                         | If true, create & use RBAC resources                    | False                                       |
+| `rbac.serviceAccountName`             | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
+| `nodeSelector`                        | Node labels for pod assignment                          | {}                                          |
+| `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
+| `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |
+| `collectors.cronjobs`                 | Enable the cronjobs collector.                          | true                                        |
+| `collectors.daemonsets`               | Enable the daemonsets collector.                        | true                                        |
+| `collectors.deployments`              | Enable the deployments collector.                       | true                                        |
+| `collectors.endpoints`                | Enable the endpoints collector.                         | true                                        |
+| `collectors.horizontalpodautoscalers` | Enable the horizontalpodautoscalers collector.          | true                                        |
+| `collectors.jobs`                     | Enable the jobs collector.                              | true                                        |
+| `collectors.limitranges`              | Enable the limitranges collector.                       | true                                        |
+| `collectors.namespaces`               | Enable the namespaces collector.                        | true                                        |
+| `collectors.nodes`                    | Enable the nodes collector.                             | true                                        |
+| `collectors.persistentvolumeclaims`   | Enable the persistentvolumeclaims collector.            | true                                        |
+| `collectors.persistentvolumes`        | Enable the persistentvolumes collector.                 | true                                        |
+| `collectors.pods`                     | Enable the pods collector.                              | true                                        |
+| `collectors.replicasets`              | Enable the replicasets collector.                       | true                                        |
+| `collectors.replicationcontrollers`   | Enable the replicationcontrollers collector.            | true                                        |
+| `collectors.resourcequotas`           | Enable the resourcequotas collector.                    | true                                        |
+| `collectors.services`                 | Enable the services collector.                          | true                                        |
+| `collectors.statefulsets`             | Enable the statefulsets collector.                      | true                                        |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -23,17 +23,38 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         args:
-{{ if .Values.collectors.daemonsets }}
+{{  if .Values.collectors.cronjobs  }}
+        - --collectors=cronjobs
+{{  end  }}
+{{ if .Values.collectors.daemonsets  }}
         - --collectors=daemonsets
 {{  end  }}
-{{  if .Values.collectors.deployments }}
+{{  if .Values.collectors.deployments  }}
         - --collectors=deployments
+{{  end  }}
+{{  if .Values.collectors.endpoints  }}
+        - --collectors=endpoints
+{{  end  }}
+{{  if .Values.collectors.horizontalpodautoscalers  }}
+        - --collectors=horizontalpodautoscalers
+{{  end  }}
+{{  if .Values.collectors.jobs  }}
+        - --collectors=jobs
 {{  end  }}
 {{  if .Values.collectors.limitranges  }}
         - --collectors=limitranges
 {{  end  }}
+{{  if .Values.collectors.namespaces  }}
+        - --collectors=namespaces
+{{  end  }}
 {{  if .Values.collectors.nodes  }}
         - --collectors=nodes
+{{  end  }}
+{{  if .Values.collectors.persistentvolumeclaims  }}
+        - --collectors=persistentvolumeclaims
+{{  end  }}
+{{  if .Values.collectors.persistentvolumes  }}
+        - --collectors=persistentvolumes
 {{  end  }}
 {{  if .Values.collectors.pods  }}
         - --collectors=pods
@@ -50,17 +71,8 @@ spec:
 {{  if .Values.collectors.services  }}
         - --collectors=services
 {{  end  }}
-{{  if .Values.collectors.jobs  }}
-        - --collectors=jobs
-{{  end  }}
-{{  if .Values.collectors.cronjobs  }}
-        - --collectors=cronjobs
-{{  end  }}
 {{  if .Values.collectors.statefulsets  }}
         - --collectors=statefulsets
-{{  end  }}
-{{  if .Values.collectors.persistentvolumeclaims  }}
-        - --collectors=persistentvolumeclaims
 {{  end  }}
 {{ if .Values.namespace }}
         - --namespace={{ .Values.namespace }}

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: k8s.gcr.io/kube-state-metrics
-  tag: v1.1.0
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 service:
   port: 8080
@@ -26,19 +26,23 @@ podAnnotations: {}
 # Available collectors for kube-state-metrics. By default all available
 # collectors are enabled.
 collectors:
+  cronjobs: true
   daemonsets: true
   deployments: true
+  endpoints: true
+  horizontalpodautoscalers: true
+  jobs: true
   limitranges: true
+  namespaces: true
   nodes: true
+  persistentvolumeclaims: true
+  persistentvolumes: true
   pods: true
   replicasets: true
   replicationcontrollers: true
   resourcequotas: true
   services: true
-  jobs: true
-  cronjobs: true
   statefulsets: true
-  persistentvolumeclaims: true
 
 # Namespace to be enabled for collecting resources. By default all namespaces are collected.
 # namespace: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR upgrades kube-state-metrics to [1.2.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.2.0) with new collectors for endpoints, persistentvolumes, and horizontalpodautoscalers.

I also sorted the collectors alphabetically so they'll be easier to manage in the future.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:  N/A

**Special notes for your reviewer**:
Having these new features enabled by default may break when deployed on older kubernetes clusters that don't have these resources. I assume thats okay because the chart user can just disable the collectors for resources their cluster does not support.