### PR TITLE
[incubator/drone] Allows custom drone annotations

### DIFF
--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 0.5.1
+version: 0.6.0
 appVersion: 0.8.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.8.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -51,10 +51,12 @@ The following table lists the configurable parameters of the drone charts and th
 | `ingress.tls`               | Ingress TLS configuration                                                                     | `[]`                        |
 | `server.host`               | Drone **server** scheme and hostname                                                          | `(internal hostname)`       |
 | `server.env`                | Drone **server** environment variables                                                        | `(default values)`          |
+| `server.annotations`        | Drone **server** annotations                                                                  | `{}`                        |
 | `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
 | `server.afinity`            | Drone **server** scheduling preferences                                                       | `{}`                        |
 | `agent.env`                 | Drone **agent** environment variables                                                         | `(default values)`          |
 | `agent.replicas`            | Drone **agent** replicas                                                                      | `1`                         |
+| `agent.annotations`         | Drone **agent** annotations                                                                   | `{}`                        |
 | `agent.resources`           | Drone **agent** pod resource requests & limits                                                | `{}`                        |
 | `agent.afinity`             | Drone **agent** scheduling preferences                                                        | `{}`                        |
 | `dind.enabled`              | Enable or disable **DinD**                                                                    | `true`                      |

--- a/incubator/drone/templates/deployment-agent.yaml
+++ b/incubator/drone/templates/deployment-agent.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- if .Values.agent.annotations }}
+{{ toYaml .Values.agent.annotations | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "drone.name" . }}
         release: "{{ .Release.Name }}"

--- a/incubator/drone/templates/deployment-server.yaml
+++ b/incubator/drone/templates/deployment-server.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+{{- if .Values.server.annotations }}
+{{ toYaml .Values.server.annotations | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "drone.name" . }}
         release: "{{ .Release.Name }}"

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -91,7 +91,7 @@ server:
   ## Additional server annotations.
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
-  resources: {}
+  annotations: {}
 
   ## CPU and memory limits for drone server
   ##
@@ -122,7 +122,7 @@ agent:
   ## Additional agent annotations.
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
-  resources: {}
+  annotations: {}
 
   ## CPU and memory limits for drone agent
   ##

--- a/incubator/drone/values.yaml
+++ b/incubator/drone/values.yaml
@@ -88,6 +88,11 @@ server:
     # DRONE_GITHUB_CLIENT: "github-oauth2-client-id"
     # DRONE_GITHUB_SECRET: "github-oauth2-client-secret"
 
+  ## Additional server annotations.
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  resources: {}
+
   ## CPU and memory limits for drone server
   ##
   resources: {}
@@ -113,6 +118,11 @@ agent:
 
   ## Number of drone agent replicas
   replicas: 1
+
+  ## Additional agent annotations.
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  resources: {}
 
   ## CPU and memory limits for drone agent
   ##


### PR DESCRIPTION
**What this PR does / why we need it**: Should be able to define custom annotations for drone agent + server, eg when using kube2iam.
