### PR TITLE
Typo fix in uchiwa/README.md

### DIFF
--- a/stable/uchiwa/Chart.yaml
+++ b/stable/uchiwa/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: uchiwa
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.22
 description: Dashboard for the Sensu monitoring framework
 keywords:

--- a/stable/uchiwa/README.md
+++ b/stable/uchiwa/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the Uchiwa chart and th
 | `image`                              | Uchiwa image                          | `sstarcher/uchiwa`                              |
 | `imageTag`                              | Uchiwa version                          | `0.22`                              |
 | `imagePullPolicy`                    | Image pull policy                        | `IfNotPresent`   |
-| `replicaCount`         | Number of uchiwa replicas | `1`  |
+| `replicaCount`         | Number of Uchiwa replicas | `1`  |
 | `httpPort` | Service port for Kubernetes | `80` |
 | `routable` | Enables routing through the Deis router | `false` |
 | `resources.requests.cpu` | CPU request for Uchiwa | `10m` |

--- a/stable/uchiwa/README.md
+++ b/stable/uchiwa/README.md
@@ -61,12 +61,12 @@ The following table lists the configurable parameters of the Uchiwa chart and th
 | `imageTag`                              | Uchiwa version                          | `0.22`                              |
 | `imagePullPolicy`                    | Image pull policy                        | `IfNotPresent`   |
 | `replicaCount`         | Number of uchiwa replicas | `1`  |
-| `httpPort` | Service port for kubernetes | `80` |
+| `httpPort` | Service port for Kubernetes | `80` |
 | `routable` | Enables routing through the Deis router | `false` |
-| `resources.requests.cpu` | CPU request for uchiwa | `10m` |
-| `resources.requests.memory` | Memory request for uchiwa | `50Mi` |
-| `resources.limits.cpu` | CPU limit for uchiwa | `` |
-| `resources.limits.memory` | Memory limit for uchiwa | `50Mi` |
+| `resources.requests.cpu` | CPU request for Uchiwa | `10m` |
+| `resources.requests.memory` | Memory request for Uchiwa | `50Mi` |
+| `resources.limits.cpu` | CPU limit for Uchiwa | `` |
+| `resources.limits.memory` | Memory limit for Uchiwa | `50Mi` |
 | `host` | Address on which Uchiwa will listen | `0.0.0.0` |
 | `port` | Port on which Uchiwa will listen | `3000` |
 | `refresh` | Determines the interval to pull the Sensu APIs, in seconds | `10` |


### PR DESCRIPTION
In the table, Uchiwa sometimes is in capital, sometimes not.
It's better use the same.