### PR TITLE
[incubator/chartmuseum] Introduce multi-tenancy option

### DIFF
--- a/incubator/chartmuseum/Chart.yaml
+++ b/incubator/chartmuseum/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 1.0.1
-appVersion: 0.5.0
+version: 1.1.0
+appVersion: 0.5.1
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png
 keywords:

--- a/incubator/chartmuseum/README.md
+++ b/incubator/chartmuseum/README.md
@@ -53,7 +53,7 @@ their default values. See values.yaml for all available options.
 |----------------------------------------|---------------------------------------------|-----------------------------------------------------|
 | `image.pullPolicy`                     | Container pull policy                       | `IfNotPresent`                                      |
 | `image.repository`                     | Container image to use                      | `chartmuseum/chartmuseum`                           |
-| `image.tag`                            | Container image tag to deploy               | `v0.4.2`                                            |
+| `image.tag`                            | Container image tag to deploy               | `v0.5.1`                                            |
 | `persistence.accessMode`               | Access mode to use for PVC                  | `ReadWriteOnce`                                     |
 | `persistence.enabled`                  | Whether to use a PVC for persistent storage | `false`                                             |
 | `persistence.size`                     | Amount of space to claim for PVC            | `8Gi`                                               |

--- a/incubator/chartmuseum/values.yaml
+++ b/incubator/chartmuseum/values.yaml
@@ -5,7 +5,7 @@ strategy:
     maxUnavailable: 0
 image:
   repository: chartmuseum/chartmuseum
-  tag: v0.4.2
+  tag: v0.5.1
   pullPolicy: IfNotPresent
 env:
   open:


### PR DESCRIPTION
A new version of ChartMuseum was released that introduces multi-tenancy, or multiple orgs/repos for your charts under one server. Update chart image to match latest release. 

