### PR TITLE
[incubator/oauth2-proxy] Enabled custom oauth-proxy configuration file

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.2.3
+version: 0.2.4
 apiVersion: v1
 appVersion: 2.2
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.2.4
+version: 0.3.0
 apiVersion: v1
 appVersion: 2.2
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -44,6 +44,7 @@ Parameter | Description | Default
 `config.clientID` | oauth client ID | `""`
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'` | `""`
+`config.configFile` | custom [oauth2_proxy.cfg](https://github.com/bitly/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `a5huynh/oauth2_proxy`

--- a/stable/oauth2-proxy/templates/configmap.yaml
+++ b/stable/oauth2-proxy/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.config.configFile }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+data:
+  oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}
+{{- end }}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
           - --{{ $key }}
           {{- end }}
         {{- end }}
+        {{- if .Values.config.configFile }}
+          - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        {{- end }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:
@@ -68,6 +71,16 @@ spec:
             port: http
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.config.configFile }}
+        volumeMounts:
+        - mountPath: /etc/oauth2_proxy
+          name: {{ template "oauth2-proxy.fullname" . }}-configmap
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: {{ template "oauth2-proxy.fullname" . }}
+        name: {{ template "oauth2-proxy.fullname" . }}-configmap
+{{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -7,6 +7,11 @@ config:
   # Create a new secret with the following command
   # python -c 'import os,base64; print base64.b64encode(os.urandom(16))'
   cookieSecret: "XXXXXXXXXX"
+  # Custom configuration file: oauth2_proxy.cfg
+  # configFile: |-
+  #   pass_basic_auth = false
+  #   pass_access_token = true
+  configFile: ""
 
 image:
   repository: "a5huynh/oauth2_proxy"


### PR DESCRIPTION
This PR is a Continuation of closed PR https://github.com/kubernetes/charts/pull/3976 which wasn't possible to rebase without force pushing.

Added the ability to define a custom oauth-proxy.cfg file in the values.yaml.  Defining the config.configFile value will instruct the chart to create a configmap, mount the volume into the deployment pod spec, and launch the container image with the argument specifying the config file.

```
config:
  # Custom configuration file: oauth2_proxy.cfg
  # configFile: |-
  #   pass_basic_auth = false
  #   pass_access_token = true
  configFile: ""
```