### PR TITLE
[stable/dask] Correctly refer to worker.resources.limits

### DIFF
--- a/stable/dask/Chart.yaml
+++ b/stable/dask/Chart.yaml
@@ -1,5 +1,5 @@
 name: dask
-version: 1.0.2
+version: 1.0.3
 appVersion: 0.17.1
 description: Distributed computation in Python with task scheduling
 home: https://dask.pydata.org

--- a/stable/dask/templates/dask-worker-deployment.yaml
+++ b/stable/dask/templates/dask-worker-deployment.yaml
@@ -31,11 +31,11 @@ spec:
           args:
             - dask-worker
             - {{ template "dask.fullname" . }}-scheduler:{{ .Values.scheduler.servicePort }}
-          {{- if .Values.worker.limits }}
+          {{- if .Values.worker.resources.limits }}
             - --nthreads
-            - {{ default .Values.worker.limits.cpu .Values.workers.default_resources.cpu | quote }}
+            - {{ .Values.worker.resources.limits.cpu | default .Values.worker.default_resources.cpu | quote }}
             - --memory-limit
-            - {{ default .Values.worker.limits.memory .Values.workers.default_resources.memory | quote }}
+            - {{ .Values.worker.resources.limits.memory | default .Values.worker.default_resources.memory | quote }}
           {{- end }}
             - --no-bokeh
           ports:


### PR DESCRIPTION
Previously we referred to worker.limits, which didn't exist.

Additionally we had the arguments of default reordered

