### PR TITLE
Add appVersion for conchdb

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,6 @@
 name: couchdb
-version: 0.1.0
+version: 0.1.1
+appVersion: 2.1.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
   reliability.


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.