### PR TITLE
Typo fix in osclass/README.md

### DIFF
--- a/stable/osclass/Chart.yaml
+++ b/stable/osclass/Chart.yaml
@@ -1,5 +1,5 @@
 name: osclass
-version: 1.0.5
+version: 1.0.6
 appVersion: 3.7.4
 description: Osclass is a php script that allows you to quickly create and manage
   your own free classifieds site.

--- a/stable/osclass/README.md
+++ b/stable/osclass/README.md
@@ -10,7 +10,7 @@ $ helm install stable/osclass
 
 ## Introduction
 
-This chart bootstraps a [Osclass](https://github.com/bitnami/bitnami-docker-osclass) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Osclass](https://github.com/bitnami/bitnami-docker-osclass) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/kubernetes/charts/tree/master/stable/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the Osclass application.
 


### PR DESCRIPTION
Line 13: a Osclass deployment->an Osclass deployment