### PR TITLE
[stable/sonatype-nexus] fix reusability of existing claim

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 0.1.9
+version: 0.2.0
 appVersion: 3.9.0
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `persistence.storageClass`                  | Type of persistent volume claim     | nil  (uses alpha storage class annotation) |
 | `persistence.accessMode`                    | ReadWriteOnce or ReadOnly           | ReadWriteOnce                              |
 | `persistence.annotations`                   | Persistent Volume annotations       | {}                                         |
+| `persistence.existingClaim`                 | Existing persistent volume name     | ""                                         |
 | `service.type`                              | Kubernetes Service type             | `LoadBalancer`                             |
 | `service.readinessProbe.initialDelaySeconds`| ReadinessProbe initial delay        | 30                                         |
 | `service.readinessProbe.periodSeconds`      | Seconds between polls               | 30                                         |

--- a/stable/sonatype-nexus/templates/deployment.yaml
+++ b/stable/sonatype-nexus/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
      {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}    
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -56,7 +56,7 @@ spec:
         - name: nexus-data-volume
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "fullname" . }}
+            claimName: {{ .Values.persistence.existingClaim | default (print (include "fullname" .)) }}
           {{- else }}
           emptyDir: {}
           {{- end -}}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -52,6 +52,7 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
+  # existingClaim: ""
   # storageClass: "-"
   # annotations:
   #  "helm.sh/resource-policy": keep


### PR DESCRIPTION
Deployment does not use the existing volume claim name when mounting
volume