### PR TITLE
Changed the liveness and readiness probe to have configurable port numbers

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -8,6 +8,7 @@ keywords:
   - nginx
 sources:
   - https://github.com/kubernetes/ingress-nginx
+home: https://nginx.org/en/
 maintainers:
   - name: jackzampolin
     email: jack.zampolin@gmail.com

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.11.2
+version: 0.11.4
 appVersion: 0.11.0
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.11.4
+version: 0.12.0
 appVersion: 0.11.0
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -87,11 +87,13 @@ Parameter | Description | Default
 `controller.livenessProbe.timeoutSeconds` | When the probe times out | 5
 `controller.livenessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
 `controller.livenessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
+`controller.livenessProbe.port` | The port number that the liveness probe will listen on. | 10254
 `controller.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated | 10
 `controller.readinessProbe.periodSeconds` | How often to perform the probe | 10
 `controller.readinessProbe.timeoutSeconds` | When the probe times out | 1
 `controller.readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed. | 1
 `controller.readinessProbe.failureThreshold` | Minimum consecutive failures for the probe to be considered failed after having succeeded. | 3
+`controller.readinessProbe.port` | The port number that the readiness probe will listen on. | 10254
 `controller.stats.enabled` | if `true`, enable "vts-status" page | `false`
 `controller.stats.service.annotations` | annotations for controller stats service | `{}`
 `controller.stats.service.clusterIP` | internal controller stats cluster service IP | `""`

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -87,7 +87,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.controller.livenessProbe.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
@@ -130,7 +130,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.controller.readinessProbe.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -88,7 +88,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.controller.livenessProbe.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
@@ -125,7 +125,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 10254
+              port: {{ .Values.controller.readinessProbereadinessProbe.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -125,7 +125,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.controller.readinessProbereadinessProbe.port }}
+              port: {{ .Values.controller.readinessProbe.port }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -109,12 +109,14 @@ controller:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+    port: 10254
   readinessProbe:
     failureThreshold: 3
     initialDelaySeconds: 10
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+    port: 10254
 
   ## Annotations to be added to controller pods
   ##


### PR DESCRIPTION
Allows you to configure the port number that the nginx ingress controller has its liveness and readiness probes on rather than being hardcoded to port 10254.  It will however still default to port 10254.
