### PR TITLE
[stable/prometheus] Add extraArgs and extraConfigmapMounts for config-reload

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 name: prometheus
 version: 6.1.0
-appVersion: 2.2
+appVersion: 2.2.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,6 @@
 name: prometheus
-version: 5.5.3
+version: 5.6.0
+appVersion: 2.2.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -131,6 +131,8 @@ Parameter | Description | Default
 `configmapReload.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
 `configmapReload.image.tag` | configmap-reload container image tag | `v0.1`
 `configmapReload.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
+`configmapReload.extraArgs` | Additional configmap-reload container arguments | `{}`
+`configmapReload.extraConfigmapMounts` | Additional configmap-reload configMap mounts | `[]`
 `configmapReload.resources` | configmap-reload pod resource requests & limits | `{}`
 `initChownData.enabled`  | If false, don't reset data ownership at startup | true
 `initChownData.name` | init-chown-data container name | `init-chown-data`

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -47,12 +47,20 @@ spec:
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://localhost:9090{{ .Values.server.prefixURL }}/-/reload
+          {{- range $key, $value := .Values.configmapReload.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
           resources:
 {{ toYaml .Values.configmapReload.resources | indent 12 }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
+          {{- range .Values.configmapReload.extraConfigmapMounts }}
+            - name: {{ $.Values.configmapReload.name }}-{{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
 
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
@@ -100,7 +108,7 @@ spec:
               readOnly: {{ .readOnly }}
           {{- end }}
           {{- range .Values.server.extraConfigmapMounts }}
-            - name: {{ .name }}
+            - name: {{ $.Values.server.name }}-{{ .name }}
               mountPath: {{ .mountPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
@@ -138,8 +146,13 @@ spec:
           hostPath:
             path: {{ .hostPath }}
       {{- end }}
+      {{- range .Values.configmapReload.extraConfigmapMounts }}
+        - name: {{ $.Values.configmapReload.name }}-{{ .name }}
+          configMap:
+            name: {{ .configMap }}
+      {{- end }}
       {{- range .Values.server.extraConfigmapMounts }}
-        - name: {{ .name }}
+        - name: {{ $.Values.server.name }}-{{ .name }}
           configMap:
             name: {{ .configMap }}
       {{- end }}
@@ -147,4 +160,9 @@ spec:
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
+      {{- end }}
+      {{- range .Values.configmapReload.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
       {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -184,6 +184,19 @@ configmapReload:
     tag: v0.1
     pullPolicy: IfNotPresent
 
+  ## Additional configmap-reload container arguments
+  ##
+  extraArgs: {}
+
+  ## Additional configmap-reload mounts
+  ##
+  extraConfigmapMounts: []
+    # - name: prometheus-alerts
+    #   mountPath: /etc/alerts.d
+    #   configMap: prometheus-alerts
+    #   readOnly: true
+
+
   ## configmap-reload resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
**What this PR does / why we need it**:
The config-reload image used in the prometheus chart allows multiple directories to be monitored to trigger config-reloads so expose `extraArgs` and `extraConfigMapMounts` in values.yaml so this functionality can be used.

This allows us to do things like separating the alert configs from the main prometheus config making them easier to manage and update.

I will close https://github.com/kubernetes/charts/pull/4415 in favour of this PR.

**NOTE:** There's an issue with the current server-deployment template in that it makes an assumption there's a 1:1 relationship between mounts and volumes then templates the volumes based on the mounts. In Kubernetes that assumption is invalid as one volume can be mounted by many containers. Refactoring the template to remove that assumption would be a breaking change and as the chart is so widely used I thought it'd be safer to make the changes in this PR i.e. let it create multiple volumes and simply prefix them with the container that requested the mount. Having more than one volume mounting the same (readonly) configmap should be ok AFAIK.