### PR TITLE
[incubator/schema-registry] Updating GroupID, and moving to using kafka coordinator master election

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.1.1
+version: 0.1.2
 description: Schema Registry provides a serving layer for your metadata. It provides a RESTful
   interface for storing and retrieving Avro schemas. It stores a versioned history of all schemas,
   provides multiple compatibility settings and allows evolution of schemas according to the

--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,11 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
 version: 0.1.2
+appVersion: 4.0.0
+keywords:
+  - confluent
+  - kafka
+  - schema-registry
 description: Schema Registry provides a serving layer for your metadata. It provides a RESTful
   interface for storing and retrieving Avro schemas. It stores a versioned history of all schemas,
   provides multiple compatibility settings and allows evolution of schemas according to the

--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.1.2
+version: 0.2.0
 appVersion: 4.0.0
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -7,11 +7,14 @@ This helm chart creates a [Confluent Schema-Registry server](https://github.com/
 * A running Zookeeper Installation
 
 ## Chart Components
-This chart will dot he following:
+This chart will do the following:
 
 * Create a Schema-Registry deployment
 * Create a Service configured to connect to the available Schema-Registry pods on the configured
   client port.
+
+Note: Distributed Schema Registry Master Election is done via Kafka Coordinator Master Election
+https://docs.confluent.io/current/schema-registry/docs/design.html#kafka-coordinator-master-election
 
 ## Installing the Chart
 You can install the chart with the release name `mysr` as below.
@@ -65,6 +68,8 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `configurationOverrides` | `SchemaRegistry` [configuration setting](https://github.com/confluentinc/schema-registry/blob/master/docs/config.rst#configuration-options) overrides in the dictionary format `setting.name: value` | `{}` |
 | `resources` | CPU/Memory resource requests/limits | `{}` |
 | `servicePort` | The port on which the SchemaRegistry server will be exposed. | `8081` |
+| `overrideGroupId` | Group ID defaults to using Release Name so each release is its own Schema Registry worker group, it can be overridden | `{- .Release.Name -}}` |
+| `kafkaStore.overrideBootstrapServers` | Defaults to Kafka Servers in the same release, it can be overridden in case there was a separate release for Kafka Deploy | `{{- printf "PLAINTEXT://%s-kafka-headless:9092" .Release.Name }}`
 | `kafka.enabled` | If `true`, install Kafka/Zookeeper alongside the `SchemaRegistry`. This is intended for testing and argument-less helm installs of this chart only and should not be used in Production. | `true` |
 | `kafka.replicas` | The number of Kafka Pods to install as part of the `StatefulSet` if `kafka.Enabled` is `true`| `1` |
 | `kafka.zookeeper.servers` | The number of Zookeeper Pods to install as part of the `StatefulSet` if `kafka.Enabled` is `true`| `1` |

--- a/incubator/schema-registry/templates/_helpers.tpl
+++ b/incubator/schema-registry/templates/_helpers.tpl
@@ -27,3 +27,26 @@ else use user-provided URL
 {{- printf "%s:%s" .Values.kafka.zookeeperUrl $port }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Form the Kafka URL. If Kafka is installed as part of this chart, use k8s service discovery,
+else use user-provided URL
+*/}}
+{{- define "schema-registry.kafkaStore.bootstrapServers" }}
+{{- if .Values.kafkaStore.overrideBootstrapServers -}}
+{{- .Values.kafkaStore.overrideBootstrapServers }}
+{{- else -}}
+{{- printf "PLAINTEXT://%s-kafka-headless:9092" .Release.Name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Default GroupId to Release Name but allow it to be overridden
+*/}}
+{{- define "schema-registry.groupId" -}}
+{{- if .Values.overrideGroupId -}}
+{{- .Values.overrideGroupId -}}
+{{- else -}}
+{{- .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -38,8 +38,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL
-            value: {{ template "kafka-zookeeper.url" . }}/
+          - name: SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
+            value: {{ template "schema-registry.kafkaStore.bootstrapServers" . }}
+          - name: SCHEMA_REGISTRY_KAFKASTORE_GROUP_ID
+            value: {{ template "schema-registry.groupId" . }}
+          - name: SCHEMA_REGISTRY_MASTER_ELIGIBILITY
+            value: "true"
           {{ range $configName, $configValue := .Values.configurationOverrides }}
           - name: SCHEMA_REGISTRY_{{ $configName | replace "." "_" | upper }}
             value: {{ $configValue }}

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -3,6 +3,10 @@
 # Declare name/value pairs to be passed into your templates.
 # name: value
 
+# By Default uses Release Name, but can be overridden.  Which means each release is its own group of
+# Schema Registry workers.  You can have multiple groups talking to same Kafka Cluster
+overrideGroupId: ""
+
 ## schema-registry repository
 image: "confluentinc/cp-schema-registry"
 ## The container tag to use
@@ -34,16 +38,19 @@ resources: {}
 ## The port on which the SchemaRegistry will be available and serving requests
 servicePort: 8081
 
+## If `Kafka.Enabled` is `false`, kafkaStore.overrideBootstrapServers must be provided for Master Election.
+## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
+## overrideBootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"
+## Charts uses Kafka Coordinator Master Election: https://docs.confluent.io/current/schema-registry/docs/design.html#kafka-coordinator-master-election
+kafkaStore:
+  overrideBootstrapServers: ""
+
 ## Kafka Settings
 kafka:
   ## This is enabled only to allow installations of this chart without arguments
   enabled: true
-  ## Install only a single Kafka pod in the StatefulSet
-  Replicas: 1
+  ## Install 3x Kafka pods in the StatefulSet, 3 are wanted for default settings in Kafka-Connect
+  Replicas: 3
   ## Install only a single Zookeeper pod in the StatefulSet
   zookeeper:
     Servers: 1
-  ## If `Kafka.Enabled` is `false`, the Zookeeper url servicing the Kafka cluster must be provided
-  zookeeperUrl: ""
-  ## If `Kafka.Enabled` is `false`, the Zookeeper port servicing the Kafka cluster must be provided
-  zookeeperPort: 2181


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates GroupID to default to release name but can be overridden.  This allows each Release to be its own group of schema registry workers by default.  Also using Kafka Coordinator Master Election instead of ZooKeeper.

Details: https://docs.confluent.io/current/schema-registry/docs/design.html#kafka-coordinator-master-election

@benjigoldberg 