### PR TITLE
Typo fix in logstash/README.md

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.6.0
+version: 0.6.1
 appVersion: 6.2.2
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -67,7 +67,7 @@ Please review the following links that expound on current best practices.
 
 ## Configuration
 
-The following tables lists the configurable parameters of the chart and its default values.
+The following table lists the configurable parameters of the chart and its default values.
 
 |              Parameter      |                    Description                     |                     Default                      |
 | --------------------------- | -------------------------------------------------- | ------------------------------------------------ |


### PR DESCRIPTION
a small typo in logstash/README.md line 70
There are many such typos in the directory /incubator.