### PR TITLE
[mssql-linux] Added mssql backup dir env var and Updated README and NOTES

### DIFF
--- a/stable/mssql-linux/Chart.yaml
+++ b/stable/mssql-linux/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: SQL Server 2017 Linux Helm Chart
 name: mssql-linux
-version: 0.1.9
+version: 0.2.0
 appVersion: 14.0.3023.8
 home: https://hub.docker.com/r/microsoft/mssql-server-linux/
 icon: https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1I4Dx

--- a/stable/mssql-linux/Chart.yaml
+++ b/stable/mssql-linux/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: SQL Server 2017 Linux Helm Chart
 name: mssql-linux
-version: 0.1.8
+version: 0.1.9
 appVersion: 14.0.3023.8
 home: https://hub.docker.com/r/microsoft/mssql-server-linux/
 icon: https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1I4Dx

--- a/stable/mssql-linux/README.md
+++ b/stable/mssql-linux/README.md
@@ -1,25 +1,32 @@
 # HELM Chart for Microsoft SQL Server 2017 on Linux
 
 ## Prerequisites
- * This chart requires Docker Engine 1.8+ in any of their supported platforms.  Please see vendor requirements [here for more information](https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker).
- * At least 2GB of RAM (3.25 GB prior to 2017-CU2). Make sure to assign enough memory to the Docker VM if you're running on Docker for Mac or Windows.
- * Requires the following variables
-   - You must change the acceptEula.value in the values.yaml file to `Y` or include `--set acceptEula.value=Y` in the command line of `helm install` to override the default value of `N`.
-   - You must change the editions variable in the values.yaml file to include the edition of SQL Server or include `--set edition.value=<your_product_id | edition_name>` in the command line of `helm install`.
+
+* This chart requires Docker Engine 1.8+ in any of their supported platforms.  Please see vendor requirements [here for more information](https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker).
+* At least 2GB of RAM (3.25 GB prior to 2017-CU2). Make sure to assign enough memory to the Docker VM if you're running on Docker for Mac or Windows.
+* Requires the following variables
+  * You must change the acceptEula.value in the values.yaml file to `Y` or include `--set acceptEula.value=Y` in the command line of `helm install` to override the default value of `N`.
+  * You must change the editions variable in the values.yaml file to include the edition of SQL Server or include `--set edition.value=<your_product_id | edition_name>` in the command line of `helm install`.
 
 ## Chart Components
- * Creates a SQL Server 2017 deployment (default edition: Express)
- * Creates a Kubernetes Service on specified port (default: 1433)
- * Creates a Secert to hold SA_PASSWORD
+
+* Creates a SQL Server 2017 deployment (default edition: Express)
+* Creates a Kubernetes Service on specified port (default: 1433)
+* Creates a Secert to hold SA_PASSWORD
 
 ## Installing the Chart
+
 You can install the chart with the release name `mymssql` as below.
+
 ```console
 $ helm install --name mymssql stable/mssql-linux --set acceptEula.value=Y --set edition.value=Developer
+...
 ```
+
 > Note - If you do not specify a name, helm will select a name for you.
 
 ### Installed Components
+
 You can use `kubectl get` to view all of the installed components.
 
 ```console
@@ -45,14 +52,20 @@ svc/mymssql-mssql-linux   ClusterIP   10.104.152.61   <none>        1433/TCP   9
 ```
 
 ### SA Password Retrieval
+
 The sa password is a randonmized in the secret.yaml file.  To retrieve the password, perform the following steps once you install the helm chart.
+
 ```console
-$ kubectl exec mymssql-mssql-linux-8688756468 -- env | grep SA_PASSWORD
+$ printf $(kubectl get secret --namespace default mymssql-mssql-linux-secret -o jsonpath="{.data.sapassword}" | base64 --decode);echo
+...
 ```
 
 ## Connecting to SQL Server Instance
-1.  Run the following command
+
+1. Run the following command
+
 This command will create a pod called `mssqlcli` that will include the SQL Server Commandline `sqlcmd` and start at a bash prompt.
+
 ```console
 $ kubectl run mssqlcli --image=microsoft/mssql-tools -ti --restart=Never --rm=true -- /bin/bash
 $ sqlcmd -S mymssql-mssql-linux -U sa
@@ -61,14 +74,15 @@ $ 1> select @@VERSION;
 $ 2> go
 ------------------------------------------------------------------------------------
 Microsoft SQL Server 2017 (RTM-CU3-GDR) (KB4052987) - 14.0.3015.40 (X64) 
-	Dec 22 2017 16:13:22 
-	Copyright (C) 2017 Microsoft Corporation
-	Express Edition (64-bit) on Linux (Ubuntu 16.04.3 LTS)
+Dec 22 2017 16:13:22 
+Copyright (C) 2017 Microsoft Corporation
+Express Edition (64-bit) on Linux (Ubuntu 16.04.3 LTS)
 (1 rows affected)
 
 ```
 
 ## Values
