### PR TITLE
[stable/external-dns] Empty clusterIP does not attempt invalid update

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.5.2
+version: 0.5.3
 appVersion: 0.4.8
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/service.yaml
+++ b/stable/external-dns/templates/service.yaml
@@ -12,7 +12,9 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "external-dns.fullname" . }}
 spec:
+{{- if .Values.service.clusterIP }}
   clusterIP: "{{ .Values.service.clusterIP }}"
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This will prevent `Error: UPGRADE FAILED: Service "my-external-dns" is invalid: spec.clusterIP: Invalid value: "": field is immutable`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: No known issue reported

**Special notes for your reviewer**:
[clusterIP cannot be updated](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#servicespec-v1-core)
The empty string is a valid value on installation, but not update.
Empty string is the default value, therefore only set `clusterIP` if a non-empty value is provided.
