### PR TITLE
fix dashboard wrong port mapping in notes

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.6.1
+version: 0.6.2
 appVersion: 1.8.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/templates/NOTES.txt
+++ b/stable/kubernetes-dashboard/templates/NOTES.txt
@@ -27,6 +27,6 @@ Get the Kubernetes Dashboard URL by running:
 
 Get the Kubernetes Dashboard URL by running:
   export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app={{ template "kubernetes-dashboard.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo https://127.0.0.1:9090/
-  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 9090:9090
+  echo https://127.0.0.1:8443/
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8443:8443
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
The pod create by dashboard charts will expose service on port 8443 not 9090.

