### PR TITLE
[stable/mongodb-replicaset] Remove args, as livenessProbes cannot use it.

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -157,7 +157,6 @@ spec:
             exec:
               command:
                 - mongo
-              args:
               {{- if .Values.tls.enabled }}
                 - --ssl
                 - --sslCAFile=/data/configdb/tls.crt


### PR DESCRIPTION
**What this PR does / why we need it**:
The current livenessProbe does not work as expected and causes out of memory errors, as it keeps starting up a `mongo` process within the Pod.

**Special notes for your reviewer**:
This one is pretty important to apply quickly, as the current implementation is not very stable.