### PR TITLE
Typo fix in concourse/README.md

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.0.4
+version: 1.0.5
 appVersion: 3.9.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -63,7 +63,7 @@ The worker's Liveness Probe will trigger a restart of the worker if it detects u
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Concourse chart and their default values.
+The following table lists the configurable parameters of the Concourse chart and their default values.
 
 | Parameter               | Description                           | Default                                                    |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |


### PR DESCRIPTION
line 66: tables lists->table lists 
There are many such errors in stable directory.