### PR TITLE
Annotations and checksum

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `service.type`              | Service type                                           | `ClusterIP`                |
 | `service.port`              | The service port                                       | `80`                       |
 | `service.targetPort`        | The target port of the container                       | `9100`                     |
+| `service.annotations`       | Custom annotations for service                         | `{}`                       |
 | `resources`                 |                                                        | `{}`                       |
 | `aws.region`                | AWS Cloudwatch region                                  | `eu-west-1`                |
 | `aws.role`                  | AWS IAM Role To Use                                    |                            |

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         {{ if .Values.aws.role}}iam.amazonaws.com/role: {{ .Values.aws.role }}{{ end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/stable/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
   labels:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -13,6 +13,7 @@ service:
   type: ClusterIP
   port: 80
   targetPort: 9100
+  annotations: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows the user to include custom annotations to the created Kubernetes service. This is [a common method of Kubernetes service discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#service) and is what the [stable Prometheus chart wants](https://github.com/kubernetes/charts/blob/master/stable/prometheus/values.yaml#L892-L922). Allowing an override of that value is vital to make this chart usable in my Prometheus installation, and I think many others.

This also adds a ConfigMap checksum to the Deployment so that changes to only the the config will cause the pods to restart. This is a technique I saw in a HelmConf video and [is in the Char tips and tricks docs](https://github.com/kubernetes/helm/blob/master/docs/charts_tips_and_tricks.md#automatically-roll-deployments-when-configmaps-or-secrets-change). I find this convenient because most of my changes after initial install are to the configuration only, but I'm less attached to this change. I'm new to Helm, so if there's a reason to *not* make that change, I'm OK with leaving it out.

**Special notes for your reviewer**:
@gianrubio thanks for your work on this chart!
