### PR TITLE
Typo fix in g2/README.md

### DIFF
--- a/stable/g2/Chart.yaml
+++ b/stable/g2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: G2 by AppsCode - Gearman in Golang
 name: g2
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.5.0
 home: https://github.com/appscode/g2
 icon: https://cdn.appscode.com/images/icon/g2.png

--- a/stable/g2/README.md
+++ b/stable/g2/README.md
@@ -36,7 +36,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Stash chart and their default values.
+The following table lists the configurable parameters of the Stash chart and their default values.
 
 
 | Parameter                | Description                                                       | Default             |


### PR DESCRIPTION
line 39: tables lists->table lists 
There are many such errors in stable directory.