### PR TITLE
Add appVersion key for kafka

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.4.7
+version: 0.4.8
+appVersion: 4.0.0
 keywords:
 - kafka
 - zookeeper


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.