### PR TITLE
Typo fix in patroni/README.md

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.6.2
+version: 0.6.3
 appVersion: 1.3-p4
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -49,7 +49,7 @@ postgres=>
 
 ## Configuration
 
-The following tables lists the configurable parameters of the patroni chart and their default values.
+The following table lists the configurable parameters of the patroni chart and their default values.
 
 |       Parameter         |           Description               |                         Default                     |
 |-------------------------|-------------------------------------|-----------------------------------------------------|


### PR DESCRIPTION
a small typo in patroni/README.md line 52
There are many such typos in the directory /incubator.