### PR TITLE
Add appVersion key for sapho

### DIFF
--- a/stable/sapho/Chart.yaml
+++ b/stable/sapho/Chart.yaml
@@ -5,7 +5,7 @@ description: A micro application development and integration platform that enabl
 name: sapho
 version: 0.2.2
 appVersion: 4.2.0
-home: http://www.sapho.com
+home: http://www.sapho.com/
 icon: https://www.sapho.com/wp-content/uploads/2016/04/sapho-logotype.svg
 sources:
 - https://bitbucket.org/sapho/ops-docker-tomcat/src

--- a/stable/sapho/Chart.yaml
+++ b/stable/sapho/Chart.yaml
@@ -3,7 +3,8 @@ description: A micro application development and integration platform that enabl
   organizations to create and deliver secure micro applications that tie into existing
   business systems and track changes to key business data.
 name: sapho
-version: 0.2.1
+version: 0.2.2
+appVersion: 4.2.0
 home: http://www.sapho.com
 icon: https://www.sapho.com/wp-content/uploads/2016/04/sapho-logotype.svg
 sources:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.