### PR TITLE
Typo fix in suitecrm/README.md

### DIFF
--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: suitecrm
-version: 1.0.3
+version: 1.0.4
 appVersion: 7.10.4
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/README.md
+++ b/stable/suitecrm/README.md
@@ -1,6 +1,6 @@
 # SuiteCRM
 
-[SuiteCRM](https://www.suitecrm.com) SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
+[SuiteCRM](https://www.suitecrm.com) is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 
 ## TL;DR;
 


### PR DESCRIPTION
line 3:    -[SuiteCRM](https://www.suitecrm.com) SuiteCRM is a completely open source
The word "SuiteCRM" is duplicated.