### PR TITLE
[stable/prometheus]: Make the security context customizable

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 6.2.1
+version: 6.3.0
 appVersion: 2.2.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -118,6 +118,7 @@ Parameter | Description | Default
 `alertmanager.podAnnotations` | annotations to be added to alertmanager pods | `{}`
 `alertmanager.replicaCount` | desired number of alertmanager pods | `1`
 `alertmanager.resources` | alertmanager pod resource requests & limits | `{}`
+`alertmanager.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for Alert Manager containers | `{}`
 `alertmanager.service.annotations` | annotations for alertmanager service | `{}`
 `alertmanager.service.clusterIP` | internal alertmanager cluster service IP | `""`
 `alertmanager.service.externalIPs` | alertmanager service external IP addresses | `[]`
@@ -150,6 +151,7 @@ Parameter | Description | Default
 `kubeStateMetrics.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `kubeStateMetrics.replicaCount` | desired number of kube-state-metrics pods | `1`
 `kubeStateMetrics.resources` | kube-state-metrics resource requests and limits (YAML) | `{}`
+`kubeStateMetrics.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for kube-state-metrics containers | `{}`
 `kubeStateMetrics.service.annotations` | annotations for kube-state-metrics service | `{prometheus.io/scrape: "true"}`
 `kubeStateMetrics.service.clusterIP` | internal kube-state-metrics cluster service IP | `None`
 `kubeStateMetrics.service.externalIPs` | kube-state-metrics service external IP addresses | `[]`
@@ -228,6 +230,7 @@ Parameter | Description | Default
 `server.podAnnotations` | annotations to be added to Prometheus server pods | `{}`
 `server.replicaCount` | desired number of Prometheus server pods | `1`
 `server.resources` | Prometheus server resource requests and limits | `{}`
+`server.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for server containers | `{}`
 `server.service.annotations` | annotations for Prometheus server service | `{}`
 `server.service.clusterIP` | internal Prometheus server cluster service IP | `""`
 `server.service.externalIPs` | Prometheus server service external IP addresses | `[]`

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -79,6 +79,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.alertmanager.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.alertmanager.securityContext }}
+      securityContext:
+{{ toYaml .Values.alertmanager.securityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.alertmanager.tolerations }}
       tolerations:
 {{ toYaml .Values.alertmanager.tolerations | indent 8 }}

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -45,6 +45,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.kubeStateMetrics.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.kubeStateMetrics.securityContext }}
+      securityContext:
+{{ toYaml .Values.kubeStateMetrics.securityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.kubeStateMetrics.tolerations }}
       tolerations:
 {{ toYaml .Values.kubeStateMetrics.tolerations | indent 8 }}

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -45,6 +45,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pushgateway.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.pushgateway.securityContext }}
+      securityContext:
+{{ toYaml .Values.pushgateway.securityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.pushgateway.tolerations }}
       tolerations:
 {{ toYaml .Values.pushgateway.tolerations | indent 8 }}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -121,6 +121,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}
     {{- end }}
+    {{- if .Values.server.securityContext }}
+      securityContext:
+{{ toYaml .Values.server.securityContext | indent 8 }}
+    {{- end }}
     {{- if .Values.server.tolerations }}
       tolerations:
 {{ toYaml .Values.server.tolerations | indent 8 }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -165,6 +165,10 @@ alertmanager:
     #   cpu: 10m
     #   memory: 32Mi
 
+  ## Security context to be added to alertmanager pods
+  ##
+  securityContext: {}
+
   service:
     annotations: {}
     labels: {}
@@ -293,6 +297,10 @@ kubeStateMetrics:
     # requests:
     #   cpu: 10m
     #   memory: 16Mi
+
+  ## Security context to be added to kube-state-metrics pods
+  ##
+  securityContext: {}
 
   service:
     annotations:
@@ -561,6 +569,10 @@ server:
     #   cpu: 500m
     #   memory: 512Mi
 
+  ## Security context to be added to server pods
+  ##
+  securityContext: {}
+
   service:
     annotations: {}
     labels: {}
@@ -660,6 +672,10 @@ pushgateway:
     # requests:
     #   cpu: 10m
     #   memory: 32Mi
+
+  ## Security context to be added to push-gateway pods
+  ##
+  securityContext: {}
 
   service:
     annotations:


### PR DESCRIPTION
Per coreos/prometheus-operator#541, a securityContext now seems to be required for the promethus container. Specifically I saw this in the `prometheus-server` container log:
```
Opening storage failed open DB in /data: open /data/608702589: permission denied
```
It seems like some people thought the problem should have been fixed by #2767 but alas it was not (I'm not really familiar enough to understand how this works but it seems like the change made in bca2be3 may have re-broken things). Adding the securityContext did seem to fix the problem for me. I also figured I might as well provide the option for setting a custom security context on the other deployments while I was at it.