### PR TITLE
Typo fix in schema-registry/README.md

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.1.0
+version: 0.1.1
 description: Schema Registry provides a serving layer for your metadata. It provides a RESTful
   interface for storing and retrieving Avro schemas. It stores a versioned history of all schemas,
   provides multiple compatibility settings and allows evolution of schemas according to the

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -54,7 +54,7 @@ $ helm install --name my-release -f values.yaml incubator/schema-registry
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ### Parameters
-The following tables lists the configurable parameters of the SchemaRegistry chart and their default values.
+The following table lists the configurable parameters of the SchemaRegistry chart and their default values.
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |


### PR DESCRIPTION
a small typo in schema-registry/README.md line 57
There are many such typos in the directory /incubator.