### PR TITLE
stable/metallb: Refactor the config-passing part of the chart.

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.3.1
+version: 0.4.0
 
 name: metallb
 appVersion: 0.5.0

--- a/stable/metallb/templates/NOTES.txt
+++ b/stable/metallb/templates/NOTES.txt
@@ -1,18 +1,11 @@
 
 MetalLB is now running in the cluster.
-{{ if .Values.config.simpleLayer2 -}}
-LoadBalancer Services in your cluster are now available on IPs within
-{{ .Values.config.simpleLayer2 }}. To see the IP assignments, try
-`kubectl get services`.
-{{- else if .Values.config.inline }}
+{{- if .Values.configInline }}
 LoadBalancer Services in your cluster are now available on the IPs you
 defined in MetalLB's configuration. To see IP assignments,
 try `kubectl get services`.
-{{- else if .Values.config.name }}
+{{- else }}
 WARNING: you specified a ConfigMap that isn't managed by
 Helm. LoadBalancer services will not function until you add that
 ConfigMap to your cluster yourself.
-{{- else }}
-WARNING: you did not provide a configuration for MetalLB. LoadBalancer
-services will not function until you provide a configuration.
 {{- end }}

--- a/stable/metallb/templates/NOTES.txt
+++ b/stable/metallb/templates/NOTES.txt
@@ -1,13 +1,17 @@
 
 MetalLB is now running in the cluster.
-{{ if .Values.arpAddresses -}}
-LoadBalancer Services in your cluster are now available on IPs
-within {{ .Values.arpAddresses }}. To see the IP assignments,
-try `kubectl get services`.
-{{- else if .Values.config }}
+{{ if .Values.config.simpleLayer2 -}}
+LoadBalancer Services in your cluster are now available on IPs within
+{{ .Values.config.simpleLayer2 }}. To see the IP assignments, try
+`kubectl get services`.
+{{- else if .Values.config.inline }}
 LoadBalancer Services in your cluster are now available on the IPs you
 defined in MetalLB's configuration. To see IP assignments,
 try `kubectl get services`.
+{{- else if .Values.config.name }}
+WARNING: you specified a ConfigMap that isn't managed by
+Helm. LoadBalancer services will not function until you add that
+ConfigMap to your cluster yourself.
 {{- else }}
 WARNING: you did not provide a configuration for MetalLB. LoadBalancer
 services will not function until you provide a configuration.

--- a/stable/metallb/templates/_helpers.tpl
+++ b/stable/metallb/templates/_helpers.tpl
@@ -60,6 +60,6 @@ Create the name of the settings ConfigMap to use.
 {{- if .Values.configInline -}}
     {{ include "metallb.fullname" . }}
 {{- else -}}
-    {{ .Values.configName }}
+    {{ .Values.existingConfigMap }}
 {{- end -}}
 {{- end -}}

--- a/stable/metallb/templates/_helpers.tpl
+++ b/stable/metallb/templates/_helpers.tpl
@@ -57,9 +57,9 @@ Create the name of the speaker service account to use
 Create the name of the settings ConfigMap to use.
 */}}
 {{- define "metallb.configMapName" -}}
-{{- if (or .Values.config.inline .Values.config.simpleLayer2) -}}
+{{- if .Values.configInline -}}
     {{ include "metallb.fullname" . }}
 {{- else -}}
-    {{ .Values.config.name }}
+    {{ .Values.configName }}
 {{- end -}}
 {{- end -}}

