### PR TITLE
Add appVersion for telegraf

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,5 +1,6 @@
 name: telegraf
-version: 0.3.2
+version: 0.3.3
+appVersion: 1.5
 deprecated: true
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.
 keywords:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing,  but it's missing in this yaml.