### PR TITLE
Typo fix in gcloud-sqlproxy/README.md

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-sqlproxy
-version: 0.3.0
+version: 0.3.1
 description: Google Cloud SQL Proxy
 keywords:
 - google

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -50,7 +50,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Drupal chart and their default values.
+The following table lists the configurable parameters of the Drupal chart and their default values.
 
 | Parameter                         | Description                            | Default                                                   |
 | --------------------------------- | -------------------------------------- | --------------------------------------------------------- |


### PR DESCRIPTION
line 53: tables lists->table lists 
There are many such errors in stable directory.