### PR TITLE
Update Nexus image

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonatype-nexus
-version: 0.1.8
-appVersion: 3.5.1
+version: 0.1.9
+appVersion: 3.9.0
 description: Sonatype Nexus is an open source repository manager
 keywords:
   - dependency

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -41,7 +41,8 @@ The following table lists the configurable parameters of the Nexus chart and the
 
 | Parameter                                   | Description                         | Default                                    |
 | ------------------------------------------  | ----------------------------------  | -------------------------------------------|
-| `image.tag`                                 | `nexus` image tag.                  | 3.5.1-02                                   |
+| `image.repository`                          | `nexus` image repository.           | cavemandaveman/nexus                       |
+| `image.tag`                                 | `nexus` image tag.                  | 3.9.0-01                                   |
 | `image.pullPolicy`                          | Image pull policy                   | `IfNotPresent`                             |
 | `nodeSelector`                              | node labels for pod assignment      | {}                                         |
 | `ingress.enabled`                           | Flag for enabling ingress           | false                                      |

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 image:
-  repository: clearent/nexus
-  tag: 3.5.1-02
+  repository: cavemandaveman/nexus
+  tag: 3.9.0-01
 
 # node labels for node selection
 # nodeSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:

https://hub.docker.com/r/clearent/nexus/ says "[DEPRECATED] All development has moved to https://hub.docker.com/r/cavemandaveman/nexus/"

**Which issue this PR fixes** 
- Deprecated image
- 5 months old default version
- Add image.repository documentation

**Special notes for your reviewer**:
@rjkernick 