### PR TITLE
[stable/gitlab] Add option to use existing volumes

### DIFF
--- a/stable/gitlab-ce/Chart.yaml
+++ b/stable/gitlab-ce/Chart.yaml
@@ -1,6 +1,6 @@
 name: gitlab-ce
 deprecated: true
-version: 0.2.1
+version: 0.2.2
 description: GitLab Community Edition
 keywords:
 - git

--- a/stable/gitlab-ce/requirements.lock
+++ b/stable/gitlab-ce/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.8.1
-digest: sha256:0f00474de1e8698b18b267f0d42db543c032b26609d6bab4a06e174232cc6ef6
-generated: 2017-09-03T14:17:06.691463708-04:00
+digest: sha256:94bbb4af5c8b8e6114938d06650c9e82b0a80613e0b60a6cdbb5031fb7771ae2
+generated: 2018-03-14T14:00:00.164104316+01:00

--- a/stable/gitlab-ce/templates/data-pvc.yaml
+++ b/stable/gitlab-ce/templates/data-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.gitlabData.enabled }}
+{{- if and .Values.persistence.gitlabData.enabled (not .Values.persistence.gitlabData.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/gitlab-ce/templates/deployment.yaml
+++ b/stable/gitlab-ce/templates/deployment.yaml
@@ -103,14 +103,14 @@ spec:
       - name: gitlab-etc
       {{- if .Values.persistence.gitlabEtc.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "gitlab-ce.fullname" . }}-etc
+          claimName: {{ .Values.persistence.gitlabEtc.existingClaim | default (printf "%s-etc" (include "gitlab-ce.fullname" .)) }}
       {{- else }}
         emptyDir: {}
       {{- end }}
       - name: gitlab-data
       {{- if .Values.persistence.gitlabData.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "gitlab-ce.fullname" . }}-data
+          claimName: {{ .Values.persistence.gitlabData.existingClaim | default (printf "%s-data" (include "gitlab-ce.fullname" .)) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/gitlab-ce/templates/etc-pvc.yaml
+++ b/stable/gitlab-ce/templates/etc-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.gitlabEtc.enabled }}
+{{- if and .Values.persistence.gitlabEtc.enabled (not .Values.persistence.gitlabEtc.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/gitlab-ce/values.yaml
+++ b/stable/gitlab-ce/values.yaml
@@ -12,12 +12,12 @@ image: gitlab/gitlab-ce:9.4.1-ce.0
 ## The URL (with protocol) that your users will use to reach the install.
 ## ref: https://docs.gitlab.com/omnibus/settings/configuration.html#configuring-the-external-url-for-gitlab
 ##
-#externalUrl: http://your-domain.com/
+# externalUrl: http://your-domain.com/
 
 ## Change the initial default admin password if set. If not set, you'll be
 ## able to set it when you first visit your install.
 ##
-#gitlabRootPassword: ""
+# gitlabRootPassword: ""
 
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types

--- a/stable/gitlab-ce/values.yaml
+++ b/stable/gitlab-ce/values.yaml
@@ -70,6 +70,8 @@ persistence:
   ##
   gitlabEtc:
     enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
     size: 1Gi
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default
@@ -81,6 +83,8 @@ persistence:
   ##
   gitlabData:
     enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
     size: 10Gi
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default

--- a/stable/gitlab-ee/Chart.yaml
+++ b/stable/gitlab-ee/Chart.yaml
@@ -1,6 +1,6 @@
 name: gitlab-ee
 deprecated: true
-version: 0.2.1
+version: 0.2.2
 description: GitLab Enterprise Edition
 keywords:
 - git

--- a/stable/gitlab-ee/requirements.lock
+++ b/stable/gitlab-ee/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.8.1
-digest: sha256:0f00474de1e8698b18b267f0d42db543c032b26609d6bab4a06e174232cc6ef6
-generated: 2017-09-03T14:17:07.733582008-04:00
+digest: sha256:94bbb4af5c8b8e6114938d06650c9e82b0a80613e0b60a6cdbb5031fb7771ae2
+generated: 2018-03-14T14:00:09.146723253+01:00

--- a/stable/gitlab-ee/templates/data-pvc.yaml
+++ b/stable/gitlab-ee/templates/data-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.gitlabData.enabled }}
+{{- if and .Values.persistence.gitlabData.enabled (not .Values.persistence.gitlabData.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/gitlab-ee/templates/deployment.yaml
+++ b/stable/gitlab-ee/templates/deployment.yaml
@@ -103,14 +103,14 @@ spec:
       - name: gitlab-etc
       {{- if .Values.persistence.gitlabEtc.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "gitlab-ee.fullname" . }}-etc
+          claimName: {{ .Values.persistence.gitlabEtc.existingClaim | default (printf "%s-etc" (include "gitlab-ee.fullname" .)) }}
       {{- else }}
         emptyDir: {}
       {{- end }}
       - name: gitlab-data
       {{- if .Values.persistence.gitlabData.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "gitlab-ee.fullname" . }}-data
+          claimName: {{ .Values.persistence.gitlabData.existingClaim | default (printf "%s-data" (include "gitlab-ee.fullname" .)) }}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/stable/gitlab-ee/templates/etc-pvc.yaml
+++ b/stable/gitlab-ee/templates/etc-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.gitlabEtc.enabled }}
+{{- if and .Values.persistence.gitlabEtc.enabled (not .Values.persistence.gitlabEtc.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/gitlab-ee/values.yaml
+++ b/stable/gitlab-ee/values.yaml
@@ -12,12 +12,12 @@ image: gitlab/gitlab-ee:9.4.1-ee.0
 ## The URL (with protocol) that your users will use to reach the install.
 ## ref: https://docs.gitlab.com/omnibus/settings/configuration.html#configuring-the-external-url-for-gitlab
 ##
-#externalUrl: http://your-domain.com/
+# externalUrl: http://your-domain.com/
 
 ## Change the initial default admin password if set. If not set, you'll be
 ## able to set it when you first visit your install.
 ##
-#gitlabRootPassword: ""
+# gitlabRootPassword: ""
 
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types

--- a/stable/gitlab-ee/values.yaml
+++ b/stable/gitlab-ee/values.yaml
@@ -53,6 +53,8 @@ persistence:
   ##
   gitlabEtc:
     enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
     size: 1Gi
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default
@@ -64,6 +66,8 @@ persistence:
   ##
   gitlabData:
     enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    # existingClaim:
     size: 10Gi
     ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
     ## Default: volume.alpha.kubernetes.io/storage-class: default


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Supports managing volumes independent of the chart lifecycle using the same technique as the dependent redis and postgres charts.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: We realise this chart has been deprecated in favor of the official Gitlab helm chart, however this is a better match to our current needs. 
