### PR TITLE
support provided value for consul gossip-key

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 1.3.3
+version: 1.3.4
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -35,6 +35,7 @@ The following tables lists the configurable parameters of the consul chart and t
 | `DatacenterName`        | Consul Datacenter Name                | `dc1` (The consul default)                                 |
 | `DisableHostNodeId`     | Disable Node Id creation (uses random)| `false`                                                    |
 | `EncryptGossip`         | Whether or not gossip is encrypted    | `true`                                                     |
+| `GossipKey`             | Gossip-key to use by all members      | `nil`                                                      |
 | `Storage`               | Persistent volume size                | `1Gi`                                                      |
 | `StorageClass`          | Persistent volume storage class       | `nil`                                                      |
 | `HttpPort`              | Consul http listening port            | `8500`                                                     |

--- a/stable/consul/templates/gossip-secret.yaml
+++ b/stable/consul/templates/gossip-secret.yaml
@@ -4,4 +4,8 @@ metadata:
   name: {{ template "consul.fullname" . }}-gossip-key
 type: Opaque
 data:
+  {{ if .Values.GossipKey }}
+  gossip-key: {{ .Values.GossipKey | b64enc }}
+  {{ else }}
   gossip-key: {{ randAlphaNum 24 | b64enc }}
+  {{ end }}

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -45,6 +45,10 @@ DisableHostNodeId: false
 ## Encrypt Gossip traffic
 EncryptGossip: true
 
+## predefined value for gossip key.
+## Will use a generated random alpha numeric if not provided
+# GossipKey: key
+
 ## consul data Persistent Volume Storage Class
 ## If defined, StorageClassName: <storageClass>
 ## If set to "-", StorageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
As mentioned in the title, this pull request make it possible for users of Consul chart to provide a predefined gossip-key value instead of having a random one generated all the time when executing / rendering the templates.

defaults still to the same behaviour of random alpha numeric