### PR TITLE
Add appVersion key for spark

### DIFF
--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,6 @@
 name: spark
-version: 0.1.12
+version: 0.1.13
+appVersion: 1.5.1
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That will cause testing failure.