### PR TITLE
stable/prestashop: fix non-existing bitnami/prestashop image-version

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.7.3
 description: A popular open source ecommerce solution. Professional tools are easily
   accessible to increase online sales including instant guest checkout, abandoned

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: bitnami/prestashop
-  tag: 1.7.3-0
+  tag: 1.7.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**What this PR does / why we need it**:

image docker.io/bitnami/prestashop:1.7.3-0 does not exist; changed to 1.7.3