### PR TITLE
Typo fix in cockroachdb/README.md

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.6.6
+version: 0.6.7
 appVersion: 1.1.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -29,7 +29,7 @@ helm install --name my-release stable/cockroachdb
 
 ## Configuration
 
-The following tables lists the configurable parameters of the CockroachDB chart and their default values.
+The following table lists the configurable parameters of the CockroachDB chart and their default values.
 
 | Parameter                     | Description                                | Default                                      |
 | ----------------------------- | ------------------------------------------ | -------------------------------------------- |


### PR DESCRIPTION
line 32: tables lists->table lists 
There are many such errors in stable directory.