### PR TITLE
Typo fix for spinnaker/README.md: "see it's documentation"->"see its documentation"

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.4.0
+version: 0.4.1
 appVersion: 1.6.0
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -8,7 +8,7 @@ that can deploy and manage applications in the cluster that it is deployed to.
 
 Redis and Minio are used as the stores for Spinnaker state.
 
-For more information on Spinnaker and its capabilities, see it's [documentation](http://www.spinnaker.io/docs).
+For more information on Spinnaker and its capabilities, see its [documentation](http://www.spinnaker.io/docs).
 
 ## Installing the Chart
 


### PR DESCRIPTION
see it's documentation->see its documentation