### PR TITLE
Add home key for stackdriver-exporter

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -3,6 +3,7 @@ description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
 version: 0.0.1
 appVersion: 0.5.1
+home: https://www.stackdriver.com/
 sources:
   - https://github.com/frodenas/stackdriver_exporter/releases
 keywords:

--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.5.1
 home: https://www.stackdriver.com/
 sources:


### PR DESCRIPTION
The key "home" is needed for ci testing, but it's missing in this yaml.