### PR TITLE
Kube-spot has to be able to run kubectl drain

### DIFF
--- a/incubator/kube-spot-termination-notice-handler/Chart.yaml
+++ b/incubator/kube-spot-termination-notice-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Watch and action AWS spot termination events
 name: kube-spot-termination-notice-handler
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.8.1-1
 home: https://github.com/egeland/kube-spot-termination-notice-handler
 source:

--- a/incubator/kube-spot-termination-notice-handler/templates/rbac.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/rbac.yaml
@@ -34,5 +34,33 @@ rules:
   verbs:
   - get
   - list
-  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - replicasets
+  - daemonsets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 {{- end -}}


### PR DESCRIPTION
One of the main functions of kube-spot is running the kubectl drain command. This needs more extensive rights to kubernetes. It has to be able to list everything running on a node + evict those things.

This is a follow-up of https://github.com/kubernetes/charts/pull/4682 and what I encountered during extensive testing.
