### PR TITLE
Typo fix in kubernetes-vault/README.md

### DIFF
--- a/incubator/kubernetes-vault/Chart.yaml
+++ b/incubator/kubernetes-vault/Chart.yaml
@@ -2,7 +2,7 @@ name: kubernetes-vault
 apiVersion: v1
 home: https://github.com/Boostport/kubernetes-vault
 description: The Kubernetes-Vault project allows pods to automatically receive a Vault token using Vaults AppRole auth backend.
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.4.8
 sources:
   - https://github.com/Boostport/kubernetes-vault

--- a/incubator/kubernetes-vault/Chart.yaml
+++ b/incubator/kubernetes-vault/Chart.yaml
@@ -9,4 +9,3 @@ sources:
 maintainers:
   - name: bbriggs
     email: briggs.brenton@gmail.com
-

--- a/incubator/kubernetes-vault/README.md
+++ b/incubator/kubernetes-vault/README.md
@@ -21,7 +21,7 @@ $ helm install --name my-release incubator/kubernetes-vault --set vault.address=
 
 ## Configuration
 
-The following tables lists the configurable parameters of the consul chart and their default values.
+The following table lists the configurable parameters of the consul chart and their default values.
 
 | Parameter                   | Description                                             | Default                                                    |
 | --------------------------  | ----------------------------------                      | ---------------------------------------------------------- |

--- a/incubator/kubernetes-vault/values.yaml
+++ b/incubator/kubernetes-vault/values.yaml
@@ -22,4 +22,3 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
-


### PR DESCRIPTION
a small typo in kubernetes-vault/README.md line 24
There are many such typos in the directory /incubator.