### PR TITLE
Typo fix in webpagetest-server/README.md

### DIFF
--- a/incubator/webpagetest-server/Chart.yaml
+++ b/incubator/webpagetest-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-server
-version: 0.1.3
+version: 0.1.4
 home: https://www.webpagetest.org/
 icon: https://www.webpagetest.org/images/logo_wpt.png
 sources:

--- a/incubator/webpagetest-server/README.md
+++ b/incubator/webpagetest-server/README.md
@@ -44,7 +44,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the WebPageTest chart and their default values.
+The following table lists the configurable parameters of the WebPageTest chart and their default values.
 
 | Parameter                            | Description                                | Default                                                    |
 | -------------------------------      | -------------------------------            | ---------------------------------------------------------- |


### PR DESCRIPTION
a small typo in webpagetest-server/README.md line 47
There are many such typos in the directory /incubator, and this is the last one.
