### PR TITLE
[stable/elastalert] Allow communication with https ES instances

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,6 +1,6 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.1.29
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:

--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.1.3
-appVersion: 0.2.0
+version: 0.2.0
+appVersion: 0.1.29
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:
 - https://github.com/jertel/elastalert-docker

--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
 version: 0.1.3
-appVersion: 0.1.29
+appVersion: 0.2.0
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:
 - https://github.com/jertel/elastalert-docker

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -38,7 +38,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replicaCount`            | number of replicas to run                           | 1                                 |
 | `elasticsearch.host`      | elasticsearch endpoint to use                       | elasticsearch                     |
 | `elasticsearch.port`      | elasticsearch port to use                           | 80                                |
-| `resources`               |  Container resource requests and limits             | {}                                |
+| `elasticsearch.use_ssl`   | use https with elasticsearch                        | False                             |
+| `resources`               | Container resource requests and limits              | {}                                |
 | `rules`                   | Rule and alert configuration for Elastalert         | {} example shown in values.yaml   |
 | `runIntervalMins`         | Default interval between alert checks, in minutes   | 1                                 |
 | `bufferTimeMins`          | Default rule buffer time, in minutes                | 15                                |

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -38,7 +38,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replicaCount`            | number of replicas to run                           | 1                                 |
 | `elasticsearch.host`      | elasticsearch endpoint to use                       | elasticsearch                     |
 | `elasticsearch.port`      | elasticsearch port to use                           | 80                                |
-| `elasticsearch.use_ssl`   | use https with elasticsearch                        | False                             |
+| `elasticsearch.useSsl`    | use https with elasticsearch                        | False                             |
 | `resources`               | Container resource requests and limits              | {}                                |
 | `rules`                   | Rule and alert configuration for Elastalert         | {} example shown in values.yaml   |
 | `runIntervalMins`         | Default interval between alert checks, in minutes   | 1                                 |

--- a/stable/elastalert/templates/config.yaml
+++ b/stable/elastalert/templates/config.yaml
@@ -18,7 +18,7 @@ data:
       minutes: {{ .Values.bufferTimeMins }}
     es_host: {{ .Values.elasticsearch.host }}
     es_port: {{ .Values.elasticsearch.port }}
-    use_ssl: {{ .Values.elasticsearch.use_ssl }}
+    use_ssl: {{ .Values.elasticsearch.useSsl }}
     writeback_index: elastalert_status
     alert_time_limit:
       days: 2

--- a/stable/elastalert/templates/config.yaml
+++ b/stable/elastalert/templates/config.yaml
@@ -18,6 +18,7 @@ data:
       minutes: {{ .Values.bufferTimeMins }}
     es_host: {{ .Values.elasticsearch.host }}
     es_port: {{ .Values.elasticsearch.port }}
+    use_ssl: {{ .Values.elasticsearch.use_ssl }}
     writeback_index: elastalert_status
     alert_time_limit:
       days: 2

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -22,6 +22,8 @@ elasticsearch:
   host: ""
   # elasticsearch port
   port: 80
+  # use_ssl allows to use ES instances via HTPS (True|False)
+  use_ssl: False
 
 # rule configurations e.g. (http://elastalert.readthedocs.io/en/latest/)
 rules: {}

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -23,7 +23,7 @@ elasticsearch:
   # elasticsearch port
   port: 80
   # use_ssl allows to use ES instances via https (True|False)
-  use_ssl: False
+  use_ssl: "False"
 
 # rule configurations e.g. (http://elastalert.readthedocs.io/en/latest/)
 rules: {}

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -22,7 +22,7 @@ elasticsearch:
   host: ""
   # elasticsearch port
   port: 80
-  # use_ssl allows to use ES instances via HTPS (True|False)
+  # use_ssl allows to use ES instances via https (True|False)
   use_ssl: False
 
 # rule configurations e.g. (http://elastalert.readthedocs.io/en/latest/)

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -23,7 +23,7 @@ elasticsearch:
   # elasticsearch port
   port: 80
   # use_ssl allows to use ES instances via https (True|False)
-  use_ssl: "False"
+  useSsl: "False"
 
 # rule configurations e.g. (http://elastalert.readthedocs.io/en/latest/)
 rules: {}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Currently it is not possible to communicate with https only endpoints (i.e. AWS Elasticsearch instances) enabling this simple flag in the configuration allows it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
