### PR TITLE
helm version upgrade 2.7.2 -> 2.8.2

### DIFF
--- a/test/circle/install.sh
+++ b/test/circle/install.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Install Helm
-HELM_LATEST_VERSION="v2.7.2"
+HELM_LATEST_VERSION="v2.8.2"
 
 wget http://storage.googleapis.com/kubernetes-helm/helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz
 tar -xvf helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz


### PR DESCRIPTION
upgrading helm version for circleci testing

since new helm release got out. I think it's better to test charts against it.

