### PR TITLE
Added support for authenticating with SASL-SCRAM:

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.2.0
+version: 0.3.0
 appVersion: 4.0.0
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -66,6 +66,16 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `imagePullPolicy` | Image Pull Policy | `IfNotPresent` |
 | `replicaCount` | The number of `SchemaRegistry` Pods in the Deployment | `1` |
 | `configurationOverrides` | `SchemaRegistry` [configuration setting](https://github.com/confluentinc/schema-registry/blob/master/docs/config.rst#configuration-options) overrides in the dictionary format `setting.name: value` | `{}` |
+| `kafkaOpts` | Additional Java arguments to pass to Kafka. | ` ` |
+| `sasl.configPath` | where to store config for sasl configurations | `/etc/kafka-config` |
+| `sasl.scram.enabled` | whether sasl-scam is enabled | `false` |
+| `sasl.scram.init.image` | which image to use for initializing sasl scram | `confluentinc/cp-schema-registry` |
+| `sasl.scram.init.imageTag` | which version/tag to use for sasl scram init | `4.0.0` |
+| `sasl.scram.init.imagePullPolicy` | the sasl scram init pull policy | `IfNotPresent` |
+| `sasl.scram.clientUser` | the sasl scram user to use to authenticate to kafka | `kafka-client` |
+| `sasl.scram.clientPassword` | the sasl scram password to use to authenticate to kafka | `kafka-password` |
+| `sasl.scram.zookeeperClientUser` | the sasl scram user to use to authenticate to zookeeper | `zookeper-client` |
+| `sasl.scram.zookeeperClientPassword` | the sasl scram password to use to authenticate to zookeeper | `zookeper-password` |
 | `resources` | CPU/Memory resource requests/limits | `{}` |
 | `servicePort` | The port on which the SchemaRegistry server will be exposed. | `8081` |
 | `overrideGroupId` | Group ID defaults to using Release Name so each release is its own Schema Registry worker group, it can be overridden | `{- .Release.Name -}}` |

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -30,24 +30,33 @@ spec:
           - name: ZOOKEEPER_CLIENT_USER
             value: {{ .Values.sasl.scram.zookeeperClientUser }}
           - name: ZOOKEEPER_CLIENT_PASSWORD
+            {{- if (hasKey .Values.sasl.scram "useExistingSecret") }}
+            valueFrom:
+{{ toYaml .Values.sasl.scram.useExistingSecret.zookeeperClientPassword | indent 14 -}}
+            {{- else }}
             valueFrom:
               secretKeyRef:
                 name: {{ template "schema-registry.fullname" . }}-sasl-scram-secret
                 key: zookeeper-client-password
+            {{- end }}
           - name: SCRAM_CLIENT_USER
             value: {{ .Values.sasl.scram.clientUser }}
           - name: SCRAM_CLIENT_PASSWORD
+            {{- if (hasKey .Values.sasl.scram "useExistingSecret") }}
+            valueFrom: 
+{{ toYaml .Values.sasl.scram.useExistingSecret.clientPassword | indent 14 -}}
+            {{- else }}
             valueFrom:
               secretKeyRef:
                 name: {{ template "schema-registry.fullname" . }}-sasl-scram-secret
                 key: scram-client-password
+            {{- end }}
         volumeMounts:
         - name: jaastemplate
           mountPath: "/tmp/kafka-template"
         - name: jaasconfig
           mountPath: {{ .Values.sasl.configPath | quote }}
     {{- end }}
-
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -81,11 +90,12 @@ spec:
           - name: SCHEMA_REGISTRY_{{ $configName | replace "." "_" | upper }}
             value: {{ $configValue }}
           {{ end }}
-          {{- if .Values.kafkaOpts }}
+          {{- if .Values.schemaRegistryOpts }}
+          # The pre-flight checks use KAFKA_OPTS instead of SCHEMA_REGISTRY_OPTS.
           - name: KAFKA_OPTS
-            value: "{{ .Values.kafkaOpts }}"
+            value: "{{ .Values.schemaRegistryOpts }}"
           - name: SCHEMA_REGISTRY_OPTS
-            value: "{{ .Values.kafkaOpts }}"
+            value: "{{ .Values.schemaRegistryOpts }}"
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -15,6 +15,39 @@ spec:
         app: {{ template "schema-registry.name" . }}
         release: {{ .Release.Name }}
     spec:
+    {{- if .Values.sasl.scram.enabled }}
+      initContainers:
+      ## ref: https://github.com/Yolean/kubernetes-kafka/blob/master/kafka/50kafka.yml
+      - name: init-sasl
+        image: "{{ .Values.sasl.scram.init.image }}:{{ .Values.sasl.scram.init.imageTag }}"
+        imagePullPolicy: "{{ .Values.sasl.scram.init.imagePullPolicy }}"
+        command:
+          - sh
+          - -euc
+          - |
+            sed "s/\$SCRAM_CLIENT_USER/${SCRAM_CLIENT_USER}/g; s/\$SCRAM_CLIENT_PASSWORD/${SCRAM_CLIENT_PASSWORD}/g; s/\$ZOOKEEPER_CLIENT_USER/${ZOOKEEPER_CLIENT_USER}/g; s/\$ZOOKEEPER_CLIENT_PASSWORD/${ZOOKEEPER_CLIENT_PASSWORD}/g;" /tmp/kafka-template/kafka_client_jaas.conf > /etc/kafka-config/kafka_client_jaas.conf
+        env:
+          - name: ZOOKEEPER_CLIENT_USER
+            value: {{ .Values.sasl.scram.zookeeperClientUser }}
+          - name: ZOOKEEPER_CLIENT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "schema-registry.fullname" . }}-sasl-scram-secret
+                key: zookeeper-client-password
+          - name: SCRAM_CLIENT_USER
+            value: {{ .Values.sasl.scram.clientUser }}
+          - name: SCRAM_CLIENT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "schema-registry.fullname" . }}-sasl-scram-secret
+                key: scram-client-password
+        volumeMounts:
+        - name: jaastemplate
+          mountPath: "/tmp/kafka-template"
+        - name: jaasconfig
+          mountPath: {{ .Values.sasl.configPath | quote }}
+    {{- end }}
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -48,5 +81,25 @@ spec:
           - name: SCHEMA_REGISTRY_{{ $configName | replace "." "_" | upper }}
             value: {{ $configValue }}
           {{ end }}
