### PR TITLE
[stable/grafana]: Update dashboard import URL to match service name

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.8.3
+version: 0.8.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/dashboards-import-job-configmap.yaml
+++ b/stable/grafana/templates/dashboards-import-job-configmap.yaml
@@ -17,16 +17,10 @@ data:
       wget -O {{ $name }} {{ $val }}
     {{- end }}
     for dashboard in $(ls); do
-      wget \
-      "http://{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/dashboards/db" \
-      --user=${ADMIN_USER} \
-      --password=${ADMIN_PASSWORD} \
-      --auth-no-challenge \
-      --content-on-error \
-      -O- \
-      --timeout=10 \
-      --header="Content-Type: application/json;charset=UTF-8" \
-      --post-data="{ \"dashboard\":$(cat $dashboard), \"overwrite\":true }" ;
+      curl "http://${ADMIN_USER}:${ADMIN_PASSWORD}@{{ template "grafana.server.fullname" . }}:{{ .Values.server.service.httpPort }}/api/dashboards/db" \
+      --max-time 10 \
+      --header "Content-Type: application/json;charset=UTF-8" \
+      --data-binary "{ \"dashboard\":$(cat $dashboard), \"overwrite\":false }" ;
     done;
 
 {{- end -}}


### PR DESCRIPTION
It seems to me that the importer URL in the dashboard importer job needs to match the service name, otherwise in situations like mine (where I have one chart wrapping another), the job tries to call a nonexistent service. The below change seems to fix things.