### PR TITLE
Rename service port to http

### DIFF
--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -5,6 +5,10 @@ version: 0.4.5
 appVersion: 0.4.2
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png
+keywords:
+- chartmuseum
+- helm
+- charts repo
 maintainers:
 - name: ChartMuseum
   email: chartmuseum@gmail.com

--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 0.4.4
+version: 0.4.5
 appVersion: 0.4.2
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/incubator/chartmuseum/requirements.yaml
+++ b/incubator/chartmuseum/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: common
-  version: 0.0.1
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/

--- a/incubator/chartmuseum/templates/_helpers.tpl
+++ b/incubator/chartmuseum/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{- /*
+name defines a template for the name of the chartmuseum chart.
+
+The prevailing wisdom is that names should only contain a-z, 0-9 plus dot (.) and dash (-), and should
+not exceed 63 characters.
+
+Parameters:
+
+- .Values.nameOverride: Replaces the computed name with this given name
+- .Values.namePrefix: Prefix
+- .Values.global.namePrefix: Global prefix
+- .Values.nameSuffix: Suffix
+- .Values.global.nameSuffix: Global suffix
+
+The applied order is: "global prefix + prefix + name + suffix + global suffix"
+
+Usage: 'name: "{{- template "chartmuseum.name" . -}}"'
+*/ -}}
+{{- define "chartmuseum.name"}}
+{{- $global := default (dict) .Values.global -}}
+{{- $base := default .Chart.Name .Values.nameOverride -}}
+{{- $gpre := default "" $global.namePrefix -}}
+{{- $pre := default "" .Values.namePrefix -}}
+{{- $suf := default "" .Values.nameSuffix -}}
+{{- $gsuf := default "" $global.nameSuffix -}}
+{{- $name := print $gpre $pre $base $suf $gsuf -}}
+{{- $name | lower | trunc 54 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- /*
+fullname defines a suitably unique name for a resource by combining
+the release name and the chartmuseum chart name.
+
+The prevailing wisdom is that names should only contain a-z, 0-9 plus dot (.) and dash (-), and should
+not exceed 63 characters.
+
+Parameters:
+
+- .Values.fullnameOverride: Replaces the computed name with this given name
+- .Values.fullnamePrefix: Prefix
+- .Values.global.fullnamePrefix: Global prefix
+- .Values.fullnameSuffix: Suffix
+- .Values.global.fullnameSuffix: Global suffix
+
+The applied order is: "global prefix + prefix + name + suffix + global suffix"
+
+Usage: 'name: "{{- template "chartmuseum.fullname" . -}}"'
+*/ -}}
+{{- define "chartmuseum.fullname"}}
+{{- $global := default (dict) .Values.global -}}
+{{- $base := default (printf "%s-%s" .Release.Name .Chart.Name) .Values.fullnameOverride -}}
+{{- $gpre := default "" $global.fullnamePrefix -}}
+{{- $pre := default "" .Values.fullnamePrefix -}}
+{{- $suf := default "" .Values.fullnameSuffix -}}
+{{- $gsuf := default "" $global.fullnameSuffix -}}
+{{- $name := print $gpre $pre $base $suf $gsuf -}}
+{{- $name | lower | trunc 54 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{- /*
+chartmuseum.labels.standard prints the standard chartmuseum Helm labels.
+
+The standard labels are frequently used in metadata.
+*/ -}}
+{{- define "chartmuseum.labels.standard" -}}
+app: {{ template "chartmuseum.name" . }}
+chart: {{ template "chartmuseum.chartref" . }}
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+{{- end -}}
+
+{{- /*
+chartmuseum.chartref prints a chart name and version.
+
+It does minimal escaping for use in Kubernetes labels.
+
+Example output:
+
+chartmuseum-0.4.5
+*/ -}}
+{{- define "chartmuseum.chartref" -}}
+{{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
+{{- end -}}

--- a/incubator/chartmuseum/templates/deployment.yaml
+++ b/incubator/chartmuseum/templates/deployment.yaml
@@ -1,11 +1,11 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ include "common.fullname" . }}
+  name: {{ include "chartmuseum.fullname" . }}
   annotations:
 {{ toYaml .Values.deployment.annotations | indent 4 }}
   labels:
-{{ include "common.labels.standard" . | indent 4 }}
+{{ include "chartmuseum.labels.standard" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
@@ -13,11 +13,11 @@ spec:
   revisionHistoryLimit: 10
   template:
     metadata:
-      name: {{ include "common.fullname" . }}
+      name: {{ include "chartmuseum.fullname" . }}
       annotations:
 {{ toYaml .Values.replica.annotations | indent 8 }}
       labels:
-        app: {{ template "common.name" . }}
+        app: {{ template "chartmuseum.name" . }}
         release: {{ .Release.Name | quote }}
     spec:
       containers:
@@ -31,7 +31,7 @@ spec:
           value: {{ $value | quote }}
 {{- end }}
 {{- end }}
-{{- $secret_name := include "common.fullname" . }}
+{{- $secret_name := include "chartmuseum.fullname" . }}
 {{- range $name, $value := .Values.env.secret }}
 {{- if not ( empty $value) }}
         - name: {{ $name | quote }}
@@ -86,7 +86,7 @@ spec:
       - name: storage-volume
       {{- if .Values.persistence.Enabled }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistence.ExistingClaim | default (include "common.fullname" .) }}
+          claimName: {{ .Values.persistence.ExistingClaim | default (include "chartmuseum.fullname" .) }}
       {{- else }}
         emptyDir: {}
       {{- end -}}

--- a/incubator/chartmuseum/templates/ingress.yaml
+++ b/incubator/chartmuseum/templates/ingress.yaml
@@ -1,18 +1,18 @@
 {{- $servicePort := .Values.service.externalPort -}}
-{{- $serviceName := include "common.fullname" . -}}
+{{- $serviceName := include "chartmuseum.fullname" . -}}
 {{- if .Values.ingress.enabled }}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ include "common.fullname" . }}
