### PR TITLE
[incubator/vault] make High Availability and TLS work

### DIFF
--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -14,23 +14,71 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: {{ .Values.maxUnavailable }}
+      maxSurge: {{ .Values.maxSurge }}
   template:
     metadata:
       labels:
         app: {{ template "vault.name" . }}
         release: {{ .Release.Name }}
+        {{- range $key, $value := .Values.vault.labels }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{- end}}
+      {{- if .Values.vault.annotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- range $key, $value := .Values.vault.annotations }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{- end}}
+      {{- end}}
     spec:
+      {{- if .Values.vault.podDNSAsClusterAddr }}
+      initContainers:
+      - name: init
+        image: stedolan/jq
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - bash
+        - -c
+        - jq -Mc ".cluster_addr=\"http{{- if not .Values.vault.config.listener.tcp.tls_disable -}}s{{- end -}}://${POD_IP//./-}.${POD_NAMESPACE}.pod.cluster.local:{{ .Values.service.clusterPort }}\"" /vault/config/config.json > /root/config.json
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: vault-config
+          mountPath: /vault/config/
+        - name: vault-root
+          mountPath: /root/
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.vault.dev }}
-        command: ["vault", "server", "-dev", "-dev-listen-address", "[::]:8200"]
+        command:
+        - "vault"
+        - "server"
+        - "-log-level={{ .Values.vault.logLevel }}"
+        - "-dev"
+        - "-dev-listen-address"
+        - "[::]:8200"
         {{- else }}
-        command: ["vault", "server", "-config", "/vault/config/config.json"]
+        command:
+        - "vault"
+        - "server"
+        - "-log-level={{ .Values.vault.logLevel }}"
+        {{- if .Values.vault.podDNSAsClusterAddr }}
+        - "-config"
+        - "/root/config.json"
+        {{- else }}
+        - "-config"
+        - "/vault/config/config.json"
         {{- end }}
         {{- if .Values.lifecycle }}
         lifecycle:
@@ -39,21 +87,27 @@ spec:
         ports:
         - containerPort: {{ .Values.service.port }}
           name: api
-        - containerPort: 8201
-          name: cluster-address
+        - containerPort: {{ .Values.service.clusterPort }}
+          name: cluster
         livenessProbe:
           # Alive if it is listening for clustering traffic
-          tcpSocket:
+          httpGet:
+            path: /v1/sys/health?standbycode=200&sealedcode=200&uninitcode=200
             port: {{ .Values.service.port }}
+            {{- if not .Values.vault.config.listener.tcp.tls_disable }}
+            scheme: HTTPS
+            {{- end }}
         readinessProbe:
           # Ready depends on preference
           httpGet:
