### PR TITLE
[mssql-linux] Updated service port and image tag to recent

### DIFF
--- a/stable/mssql-linux/Chart.yaml
+++ b/stable/mssql-linux/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 description: SQL Server 2017 Linux Helm Chart
 name: mssql-linux
-version: 0.1.7
+version: 0.1.8
+appVersion: 14.0.3023.8
+home: https://hub.docker.com/r/microsoft/mssql-server-linux/
 icon: https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1I4Dx
 sources:
 - https://hub.docker.com/r/microsoft/mssql-server-linux/

--- a/stable/mssql-linux/templates/deployment.yaml
+++ b/stable/mssql-linux/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               value: /mssql-translog/translog
           ports:
             - name: db
-              containerPort: 1433
+              containerPort: {{ .Values.service.port }}
           volumeMounts:
             - name: data
               mountPath: /mssql-data/data

--- a/stable/mssql-linux/templates/deployment.yaml
+++ b/stable/mssql-linux/templates/deployment.yaml
@@ -37,8 +37,10 @@ spec:
               value: /mssql-data/data
             - name: MSSQL_LOG_DIR
               value: /mssql-translog/translog
+            - name: MSSQL_TCP_PORT
+              value: "{{ .Values.service.port }}"
           ports:
-            - name: db
+            - name: mssql
               containerPort: {{ .Values.service.port }}
           volumeMounts:
             - name: data
@@ -47,12 +49,12 @@ spec:
               mountPath: /mssql-translog/translog
           livenessProbe:
              tcpSocket:
-               port: db
+               port: mssql
              initialDelaySeconds: {{ .Values.livenessprobe.initialDelaySeconds }}
              periodSeconds: {{ .Values.livenessprobe.periodSeconds }}
           readinessProbe:
              tcpSocket:
-               port: db
+               port: mssql
              initialDelaySeconds: {{ .Values.readinessprobe.initialDelaySeconds }}
              periodSeconds: {{ .Values.readinessprobe.periodSeconds }}
           resources:

--- a/stable/mssql-linux/templates/service.yaml
+++ b/stable/mssql-linux/templates/service.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - name: db
-    port: 1433
+  - name: {{ template "mssql.name" . }}-svc
+    port: {{ .Values.service.port }}
     targetPort: db
     protocol: TCP
   selector:

--- a/stable/mssql-linux/templates/service.yaml
+++ b/stable/mssql-linux/templates/service.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - name: {{ template "mssql.name" . }}-svc
+  - name: mssql
     port: {{ .Values.service.port }}
-    targetPort: db
+    targetPort: mssql
     protocol: TCP
   selector:
     app: {{ template "mssql.name" . }}

--- a/stable/mssql-linux/values.yaml
+++ b/stable/mssql-linux/values.yaml
@@ -6,10 +6,11 @@ edition:
 # sapassword: "MyStrongPassword1234"
 image:
   repository: microsoft/mssql-server-linux
-  tag: 2017-CU3
+  tag: 2017-CU5
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
+  port: 1433
 persistence:
   enabled: false
   # existingDataClaim:


### PR DESCRIPTION
This PR allows chart installer to change the mssql port, if needed.  In addition, changed the image tag to install the most recent docker image.
