### PR TITLE
apiVersion shouldn't be hardcoded

### DIFF
--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.4.1"
 description: A Helm chart for Elasticseach Curator
 name: elasticsearch-curator
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/incubator/elasticsearch-curator/README.md
+++ b/incubator/elasticsearch-curator/README.md
@@ -6,6 +6,9 @@ This directory contains a Kubernetes chart to deploy the [Elasticsearch Curator]
 
 * Elasticsearch
 
+* The `elasticsearch-curator` cron job requires [K8s CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) support: 
+    > You need a working Kubernetes cluster at version >= 1.8 (for CronJob). For previous versions of cluster (< 1.8) you need to explicitly enable `batch/v2alpha1` API by passing `--runtime-config=batch/v2alpha1=true` to the API server ([see Turn on or off an API version for your cluster for more](https://kubernetes.io/docs/admin/cluster-management/#turn-on-or-off-an-api-version-for-your-cluster)).
+
 ## Chart Details
 
 This chart will do the following:

--- a/incubator/elasticsearch-curator/templates/_helpers.tpl
+++ b/incubator/elasticsearch-curator/templates/_helpers.tpl
@@ -4,9 +4,9 @@
 Return the appropriate apiVersion for cronjob APIs.
 */}}
 {{- define "cronjob.apiVersion" -}}
-{{- if semverCompare "< 1.8" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "< 1.8-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "batch/v2alpha1" }}
-{{- else if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.8-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "batch/v1beta1" }}
 {{- end -}}
 {{- end -}}

--- a/incubator/elasticsearch-curator/templates/_helpers.tpl
+++ b/incubator/elasticsearch-curator/templates/_helpers.tpl
@@ -1,6 +1,17 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Return the appropriate apiVersion for cronjob APIs.
+*/}}
+{{- define "cronjob.apiVersion" -}}
+{{- if semverCompare "< 1.8" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "batch/v2alpha1" }}
+{{- else if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "batch/v1beta1" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "elasticsearch-curator.name" -}}

--- a/incubator/elasticsearch-curator/templates/cronjob.yaml
+++ b/incubator/elasticsearch-curator/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: {{ template "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ template "elasticsearch-curator.fullname" . }}
@@ -19,7 +19,7 @@ spec:
         spec:
           volumes:
             - name: config-volume
-              configMap: 
+              configMap:
                 name: curator-config
           restartPolicy: Never
           containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Cronjobs have different api versions for kubernetes versions < 1.8, so it shouldn't be hardcoded into the chart. This PR : 
- adds info to readme clarifying api version of cronjobs
- adds cronjob.apiVersion to _helpers.tpl file to check k8s version before deploy

