### PR TITLE
Properly specify namespace in NOTES.txt

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.12.2

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -16,7 +16,7 @@ To connect from outside the K8s cluster:
 
      # Execute the following commands to route the connection to Admin SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ .Values.admin.servicePort }}:{{ .Values.admin.servicePort }}
+     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.admin.servicePort }}:{{ .Values.admin.servicePort }}
    {{- end }}
 
 
@@ -39,5 +39,5 @@ To connect from outside the K8s cluster:
 
      # Execute the following commands to route the connection to proxy SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward $POD_NAME {{ .Values.proxy.servicePort }}:{{ .Values.proxy.servicePort }}
+     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.proxy.servicePort }}:{{ .Values.proxy.servicePort }}
    {{- end }}


### PR DESCRIPTION
The namespace was properly specified in the first command (getting the pod), but not in the actual port-forward command. This is just annoying because copy/paste doesn't work out-of-the-box.

@shashiranjan84