### PR TITLE
Typo fix in tensorflow-serving/README.md

### DIFF
--- a/stable/tensorflow-serving/Chart.yaml
+++ b/stable/tensorflow-serving/Chart.yaml
@@ -1,6 +1,6 @@
 name: tensorflow-serving
 home: https://github.com/kubernetes/charts
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.14.0
 description: TensorFlow Serving is an open-source software library for serving machine learning models.
 sources:

--- a/stable/tensorflow-serving/README.md
+++ b/stable/tensorflow-serving/README.md
@@ -140,10 +140,10 @@ chart and their default values.
 |`replicas`| K8S deployment replicas | `1` |
 |`modelName`|  The model name | `mnist`|
 |`modelBasePath`| The model base path | `/serving/model/mnist"` |
-|`mountPath`| the mount path inside the container | `/serving/model/mnist` |
-|`persistence.enabled` | enable pvc for the tensorflow serving | `false` |
-|`persistence.size`| the storage size to request | `5Gi` |
-|`persistence.matchLabels`| the selector for pv | `{}` |
+|`mountPath`| The mount path inside the container | `/serving/model/mnist` |
+|`persistence.enabled` | Enable pvc for the tensorflow serving | `false` |
+|`persistence.size`| The storage size to request | `5Gi` |
+|`persistence.matchLabels`| The selector for pv | `{}` |
 
 
 


### PR DESCRIPTION
In the table in this doc, mostly the first word of column "Description" is in capital, 
while line 143-146 not.