### PR TITLE
typo fix in percona-xtradb-cluster/README.md: duplicated word "image image"

### DIFF
--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 name: percona-xtradb-cluster
-version: 0.1.3
+version: 0.1.4
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/README.md
+++ b/stable/percona-xtradb-cluster/README.md
@@ -95,7 +95,7 @@ $ helm install --name my-release -f values.yaml stable/percona-xtradb-cluster
 
 ## Persistence
 
-The [Percona XtraDB Cluster DockerHub image](https://hub.docker.com/r/percona/percona-xtradb-cluster/) image stores the MySQL data and configurations at the `/var/lib/mysql` path of the container.
+The [Percona XtraDB Cluster DockerHub image](https://hub.docker.com/r/percona/percona-xtradb-cluster/) stores the MySQL data and configurations at the `/var/lib/mysql` path of the container.
 
 By default, an emptyDir volume is mounted at that location.
 


### PR DESCRIPTION
line 98:
'image' is duplicated.