### PR TITLE
Support additional k8s filter params

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.2.12
+version: 0.2.13
 appVersion: 0.12.15
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -25,9 +25,9 @@ data:
     [FILTER]
         Name             kubernetes
         Match            kube.*
-        Kube_URL         {{ .Values.filter.KubeURL }}
-        Kube_CA_File     {{ .Values.filter.KubeCAFile }}
-        Kube_Token_File  {{ .Values.filter.KubeTokenFile }}
+        Kube_URL         {{ .Values.filter.kubeURL }}
+        Kube_CA_File     {{ .Values.filter.kubeCAFile }}
+        Kube_Token_File  {{ .Values.filter.kubeTokenFile }}
 {{- if .Values.filter.mergeJSONLog }}
         Merge_JSON_Log   On
 {{- end }}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -23,8 +23,11 @@ data:
         Skip_Long_Lines  On
 
     [FILTER]
-        Name   kubernetes
-        Match  kube.*
+        Name             kubernetes
+        Match            kube.*
+        Kube_URL         {{ .Values.filter.KubeURL }}
+        Kube_CA_File     {{ .Values.filter.KubeCAFile }}
+        Kube_Token_File  {{ .Values.filter.KubeTokenFile }}
 {{- if .Values.filter.mergeJSONLog }}
         Merge_JSON_Log   On
 {{- end }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -68,9 +68,9 @@ tolerations: []
 nodeSelector: {}
 
 filter:
-  KubeURL: https://kubernetes.default.svc:443
-  KubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  KubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  kubeURL: https://kubernetes.default.svc:443
+  kubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  kubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 # If true, check to see if the log field content is a JSON string map, if so,
 # it append the map fields as part of the log structure.
 #  mergeJSONLog: true

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -69,7 +69,7 @@ nodeSelector: {}
 
 filter:
   KubeURL: https://kubernetes.default.svc:443
-  KubeCAFILE: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  KubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   KubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 # If true, check to see if the log field content is a JSON string map, if so,
 # it append the map fields as part of the log structure.

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -67,7 +67,7 @@ tolerations: []
 ##
 nodeSelector: {}
 
-filter: 
+filter:
   KubeURL: https://kubernetes.default.svc:443
   KubeCAFILE: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   KubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -67,7 +67,10 @@ tolerations: []
 ##
 nodeSelector: {}
 
-filter: {}
+filter: 
+  KubeURL: https://kubernetes.default.svc:443
+  KubeCAFILE: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  KubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 # If true, check to see if the log field content is a JSON string map, if so,
 # it append the map fields as part of the log structure.
 #  mergeJSONLog: true


### PR DESCRIPTION
Several values are missing from the fluent-bit generated configuration:
- `Kube_URL`
- `Kube_CA_File`
- `Kube_Token_File`

I've added the values based on the [documentation](http://fluentbit.io/documentation/current/filter/kubernetes.html). 
The main reason for this PR is a hardcoded configuration that is causing issues when configuring cluster domain to be other than `cluster.local` ([issue](https://github.com/fluent/fluent-bit/issues/542), [PR](https://github.com/fluent/fluent-bit/pull/543))