### PR TITLE
dnk: Use user.password if present

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.10
+version: 0.1.11
 appVersion: 8.17
 keywords:
   - debugging

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -15,4 +15,8 @@ data:
   sentry-secret: {{ randAlphaNum 40 | b64enc | quote }}
   {{ end }}
   smtp-password: {{ default "" .Values.email.password | b64enc | quote }}
+  {{ if .Values.user.password }}
+  user-password: {{ .Values.user.password | b64enc | quote }}
+  {{ else }}
   user-password: {{ randAlphaNum 16 | b64enc | quote }}
+  {{ end }}


### PR DESCRIPTION
When we update the Sentry Chart (helm update) we have a changed password (change of secret), however, the password in the database remains the same. It is necessary to set the password hardly, in order to maintain consistency.