### PR TITLE
Optionally set mariadb securityContext

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 2.1.14
+version: 2.1.15
 appVersion: 10.1.31
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -13,9 +13,11 @@ spec:
       labels:
         app: {{ template "mariadb.name" . }}
     spec:
+      {{- if .Values.securitySettings.enabled }}
       securityContext:
         runAsUser: {{ .Values.securitySettings.runAsUser }}
         fsGroup: {{ .Values.securitySettings.fsGroup }}
+      {{- end}}
       initContainers:
       - name: "copy-custom-config"
         image: "busybox"

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -97,5 +97,6 @@ resources:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 ##
 securitySettings:
+  enabled: true
   runAsUser: 1001
   fsGroup: 1001


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This makes it possible to disable the `securityContext` settings when using mariadb, for example: when installing the chart in OpenShift.

**Special notes for your reviewer**:

N/A