### PR TITLE
[stable/metallb] Fix typo + clarify verbiage in docs.

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.3.0
+version: 0.3.1
 
 name: metallb
 appVersion: 0.5.0

--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -37,7 +37,7 @@ $ helm install --name metallb stable/metallb
 ```
 
 The command deploys MetalLB on the Kubernetes cluster. This chart does
-not provide a default configuration, MetalLB will not act on your
+not provide a default configuration; MetalLB will not act on your
 Kubernetes Services until you provide
 one. The [configuration](#configuration) section lists various ways to
 provide this configuration.
@@ -52,7 +52,14 @@ $ helm delete metallb
 ```
 
 The command removes all the Kubernetes components associated with the
-chart and deletes the release.
+chart, but will not remove the release metadata from `helm` — this will prevent
+you, for example, if you later try to create a release also named `metallb`). To
+fully delete the release and release history, simply [include the `--purge`
+flag][helm-usage]:
+
+```console
+$ helm delete --purge metallb
+```
 
 Configuration
 -------------
@@ -111,6 +118,7 @@ $ helm install --name metallb -f values.yaml stable/metallb
 ```
 
 [helm-home]: https://helm.sh
+[helm-usage]: https://docs.helm.sh/using_helm/
 [k8s-home]: https://kubernetes.io
 [metallb-arpndp-concepts]: https://metallb.universe.tf/concepts/arp-ndp/
 [metallb-config]: https://metallb.universe.tf/configuration/

--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -1,9 +1,8 @@
 MetalLB
 -------
 
-MetalLB is a load-balancer implementation for bare
-metal [Kubernetes](https://kubernetes.io) clusters, using standard
-routing protocols.
+MetalLB is a load-balancer implementation for bare metal [Kubernetes][k8s-home]
+clusters, using standard routing protocols.
 
 TL;DR;
 ------
@@ -15,10 +14,9 @@ $ helm install --name metallb stable/metallb
 Introduction
 ------------
 
-This chart bootstraps a [MetalLB](https://metallb.universe.tf)
-installation on a [Kubernetes](http://kubernetes.io) cluster using
-the [Helm](https://helm.sh) package manager. This chart provides an
-implementation for LoadBalancer Service objects.
+This chart bootstraps a [MetalLB][metallb-home] installation on
+a [Kubernetes][k8s-home] cluster using the [Helm][helm-home] package manager.
+This chart provides an implementation for LoadBalancer Service objects.
 
 MetalLB is a cluster service, and as such can only be deployed as a
 cluster singleton. Running multiple installations of MetalLB in a
@@ -27,7 +25,7 @@ single cluster is not supported.
 Prerequisites
 -------------
 
--	Kubernetes 1.9+
+-  Kubernetes 1.9+
 
 Installing the Chart
 --------------------
@@ -78,16 +76,13 @@ parameters can be provided while installing the chart. For example,
 $ helm install --name metallb -f values.yaml stable/metallb
 ```
 
-By default, this chart does not install a configuration for MetalLB,
-and simply warns you that you must
-follow
-[the configuration instructions on MetalLB's website](https://metallb.universe.tf/configuration/) to
-create an appropriate ConfigMap.
+By default, this chart does not install a configuration for MetalLB, and simply
+warns you that you must follow [the configuration instructions on MetalLB's
+website][metallb-config] to create an appropriate ConfigMap.
 
-For simple setups that only use
-MetalLB's [ARP mode](https://metallb.universe.tf/concepts/arp-ndp/),
-you can specify a single IP range using the `arpAddresses` parameter
-to have the chart install a working configuration for you:
+For simple setups that only use MetalLB's [ARP mode][metallb-arpndp-concepts],
+you can specify a single IP range using the `arpAddresses` parameter to have the
+chart install a working configuration for you:
 
 ```console
 $ helm install --name metallb \
@@ -95,11 +90,9 @@ $ helm install --name metallb \
   stable/metallb
 ```
 
-If you have a more complex configuration and want Helm to manage it
-for you, you can provide it in the `config` parameter. The
-configuration format
-is
-[documented on MetalLB's website](https://metallb.universe.tf/configuration/).
+If you have a more complex configuration and want Helm to manage it for you, you
+can provide it in the `config` parameter. The configuration format is
+[documented on MetalLB's website][metallb-config].
 
 ```console
 $ cat values.yaml
@@ -116,3 +109,9 @@ config:
 
 $ helm install --name metallb -f values.yaml stable/metallb
 ```
+
+[helm-home]: https://helm.sh
+[k8s-home]: https://kubernetes.io
+[metallb-arpndp-concepts]: https://metallb.universe.tf/concepts/arp-ndp/
+[metallb-config]: https://metallb.universe.tf/configuration/
+[metallb-home]: https://metallb.universe.tf

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -21,7 +21,7 @@ prometheus:
   # scrape annotations specifies whether to add Prometheus metric
   # auto-collection annotations to pods. See
   # https://github.com/prometheus/prometheus/blob/release-2.1/documentation/examples/prometheus-kubernetes.yml
-  # for a corresponding Prometheus configuration.  Alternatively, you
+  # for a corresponding Prometheus configuration. Alternatively, you
   # may want to use the Prometheus Operator
   # (https://github.com/coreos/prometheus-operator) for more powerful
   # monitoring configuration. If you use the Prometheus operator, this
@@ -54,7 +54,7 @@ controller:
       # cpu: 100m
       # memory: 100Mi
 
-# controller contains configuration specific to the MetalLB speaker
+# speaker contains configuration specific to the MetalLB speaker
 # daemonset.
 speaker:
   image:


### PR DESCRIPTION
**What this PR does / why we need it**:
This provides minor tweaks to MetalLB docs in two places:

1. In `values.yaml`, fixes what looks like a small [copy/paste whoopsie](https://github.com/kubernetes/charts/compare/master...jessestuart:master#diff-55948e35c0ad4ea3e22559e3cbd7f659R57).

2. In the README:
  - Switch to using Github-flavored Markdown [link reference definitions](https://github.github.com/gfm/#link-reference-definitions) to avoid cluttering the documentation body with inline URLs. I'm a fan, but it's easy to revert 5842cd0 if you prefer the former style.
  - Fixes a potentially misleading statement regarding the deletion of `helm` releases; namely that a release isn't *actually* deleted unless you provide the `--purge` flag (its release data is retained to allow rollbacks).

(Side note — been using MetalLB for several months now, and loving it. Awesome work, and it's been cool to see how quickly it's matured — like the [TCP+UDP PR](https://github.com/google/metallb/pull/209) merged a couple weeks ago ==> ❤️)