### PR TITLE
Add appVersion key for memcached

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,6 @@
 name: memcached
-version: 2.0.3
+version: 2.0.4
+appVersion: 1.5.6
 description: Free & open source, high-performance, distributed memory object caching
   system.
 keywords:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.