### PR TITLE
[stable/buildkite] Fix newline issue when using extraEnv

### DIFF
--- a/stable/buildkite/Chart.yaml
+++ b/stable/buildkite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Agent for Buildkite
 name: buildkite
-version: 0.2.1
+version: 0.2.2
 appVersion: 3.0
 icon: https://github.com/buildkite/media/blob/master/marks/Buildkite%20-%20Mark%20-%20colour.png
 keywords:

--- a/stable/buildkite/templates/deployment.yaml
+++ b/stable/buildkite/templates/deployment.yaml
@@ -40,7 +40,9 @@ spec:
                   key: agent-ssh
             {{- end }}
             # EXTRA BUILDKITE AGENT ENV VARS
-{{- if .Values.extraEnv }}{{ toYaml .Values.extraEnv | indent 12 }}{{- end }}
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
I was seeing a missing newline when using `extraEnv` causing:

```yaml
          env:
            # BUILDKITE AGENT ENV VARS
            - name: BUILDKITE_AGENT_TOKEN
              valueFrom:
                secretKeyRef:
                  name: RELEASE-NAME-buildkite
                  key: agent-token
            - name: BUILDKITE_AGENT_META_DATA
              value: "role=agent,queue=bryan-testing"
            # EXTRA BUILDKITE AGENT ENV VARS            - name: HELLO
              value: world
```

Thanks!