### PR TITLE
[stable/rabbitmq-ha] set NODE_IP to ExternalIP rather than InternalIP for external access

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.3
-version: 1.0.5
+version: 1.0.6
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/NOTES.txt
+++ b/stable/rabbitmq-ha/templates/NOTES.txt
@@ -12,7 +12,7 @@
 
 {{- if contains "NodePort" .Values.service.type }}
 
-    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[?(@.type=='ExternalIP')].address}")    
     export NODE_PORT_AMQP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name=="amqp")].nodePort}' services {{ template "rabbitmq-ha.fullname" . }})
     {{- if .Values.rabbitmqAmqpsSupport.enabled }}
     export NODE_PORT_AMQPS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name=="amqps")].nodePort}' services {{ template "rabbitmq-ha.fullname" . }})


### PR DESCRIPTION
**What this PR does / why we need it**:
When a rabbitmq-ha chart is deployed, helm prints an external URL to access the management UI
the external URL contains node's private IP rather than the external IP
```
jsonpath="{.items[0].status.addresses[0].address}" 
```
addresses[0] is the private ip

I changed the query to 
```
jsonpath="{.items[0].status.addresses[?(@.type=='ExternalIP')].address}"
```

If the intent was to access it via private ip, the documentation (imho) needs to tell the user the appropriate `kubectl proxy` command to execute