### PR TITLE
Change service port to 80 because the pod does not enable tls  by default

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.2.1
+version: 0.2.2
 apiVersion: v1
 appVersion: 2.2
 description: A reverse proxy that provides authentication with Google, Github or other providers

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -55,7 +55,7 @@ Parameter | Description | Default
 `podLabels` | additional labesl to add to each pod | `{}`
 `replicaCount` | desired number of pods | `1`
 `resources` | pod resource requests & limits | `{}`
-`service.port` | port for the service | `443`
+`service.port` | port for the service | `80`
 `service.type` | type of service | `ClusterIP`
 `tolerations` | List of node taints to tolerate | `[]`
 

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -26,7 +26,7 @@ extraArgs:
 
 service:
   type: ClusterIP
-  port: 443
+  port: 80
 
 ingress:
   enabled: false


### PR DESCRIPTION
This chart is configured to export svc port 443 and it doesn't make sense because tls termination is not enabled by default. I'm using tls termination in the pods for all my containers and to enable this you should enable proxy protocol  in the load balancer. When you have it enabled, all the traffic sent to port 443 will use https rather than http. I was struggling into this issue for around 8 hours until I figured out what was the issue. To avoid other users to stuck in the same issue  I'm changing the default service port to 80.

@compleatang