### PR TITLE
Typo fix in kubeless/README.md

### DIFF
--- a/incubator/kubeless/Chart.yaml
+++ b/incubator/kubeless/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubeless
-version: 0.2.1
+version: 0.2.2
 appVersion: v0.3.1
 description: Kubeless is a Kubernetes-native serverless framework. It runs on top of your Kubernetes cluster and allows you to deploy small unit of code without having to build container images.
 icon: https://cloud.githubusercontent.com/assets/4056725/25480209/1d5bf83c-2b48-11e7-8db8-bcd650f31297.png

--- a/incubator/kubeless/README.md
+++ b/incubator/kubeless/README.md
@@ -46,7 +46,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Kubeless chart and their default values.
+The following table lists the configurable parameters of the Kubeless chart and their default values.
 
 |                Parameter                 |          Description          |            Default            |
 |------------------------------------------|-------------------------------|-------------------------------|


### PR DESCRIPTION
a small typo in kubeless/README.md line 49
There are many such typos in the directory /incubator.