### PR TITLE
[stable/datadog] Add nodeSelector and affinity values for daemonset

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.14.0
+version: 0.15.0
 appVersion: 6.2.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -59,9 +59,10 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `kubeStateMetrics.enabled`  | If true, create kube-state-metrics | `true`                                    |
 | `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
 | `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |
+| `daemonset.nodeSelector`    | Node selectors                     | `nil`                                     |
+| `daemonset.affinity`        | Node affinities                    | `nil`                                     |
 | `daemonset.useHostNetwork`  | If true, use the host's network    | `nil`                                     |
 | `daemonset.useHostPort`     | If true, use the same ports for both host and container  | `nil`               |
-| `daemonset.nodeSelector`    | Node labels for pod assignment     | `{}`                                      |
 | `datadog.leaderElection`    | Adds the leader Election feature   | `false`                                   |
 | `datadog.leaderLeaseDuration`| The duration for which a leader stays elected.| `nil`                         |
 | `deployment.affinity`       | Node / Pod affinities              | `{}`                                      |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -169,10 +169,6 @@ spec:
       tolerations:
 {{ toYaml .Values.daemonset.tolerations | indent 8 }}
       {{- end }}
-      {{- if .Values.daemonset.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
-      {{- end }}
       {{- if .Values.daemonset.affinity }}
       affinity:
 {{ toYaml .Values.daemonset.affinity | indent 8 }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -169,6 +169,14 @@ spec:
       tolerations:
 {{ toYaml .Values.daemonset.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.daemonset.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.daemonset.affinity }}
+      affinity:
+{{ toYaml .Values.daemonset.affinity | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       {{- if .Values.daemonset.nodeSelector }}
       nodeSelector:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -37,9 +37,11 @@ daemonset:
   # tolerations: []
 
   ## Allow the DaemonSet to schedule on selected nodes
+  # Ref: https://kubernetes.io/docs/user-guide/node-selection/
   # nodeSelector: {}
 
   ## Allow the DaemonSet to schedule ussing affinity rules
+  # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   # affinity: {}
 
   ## Allow the DaemonSet to perform a rolling update on helm update

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -36,9 +36,11 @@ daemonset:
   ## Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >= 1.6)
   # tolerations: []
 
-  # Node labels for pod assignment
-  # Ref: https://kubernetes.io/docs/user-guide/node-selection/
-  nodeSelector: {}
+  ## Allow the DaemonSet to schedule on selected nodes
+  # nodeSelector: {}
+
+  ## Allow the DaemonSet to schedule ussing affinity rules
+  # affinity: {}
 
   ## Allow the DaemonSet to perform a rolling update on helm update
   ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/


### PR DESCRIPTION
Adding `nodeSelector` and `affinity` values for the agent daemonset to have more control on where this will be installed.

While testing chart changes locally I've noticed that there is a new `kube-state-metrics` minor version `0.5.3` available, if the changes of this PR are merged might make sense to bump also the dependency version for the packaging and pushing of the new chart. (If this comes with something worth of it)

@hkaj @irabinovitch @xvello 
