### PR TITLE
add an InitContainer to the Deployment to copy the files from the ConfigMap to an EmptyDir

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.8.3
+version: 0.8.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -50,6 +50,19 @@ spec:
                   app: {{ template "grafana.server.fullname" . }}
           {{- end }}
       {{- end }}
+      initContainers:
+        - name: copy-configs
+          image: busybox
+          command: ['sh', '-c', 'cp /tmp/config-volume-configmap/* /tmp/config-volume 2>/dev/null || true; cp /tmp/dashboard-volume-configmap/* /tmp/dashboard-volume 2>/dev/null || true']
+          volumeMounts:
+            - name: config-volume-configmap
+              mountPath: /tmp/config-volume-configmap
+            - name: dashboard-volume-configmap
+              mountPath: /tmp/dashboard-volume-configmap
+            - name: config-volume
+              mountPath: /tmp/config-volume
+            - name: dashboard-volume
+              mountPath: /tmp/dashboard-volume
       containers:
         - name: {{ template "grafana.name" . }}
           image: "{{ .Values.server.image }}"
@@ -92,9 +105,13 @@ spec:
       terminationGracePeriodSeconds: {{ default 300 .Values.server.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume
+          emptyDir: {}
+        - name: dashboard-volume
+          emptyDir: {}
+        - name: config-volume-configmap
           configMap:
             name: {{ template "grafana.server.fullname" . }}-config
-        - name: dashboard-volume
+        - name: dashboard-volume-configmap
           configMap:
             name: {{ template "grafana.server.fullname" . }}-dashs
         - name: storage-volume


### PR DESCRIPTION
ConfigMaps are mounted read-only since Kubernetes 1.9.4 (kubernetes/kubernetes#58720). The Grafana Chart uses a ConfigMap to provision the config- and dashboard directories. Grafana tries to create/modify files in these directories, which is not allowed anymore. This PR adds an busybox initContainer to the Deployment that copies the files from the ConfigMap to a new emptyDir, similar to #4169. Fixes #4267.
