### PR TITLE
Fix Vault for `cert` and `token` auth

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.0.7
+version: 1.1.0
 appVersion: 3.9.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -148,7 +148,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `credentialManager.vault.enabled` | Use Hashicorp Vault as a Credential Manager | `false` |
 | `credentialManager.vault.url` | Vault Server URL | `nil` |
 | `credentialManager.vault.pathPrefix` | Vault path to namespace secrets | `/concourse` |
-| `credentialManager.vault.caCert` | CA public certificate when using self-signed TLS with Vault | `nil` |
+| `credentialManager.vault.useCaCert` | CA public certificate when using self-signed TLS with Vault | `nil` |
 | `credentialManager.vault.authBackend` | Vault Authentication Backend to use, leave blank when using clientToken | `nil` |
 | `rbac.create` | Enables creation of RBAC resources | `true` |
 | `rbac.apiVersion` | RBAC version | `v1beta1` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -200,10 +200,12 @@ spec:
             - name: CONCOURSE_VAULT_CA_CERT
               value: "/concourse-vault/ca.cert"
             {{- end }}
+            {{- if eq (default "" .Values.credentialManager.vault.authBackend) "cert" }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
               value: "/concourse-vault/client.cert"
             - name: CONCOURSE_VAULT_CLIENT_KEY
               value: "/concourse-vault/client.key"
+            {{- end }}
             {{- if eq (default "" .Values.credentialManager.vault.authBackend) "approle" }}
             - name: CONCOURSE_VAULT_APPROLE_ID
               valueFrom:
@@ -312,8 +314,10 @@ spec:
               - key: vault-ca-cert
                 path: ca.cert
             {{- end }}
+            {{- if eq (default "" .Values.credentialManager.vault.authBackend) "cert" }}
               - key: vault-client-cert
                 path: client.cert
               - key: vault-client-key
                 path: client.key
+            {{- end }}
         {{- end }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -493,7 +493,7 @@ credentialManager:
     ## if the Vault server is using a self-signed certificate, set this to true,
     ## and provide a value for the cert in secrets.
     ##
-    # caCert:
+    # useCaCert:
 
     ## vault authentication backend, leave this blank if using an initial periodic token
     ## currently supported backends: token, approle, cert.


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

- `caCert` was renamed to `useCaCert` but not in README or values.yaml
- `vault-client-key` and `vault-client-cert` should only need to be set
  when the auth mode has been set to `cert`. Without the check, `approle`
  and `token` auth will fail (due to Go not being able to parse the PEM
  of "")