### PR TITLE
[stable/drupal] Sidecar template pattern

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 0.11.11
+version: 0.12.0
 appVersion: 8.5.0
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -84,6 +84,9 @@ spec:
         - name: apache-data
           mountPath: {{ .Values.volumeMounts.apache.mountPath }}
         {{- end }}
+{{- if .Values.sidecarContainers }}
+{{ toYaml .Values.sidecarContainers | indent 6}}
+{{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -206,3 +206,8 @@ readinessProbe:
     path: /user/login
     port: http
   initialDelaySeconds: 30
+
+## Additional containers to be added to the Drupal pod.
+# sidecarContainers:
+# - name: my-sidecar
+#   image: nginx:latest


### PR DESCRIPTION
See #4283 

Example block for a values override file (in this example, someone is choosing to run memcached as a sidecar instead of stable/memcached):

`helm install stable/drupal -f memcached-sidecar.yaml`
```yaml
sidecarContainers:
- name: memcached
  image: memcached:alpine
  command:
  - memcached
  - -m 64
  - -o modern
  - -v
  ports:
  - name: memcache
    containerPort: 11211
  livenessProbe:
    tcpSocket:
      port: memcache
    initialDelaySeconds: 30
    timeoutSeconds: 5
  readinessProbe:
    tcpSocket:
      port: memcache
    initialDelaySeconds: 5
    timeoutSeconds: 1
```