+  name: {{ include "chartmuseum.fullname" . }}
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
   labels:
 {{- if .Values.ingress.labels }}
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
-{{ include "common.labels.standard" . | indent 4 }}
+{{ include "chartmuseum.labels.standard" . | indent 4 }}
 spec:
   rules:
   {{- range $host, $paths := .Values.ingress.hosts }}

--- a/incubator/chartmuseum/templates/pvc.yaml
+++ b/incubator/chartmuseum/templates/pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ include "common.fullname" . }}
+  name: {{ include "chartmuseum.fullname" . }}
   labels:
-    app: {{ include "common.fullname" . }}
+    app: {{ include "chartmuseum.fullname" . }}
     release: {{ .Release.Name | quote }}
 spec:
   accessModes:

--- a/incubator/chartmuseum/templates/secret.yaml
+++ b/incubator/chartmuseum/templates/secret.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.fullname" . }}
+  name: {{ include "chartmuseum.fullname" . }}
   labels:
-{{ include "common.labels.standard" . | indent 4 }}
+{{ include "chartmuseum.labels.standard" . | indent 4 }}
 type: Opaque
 data:
 {{- range $name, $value := .Values.env.secret }}

--- a/incubator/chartmuseum/templates/service.yaml
+++ b/incubator/chartmuseum/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
     targetPort: {{ .Values.service.internalPort }}
 {{- end }}
     protocol: TCP
-    name: {{ .Release.Name }}
+    name: http
   selector:
     app: {{ template "common.name" . }}
     release: {{ .Release.Name | quote }}

--- a/incubator/chartmuseum/templates/service.yaml
+++ b/incubator/chartmuseum/templates/service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "common.fullname" . }}
+  name: {{ include "chartmuseum.fullname" . }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
   labels:
-{{ include "common.labels.standard" . | indent 4 }}
+{{ include "chartmuseum.labels.standard" . | indent 4 }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
@@ -22,5 +22,5 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: {{ template "common.name" . }}
+    app: {{ template "chartmuseum.name" . }}
     release: {{ .Release.Name | quote }}


### PR DESCRIPTION
## What
* Rename service port from `Release.name` to `http`
* Remove dependency from `common` chart
* Added keywords to `Chart.yaml`

## Why
* Follow this issue https://github.com/kubernetes-helm/chartmuseum/issues/80
* Allow to move `chartmuseum` chart to stable repo
* Improve visibility of chart for search

*****************************************************************************************

Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the 
history. This will make it easier to identify new changes. The PR will be squashed 
anyways when it is merged. Thanks.

*****************************************************************************************
