### PR TITLE
[incubator/jaeger] support ES_NODES_WAN_ONLY for spark job

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.10
+version: 0.3.11
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -199,6 +199,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.elasticsearch.port`             | Provisioned elasticsearch port      |  9200                                  |
 | `storage.elasticsearch.scheme`           | Provisioned elasticsearch scheme    |  http                                  |
 | `storage.elasticsearch.user`             | Provisioned elasticsearch user      |  elastic                               |
+| `storage.elasticsearch.nodesWanOnly`     | Only access specified es host       |  false                                 |
 | `storage.type`                           | Storage type (ES or Cassandra)      |  cassandra                             |
 |------------------------------------------|-------------------------------------|----------------------------------------|
 

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -22,7 +22,7 @@ data:
   es.password: {{ .Values.storage.elasticsearch.password }}
   es.server-urls: {{ template "elasticsearch.client.url" . }}
   es.username: {{ .Values.storage.elasticsearch.user }}
-  es.nodes-wan-only: {{ .Values.storage.elasticsearch.nodesWanOnly }}
+  es.nodes-wan-only: {{ .Values.storage.elasticsearch.nodesWanOnly | quote }}
   hotrod.agent-host: {{ template "jaeger.hotrod.tracing.host" . }}
   hotrod.agent-port: {{ .Values.hotrod.tracing.port | quote }}
   span-storage.type: {{ .Values.storage.type | quote }}

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -22,6 +22,7 @@ data:
   es.password: {{ .Values.storage.elasticsearch.password }}
   es.server-urls: {{ template "elasticsearch.client.url" . }}
   es.username: {{ .Values.storage.elasticsearch.user }}
+  es.nodes-wan-only: {{ .Values.storage.elasticsearch.nodesWanOnly }}
   hotrod.agent-host: {{ template "jaeger.hotrod.tracing.host" . }}
   hotrod.agent-port: {{ .Values.hotrod.tracing.port | quote }}
   span-storage.type: {{ .Values.storage.type | quote }}

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -62,6 +62,11 @@ spec:
                 configMapKeyRef:
                   name: {{ template "jaeger.fullname" . }}
                   key: es.server-urls
+            - name: ES_NODES_WAN_ONLY
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ template "jaeger.fullname" . }}
+                  key: es.nodes-wan-only
             - name: ES_PASSWORD
               valueFrom:
                 configMapKeyRef:

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -20,6 +20,7 @@ storage:
     port: 9200
     user: elastic
     password: changeme
+    nodesWanOnly: false
 
 # Begin: Override values on the Cassandra subchart to customize for Jaeger
 cassandra:


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows the [ES_NODES_WAN_ONLY](https://github.com/jaegertracing/spark-dependencies/blob/master/README.md#elasticsearch) environment variable to be set for the spark dependencies job. Defaults to `false` (current behavior).

Setting this is necessary for the spark job to work in situations where ES node discovery causes issues. In particular we need it for the job to work with AWS elasticsearch clusters.

@dvonthenen @pavelnikolov 