### PR TITLE
initial commit of new dmarc2logstash chart

### DIFF
--- a/stable/dmarc2logstash/.helmignore
+++ b/stable/dmarc2logstash/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/dmarc2logstash/Chart.yaml
+++ b/stable/dmarc2logstash/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "1.0.0"
+description: Provides a POP3-polled DMARC XML report injector into Elasticsearch via Logstash and Filebeat
+name: dmarc2logstash
+version: 1.0.0
+sources:
+- https://github.com/jertel/dmarc2logstash
+maintainers:
+  - name: jertel
+    email: jertel@codesim.com
+engine: gotpl

--- a/stable/dmarc2logstash/OWNERS
+++ b/stable/dmarc2logstash/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- jertel
+reviewers:
+- jertel

--- a/stable/dmarc2logstash/README.md
+++ b/stable/dmarc2logstash/README.md
@@ -34,10 +34,22 @@ filebeat.image.tag                | Elastic filebeat tag, typically the version,
 filebeat.image.pullPolicy         | Elastic filebeat Kubernetes image pull policy                                                                         | IfNotPresent
 filebeat.logstash.host            | Logstash service host; ex: logstash (this value must be provided)                                                     | ""
 filebeat.logstash.port            | Logstash service port                                                                                                 | 5000
-filebeat.logstash.externalName    | If the logstash.host refers to a logstash service in another Kubernetes namespace, define the full service name here. | ""
+filebeat.logstash.externalName    | If the logstash host is a service in another Kubernetes namespace, define the full service name here. See note below. | ""
 filebeat.logstash.sourceType      | Logstash source type will allow custom filtering via the Logstash configuration                                       | json-logs
 filebeat.logstash.index           | Elastisearch index that will contain the new DMARC data (index will be created on-the-fly if doesn't exist)           | dmarc
 filebeat.logstash.timeout         | Seconds to wait before timing out the connection to logstash                                                          | 15
+
+### filebeat.logstash.externalName
+
+If logstash is running within the Kubernetes cluster, set the filebeat.logstash.externalName value to the fully-qualified cluster hostname, such as logstash.elastic.svc.cluster.local. Then, set filebeat.logstash.host to Chart fullname, which is usually `dmarc2logstash`. Following the above example namespace for logstash, the override yaml file would contain the following:
+
+```
+filebeat:
+  logstash:
+    host: dmarc2logstash
+    port: 5000
+    externalName: logstash.elastic.svc.cluster.local
+```
 
 ## Secrets
 

--- a/stable/dmarc2logstash/README.md
+++ b/stable/dmarc2logstash/README.md
@@ -1,0 +1,70 @@
+# dmarc2logstash Helm Chart
+
+[dmarc2logstash](https://github.com/jertel/dmarc2logstash): A POP3 polling service that converts Domain-based Message Authentication, Reporting, and Complicane (DMARC) reports into a logstash feed. More information about the DMARC organization and RFC 7489 standards can be found at https://dmarc.org. An accompanying [dashboard](https://github.com/jertel/dmarc2logstash/blob/master/grafana-dashboard.json) is available for import into Grafana.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install --name my-release stable/dmarc2logstash
+```
+
+The command deploys dmarc2logstash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation. The [secrets](#secrets) section lists the required Kubernetes secrets.
+
+## Uninstalling the Chart
+
+To uninstall/delete the my-release deployment:
+
+```console
+helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+setting                           | description                                                                                                           | default
+----------------------------------|-----------------------------------------------------------------------------------------------------------------------|----------
+dmarc2logstash.image.repository   | dmarc2logstash Docker image repository                                                                                | jertel/dmarc2logstash
+dmarc2logstash.image.tag          | dmarc2logstash image tag, typically the version, of the Docker image                                                  | 1.0.0
+dmarc2logstash.image.pullPolicy   | dmarc2logstash Kubernetes image pull policy                                                                           | IfNotPresent
+filebeat.image.repository         | Elastic filebeat Docker image repository                                                                              | docker.elastic.co/beats/filebeat
+filebeat.image.tag                | Elastic filebeat tag, typically the version, of the Docker image                                                      | 6.2.1
+filebeat.image.pullPolicy         | Elastic filebeat Kubernetes image pull policy                                                                         | IfNotPresent
+filebeat.logstash.host            | Logstash service host; ex: logstash (this value must be provided)                                                     | ""
+filebeat.logstash.port            | Logstash service port                                                                                                 | 5000
+filebeat.logstash.externalName    | If the logstash.host refers to a logstash service in another Kubernetes namespace, define the full service name here. | ""
+filebeat.logstash.sourceType      | Logstash source type will allow custom filtering via the Logstash configuration                                       | json-logs
+filebeat.logstash.index           | Elastisearch index that will contain the new DMARC data (index will be created on-the-fly if doesn't exist)           | dmarc
+filebeat.logstash.timeout         | Seconds to wait before timing out the connection to logstash                                                          | 15
+
+## Secrets
+
+The following dmarc2logstash-secrets are required to be present in order for this chart to deploy:
+
+variable               | required | description
+-----------------------|----------|------------
+pop3_server            | true     | The POP3 server hostname or IP address (must support TLS)
+pop3_username          | true     | POP3 account username
+pop3_password          | true     | POP3 account password
+
+Below is a sample secrets.yaml file that can be used as a template. Remember that all secrets must be base64-encoded.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dmarc2logstash-secrets
+type: Opaque
+data:
+  pop3_server: ""
+  pop3_username: ""
+  pop3_password: ""
+```
+
+Once you have provided the base64-encoded secret values, apply the file to your Kubernetes cluster as follows:
+
+```console
+kubectl apply -f secrets.yaml
+```

--- a/stable/dmarc2logstash/templates/NOTES.txt
+++ b/stable/dmarc2logstash/templates/NOTES.txt
@@ -1,0 +1,16 @@
+{{- if .Values.filebeat.logstash.host -}}
+The dmarc2logstash application has been deployed. If the pod enounters crash-
+looping you might have missed the step to set the POP3 secrets. Review the 
+chart's README.md for more information.
+
+If successfully configured to reach the POP3 account containing the DMARC
+reports, and if filebeat is successfully connecting to your logstash service, 
+then you are ready to start reviewing the DMARC data in Kibana. 
+
+Optionally, if you use Grafana for visualizations, consider importing the DMARC
+dashboard, available in the https://github.com/jertel/dmarc2logstash project.
+{{- else -}}
+NOTE: The logstash.host, logstash.port, and optionally, logstash.externalName values must be correctly defined in order for this deployment to be created. By default, no logstash service endpoint is provided.
+
+Additionally, the POP3 secrets must be applied so that the application can login to the POP3 host.
+{{- end -}}

--- a/stable/dmarc2logstash/templates/_helpers.tpl
+++ b/stable/dmarc2logstash/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dmarc2logstash.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dmarc2logstash.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dmarc2logstash.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/dmarc2logstash/templates/configmap.yaml
+++ b/stable/dmarc2logstash/templates/configmap.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: filebeat-config
+  name: {{ template "dmarc2logstash.fullname" . }}-config
+  labels:
+    app: {{ template "dmarc2logstash.name" . }}
+    chart: {{ template "dmarc2logstash.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 data:
   filebeat.yml: |
     filebeat.registry_file: /tmp/filebeat_registry

--- a/stable/dmarc2logstash/templates/configmap.yaml
+++ b/stable/dmarc2logstash/templates/configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filebeat-config
+data:
+  filebeat.yml: |
+    filebeat.registry_file: /tmp/filebeat_registry
+    filebeat.prospectors:
+    - type: log
+      enabled: true
+      paths:
+        - "/app/log/forward/*.log"
+      json.keys_under_root: true
+      json.add_error_key: true
+      fields_under_root: true
+      fields:
+        source_type: {{ .Values.filebeat.sourceType }}
+    output.logstash:
+      hosts: 
+        - {{ .Values.filebeat.logstash.host }}:{{ .Values.filebeat.logstash.port }}
+      index: {{ .Values.filebeat.logstash.index }}
+      timeout: {{ .Values.filebeat.logstash.timeout }}
+{{ if .Values.filebeat.logstash.extraOutput }}
+      {{ .Values.filebeat.logstash.extraOutput | indent 8 }}
+{{ end }}
+    logging.level: info

--- a/stable/dmarc2logstash/templates/deployment.yaml
+++ b/stable/dmarc2logstash/templates/deployment.yaml
@@ -1,0 +1,96 @@
+{{ if .Values.filebeat.logstash.host }}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "dmarc2logstash.fullname" . }}
+  labels:
+    app: {{ template "dmarc2logstash.name" . }}
+    chart: {{ template "dmarc2logstash.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "dmarc2logstash.name" . }}
+      release: {{ .Release.Name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ template "dmarc2logstash.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+{{ if .Values.specExtras }}
+{{ toYaml .Values.extras | indent 6 }}
+{{ end }}
+      volumes:
+        - name: shared-log
+          emptyDir: {}
+        - name: filebeat-config
+          configMap:
+            name: filebeat-config
+            items:
+            - key: filebeat.yml
+              path: filebeat.yml
+      containers:
+        - name: dmarc2logstash
+          image: "{{ .Values.dmarc2logstash.image.repository }}:{{ .Values.dmarc2logstash.image.tag }}"
+          imagePullPolicy: {{ .Values.dmarc2logstash.image.pullPolicy }}
+{{ if .Values.dmarc2logstash.containerExtras }}
+          {{ .Values.dmarc2logstash.containerExtras | indent 10 }}
+{{ end }}
+          env:
+{{ if .Values.dmarc2logstash.envExtras }}
+            {{ .Values.dmarc2logstash.envExtras | indent 12 }}
+{{ end }}
+            - name: JSON_OUTPUT_FILE
+              value: /opt/dmarc2logstash/output/dmarc.log
+            - name: POP3_SERVER
+              valueFrom:
+                secretKeyRef:
+                  name: dmarc2logstash-secrets
+                  key: pop3_server
+            - name: POP3_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: dmarc2logstash-secrets
+                  key: pop3_username
+            - name: POP3_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dmarc2logstash-secrets
+                  key: pop3_password
+          volumeMounts:
+            - name: shared-log
+              mountPath: /opt/dmarc2logstash/output
+          resources:
+{{ toYaml .Values.dmarc2logstash.resources | indent 12 }}
+    {{- with .Values.dmarc2logstash.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.dmarc2logstash.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.dmarc2logstash.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+        - name: filebeat
+          image: "{{ .Values.filebeat.image.repository }}:{{ .Values.filebeat.image.tag }}"
+          imagePullPolicy: {{ .Values.filebeat.image.pullPolicy }}
+{{ if .Values.filebeat.containerExtras }}
+          {{ .Values.filebeat.containerExtras | indent 10 }}
+{{ end }}
+          volumeMounts:
+            - name: filebeat-config
+              mountPath: /usr/share/filebeat/filebeat.yml
+              subPath: filebeat.yml
+            - name: shared-log
+              mountPath: /app/log/forward
+          resources:
+{{ toYaml .Values.filebeat.resources | indent 12 }}
+{{ end }}

--- a/stable/dmarc2logstash/templates/deployment.yaml
+++ b/stable/dmarc2logstash/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           emptyDir: {}
         - name: filebeat-config
           configMap:
-            name: filebeat-config
+            name: {{ template "dmarc2logstash.fullname" . }}-config
             items:
             - key: filebeat.yml
               path: filebeat.yml
@@ -50,17 +50,17 @@ spec:
             - name: POP3_SERVER
               valueFrom:
                 secretKeyRef:
-                  name: dmarc2logstash-secrets
+                  name: {{ template "dmarc2logstash.name" . }}-secrets
                   key: pop3_server
             - name: POP3_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: dmarc2logstash-secrets
+                  name: {{ template "dmarc2logstash.name" . }}-secrets
                   key: pop3_username
             - name: POP3_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: dmarc2logstash-secrets
+                  name: {{ template "dmarc2logstash.name" . }}-secrets
                   key: pop3_password
           volumeMounts:
             - name: shared-log

--- a/stable/dmarc2logstash/templates/deployment.yaml
+++ b/stable/dmarc2logstash/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
         app: {{ template "dmarc2logstash.name" . }}
         release: {{ .Release.Name }}
     spec:
-{{ if .Values.specExtras }}
-{{ toYaml .Values.extras | indent 6 }}
+{{ if .Values.extraSpec }}
+{{ toYaml .Values.extraSpec | indent 6 }}
 {{ end }}
       volumes:
         - name: shared-log
@@ -38,12 +38,12 @@ spec:
         - name: dmarc2logstash
           image: "{{ .Values.dmarc2logstash.image.repository }}:{{ .Values.dmarc2logstash.image.tag }}"
           imagePullPolicy: {{ .Values.dmarc2logstash.image.pullPolicy }}
-{{ if .Values.dmarc2logstash.containerExtras }}
-          {{ .Values.dmarc2logstash.containerExtras | indent 10 }}
+{{ if .Values.dmarc2logstash.extraContainer }}
+          {{ .Values.dmarc2logstash.extraContainer | indent 10 }}
 {{ end }}
           env:
-{{ if .Values.dmarc2logstash.envExtras }}
-            {{ .Values.dmarc2logstash.envExtras | indent 12 }}
+{{ if .Values.dmarc2logstash.extraEnv }}
+            {{ .Values.dmarc2logstash.extraEnv | indent 12 }}
 {{ end }}
             - name: JSON_OUTPUT_FILE
               value: /opt/dmarc2logstash/output/dmarc.log
@@ -82,8 +82,8 @@ spec:
         - name: filebeat
           image: "{{ .Values.filebeat.image.repository }}:{{ .Values.filebeat.image.tag }}"
           imagePullPolicy: {{ .Values.filebeat.image.pullPolicy }}
-{{ if .Values.filebeat.containerExtras }}
-          {{ .Values.filebeat.containerExtras | indent 10 }}
+{{ if .Values.filebeat.extraContainer }}
+          {{ .Values.filebeat.extraContainer | indent 10 }}
 {{ end }}
           volumeMounts:
             - name: filebeat-config

--- a/stable/dmarc2logstash/templates/deployment.yaml
+++ b/stable/dmarc2logstash/templates/deployment.yaml
@@ -42,8 +42,8 @@ spec:
           {{ .Values.dmarc2logstash.extraContainer | indent 10 }}
 {{ end }}
           env:
-{{ if .Values.dmarc2logstash.extraEnv }}
-            {{ .Values.dmarc2logstash.extraEnv | indent 12 }}
+{{ if .Values.dmarc2logstash.extraEnvs }}
+            {{ .Values.dmarc2logstash.extraEnvs | indent 12 }}
 {{ end }}
             - name: JSON_OUTPUT_FILE
               value: /opt/dmarc2logstash/output/dmarc.log

--- a/stable/dmarc2logstash/templates/logstash-service.yaml
+++ b/stable/dmarc2logstash/templates/logstash-service.yaml
@@ -2,9 +2,9 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: logstash
+  name: {{ template "dmarc2logstash.fullname" . }}
   labels:
-    app: filebeat
+    app: {{ template "dmarc2logstash.name" . }}
     chart: {{ template "dmarc2logstash.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/stable/dmarc2logstash/templates/logstash-service.yaml
+++ b/stable/dmarc2logstash/templates/logstash-service.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.filebeat.logstash.externalName }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: logstash
+  labels:
+    app: filebeat
+    chart: {{ template "dmarc2logstash.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.filebeat.logstash.externalName }}
+  ports:
+  - port: {{ .Values.filebeat.logstash.port }}
+{{ end }}

--- a/stable/dmarc2logstash/values.yaml
+++ b/stable/dmarc2logstash/values.yaml
@@ -1,0 +1,23 @@
+dmarc2logstash:
+  image:
+    repository: jertel/dmarc2logstash
+    tag: 1.0.0
+    pullPolicy: IfNotPresent
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+filebeat:
+  image:
+    repository: docker.elastic.co/beats/filebeat
+    tag: 6.2.1
+    pullPolicy: IfNotPresent
+  logstash:
+    host: ""
+    port: 5000
+    sourceType: json-logs
+    index: dmarc
+    timeout: 15
+    externalName: ""
+  resources: {}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds a new chart to the stable repository. The chart will deploy an application called dmarc2logstash. This app polls a POP3 account for DMARC aggregated reports, unpacks them, converts them into JSON, and uses filebeat to forward them into Logstash. The purpose of the application is to provide all of the standardized RFC 7489 DMARC summary data into Elasticsearch so that email administrators have an easier job at locating problems with DKIM and SPF email/domain settings. This will reduce the level of effort to troubleshoot email messages not reaching their intended recipients due to various problems, such as messages landing in spam folders, being rejected from MTAs, etc.

A quick review of available, similar solutions resulted in none that were Docker-friendly and Helm-compatible, this PR aims to close that gap.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Not applicable as this is a new chart.

**Special notes for your reviewer**:
The dmarc2logstash application is open-sourced at https://github.com/jertel/dmarc2logstash, along with the Dockerfile which auto-builds into https://hub.docker.com/r/jertel/dmarc2logstash/.