### PR TITLE
Improving MongoDB chart NOTES.txt && Standardise Service Parameters

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 1.0.3
+version: 2.0.0
 appVersion: 3.7.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 1.0.2
+version: 1.0.3
 appVersion: 3.7.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -54,7 +54,8 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `mongodbUsername`                   | MongoDB custom user                        | `nil`                                                    |
 | `mongodbPassword`                   | MongoDB custom user password               | `random alhpanumeric string (10)`                        |
 | `mongodbDatabase`                   | Database to create                         | `nil`                                                    |
-| `serviceType`                       | Kubernetes Service type                    | `ClusterIP`                                              |
+| `service.type`                      | Kubernetes Service type                    | `ClusterIP`                                              |
+| `service.nodePort`                  | Port to bind to for NodePort service type  | `nil`                                                    |
 | `persistence.enabled`               | Use a PVC to persist data                  | `true`                                                   |
 | `persistence.storageClass`          | Storage class of backing PVC               | `nil` (uses alpha storage class annotation)              |
 | `persistence.accessMode`            | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                          |

--- a/stable/mongodb/templates/NOTES.txt
+++ b/stable/mongodb/templates/NOTES.txt
@@ -1,7 +1,50 @@
+{{- if contains .Values.service.type "LoadBalancer" }}
+{{- if not .Values.mongodbRootPassword }}
+-------------------------------------------------------------------------------
+ WARNING
+
+    By specifying "service.type=LoadBalancer" and not specifying "mongodbRootPassword"
+    you have most  likely exposed the MongoDB service externally without any
+    authentication mechanism.
+
+    For security reasons, we strongly suggest that you switch to "ClusterIP" or
+    "NodePort". As alternative, you can also specify a valid password on the
+    "mongodbRootPassword" parameter.
+
+-------------------------------------------------------------------------------
+{{- end }}
+{{- end }}
+
+** Please be patient while the chart is being deployed **
+
 MongoDB can be accessed via port 27017 on the following DNS name from within your cluster:
-{{ template "mongodb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+
+    {{ template "mongodb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To connect to your database run the following command:
 
-   kubectl run {{ template "mongodb.fullname" . }}-client --rm --tty -i --image bitnami/mongodb --command -- mongo --host {{ template "mongodb.fullname" . }} {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end -}}
+    kubectl run {{ template "mongodb.fullname" . }}-client --rm --tty -i --image bitnami/mongodb --command -- mongo --host {{ template "mongodb.fullname" . }} {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end }}
 
+To connect to your database from outside the cluster execute the following commands:
+
+{{- if contains "NodePort" .Values.service.type }}
+
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mongodb.fullname" . }})
+    mongo --host $NODE_IP --port $NODE_PORT {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end }}
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "mongodb.fullname" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mongodb.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    mongo --host $SERVICE_IP --port {{ .Values.service.nodePort }} {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end }}
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mongodb.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 27017:27017 &
+    mongo --host 127.0.0.1 {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end }}
+
+{{- end }}

--- a/stable/mongodb/templates/deployment.yaml
+++ b/stable/mongodb/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "mongodb.fullname" . }}
   labels:
-    app: {{ template "mongodb.fullname" . }}
+    app: {{ template "mongodb.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "mongodb.fullname" . }}
+        app: {{ template "mongodb.name" . }}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/stable/mongodb/templates/secrets.yaml
+++ b/stable/mongodb/templates/secrets.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ template "mongodb.fullname" . }}
   labels:
-    app: {{ template "mongodb.fullname" . }}
+    app: {{ template "mongodb.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/stable/mongodb/templates/svc.yaml
+++ b/stable/mongodb/templates/svc.yaml
@@ -3,15 +3,18 @@ kind: Service
 metadata:
   name: {{ template "mongodb.fullname" . }}
   labels:
-    app: {{ template "mongodb.fullname" . }}
+    app: {{ template "mongodb.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  type: {{ .Values.serviceType }}
+  type: {{ .Values.service.type }}
   ports:
   - name: mongodb
     port: 27017
     targetPort: mongodb
+{{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
   selector:
-    app: {{ template "mongodb.fullname" . }}
+    app: {{ template "mongodb.name" . }}

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -29,8 +29,14 @@ image:
 # mongodbPassword:
 # mongodbDatabase:
 
-## Kubernetes service type
-serviceType: ClusterIP
+service:
+  ## Kubernetes service type
+  type: ClusterIP
+
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the Notes displayed to the user when installing the MongoDB Chart:

- Provides information about how to connect to MongoDB from outside the cluster.
- Adds a Security Warning when using LoadBalancer as Service Type.

Standardise Service Parameters

- Adapt `values.yaml`, `svc.yaml` and `README.md`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
