### PR TITLE
Add home and appVersion for sumokube

### DIFF
--- a/stable/sumokube/Chart.yaml
+++ b/stable/sumokube/Chart.yaml
@@ -1,5 +1,7 @@
 name: sumokube
-version: 0.1.3
+version: 0.1.4
+appVersion: latest
+home: https://www.sumologic.com/
 description: Sumologic Log Collector
 keywords:
 - monitoring


### PR DESCRIPTION
The key "appVersion" and "home" are needed for ci testing, they are missing in this yaml.