### PR TITLE
Add appVersion for luigi

### DIFF
--- a/stable/luigi/Chart.yaml
+++ b/stable/luigi/Chart.yaml
@@ -18,4 +18,5 @@ keywords:
 - spark
 - kubernetes job manager
 name: luigi
-version: 2.7.2
+version: 2.7.3
+appVersion: 2.7.2


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.