### PR TITLE
Update cert-manager chart with changes from upstream repo

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: 0.2.4
-appVersion: 0.2.3
+version: 0.2.8
+appVersion: 0.2.4
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -13,7 +13,7 @@ to renew certificates at an appropriate time before expiry.
 ## Installing the Chart
 
 Full installation instructions, including details on how to configure extra
-functionality in cert-manager can be found in the [official deploying docs](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/deploying.md#addendum).
+functionality in cert-manager can be found in the [getting started docs](https://cert-manager.readthedocs.io/en/latest/getting-started/).
 
 To install the chart with the release name `my-release`:
 
@@ -27,13 +27,13 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://github.com/jetstack/cert-manager/tree/master/docs/api-types/issuer
+https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/ingress-shim.md
+https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
 
 > **Tip**: List all releases using `helm list`
 
@@ -49,7 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following table lists the configurable parameters of the cert-manager chart and their default values.
+The following tables lists the configurable parameters of the cert-manager chart and their default values.
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
@@ -58,18 +58,22 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |
+| `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |
 | `extraArgs` | Optional flags for cert-manager | `[]` |
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`
 | `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
 | `resources` | CPU/memory resource requests/limits | `requests: {cpu: 10m, memory: 32Mi}` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
+| `affinity` | Node affinity for pod assignment | `{}` |
+| `tolerations` | Node tolerations for pod assignment | `[]` |
 | `ingressShim.enabled` | Enable ingress-shim for automatic ingress integration | `true`|
 | `ingressShim.extraArgs` | Optional flags for ingress-shim | `[]` |
 | `ingressShim.resources` | CPU/memory resource requests/limits for ingress-shim | `requests: {cpu: 10m, memory: 32Mi}` |
 | `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
 | `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
 | `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
+| `podAnnotations` | Annotations to add to the cert-manager pod | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cert-manager/templates/NOTES.txt
+++ b/stable/cert-manager/templates/NOTES.txt
@@ -6,10 +6,10 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://github.com/jetstack/cert-manager/tree/v0.2.3/docs/api-types/issuer
+https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://github.com/jetstack/cert-manager/blob/v0.2.3/docs/user-guides/ingress-shim.md
+https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html

--- a/stable/cert-manager/templates/certificate-crd.yaml
+++ b/stable/cert-manager/templates/certificate-crd.yaml
@@ -11,8 +11,12 @@ metadata:
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
+  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
-  scope: Namespaced
+    {{- if .Values.certificateResourceShortNames }}
+    shortNames:
+{{ toYaml .Values.certificateResourceShortNames | indent 6 }}
+    {{- end -}}
 {{- end -}}

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "cert-manager.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}
@@ -9,21 +10,39 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "cert-manager.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "cert-manager.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+      {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.extraArgs }}
           args:
-{{ toYaml .Values.extraArgs | indent 12 }}
+          # This is currently commented out until the 0.3 release of
+          # cert-manager, as it results in a breaking change (users will need
+          # to move credentials/acme private keys from kube-system into the
+          # same namespace cert-manager is deployed into.
+          # - --cluster-resource-namespace=$(POD_NAMESPACE)
+        {{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 10 }}
         {{- end }}
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.ingressShim.enabled }}
@@ -32,12 +51,20 @@ spec:
           imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
         {{- if .Values.ingressShim.extraArgs }}
           args:
-{{ toYaml .Values.ingressShim.extraArgs | indent 12 }}
+{{ toYaml .Values.ingressShim.extraArgs | indent 10 }}
         {{- end }}
           resources:
 {{ toYaml .Values.ingressShim.resources | indent 12 }}
 {{- end }}
-{{- if .Values.nodeSelector }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-{{- end }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/cert-manager/templates/rbac.yaml
+++ b/stable/cert-manager/templates/rbac.yaml
@@ -13,7 +13,12 @@ rules:
     resources: ["certificates", "issuers", "clusterissuers"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["secrets", "events", "endpoints", "services", "pods"]
+    # TODO: remove endpoints once 0.4 is released. We include it here in case
+    # users use the 'master' version of the Helm chart with a 0.2.x release of
+    # cert-manager that still performs leader election with Endpoint resources.
+    # We advise users don't do this, but some will anyway and this will reduce
+    # friction.
+    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
     resources: ["ingresses"]

--- a/stable/cert-manager/templates/serviceaccount.yaml
+++ b/stable/cert-manager/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "cert-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -5,10 +5,12 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.2.3
+  tag: v0.2.4
   pullPolicy: IfNotPresent
 
 createCustomResource: true
+
+certificateResourceShortNames: ["cert", "certs"]
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -32,6 +34,8 @@ resources: {}
   #   cpu: 10m
   #   memory: 32Mi
 
+podAnnotations: {}
+
 nodeSelector: {}
 
 ingressShim:
@@ -39,6 +43,10 @@ ingressShim:
 
   # Optional additional arguments for ingress-shim
   extraArgs: []
+    # Use these flags to specify the default Issuer/ClusterIssuer
+    # (IMPORTANT: You need to create this Issuer/ClusterIssuer resource yourself)
+    # - --default-issuer-name=letsencrypt-prod
+    # - --default-issuer-kind=ClusterIssuer
 
   resources: {}
     # requests:
@@ -53,3 +61,8 @@ ingressShim:
     # tag: v0.2.3
 
     pullPolicy: IfNotPresent
+
+# This is used by the static manifest generator in order to create a static
+# namespace manifest for the namespace that cert-manager is being installed
+# within. It should **not** be used if you are using Helm for deployment.
+createNamespaceResource: false


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the cert-manager chart with the latest changes from the upstream jetstack/cert-manager repo.

We've been working on some better versioning strategies for charts, and in future will be syncing this directory from release tags in the upstream repo (with a more regular patch release cadence).

This also updates paths for documentation since moving to readthedocs.