### PR TITLE
Typo fix in gcloud-endpoints/README.md

### DIFF
--- a/stable/gcloud-endpoints/Chart.yaml
+++ b/stable/gcloud-endpoints/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-endpoints
-version: 0.1.0
+version: 0.1.1
 description: Develop, deploy, protect and monitor your APIs with Google Cloud Endpoints.
 keywords:
 - google

--- a/stable/gcloud-endpoints/README.md
+++ b/stable/gcloud-endpoints/README.md
@@ -42,7 +42,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Drupal chart and their default values.
+The following table lists the configurable parameters of the Drupal chart and their default values.
 
 | Parameter                         | Description                            | Default                                                   |
 | --------------------------------- | -------------------------------------- | --------------------------------------------------------- |

--- a/stable/gcloud-endpoints/values.yaml
+++ b/stable/gcloud-endpoints/values.yaml
@@ -11,18 +11,18 @@ image: b.gcr.io/endpoints/endpoints-runtime:1
 ## Set the application server address to which ESP proxies the requests. For
 ## GRPC backends, please use grpc:// prefix, e.g. grpc://localhost:8081.
 ## (default: localhost:8081)
-## 
-# backend: 
+##
+# backend:
 
 ## Set the name of the Endpoints service. If omitted and serviceConfigURL not
 ## specified, ESP contacts the metadata service to fetch the service name.
 ## (default: None)
-## 
-# service: 
+##
+# service:
 
 ## Specify the URL to fetch the service configuration. (default: None)
 ##
-# serviceConfigURL: 
+# serviceConfigURL:
 
 ## Expose a port to accept HTTP/1.x connections. Note that if you do not
 ## specify httpPort, http2Port, and sslPort, then the default httpPort 8080 is
@@ -38,7 +38,7 @@ image: b.gcr.io/endpoints/endpoints-runtime:1
 ## Expose a port for HTTPS requests. Accepts both HTTP/1.x and HTTP/2
 ## connections. (default: None)
 ##
-# sslPort: 
+# sslPort:
 
 ## Set the ESP status port. Status information is available at
 ## /endpoints_status location over HTTP/1.x. (default: 8090)
@@ -49,17 +49,17 @@ statusPort: 8090
 ## serviceConfigURL not specified, ESP contacts the metadata service to fetch
 ## the service version. (default: None)
 ##
-# version: 
+# version:
 
 ## Set the service account key JSON file. Used to access the service control
 ## and the service management. If the option is omitted, ESP contacts the
 ## metadata service to fetch an access token. (default: None)
 ##
-# serviceAccountKey: 
+# serviceAccountKey:
 
 ## Set a custom nginx config file. (default: None)
 ##
-# nginxConfig: 
+# nginxConfig:
 
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer


### PR DESCRIPTION
line 45: tables lists->table lists 
There are many such errors in stable directory.