### PR TITLE
Add home key to kubewatch

### DIFF
--- a/incubator/kubewatch/Chart.yaml
+++ b/incubator/kubewatch/Chart.yaml
@@ -1,6 +1,7 @@
 name: kubewatch
-version: 0.2.1
+version: 0.2.2
 appVersion: v0.0.3
+home: https://github.com/skippbox/kubewatch
 description: Kubewatch notifies your slack rooms when changes to your cluster occur
 keywords:
 - kubernetes


### PR DESCRIPTION
The key "home" is needed for ci testing, it's missing in this yaml. That sometimes will cause testing failure.