### PR TITLE
Added template for kubernetes hook

### DIFF
--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -158,6 +158,26 @@ mongodb with your `mongo.pem` certificate:
 $ mongo --ssl --sslCAFile=ca.crt --sslPEMKeyFile=mongo.pem --eval "db.adminCommand('ping')"
 ```
 
+## Helm Hook support
+Enabling it will spawn a kubernetes job at different stages of installing, upgrading, deleting or rolling-back a mongodb-replicaset helm. This will allow the automation of some tasks which in a way are directly related to the replica set helm deployment stages. Examples of the tasks that can be automated: adding databases, collections and users to the a newly instaled replica, backup the entire database before deleting the replica.
+
+To customization options of the helm hook and the kubernetes job can be done by modifying the hook section 'values.yaml'
+'''
+hook:
+  ## Enable or disable helm hook support
+  enabled: false
+  ## All the values supplied to the following variables must comply with
+  ## helm hook and kubernetes standards
+  type: post-install
+  weight: 0
+  deletePolicy: hook-failed, hook-succeeded
+  image: docker-database-generator
+  command: 'entry point command for the docker image'
+  imagePullPolicy: IfNotPresent
+'''
+
+More information on the concept and possible values can be found here: https://github.com/kubernetes/helm/blob/master/docs/charts_hooks.md
+
 ## Deep dive
 
 Because the pod names are dependent on the name chosen for it, the following examples use the

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -161,8 +161,9 @@ $ mongo --ssl --sslCAFile=ca.crt --sslPEMKeyFile=mongo.pem --eval "db.adminComma
 ## Helm Hook support
 Enabling it will spawn a kubernetes job at different stages of installing, upgrading, deleting or rolling-back a mongodb-replicaset helm. This will allow the automation of some tasks which in a way are directly related to the replica set helm deployment stages. Examples of the tasks that can be automated: adding databases, collections and users to the a newly instaled replica, backup the entire database before deleting the replica.
 
-To customization options of the helm hook and the kubernetes job can be done by modifying the hook section 'values.yaml'
-'''
+To customization can be done by modifying the hook section in 'values.yaml':
+
+```yml
 hook:
   ## Enable or disable helm hook support
   enabled: false
@@ -174,7 +175,7 @@ hook:
   image: docker-database-generator
   command: 'entry point command for the docker image'
   imagePullPolicy: IfNotPresent
-'''
+```
 
 More information on the concept and possible values can be found here: https://github.com/kubernetes/helm/blob/master/docs/charts_hooks.md
 

--- a/stable/mongodb-replicaset/templates/mongodb-hook.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-hook.yaml
@@ -1,3 +1,4 @@
+{{- if and (.Values.hook.enabled) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -25,3 +26,5 @@ spec:
         imagePullPolicy: {{ .Values.hook.imagePullPolicy }}
         image: {{ .Values.hook.image }}
         command: [ {{ .Values.hook.command }} ]
+{{- end -}}
+

--- a/stable/mongodb-replicaset/templates/mongodb-hook.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-hook.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": {{ .Values.hook.type }}
+    "helm.sh/hook-weight": "{{ .Values.hook.weight }}"
+    "helm.sh/hook-delete-policy": {{ .Values.hook.deletePolicy }}
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: post-install-job
+        imagePullPolicy: {{ .Values.hook.imagePullPolicy }}
+        image: {{ .Values.hook.image }}
+        command: [ {{ .Values.hook.command }} ]

--- a/stable/mongodb-replicaset/templates/mongodb-hook.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-hook.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: post-install-job
+      - name: hook-job
         imagePullPolicy: {{ .Values.hook.imagePullPolicy }}
         image: {{ .Values.hook.image }}
         command: [ {{ .Values.hook.command }} ]

--- a/stable/mongodb-replicaset/templates/mongodb-hook.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-hook.yaml
@@ -2,11 +2,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{.Release.Name}}"
+  name: "{{ .Release.Name }}"
   labels:
-    heritage: {{.Release.Service | quote }}
-    release: {{.Release.Name | quote }}
-    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
     "helm.sh/hook": {{ .Values.hook.type }}
     "helm.sh/hook-weight": "{{ .Values.hook.weight }}"
@@ -14,11 +14,11 @@ metadata:
 spec:
   template:
     metadata:
-      name: "{{.Release.Name}}"
+      name: "{{ .Release.Name }}"
       labels:
-        heritage: {{.Release.Service | quote }}
-        release: {{.Release.Name | quote }}
-        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       restartPolicy: Never
       containers:

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -89,12 +89,11 @@ configmap:
 hook:
   ## Enable or disable helm hook support
   enabled: false
-  ## Helm hook type can be any of the valid helm hooks types:
-  ## pre-install, post-install, pre-delete, post-delete, pre-upgrade, post-upgrade, pre-rollback, post-rollback
-  #  type: post-install
-  #  weight: 1
-  #  deletePolicy: hook-failed, hook-succedded
-  #  image: docker image name
-  #  command: 'entry point command for the docker image'
-  ## Any of the imagePullPolicy valid values
-  #  imagePullPolicy: IfNotPresent
+  ## All the values supplied to the following variables must comply with
+  ## helm hook and kubernetes standards
+  # type: post-install
+  # weight: 0
+  # deletePolicy: hook-failed, hook-succeeded
+  # image: docker image name
+  # command: 'entry point command for the docker image'
+  # imagePullPolicy: IfNotPresent

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -85,3 +85,16 @@ configmap:
   # security:
   #   authorization: enabled
   #   keyFile: /keydir/key.txt
+
+hook:
+  ## Enable or disable helm hook support
+  enabled: false
+  ## Helm hook type can be any of the valid helm hooks types:
+  ## pre-install, post-install, pre-delete, post-delete, pre-upgrade, post-upgrade, pre-rollback, post-rollback
+  #  type: post-install
+  #  weight: 1
+  #  deletePolicy: hook-failed, hook-succedded
+  #  image: docker image name
+  #  command: 'entry point command for the docker image'
+  ## Any of the imagePullPolicy valid values
+  #  imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR aims to provide a way to automate the running of provisioning tasks that can be directly related to different stages of deployment of a mongodb-replicaset helm.
Specifically I use this to automatically create new databases, users, collections and default data immediately after a new replicaset is deployed. This is particularly useful when new deployments are frequently required and default and/or custom databases, collections, users and data are needed for each of them. 
This uses a helm hook to spawn a kubernetes job based on the supplied image and entry point. This allows me to run the same image(script) with different entry values to automatically add mongo information each time the replica is newly deployed.

**Special notes for your reviewer**:
Dear @foxish I believe this PR provides a solid way for people to automatically run their own provisioning jobs when a mongodb-replicaset is deployed.