### PR TITLE
Typo fix in cert-manager/README.md

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.8
+version: 0.2.9
 appVersion: 0.2.4
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -49,7 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the cert-manager chart and their default values.
+The following table lists the configurable parameters of the cert-manager chart and their default values.
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |


### PR DESCRIPTION
line 52: 
"The following tables lists"->"The following table lists"