### PR TITLE
Add home key for elasticsearch-exporter

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,8 +1,9 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.0.2
+home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:
   - https://github.com/justwatchcom/elasticsearch_exporter
 keywords:


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.