### PR TITLE
stable/metallb: update to 0.5.0

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-version: 0.2.0
+version: 0.3.0
 
 name: metallb
-appVersion: 0.4.6
+appVersion: 0.5.0
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
 home: https://metallb.universe.tf

--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -86,12 +86,12 @@ create an appropriate ConfigMap.
 
 For simple setups that only use
 MetalLB's [ARP mode](https://metallb.universe.tf/concepts/arp-ndp/),
-you can specify a single IP range using the `arpCIDR` parameter to
-have the chart install a working configuration for you:
+you can specify a single IP range using the `arpAddresses` parameter
+to have the chart install a working configuration for you:
 
 ```console
 $ helm install --name metallb \
-  --set arpCIDR=192.168.16.240/30 \
+  --set arpAddresses=192.168.16.240/30 \
   stable/metallb
 ```
 

--- a/stable/metallb/templates/NOTES.txt
+++ b/stable/metallb/templates/NOTES.txt
@@ -1,8 +1,8 @@
 
 MetalLB is now running in the cluster.
-{{ if .Values.arpCIDR -}}
+{{ if .Values.arpAddresses -}}
 LoadBalancer Services in your cluster are now available on IPs
-within {{ .Values.arpCIDR }}. To see the IP assignments,
+within {{ .Values.arpAddresses }}. To see the IP assignments,
 try `kubectl get services`.
 {{- else if .Values.config }}
 LoadBalancer Services in your cluster are now available on the IPs you

--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -1,4 +1,4 @@
-{{- if (or .Values.config .Values.arpCIDR) }}
+{{- if (or .Values.config .Values.arpAddresses) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,6 +17,6 @@ data:
     - name: default
       protocol: arp
       cidr:
-      - {{ .Values.arpCIDR }}
+      - {{ .Values.arpAddresses }}
 {{- end }}
 {{- end }}

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -6,12 +6,12 @@
 # https://metallb.universe.tf/configuration/ for available options.
 config:
 
-# When arpCIDR is specified instead of config, the chart will install
-# a trivial "quick start" MetalLB configuration that uses ARP
+# When arpAddresses is specified instead of config, the chart will
+# install a trivial "quick start" MetalLB configuration that uses ARP
 # mode. Refer to https://metallb.universe.tf/ for more
 # information. For production configurations, use of the `config`
-# field is recommended instead of arpCIDR.
-arpCIDR:
+# field is recommended instead of arpAddresses.
+arpAddresses:
 
 rbac:
   # create specifies whether to install and use RBAC rules.

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -47,7 +47,7 @@ serviceAccounts:
 controller:
   image:
     repository: metallb/controller
-    tag: v0.4.6
+    tag: v0.5.0
     pullPolicy: IfNotPresent
   resources:
     # limits:
@@ -59,7 +59,7 @@ controller:
 speaker:
   image:
     repository: metallb/speaker
-    tag: v0.4.6
+    tag: v0.5.0
     pullPolicy: IfNotPresent
   resources:
     # limits:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the chart to use MetalLB 0.5.0.

Other than the version bumps, the `arpCIDR` config value is renamed to `arpAddresses`, to align with a similar renaming in upstream MetalLB.