### PR TITLE
[JENKINS] Secure Defaults

### DIFF
--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -52,6 +52,10 @@ The following tables lists the configurable parameters of the Jenkins chart and 
 | `Master.HealthProbesTimeout`      | Set the timeout for the liveness and readiness probes | `120`                                                       |
 | `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
+| `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                                      |
+| `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                      |
+| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatability | `true`                                                                      |
+| `Master.CLI`                      | Enable CLI over remoting             | `false`                                                                      |
 | `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |
 | `Master.LoadBalancerIP`           | Optional fixed external IP           | Not set                                                                      |
 | `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -145,10 +145,20 @@ data:
       <pendingClasspathEntries/>
     </scriptApproval>
 {{- end }}
+  jenkins.CLI.xml |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <jenkins.CLI>
+{{- if .Values.Master.CLI }}
+      <enabled>true</enabled>
+{{- else }}
+      <enabled>false</enabled>
+{{- fi }}
+    </jenkins.CLI>
   apply_config.sh: |-
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
+    cp -n /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
 {{- if .Values.Master.InstallPlugins }}
     cp /var/jenkins_config/plugins.txt /var/jenkins_home;
     rm -rf /usr/share/jenkins/ref/plugins/*.lock

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -118,6 +118,11 @@ data:
       </views>
       <primaryView>All</primaryView>
       <slaveAgentPort>50000</slaveAgentPort>
+      <disabledAgentProtocols>
+{{- range $key, $val := .Values.Master.DisabledAgentProtocols }}
+        <string>{{ $val }}</string>
+{{- end }}
+      </disabledAgentProtocols>
       <label></label>
       <nodeProperties/>
       <globalNodeProperties/>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -124,6 +124,13 @@ data:
 {{- end }}
       </disabledAgentProtocols>
       <label></label>
+{{- if .Values.Master.CSRF.DefaultCrumbIssuer.Enabled }}
+      <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+{{- if .Values.Master.CSRF.DefaultCrumbIssuer.ProxyCompatability }}
+        <excludeClientIPFromCrumb>true</excludeClientIPFromCrumb>
+{{- end }}
+      </crumbIssuer>
+{{- end }}
       <nodeProperties/>
       <globalNodeProperties/>
       <noUsageStatistics>true</noUsageStatistics>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -57,6 +57,7 @@ Master:
     DefaultCrumbIssuer:
       Enabled: true
       ProxyCompatability: true
+  CLI: false
   # Kubernetes service type for the JNLP slave service
   # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341
   SlaveListenerServiceType: ClusterIP

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -50,6 +50,13 @@ Master:
   HealthProbes: true
   HealthProbesTimeout: 60
   SlaveListenerPort: 50000
+  DisabledAgentProtocols:
+    - JNLP-connect
+    - JNLP2-connect
+  CSRF:
+    DefaultCrumbIssuer:
+      Enabled: false
+      ProxyCompatability: true
   # Kubernetes service type for the JNLP slave service
   # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341
   SlaveListenerServiceType: ClusterIP

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -55,7 +55,7 @@ Master:
     - JNLP2-connect
   CSRF:
     DefaultCrumbIssuer:
-      Enabled: false
+      Enabled: true
       ProxyCompatability: true
   # Kubernetes service type for the JNLP slave service
   # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341


### PR DESCRIPTION
This PR makes a more secure out-of-the-box configuration for Jenkins installs by allowing the user to disable insecure agent protocols, enable CSRF, and disable CLI over remoting, while still allowing a user to run with their pants down if they so wish.

- [x]  Add toggles to config template
- [x]  Secure defaults
- [x]  Add documentation
- [ ]  Make linter happy