### PR TITLE
[stable/grafana] - Fix for config-map read-only mountpoint issue (#4708)

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 0.8.5
+version: 0.8.6
 appVersion: 5.0.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/templates/dashboards-import-job-configmap.yaml
+++ b/stable/grafana/templates/dashboards-import-job-configmap.yaml
@@ -12,13 +12,12 @@ data:
   init.sh: |
     #!/bin/sh
     set -e
-    mkdir -p /tmp/grafana/
-    cp -r /var/lib/grafana/import /tmp/grafana/
+    mkdir -p /tmp/grafana/import
     cd /tmp/grafana/import
     {{- range $name, $val := .Values.dashboardImports.dashboards }}
       wget -O {{ $name }} {{ $val }}
     {{- end }}
-    for dashboard in $(ls); do
+    for dashboard in $(ls /var/lib/grafana/import/* /tmp/grafana/import/* 2> /dev/null); do
       wget \
       "http://{{ template "grafana.server.fullname" . }}:{{ .Values.server.service.httpPort }}/api/dashboards/db" \
       --user=${ADMIN_USER} \

--- a/stable/grafana/templates/dashboards-import-job-configmap.yaml
+++ b/stable/grafana/templates/dashboards-import-job-configmap.yaml
@@ -12,7 +12,9 @@ data:
   init.sh: |
     #!/bin/sh
     set -e
-    cd /var/lib/grafana/import
+    mkdir -p /tmp/grafana/
+    cp -r /var/lib/grafana/import /tmp/grafana/
+    cd /tmp/grafana/import
     {{- range $name, $val := .Values.dashboardImports.dashboards }}
       wget -O {{ $name }} {{ $val }}
     {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: this PR fixes issue when writing JSON dashboard files to disk under dashboardimport config-map mountpoint. @zanhsieh  @jgoclawski 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4708 

