### PR TITLE
Add rbac and serviceaccount for kube-spot-termination-notice-handler chart

### DIFF
--- a/incubator/kube-spot-termination-notice-handler/Chart.yaml
+++ b/incubator/kube-spot-termination-notice-handler/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 description: Watch and action AWS spot termination events
 name: kube-spot-termination-notice-handler
 version: 0.2.0
+appVersion: 1.8.1-1
 home: https://github.com/egeland/kube-spot-termination-notice-handler
 source:
   - https://hub.docker.com/r/egeland/kube-spot-termination-notice-handler/

--- a/incubator/kube-spot-termination-notice-handler/Chart.yaml
+++ b/incubator/kube-spot-termination-notice-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Watch and action AWS spot termination events
 name: kube-spot-termination-notice-handler
-version: 0.1.2
+version: 0.2.0
 home: https://github.com/egeland/kube-spot-termination-notice-handler
 source:
   - https://hub.docker.com/r/egeland/kube-spot-termination-notice-handler/

--- a/incubator/kube-spot-termination-notice-handler/README.md
+++ b/incubator/kube-spot-termination-notice-handler/README.md
@@ -29,3 +29,9 @@ You may set these options in your values file:
 * `clusterName` - optional - when slack is configured use this cluster name for reports
 
 * `pollInterval` - how often to query the EC2 metadata for termination notices. Defaults to every `5` seconds.
+
+* `rbac.create` -  Specifies whether RBAC resources should be created. Defaults to `true`.
+
+* `serviceAccount.create` -  Specifies whether a ServiceAccount should be created. Defaults to `true`.
+
+* `serviceAccount.name` - The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template.

--- a/incubator/kube-spot-termination-notice-handler/templates/_helpers.tpl
+++ b/incubator/kube-spot-termination-notice-handler/templates/_helpers.tpl
@@ -14,3 +14,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kube-spot-termination-notice-handler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/kube-spot-termination-notice-handler/templates/daemonset.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ template "kube-spot-termination-notice-handler.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/incubator/kube-spot-termination-notice-handler/templates/rbac.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/rbac.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace | quote }}
+  name: {{ template "kube-spot-termination-notice-handler.serviceAccountName" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/incubator/kube-spot-termination-notice-handler/templates/serviceaccount.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kube-spot-termination-notice-handler.serviceAccountName" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/incubator/kube-spot-termination-notice-handler/values.yaml
+++ b/incubator/kube-spot-termination-notice-handler/values.yaml
@@ -29,3 +29,14 @@ resources: {}
 # requests:
 #  cpu: 100m
 #  memory: 128Mi
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
This code is based on the work of @innovia done in https://github.com/mumoshu/kube-spot-termination-notice-handler/pull/10. I adapted it to work nicely with the HELM chart and be inline with the other charts.

cc @egeland 

