### PR TITLE
Improving RabbitMQ chart NOTES.txt

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.7.4
+version: 0.7.5
 appVersion: 3.7.4
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/NOTES.txt
+++ b/stable/rabbitmq/templates/NOTES.txt
@@ -1,54 +1,61 @@
 
 ** Please be patient while the chart is being deployed **
 
-  Credentials:
+Credentials:
 
-    echo Username      : {{ .Values.rabbitmq.username }}
-    echo Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
-    echo ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
+    Username      : {{ .Values.rabbitmq.username }}
+    Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
+    ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
 
-  RabbitMQ can be accessed within the cluster on port {{ .Values.rabbitmq.nodePort }} at {{ template "rabbitmq.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+RabbitMQ can be accessed within the cluster on port {{ .Values.rabbitmq.nodePort }} at {{ template "rabbitmq.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
-  To access for outside the cluster execute the following commands:
+To access for outside the cluster, perform the following steps:
 
 {{- if contains "NodePort" .Values.serviceType }}
+
+Obtain the NodePort IP and ports:
 
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     export NODE_PORT_AMQP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "rabbitmq.fullname" . }})
     export NODE_PORT_STATS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[3].nodePort}" services {{ template "rabbitmq.fullname" . }})
 
-  To Access the RabbitMQ AMQP port:
+To Access the RabbitMQ AMQP port:
 
-    echo amqp://$NODE_IP:$NODE_PORT_AMQP/
+    URL : amqp://$NODE_IP:$NODE_PORT_AMQP/
 
-  To Access the RabbitMQ Management interface:
+To Access the RabbitMQ Management interface:
 
-    echo http://$NODE_IP:$NODE_PORT_STATS/
+    URL : http://$NODE_IP:$NODE_PORT_STATS/
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "rabbitmq.fullname" . }}'
+Obtain the LoadBalancer IP:
+
+NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+      Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "rabbitmq.fullname" . }}'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
-  To Access the RabbitMQ AMQP port:
+To Access the RabbitMQ AMQP port:
 
-    echo amqp://$SERVICE_IP:{{ .Values.rabbitmq.nodePort }}/
+    URL : amqp://$SERVICE_IP:{{ .Values.rabbitmq.nodePort }}/
 
-  To Access the RabbitMQ Management interface:
+To Access the RabbitMQ Management interface:
 
-    echo http://$SERVICE_IP:{{ .Values.rabbitmq.managerPort }}/
+    URL : http://$SERVICE_IP:{{ .Values.rabbitmq.managerPort }}/
 
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-   kubectl port-forward {{ template "rabbitmq.fullname" . }}-0  --namespace {{ .Release.Namespace }} {{ .Values.rabbitmq.nodePort }}:{{ .Values.rabbitmq.nodePort }} {{ .Values.rabbitmq.managerPort }}:{{ .Values.rabbitmq.managerPort }}
+Create a proxy server between localhost and the Kubernetes API Server:
 
-  To Access the RabbitMQ AMQP port:
+    kubectl proxy --port 8002 &
 
-    echo amqp://127.0.0.1:{{ .Values.rabbitmq.nodePort }}/
+To Access the RabbitMQ AMQP port:
 
-  To Access the RabbitMQ Management interface:
+    URL : amqp://127.0.0.1:8002/api/v1/proxy/namespaces/{{ .Release.Namespace }}/services/{{ template "rabbitmq.fullname" . }}:{{ .Values.rabbitmq.nodePort }}/
 
-    echo URL : http://127.0.0.1:{{ .Values.rabbitmq.managerPort }}
+To Access the RabbitMQ Management interface:
+
+    URL : http://127.0.0.1:8002/api/v1/proxy/namespaces/{{ .Release.Namespace }}/services/{{ template "rabbitmq.fullname" . }}:{{ .Values.rabbitmq.managerPort }}/
+
 {{- end }}

--- a/stable/rabbitmq/templates/NOTES.txt
+++ b/stable/rabbitmq/templates/NOTES.txt
@@ -4,8 +4,8 @@
 Credentials:
 
     Username      : {{ .Values.rabbitmq.username }}
-    Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
-    ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
+    echo Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
+    echo ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
 
 RabbitMQ can be accessed within the cluster on port {{ .Values.rabbitmq.nodePort }} at {{ template "rabbitmq.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
@@ -21,11 +21,11 @@ Obtain the NodePort IP and ports:
 
 To Access the RabbitMQ AMQP port:
 
-    URL : amqp://$NODE_IP:$NODE_PORT_AMQP/
+    echo URL : amqp://$NODE_IP:$NODE_PORT_AMQP/
 
 To Access the RabbitMQ Management interface:
 
-    URL : http://$NODE_IP:$NODE_PORT_STATS/
+    echo URL : http://$NODE_IP:$NODE_PORT_STATS/
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
@@ -38,11 +38,11 @@ NOTE: It may take a few minutes for the LoadBalancer IP to be available.
 
 To Access the RabbitMQ AMQP port:
 
-    URL : amqp://$SERVICE_IP:{{ .Values.rabbitmq.nodePort }}/
+    echo URL : amqp://$SERVICE_IP:{{ .Values.rabbitmq.nodePort }}/
 
 To Access the RabbitMQ Management interface:
 
-    URL : http://$SERVICE_IP:{{ .Values.rabbitmq.managerPort }}/
+    echo URL : http://$SERVICE_IP:{{ .Values.rabbitmq.managerPort }}/
 
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 

--- a/stable/rabbitmq/templates/NOTES.txt
+++ b/stable/rabbitmq/templates/NOTES.txt
@@ -48,7 +48,7 @@ To Access the RabbitMQ Management interface:
 
 Create a proxy server between localhost and the Kubernetes API Server:
 
-    kubectl proxy --port 8002 &
+    kubectl proxy --port 8002
 
 To Access the RabbitMQ AMQP port:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the Notes displayed to the user when installing the RabbitMQ Chart:

 - Substitute the `kubectl port-forward` with `kubectl proxy` on instructions to connect remotely when using "ClusterIP".

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

The user should always access through RabbitMQ the service instead of directly accessing the pod.

**Special notes for your reviewer**:
