### PR TITLE
dnk: Grafana - fix jobs service name

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.8.3
+version: 0.8.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net
 icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_transparent_400x.png

--- a/stable/grafana/templates/dashboards-import-job-configmap.yaml
+++ b/stable/grafana/templates/dashboards-import-job-configmap.yaml
@@ -18,7 +18,7 @@ data:
     {{- end }}
     for dashboard in $(ls); do
       wget \
-      "http://{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/dashboards/db" \
+      "http://{{ template "grafana.server.fullname" . }}:{{ .Values.server.service.httpPort }}/api/dashboards/db" \
       --user=${ADMIN_USER} \
       --password=${ADMIN_PASSWORD} \
       --auth-no-challenge \

--- a/stable/grafana/templates/job.yaml
+++ b/stable/grafana/templates/job.yaml
@@ -37,7 +37,7 @@ spec:
               name: {{ template "grafana.server.fullname" . }}
               key: grafana-admin-password
         args:
-          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.fullname" . }}:{{ .Values.server.service.httpPort }}/api/datasources"
+          - "http://$(ADMIN_USER):$(ADMIN_PASSWORD)@{{ template "grafana.server.fullname" . }}:{{ .Values.server.service.httpPort }}/api/datasources"
           - "--max-time"
           - "10"
           - "-H"


### PR DESCRIPTION
In jobs of Grafana Chart used incorrect name of service (do not match). I'm fix this.
