### PR TITLE
Add appVersion for rethinkdb

### DIFF
--- a/stable/rethinkdb/Chart.yaml
+++ b/stable/rethinkdb/Chart.yaml
@@ -1,6 +1,7 @@
 name: rethinkdb
 description: The open-source database for the realtime web
-version: 0.1.1
+version: 0.1.2
+appVersion: 0.1.0
 keywords:
 - rethinkdb
 - database


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.