### PR TITLE
Add appVersion key for lamp

### DIFF
--- a/stable/lamp/Chart.yaml
+++ b/stable/lamp/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 description: Modular and transparent LAMP stack chart supporting PHP-FPM, Release Cloning, LoadBalancer, Ingress, SSL and lots more!
 name: lamp
-version: 0.1.4
+version: 0.1.5
+appVersion: 5.7
 home: https://github.com/lead4good/helm-lamp-stack
 maintainers:
   - name: lead4good


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.