### PR TITLE
[incubator/jaeger] Use additional cli parameters for collector and query components

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.2.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.3.10
+version: 0.3.11
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -92,7 +92,7 @@ spec:
                 key: collector.zipkin.http-port
           {{- range $key, $value := .Values.collector.cmdlineParams }}
           - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
-          value: {{ $value }}
+            value: {{ $value }}
           {{- end }}
         ports:
         - containerPort: {{ .Values.collector.service.tchannelPort }}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -90,6 +90,10 @@ spec:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: collector.zipkin.http-port
+          {{- range $key, $value := .Values.collector.cmdlineParams }}
+          - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
+          value: {{ $value }}
+          {{- end }}
         ports:
         - containerPort: {{ .Values.collector.service.tchannelPort }}
           name: tchannel

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -85,6 +85,10 @@ spec:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: query.health-check-http-port
+          {{- range $key, $value := .Values.query.cmdlineParams }}
+          - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
+            value: {{ $value }}
+          {{- end }}
         ports:
         - containerPort: {{ .Values.query.service.targetPort }}
           protocol: TCP


### PR DESCRIPTION
**What this PR does / why we need it**: Uses the already existent collector.cmdlineParams and query.cmdlineParams in the deploy.yaml in order to enable dynamic configuration. I need to set **es.sniffer** to false to use this chart with AWS ElasticSearch service
