### PR TITLE
[kubernetes-dashboard] Adds docs about fullnameOverride for kubectl proxy

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.6.3
+version: 0.6.4
 appVersion: 1.8.3
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -76,3 +76,10 @@ $ helm install stable/kubernetes-dashboard --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Using the dashboard with 'kubectl proxy'
+
+When running 'kubectl proxy', the address `localhost:8001/ui` automatically expands to `http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/`. For this to reach the dashboard, the name of the service must be 'kubernetes-dashboard', not any other value as set by Helm. You can manually specify this using the value 'fullnameOverride':
+```
+fullnameOverride: 'kubernetes-dashboard'
+```


### PR DESCRIPTION
If you want to use 'localhost:8001/ui' as a shorthand to get
to the kubernetes-dashboard, the service name must be
'kubernetes-dashboard', but this is not typically what
Helm generates. This commit adds a short note
about how to override that.

I initially looked into changing the value which is used to set `service.name`, but it looks like that's been revised a few times already. That might be a preferable change (to only override one value instead of several), but I didn't want go backwards on previous work.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Adds extra documentation for people wanting to use the kubernetes-dashboard chart in combination with kubectl proxy and the 'localhost:8001/ui' shorthand.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Happy to find a different technique if this isn't the best solution, but I think it'd be good to have some documentation for how people can use the Helm chart in combination with the kubectl proxy shorthand address.
