### PR TITLE
Add appVersion key for sensu

### DIFF
--- a/stable/sensu/Chart.yaml
+++ b/stable/sensu/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 name: sensu
-version: 0.2.1
+version: 0.2.2
+appVersion: 0.28
 description: Sensu monitoring framework backed by the Redis transport
 keywords:
 - sensu


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.