### PR TITLE
This fixes two testing issues

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -21,7 +21,7 @@ set -o xtrace
 git remote add k8s https://github.com/kubernetes/charts
 git fetch k8s master
 
-NAMESPACE="pr-${PULL_NUMBER}-${BUILD_NUMBER}"
+NAMESPACE="${JOB_TYPE}-${PULL_INFO}-${BUILD_ID}"
 CHANGED_FOLDERS=`git diff --find-renames --name-only $(git merge-base k8s/master HEAD) stable/ incubator/ | awk -F/ '{print $1"/"$2}' | uniq`
 CURRENT_RELEASE=""
 
@@ -127,7 +127,7 @@ for directory in ${CHANGED_FOLDERS}; do
     # re-run right before the bot merges a PR so we can make sure the chart
     # version is always incremented.
     dosemvercompare ${directory}
-    RELEASE_NAME="${CHART_NAME:0:7}-${BUILD_NUMBER}"
+    RELEASE_NAME="${CHART_NAME:0:7}-${BUILD_ID}"
     CURRENT_RELEASE=${RELEASE_NAME}
     helm dep build ${directory}
     helm install --timeout 600 --name ${RELEASE_NAME} --namespace ${NAMESPACE} ${directory} | tee install_output

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -36,10 +36,20 @@ else
   exit 1
 fi
 
+# Pull numbers are only available on presubmit jobs. When the tests are run as
+# part of a batch job (e.g., batch merge) the PULL_NUMBER is not available. Pull
+# numbers are useful for some debugging. When no PULL_NUMBER is supplied we build
+# from other info.
+PULL_INFO=${PULL_NUMBER}
+if [ -z "$PULL_INFO" ]; then
+  PULL_INFO=${PULL_BASE_SHA}
+fi
+
 docker run ${VOLUMES} ${GKE_CREDS} \
            -e GOOGLE_APPLICATION_CREDENTIALS=/service-account.json \
-           -e "PULL_NUMBER=$PULL_NUMBER" \
-           -e "BUILD_NUMBER=$BUILD_NUMBER" \
+           -e "JOB_TYPE=$JOB_TYPE" \
+           -e "PULL_INFO=$PULL_INFO" \
+           -e "BUILD_ID=$BUILD_ID" \
            -e "VERIFICATION_PAUSE=${VERIFICATION_PAUSE:=0}" \
            ${IMAGE_NAME} /src/test/changed.sh
 echo "Done Testing!"

--- a/test/pr-review.sh
+++ b/test/pr-review.sh
@@ -29,7 +29,7 @@ fi
 git fetch -f origin pull/${PULL_NUMBER}/head:${BRANCH_NAME}
 git checkout ${BRANCH_NAME}
 git rebase master
-export BUILD_NUMBER=0
+export BUILD_ID=0
 ./test/e2e.sh
 git checkout master
 git branch -D ${BRANCH_NAME}


### PR DESCRIPTION
1. BUILD_NUMBER is deprecated and needed to be replaced for prow jobs
2. PULL_NUMBER is not available when batch jobs, including merges,
   are executed. Need a fallback to avoid errors.