### PR TITLE
Typo fix in kubewatch/README.md

### DIFF
--- a/incubator/kubewatch/Chart.yaml
+++ b/incubator/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 0.2.1
+version: 0.2.2
 appVersion: v0.0.3
 description: Kubewatch notifies your slack rooms when changes to your cluster occur
 keywords:

--- a/incubator/kubewatch/README.md
+++ b/incubator/kubewatch/README.md
@@ -35,7 +35,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the kubewatch chart and their default values.
+The following table lists the configurable parameters of the kubewatch chart and their default values.
 
 Parameter | Description | Default
 --- | --- | ---


### PR DESCRIPTION
a small typo in kubewatch/README.md line 38
There are many such typos in the directory /incubator.