### PR TITLE
Add appVersion for kube-ops-view

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,5 +1,6 @@
 name: kube-ops-view
-version: 0.4.1
+version: 0.4.2
+appVersion: 1.0.0
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters
 keywords:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.
The value of appVersion 1.1.0 is from https://github.com/hjacobs/kube-ops-view/blob/master/app/package.json