### PR TITLE
[stable/osclass] Fix wrong image format

### DIFF
--- a/stable/osclass/Chart.yaml
+++ b/stable/osclass/Chart.yaml
@@ -1,5 +1,5 @@
 name: osclass
-version: 1.0.1
+version: 1.0.2
 appVersion: 3.7.4
 description: Osclass is a php script that allows you to quickly create and manage
   your own free classifieds site.

--- a/stable/osclass/templates/deployment.yaml
+++ b/stable/osclass/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "osclass.fullname" . }}
-        image: "{{ .Values.image }}"
-        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
           value: {{ .Values.allowEmptyPassword | quote }}


### PR DESCRIPTION
The way of retrieving the docker image was not coherent with the values.yaml file. Now it is