### PR TITLE
Add appVersion key for rocketchat

### DIFF
--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,5 +1,6 @@
 name: rocketchat
-version: 0.1.2
+version: 0.1.3
+appVersion: 0.56
 description: Prepare to take off with the ultimate chat platform, experience the next
   level of team communications
 keywords:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.