### PR TITLE
[stable/kube2iam] Support extra container environment variables

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.8.6
+version: 0.8.7
 appVersion: 0.10.0
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/README.md
+++ b/stable/kube2iam/README.md
@@ -43,6 +43,7 @@ Parameter | Description | Default
 --- | --- | ---
 `affinity` | affinity configuration for pod assignment | `{}`
 `extraArgs` | Additional container arguments | `{}`
+`extraEnv` | Additional container environment variables | `{}`
 `host.ip` | IP address of host | `$(HOST_IP)`
 `host.iptables` | Add iptables rule | `false`
 `host.interface` | Host interface for proxying AWS metadata | `docker0`
@@ -56,7 +57,7 @@ Parameter | Description | Default
 `resources` | pod resource requests & limits | `{}`
 `updateStrategy` | Strategy for DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
 `verbose` | Enable verbose output | `false`
-`tolerations` | List of node taints to tolerate (requires Kubernetes 1.6+) | `[]`          
+`tolerations` | List of node taints to tolerate (requires Kubernetes 1.6+) | `[]`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -65,7 +65,7 @@ spec:
           {{- end }}
           {{- range $name, $value := .Values.extraEnv }}
             - name: {{ $name }}
-              value: {{ $value }}
+              value: {{ quote $value }}
           {{- end }}
           ports:
             - containerPort: {{ .Values.host.port }}

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -63,6 +63,10 @@ spec:
             - name: AWS_DEFAULT_REGION
               value: {{ .Values.aws.region }}
           {{- end }}
+          {{- range $name, $value := .Values.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.host.port }}
         {{- if .Values.probe }}

--- a/stable/kube2iam/values.yaml
+++ b/stable/kube2iam/values.yaml
@@ -4,6 +4,10 @@ extraArgs: {}
 #   api-server: ...
 #   api-token: ...
 
+extraEnv: {}
+#    http_proxy: http://example.com:8080
+#    NO_PROXY: localhost,127.0.0.1
+
 host:
   ip: $(HOST_IP)
   iptables: false


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Add support for extra container environment variables.
Useful when using an HTTP proxy for communication with AWS APIs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5088 

**Special notes for your reviewer**:
Some testing.
No extra environment variables:
```
helm install --dry-run --debug stable/kube2iam

COMPUTED VALUES:
affinity: {}
aws:
  access_key: ""
  region: ""
  secret_key: ""
extraArgs: {}
extraEnv: {}
host:
  interface: docker0
  ip: $(HOST_IP)
  iptables: false
  port: 8181
image:
  pullPolicy: IfNotPresent
  repository: jtblin/kube2iam
  tag: 0.10.0
nodeSelector: {}
podAnnotations: {}
podLabels: {}
probe: true
rbac:
  create: false
  serviceAccountName: default
resources: {}
tolerations: []
updateStrategy: OnDelete
verbose: false

HOOKS:
MANIFEST:

---
# Source: kube2iam/templates/daemonset.yaml
apiVersion: extensions/v1beta1
kind: DaemonSet
metadata:
  labels:
    app: kube2iam
    chart: kube2iam-0.8.7
    heritage: Tiller
    release: goodly-crab
  name: goodly-crab-kube2iam
spec:
  template:
    metadata:
      labels:
        app: kube2iam
        release: goodly-crab
    spec:
      containers:
        - name: kube2iam
          image: "jtblin/kube2iam:0.10.0"
          imagePullPolicy: "IfNotPresent"
          args:
            - --host-interface=docker0
            - --iptables=false
            - --app-port=8181
          env:
            - name: HOST_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
          ports:
            - containerPort: 8181
          livenessProbe:
            httpGet:
              path: /healthz
              port: 8181
              scheme: HTTP
            initialDelaySeconds: 30
            periodSeconds: 5
            successThreshold: 1
            failureThreshold: 3
            timeoutSeconds: 1
          resources:
            {}
            
      hostNetwork: true
      serviceAccountName: "default"
      tolerations:
        []
        
  updateStrategy:
    type: OnDelete
```

Extra environment variables:
```
helm install --dry-run --debug stable/kube2iam

COMPUTED VALUES:
affinity: {}
aws:
  access_key: ""
  region: ""
  secret_key: ""
extraArgs: {}
extraEnv:
  NO_PROXY: localhost,127.0.0.1
  http_proxy: http://example.com:8080
host:
  interface: docker0
  ip: $(HOST_IP)
  iptables: false
  port: 8181
image:
  pullPolicy: IfNotPresent
  repository: jtblin/kube2iam
  tag: 0.10.0
nodeSelector: {}
podAnnotations: {}
podLabels: {}
probe: true
rbac:
  create: false
  serviceAccountName: default
resources: {}
tolerations: []
updateStrategy: OnDelete
verbose: false

HOOKS:
MANIFEST:

---
# Source: kube2iam/templates/daemonset.yaml
apiVersion: extensions/v1beta1
kind: DaemonSet
metadata:
  labels:
    app: kube2iam
    chart: kube2iam-0.8.7
    heritage: Tiller
    release: awesome-fly
  name: awesome-fly-kube2iam
spec:
  template:
    metadata:
      labels:
        app: kube2iam
        release: awesome-fly
    spec:
      containers:
        - name: kube2iam
          image: "jtblin/kube2iam:0.10.0"
          imagePullPolicy: "IfNotPresent"
          args:
            - --host-interface=docker0
            - --iptables=false
            - --app-port=8181
          env:
            - name: HOST_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
            - name: NO_PROXY
              value: localhost,127.0.0.1
            - name: http_proxy
              value: http://example.com:8080
          ports:
            - containerPort: 8181
          livenessProbe:
            httpGet:
              path: /healthz
              port: 8181
              scheme: HTTP
            initialDelaySeconds: 30
            periodSeconds: 5
            successThreshold: 1
            failureThreshold: 3
            timeoutSeconds: 1
          resources:
            {}
            
      hostNetwork: true
      serviceAccountName: "default"
      tolerations:
        []
        
  updateStrategy:
    type: OnDelete
```