### PR TITLE
Added Elasticsearch Curator chart

### DIFF
--- a/incubator/elasticsearch-curator/.helmignore
+++ b/incubator/elasticsearch-curator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -14,3 +14,5 @@ sources:
 maintainers:
   - name: tmestdagh
     email: mestdagh.tom@gmail.com
+  - name: gianrubio
+    email: gianrubio@gmail.com

--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -1,8 +1,15 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "5.4.1"
 description: A Helm chart for Elasticseach Curator
 name: elasticsearch-curator
 version: 0.1.0
+keywords:
+- curator
+- elasticsearch
+- elasticsearch-curator
+sources:
+- https://github.com/kubernetes/charts/incubator/elasticsearch-curator
+- https://github.com/pires/docker-elasticsearch-curator
 maintainers:
-  - name: Tom Mestdagh
+  - name: tmestdagh
     email: mestdagh.tom@gmail.com

--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: "5.4.1"
 description: A Helm chart for Elasticseach Curator
 name: elasticsearch-curator
 version: 0.1.0
+home: https://github.com/elastic/curator
 keywords:
 - curator
 - elasticsearch

--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Elasticseach Curator
+name: elasticsearch-curator
+version: 0.1.0
+maintainers:
+  - name: Tom Mestdagh
+    email: mestdagh.tom@gmail.com

--- a/incubator/elasticsearch-curator/OWNERS
+++ b/incubator/elasticsearch-curator/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - tmestdagh
+  - gianrubio
+reviewers:
+  - tmestdagh
+  - gianrubio

--- a/incubator/elasticsearch-curator/README.md
+++ b/incubator/elasticsearch-curator/README.md
@@ -17,7 +17,7 @@ This chart will do the following:
 To install the chart, use the following:
 
 ```console
-$ helm install stable/elasticsearch-curator --namespace logging --name es-curator
+$ helm install stable/elasticsearch-curator
 ```
 
 ## Configuration
@@ -32,7 +32,7 @@ their default values.
 | `image.tag`                 | Container image tag to deploy                                                            | `5.4.1`                                      |
 | `cronjob.schedule`          | Schedule for the CronJob                                                                 | `0 1 * * *`                                  |
 | `config.elasticsearch.hosts`| Array of Elasticsearch hosts to curate                                                   | - CHANGEME.host                              |
-| `config.elasticsearch.port` | Elasticsearch port to connect to                                                         | 9200                                         |
+| `config.elasticsearch.port` | Elasticsearch port to connect too                                                        | 9200                                         |
 | `configMaps.action_file_yml`| Contents of the Curator action_file.yml                                                  | See values.yaml                              |
 | `configMaps.config_yml`     | Contents of the Curator config.yml (overrides config)                                    | See values.yaml                              |
 

--- a/incubator/elasticsearch-curator/README.md
+++ b/incubator/elasticsearch-curator/README.md
@@ -17,7 +17,7 @@ This chart will do the following:
 To install the chart, use the following:
 
 ```console
-$ helm install stable/elasticsearch-curator
+$ helm install incubator/elasticsearch-curator
 ```
 
 ## Configuration

--- a/incubator/elasticsearch-curator/README.md
+++ b/incubator/elasticsearch-curator/README.md
@@ -25,16 +25,17 @@ $ helm install incubator/elasticsearch-curator
 The following table lists the configurable parameters of the docker-registry chart and
 their default values.
 
