### PR TITLE
Update jaeger README to use correct parameters

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.8
+version: 0.3.9
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -99,7 +99,7 @@ helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=fa
 To install the chart with the release name `myrel` using a new ElasticSearch cluster instead of Cassandra (default), run the following command:
 
 ```bash
-$ helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=false  --set provisionDataStore.elasticsearch=true
+$ helm install incubator/jaeger --name myrel --set provisionDataStore.cassandra=false  --set provisionDataStore.elasticsearch=true --set storage.type=elasticsearch
 ```
 
 After a few minutes, you should see 2 ElasticSearch client nodes, 2 ElasticSearch data nodes, 3 ElasticSearch master nodes, a Jaeger DaemonSet, a Jaeger Collector, and a Jaeger Query (UI) pod deployed into your Kubernetes cluster.
@@ -174,10 +174,10 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `query.image`                            | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
 | `query.ingress.enabled`                  | Allow external traffic access       |  false                                 |
 | `query.pullPolicy`                       | Query UI image pullPolicy           |  IfNotPresent                          |
-| `query.queryPort`                        | External accessible port            |  80                                    |
+| `query.service.queryPort`                | External accessible port            |  80                                    |
+| `query.service.targetPort`               | Internal Query UI port              |  16686                                 |
+| `query.service.type`                     | Service type                        |  ClusterIP                             |
 | `query.tag`                              | Image tag/version                   |  0.6                                   |
-| `query.targetPort`                       | Internal Query UI port              |  16686                                 |
-| `query.type`                             | Service type                        |  ClusterIP                             |
 | `schema.annotations`                     | Annotations for the schema job      |  nil                                   |
 | `schema.image`                           | Image to setup cassandra schema     |  jaegertracing/jaeger-cassandra-schema |
 | `schema.mode`                            | Schema mode (prod or test)          |  prod                                  |


### PR DESCRIPTION
This fixes two separate documentation bugs:
1. When using the elasticsearch storage backend, `storage.type=elasticsearch` must be set. The given example didn't include this param.
2. The param names for the query service didn't match the ones in the code.