### PR TITLE
stable/prometheus: Update default version to 2.2.1

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 5.4.4
+version: 5.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -388,7 +388,7 @@ server:
   ##
   image:
     repository: prom/prometheus
-    tag: v2.1.0
+    tag: v2.2.1
     pullPolicy: IfNotPresent
 
   ## The URL prefix at which the container can be accessed. Useful in the case the '-web.external-url' includes a slug


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the default Prometheus version from 2.1.0 to 2.2.1. There are important fixes in the 2.2.x series that make operating a higher-traffic Prometheus setup more viable. 

**Special notes for your reviewer**:

See the release notes for [2.2.0](https://github.com/prometheus/prometheus/releases/tag/v2.2.0) and [2.2.1](https://github.com/prometheus/prometheus/releases/tag/v2.2.1).