### PR TITLE
add init container for configs, fixes #4666

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 0.1.0
+version: 0.1.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
   reliability.

--- a/incubator/couchdb/templates/statefulset.yaml
+++ b/incubator/couchdb/templates/statefulset.yaml
@@ -21,6 +21,15 @@ spec:
         app: {{ template "couchdb.name" . }}
         release: {{ .Release.Name }}
     spec:
+      initContainers:
+        - name: couchdb-config
+          image: busybox
+          command: [ "/bin/sh", "-c", "cp -RvpL /config/* /opt/couchdb/etc/default.d"]
+          volumeMounts:
+          - name: init-config
+            mountPath: /config
+          - name: config
+            mountPath: /opt/couchdb/etc/default.d
       containers:
         - name: couchdb
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -52,6 +61,7 @@ spec:
             - name: ERL_FLAGS
               value: "{{ range $k, $v := .Values.erlangFlags }} -{{ $k }} {{ $v }} {{ end }}"
           livenessProbe:
+            initialDelaySeconds: 60
             httpGet:
               path: /
               port: 5984
@@ -87,12 +97,14 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}
       volumes:
-        - name: config
+        - name: init-config
           configMap:
             name: {{ template "couchdb.fullname" . }}
             items:
               - key: inifile
                 path: chart.ini
+        - name: config
+          emptyDir: {}
 {{- if not .Values.persistentVolume.enabled }}
         - name: database-storage
           emptyDir: {}


### PR DESCRIPTION
**What this PR does / why we need it**: 
Adds an init container to copy CouchDB configs, since configMap mounts are now read-only, and the CouchDB image has an explicit `chown -R`.

**Which issue this PR fixes**
fixes #4666 

**Special notes for your reviewer**:
/cc @kocolosk 
