### PR TITLE
[bitcoind] Add initcontainer copy to bypass 1.9.4 read-only configmap mount

### DIFF
--- a/stable/bitcoind/Chart.yaml
+++ b/stable/bitcoind/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: bitcoind
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.15.1"
 description: Bitcoin is an innovative payment network and a new kind of money.
 keywords:

--- a/stable/bitcoind/templates/deployment.yaml
+++ b/stable/bitcoind/templates/deployment.yaml
@@ -18,6 +18,17 @@ spec:
         app: {{ template "bitcoind.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.configurationFile }}
+      initContainers:
+        - name: copy-bitcoind-config
+          image: busybox
+          command: ['sh', '-c', 'cp /configmap/bitcoin.conf /bitcoin/.bitcoin/bitcoin.conf']
+          volumeMounts:
+            - name: configmap
+              mountPath: /configmap
+            - name: config
+              mountPath: /bitcoin/.bitcoin/
+      {{- end }}
       containers:
         - name: {{ template "bitcoind.fullname" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -44,6 +55,8 @@ spec:
       volumes:
         {{- if .Values.configurationFile }}
         - name: config
+          emptyDir: {}
+        - name: configmap
           configMap:
             name: {{ template "bitcoind.fullname" . }}
         {{- end }}


### PR DESCRIPTION
This PR fixes issue https://github.com/kubernetes/charts/issues/4407

Another chart bug from 1.9.4's read-only configmap mounts.

@govale @daniel-yavorovich