### PR TITLE
Typo fix in elasticsearch-exporter/README.md: a->an

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/README.md
+++ b/stable/elasticsearch-exporter/README.md
@@ -12,7 +12,7 @@ $ helm install stable/elasticsearch-exporter
 
 ## Introduction
 
-This chart creates a Elasticsearch-Exporter deployment on a [Kubernetes](http://kubernetes.io) 
+This chart creates an Elasticsearch-Exporter deployment on a [Kubernetes](http://kubernetes.io) 
 cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites


### PR DESCRIPTION
Line 15: a Elasticsearch-Exporter deployment->an Elasticsearch-Exporter deployment