### PR TITLE
[stable/filebeat] Allow volumes, env vars, and http metrics to be configurable

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -4,6 +4,7 @@ icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.sv
 name: filebeat
 version: 0.2.0
 appVersion: 6.2.3
+home: https://www.elastic.co/products/beats/filebeat
 sources:
 - https://www.elastic.co/guide/en/beats/filebeat/current/index.html
 maintainers:

--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 0.1.1
+version: 0.2.0
 appVersion: 6.2.3
 sources:
 - https://www.elastic.co/guide/en/beats/filebeat/current/index.html

--- a/stable/filebeat/templates/clusterrole.yaml
+++ b/stable/filebeat/templates/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "filebeat.name" . }}
     chart: {{ template "filebeat.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}   
+    heritage: {{ .Release.Service }}
 rules:
 - apiGroups: [""]
   resources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -44,6 +44,10 @@ spec:
         - name: {{ $key }}
           value: {{ $value }}
 {{- end }}
+        {{- if index .Values.config "http.enabled" }}
+        ports:
+          - containerPort: {{ index .Values.config "http.port" }}
+        {{- end }}
         securityContext:
           runAsUser: 0
         resources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "filebeat.name" . }}
     chart: {{ template "filebeat.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}   
+    heritage: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
@@ -27,7 +27,7 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: 
+        args:
         - "-e"
         env:
         - name: POD_NAMESPACE
@@ -47,7 +47,7 @@ spec:
           mountPath: /usr/share/filebeat/data
         - name: varlog
           mountPath: /var/log
-          readOnly: true          
+          readOnly: true
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
@@ -64,7 +64,7 @@ spec:
       - name: data
         hostPath:
           path: /var/lib/filebeat
-          type: DirectoryOrCreate    
+          type: DirectoryOrCreate
       terminationGracePeriodSeconds: 60
       serviceAccountName: {{ template "filebeat.serviceAccountName" . }}
       tolerations:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -36,6 +36,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
         resources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -40,6 +40,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+{{- range $key, $value := .Values.extraVars }}
+        - name: {{ $key }}
+          value: {{ $value }}
+{{- end }}
         securityContext:
           runAsUser: 0
         resources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -65,6 +65,9 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
       volumes:
       - name: varlog
         hostPath:
@@ -79,6 +82,9 @@ spec:
         hostPath:
           path: /var/lib/filebeat
           type: DirectoryOrCreate
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
       terminationGracePeriodSeconds: 60
       serviceAccountName: {{ template "filebeat.serviceAccountName" . }}
       tolerations:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: {{ template "filebeat.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/secret: {{ toYaml .Values.config | sha256sum }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/stable/filebeat/templates/secret.yaml
+++ b/stable/filebeat/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ template "filebeat.name" . }}
     chart: {{ template "filebeat.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}   
-type: Opaque    
+    heritage: {{ .Release.Service }}
+type: Opaque
 data:
   filebeat.yml: {{ toYaml .Values.config | indent 4 | b64enc }}

--- a/stable/filebeat/templates/serviceaccount.yaml
+++ b/stable/filebeat/templates/serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
     app: {{ template "filebeat.name" . }}
     chart: {{ template "filebeat.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}   
+    heritage: {{ .Release.Service }}
 {{- end -}}

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -40,6 +40,11 @@ config:
     rotate_every_kb: 10000
     number_of_files: 5
 
+  # When a key contains a period, use this format for setting values on the command line:
+  # --set config."http\.enabled"=true
+  http.enabled: false
+  http.port: 5066
+
 # A map of additional environment variables
 extraVars: {}
   # test1: "test2"

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -40,6 +40,10 @@ config:
     rotate_every_kb: 10000
     number_of_files: 5
 
+# A map of additional environment variables
+extraVars: {}
+  # test1: "test2"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -49,6 +49,16 @@ config:
 extraVars: {}
   # test1: "test2"
 
+# Add additional volumes and mounts, for example to read other log files on the host
+extraVolumes: []
+  # - hostPath:
+  #     path: /var/log
+  #   name: varlog
+extraVolumeMounts: []
+  # - name: varlog
+  #   mountPath: /host/var/log
+  #   readOnly: true
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows additional volumes to be mounted along with additional prospectors configured.

This way we can watch logs from the host's `/var/log` that aren't from container logs themselves.

Additional environment variables can be specified as a key-value map in order to support interpolation in the prospector configurations.

Example `values.yaml` for capturing kube-proxy logs on a Kops cluster:
```
volumes:
  - hostPath:
      path: /var/log
    name: varlog
volumeMounts:
  - name: varlog
    mountPath: /host/var/log
    readOnly: true

extraEnv:
  CLUSTER_NAME: set-me-at-runtime

config:
  kube-proxy.yml: |-
    - type: log
      paths:
        - /host/var/log/kube-proxy.log
      tags: ["proxy"]
      processors:
        - add_kubernetes_metadata:
            in_cluster: true
            namespace: kube-system
        - add_cloud_metadata:
      fields:
        kubernetes.cluster: ${CLUSTER_NAME}
      fields_under_root: true
```

I also cleaned up some trailing whitespace and added checksums of the Secret and ConfigMap to the Daemonset annotations so pods will be rolled whenever either the Secret or ConfigMap change.

**Which issue this PR fixes**: N/A

**Special notes for your reviewer**:

Default behavior should be unchanged, but pods will be rolled upon upgrading due to the annotation change.