### PR TITLE
Add appVersion for sumologic-fluentd

### DIFF
--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
 version: 0.2.8
+appVersion: 1.3.0
+home: https://www.heapster.net/
 sources:
 - https://github.com/kubernetes/heapster
 - https://github.com/kubernetes/contrib/tree/master/addon-resizer

--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,6 @@
 name: sumologic-fluentd
-version: 0.3.1
+version: 0.3.2
+appVersion: 1.6
 description: Sumologic Log Collector
 keywords:
   - monitoring


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, otherwise the testing will fail, but it's missing in this yaml.