### PR TITLE
[stable/sumologic-fluentd] Allow the time_key field to be defined via environment variables

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 name: sumologic-fluentd
 version: 0.4.0
-appVersion: 1.8
+appVersion: 1.9
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.3.2
+version: 0.4.0
 appVersion: 1.8
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 name: sumologic-fluentd
-version: 0.3.3
-appVersion: v1.6
+version: 0.3.2
+appVersion: 1.8
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 name: sumologic-fluentd
 version: 0.4.0
-appVersion: 1.10
+appVersion: 1.11
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 name: sumologic-fluentd
 version: 0.4.0
-appVersion: 1.9
+appVersion: 1.10
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -89,8 +89,8 @@ The following tables lists the configurable parameters of the sumologic-fluentd 
 | `sumologic.concatSeparator` | The character to use to delimit lines within the final concatenated message. Most multi-line messages contain a newline at the end of each line | `Nil` |
 | `sumologic.auditLogPath` | Define the path to the [Kubernetes Audit Log](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) | `/mnt/log/kube-apiserver-audit.log` |
 | `image.name` | The image repository and name to pull from | `sumologic/fluentd-kubernetes-sumologic` |
-| `image.tag` | The image tag to pull | `v1.6` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.tag` | The image tag to pull | `v1.11` |
+| `imagePullPolicy` | Image pull policy | `IfNotPresent` |
 | `persistence.enabled` | Boolean value, used to turn on or off fluentd position file persistence, on nodes (requires Kubernetes >= 1.8) | `false` |
 | `persistence.hostPath` | The path, on each node, to a directory for fluentd pos files. You must create the directory on each node first or set `persistence.createPath` (requires Kubernetes >= 1.8) | `/var/run/fluentd-pos` |
 | `persistence.createPath` | Whether to create the directory on the host for you (requires Kubernetes >= 1.8) | `false` |

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -90,7 +90,7 @@ The following tables lists the configurable parameters of the sumologic-fluentd 
 | `sumologic.auditLogPath` | Define the path to the [Kubernetes Audit Log](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) | `/mnt/log/kube-apiserver-audit.log` |
 | `image.name` | The image repository and name to pull from | `sumologic/fluentd-kubernetes-sumologic` |
 | `image.tag` | The image tag to pull | `v1.11` |
-| `imagePullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `persistence.enabled` | Boolean value, used to turn on or off fluentd position file persistence, on nodes (requires Kubernetes >= 1.8) | `false` |
 | `persistence.hostPath` | The path, on each node, to a directory for fluentd pos files. You must create the directory on each node first or set `persistence.createPath` (requires Kubernetes >= 1.8) | `/var/run/fluentd-pos` |
 | `persistence.createPath` | Whether to create the directory on the host for you (requires Kubernetes >= 1.8) | `false` |

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -139,6 +139,10 @@ spec:
             - name: FLUENTD_OPT
               value: {{ quote .Values.sumologic.fluentdOpt }}
             {{- end }}
+            {{- if quote .Values.sumologic.timeKey }}
+            - name: TIME_KEY
+              value: {{ quote .Values.sumologic.timeKey }}
+            {{- end }}
             {{- if quote .Values.sumologic.verifySsl }}
             - name: VERIFY_SSL
               value: {{ quote .Values.sumologic.verifySsl }}

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for sumologic-fluentd.
 image:
   name: sumologic/fluentd-kubernetes-sumologic
-  tag: v1.6
+  tag: v1.8
   pullPolicy: IfNotPresent
 
 ## Annotations to add to the DaemonSet's Pods
@@ -114,6 +114,10 @@ sumologic:
   ## ref: http://rubular.com/
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
   excludeUnitRegex: ""
+
+  ## The field name for json formatted sources that should be used as the time
+  ## ref: https://docs.fluentd.org/v0.12/articles/formatter_json#time_key-(string,-optional,-defaults-to-%E2%80%9Ctime%E2%80%9D)
+  # timeKey: 
 
   ## Fluentd command line options
   ## ref: http://docs.fluentd.org/v0.12/articles/command-line-option

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for sumologic-fluentd.
 image:
   name: sumologic/fluentd-kubernetes-sumologic
-  tag: v1.8
+  tag: v1.9
   pullPolicy: IfNotPresent
 
 ## Annotations to add to the DaemonSet's Pods

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -117,7 +117,7 @@ sumologic:
 
   ## The field name for json formatted sources that should be used as the time
   ## ref: https://docs.fluentd.org/v0.12/articles/formatter_json#time_key-(string,-optional,-defaults-to-%E2%80%9Ctime%E2%80%9D)
-  # timeKey: 
+  # timeKey:
 
   ## Fluentd command line options
   ## ref: http://docs.fluentd.org/v0.12/articles/command-line-option

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for sumologic-fluentd.
 image:
   name: sumologic/fluentd-kubernetes-sumologic
-  tag: v1.9
+  tag: v1.10
   pullPolicy: IfNotPresent
 
 ## Annotations to add to the DaemonSet's Pods

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for sumologic-fluentd.
 image:
   name: sumologic/fluentd-kubernetes-sumologic
-  tag: v1.10
+  tag: v1.11
   pullPolicy: IfNotPresent
 
 ## Annotations to add to the DaemonSet's Pods


### PR DESCRIPTION
## what

Allow the `time_key` field to be defined via environment variables

## why

`time_key` tells fluentd which field in a json input contains the timestamp for the event. If the field is not found, fluentd adds its own. Previously the fluentd config for docker containers was hardcoded to use `time` as the name of the field but this is not a universal standard.

See https://docs.fluentd.org/v0.12/articles/formatter_json#time_key-(string,-optional,-defaults-to-%E2%80%9Ctime%E2%80%9D
