### PR TITLE
[stable/mongodb-replicaset] add env var settings

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.1.1
+version: 3.2.0
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -63,7 +63,7 @@ The following tables lists the configurable parameters of the mongodb chart and 
 | `tolerations`                       | List of node taints to tolerate                                           | `[]`                                                |
 | `livenessProbe`                     | Liveness probe configuration                                              | See below                                           |
 | `readynessProbe`                    | Readyness probe configuration                                             | See below                                           |
-| `envVars`                           | Set environment variables for the main container                          | `{}`                                                |
+| `extraVars`                         | Set environment variables for the main container                          | `{}`                                                |
 
 *MongoDB config file*
 

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -63,6 +63,7 @@ The following tables lists the configurable parameters of the mongodb chart and 
 | `tolerations`                       | List of node taints to tolerate                                           | `[]`                                                |
 | `livenessProbe`                     | Liveness probe configuration                                              | See below                                           |
 | `readynessProbe`                    | Readyness probe configuration                                             | See below                                           |
+| `envVars`                           | Set environment variables for the main container                          | `{}`                                                |
 
 *MongoDB config file*
 

--- a/stable/mongodb-replicaset/templates/_helpers.tpl
+++ b/stable/mongodb-replicaset/templates/_helpers.tpl
@@ -52,16 +52,3 @@ Create the name for the key secret.
         {{- template "mongodb-replicaset.fullname" . -}}-keyfile
     {{- end -}}
 {{- end -}}
-
-{{/*
-Expand the YAML dict to proper env variables for Kubernetes config.
-*/}}
-{{- define "mongodb-replicaset.envVars" -}}
-{{- if .Values.envVars -}}
-env:
-{{- range $key, $val := .Values.envVars }}
-- name: {{ $key }}
-  value: {{ $val | quote }}
-{{- end -}}
-{{- end -}}
-{{- end -}}

--- a/stable/mongodb-replicaset/templates/_helpers.tpl
+++ b/stable/mongodb-replicaset/templates/_helpers.tpl
@@ -52,3 +52,16 @@ Create the name for the key secret.
         {{- template "mongodb-replicaset.fullname" . -}}-keyfile
     {{- end -}}
 {{- end -}}
+
+{{/*
+Expand the YAML dict to proper env variables for Kubernetes config.
+*/}}
+{{- define "mongodb-replicaset.envVars" -}}
+{{- if .Values.envVars -}}
+env:
+{{- range $key, $val := .Values.envVars }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -128,6 +128,7 @@ spec:
         - name: {{ template "mongodb-replicaset.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          {{ template "mongodb-replicaset.envVars" . }}
           securityContext:
             runAsUser: {{ $user }}
             allowPrivilegeEscalation: false

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -128,7 +128,7 @@ spec:
         - name: {{ template "mongodb-replicaset.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-          {{ template "mongodb-replicaset.envVars" . }}
+{{ include "mongodb-replicaset.envVars" . | indent 10 }}
           securityContext:
             runAsUser: {{ $user }}
             allowPrivilegeEscalation: false

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -130,7 +130,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           {{- if .Values.extraVars }}
           env:
-{{ toYaml .Values.extraVars | indent 10 }}
+{{ toYaml .Values.extraVars | indent 12 }}
           {{- end }}
           securityContext:
             runAsUser: {{ $user }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -128,7 +128,10 @@ spec:
         - name: {{ template "mongodb-replicaset.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-{{ include "mongodb-replicaset.envVars" . | indent 10 }}
+          {{- if .Values.extraVars }}
+          env:
+{{ toYaml .Values.extraVars | indent 10 }}
+          {{- end }}
           securityContext:
             runAsUser: {{ $user }}
             allowPrivilegeEscalation: false

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -28,8 +28,9 @@ image:
   pullPolicy: IfNotPresent
 
 # Additional environment variables to be set in the container
-envVars: {}
-# TCMALLOC_AGGRESSIVE_DECOMMIT: "true"
+extraVars: {}
+# - name: TCMALLOC_AGGRESSIVE_DECOMMIT
+#   value: "true"
 
 # Annotations to be added to MongoDB pods
 podAnnotations: {}

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -27,6 +27,10 @@ image:
   tag: 3.6
   pullPolicy: IfNotPresent
 
+# Additional environment variables to be set in the container
+envVars:
+  TCMALLOC_AGGRESSIVE_DECOMMIT: "true"
+
 # Annotations to be added to MongoDB pods
 podAnnotations: {}
 

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -28,8 +28,8 @@ image:
   pullPolicy: IfNotPresent
 
 # Additional environment variables to be set in the container
-envVars:
-  TCMALLOC_AGGRESSIVE_DECOMMIT: "true"
+envVars: {}
+# TCMALLOC_AGGRESSIVE_DECOMMIT: "true"
 
 # Annotations to be added to MongoDB pods
 podAnnotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the option to set an environment variable for the mongo container. This is needed because some options can only be set via environment variables.
