### PR TITLE
[stable/kube-state-metrics] Update ClusterRole to match new collectors

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.7.0
+version: 0.7.1
 appVersion: 1.2.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -9,6 +9,12 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "kube-state-metrics.fullname" . }}
 rules:
+{{ if .Values.collectors.cronjobs }}
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if .Values.collectors.daemonsets }}
 - apiGroups: ["extensions"]
   resources:
@@ -21,10 +27,34 @@ rules:
   - deployments
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if .Values.collectors.endpoints }}
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.horizontalpodautoscalers }}
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.jobs }}
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if .Values.collectors.limitranges }}
 - apiGroups: [""]
   resources:
   - limitranges
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.namespaces }}
+- apiGroups: [""]
+  resources:
+  - namespaces
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if .Values.collectors.nodes }}
@@ -33,6 +63,18 @@ rules:
   - nodes
   verbs: ["list", "watch"]
 {{ end -}}
+{{ if .Values.collectors.persistentvolumeclaims }}
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+{{ end }}
+{{ if .Values.collectors.persistentvolumes }}
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+{{ end }}
 {{ if .Values.collectors.pods }}
 - apiGroups: [""]
   resources:
@@ -63,28 +105,10 @@ rules:
   - services
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.jobs }}
-- apiGroups: ["batch"]
-  resources:
-  - jobs
-  verbs: ["list", "watch"]
-{{ end -}}
-{{ if .Values.collectors.cronjobs }}
-- apiGroups: ["batch"]
-  resources:
-  - cronjobs
-  verbs: ["list", "watch"]
-{{ end -}}
 {{ if .Values.collectors.statefulsets }}
 - apiGroups: ["apps"]
   resources:
   - statefulsets
   verbs: ["list", "watch"]
 {{ end -}}
-{{ if .Values.collectors.persistentvolumeclaims }}
-- apiGroups: [""]
-  resources:
-  - persistentvolumeclaims
-  verbs: ["list", "watch"]
-{{ end }}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**: This is a followup to #4146, I forgot to update the ClusterRole template to match the permissions needed for the new collectors so this adds the missing rules. I also reordered the rules alphabetically just like the container args and values in the original PR.

**Which issue this PR fixes**: N/A

**Special notes for your reviewer**: N/A
