### PR TITLE
[Datadog] modify template generate bugs

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.10.11
+version: 0.10.12
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/serviceaccount.yaml
+++ b/stable/datadog/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 # You need to use that account for your dd-agent DaemonSet
-{{ if .Values.rbac.create -}}
+{{ if .Values.rbac.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
mistaken go template format when generate service account YAML.
"apiVersion" line needs newline character

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

The Datadog Service account is not created...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4413

Golang tempalate is mistaken.
So apiVersion line is deleted.
We prefer to change from "-}}" to "}}".

* Template (Now)

```
# You need to use that account for your dd-agent DaemonSet
{{ if .Values.rbac.create -}}
apiVersion: v1
kind: ServiceAccount
...
```

The template generating...

* Before

```
---
# Source: datadog/templates/serviceaccount.yaml
# You need to use that account for your dd-agent DaemonSetapiVersion: v1
kind: ServiceAccount
...
```

* After

```
---
# Source: datadog/templates/serviceaccount.yaml
# You need to use that account for your dd-agent DaemonSet
apiVersion: v1
kind: ServiceAccount
...
```

**Special notes for your reviewer**:

I confirm with following command.
```
helm template --values ./values.yml --name dd-agent datadog
```
I try helm 2.7, 2.8 and latest, but it has same issue.