### PR TITLE
Typo fix in sentry-kubernetes/README.md

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.1.1
+version: 0.1.2
 sources:
 - https://github.com/getsentry/sentry-kubernetes
 keywords:

--- a/incubator/sentry-kubernetes/README.md
+++ b/incubator/sentry-kubernetes/README.md
@@ -10,7 +10,7 @@ $ helm install incubator/sentry-kubernetes --name my-release --set sentry.dsn=<y
 
 ## Configuration
 
-The following tables lists the configurable parameters of the sentry-kubernetes chart and their default values.
+The following table lists the configurable parameters of the sentry-kubernetes chart and their default values.
 
 |       Parameter         |           Description               |                         Default                     |
 |-------------------------|-------------------------------------|-----------------------------------------------------|


### PR DESCRIPTION
a small typo in sentry-kubernetes/README.md line 13
There are many such typos in the directory /incubator.