+          {{- if .Values.kafkaOpts }}
+          - name: KAFKA_OPTS
+            value: "{{ .Values.kafkaOpts }}"
+          - name: SCHEMA_REGISTRY_OPTS
+            value: "{{ .Values.kafkaOpts }}"
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+          {{- if .Values.sasl.scram.enabled }}
+          - name: jaasconfig
+            mountPath: {{ .Values.sasl.configPath | quote }}
+          {{- end }}
+      volumes:
+      {{- if .Values.sasl.scram.enabled }}
+      - name: jaasconfig
+        emptyDir: { medium: "Memory" }
+      - name: jaastemplate
+        configMap:
+          name: {{ template "schema-registry.fullname" . }}
+      {{- end }}
+          

--- a/incubator/schema-registry/templates/sasl-scram-config-map.yaml
+++ b/incubator/schema-registry/templates/sasl-scram-config-map.yaml
@@ -1,0 +1,30 @@
+{{ if .Values.sasl.scram.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "schema-registry.fullname" . }}
+  labels:
+    app: {{ include "schema-registry.name" . | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+
+  {{/* - range $i, $e := until (int .Values.replicas) */}}
+data:
+  kafka_client_jaas.conf: |-
+    // Info for Schema Registry to connect to Zookeeper
+    Client {
+        org.apache.zookeeper.server.auth.DigestLoginModule required
+        username="$ZOOKEEPER_CLIENT_USER"
+        password="$ZOOKEEPER_CLIENT_PASSWORD";
+    };
+
+    // Info for third-party clients to connect to Kafka
+    KafkaClient {
+        org.apache.kafka.common.security.scram.ScramLoginModule required
+        username="$SCRAM_CLIENT_USER"
+        password="$SCRAM_CLIENT_PASSWORD";
+    };
+  {{/* - end */}}
+{{- end }}
+

--- a/incubator/schema-registry/templates/sasl-scram-config-map.yaml
+++ b/incubator/schema-registry/templates/sasl-scram-config-map.yaml
@@ -9,7 +9,6 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 
-  {{/* - range $i, $e := until (int .Values.replicas) */}}
 data:
   kafka_client_jaas.conf: |-
     // Info for Schema Registry to connect to Zookeeper
@@ -25,6 +24,4 @@ data:
         username="$SCRAM_CLIENT_USER"
         password="$SCRAM_CLIENT_PASSWORD";
     };
-  {{/* - end */}}
 {{- end }}
-

--- a/incubator/schema-registry/templates/sasl-scram-secret.yaml
+++ b/incubator/schema-registry/templates/sasl-scram-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.sasl.scram.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "schema-registry.fullname" . }}-sasl-scram-secret
+  labels:
+    app: {{ template "schema-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  scram-client-password: {{ .Values.sasl.scram.clientPassword | b64enc }}
+  zookeeper-client-password: {{ .Values.sasl.scram.zookeeperClientPassword | b64enc }}
+{{- end -}}

--- a/incubator/schema-registry/templates/sasl-scram-secret.yaml
+++ b/incubator/schema-registry/templates/sasl-scram-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sasl.scram.enabled -}}
+{{-  if and .Values.sasl.scram.enabled (not (hasKey .Values.sasl.scram "useExistingSecret")) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -45,7 +45,7 @@ servicePort: 8081
 kafkaStore:
   overrideBootstrapServers: ""
 ## Additional Java arguments to pass to Kafka.
-# kafkaOpts: -Dfoo=bar
+# schemaRegistryOpts: -Dfoo=bar
 
 # Options for connecting to SASL kafka brokers
 sasl:
@@ -57,9 +57,23 @@ sasl:
       imageTag: "4.0.0"
       imagePullPolicy: "IfNotPresent"
     clientUser: "kafka-client"
-    clientPassword: "client-password"
     zookeeperClientUser: "zookeeper-client"
+    # Passwords can be either provided here or pulled from an existing k8s secret.
+    # If user wants to specify the password here:
+    clientPassword: "client-password"
     zookeeperClientPassword: "zookeeper-client-password"
+    # If user has an existing k8s secret they would like to use instead of generating them:
+    # useExistingSecret:
+    #   # Where to find the schema registry user secret
+    #   clientPassword:
+    #     secretKeyRef:
+    #       name: "schema-reg-secret"
+    #       key: "client-password"
+    #   # Where to find the zookeeper user secret
+    #   zookeeperClientPassword:
+    #     secretKeyRef:
+    #       name: "zookeeper-secret"
+    #       key: "zokeeper-client-password"
 
 ## Kafka Settings
 kafka:

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -44,6 +44,22 @@ servicePort: 8081
 ## Charts uses Kafka Coordinator Master Election: https://docs.confluent.io/current/schema-registry/docs/design.html#kafka-coordinator-master-election
 kafkaStore:
   overrideBootstrapServers: ""
+## Additional Java arguments to pass to Kafka.
+# kafkaOpts: -Dfoo=bar
+
+# Options for connecting to SASL kafka brokers
+sasl:
+  configPath: "/etc/kafka-config"
+  scram:
+    enabled: false
+    init:
+      image: "confluentinc/cp-schema-registry"
+      imageTag: "4.0.0"
+      imagePullPolicy: "IfNotPresent"
+    clientUser: "kafka-client"
+    clientPassword: "client-password"
+    zookeeperClientUser: "zookeeper-client"
+    zookeeperClientPassword: "zookeeper-client-password"
 
 ## Kafka Settings
 kafka:


### PR DESCRIPTION
 - added secrets file for kafka and zookeeper auth
 - updated values.yaml with config for sasl-scram
 - add config-map for jaas file to use for java authentication
 - added KAFKA_OPTS environment variable for specifying location of jaas file
 - added init container to substitute secrets into jaas file before application startup

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This enables the schema-registry to authenticate with kafka clusters using SASL-SCRAM.
It does so by creating kubernetes secrets and injecting them into tempfs in the form of a jaas file for the schema registry to use, therefore the secrets are only available in memory.

Default behaviour has not been changed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
