### PR TITLE
Add appVersion key for openvpn

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,8 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 2.0.3
+version: 2.0.4
+appVersion: 1.1.0
 maintainers:
 - name: jfelten
   email: john.felten@gmail.com


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.