### PR TITLE
Add appVersion key for etcd

### DIFF
--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,6 +1,7 @@
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.3.8
+version: 0.3.9
+appVersion: 2.2.5
 description: Distributed reliable key-value store for the most critical data of a
   distributed system.
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.