### PR TITLE
Add appVersion key for heapster

### DIFF
--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 description: Heapster enables Container Cluster Monitoring and Performance Analysis.
 name: heapster
-version: 0.2.8
+version: 0.2.9
+appVersion: 1.3.0
 sources:
 - https://github.com/kubernetes/heapster
 - https://github.com/kubernetes/contrib/tree/master/addon-resizer

--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -3,7 +3,7 @@ description: Heapster enables Container Cluster Monitoring and Performance Analy
 name: heapster
 version: 0.2.9
 appVersion: 1.3.0
-home: https://www.heapster.net/
+home: https://github.com/kubernetes/heapster
 sources:
 - https://github.com/kubernetes/heapster
 - https://github.com/kubernetes/contrib/tree/master/addon-resizer

--- a/stable/heapster/Chart.yaml
+++ b/stable/heapster/Chart.yaml
@@ -3,6 +3,7 @@ description: Heapster enables Container Cluster Monitoring and Performance Analy
 name: heapster
 version: 0.2.9
 appVersion: 1.3.0
+home: https://www.heapster.net/
 sources:
 - https://github.com/kubernetes/heapster
 - https://github.com/kubernetes/contrib/tree/master/addon-resizer


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.