### PR TITLE
Add home key for verdaccio

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.2.1
+version: 0.2.2
 appVersion: 2.7.3
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -3,6 +3,7 @@ description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
 version: 0.2.1
 appVersion: 2.7.3
+home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png
 sources:
 - http://www.verdaccio.org


### PR DESCRIPTION
"home" key is needed for ci testing now, otherwise testing will fail.