--- a/stable/metallb/templates/_helpers.tpl
+++ b/stable/metallb/templates/_helpers.tpl
@@ -52,3 +52,14 @@ Create the name of the speaker service account to use
     {{ default "default" .Values.serviceAccounts.speaker.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the settings ConfigMap to use.
+*/}}
+{{- define "metallb.configMapName" -}}
+{{- if (or .Values.config.inline .Values.config.simpleLayer2) -}}
+    {{ include "metallb.fullname" . }}
+{{- else -}}
+    {{ .Values.config.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -1,4 +1,4 @@
-{{- if (or .Values.config .Values.arpAddresses) }}
+{{- if (or .Values.config.inline .Values.config.simpleLayer2) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,13 +10,13 @@ metadata:
     app: {{ template "metallb.name" . }}
 data:
   config: |
-{{- if .Values.config }}
-{{ toYaml .Values.config | indent 4 }}
+{{- if .Values.config.inline }}
+{{ toYaml .Values.config.inline | indent 4 }}
 {{- else }}
     address-pools:
     - name: default
-      protocol: arp
-      cidr:
-      - {{ .Values.arpAddresses }}
+      protocol: layer2
+      addresses:
+      - {{ .Values.config.simpleLayer2 }}
 {{- end }}
 {{- end }}

--- a/stable/metallb/templates/config.yaml
+++ b/stable/metallb/templates/config.yaml
@@ -1,4 +1,4 @@
-{{- if (or .Values.config.inline .Values.config.simpleLayer2) }}
+{{- if .Values.configInline }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,13 +10,5 @@ metadata:
     app: {{ template "metallb.name" . }}
 data:
   config: |
-{{- if .Values.config.inline }}
-{{ toYaml .Values.config.inline | indent 4 }}
-{{- else }}
-    address-pools:
-    - name: default
-      protocol: layer2
-      addresses:
-      - {{ .Values.config.simpleLayer2 }}
-{{- end }}
+{{ toYaml .Values.configInline | indent 4 }}
 {{- end }}

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -40,7 +40,7 @@ spec:
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         args:
         - --port=7472
-        - --config={{ template "metallb.fullname" . }}
+        - --config={{ template "metallb.configMapName" . }}
         ports:
         - name: monitoring
           containerPort: 7472

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -19,7 +19,7 @@ rules:
   verbs: ["update"]
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"]
+  verbs: ["create", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -37,7 +37,7 @@ spec:
         imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
         args:
         - --port=7472
-        - --config={{ template "metallb.fullname" . }}
+        - --config={{ template "metallb.configMapName" . }}
         env:
         - name: METALLB_NODE_IP
           valueFrom:

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -2,21 +2,22 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# config lets you specify MetalLB's configuration in various
-# ways. Use one of name, inline, or simpleLayer2.
-config:
-  # name specifies the name of an externally-defined ConfigMap to use
-  # as the configuration.
-  name: metallb-config
-  # inline specifies MetalLB's configuration directly, in yaml
-  # format. Refer to https://metallb.universe.tf/configuration/ for
-  # available options.
-  inline:
-  # simpleLayer2 accepts an IP address range and generates a trivial
-  # "quick start" MetalLB configuration that uses layer 2 mode. Refer
-  # to https://metallb.universe.tf/ for more information. This option
-  # is not recommended for production use.
-  simpleLayer2:
+# To configure MetalLB, you must specify ONE of the following two
+# options.
+
+# configName specifies the name of an externally-defined ConfigMap to
+# use as the configuration. Helm will not manage the contents of this
+# ConfigMap, it is your responsibility to create it.
+configName: metallb-config
+
+# configInline specifies MetalLB's configuration directly, in yaml
+# format. When configInline is used, Helm manages MetalLB's
+# configuration ConfigMap as part of the release, and configName is
+# ignored.
+#
+# Refer to https://metallb.universe.tf/configuration/ for
+# available options.
+configInline:
 
 rbac:
   # create specifies whether to install and use RBAC rules.

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -5,15 +5,15 @@
 # To configure MetalLB, you must specify ONE of the following two
 # options.
 
-# configName specifies the name of an externally-defined ConfigMap to
-# use as the configuration. Helm will not manage the contents of this
-# ConfigMap, it is your responsibility to create it.
-configName: metallb-config
+# existingConfigMap specifies the name of an externally-defined
+# ConfigMap to use as the configuration. Helm will not manage the
+# contents of this ConfigMap, it is your responsibility to create it.
+existingConfigMap: metallb-config
 
 # configInline specifies MetalLB's configuration directly, in yaml
 # format. When configInline is used, Helm manages MetalLB's
-# configuration ConfigMap as part of the release, and configName is
-# ignored.
+# configuration ConfigMap as part of the release, and
+# existingConfigMap is ignored.
 #
 # Refer to https://metallb.universe.tf/configuration/ for
 # available options.

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -2,16 +2,21 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# config is the MetalLB configuration, in YAML format. Refer to
-# https://metallb.universe.tf/configuration/ for available options.
+# config lets you specify MetalLB's configuration in various
+# ways. Use one of name, inline, or simpleLayer2.
 config:
-
-# When arpAddresses is specified instead of config, the chart will
-# install a trivial "quick start" MetalLB configuration that uses ARP
-# mode. Refer to https://metallb.universe.tf/ for more
-# information. For production configurations, use of the `config`
-# field is recommended instead of arpAddresses.
-arpAddresses:
+  # name specifies the name of an externally-defined ConfigMap to use
+  # as the configuration.
+  name: metallb-config
+  # inline specifies MetalLB's configuration directly, in yaml
+  # format. Refer to https://metallb.universe.tf/configuration/ for
+  # available options.
+  inline:
+  # simpleLayer2 accepts an IP address range and generates a trivial
+  # "quick start" MetalLB configuration that uses layer 2 mode. Refer
+  # to https://metallb.universe.tf/ for more information. This option
+  # is not recommended for production use.
+  simpleLayer2:
 
 rbac:
   # create specifies whether to install and use RBAC rules.


### PR DESCRIPTION
Replaces `simpleLayer2` with a choice between 2 ways of configuring MetalLB:

- use `configInline` to specify a MetalLB configuration in values.yaml. Helm will manage the ConfigMap in the release.
- use `configName` to specify an existing external ConfigMap. Helm will not manage the ConfigMap, it will just point to it in pod specs.