### PR TITLE
Add appVersion key for gcloud-sqlproxy

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,6 @@
 name: gcloud-sqlproxy
-version: 0.3.1
+version: 0.3.2
+appVersion: 1.11
 description: Google Cloud SQL Proxy
 keywords:
 - google


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.