### PR TITLE
Typo fix in mysqlha/README.md

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysqlha
-version: 0.1.1
+version: 0.1.2
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:
   - mysql

--- a/incubator/mysqlha/README.md
+++ b/incubator/mysqlha/README.md
@@ -31,7 +31,7 @@ $ helm delete my-release
 
 ## Configuration
 
-The following tables lists the configurable parameters of the MySQL chart and their default values.
+The following table lists the configurable parameters of the MySQL chart and their default values.
 
 | Parameter                  | Description                         | Default                                |
 | -----------------------    | ----------------------------------- | -------------------------------------- |


### PR DESCRIPTION
a small typo in mysqlha/README.md line 34
There are many such typos in the directory /incubator.