### PR TITLE
[stable/traefik] Add Entrypoint whiteListSourceRange support

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.27.1
+version: 1.28.0
 appVersion: 1.5.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.27.0
+version: 1.27.1
 appVersion: 1.5.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -91,6 +91,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
 | `loadBalancerSourceRanges`      | list of IP CIDRs allowed access to load balancer (if supported)      | None                                      |
+| `whiteListSourceRange`          | Enable IP whitelisting at the entrypoint level.                      | `false`                                   |
 | `externalTrafficPolicy`         | Set the externalTrafficPolicy in the Service to either Cluster or Local | `Cluster`                              |
 | `replicas`                      | The number of replicas to run; __NOTE:__ Full Traefik clustering with leader election is not yet supported, which can affect any configured Let's Encrypt setup; see Clustering section | `1` |
 | `cpuRequest`                    | Initial share of CPU requested per Traefik pod                       | `100m`                                    |

--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -37,3 +37,15 @@ Create the block for the ProxyProtocol's Trusted IPs.
 	   {{- end -}}
          ]
 {{- end -}}
+
+{{/*
+Create the block for whiteListSourceRange.
+*/}}
+{{- define "traefik.whiteListSourceRange" -}}
+       whiteListSourceRange = [
+	   {{- range $idx, $ips := .Values.whiteListSourceRange }}
+	     {{- if $idx }}, {{ end }}
+	     {{- $ips | quote }}
+	   {{- end -}}
+         ]
+{{- end -}}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -28,6 +28,9 @@ data:
     [entryPoints]
       [entryPoints.http]
       address = ":80"
+      {{- if .Values.whiteListSourceRange }}
+      {{ template "traefik.whiteListSourceRange" . }}
+      {{- end }}
       {{- if .Values.proxyProtocol.enabled }}
         [entryPoints.http.proxyProtocol]
         {{ template "traefik.trustedips" . }}
@@ -40,6 +43,9 @@ data:
         {{- end }}
       {{- if .Values.ssl.enabled }}
       [entryPoints.https]
+      {{- if .Values.whiteListSourceRange }}
+      {{ template "traefik.whiteListSourceRange" . }}
+      {{- end }}
       address = ":443"
       {{- if .Values.proxyProtocol.enabled }}
         [entryPoints.https.proxyProtocol]
@@ -52,6 +58,9 @@ data:
           KeyFile = "/ssl/tls.key"
       {{- else }}
       [entryPoints.httpn]
+      {{- if .Values.whiteListSourceRange }}
+      {{ template "traefik.whiteListSourceRange" . }}
+      {{- end }}
       address = ":8880"
       compress = {{ .Values.gzip.enabled }}
       {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -5,6 +5,7 @@ imageTag: 1.5.4
 serviceType: LoadBalancer
 loadBalancerIP:
 # loadBalancerSourceRanges: []
+whiteListSourceRange: []
 externalTrafficPolicy: Cluster
 replicas: 1
 cpuRequest: 100m


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the ability to add `whiteListSourceRange` for Entrypoints. This is useful for long whitelists that might hit API limits in cloud providers when using `loadBalancerSourceRanges`