### PR TITLE
Add appVersion for webpagetest-server

### DIFF
--- a/incubator/webpagetest-server/Chart.yaml
+++ b/incubator/webpagetest-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-server
 version: 0.1.5
-appVersion: 2018-01-12
+appVersion: "2018-01-12"
 home: https://www.webpagetest.org/
 icon: https://www.webpagetest.org/images/logo_wpt.png
 sources:

--- a/incubator/webpagetest-server/Chart.yaml
+++ b/incubator/webpagetest-server/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: webpagetest-server
-version: 0.1.4
+version: 0.1.5
+appVersion: 2018-01-12
 home: https://www.webpagetest.org/
 icon: https://www.webpagetest.org/images/logo_wpt.png
 sources:


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.