### PR TITLE
Typo fix in testlink/README.md

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.9.16
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -48,8 +48,8 @@ The following table lists the configurable parameters of the TestLink chart and 
 |              Parameter              |               Description               |                         Default                         |
 |-------------------------------------|-----------------------------------------|---------------------------------------------------------|
 | `image.registry`                    | TestLink image registry                 | `docker.io`                                             |
-| `image.repository`                  | TestLink Image name                     | `bitnami/testlink`                                      |
-| `image.tag`                         | TestLink Image tag                      | `{VERSION}`                                             |
+| `image.repository`                  | TestLink image name                     | `bitnami/testlink`                                      |
+| `image.tag`                         | TestLink image tag                      | `{VERSION}`                                             |
 | `image.pullPolicy`                  | Image pull policy                       | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
 | `image.pullSecrets`                 | Specify image pull secrets              | `nil`                                                   |
 | `testlinkUsername`                  | Admin username                          | `user`                                                  |


### PR DESCRIPTION
In the table of this doc's line 50-52, "image" some in capital, some not, Better to use same format.
"TestLink image registry"
"TestLink Image name"
"TestLink Image tag"