### PR TITLE
[stable/kanister-operator] Icon and README changes

### DIFF
--- a/stable/kanister-operator/Chart.yaml
+++ b/stable/kanister-operator/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 description: Kanister-operator Helm chart for Kubernetes
 name: kanister-operator
-version: 0.2.0
+version: 0.2.1
 home: https://kanister.io/
 maintainers:
   - email: ilya@kasten.io
     name: depohmel
   - email: tom@kasten.io
     name: tdmanv
-icon: https://avatars3.githubusercontent.com/u/30535216?s=200&v=4
-appVersion: 0.2.0
+icon: https://kasten.io/assets/img/kanister-logo.png
+appVersion: v0.2.0
 source: https://github.com/kanisterio/kanister

--- a/stable/kanister-operator/README.md
+++ b/stable/kanister-operator/README.md
@@ -1,10 +1,10 @@
 # kanister-operator
 
-[kanister-operator](https://github.com/kanisterio/kanister) is a Kubernetes operator for Kanister framework.
+[kanister-operator](https://github.com/kanisterio/kanister) is a Kubernetes operator for the Kanister framework.
 
 Kanister is a framework that enables application-level data management on Kubernetes. It allows domain experts to capture application specific data management tasks via blueprints, which can be easily shared and extended. The framework takes care of the tedious details surrounding execution on Kubernetes and presents a homogeneous operational experience across applications at scale.
 
-## TL;DR;
+## TL;DR
 
 ```console
 $ helm install stable/kanister-operator
@@ -47,7 +47,7 @@ Parameter | Description | Default
 --- | --- | ---
 `rbac.create` | all required roles and SA will be created | `true`
 `serviceAccount.create`| specify if SA will be created | `true`
-`serviceAccount.name`| porvided service account name will be used | `None`
+`serviceAccount.name`| provided service account name will be used | `None`
 `image.repository` | controller container image repository | `kanisterio/controller`
 `image.tag` | controller container image tag | `v0.2.0`
 `image.pullPolicy` | controller container image pull policy | `IfNotPresent`


### PR DESCRIPTION
Minor changes:

- icon url changed from github avator to png file
- minor cleanups in REAME file
- correcting appVersion
