### PR TITLE
Typo fix in riemann/README.md it's->its

### DIFF
--- a/incubator/riemann/Chart.yaml
+++ b/incubator/riemann/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Riemann monitors distributed systems. Riemann aggregates events from your servers and applications with a powerful stream processing language.
 name: riemann
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.2.14
 keywords:
 - riemann

--- a/incubator/riemann/README.md
+++ b/incubator/riemann/README.md
@@ -1,7 +1,7 @@
 # Riemann Helm Chart
 
 Riemann is an event stream processor for monitoring distributed systems. The
-heart of Riemann is in it's clojure based stream configurations. Read more about Riemann at [http://riemann.io/](http://riemann.io/).
+heart of Riemann is in its clojure based stream configurations. Read more about Riemann at [http://riemann.io/](http://riemann.io/).
 
 Riemann was created by [Kyle Kingsbury](https://github.com/aphyr) with help
 from many others.


### PR DESCRIPTION
Line 4: "The heart of Riemann is in it's clojure based stream configurations. "
 it's->its