### PR TITLE
Add home key to prometheus-postgres-exporter

### DIFF
--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
-appVersion: "0.4.4"
+appVersion: 0.4.4
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 0.1.0
+version: 0.1.1
+home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter
 keywords:


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.