### PR TITLE
Typo fix in oauth-proxy/README.md

### DIFF
--- a/incubator/oauth-proxy/Chart.yaml
+++ b/incubator/oauth-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth-proxy
-version: 0.1.7
+version: 0.1.8
 appVersion: 2.2
 deprecated: true  # moved to stable
 description: A reverse proxy that provides authentication with Google, Github or other providers

--- a/incubator/oauth-proxy/README.md
+++ b/incubator/oauth-proxy/README.md
@@ -38,7 +38,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the oauth-proxy chart and their default values.
+The following table lists the configurable parameters of the oauth-proxy chart and their default values.
 
 Parameter | Description | Default
 --- | --- | ---


### PR DESCRIPTION
a small typo in oauth-proxy/README.md line 41
There are many such typos in the directory /incubator.