### PR TITLE
[stable/anchore-engine] Fixes configMap mount issue with newer k8s

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,6 +1,6 @@
 name: anchore-engine
-version: 0.1.4
-appVersion: 0.1.6
+version: 0.1.5
+appVersion: 0.1.9
 description: Anchore container analysis and policy evaluation engine service
 keywords:
  - analysis

--- a/stable/anchore-engine/templates/core_configmap.yaml
+++ b/stable/anchore-engine/templates/core_configmap.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   config.yaml: |
     # Anchore Service Configuration File from ConfigMap
-    service_dir: {{ default "/config" .Values.globalConfig.configDir }}
+    service_dir: {{ .Values.globalConfig.configDir }}
     tmp_dir: "/tmp"
 
     allow_awsecr_iam_auto: {{ .Values.globalConfig.allowECRUseIAMRole }}

--- a/stable/anchore-engine/templates/worker_configmap.yaml
+++ b/stable/anchore-engine/templates/worker_configmap.yaml
@@ -15,7 +15,7 @@ data:
     # General system-wide configuration options, these should not need to
     # be altered for basic operation
     #
-    service_dir: {{ default "/config" .Values.globalConfig.configDir }}
+    service_dir: {{ .Values.globalConfig.configDir }}
     tmp_dir: {{ default "/tmp" .Values.workerConfig.analyzerScratchDir }}
 
     allow_awsecr_iam_auto: {{ .Values.globalConfig.allowECRUseIAMRole }}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -11,8 +11,8 @@ service:
     k8sImagePolicyWebhook: 8338
 
 image:
-  # Specific version tags are also available, e.g. v0.1.5, v0.1.6,...
-  tag: docker.io/anchore/anchore-engine:latest
+  # Can use 'latest' but not recommended
+  tag: docker.io/anchore/anchore-engine:v0.1.9
   # pullPolicy: IfNotPresent
 
 # Used to create Ingress record (should used with service.type: ClusterIP or NodePort depending on platform)
@@ -42,6 +42,9 @@ postgresql:
 
 # Global configuration shared by both core and worker
 globalConfig:
+  # Set where default configs are placed at startup. This must be a writable location for the pod.
+  configDir: /anchore_service_config
+
   dbConfig:
     timeout: 120
     # Use ssl, but the default postgresql config in helm's stable repo does not support ssl on server side, so this should be set for external dbs only for the time being


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes error in stable/anchore-engine chart when used in K8s v1.9 caused by read-only configmap mounts and locks application version in chart. Adds new default value for globalConfig.configDir to specify different config directory than the where configMap is mounted. Users should not need to change this value.

Also, locks specific app version and specific tag instead of 'latest' to ensure no unexpected upgrades and that chart updates coincide with application version upgrades by default.

**Special notes for your reviewer**:
The issue this fixes is a result of changes in v1.9 of K8s (https://github.com/kubernetes/kubernetes/pull/58720), so the issue not affect older k8s versions. For best testing please use a v1.9 cluster if available.