### PR TITLE
Fix template render bug when using external db

### DIFF
--- a/stable/owncloud/templates/ingress.yaml
+++ b/stable/owncloud/templates/ingress.yaml
@@ -2,9 +2,9 @@
 apiVersion: {{ required "A valid .Values.networkPolicyApiVersion entry required!" .Values.networkPolicyApiVersion }}
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "owncloud.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "owncloud.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ template "fullname" . }}
+          serviceName: {{ template "owncloud.fullname" . }}
           servicePort: {{ .Values.ingress.servicePort }}
 {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
If using ingress.enable: true and mariadb.enabled: false the ingress.yaml template would fail with an error:
Error: render error in "owncloud/templates/ingress.yaml": template: owncloud/templates/ingress.yaml:5:20: executing "owncloud/templates/ingress.yaml" at <{{template "fullname...>: template "fullname" not defined

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
