### PR TITLE
Add the option for Pod Annotations.

### DIFF
--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
-version: 0.2.7
+version: 0.2.8
 sources:
 - https://github.com/kubernetes/heapster
 - https://github.com/kubernetes/contrib/tree/master/addon-resizer

--- a/stable/heapster/README.md
+++ b/stable/heapster/README.md
@@ -47,6 +47,7 @@ The default configuration values for this chart are listed in `values.yaml`.
 | `rbac.serviceAccountName`             | existing ServiceAccount to use (ignored if rbac.create=true) | default                                           |
 | `resizer.enabled`                     | If enabled, scale resources                                  | true                                              |
 | `eventer.enabled`                     | If enabled, start eventer                                    | false                                             |
+| `podAnnotations`                      | Pod Annotations to be added to the heapster Pod              | `{}`                                              |
 | `nodeSelector`                        | Node labels for pod assignment                               | `{}`                                              |
 
 The table below is only applicable if `resizer.enabled` is `true`. More information on resizer can be found [here](https://github.com/kubernetes/contrib/blob/master/addon-resizer/README.md).

--- a/stable/heapster/templates/deployment.yaml
+++ b/stable/heapster/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
       labels:
         app: {{ template "heapster.fullname" . }}
     spec:

--- a/stable/heapster/values.yaml
+++ b/stable/heapster/values.yaml
@@ -16,6 +16,11 @@ labels: {}
 #   scheduler.alpha.kubernetes.io/critical-pod: ''
 annotations: {}
 
+## Here annotations can be added for the heapster Pod
+# podAnnotations:
+#   prometheus.io/scrape: "true"
+podAnnotations: {}
+
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##


### PR DESCRIPTION

**What this PR does / why we need it**:

This adds the ability to add Pod annotations. This is needed for adding (for instance) Prometheus scrape annotations.