### PR TITLE
Add home key for magic-namespace

### DIFF
--- a/stable/magic-namespace/Chart.yaml
+++ b/stable/magic-namespace/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: magic-namespace
 version: 0.1.1
 appVersion: 2.8.1
-home: https://www.mediawiki.org
+home: https://github.com/kubernetes/helm
 description: Elegantly enables a Tiller per namespace in RBAC-enabled clusters
 maintainers:
 - name: krancour

--- a/stable/magic-namespace/Chart.yaml
+++ b/stable/magic-namespace/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 name: magic-namespace
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.8.1
+home: https://www.mediawiki.org
 description: Elegantly enables a Tiller per namespace in RBAC-enabled clusters
 maintainers:
 - name: krancour


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.