### PR TITLE
Fix SSL certs for docker registry chart

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.6.2
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -134,5 +134,5 @@ spec:
 {{- if .Values.tlsSecretName }}
         - name: tls-cert
           secret:
-            secretName: {{ .Values.tlsSecretName }}.tls
+            secretName: {{ .Values.tlsSecretName }}
 {{- end }}

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -60,6 +60,12 @@ spec:
                 secretKeyRef:
                   name: {{ template "docker-registry.fullname" . }}-secret
                   key: haSharedSecret
+{{- if .Values.tlsSecretName }}
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: /etc/ssl/docker/tls.crt
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: /etc/ssl/docker/tls.key
+{{- end }}
 {{- if eq .Values.storage "filesystem" }}
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"


### PR DESCRIPTION
**What this PR does / why we need it**:
@jpds Thanks for creating this chart! I ran into issues using the SSL support: generating a k8s TLS secret didn't template properly into the secret volume due to what I think is an extraneous `.tls`; and also, the current template creates the TLS cert in a secret volume, but does not instruct the registry process to use it, and this resulted in it listening on HTTP when I deployed it. (Not sure if that is something that varies with docker registry version.)

Fixing both of these issues required two commits. With my local checkout with these commits applied I was able to successfully have the daemon listen on SSL with a self signed cert.

**Which issue this PR fixes**
(no issue created yet)