### PR TITLE
[stable/chartmuseum] Mount volumes from secrets

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 1.2.0
+version: 1.3.0
 appVersion: 0.5.1
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -12,6 +12,7 @@ Please also see https://github.com/kubernetes-helm/chartmuseum
 
 - [Prerequisites](#prerequisites)
 - [Configuration](#configuration)
+  - [Mount Secrets as Volumes](#mount-secrets-as-volumes)
 - [Installation](#installation)
   - [Using with Amazon S3](#using-with-amazon-s3)
     - [permissions grant with access keys](#permissions-grant-with-access-keys)
@@ -96,6 +97,18 @@ their default values. See values.yaml for all available options.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.
+
+### Mount secrets as volumes
+
+If you want to mount arbitrary, pre-existing secrets as volumes you can specify them in your `values.yaml` like so:
+
+```yaml
+volumes:
+  secrets:
+    - volumeName: name-your-volume
+      secretName: name-of-the-existing-secret
+      mountPath: /var/secrets/somewhere
+```
 
 ## Installation
 
@@ -224,6 +237,11 @@ Run command to install
 ```shell
 helm install --name my-chartmuseum -f custom.yaml stable/chartmuseum
 ```
+
+#### Connecting to GCS from outside GKE/GCE
+If you are running chartmuseum in an on-premise cluster, you need to specify `GOOGLE_APPLICATION_CREDENTIALS` and point it to your `service-account.json`. See [Mount Secrets as Volumes](#mount-secrets-as-volumes) on how to mount secrets as volumes.
+
+See [Server-to-Server Authentication](https://cloud.google.com/docs/authentication/production) on Google Cloud Docs for more general information about Authentication for GCS.
 
 ### Using with Microsoft Azure Blob Storage
 

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -64,6 +64,11 @@ spec:
         - mountPath: /storage
           name: storage-volume
 {{- end }}
+{{- range $_, $secretVolume := .Values.volumes.secrets }}
+        - name: {{ $secretVolume.volumeName | quote }}
+          mountPath: {{ $secretVolume.mountPath | quote }}
+          readOnly: true
+{{- end }}
       {{- with .Values.resources }}
         resources:
 {{ toYaml . | indent 10 }}
@@ -89,3 +94,8 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end -}}
+{{- range $_, $secretVolume := .Values.volumes.secrets }}
+      - name: {{ $secretVolume.volumeName | quote }}
+        secret:
+          secretName: {{ $secretVolume.secretName | quote }}
+{{- end }}

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -59,8 +59,8 @@ spec:
             path: {{ .Values.env.open.CONTEXT_PATH }}/health
             port: http
 {{ toYaml .Values.probes.readiness | indent 10 }}
-{{- if eq .Values.env.open.STORAGE "local" }}
         volumeMounts:
+{{- if eq .Values.env.open.STORAGE "local" }}
         - mountPath: /storage
           name: storage-volume
 {{- end }}

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -64,10 +64,12 @@ spec:
         - mountPath: /storage
           name: storage-volume
 {{- end }}
-{{- range $_, $secretVolume := .Values.volumes.secrets }}
+{{- if not (empty .Values.volumes) }}
+  {{- range $_, $secretVolume := .Values.volumes.secrets }}
         - name: {{ $secretVolume.volumeName | quote }}
           mountPath: {{ $secretVolume.mountPath | quote }}
           readOnly: true
+  {{- end }}
 {{- end }}
       {{- with .Values.resources }}
         resources:
@@ -94,8 +96,10 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end -}}
-{{- range $_, $secretVolume := .Values.volumes.secrets }}
+{{- if not (empty .Values.volumes) }}
+  {{- range $_, $secretVolume := .Values.volumes.secrets }}
       - name: {{ $secretVolume.volumeName | quote }}
         secret:
           secretName: {{ $secretVolume.secretName | quote }}
+  {{- end }}
 {{- end }}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -158,3 +158,14 @@ ingress:
 #   - secretName: chartmuseum-server-tls
 #     hosts:
 #     - chartmuseum.domain.com
+#
+
+## Mount additional, arbitrary volumes
+# volumes:
+#   # Mount volumes from secret
+#   # This is useful, for example, when you want to mount a service-account.json
+#   # for accessing GCS from an on-premise K8s cluster.
+#   secrets:
+#     - volumeName: gcs-service-account
+#       secretName: gcs-service-account
+#       mountPath: /var/secrets/gcs


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: To access GCS storage from an on-premise cluster a `service-account.json` needs to be provided. Only if we can mount volumes from secrets, can we actually provide the required file in a safe and standard-compliant way.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5085 

**Special notes for your reviewer**:
CC @chartmuseum @cloudposse @codefresh-io @jdolitsky 