### PR TITLE
[stable/mariadb] add release to pod selector

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 3.0.2
+version: 3.0.3
 appVersion: 10.1.32
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software.
 keywords:

--- a/stable/mariadb/templates/deployment.yaml
+++ b/stable/mariadb/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: {{ template "mariadb.name" . }}
+        release: "{{ .Release.Name }}"
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/mariadb/templates/svc.yaml
+++ b/stable/mariadb/templates/svc.yaml
@@ -30,3 +30,4 @@ spec:
 {{- end }}
   selector:
     app: {{ template "mariadb.name" . }}
+    release: "{{ .Release.Name }}"


### PR DESCRIPTION
#3811 refactored the `app` label to exclude the release prefix. This requires the service to use `release` as an additional pod selector.