### PR TITLE
Typo fix in chartmuseum/README.md: if->it

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.5.1
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -282,8 +282,8 @@ helm install --name my-chartmuseum -f custom.yaml stable/chartmuseum
 ```
 
 ### Using with local filesystem storage
-By default chartmuseum use local filesystem storage. 
-But on pod recreation if will lose all charts, to prevent that enable persistent storage. 
+By default chartmuseum uses local filesystem storage. 
+But on pod recreation it will lose all charts, to prevent that enable persistent storage. 
 
 ```yaml
 env:


### PR DESCRIPTION
Line 285: By default chartmuseum use local filesystem storage. 
use->uses
Line 286: But on pod recreation if will lose all charts,
if->it