### PR TITLE
[stable/postgresql] add init-db script with creating db and non super…

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.9.5
+version: 0.9.6
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.9.6
+version: 0.9.7
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/configmaps.yaml
+++ b/stable/postgresql/templates/configmaps.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.EntrypointInitDB.enable }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "postgresql.fullname" . }}-init-db
+  labels:
+    app: {{ template "postgresql.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  init-db.sh: |-
+{{ printf .Values.EntrypointInitDB.initScript | indent 4 }}
+{{- end }}

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -56,6 +56,20 @@ spec:
               key: postgres-password
         - name: POD_IP
           valueFrom: { fieldRef: { fieldPath: status.podIP } }
+        {{- if .Values.EntrypointInitDB.enable }}
+        - name: PROJECT_DB_NAME
+          value: {{ default "test" .Values.EntrypointInitDB.projectDatabase | quote }}
+        - name: PROJECT_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "postgresql.fullname" . }}
+              key: project-user
+        - name: PROJECT_DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "postgresql.fullname" . }}
+              key: project-pass
+        {{- end }}
         ports:
         - name: postgresql
           containerPort: 5432
@@ -83,6 +97,8 @@ spec:
         - name: data
           mountPath: {{ .Values.persistence.mountPath }}
           subPath: {{ .Values.persistence.subPath }}
+        - name: init-db
+          mountPath: /docker-entrypoint-initdb.d
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
@@ -118,6 +134,13 @@ spec:
           items:
             - key: custom-metrics.yaml
               path: custom-metrics.yaml
+      {{- end }}
+      - name: init-db
+      {{- if .Values.EntrypointInitDB.enable }}
+        configMap:
+          name: {{ template "postgresql.fullname" . }}-init-db
+      {{- else }}
+        emptyDir: {}
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/postgresql/templates/secrets.yaml
+++ b/stable/postgresql/templates/secrets.yaml
@@ -17,3 +17,7 @@ data:
   {{- if .Values.metrics.customMetrics }}
   custom-metrics.yaml: {{ toYaml .Values.metrics.customMetrics | b64enc | quote }}
   {{- end }}
+  {{- if .Values.EntrypointInitDB.enable }}
+  project-user: {{ .Values.EntrypointInitDB.projectUser | b64enc | quote }}
+  project-pass: {{ .Values.EntrypointInitDB.projectPass | b64enc | quote }}
+  {{- end }}

--- a/stable/postgresql/templates/svc.yaml
+++ b/stable/postgresql/templates/svc.yaml
@@ -10,7 +10,7 @@ metadata:
 {{- if .Values.metrics.enabled }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "9187"
+    prometheus.io/port: "{{ .Values.metrics.servicePort }}"
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -25,5 +25,11 @@ spec:
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}
 {{- end }}
+{{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: {{ .Values.metrics.servicePort }}
+    targetPort: metrics
+{{- end }}
   selector:
     app: {{ template "postgresql.fullname" . }}
+

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -68,8 +68,9 @@ persistence:
 metrics:
   enabled: false
   image: wrouesnel/postgres_exporter
-  imageTag: v0.1.1
+  imageTag: v0.4.6
   imagePullPolicy: IfNotPresent
+  servicePort: 9187
   resources:
     requests:
       memory: 256Mi

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -121,3 +121,23 @@ networkPolicy:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Custom database,user that will be initialized during sturtup with non superuser privileges for future use in project
+
+EntrypointInitDB: 
+  enable: false      # if true will use initdb script and creates new env variable for project user, default is false
+
+  projectDatabase: ""  # Creates in deployment env varaible PROJECT_DB_NAME
+  projectUser: ""      # Creates in deployment env varaible PROJECT_DB_USER
+  projectPass: ""      # Creates in deployment env varaible PROJECT_DB_PASS
+
+  # You can change init script to anything you want
+  initScript: |-
+    #!/bin/bash
+    set -e
+
+    psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" <<-EOSQL
+        CREATE USER ${PROJECT_DB_USER} WITH NOSUPERUSER PASSWORD '${PROJECT_DB_PASS}';
+        CREATE DATABASE ${PROJECT_DB_NAME};
+        GRANT ALL PRIVILEGES ON DATABASE ${PROJECT_DB_NAME} TO ${PROJECT_DB_USER};
+    EOSQL

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -124,7 +124,7 @@ affinity: {}
 
 # Custom database,user that will be initialized during sturtup with non superuser privileges for future use in project
 
-EntrypointInitDB: 
+EntrypointInitDB:
   enable: false      # if true will use initdb script and creates new env variable for project user, default is false
 
   projectDatabase: ""  # Creates in deployment env varaible PROJECT_DB_NAME


### PR DESCRIPTION
…user for porject

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
1) Add possibility to define init-db script that will run and create database and non superuser for future use in any project. Yoy can yeasely change script thru variables. By default this functionality is disabled and nothing actually changed. I made this because running ptoject with superuser its security issue.
2) add service for metrics to be able to scrape by prometheus operator or use in other container

**Special notes for your reviewer**:
Need to update README, will do it tomorrow