-            path: /v1/sys/health?
-              {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
-              {{- if .Values.vault.readiness.readyIfStandby -}}standbycode=204&{{- end }}
-              {{- if .Values.vault.readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
+            path: "/v1/sys/health?
+            {{- range $key, $value := .Values.vault.readinessParams -}}
+              {{ $key }}={{ $value }}&
+            {{- end -}}"
             port: {{ .Values.service.port }}
-            scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
+            {{- if not .Values.vault.config.listener.tcp.tls_disable }}
+            scheme: HTTPS
+            {{- end }}
         securityContext:
           readOnlyRootFilesystem: true
           capabilities:
@@ -115,16 +169,16 @@ spec:
 {{ tpl .Values.affinity . | indent 8 }}
       {{- end }}
       volumes:
-        - name: vault-config
-          configMap:
-            name: "{{ template "vault.fullname" . }}-config"
-        - name: vault-root
-          emptyDir: {}
-        {{- range .Values.vault.customSecrets }}
-        - name: {{ .secretName }}
-          secret:
-            secretName: {{ .secretName }}
-        {{- end }}
+      - name: vault-config
+        configMap:
+          name: "{{ template "vault.fullname" . }}-config"
+      - name: vault-root
+        emptyDir: {}
+      {{- range .Values.vault.customSecrets }}
+      - name: {{ .secretName }}
+        secret:
+          secretName: {{ .secretName }}
+      {{- end }}
         {{- if .Values.consulAgent.join }}
         - name: consul-data
           emptyDir: {}

--- a/incubator/vault/templates/poddisruptionbudget.yaml
+++ b/incubator/vault/templates/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "vault.fullname" . }}
+spec:
+  maxUnavailable: {{ .Values.vault.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ template "vault.name" . }}
+      release: {{ .Release.Name }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -4,6 +4,10 @@
 replicaCount: 3
 ## The name of the secret to use if pulling images from a private registry.
 # imagePullSecret:
+replicaCount: 1
+maxUnavailable: 1
+# Allow to create all missing pods
+maxSurge: "100%"
 image:
   repository: vault
   tag: 0.10.1
@@ -34,10 +38,8 @@ service:
   #  - 130.211.204.2/32
   externalPort: 8200
   port: 8200
+  clusterPort: 8201
   # clusterIP: None
-  annotations: {}
-  #   cloud.google.com/load-balancer-type: "Internal"
-  #
   # An example using type:loadbalancer and AWS internal ELB on kops
   # type: LoadBalancer
   # annotations:
@@ -79,6 +81,7 @@ affinity: |
             app: {{ template "vault.fullname" . }}
             release: {{ .Release.Name }}
 
+
 ## Deployment annotations
 annotations: {}
 
@@ -101,23 +104,33 @@ vault:
   # https://www.vaultproject.io/intro/getting-started/dev-server.html for more
   # information.
   dev: true
+  logLevel: info
+  podDNSAsClusterAddr: false
   # Allows the mounting of various custom secrets th enable production vault
   # configurations. The comments show an example usage for mounting a TLS
   # secret. The two fields required are a secretName indicating the name of
   # the Kubernetes secret (created outside of this chart), and the mountPath
   # at which it should be mounted in the Vault container.
+  extraEnv:
+  - name: VAULT_ADDR
+    value: http://127.0.0.1:8200
+  # - name: VAULT_CAPATH
+  #   value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   customSecrets: []
-    # - secretName: vault-tls
-    #   mountPath: /vault/tls
-  #
-  # Configure additional environment variables for the Vault containers
-  extraEnv: {}
-  #   - name: VAULT_API_ADDR
-  #     value: "https://vault.internal.domain.name:8200"
-  readiness:
-    readyIfSealed: false
-    readyIfStandby: true
-    readyIfUninitialized: true
+  # - secretName: vault-tls
+  #   mountPath: /vault/tls
+  annotations: []
+  # - key: example-key
+  #   value: example-value
+  labels: {}
+  readinessParams:
+    # https://www.vaultproject.io/api/system/health.html
+    standbycode: "200"
+    #  standbyok: "false"
+    #  activecode: "200"
+    #  standbycode: "429"
+    #  sealedcode: "503"
+    #  uninitcode: "501"
   config:
     # A YAML representation of a final vault config.json file.
     # See https://www.vaultproject.io/docs/configuration/ for more information.


### PR DESCRIPTION
Builds on top of #4709 

**What this PR does / why we need it**:
We need this PR to make it possible to run High Availability Vault with TLS enabled and request forwarding working (behind LoadBalancer/Ingress).

This PR adds following:
- changes `livenessProbe` to `httpGet` always returning `200`,
- makes `readinessProbe` customization map more directly to GET parameters,
- allows setting environment variables through `.Values.vault.env` (sets `VAULT_ADDR` to `http://` by default),
- allows using `Pod` cluster DNS name as `cluster_address` (`.Values.vault.podDNSAsClusterAddr`) enabling creation of wildcard TLS certificate (`*.<namespaces>.pod.cluster.local`) therefore enabling request forwarding instead of redirection in TLS setup,
- moved `podAnnotations` to `vault.annotations`,
- adds HA & TLS examples to `README.md`,
- adds `maxSurge` and `maxUnavailable` customization,