### PR TITLE
Include pre-releases in the semver ranges

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.1.7
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/templates/_helpers.tpl
+++ b/stable/cockroachdb/templates/_helpers.tpl
@@ -2,9 +2,9 @@
 Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "cockroachdb.networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4, <=1.6" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.4-0, <=1.7-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "^1.7" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This is important when testing against alpha and beta builds of
Kubernetes along with environments that use pre-releases to denote
things other than pre-releases (e.g., gke denotes the environment
with a pre-releases)