### PR TITLE
Add home key for spartakus

### DIFF
--- a/stable/spartakus/Chart.yaml
+++ b/stable/spartakus/Chart.yaml
@@ -1,5 +1,7 @@
 name: spartakus
-version: 1.1.4
+version: 1.1.5
+appVersion: 1.0.0
+home: https://www.shdlr.com
 description: Collect information about Kubernetes clusters to help improve the project.
 sources:
   - https://github.com/kubernetes-incubator/spartakus


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That will cause testing failure.