### PR TITLE
Add appVersion for namerd

### DIFF
--- a/stable/namerd/Chart.yaml
+++ b/stable/namerd/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 description: Service that manages routing for multiple linkerd instances
 name: namerd
-version: 0.2.0
+version: 0.2.1
+appVersion: 0.9.1
 home: https://linkerd.io/in-depth/namerd/
 icon: https://pbs.twimg.com/profile_images/690258997237014528/KNgQd9GL_400x400.png
 sources:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.