### PR TITLE
Typo fix in vault/README.md

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.9.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -43,7 +43,7 @@ vault:
 
 ## Configuration
 
-The following tables lists the configurable parameters of the vault chart and their default values.
+The following table lists the configurable parameters of the vault chart and their default values.
 
 |       Parameter         |           Description               |                         Default                     |
 |-------------------------|-------------------------------------|-----------------------------------------------------|


### PR DESCRIPTION
a small typo in vault/README.md line 46
There are many such typos in the directory /incubator.