### PR TITLE
Add appVersion key for elasticsearch

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,7 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.4.8
+version: 0.4.9
+appVersion: 5.4
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.