### PR TITLE
Add home key for fluentd-cloudwatch

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,7 +1,7 @@
 name: fluentd-cloudwatch
 version: 0.2.3
 appVersion: 0.1.1
-home: https://aws.amazon.com/cloudwatch/
+home: https://www.fluentd.org/
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 keywords:

--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,7 @@
 name: fluentd-cloudwatch
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.1.1
+home: https://aws.amazon.com/cloudwatch/
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 keywords:


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.