### PR TITLE
Add home and appVersion for redis-cache

### DIFF
--- a/incubator/redis-cache/Chart.yaml
+++ b/incubator/redis-cache/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 description: A pure in-memory redis cache, using statefulset and redis-sentinel-micro
 name: redis-cache
-version: 0.3.1
+version: 0.3.2
+appVersion: 3.0
+home: https://redis.io/
 icon: https://redis.io/images/redis-white.png
 sources:
 - https://github.com/antirez/redis

--- a/incubator/redis-cache/values.yaml
+++ b/incubator/redis-cache/values.yaml
@@ -2,8 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-##Statefulset related configurations ss.yaml
-antiAffinity : "hard"
+## Statefulset related configurations ss.yaml
+antiAffinity: "hard"
 replicaCount: 3
 redis:
   image:


### PR DESCRIPTION
The key "appVersion" and "home" are needed for ci testing, they are missing in this yaml. That sometimes will cause testing failure.