### PR TITLE
Adds full support for gcs storage options

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.1.1
+version: 1.2.0
 appVersion: 2.6.2
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -42,7 +42,7 @@ their default values.
 | `updateStrategy`            | update strategy for deployment                                                           | `{}`            |
 | `resources.limits.cpu`      | Container requested CPU                                                                  | `nil`           |
 | `resources.limits.memory`   | Container requested memory                                                               | `nil`           |
-| `storage`                   | Storage system to use                                                                    | `fileststem`    |
+| `storage`                   | Storage system to use (i.e. filesystem, s3, gcs)                                         | `filesystem`    |
 | `tlsSecretName`             | Name of secret for TLS certs                                                             | `nil`           |
 | `secrets.htpasswd`          | Htpasswd authentication                                                                  | `nil`           |
 | `secrets.s3.accessKey`      | Access Key for S3 configuration                                                          | `nil`           |
@@ -53,6 +53,10 @@ their default values.
 | `s3.bucket`                 | S3 bucket name                                                                           | `nil`           |
 | `s3.encrypt`                | Store images in encrypted format                                                         | `nil`           |
 | `s3.secure`                 | Use HTTPS                                                                                | `nil`           |
+| `gcs.bucket`                | Storage bucket name (required if using gcs storage)                                      | `nil`           |
+| `gcs.keyfile`               | A private service account key file in JSON format.                                       | `nil`           |
+| `gcs.rootdirectory`         | This is a prefix that is applied to all GCS keys to allow you to segment data.           | `/`             |
+| `gcs.chunksize`             | This is the chunk size used for uploading large blobs, must be a multiple of 256*1024.   | `5242880`       |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/stable/docker-registry/templates/configmap.yaml
+++ b/stable/docker-registry/templates/configmap.yaml
@@ -7,6 +7,24 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{ if eq .Values.storage "gcs" -}}
+{{ $_ := required ".Values.gcs required" .Values.gcs -}}
+{{ $_ := required ".Values.gcs.bucket required" .Values.gcs.bucket -}}
+{{ $gcs := dict "bucket" .Values.gcs.bucket -}}
+{{ if .Values.secrets.gcs -}}
+{{ if .Values.secrets.gcs.keyfile -}}
+{{ $keyfile := print "/var/run/secrets/" .Chart.Name "/gcsKeyfile" -}}
+{{ $gcs := set $gcs "keyfile" $keyfile -}}
+{{ end -}}
+{{ end -}}
+{{ if .Values.gcs.rootdirectory -}}
+{{ $gcs := set $gcs "rootdirectory" .Values.gcs.rootdirectory -}}
+{{ end -}}
+{{ if .Values.gcs.chunksize -}}
+{{ $gcs := set $gcs "chunksize" .Values.gcs.chunksize -}}
+{{ end -}}
+{{ $_ := set .Values.configData.storage "gcs" $gcs -}}
+{{ end -}}
 data:
   config.yml: |-
 {{ toYaml .Values.configData | indent 4 }}

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -19,6 +19,13 @@ spec:
       labels:
         app: {{ template "docker-registry.name" . }}
         release: {{ .Release.Name }}
+        annotations:
+          sha256/configmap: {{- include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+{{- if .Values.secrets.gcs }}
+{{- if .Values.secrets.gcs.keyfile }}
+          sha256/gcsKeyfile: {{- .Files.Get .Values.secrets.gcs.keyfile | sha256sum | quote }}
+{{- end }}
+{{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -88,6 +95,11 @@ spec:
               value: {{ .Values.s3.encrypt }}
             - name: REGISTRY_STORAGE_S3_SECURE
               value: {{ .Values.s3.secure }}
+{{- else if .Values.secrets.gcs }}
+{{- if .Values.secrets.gcs.keyfile }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/var/run/secrets/{{ .Chart.Name }}/gcsKeyfile"
+{{- end }}
 {{- end }}
           volumeMounts:
 {{- if .Values.secrets.htpasswd }}
@@ -106,6 +118,13 @@ spec:
               name: tls-cert
               readOnly: true
 {{- end }}
+{{- if .Values.secrets.gcs }}
+{{- if .Values.secrets.gcs.keyfile }}
+            - name: "{{ template "docker-registry.fullname" . }}-gcsKeyfile"
+              mountPath: /var/run/secrets/{{ .Chart.Name }}
+              readOnly: true
+{{- end }}
+{{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
@@ -118,6 +137,16 @@ spec:
             items:
             - key: htpasswd
               path: htpasswd
+{{- end }}
+{{- if .Values.secrets.gcs }}
+{{- if .Values.secrets.gcs.keyfile }}
+        - name: "{{ template "docker-registry.fullname" . }}-gcsKeyfile"
+          secret:
+            secretName: {{ template "docker-registry.fullname" . }}-secret
+            items:
+            - key: gcsKeyfile
+              path: gcsKeyfile
+{{- end }}
 {{- end }}
 {{- if eq .Values.storage "filesystem" }}
         - name: data

--- a/stable/docker-registry/templates/secret.yaml
+++ b/stable/docker-registry/templates/secret.yaml
@@ -23,3 +23,9 @@ data:
   s3SecretKey: {{ .Values.secrets.s3.secretKey | b64enc | quote }}
   {{- end }}
   {{- end }}
+  {{- if .Values.secrets.gcs }}
+  {{- if .Values.secrets.gcs.keyfile }}
+  # gcsKeyfile source: "{{ .Values.secrets.gcs.keyfile }}"
+  gcsKeyfile: {{- .Files.Get .Values.secrets.gcs.keyfile | b64enc | quote }}
+  {{- end }}
+  {{- end }}

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -62,6 +62,9 @@ secrets:
 #   s3:
 #     accessKey: ""
 #     secretKey: ""
+# Secrets for gcs service account file json
+#   gcs:
+#     keyfile: "example.json" # A private service account key file in JSON format. (optional)
 
 # Options for s3 storage type:
 # s3:
@@ -69,6 +72,11 @@ secrets:
 #  bucket: my-bucket
 #  encrypt: false
 #  secure: true
+# Options for gcs storage type:
+# gcs:
+#  bucket: my-bucket # Storage bucket name (required if using gcs storage)
+#  rootdirectory: /repo1 # This is a prefix that is applied to all GCS keys to allow you to segment data. (optional)
+#  chunksize: 5242880 # This is the chunk size used for uploading large blobs, must be a multiple of 256*1024. (optional)
 
 configData:
   version: 0.1


### PR DESCRIPTION
Adds full support for gcs storage options:
https://docs.docker.com/registry/storage-drivers/gcs/#parameters
Maintains existing chart config pattern established by s3.

