### PR TITLE
[kubernetes-sigs/poseidon] Added chart for firmament-poseidon

### DIFF
--- a/stable/firmament-poseidon/.helmignore
+++ b/stable/firmament-poseidon/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/firmament-poseidon/Chart.yaml
+++ b/stable/firmament-poseidon/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for Kubernetes
+description: A Helm chart of firmament-poseidon for Kubernetes
 name: firmament-poseidon
 version: 0.1.0
+home: https://github.com/kubernetes-sigs/poseidon
+maintainers: 
+- name: dhilipkumars
+  email: dhilip.kumar.s@huawei.com
+- name: nikita15p
+  email: nikita.pande@huawei.com

--- a/stable/firmament-poseidon/Chart.yaml
+++ b/stable/firmament-poseidon/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for Kubernetes
+description: A Helm chart of firmament-poseidon for Kubernetes
 name: firmament-poseidon
 version: 0.1.0
+home: https://github.com/kubernetes-sigs/poseidon
+maintainers:
+- name: dhilipkumars
+  email: dhilip.kumar.s@huawei.com
+- name: nikita15p
+  email: nikita.pande@huawei.com

--- a/stable/firmament-poseidon/Chart.yaml
+++ b/stable/firmament-poseidon/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: firmament-poseidon
+version: 0.1.0

--- a/stable/firmament-poseidon/Chart.yaml
+++ b/stable/firmament-poseidon/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart of firmament-poseidon for Kubernetes
+name: firmament-poseidon
+version: 0.1.0
+home: https://github.com/kubernetes-sigs/poseidon
+maintainers:
+- name: dhilipkumars
+  email: dhilip.kumar.s@huawei.com
+- name: nikita15p
+  email: nikita.pande@huawei.com

--- a/stable/firmament-poseidon/Chart.yaml
+++ b/stable/firmament-poseidon/Chart.yaml
@@ -9,3 +9,6 @@ maintainers:
   email: dhilip.kumar.s@huawei.com
 - name: nikita15p
   email: nikita.pande@huawei.com
+- name: shivramsrivastava
+  email: shivram.srivastava@huawei.com
+

