### PR TITLE
Fix anti-affinity policy and bump version of cockroachdb chart

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 0.6.7
-appVersion: 1.1.5
+version: 0.6.8
+appVersion: 1.1.7
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -92,10 +92,10 @@ spec:
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                - key: app
+                - key: component
                   operator: In
                   values:
-                  - cockroachdb
+                  - "{{ .Release.Name }}-{{ .Values.Component }}"
               topologyKey: kubernetes.io/hostname
       containers:
       - name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the anti-affinity policy of the cockroachdb chart and updates it to default to the newest stable release of cockroachdb.