### PR TITLE
Add appVersion key for linkerd

### DIFF
--- a/stable/linkerd/Chart.yaml
+++ b/stable/linkerd/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 description: Service mesh for cloud native apps
 name: linkerd
-version: 0.4.0
+version: 0.4.1
+appVersion: 1.1.2
 home: https://linkerd.io/
 icon: https://pbs.twimg.com/profile_images/690258997237014528/KNgQd9GL_400x400.png
 sources:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.