### PR TITLE
Add home key for fluentd

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.12
+home: https://www.fluentd.org/
 sources:
 - https://quay.io/repository/coreos/fluentd-kubernetes
 - https://github.com/coreos/fluentd-kubernetes-daemonset


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.