### PR TITLE
Add home key for acs-engine-autoscaler

### DIFF
--- a/stable/acs-engine-autoscaler/Chart.yaml
+++ b/stable/acs-engine-autoscaler/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 description: Scales worker nodes within agent pools
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: acs-engine-autoscaler
-version: 2.1.3
+version: 2.1.4
 appVersion: 2.1.1
+home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
 sources:
 - https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
 maintainers:


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.