### PR TITLE
Fix wrong service name in NOTES.txt

### DIFF
--- a/stable/minio/templates/NOTES.txt
+++ b/stable/minio/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{- if eq .Values.service.type "ClusterIP" "NodePort" }}
 Minio can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
-{{ template "minio.fullname" . }}-svc.{{ .Release.Namespace }}.svc.cluster.local
+{{ template "minio.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To access Minio from localhost, run the below commands:
 


### PR DESCRIPTION
The `-svc` post fix is not correct anymore.
