### PR TITLE
Nfs server

### DIFF
--- a/stable/nfs-server/.helmignore
+++ b/stable/nfs-server/.helmignore
@@ -1,0 +1,3 @@
+.git
+# OWNERS file for Kubernetes
+OWNERS

--- a/stable/nfs-server/Chart.yaml
+++ b/stable/nfs-server/Chart.yaml
@@ -1,0 +1,17 @@
+name: nfs-server
+version: 0.1.0
+appVersion: 0.8
+description: File sharing for a PVC with a deployment over NFS.
+# needs changing
+icon: https://d33np9n32j53g7.cloudfront.net/assets/new/stack-badge-plus-dashed-16aa25b68d7ea9e3371f4b95c01b70b8.png
+keywords:
+- nfs
+- shared
+- filesystem
+home: tbd
+sources:
+- tbd
+maintainers:
+- name: bitnami-bot
+  email: containers@bitnami.com
+engine: gotpl

--- a/stable/nfs-server/Chart.yaml
+++ b/stable/nfs-server/Chart.yaml
@@ -8,9 +8,9 @@ keywords:
 - nfs
 - shared
 - filesystem
-home: tbd
+home: https://github.com/kubernetes/examples/tree/master/staging/volumes/nfs
 sources:
-- tbd
+- https://github.com/kubernetes/examples/tree/master/staging/volumes/nfs
 maintainers:
 - name: bitnami-bot
   email: containers@bitnami.com

--- a/stable/nfs-server/OWNERS
+++ b/stable/nfs-server/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+- prydonius
+- tompizmor
+- sameersbn
+- carrodher
+reviewers:
+- prydonius
+- tompizmor
+- sameersbn
+- carrodher

