### PR TITLE
Fix #5078: RabbitMQ wrong service account

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.7.5
+version: 0.7.6
 appVersion: 3.7.4
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/rolebinding.yaml
+++ b/stable/rabbitmq/templates/rolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 subjects:
 - kind: ServiceAccount
-  name: rabbitmq
+  name: {{ template "rabbitmq.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
fixes #5078 where the wrong serviceaccount name is used for rbac enabled rabbitmq deployments