### PR TITLE
Add appVersion for kube-registry-proxy

### DIFF
--- a/incubator/kube-registry-proxy/Chart.yaml
+++ b/incubator/kube-registry-proxy/Chart.yaml
@@ -1,6 +1,7 @@
 name: kube-registry-proxy
 home: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry
-version: 0.2.1
+version: 0.2.2
+appVersion: 0.4
 description: Installs the kubernetes-registry-proxy cluster addon.
 maintainers:
 - name: Deis Team


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.