### PR TITLE
Add appVersion for webpagetest-agent

### DIFF
--- a/incubator/webpagetest-agent/Chart.yaml
+++ b/incubator/webpagetest-agent/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-agent
-version: 0.1.2
+version: 0.1.3
+appVersion: 2018-01-08
 home: https://www.webpagetest.org/
 icon: https://www.webpagetest.org/images/logo_wpt.png
 sources:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.