### PR TITLE
[rabbitmq] Use a safe cluster_formation.node_cleanup.only_log_warning value

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.3
-version: 1.3.1
+version: 1.3.2
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -58,7 +58,7 @@ data:
     cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
     cluster_formation.k8s.address_type = hostname
     cluster_formation.node_cleanup.interval = 10
-    # Set to true if automatic cleanup of absent nodes is desired.
+    # Set to false if automatic cleanup of absent nodes is desired.
     # This can be dangerous, see http://www.rabbitmq.com/cluster-formation.html#node-health-checks-and-cleanup.
     cluster_formation.node_cleanup.only_log_warning = true
     cluster_partition_handling = autoheal

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -58,7 +58,9 @@ data:
     cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
     cluster_formation.k8s.address_type = hostname
     cluster_formation.node_cleanup.interval = 10
-    cluster_formation.node_cleanup.only_log_warning = false
+    # Set to true if automatic cleanup of absent nodes is desired.
+    # This can be dangerous, see http://www.rabbitmq.com/cluster-formation.html#node-health-checks-and-cleanup.
+    cluster_formation.node_cleanup.only_log_warning = true
     cluster_partition_handling = autoheal
 
     ## The default "guest" user is only permitted to access the server


### PR DESCRIPTION
This chart ended up adopting an unfortunate value used in an example
that can be found in the K8S peer discovery plugin [1].

The goal was never to recommend it to all users, as the docs are pretty
clear [2] on that automatic node cleanup can have dangerous side effects when nodes go offline temporarily, e.g. as in [3].

Kudos to Petr Šebek for pointing this out on rabbitmq-users [4].

References kubernetes/charts#4474, kubernetes/charts#4519.

1. https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/blob/b309d641ce7ccf135d02fb39254e8c67c98d3a63/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml#L40
2. http://www.rabbitmq.com/cluster-formation.html#node-health-checks-and-cleanup
3. https://groups.google.com/d/msg/rabbitmq-users/wuOfzEywHXo/vm3n1VsfBgAJ
4. https://groups.google.com/forum/#!msg/rabbitmq-users/wuOfzEywHXo/k8z_HWIkBgAJ
