### PR TITLE
Add appVersion key for spotify-docker-gc

### DIFF
--- a/stable/spotify-docker-gc/Chart.yaml
+++ b/stable/spotify-docker-gc/Chart.yaml
@@ -1,6 +1,7 @@
 name: spotify-docker-gc
 home: https://github.com/spotify/docker-gc
-version: 0.1.2
+version: 0.1.3
+appVersion: latest
 description: A simple Docker container and image garbage collection script.
 sources:
   - https://github.com/spotify/docker-gc


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That will cause testing failure.