### PR TITLE
[stable/fluent-bit] Add option to output to stdout

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.2.12
+version: 0.2.13
 appVersion: 0.12.15
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -59,5 +59,9 @@ data:
         Proxy {{ .Values.backend.http.proxy }}
 {{- end }}
         Format {{ .Values.backend.http.format }}
+{{ else if eq .Values.backend.type "stdout" }}
+    [OUTPUT]
+        Name  stdout
+        Match *
 {{- end }}
 {{- end -}}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -26,6 +26,7 @@ backend:
     ## Specify the data format to be used in the HTTP request body
     ## Can be either 'msgpack' or 'json'
     format: msgpack
+  stdout:
 
 env: []
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the option to output to stdout, which is useful for debugging. Can be used as - `helm install stable/fluent-bit --set backend.type=stdout`

@kfox1111 @edsiper 