### PR TITLE
[stable/datadog] Non-local traffic for agent v6 deployment

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 name: datadog
-version: 0.11.1
-appVersion: 6.0.0
+version: 0.11.2
+appVersion: 6.1.2
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -45,7 +45,9 @@ spec:
             value: {{ .Values.datadog.logLevel | quote }}
           {{- end }}
           {{- if .Values.datadog.nonLocalTraffic }}
-          - name: NON_LOCAL_TRAFFIC
+          - name: NON_LOCAL_TRAFFIC # agent5
+            value: {{ .Values.datadog.nonLocalTraffic | quote }}
+          - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC # agent6
             value: {{ .Values.datadog.nonLocalTraffic | quote }}
           {{- end }}
           {{- if .Values.datadog.tags }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: datadog/agent               # Agent6
   # repository: datadog/dogstatsd         # Standalone DogStatsD6
   # repository: datadog/docker-dd-agent   # Agent5
-  tag: 6.0.0  # Use 6.0.0-jmx to enable jmx fetch collection
+  tag: 6.1.2  # Use 6.1.2-jmx to enable jmx fetch collection
   pullPolicy: IfNotPresent
 
 # NB! Normally you need to keep Datadog DaemonSet enabled!


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/charts/pull/3938, if we want to run dogstatd with agent 6 currently it won't accept non local traffic.