+
 The configuration parameters in this section control the resources requested and utilized by the SQL Server instance.
 
 | Parameter        | Description                                                                                    | Default                          |
@@ -77,37 +91,47 @@ The configuration parameters in this section control the resources requested and
 | edition.value    | The edition of SQL Server to install.  See section [Editions](#sql-server-for-linux-editions). | `Express`                        |
 | sapassword       | Password for sa login                                                                          | `Random (20-AlphNum)`<sup>1<sup> |
 | image.repository | The docker hub repo for SQL Server                                                             | `microsoft/mssql-server-linux`   |
-| image.tag        | The tag for the image                                                                          | `2017-CU3`                       |
+| image.tag        | The tag for the image                                                                          | `2017-CU5`                       |
 | image.pullPolicy | The pull policy for the deployment                                                             | `IfNotPresent`                   |
+| nodeSelector     | Node labels for pod assignment                                                                 | `{}`                             |
 | service.type     | Service Type                                                                                   | `ClusterIP`                      |
 | persistence.enabled | Presist the Data and Log files for SQL Server                                               | `false`                          |
 | persistence.existingDataClaim | Identify an existing Claim to be used for the Data Directory                      | `Commented Out`                  |
 | persistence.existingLogClaim  | Identify an existing Claim to be used for the Log Directory                       | `Commented Out`                  |
+| persistence.existingBackupClaim | Identify an existing Claim to be used for the SQL Database Backups              | `Commented Out`                  |
 | persistence.storageClass      | Storage Class to be used                                                          | `Commented Out`                  |
 | persistence.dataAccessMode    | Data Access Mode to be used for the Data Directory                                | `ReadWriteOnce`                  |
 | persistence.dataSize          | PVC Size for Data Directory                                                       | `1Gi`                            |
 | persistence.logAccessMode     | Data Access Mode to be used for the Log Directory                                 | `ReadWriteOnce`                  |
 | persistence.logSize           | PVC Size for Log Directory                                                        | `1Gi`                            |
+| persistence.backupAccessMode     | Data Access Mode to be used for the Backup Directory                           | `ReadWriteOnce`                  |
+| persistence.backupSize           | PVC Size for Backup Directory                                                  | `1Gi`                            |
 
 > 1 - [Please read password requirements](https://docs.microsoft.com/en-us/sql/relational-databases/security/password-policy)
 
 ## Liveness and Readiness
+
 The SQL Server instance has liveness and readiness checks specified. These parameters can be used to tune the sensitivity of the liveness and readiness checks.
+
 ### Liveness Probes
+
 | Parameter                         | Description                                                                          | Default |
 | --------------------------------- | ------------------------------------------------------------------------------------ | ------- |
 | livenessprobe.initialDelaySeconds | Tells the kubelet that it should wait XX second(s) before performing the first probe | `15`    |
 | livenessprobe.periodSeconds       | Field specifies that the kubelet should perform a liveness probe every XX seconds(s) | `20`    |
 
 ### Readiness Probes
+
 | Parameter                           | Description                                                                          | Default |
 | ----------------------------------- | ------------------------------------------------------------------------------------ | ------- |
 | readinessprobe.initialDelaySeconds  | Tells the kubelet that it should wait XX second(s) before performing the first probe | 5       |
 | readinessprobe.periodSeconds        | Field specifies that the kubelet should perform a liveness probe every XX second(s)  | 10      |
 
 ## Resources
+
 You can specify the resource limits for this chart in the values.yaml file.  Make sure you comment out or remove the curly brackets from the values.yaml file before specifying resource limits.
 Example:
+
 ```yaml
 resources:
   limits:
@@ -117,43 +141,54 @@ resources:
     cpu: 0.5
     memory: 2Gi
 ```
+
 ## Persistence Examples
+
 Persistence in this chart can be enabled by specifying `persistence.enabled=true`.  The path to the database's data and log files can be customized to fit different requirements.
 
 * Example 1 - Enable persistence in values.yaml without specifying claim
 > Note - This is useful for local development in a minikube environment
+
 ```yaml
 persistence:
   enabled: true
   # existingDataClaim:
   # existingLogClaim:
+  # existingBackupClaim:
   # storageClass: "-"
   dataAccessMode: ReadWriteOnce
   dataSize: 1Gi
   logAccessMode: ReadWriteOnce
   logSize: 1Gi
+  backupAccessMode: ReadWriteOnce
+  backupLogSize: 1Gi
 ```
 
 * Example 2 - Enable persistence in values.yaml with existing claim
 > Note - This is useful for production based environments for persistence volumes and claims already exist.
+
 ```yaml
 persistence:
   enabled: true
   existingDataClaim: pvc-mssql-data
   existingLogClaim: pvc-mssql-log
+  existingBackupClaim: pvc-mssql-backup
   # storageClass: "-"
   dataAccessMode: ReadWriteOnce
   dataSize: 1Gi
   logAccessMode: ReadWriteOnce
   logSize: 1Gi
+  backupAccessMode: ReadWriteOnce
+  backupLogSize: 1Gi
 ```
 
 ## SQL Server for Linux Editions
+
 Below are the supported versions of SQL Server on Linux.  You can find out more information [here](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-editions-and-components-2017).
- * Developer : This will run the container using the Developer Edition (this is the default if no MSSQL_PID environment variable is supplied)
- * Express : This will run the container using the Express Edition
- * Standard : This will run the container using the Standard Edition
- * Enterprise : This will run the container using the Enterprise Edition
- * EnterpriseCore : This will run the container using the Enterprise Edition Core
- * Product ID: This will run the container with the edition that is associated with the PID
- 
+
+* Developer : This will run the container using the Developer Edition (this is the default if no MSSQL_PID environment variable is supplied)
+* Express : This will run the container using the Express Edition
+* Standard : This will run the container using the Standard Edition
+* Enterprise : This will run the container using the Enterprise Edition
+* EnterpriseCore : This will run the container using the Enterprise Edition Core
+* Product ID: This will run the container with the edition that is associated with the PID

--- a/stable/mssql-linux/templates/NOTES.txt
+++ b/stable/mssql-linux/templates/NOTES.txt
@@ -13,7 +13,7 @@ $ printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "
 2. You can test that SQL Server is available by the service port with with the following set of command:
 (Note: You will be prompted for the SA password, use the password generated in Step 1)
 $ kubectl run mssqlcli --image=microsoft/mssql-tools -ti --restart=Never --rm=true -- /bin/bash
-$ sqlcmd -S {{ template "mssql.fullname" . }}.{{ .Release.Namespace }},1433 -U sa 
+$ sqlcmd -S {{ template "mssql.fullname" . }}.{{ .Release.Namespace }},{{ .Values.service.port }} -U sa 
 $ Password: <Enter Password for SA>
 
 2.  Connection Library Information
@@ -23,4 +23,4 @@ https://docs.microsoft.com/en-us/sql/connect/sql-connection-libraries
 https://docs.microsoft.com/en-us/sql/connect/jdbc/connecting-to-sql-server-with-the-jdbc-driver
 
 SQL Server Name: {{ template "mssql.fullname" . }}.{{ .Release.Namespace }}
-Port: 1433
+Port: {{ .Values.service.port }}

--- a/stable/mssql-linux/templates/deployment.yaml
+++ b/stable/mssql-linux/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: /mssql-translog/translog
             - name: MSSQL_TCP_PORT
               value: "{{ .Values.service.port }}"
+            - name: MSSQL_BACKUP_DIR
+              value: "/mssql-backup/backup"
           ports:
             - name: mssql
               containerPort: {{ .Values.service.port }}
@@ -47,6 +49,8 @@ spec:
               mountPath: /mssql-data/data
             - name: transactionlog
               mountPath: /mssql-translog/translog
+            - name: backup
+              mountPath: /mssql-backup/backup
           livenessProbe:
              tcpSocket:
                port: mssql
@@ -82,6 +86,17 @@ spec:
           claimName: {{ .Values.persistence.existingLogClaim }}
           {{- else }}
           claimName: {{ template "mssql.fullname" . }}-translog
+          {{- end }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      - name: backup
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          {{- if .Values.persistence.existingBackupClaim }}
+          claimName: {{ .Values.persistence.existingBackupClaim }}
+          {{- else }}
+          claimName: {{ template "mssql.fullname" . }}-backup
           {{- end }}
       {{- else }}
         emptyDir: {}

--- a/stable/mssql-linux/templates/pvc-backup.yaml
+++ b/stable/mssql-linux/templates/pvc-backup.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingBackupClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "mssql.fullname" . }}-backup
+  labels:
+    app: {{ template "mssql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.backupAccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.backupSize | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/stable/mssql-linux/values.yaml
+++ b/stable/mssql-linux/values.yaml
@@ -15,11 +15,14 @@ persistence:
   enabled: false
   # existingDataClaim:
   # existingTransactionLogClaim:
+  # existingBackupClaim:
   # storageClass: "-"
   dataAccessMode: ReadWriteOnce
   dataSize: 1Gi
   transactionLogAccessMode: ReadWriteOnce
   transactionLogSize: 1Gi
+  backupAccessMode: ReadWriteOnce
+  backupSize: 1Gi
 livenessprobe:
   initialDelaySeconds: 15
   periodSeconds: 20


### PR DESCRIPTION
- Added feature to persist the backup directory variable in MSSQL

- Updated the README.md to reflect new feature for backup directory

- Updated README.md with markdown linting requirements (spaces...new line...etc)

- Updated NOTES.txt to remove hard-coded values with service port
