### PR TITLE
[stable/kube2iam] make liveness probe conditional

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.8.4
+version: 0.8.5
 appVersion: 0.10.0
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -65,6 +65,7 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.host.port }}
+        {{- if .Values.probe }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -75,6 +76,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
             timeoutSeconds: 1
+        {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         {{- if .Values.host.iptables }}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -37,6 +37,8 @@ podAnnotations: {}
 
 podLabels: {}
 
+probe: true
+
 rbac:
   ## If true, create & use RBAC resources
   ##


### PR DESCRIPTION
The liveness probe queries the kube2iam health check, which performs a basic sanity test against the metadata service. However, the metadata service doesn't exist when running kube2iam on bare metal on-prem (unusual but possible). I would like to make the liveness probe optional for that peculiar circumstance.