### PR TITLE
Typo fix in aws-cluster-autoscaler/README.md

### DIFF
--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -3,7 +3,7 @@ deprecated: true
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: aws-cluster-autoscaler
-version: 0.3.2
+version: 0.3.3
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -75,7 +75,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the aws-cluster-autoscaler chart and their default values.
+The following table lists the configurable parameters of the aws-cluster-autoscaler chart and their default values.
 
 Parameter | Description | Default
 --- | --- | ---


### PR DESCRIPTION
line 78: tables lists->table lists 
There are many such errors in stable directory.