### PR TITLE
proper noun should be in capital

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.9.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -14,14 +14,14 @@ This chart will do the following:
 
 Please note that a backend service for Vault (for example, Consul) must
 be deployed beforehand and configured with the `vault.config` option. YAML
-provided under this option will be converted to JSON for the final vault
+provided under this option will be converted to JSON for the final Vault
 `config.json` file.
 
 > See https://www.vaultproject.io/docs/configuration/ for more information.
 
 ## Installing the Chart
 
-To install the chart, use the following, this backs vault with a Consul cluster:
+To install the chart, use the following, this backs Vault with a Consul cluster:
 
 ```console
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
@@ -43,7 +43,7 @@ vault:
 
 ## Configuration
 
-The following table lists the configurable parameters of the vault chart and their default values.
+The following table lists the configurable parameters of the Vault chart and their default values.
 
 |       Parameter         |           Description               |                         Default                     |
 |-------------------------|-------------------------------------|-----------------------------------------------------|


### PR DESCRIPTION
Vault is a proper noun, in this doc's main text, most words "vault" are in capital while 3 in lower case. 
It's better use the same.