### PR TITLE
Add appVersion key for check-mk and fix Yaml format error

### DIFF
--- a/incubator/check-mk/Chart.yaml
+++ b/incubator/check-mk/Chart.yaml
@@ -14,4 +14,5 @@ name: check-mk
 sources:
 - https://github.com/kubernetes/charts
 - http://git.mathias-kettner.de/git/
-version: 0.2.0
+version: 0.2.1
+appVersion: 1.4.0p26

--- a/incubator/check-mk/values.yaml
+++ b/incubator/check-mk/values.yaml
@@ -17,7 +17,7 @@ ingress:
   hosts:
     - monitor.ijuned.com
   annotations:
-     kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:
     # Secrets must be manually created in the namespace.
@@ -25,13 +25,13 @@ ingress:
     #   hosts:
     #     - chart-example.local
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious 
-  # choice for the user. This also increases chances charts run on environments with little 
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following 
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #  cpu: 100m
   #  memory: 128Mi
-  #requests:
+  # requests:
   #  cpu: 100m
   #  memory: 128Mi


### PR DESCRIPTION
The key "appVersion" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.