### PR TITLE
Compiling peer-finder from source with multistep docker build

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 2.3.1
+version: 2.3.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/init/Dockerfile
+++ b/stable/mongodb-replicaset/init/Dockerfile
@@ -12,10 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM golang
+
+RUN git clone https://github.com/kubernetes/contrib.git \
+ && cd contrib/peer-finder \
+ && go get k8s.io/apimachinery/pkg/util/sets \
+ && make server
+
 FROM alpine:3.4
 MAINTAINER Anirudh Ramanathan <foxish@google.com>
 
-RUN apk update && apk add bash openssl && wget -qO /peer-finder http://storage.googleapis.com/kubernetes-release/pets/peer-finder 
+RUN apk update && apk add bash openssl
+
+COPY --from=0 /go/contrib/peer-finder/peer-finder /peer-finder
 
 ENTRYPOINT ["/install.sh"]
 


### PR DESCRIPTION
@foxish and @unguiculus This PR updates the Dockerfile for mongo-install so the newest version of peer-finder is compiled from the kubernetes contrib repo instead of being downloaded from http://storage.googleapis.com/kubernetes-release/pets/peer-finder

This should help resolve issue #1399 so we don't have to wait for a newer version of peer-finder to be built.  