### PR TITLE
typo fix in quassel/README.md

### DIFF
--- a/stable/quassel/Chart.yaml
+++ b/stable/quassel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.12.4
 description: Quassel IRC is a modern, cross-platform, distributed IRC client.
 name: quassel
-version: 0.2.8
+version: 0.2.9
 icon: https://avatars3.githubusercontent.com/u/2965670
 home: https://quassel-irc.org/
 maintainers:

--- a/stable/quassel/README.md
+++ b/stable/quassel/README.md
@@ -94,7 +94,7 @@ $ helm install stable/quassel --name my-release -f values.yaml
 ## Persistence
 
 The [quassel-core](https://hub.docker.com/r/linuxserver/quassel-core) image
-stores it's configuration data, and if using SQLite, it's SQLite database at the
+stores its configuration data, and if using SQLite, its SQLite database at the
 `/config` path of the container.
 
 The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/)


### PR DESCRIPTION
line 97: "image
-stores it's configuration data, and if using SQLite, it's SQLite database at the"

it's->its