-| Parameter                   | Description                                                                              | Default                                      |
-|:----------------------------|:-----------------------------------------------------------------------------------------|:---------------------------------------------|
-| `image.pullPolicy`          | Container pull policy                                                                    | `IfNotPresent`                               |
-| `image.repository`          | Container image to use                                                                   | `quay.io/pires/docker-elasticsearch-curator` |
-| `image.tag`                 | Container image tag to deploy                                                            | `5.4.1`                                      |
-| `cronjob.schedule`          | Schedule for the CronJob                                                                 | `0 1 * * *`                                  |
-| `config.elasticsearch.hosts`| Array of Elasticsearch hosts to curate                                                   | - CHANGEME.host                              |
-| `config.elasticsearch.port` | Elasticsearch port to connect too                                                        | 9200                                         |
-| `configMaps.action_file_yml`| Contents of the Curator action_file.yml                                                  | See values.yaml                              |
-| `configMaps.config_yml`     | Contents of the Curator config.yml (overrides config)                                    | See values.yaml                              |
+|          Parameter           |                      Description                      |                   Default                    |
+| :--------------------------- | :---------------------------------------------------- | :------------------------------------------- |
+| `image.pullPolicy`           | Container pull policy                                 | `IfNotPresent`                               |
+| `image.repository`           | Container image to use                                | `quay.io/pires/docker-elasticsearch-curator` |
+| `image.tag`                  | Container image tag to deploy                         | `5.4.1`                                      |
+| `cronjob.schedule`           | Schedule for the CronJob                              | `0 1 * * *`                                  |
+| `config.elasticsearch.hosts` | Array of Elasticsearch hosts to curate                | - CHANGEME.host                              |
+| `config.elasticsearch.port`  | Elasticsearch port to connect too                     | 9200                                         |
+| `configMaps.action_file_yml` | Contents of the Curator action_file.yml               | See values.yaml                              |
+| `configMaps.config_yml`      | Contents of the Curator config.yml (overrides config) | See values.yaml                              |
+| `resources`                  | Resource requests and limits                          | {}                                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/incubator/elasticsearch-curator/README.md
+++ b/incubator/elasticsearch-curator/README.md
@@ -1,0 +1,40 @@
+# Elasticsearch Curator Helm Chart
+
+This directory contains a Kubernetes chart to deploy the [Elasticsearch Curator](https://github.com/elastic/curator).
+
+## Prerequisites Details
+
+* Elasticsearch
+
+## Chart Details
+
+This chart will do the following:
+
+* Create a CronJob which runs the Curator
+
+## Installing the Chart
+
+To install the chart, use the following:
+
+```console
+$ helm install stable/elasticsearch-curator --namespace logging --name es-curator
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the docker-registry chart and
+their default values.
+
+| Parameter                   | Description                                                                              | Default                                      |
+|:----------------------------|:-----------------------------------------------------------------------------------------|:---------------------------------------------|
+| `image.pullPolicy`          | Container pull policy                                                                    | `IfNotPresent`                               |
+| `image.repository`          | Container image to use                                                                   | `quay.io/pires/docker-elasticsearch-curator` |
+| `image.tag`                 | Container image tag to deploy                                                            | `5.4.1`                                      |
+| `cronjob.schedule`          | Schedule for the CronJob                                                                 | `0 1 * * *`                                  |
+| `config.elasticsearch.hosts`| Array of Elasticsearch hosts to curate                                                   | - CHANGEME.host                              |
+| `config.elasticsearch.port` | Elasticsearch port to connect to                                                         | 9200                                         |
+| `configMaps.action_file_yml`| Contents of the Curator action_file.yml                                                  | See values.yaml                              |
+| `configMaps.config_yml`     | Contents of the Curator config.yml (overrides config)                                    | See values.yaml                              |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.

--- a/incubator/elasticsearch-curator/templates/NOTES.txt
+++ b/incubator/elasticsearch-curator/templates/NOTES.txt
@@ -1,0 +1,6 @@
+A CronJob will run with schedule {{ .Values.cronjob.schedule }}.
+
+The Jobs will not be removed automagically when deleting this Helm chart.
+To remove these jobs, run the following :
+
+    kubectl -n logging delete job -l app=elasticsearch-curator

--- a/incubator/elasticsearch-curator/templates/NOTES.txt
+++ b/incubator/elasticsearch-curator/templates/NOTES.txt
@@ -3,4 +3,4 @@ A CronJob will run with schedule {{ .Values.cronjob.schedule }}.
 The Jobs will not be removed automagically when deleting this Helm chart.
 To remove these jobs, run the following :
 
-    kubectl -n logging delete job -l app=elasticsearch-curator
+    kubectl -n logging delete job -l app={{ template "elasticsearch-curator.name" . }}

--- a/incubator/elasticsearch-curator/templates/_helpers.tpl
+++ b/incubator/elasticsearch-curator/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch-curator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elasticsearch-curator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elasticsearch-curator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/elasticsearch-curator/templates/_helpers.tpl
+++ b/incubator/elasticsearch-curator/templates/_helpers.tpl
@@ -5,13 +5,6 @@ Expand the name of the chart.
 {{/*
 Return the appropriate apiVersion for cronjob APIs.
 */}}
-{{- define "cronjob.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "batch/v1beta1" -}}
-"batch/v1beta1"
-{{- else -}}
-"batch/v2alpha1"
-{{- end -}}
-{{- end -}}
 
 {{- define "elasticsearch-curator.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}

--- a/incubator/elasticsearch-curator/templates/_helpers.tpl
+++ b/incubator/elasticsearch-curator/templates/_helpers.tpl
@@ -2,6 +2,17 @@
 {{/*
 Expand the name of the chart.
 */}}
+{{/*
+Return the appropriate apiVersion for cronjob APIs.
+*/}}
+{{- define "cronjob.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "batch/v1beta1" -}}
+"batch/v1beta1"
+{{- else -}}
+"batch/v2alpha1"
+{{- end -}}
+{{- end -}}
+
 {{- define "elasticsearch-curator.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/incubator/elasticsearch-curator/templates/_helpers.tpl
+++ b/incubator/elasticsearch-curator/templates/_helpers.tpl
@@ -1,11 +1,8 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
 Expand the name of the chart.
 */}}
-{{/*
-Return the appropriate apiVersion for cronjob APIs.
-*/}}
-
 {{- define "elasticsearch-curator.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/incubator/elasticsearch-curator/templates/configmap.yaml
+++ b/incubator/elasticsearch-curator/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curator-config
+data:
+  action_file.yml: {{ toYaml .Values.configMaps.action_file_yml | indent 2 }}
+  {{ if .Values.configMaps.config_yml }}
+  config.yml: {{ toYaml .Values.configMaps.config_yml | indent 2 }}
+  {{ else }}
+  config.yml: |
+    client:
+      hosts: 
+        - {{ range .Values.config.elasticsearch.hosts }} {{ . }} {{ end }}
+      port: {{ .Values.config.elasticsearch.port }}
+  {{ end }}

--- a/incubator/elasticsearch-curator/templates/configmap.yaml
+++ b/incubator/elasticsearch-curator/templates/configmap.yaml
@@ -18,3 +18,4 @@ data:
         - {{ range .Values.config.elasticsearch.hosts }} {{ . }} {{ end }}
       port: {{ .Values.config.elasticsearch.port }}
   {{ end }}
+  

--- a/incubator/elasticsearch-curator/templates/configmap.yaml
+++ b/incubator/elasticsearch-curator/templates/configmap.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: curator-config
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
   action_file.yml: {{ toYaml .Values.configMaps.action_file_yml | indent 2 }}
   {{ if .Values.configMaps.config_yml }}

--- a/incubator/elasticsearch-curator/templates/cronjob.yaml
+++ b/incubator/elasticsearch-curator/templates/cronjob.yaml
@@ -1,4 +1,5 @@
-apiVersion: batch/v1beta1
+{{- if or (.Capabilities.APIVersions.Has "batch/v1beta1") (.Capabilities.APIVersions.Has "batch/v2alpha1") -}}
+apiVersion: {{ template "cronjob.apiVersion" $ }}
 kind: CronJob
 metadata:
   name: {{ template "elasticsearch-curator.fullname" . }}
@@ -45,4 +46,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 12 }}
     {{- end }}
-
+{{- end -}}

--- a/incubator/elasticsearch-curator/templates/cronjob.yaml
+++ b/incubator/elasticsearch-curator/templates/cronjob.yaml
@@ -1,5 +1,4 @@
-{{- if or (.Capabilities.APIVersions.Has "batch/v1beta1") (.Capabilities.APIVersions.Has "batch/v2alpha1") -}}
-apiVersion: {{ template "cronjob.apiVersion" $ }}
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ template "elasticsearch-curator.fullname" . }}
@@ -46,4 +45,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 12 }}
     {{- end }}
-{{- end -}}

--- a/incubator/elasticsearch-curator/templates/cronjob.yaml
+++ b/incubator/elasticsearch-curator/templates/cronjob.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "elasticsearch-curator.fullname" . }}
+  labels:
+    app: {{ template "elasticsearch-curator.name" . }}
+    chart: {{ template "elasticsearch-curator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "{{ .Values.cronjob.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: {{ template "elasticsearch-curator.name" . }}
+            release: {{ .Release.Name }}
+        spec:
+          volumes:
+            - name: config-volume
+              configMap: 
+                name: curator-config
+          restartPolicy: Never
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              volumeMounts:
+              - name: config-volume
+                mountPath: /etc/es-curator
+              command: [ "curator" ]
+              args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+              resources:
+{{ toYaml .Values.resources | indent 16 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+

--- a/incubator/elasticsearch-curator/templates/cronjob.yaml
+++ b/incubator/elasticsearch-curator/templates/cronjob.yaml
@@ -28,8 +28,8 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               volumeMounts:
-              - name: config-volume
-                mountPath: /etc/es-curator
+                - name: config-volume
+                  mountPath: /etc/es-curator
               command: [ "curator" ]
               args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
               resources:

--- a/incubator/elasticsearch-curator/values.yaml
+++ b/incubator/elasticsearch-curator/values.yaml
@@ -2,8 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-cronjob: 
-  schedule: "0 1 * * *" # At 01:00 every day
+cronjob:
+  # At 01:00 every day
+  schedule: "0 1 * * *"
 
 image:
   repository: quay.io/pires/docker-elasticsearch-curator
@@ -49,7 +50,7 @@ configMaps:
   #     port: 9200
   #     url_prefix:
   #     use_ssl: True
-  #     certificate: 
+  #     certificate:
   #     client_cert:
   #     client_key:
   #     ssl_no_validate: True

--- a/incubator/elasticsearch-curator/values.yaml
+++ b/incubator/elasticsearch-curator/values.yaml
@@ -1,0 +1,80 @@
+# Default values for elasticsearch-curator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+cronjob: 
+  schedule: "0 1 * * *" # At 01:00 every day
+
+image:
+  repository: quay.io/pires/docker-elasticsearch-curator
+  tag: 5.4.1
+  pullPolicy: IfNotPresent
+
+config:
+  elasticsearch:
+    hosts:
+      - CHANGEME.host
+    port: 9200
+
+configMaps:
+  action_file_yml: |-
+    ---
+    actions:
+      1:
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '%Y.%m.%d'
+          unit: days
+          unit_count: 7
+          field:
+          stats_result:
+          epoch:
+          exclude: False
+  # config_yml: |-
+  #   ---
+  #   client:
+  #     hosts:
+  #       - elasticsearch-logging-cluster
+  #     port: 9200
+  #     url_prefix:
+  #     use_ssl: True
+  #     certificate: 
+  #     client_cert:
+  #     client_key:
+  #     ssl_no_validate: True
+  #     http_auth:
+  #     timeout: 30
+  #     master_only: False
+  #   logging:
+  #     loglevel: INFO
+  #     logfile:
+  #     logformat: default
+  #     blacklist: ['elasticsearch', 'urllib3']
+
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/incubator/elasticsearch-curator/values.yaml
+++ b/incubator/elasticsearch-curator/values.yaml
@@ -75,9 +75,3 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}

--- a/incubator/elasticsearch-curator/values.yaml
+++ b/incubator/elasticsearch-curator/values.yaml
@@ -17,6 +17,7 @@ config:
     port: 9200
 
 configMaps:
+  # Delete indices older than 7 days
   action_file_yml: |-
     ---
     actions:
@@ -39,6 +40,7 @@ configMaps:
           stats_result:
           epoch:
           exclude: False
+  # Having config_yaml WILL override the other config
   # config_yml: |-
   #   ---
   #   client:


### PR DESCRIPTION
This PR adds the elasticsearch curator Helm chart.
After installing this chart, a CronJob will be created which runs the curator according to a schedule and configuration you can set.
