### PR TITLE
Add appVersion for uchiwa

### DIFF
--- a/stable/uchiwa/Chart.yaml
+++ b/stable/uchiwa/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 name: uchiwa
-version: 0.2.4
+version: 0.2.5
+appVersion: 0.22
 description: Dashboard for the Sensu monitoring framework
 keywords:
 - uchiwa


### PR DESCRIPTION
"appVersion" key is needed for ci testing now, otherwise testing will fail.