### PR TITLE
[etcd-operator] readiness/liveness checks for operator

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.7.5
+version: 0.7.6
 appVersion: 0.7.0
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -44,14 +44,28 @@ spec:
           requests:
             cpu: {{ .Values.etcdOperator.resources.cpu }}
             memory: {{ .Values.etcdOperator.resources.memory }}
+        {{- if .Values.etcdOperator.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /readyz
             port: 8080
+          initialDelaySeconds: {{ .Values.etcdOperator.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.etcdOperator.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.etcdOperator.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.etcdOperator.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.etcdOperator.livenessProbe.failureThreshold }}
+        {{- end}}
+        {{- if .Values.etcdOperator.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /readyz
             port: 8080
+          initialDelaySeconds: {{ .Values.etcdOperator.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.etcdOperator.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.etcdOperator.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.etcdOperator.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.etcdOperator.readinessProbe.failureThreshold }}
+        {{- end }}
     {{- if .Values.etcdOperator.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.etcdOperator.nodeSelector | indent 8 }}

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -44,6 +44,14 @@ spec:
           requests:
             cpu: {{ .Values.etcdOperator.resources.cpu }}
             memory: {{ .Values.etcdOperator.resources.memory }}
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
     {{- if .Values.etcdOperator.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.etcdOperator.nodeSelector | indent 8 }}

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -54,7 +54,21 @@ etcdOperator:
   ## additional command arguments go here; will be translated to `--key=value` form
   ## e.g., analytics: true
   commandArgs: {}
-
+  ## Configurable health checks against the /readyz endpoint that etcd-operator exposes
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
 # backup spec
 backupOperator:
   name: etcd-backup-operator

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -56,14 +56,14 @@ etcdOperator:
   commandArgs: {}
   ## Configurable health checks against the /readyz endpoint that etcd-operator exposes
   readinessProbe:
-    enabled: true
+    enabled: false
     initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
   livenessProbe:
-    enabled: true
+    enabled: false
     initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 1


### PR DESCRIPTION
This PR simply adds health checking for the etcd-operator chart. The operator exposes a `/readyz` endpoint by default on port 8080. The probes simply make use of that endpoint and utilizes the default success and failure conditions.