### PR TITLE
Add appVersion and home key in nginx-lego/Chart

### DIFF
--- a/stable/nginx-lego/Chart.yaml
+++ b/stable/nginx-lego/Chart.yaml
@@ -1,5 +1,7 @@
 name: nginx-lego
 version: 0.3.1
+appVersion: 0.8.3
+home: https://github.com/jetstack/kube-lego
 deprecated: true
 description: Chart for nginx-ingress-controller and kube-lego
 keywords:

--- a/stable/nginx-lego/Chart.yaml
+++ b/stable/nginx-lego/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-lego
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.8.3
 home: https://github.com/jetstack/kube-lego
 deprecated: true


### PR DESCRIPTION
To solve the ci testing failure problem, the appVersion and home key are needed in the yaml file.
appVersion: 0.8.3
home: https://github.com/jetstack/kube-lego