### PR TITLE
Add home and appVersion key for minecraft

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 name: minecraft
 version: 0.2.1
-appVersion: 1.7.9
+appVersion: 1.12.2
 home: https://minecraft.net/
 description: Minecraft server
 keywords:

--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,6 +1,6 @@
 name: minecraft
 version: 0.2.1
-appVersion: latest
+appVersion: 1.7.9
 home: https://minecraft.net/
 description: Minecraft server
 keywords:

--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,5 +1,7 @@
 name: minecraft
-version: 0.2.0
+version: 0.2.1
+appVersion: latest
+home: https://minecraft.net/
 description: Minecraft server
 keywords:
 - game


### PR DESCRIPTION
The key "appVersion"and "home" are needed for ci testing, they are missing in this yaml. That sometimes will cause testing failure.