### PR TITLE
Typo fix in jaeger/README.md

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.2.0
+appVersion: 1.2.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 version: 0.3.7

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.2.1
+appVersion: 1.2.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.7
+version: 0.3.8
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -131,7 +131,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Jaeger chart and their default values.
+The following table lists the configurable parameters of the Jaeger chart and their default values.
 
 |             Parameter                    |            Description              |                  Default               |
 |------------------------------------------|-------------------------------------|----------------------------------------|


### PR DESCRIPTION
a small typo in jaeger/README.md line 134
there are many such typos in the directory /incubator