### PR TITLE
udpates to configmap

### DIFF
--- a/stable/janusgraph/Chart.yaml
+++ b/stable/janusgraph/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Open source, scalable graph database.
 name: janusgraph
-version: 0.1.0
+version: 0.1.1
 home: http://janusgraph.org
 icon: https://raw.githubusercontent.com/JanusGraph/janusgraph/master/janusgraph.png
 sources:

--- a/stable/janusgraph/templates/configmap.yaml
+++ b/stable/janusgraph/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if (empty .Values.configMapOverrideName) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,6 +16,45 @@ data:
 
     {{- if eq (index .Values.properties "index.search.backend") "elasticsearch" "es"}}
     index.search.hostname={{ $eshostname }}
+    {{- end }}
+  gremlin-server.yaml: |-
+    host: 0.0.0.0
+    port: 8182
+    scriptEvaluationTimeout: 30000
+    channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
+    graphs: {
+      graph: conf/gremlin-server/janusgraph.properties
+    }
+    plugins:
+      - janusgraph.imports
+    scriptEngines: {
+      gremlin-groovy: {
+        imports: [java.lang.Math],
+        staticImports: [java.lang.Math.PI],
+        scripts: [scripts/empty-sample.groovy]}}
+    serializers:
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+      - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+    processors:
+      - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
+      - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
+    metrics: {
+      consoleReporter: {enabled: true, interval: 180000},
+      csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+      jmxReporter: {enabled: true},
+      slf4jReporter: {enabled: true, interval: 180000},
+      gangliaReporter: {enabled: false, interval: 180000, addressingMode: MULTICAST},
+      graphiteReporter: {enabled: false, interval: 180000}}
+    maxInitialLineLength: 4096
+    maxHeaderSize: 8192
+    maxChunkSize: 8192
+    maxContentLength: 65536
+    maxAccumulationBufferComponents: 1024
+    resultIterationBatchSize: 64
+    writeBufferLowWaterMark: 32768
+    writeBufferHighWaterMark: 65536
     {{- end -}}
-
-

--- a/stable/janusgraph/templates/deployment.yaml
+++ b/stable/janusgraph/templates/deployment.yaml
@@ -33,12 +33,16 @@ spec:
               mountPath: /janusgraph-config
             - name: local-db
               mountPath: {{ .Values.persistence.path }}
+          livenessProbe:
+            exec:
+              command:
+                - /tmp/healthcheck.py
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
         - name: janusgraph-config
           configMap:
-            name: {{ .Release.Name }}-config
+            name: {{ .Values.configMapOverrideName | default ( printf "%s-config" .Release.Name ) }}
         - name: local-db
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/stable/janusgraph/values.yaml
+++ b/stable/janusgraph/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: gcr.io/cloud-solutions-images/janusgraph
-  tag: v1
+  tag: v2
   pullPolicy: IfNotPresent
 
 ## The default configuration provided here uses attached storage for db and indexing
@@ -73,3 +73,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 4Gi  # adjust size as needed depending on the size of local storage and indexing required
   existingClaim:  # to reattach to previously used storage, provide an existing claim (or use --set)
+
+## To make adjustments to janusgraph.properties and gremlin-server.yaml, provide a
+## custom ConfigMap in your k8s cluster (using the helm created ConfigMap as a base).
+configMapOverrideName: ""


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: changes to allow additional JanusGraph parameters to be set

**Special notes for your reviewer**: follows pattern to to allow bring-your-own-configmap
