### PR TITLE
Add appVersion and home key for risk-advisor

### DIFF
--- a/stable/risk-advisor/Chart.yaml
+++ b/stable/risk-advisor/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 name: risk-advisor
 description: Risk Advisor add-on module for Kubernetes
-version: 2.0.1
+version: 2.0.2
+appVersion: 1.0.0
+home: https://www.riskadvisory.net/
 sources:
 - https://github.com/Prytu/risk-advisor/
 maintainers:


### PR DESCRIPTION
The key "appVersion" and "home" are needed for ci testing, but they are missing in this yaml. That sometimes will cause testing failure.