### PR TITLE
Add appVersion for locust

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,7 @@
 name: locust
 description: A modern load testing framework
-version: 0.1.2
+version: 0.1.3
+appVersion: 0.7.5
 maintainers:
   - name: Vincent De Smet
     email: vincent.drl@gmail.com


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.