### PR TITLE
External traffic policy

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 0.8.15
+version: 0.8.16
 appVersion: 4.9.4
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -15,7 +15,7 @@ spec:
       port: 80
       targetPort: http
       {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.nodePorts.http)))}}
-      nodePort: {{ .Values.nodePorts.http }}
+      nodePort: {{ .Values.nodePorts.http | quote }}
       {{- end }}
     - name: https
       port: 443

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.serviceType }}
-  externalTrafficPolicy" {{ .Value.serviceExternalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Value.serviceExternalTrafficPolicy }}
   ports:
     - name: http
       port: 80

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -9,13 +9,13 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.serviceType }}
-  externalTrafficPolicy: {{ .Value.serviceExternalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Value.serviceExternalTrafficPolicy | quote }}
   ports:
     - name: http
       port: 80
       targetPort: http
       {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.nodePorts.http)))}}
-      nodePort: {{ .Values.nodePorts.http | quote }}
+      nodePort: {{ .Values.nodePorts.http }}
       {{- end }}
     - name: https
       port: 443

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.serviceType }}
-  externalTrafficPolicy: {{ .Value.serviceExternalTrafficPolicy | quote }}
+  externalTrafficPolicy: {{ .Values.serviceExternalTrafficPolicy | quote }}
   ports:
     - name: http
       port: 80

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.serviceType }}
+  externalTrafficPolicy" {{ .Value.serviceExternalTrafficPolicy }}
   ports:
     - name: http
       port: 80

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -191,6 +191,11 @@ ingress:
   #   key:
   #   certificate:
 
+## Enable client source IP preservation
+## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+##
+serviceExternalTrafficPolicy: Local
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -126,6 +126,10 @@ serviceType: LoadBalancer
 nodePorts:
   http: ""
   https: ""
+## Enable client source IP preservation
+## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+##
+serviceExternalTrafficPolicy: Local
 
 ## Allow health checks to be pointed at the https port
 healthcheckHttps: false
@@ -190,11 +194,6 @@ ingress:
   # - name: wordpress.local-tls
   #   key:
   #   certificate:
-
-## Enable client source IP preservation
-## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-##
-serviceExternalTrafficPolicy: Local
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
This PR adds support for setting the External Traffic Policy. It allows to configure the WordPress service so it preserves the client source IPs. 

That can be very useful to implement rules on the WordPress POD to allow/deny access when lacking of a NGINX Ingress to handle this.