### PR TITLE
Typo fix in keycloak/README.md

### DIFF
--- a/incubator/keycloak/Chart.yaml
+++ b/incubator/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 0.2.1
+version: 0.2.2
 appVersion: 3.4.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/incubator/keycloak/README.md
+++ b/incubator/keycloak/README.md
@@ -38,7 +38,7 @@ $ helm delete keycloak
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Keycloak chart and their default values.
+The following table lists the configurable parameters of the Keycloak chart and their default values.
 
 Parameter | Description | Default
 --- | --- | ---


### PR DESCRIPTION
a small typo in keycloak/README.md line 41
there are many such typos in the directory /incubator
