### PR TITLE
[stable/grafana] add pod annotations to grafana chart

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.0.2
+version: 1.0.3
 appVersion: 5.0.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -58,4 +58,5 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dashboardProviders`       | Configure grafana dashboard providers | `{}` |
 | `dashboards`               | Dashboards to import | `{}` |
 | `grafana.ini`              | Grafana's primary configuration | `{}` |
-
+| `annotations`              | Deployment annotations | `{}` |
+| `podAnnotations`           | Pod annotations | `{}` |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         app: {{ template "grafana.name" . }}
         release: {{ .Release.Name }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
     spec:
 {{- if .Values.dashboards }}
       initContainers:

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         release: {{ .Release.Name }}
 {{- with .Values.podAnnotations }}
       annotations:
-{{ toYaml . | indent 4 }}
+{{ toYaml . | indent 8 }}
 {{- end }}
     spec:
 {{- if .Values.dashboards }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -9,6 +9,13 @@ downloadDashboardsImage:
   repository: appropriate/curl
   tag: latest
   pullPolicy: IfNotPresent
+
+## Pod Annotations
+# podAnnotations: {}
+
+## Deployment annotations
+# annotations: {}
+
 ## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).
 ## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
 ## ref: http://kubernetes.io/docs/user-guide/services/


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently you cannot add pod annotations to the grafana chart, only deployment annotations. Kube2iam only used pod annotations when detecting the role to use and kube2iam is very useful for the cloudwatch datasource.

**Special notes for your reviewer**:
- I would have name spaced the value `annotations` to sometthing like `deploymentAnnotations` but this is a breaking change.
- I followed the existing style of `with` instead of `if` on `.Values.podAnnotations` as per `annotations`.

@rtluckie can you review please 😸 