### PR TITLE
Add back the kakfa.configmap helper

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.5.0
+version: 0.5.1
 appVersion: 4.0.0
 keywords:
 - kafka

--- a/incubator/kafka/templates/_helpers.tpl
+++ b/incubator/kafka/templates/_helpers.tpl
@@ -16,13 +16,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Create the name for our kafka configmap.
-*/}}
-{{- define "kafka.configmap" -}}
-{{- printf "%s-configmap-%d" (include "kafka.fullname" .) .Release.Revision -}}
-{{- end -}}
-
-{{/*
 Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/incubator/kafka/templates/_helpers.tpl
+++ b/incubator/kafka/templates/_helpers.tpl
@@ -16,6 +16,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create the name for our kafka configmap.
+*/}}
+{{- define "kafka.configmap" -}}
+{{- printf "%s-configmap-%d" (include "kafka.fullname" .) .Release.Revision -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/incubator/kafka/templates/jmx-configmap.yaml
+++ b/incubator/kafka/templates/jmx-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "kafka.configmap" . }}-metrics
+  name: {{ template "kafka.fullname" . }}-metrics
   labels:
     app: "{{ template "kafka.name" . }}"
     release: {{ .Release.Name | quote }}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
       {{- if .Values.metrics.jmx.enabled }}
       - name: jmx-config
         configMap:
-          name: {{ template "kafka.configmap" . }}-metrics
+          name: {{ template "kafka.fullname" . }}-metrics
       {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:


### PR DESCRIPTION
This PR (https://github.com/kubernetes/charts/pull/3929) removed this helper, which was used by a subsequent PR (https://github.com/kubernetes/charts/pull/4138). This caused a conflict.



