### PR TITLE
[stable/mongodb] Allow passing extra flags to mongodb daemon

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 2.0.0
+version: 2.0.1
 appVersion: 3.7.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `mongodbUsername`                   | MongoDB custom user                        | `nil`                                                    |
 | `mongodbPassword`                   | MongoDB custom user password               | `random alhpanumeric string (10)`                        |
 | `mongodbDatabase`                   | Database to create                         | `nil`                                                    |
-| `mongodbExtraFlags`                 | MongoDB additional command line flags      | `[]`                                                     |
+| `mongodbExtraFlags`                 | MongoDB additional command line flags      | []                                                       |
 | `service.type`                      | Kubernetes Service type                    | `ClusterIP`                                              |
 | `service.nodePort`                  | Port to bind to for NodePort service type  | `nil`                                                    |
 | `persistence.enabled`               | Use a PVC to persist data                  | `true`                                                   |

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -54,6 +54,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `mongodbUsername`                   | MongoDB custom user                        | `nil`                                                    |
 | `mongodbPassword`                   | MongoDB custom user password               | `random alhpanumeric string (10)`                        |
 | `mongodbDatabase`                   | Database to create                         | `nil`                                                    |
+| `mongodbExtraFlags`                 | MongoDB additional command line flags      | `[]`                                                     |
 | `service.type`                      | Kubernetes Service type                    | `ClusterIP`                                              |
 | `service.nodePort`                  | Port to bind to for NodePort service type  | `nil`                                                    |
 | `persistence.enabled`               | Use a PVC to persist data                  | `true`                                                   |

--- a/stable/mongodb/templates/deployment.yaml
+++ b/stable/mongodb/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
         {{ end }}
         - name: MONGODB_DATABASE
           value: {{ default "" .Values.mongodbDatabase | quote }}
+        - name: MONGODB_EXTRA_FLAGS
+          value: {{ default "" .Values.mongodbExtraFlags | join " " }}
         ports:
         - name: mongodb
           containerPort: 27017

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -29,6 +29,14 @@ image:
 # mongodbPassword:
 # mongodbDatabase:
 
+## MongoDB additional command line flags
+##
+## Can be used to specify command line flags, for example:
+##
+## mongodbExtraFlags:
+##  - "--wiredTigerCacheSizeGB=2"
+mongodbExtraFlags: []
+
 service:
   ## Kubernetes service type
   type: ClusterIP


### PR DESCRIPTION
**What this PR does / why we need it**: Allows passing extra flags to mongodb daemon.
