### PR TITLE
Add home key for fluentd-elasticsearch

### DIFF
--- a/incubator/fluentd-elasticsearch/Chart.yaml
+++ b/incubator/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,7 @@
 name: fluentd-elasticsearch
-version: 0.2.0
+version: 0.2.1
 appVersion: 2.0.4
+home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 keywords:


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.