### PR TITLE
[incubator/vault] add standbyok to readinessProbe

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.4.3
+version: 0.4.4
 appVersion: 0.9.0
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             port: {{ .Values.service.port }}
         readinessProbe:
           httpGet:
-            path: /v1/sys/health
+            path: /v1/sys/health?standbyok=true
             port: {{ .Values.service.port }}
         securityContext:
           readOnlyRootFilesystem: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Continues on #4068 , current version does not pass `readinessProbe` even after unsealing all instances due to Vault returning `429` instead of `200` on standby nodes by default

As per [documentation](https://www.vaultproject.io/docs/concepts/ha.html#request-forwarding) Vault automatically forwards requests within cluster so this is safe option.

**Special notes for your reviewer**:
