### PR TITLE
Add appVersion key for mysqlha

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,5 +1,6 @@
 name: mysqlha
-version: 0.1.2
+version: 0.1.3
+appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:
   - mysql


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.