### PR TITLE
helm upgrade for tests 2.7.2 -> 2.8.2

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -90,7 +90,7 @@ fi
 
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.7.2-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.8.2-linux-amd64.tar.gz
 INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 pushd /opt
   wget -q ${HELM_URL}/${HELM_TARBALL}

--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -15,7 +15,7 @@
 
 # Setup Helm
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.7.2-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.8.2-linux-amd64.tar.gz
 STABLE_REPO_URL=https://kubernetes-charts.storage.googleapis.com/
 INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 wget -q ${HELM_URL}/${HELM_TARBALL}


### PR DESCRIPTION
followup for https://github.com/kubernetes/charts/pull/4158
@mattfarina , I was not able to find any helm installations inside test.

please let me know if I missed any files.
