### PR TITLE
Add home and appVersion keys for sentry-kubernetes

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.1.2
+version: 0.1.3
+appVersion: latest
+home: https://github.com/getsentry/sentry-kubernetes
 sources:
 - https://github.com/getsentry/sentry-kubernetes
 keywords:


### PR DESCRIPTION
appVersion: latest
home: https://github.com/getsentry/sentry-kubernetes
The key "appVersion" and "home" are needed for ci testing, they are missing in this yaml. That sometimes will cause testing failure.