### PR TITLE
[stable/mongodb-replicaset] Use security context on pod level

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.2.1
+version: 3.3.0
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -32,7 +32,7 @@ The following tables lists the configurable parameters of the mongodb chart and 
 | ----------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------- |
 | `replicas`                          | Number of replicas in the replica set                                     | `3`                                                 |
 | `replicaSetName`                    | The name of the replica set                                               | `rs0`                                               |
-| `podDisruptionBudget`               | Pod disruption budget                                                     | `{}`                                 |
+| `podDisruptionBudget`               | Pod disruption budget                                                     | `{}`                                                |
 | `port`                              | MongoDB port                                                              | `27017`                                             |
 | `installImage.repository`           | Image name for the install container                                      | `k8s.gcr.io/mongodb-install`                        |
 | `installImage.tag`                  | Image tag for the install container                                       | `0.5`                                               |
@@ -41,6 +41,7 @@ The following tables lists the configurable parameters of the mongodb chart and 
 | `image.tag`                         | MongoDB image tag                                                         | `3.6`                                               |
 | `image.pullPolicy`                  | MongoDB image pull policy                                                 | `IfNotPresent`                                      |
 | `podAnnotations`                    | Annotations to be added to MongoDB pods                                   | `{}`                                                |
+| `securityContext`                   | Security context for the pod                                              | `{runAsUser: 999, fsGroup: 999, runAsNonRoot: true}`|
 | `resources`                         | Pod resource requests and limits                                          | `{}`                                                |
 | `persistentVolume.enabled`          | If `true`, persistent volume claims are created                           | `true`                                              |
 | `persistentVolume.storageClass`     | Persistent volume storage class                                           | ``                                                  |
@@ -62,7 +63,7 @@ The following tables lists the configurable parameters of the mongodb chart and 
 | `affinity`                          | Node/pod affinities                                                       | `{}`                                                |
 | `tolerations`                       | List of node taints to tolerate                                           | `[]`                                                |
 | `livenessProbe`                     | Liveness probe configuration                                              | See below                                           |
-| `readynessProbe`                    | Readyness probe configuration                                             | See below                                           |
+| `readinessProbe`                    | Readiness probe configuration                                             | See below                                           |
 | `extraVars`                         | Set environment variables for the main container                          | `{}`                                                |
 
 *MongoDB config file*
@@ -180,7 +181,7 @@ livenessProbe:
   failureThreshold: 3
   periodSeconds: 10
   successThreshold: 1
-```  
+```
 
 ## Deep dive
 

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -1,4 +1,3 @@
-{{ $user := .Values.securityContext.runAsUser }}
 apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
@@ -25,6 +24,8 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
         - name: copy-config
           image: busybox
@@ -45,6 +46,7 @@ spec:
 
             {{- if .Values.auth.enabled }}
               cp /keydir-readonly/key.txt /data/configdb/key.txt
+              chmod 600 /data/configdb/key.txt
             {{- end }}
           volumeMounts:
             - name: workdir
@@ -108,33 +110,14 @@ spec:
               mountPath: /data/configdb
             - name: datadir
               mountPath: /data/db
-        - name: permissions
-          image: busybox
-          command:
-            - "sh"
-          args:
-            - "-c"
-            - |
-              set -e
-              set -x
-
-              chown -R '{{ $user }}:{{ $user }}' /data/configdb /data/db
-          volumeMounts:
-            - name: configdir
-              mountPath: /data/configdb
-            - name: datadir
-              mountPath: /data/db
       containers:
         - name: {{ template "mongodb-replicaset.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-          {{- if .Values.extraVars }}
+        {{- if .Values.extraVars }}
           env:
 {{ toYaml .Values.extraVars | indent 12 }}
-          {{- end }}
-          securityContext:
-            runAsUser: {{ $user }}
-            allowPrivilegeEscalation: false
+        {{- end }}
           ports:
             - name: peer
               containerPort: 27017
@@ -194,6 +177,8 @@ spec:
               mountPath: /data/db
             - name: configdir
               mountPath: /data/configdb
+            - name: workdir
+              mountPath: /work-dir
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -37,6 +37,8 @@ podAnnotations: {}
 
 securityContext:
   runAsUser: 999
+  fsGroup: 999
+  runAsNonRoot: true
 
 resources: {}
 # limits:


### PR DESCRIPTION
* Use security context on pod level, which allows us to run all
  containers as non-root and to get rid of the init container for
  changing permissions
* Fix typos in readme
* Fix permissions for key when auth is enabled

/cc @lachie83 @foxish @timstoop 
