### PR TITLE
Remove empty configurationFiles key from mysql values.

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.3.7
+version: 0.3.8
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -68,11 +68,11 @@ resources:
     memory: 256Mi
     cpu: 100m
 
-# Custom mysql configuration files used to override default mysql settings
-configurationFiles:
-#  mysql.cnf: |-
-#    [mysqld]
-#    skip-name-resolve
+## Custom mysql configuration files used to override default mysql settings
+# configurationFiles:
+#   mysql.cnf: |-
+#     [mysqld]
+#     skip-name-resolve
 
 
 ## Configure the service


### PR DESCRIPTION
If you want to override empty value from parent chart it isn't recognized as a table and helm shows an annoying warning message.

["warning: skipped value for %s: Not a table."](https://github.com/kubernetes/helm/blob/531deec220a2b7dc748e86f760a08248e6f39527/pkg/chartutil/values.go#L292)