--- a/stable/nfs-server/README.md
+++ b/stable/nfs-server/README.md
@@ -1,0 +1,87 @@
+# NFS Server
+
+## TL;DR;
+
+```console
+$ helm install stable/nfs-server
+```
+
+## Introduction
+
+This chart bootstraps a NFS server deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+The NFS-server mounts a ReadWriteOnce Persistence Volume Claim in a single node, and creates an NFS service that is connected to a new Persistence Volume of type NFS. This new Volume is of type ReadWriteMany.
+
+This chart hence allows to share within a cluster a filesystem across nodes, where a native ReadWriteMany PV is not available.
+
+```
+  |-----|  ClusterIP    |---------|
+  | PV  |  --------->   | NFS Svc |
+  |-----|               |---------|
+ ReadWriteMany               |
+                             |
+  |-----|   Mounted     |-----------------|
+  | PVC |  ---------->  |  NFS deployment |
+  |-----|               |-----------------|
+ ReadWriteOnce                          
+
+```     
+
+
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/nfs-server
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the WordPress chart and their default values.
+
+| Parameter                            | Description                                | Default                                                    |
+| ------------------------------------ | ------------------------------------------ | ---------------------------------------------------------- |
+| `image.registry`                     |  Image registry                   | `k8s.gcr.io`                                                |
+| `image.repository`                   |  Image name                       | `volume-nfs`                                        |
+| `image.tag`                          |  Image tag                        | `0.8`                                                |
+| `image.pullPolicy`                   | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `image.pullSecrets`                  | Specify image pull secrets                 | `nil`                                                      |
+| `nfs.enabled`                        | disables chart, useful for chart dependencies   | `true`                                                |
+| `nfs.existingPVC`                    | existing PVC to use for sharing            | not defined                                                |
+| `nfs.storageClass`                   | storage class to use if creating a new PVC | not defined                                                |
+| `nfs.nfsStorageClass`                | storage class label for the new nfs PV     | not defined, uses release name                       |
+| `nfs.clusterIp`                      | Static clusterIP for NFS service           | `10.96.0.200`                                                |
+| `nfs.size`                           | WordPress image tag                        | `10Gi`                                                |
+
+
+Highly recommend that you define a nfs.clusterIP that fits with your network configuration. You can do this by:
+
+```console
+$ helm install --name my-release --set nfs.clusterIP=10.96.0.5 stable/nfs-server
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/nfs-server
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+

--- a/stable/nfs-server/README.md
+++ b/stable/nfs-server/README.md
@@ -63,7 +63,6 @@ The following table lists the configurable parameters of the WordPress chart and
 | `image.tag`                          |  Image tag                        | `0.8`                                                |
 | `image.pullPolicy`                   | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
 | `image.pullSecrets`                  | Specify image pull secrets                 | `nil`                                                      |
-| `nfs.enabled`                        | disables chart, useful for chart dependencies   | `true`                                                |
 | `nfs.existingPVC`                    | existing PVC to use for sharing            | not defined                                                |
 | `nfs.storageClass`                   | storage class to use if creating a new PVC | not defined                                                |
 | `nfs.nfsStorageClass`                | storage class label for the new nfs PV     | not defined, uses release name                       |

--- a/stable/nfs-server/templates/NOTES.txt
+++ b/stable/nfs-server/templates/NOTES.txt
@@ -1,0 +1,6 @@
+To use this NFS service, create a PVC with storageclass:
+{{- if .Values.nfs.nfsStorageClass }}
+  storageClassName: "{{ .Values.nfs.nfsStorageClass }}"
+{{- else }}
+  storageClassName: {{ template "fullname" . }}-nfs
+{{- end }}

--- a/stable/nfs-server/templates/_helpers.tpl
+++ b/stable/nfs-server/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/nfs-server/templates/deployment-nfs.yaml
+++ b/stable/nfs-server/templates/deployment-nfs.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.nfs.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -48,4 +47,3 @@ spec:
           {{- else }}
             claimName: {{ template "fullname" . }}
           {{- end }}
-{{- end }}

--- a/stable/nfs-server/templates/deployment-nfs.yaml
+++ b/stable/nfs-server/templates/deployment-nfs.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.nfs.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    selector:
+        matchLabels:
+            app: {{ template "name" . }}
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+      - name: {{ template "name" . }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        ports:
+          - name: nfs
+            containerPort: 2049
+          - name: mountd
+            containerPort: 20048
+          - name: rpcbind
+            containerPort: 111
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /exports
+            name: rwopvc
+      volumes:
+        - name: rwopvc
+          persistentVolumeClaim:
+          {{- if .Values.nfs.existingPVC}}
+            claimName: {{ .Values.nfs.existingPVC }}
+          {{- else }}
+            claimName: {{ template "fullname" . }}
+          {{- end }}
+{{- end }}

--- a/stable/nfs-server/templates/pv-nfs.yaml
+++ b/stable/nfs-server/templates/pv-nfs.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.nfs.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "fullname" . }}
+spec:
+{{- if .Values.nfs.nfsStorageClass }}
+  storageClassName: "{{ .Values.nfs.nfsStorageClass }}"
+{{- else }}
+  storageClassName: {{ template "fullname" . }}
+{{- end }}
+  capacity:
+    storage:  {{ .Values.nfs.size | quote }}
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: {{ .Values.nfs.clusterIp }}
+    path: "/exports"
+{{- end }}

--- a/stable/nfs-server/templates/pv-nfs.yaml
+++ b/stable/nfs-server/templates/pv-nfs.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.nfs.enabled }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -16,4 +15,3 @@ spec:
   nfs:
     server: {{ .Values.nfs.clusterIp }}
     path: "/exports"
-{{- end }}

--- a/stable/nfs-server/templates/pvc.yaml
+++ b/stable/nfs-server/templates/pvc.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.nfs.enabled -}}
 {{- if not .Values.nfs.existingPVC}}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -20,7 +19,6 @@ spec:
   storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.nfs.storageClass }}"
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/nfs-server/templates/pvc.yaml
+++ b/stable/nfs-server/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.nfs.enabled -}}
+{{- if not .Values.nfs.existingPVC}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.nfs.size | quote }}
+{{- if .Values.nfs.storageClass }}
+{{- if (eq "-" .Values.nfs.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.nfs.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/nfs-server/templates/service-nfs.yaml
+++ b/stable/nfs-server/templates/service-nfs.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.nfs.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -19,4 +18,3 @@ spec:
       port: 111
   selector:
     app: {{ template "name" . }}
-{{- end}}

--- a/stable/nfs-server/templates/service-nfs.yaml
+++ b/stable/nfs-server/templates/service-nfs.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.nfs.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusterIP: {{ required "a ClusterIP for the nfs service is required" .Values.nfs.clusterIp }}
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+  selector:
+    app: {{ template "name" . }}
+{{- end}}

--- a/stable/nfs-server/values.yaml
+++ b/stable/nfs-server/values.yaml
@@ -18,9 +18,7 @@ image:
   #   - myRegistrKeySecretName
   
 nfs:
-  enabled: true
-
-  ## to provide an exiting PVC to mount and share using the existing PVC value, this should be ReadWriteOnce type
+   ## to provide an exiting PVC to mount and share using the existing PVC value, this should be ReadWriteOnce type
   ## existingPVC: your-pvc
   
   ## if you want to create a new ReadWriteOnce PVC you can use storageClass to define a specific storage class to use

--- a/stable/nfs-server/values.yaml
+++ b/stable/nfs-server/values.yaml
@@ -16,11 +16,11 @@ image:
   ##
   # pullSecrets:
   #   - myRegistrKeySecretName
-  
+
 nfs:
    ## to provide an exiting PVC to mount and share using the existing PVC value, this should be ReadWriteOnce type
   ## existingPVC: your-pvc
-  
+
   ## if you want to create a new ReadWriteOnce PVC you can use storageClass to define a specific storage class to use
   ## storageClass: "-"
 

--- a/stable/nfs-server/values.yaml
+++ b/stable/nfs-server/values.yaml
@@ -1,0 +1,43 @@
+## Bitnami WordPress image version
+## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
+##
+image:
+  registry: k8s.gcr.io
+  repository: volume-nfs
+  tag: 0.8
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+  
+nfs:
+  enabled: true
+
+  ## to provide an exiting PVC to mount and share using the existing PVC value, this should be ReadWriteOnce type
+  ## existingPVC: your-pvc
+  
+  ## if you want to create a new ReadWriteOnce PVC you can use storageClass to define a specific storage class to use
+  ## storageClass: "-"
+
+  ## To define a name for the storageclass of the NFS PV use nfsStorageClass, if not used the release name would be used
+  ## nfsStorageClass: "-"
+
+  ## nfs service requires a static clusterIP so the PV object can point to it
+  ## please change to match your cluster network definition
+  clusterIp: 10.96.0.200
+
+  ## Size on the PV to share
+  size: 10Gi
+
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
I have been looking to how you can scale the wordpress and other stateful application deployments beyond 1 replica. The problem is that some of these applications (like wordpress) can be administer via the /admin console. This allows the user to install/update plugins and configuration, set themes... this is persisted in a locally mounted volume, which can be mapped/mounted to a PVC.

However, if (as in many cloud providers) you only have access to PVCs that allow ReadWriteOnce, you can not scale your deployment outside a single node.

To have better high availability and allow for horizontal scaling, this PR create a NFS server that maps to a ReadWriteOnce PVC. Then it defines a NFS PV (ReadWriteMany)  that can be mounted in multiple Replicas. This means that all replicas can read the data, and changes done via /admin panel will be persisted and shared across them. As these are not performance sensitive write actions, an NFS should be good enough.

The idea is that this chart will be added as a dependency in other charts that might need this functionality.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This chart comes out of a discussion on this Wordpress PR as we think this can be helpful for other charts https://github.com/kubernetes/charts/pull/5009

**Special notes for your reviewer**:
NFS PV requires to have provision the actual clusterip of the service, I have tried using the FDQN (svc.namespace.cluster.local) but this is not currently supported/working, so a clusterip has to statically be provision in the nfs-service, so it can be referred in the PV when installing a release.