### PR TITLE
[stable/concourse] Prevent the secrets namespace from being deleted

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.2.3
+version: 1.3.0
 appVersion: 3.10.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -140,7 +140,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistence using Persistent Volume Claims | `true` |
 | `credentialManager.kubernetes.enabled` | Enable Kubernetes Secrets Credential Manager | `true` |
 | `credentialManager.kubernetes.namespacePrefix` | Prefix for namespaces to look for secrets in | `.Release.Name-` |
-| `credentialManager.kubernetes.teams` | Teams to allow secret access when RBAC is enabled | `["main"]` |
+| `credentialManager.kubernetes.teams` | Teams to create namespaces for to hold secrets | `["main"]` |
+| `credentialManager.kubernetes.keepNamespaces` | Don't delete namespaces when the release is deleted | `true` |
 | `credentialManager.ssm.enabled` | Use AWS SSM as a Credential Manager | `false` |
 | `credentialManager.ssm.region` | AWS Region to use for SSM | `nil` |
 | `credentialManager.ssm.pipelineSecretsTemplate` | Pipeline secrets template | `nil` |
@@ -316,7 +317,9 @@ Pipelines usually need credentials to do things. Concourse supports the use of a
 
 #### Kubernetes Secrets
 
-By default, this chart will use Kubernetes Secrets as a credential manager. For a given Concourse *team*, a pipeline will look for secrets in a namespace named `[namespacePrefix][teamName]`. The namespace prefix is the release name hyphen by default, and can be overridden with the value `credentialManager.kubernetes.namespacePrefix`. The service account used by Concourse must have `get` access to secrets in that namespace. When `rbac.create` is true, this access is granted for each team listed under `credentialManager.kubernetes.teams`.
+By default, this chart will use Kubernetes Secrets as a credential manager. For a given Concourse *team*, a pipeline will look for secrets in a namespace named `[namespacePrefix][teamName]`. The namespace prefix is the release name hyphen by default, and can be overridden with the value `credentialManager.kubernetes.namespacePrefix`. Each team listed under `credentialManager.kubernetes.teams` will have a namespace created for it, and the namespace will remain after deletion of the release unless you set `credentialManager.kubernetes.keepNamespace` to `false`. By default, a namespace will be created for the `main` team.
+
+The service account used by Concourse must have `get` access to secrets in that namespace. When `rbac.create` is true, this access is granted for each team listed under `credentialManager.kubernetes.teams`.
 
 Here are some examples of the lookup heuristics, given release name `concourse`:
 

--- a/stable/concourse/templates/namespace.yaml
+++ b/stable/concourse/templates/namespace.yaml
@@ -4,6 +4,10 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+{{- if $.Values.credentialManager.kubernetes.keepNamespaces }}
+  annotations:
+    "helm.sh/resource-policy": keep
+{{- end }}
   name: {{ template "concourse.namespacePrefix" $ }}{{ . }}
   labels:
     app: {{ template "concourse.concourse.fullname" $ }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -457,6 +457,10 @@ credentialManager:
     teams:
       - main
 
+    ## When true, namespaces are not deleted when the release is deleted.
+
+    keepNamespaces: true
+
   ## Configuration for AWS SSM as the Credential Manager. Supported in Concourse 3.9.0.
   ##
   ssm:


### PR DESCRIPTION
When using Kubernetes secrets as a credentials manager, the chart will create a namespace where pipeline secrets are read from. When the release is deleted, the namespace will also be deleted, along with the secrets it stores. This might not be desirable in some situations, e.g. the namespace is used for other purposes, or if you are upgrading by creating a new release and setting the `credentialManager.kubernetes.namespacePrefix` value so that the old and new release use the same secrets namespace.