### PR TITLE
Typo fix in sentry/README.md：“have available an Ingress Controller”

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.13
+version: 0.1.14
 appVersion: 8.17
 keywords:
   - debugging

--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.1.12
+version: 0.1.13
 appVersion: 8.17
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -109,4 +109,4 @@ See the [Configuration](#configuration) section to configure the PVC or to disab
 
 ## Ingress
 
-This chart provides support for Ingress resource. If you have available an Ingress Controller such as Nginx or Traefik you maybe want to set up `ingress.enabled` to true and choose a `ingress.hostname` for the URL. Then, you should be able to access the installation using that address.
+This chart provides support for Ingress resource. If you have an available Ingress Controller such as Nginx or Traefik you maybe want to set `ingress.enabled` to true and choose an `ingress.hostname` for the URL. Then, you should be able to access the installation using that address.


### PR DESCRIPTION
There are 3 typos in line 112:
have available an Ingress Controller->have an available Ingress Controller
set up `ingress.enabled` to true->set `ingress.enabled` to true
choose a `ingress.hostname`->choose an `ingress.hostname`
