### PR TITLE
[stable/postgresql] Add option to inject password via file

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.9.6
+version: 0.10.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.9.5
+version: 0.9.6
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `imagePullSecrets`         | Image pull secrets                              | `nil`                                                      |
 | `postgresUser`             | Username of new user to create.                 | `postgres`                                                 |
 | `postgresPassword`         | Password for the new user.                      | random 10 characters                                       |
+| `usePasswordFile`          | Inject the password via file instead of env var | `false`                                                    |
 | `postgresDatabase`         | Name for new database to create.                | `postgres`                                                 |
 | `postgresInitdbArgs`       | Initdb Arguments                                | `nil`                                                      |
 | `schedulerName`            | Name of an alternate scheduler                  | `nil`                                                      |

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
             - key: custom-metrics.yaml
               path: custom-metrics.yaml
       {{- end }}
-      {{- if and .Values.usePasswordFile }}
+      {{- if .Values.usePasswordFile }}
       - name: password-file
         secret:
           secretName: {{ template "postgresql.fullname" . }}

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -49,11 +49,16 @@ spec:
           value: {{ default "" .Values.postgresInitdbArgs | quote }}
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
+        {{- if .Values.usePasswordFile }}
+        - name: POSTGRES_PASSWORD_FILE
+          value: /conf/postgres-password
+        {{- else }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "postgresql.fullname" . }}
               key: postgres-password
+        {{- end }}
         - name: POD_IP
           valueFrom: { fieldRef: { fieldPath: status.podIP } }
         ports:
@@ -83,6 +88,11 @@ spec:
         - name: data
           mountPath: {{ .Values.persistence.mountPath }}
           subPath: {{ .Values.persistence.subPath }}
+        {{- if .Values.usePasswordFile }}
+        - name: password-file
+          mountPath: /conf
+          readOnly: true
+        {{- end }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
@@ -118,6 +128,14 @@ spec:
           items:
             - key: custom-metrics.yaml
               path: custom-metrics.yaml
+      {{- end }}
+      {{- if and .Values.usePasswordFile }}
+      - name: password-file
+        secret:
+          secretName: {{ template "postgresql.fullname" . }}
+          items:
+            - key: postgres-password
+              path: postgres-password
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -22,6 +22,9 @@ imageTag: "9.6.2"
 ## Default: random 10 character string
 # postgresPassword:
 
+## Inject postgresPassword via a volume mount instead of environment variable
+usePasswordFile: false
+
 ## Create a database
 ## Default: the postgres user
 # postgresDatabase:


### PR DESCRIPTION
This adds an option to inject the password by volume mount instead of by environment variable for users that have policies against keeping secrets in environment variables.