### PR TITLE
Typo fix in cluster-autoscaler/README.md

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.5.0
+version: 0.5.1
 appVersion: 1.1.0
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -68,7 +68,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the cluster-autoscaler chart and their default values.
+The following table lists the configurable parameters of the cluster-autoscaler chart and their default values.
 
 Parameter | Description | Default
 --- | --- | ---


### PR DESCRIPTION
line 71: tables lists->table lists 
There are many such errors in stable directory.