### PR TITLE
Typo fix in gogs/README.md

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.5.1
+version: 0.5.2
 appVersion: 0.11.29
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/incubator/gogs/README.md
+++ b/incubator/gogs/README.md
@@ -38,7 +38,7 @@ chart and deletes the release.
 
 ## Configuration
 
-The following tables lists some of the configurable parameters of the Gogs
+The following table lists some of the configurable parameters of the Gogs
 chart and their default values.
 
 | Parameter                        | Description                                                  | Default                                                    |


### PR DESCRIPTION
a small typo in gogs/README.md line 41
there are many such typos in the directory /incubator