### PR TITLE
Add home key for oauth2-proxy

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,7 +1,8 @@
 name: oauth2-proxy
-version: 0.2.2
+version: 0.2.3
 apiVersion: v1
 appVersion: 2.2
+home: http://www.videntity.com/
 description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
 - kubernetes


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.