--- a/stable/firmament-poseidon/README.md
+++ b/stable/firmament-poseidon/README.md
@@ -1,0 +1,64 @@
+# firmament-poseidon
+
+The Firmament/Poseidon scheduler incubation project is to bring integration of Firmament Scheduler [OSDI paper](https://www.usenix.org/conference/osdi16/technical-sessions/presentation/gog) in Kubernetes.
+
+## TL;DR;
+
+```console
+$ helm install stable/firmament-poseidon
+```
+
+## Introduction
+
+This chart bootstraps the poseidon and firmament deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install stable/firmament-poseidon --name my-release
+```
+The command deploys firmament and poseidon on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Access control
+It is critical for the Kubernetes custer to correctly setup access control of poseidon.
+
+It is highly recommended to use RBAC with minimal privileges needed for poseidon to run.  
+
+## Configuration
+
+The following table lists the configurable parameters of the poseidon-firmament chart and their default values.
+
+| Parameter                           | Description                                                                                                                 | Default                                                                  |
+|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `poseidon.repository`               | Repository for poseoidon container image                                                                                    | `gcr.io/poseidon-173606/poseidon`                                        |
+| `poseidon.tag`                      | Image tag                                                                                                                   | `latest`                                                                 |
+| `poseidon.pullPolicy`               | Image pull policy                                                                                                           | `IfNotPresent`                                                           |
+| `poseidon.extraContainerArgs`       | Additional container arguments                                                                                              | `poseidon`                                                               |
+| `firmament.repository`              | Repository for firmament container image                                                                                    | `huaweifirmament/firmament`                                              |
+| `firmament.tag`                     | Image tag                                                                                                                   | `latest`                                                                 |
+| `firmament.pullPolicy`              | Image pull policy                                                                                                           | `IfNotPresent`                                                           |
+| `firmament.extraContainerArgs`      | Additional container arguments                                                                                              | `firmament-scheduler`                                                    |
+| `service.port`                      | Service port to expose                                                                                                      | `80`                                                                     |
+| `service.type`                      | Type of service to create                                                                                                   | `ClusterIP`                                                              |
+| `rbac.create`                       | Create & use RBAC resources                                                                                                 | `true`                                                                   |
+| `serviceAccount.create`             | Whether a new service account name that the agent will use should be created.                                               | `true`                                                                   |
+| `serviceAccount.name`               | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template. | `poseidon`                                                               |
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install stable/firmament-poseidon --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/firmament-poseidon/templates/NOTES.txt
+++ b/stable/firmament-poseidon/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "firmament-poseidon.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "firmament-poseidon.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "firmament-poseidon.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "firmament-poseidon.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/stable/firmament-poseidon/templates/_helpers.tpl
+++ b/stable/firmament-poseidon/templates/_helpers.tpl
@@ -30,13 +30,6 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.poseidon.name -}}
-
-{{- define "firmament-poseidon.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}

--- a/stable/firmament-poseidon/templates/_helpers.tpl
+++ b/stable/firmament-poseidon/templates/_helpers.tpl
@@ -11,11 +11,24 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "firmament-poseidon.fullname" -}}
+{{- define "firmament.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default .Chart.Name .Values.firmament.name -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "poseidon.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.poseidon.name -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}

--- a/stable/firmament-poseidon/templates/_helpers.tpl
+++ b/stable/firmament-poseidon/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "firmament-poseidon.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "firmament-poseidon.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "firmament-poseidon.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "firmament-poseidon.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "firmament-poseidon.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/firmament-poseidon/templates/firmament_deployment.yaml
+++ b/stable/firmament-poseidon/templates/firmament_deployment.yaml
@@ -1,23 +1,27 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: firmament-scheduler
-  namespace: kube-system
+  name: {{ template "firmament.fullname" .}}
+  namespace: {{ .Values.namespace }}
   labels:
-    scheduler: firmament
+    app: {{ template "firmament-poseidon.name" .}}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    scheduler: {{ .Values.firmament.scheduler }}
 spec:
-  replicas: {{ .Values.firmamentReplicaCount }}
+  replicas: {{ .Values.firmament.replica }}
   template:
     metadata:
       labels:
-        scheduler: firmament
+        scheduler: {{ .Values.firmament.scheduler }}
     spec:
       containers:
       - command: [/firmament/build/src/firmament_scheduler, --flagfile=/firmament/config/firmament_scheduler_cpu_mem.cfg]
-        image: "{{ .Values.firmamentImage.repository }}:{{ .Values.firmamentImage.tag }}"
-        name: {{.Values.extraFirmamentContainerArgs.name}}
+        image: "{{ .Values.firmament.repository }}:{{ .Values.firmament.tag }}"
+        name: {{.Values.firmament.extraContainerArgs}}
         ports:
-         - containerPort: 9090
+         - containerPort:  {{ .Values.firmament.containerPort }}
       hostNetwork: true
       hostPID: false
       volumes: []

--- a/stable/firmament-poseidon/templates/firmament_deployment.yaml
+++ b/stable/firmament-poseidon/templates/firmament_deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: firmament-scheduler
+  namespace: kube-system
+  labels:
+    scheduler: firmament
+spec:
+  replicas: {{ .Values.firmamentReplicaCount }}
+  template:
+    metadata:
+      labels:
+        scheduler: firmament
+    spec:
+      containers:
+      - command: [/firmament/build/src/firmament_scheduler, --flagfile=/firmament/config/firmament_scheduler_cpu_mem.cfg]
+        image: "{{ .Values.firmamentImage.repository }}:{{ .Values.firmamentImage.tag }}"
+        name: {{.Values.extraFirmamentContainerArgs.name}}
+        ports:
+         - containerPort: 9090
+      hostNetwork: true
+      hostPID: false
+      volumes: []
+

--- a/stable/firmament-poseidon/templates/firmament_service.yaml
+++ b/stable/firmament-poseidon/templates/firmament_service.yaml
@@ -2,7 +2,13 @@ kind: Service
 apiVersion: v1
 metadata:
   name: firmament-service
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
+  labels:
+   app: {{ template "firmament-poseidon.name" . }}
+   chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+   heritage: {{ .Release.Service }}
+   release: {{ .Release.Name }}
+   scheduler: {{ .Values.firmament.scheduler }}
 spec:
   selector:
     scheduler: firmament

--- a/stable/firmament-poseidon/templates/firmament_service.yaml
+++ b/stable/firmament-poseidon/templates/firmament_service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: firmament-service
+  namespace: kube-system
+spec:
+  selector:
+    scheduler: firmament
+  ports:
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090

--- a/stable/firmament-poseidon/templates/ingress.yaml
+++ b/stable/firmament-poseidon/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "firmament-poseidon.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "firmament-poseidon.name" . }}
+    chart: {{ template "firmament-poseidon.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/stable/firmament-poseidon/templates/poseidon_deployment.yaml
+++ b/stable/firmament-poseidon/templates/poseidon_deployment.yaml
@@ -2,29 +2,33 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   labels:
-    component: {{.Values.serviceAccount.name}}
+    app: {{ template "firmament-poseidon.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.poseidon.component }}
     tier: control-plane
-    poseidonservice: {{.Values.serviceAccount.name}}
-  name: {{.Values.serviceAccount.name}}
-  namespace: kube-system
+    poseidonservice: {{ .Values.poseidon.service }}
+  name: {{ template "poseidon.fullname" . }}
+  namespace: {{ .Values.namespace }}
 spec:
-  replicas: {{.Values.poseidonReplicaCount}}
+  replicas: {{.Values.poseidon.replica}}
   template:
     metadata:
       labels:
-        component: {{.Values.serviceAccount.name}}
+        component: {{ .Values.poseidon.component }}
         tier: control-plane
         version: first
-        poseidonservice: {{.Values.serviceAccount.name}}
+        poseidonservice: {{ .Values.poseidon.service }}
     spec:
       serviceAccountName: {{.Values.serviceAccount.name}}
       containers:
       - command: [/poseidon, --logtostderr, --kubeConfig=, --kubeVersion=1.6]
-        image: "{{ .Values.poseidonImage.repository }}:{{ .Values.poseidonImage.tag }}"
-        name: {{.Values.extraPoseidonContainerArgs.name}}
+        image: "{{ .Values.poseidon.repository }}:{{ .Values.poseidon.tag }}"
+        name: {{.Values.poseidon.extraContainerArgs}}
       initContainers:
-      - name: {{.Values.extraBusyBoxContainerArgs.name}}
-        image: "{{ .Values.busyboxImage.repository }}:{{ .Values.busyboxImage.tag }}"
+      - name: {{ .Values.busybox.extraContainerArgs }}
+        image: "{{ .Values.busybox.repository }}:{{ .Values.busybox.tag }}"
         command: ['sh', '-c', 'until nslookup firmament-service.kube-system; do echo waiting for firmamentservice; sleep 1; done;']
         securityContext:
           privileged: false

--- a/stable/firmament-poseidon/templates/poseidon_deployment.yaml
+++ b/stable/firmament-poseidon/templates/poseidon_deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    component: {{.Values.serviceAccount.name}}
+    tier: control-plane
+    poseidonservice: {{.Values.serviceAccount.name}}
+  name: {{.Values.serviceAccount.name}}
+  namespace: kube-system
+spec:
+  replicas: {{.Values.poseidonReplicaCount}}
+  template:
+    metadata:
+      labels:
+        component: {{.Values.serviceAccount.name}}
+        tier: control-plane
+        version: first
+        poseidonservice: {{.Values.serviceAccount.name}}
+    spec:
+      serviceAccountName: {{.Values.serviceAccount.name}}
+      containers:
+      - command: [/poseidon, --logtostderr, --kubeConfig=, --kubeVersion=1.6]
+        image: "{{ .Values.poseidonImage.repository }}:{{ .Values.poseidonImage.tag }}"
+        name: {{.Values.extraPoseidonContainerArgs.name}}
+      initContainers:
+      - name: {{.Values.extraBusyBoxContainerArgs.name}}
+        image: "{{ .Values.busyboxImage.repository }}:{{ .Values.busyboxImage.tag }}"
+        command: ['sh', '-c', 'until nslookup firmament-service.kube-system; do echo waiting for firmamentservice; sleep 1; done;']
+        securityContext:
+          privileged: false
+        volumeMounts: []
+      hostNetwork: false
+      hostPID: false
+volumes: []
+

--- a/stable/firmament-poseidon/templates/poseidon_service.yaml
+++ b/stable/firmament-poseidon/templates/poseidon_service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{.Values.serviceAccount.name}}
+  namespace: kube-system
+spec:
+  selector:
+    poseidonservice: {{.Values.serviceAccount.name}}
+  ports:
+    - protocol: TCP
+      port: 9091
+      targetPort: 9091

--- a/stable/firmament-poseidon/templates/poseidon_service.yaml
+++ b/stable/firmament-poseidon/templates/poseidon_service.yaml
@@ -2,11 +2,17 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{.Values.serviceAccount.name}}
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
+  labels:
+   app: {{ template "firmament-poseidon.name" . }}
+   chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+   heritage: {{ .Release.Service }}
+   release: {{ .Release.Name }}
+   scheduler: {{ .Values.firmament.scheduler }}
 spec:
   selector:
     poseidonservice: {{.Values.serviceAccount.name}}
   ports:
     - protocol: TCP
-      port: 9091
-      targetPort: 9091
+      port: {{ .Values.poseidon.servicePort }}
+      targetPort: {{ .Values.poseidon.containerPort }}

--- a/stable/firmament-poseidon/templates/poseidon_serviceaccount.yaml
+++ b/stable/firmament-poseidon/templates/poseidon_serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.serviceAccount.name}}
+  namespace: kube-system
+{{- end -}}

--- a/stable/firmament-poseidon/templates/rbac.yaml
+++ b/stable/firmament-poseidon/templates/rbac.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    app: {{ template "firmament-poseidon.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ .Values.clusterrolebinding.name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.clusterrolebinding.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+    app: {{ template "firmament-poseidon.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name:  {{ .Values.clusterrole.name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - poseidon
+  resources:
+  - endpoints
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - pods/binding
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/stable/firmament-poseidon/values.yaml
+++ b/stable/firmament-poseidon/values.yaml
@@ -1,4 +1,4 @@
-# Default values for firmament-poseidon.
+:# Default values for firmament-poseidon.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -8,7 +8,7 @@ poseidon:
   repository: gcr.io/poseidon-173606/poseidon
   tag: latest
   pullPolicy: IfNotPresent
-  extraContainerArgs:  poseidon
+  extraContainerArgs: poseidon
   replica: 1
   servicePort: 9091
   containerPort: 9091
@@ -87,5 +87,4 @@ clusterrole:
   name: system:poseidon
 
 clusterrolebinding:
-  name: system:poseidon                
-
+  name: system:poseidon

--- a/stable/firmament-poseidon/values.yaml
+++ b/stable/firmament-poseidon/values.yaml
@@ -2,33 +2,38 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-poseidonReplicaCount: 1
-firmamentReplicaCount: 1
-
-poseidonImage:
+poseidon:
+  name: poseidon
   repository: gcr.io/poseidon-173606/poseidon
   tag: latest
   pullPolicy: IfNotPresent
+  extraContainerArgs:  poseidon
+  replica: 1
+  servicePort: 9091
+  containerPort: 9091
+  service: poseidon
+  component: poseidon
 
-firmamentImage:
+
+firmament:
+  name: firmament-scheduler
   repository: huaweifirmament/firmament
   tag: latest
   pullPolicy: IfNotPresent
+  extraContainerArgs: firmament-scheduler
+  replica: 1
+  servicePort: 9090
+  containerPort: 9090
+  scheduler: firmament
 
-busyboxImage:
+busybox:
+  name: busysbox
   repository: radial/busyboxplus
   tag: curl
   pullPolicy: IfNotPresent
+  extraContainerArgs: init-firmamentservice
 
-## Additional container arguments
-##
-extraPoseidonContainerArgs:
-  name: poseidon
-extraFirmamentContainerArgs:
-  name: firmament-scheduler
-extraBusyBoxContainerArgs:
-  name: init-firmamentservice
-
+namespace: kube-system
 
 service:
   type: ClusterIP
@@ -71,3 +76,15 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: poseidon
+
+
+rbac:
+  ## If true, create & use RBAC resources
+  ##
+  create: true
+
+clusterrole:
+  name: system:poseidon
+
+clusterrolebinding:
+  name: system:poseidon                

--- a/stable/firmament-poseidon/values.yaml
+++ b/stable/firmament-poseidon/values.yaml
@@ -1,0 +1,73 @@
+# Default values for firmament-poseidon.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+poseidonReplicaCount: 1
+firmamentReplicaCount: 1
+
+poseidonImage:
+  repository: gcr.io/poseidon-173606/poseidon
+  tag: latest
+  pullPolicy: IfNotPresent
+
+firmamentImage:
+  repository: huaweifirmament/firmament
+  tag: latest
+  pullPolicy: IfNotPresent
+
+busyboxImage:
+  repository: radial/busyboxplus
+  tag: curl
+  pullPolicy: IfNotPresent
+
+## Additional container arguments
+##
+extraPoseidonContainerArgs:
+  name: poseidon
+extraFirmamentContainerArgs:
+  name: firmament-scheduler
+extraBusyBoxContainerArgs:
+  name: init-firmamentservice
+
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: poseidon

--- a/stable/firmament-poseidon/values.yaml
+++ b/stable/firmament-poseidon/values.yaml
@@ -1,4 +1,4 @@
-:# Default values for firmament-poseidon.
+# Default values for firmament-poseidon.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 


### PR DESCRIPTION
**What this PR does / why we need it**: The firmament-poseidon chart is used to plug in the Poseidon/Firmament scheduler to the Kubernetes cluster.This scheduler augments the current Kubernetes scheduling capabilities by incorporating a new novel flow network graph based scheduling capabilities alongside the default Kubernetes Scheduler. 
