### PR TITLE
Typo fix in stash/README.md

### DIFF
--- a/stable/stash/Chart.yaml
+++ b/stable/stash/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Stash by AppsCode - Backup your Kubernetes Volumes'
 name: stash
-version: 0.5.1
+version: 0.5.2
 appVersion: 0.7.0-rc.1
 home: https://github.com/appscode/stash
 icon: https://cdn.appscode.com/images/icon/stash.png

--- a/stable/stash/README.md
+++ b/stable/stash/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters of the Stash chart and the
 
 | Parameter                           | Description                                                       | Default            |
 | ----------------------------------- | ----------------------------------------------------------------- | ------------------ |
-| `replicaCount`                      | Number of stash operator replicas to create (only 1 is supported) | `1`                |
+| `replicaCount`                      | Number of Stash operator replicas to create (only 1 is supported) | `1`                |
 | `operator.image`                    | operator container image                                          | `appscode/stash`   |
 | `operator.tag`                      | operator container image tag                                      | `0.7.0-rc.1`       |
 | `operator.pullPolicy`               | operator container image pull policy                              | `IfNotPresent`     |
@@ -51,8 +51,8 @@ The following table lists the configurable parameters of the Stash chart and the
 | `rbac.create`                       | If `true`, create and use RBAC resources                          | `true`             |
 | `serviceAccount.create`             | If `true`, create a new service account                           | `true`             |
 | `serviceAccount.name`               | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `` |
-| `apiserver.groupPriorityMinimum`    | The minimum priority the group should have.                       | 10000              |
-| `apiserver.versionPriority`         | The ordering of this API inside of the group.                     | 15                 |
+| `apiserver.groupPriorityMinimum`    | The minimum priority the group should have                       | 10000              |
+| `apiserver.versionPriority`         | The ordering of this API inside of the group                     | 15                 |
 | `apiserver.enableValidatingWebhook` | Enable validating webhooks for Stash CRDs                         | false              |
 | `apiserver.enableMutatingWebhook`   | Enable mutating webhooks for Kubernetes workloads                 | false              |
 | `apiserver.ca`                      | CA certificate used by main Kubernetes api server                 | ``                 |


### PR DESCRIPTION
In the table in this doc, 
1) the word Stash is in capital mostly, while in line 43 not in capital.
2) mostly, column Description do not need to end with "." while line 54-55 end with "."
