### PR TITLE
Add appVersion key for factorio

### DIFF
--- a/stable/factorio/Chart.yaml
+++ b/stable/factorio/Chart.yaml
@@ -1,5 +1,6 @@
 name: factorio
-version: 0.3.0
+version: 0.3.1
+appVersion: 0.14.22
 description: Factorio dedicated server.
 keywords:
 - game

--- a/stable/factorio/values.yaml
+++ b/stable/factorio/values.yaml
@@ -17,7 +17,7 @@ factorioServer:
   description: Factorio running on Kubernetes
   port: 34197
   # Lock this server down with a password.
-  #password: change.me
+  # password: change.me
   maxPlayers: 255
   # Publishes this server in the server browser if true.
   # You'll want to set Factorio.User below if true, as it becomes required.


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.