### PR TITLE
[stable/jenkins] Secure Defaults

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.14.6
+version: 0.15.0
 appVersion: 2.107
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -53,6 +53,10 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
 | `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
+| `Master.DisabledAgentProtocols`   | Disabled agent protocols             | `JNLP-connect JNLP2-connect`                                                                      |
+| `Master.CSRF.DefaultCrumbIssuer.Enabled` | Enable the default CSRF Crumb issuer | `true`                                                                      |
+| `Master.CSRF.DefaultCrumbIssuer.ProxyCompatability` | Enable proxy compatability | `true`                                                                      |
+| `Master.CLI`                      | Enable CLI over remoting             | `false`                                                                      |
 | `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |
 | `Master.LoadBalancerIP`           | Optional fixed external IP           | Not set                                                                      |
 | `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -119,8 +119,8 @@ data:
       <primaryView>All</primaryView>
       <slaveAgentPort>50000</slaveAgentPort>
       <disabledAgentProtocols>
-{{- range $key, $val := .Values.Master.DisabledAgentProtocols }}
-        <string>{{ $val }}</string>
+{{- range .Values.Master.DisabledAgentProtocols }}
+        <string>{{ . }}</string>
 {{- end }}
       </disabledAgentProtocols>
       <label></label>
@@ -152,14 +152,14 @@ data:
       <pendingClasspathEntries/>
     </scriptApproval>
 {{- end }}
-  jenkins.CLI.xml |-
+  jenkins.CLI.xml: |-
     <?xml version='1.1' encoding='UTF-8'?>
     <jenkins.CLI>
 {{- if .Values.Master.CLI }}
       <enabled>true</enabled>
 {{- else }}
       <enabled>false</enabled>
-{{- fi }}
+{{- end }}
     </jenkins.CLI>
   apply_config.sh: |-
     mkdir -p /usr/share/jenkins/ref/secrets/;

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -145,10 +145,20 @@ data:
       <pendingClasspathEntries/>
     </scriptApproval>
 {{- end }}
+  jenkins.CLI.xml |-
+    <?xml version='1.1' encoding='UTF-8'?>
+    <jenkins.CLI>
+{{- if .Values.Master.CLI }}
+      <enabled>true</enabled>
+{{- else }}
+      <enabled>false</enabled>
+{{- fi }}
+    </jenkins.CLI>
   apply_config.sh: |-
     mkdir -p /usr/share/jenkins/ref/secrets/;
     echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
+    cp -n /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
 {{- if .Values.Master.InstallPlugins }}
     cp /var/jenkins_config/plugins.txt /var/jenkins_home;
     rm -rf /usr/share/jenkins/ref/plugins/*.lock

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -118,6 +118,11 @@ data:
       </views>
       <primaryView>All</primaryView>
       <slaveAgentPort>50000</slaveAgentPort>
+      <disabledAgentProtocols>
+{{- range $key, $val := .Values.Master.DisabledAgentProtocols }}
+        <string>{{ $val }}</string>
+{{- end }}
+      </disabledAgentProtocols>
       <label></label>
       <nodeProperties/>
       <globalNodeProperties/>

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -124,6 +124,13 @@ data:
 {{- end }}
       </disabledAgentProtocols>
       <label></label>
+{{- if .Values.Master.CSRF.DefaultCrumbIssuer.Enabled }}
+      <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+{{- if .Values.Master.CSRF.DefaultCrumbIssuer.ProxyCompatability }}
+        <excludeClientIPFromCrumb>true</excludeClientIPFromCrumb>
+{{- end }}
+      </crumbIssuer>
+{{- end }}
       <nodeProperties/>
       <globalNodeProperties/>
       <noUsageStatistics>true</noUsageStatistics>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -59,6 +59,7 @@ Master:
     DefaultCrumbIssuer:
       Enabled: true
       ProxyCompatability: true
+  CLI: false
   # Kubernetes service type for the JNLP slave service
   # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341
   SlaveListenerServiceType: ClusterIP

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -52,6 +52,13 @@ Master:
   # ~2 minutes to allow Jenkins to restart when upgrading plugins
   HealthProbeLivenessFailureThreshold: 12
   SlaveListenerPort: 50000
+  DisabledAgentProtocols:
+    - JNLP-connect
+    - JNLP2-connect
+  CSRF:
+    DefaultCrumbIssuer:
+      Enabled: false
+      ProxyCompatability: true
   # Kubernetes service type for the JNLP slave service
   # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341
   SlaveListenerServiceType: ClusterIP

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -57,7 +57,7 @@ Master:
     - JNLP2-connect
   CSRF:
     DefaultCrumbIssuer:
-      Enabled: false
+      Enabled: true
       ProxyCompatability: true
   # Kubernetes service type for the JNLP slave service
   # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Secure defaults for the Jenkins chart.  From https://github.com/kubernetes/charts/pull/4435:

> This PR makes a more secure out-of-the-box configuration for Jenkins installs by allowing the user to disable insecure agent protocols, enable CSRF, and disable CLI over remoting, while still allowing a user to run with their pants down if they so wish.

**Which issue this PR fixes**

The default install for the `stable/jenkins` chart currently results in the following security warnings:
<img width="1079" alt="screen shot 2018-04-14 at 12 37 11 pm" src="https://user-images.githubusercontent.com/6752382/38770399-97d60a00-3fe0-11e8-8ffa-ff664f61e117.png">

**Special notes for your reviewer**:

This builds on https://github.com/kubernetes/charts/pull/4435 with an incremented chart version and a couple templating fixes.  The chart installs successfully on minikube and I can confirm that the above warnings no longer show up in Jenkins admin.

CC @viglesiasce @lachie83 @pnovotnak
