### PR TITLE
openvpn: add common client/server config section

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 2.0.4
+version: 2.0.5
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -60,6 +60,7 @@ New certificates are generated with each deployment.  If persistence is enabled 
 * openvpn.OVPN_PROTO: tcp - Protocol used by openvpn tcp or udp (default: tcp).
 * openvpn.OVPN_K8S_POD_NETWORK: "10.0.0.0" - Kubernetes pod network (optional).
 * openvpn.OVPN_K8S_POD_SUBNET: "255.0.0.0" - Kubernetes pod network subnet (optional).
-* openvpn.conf: "" - Arbitrary lines appended to the end of the server configuration file
+* openvpn.commonConf: "" - Arbitrary lines appended to the end of the client and server configuration files(default: cipher AES-256-CBC, comp-lzo)
+* openvpn.serverConf: "" - Arbitrary lines appended to the end of the server configuration file
 
 #### Note: As configured the chart will create a route for a large 10.0.0.0/8 network that may cause issues if that is your local network.  If so tweak this value to something more restrictive.  This route is added, because GKE generates pods with IPs in this range.

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -32,6 +32,9 @@ data:
       nobind
       dev tun
       redirect-gateway def1
+      {{- if .Values.openvpn.commonConf }}
+{{ indent 6 .Values.openvpn.commonConf }}
+      {{- end -}}
       <key>
       `cat ${EASY_RSA_LOC}/pki/private/$1.key`
       </key>
@@ -104,6 +107,9 @@ data:
       push "dhcp-option DOMAIN OVPN_K8S_SEARCH"
       push "dhcp-option DNS OVPN_K8S_DNS"
 
-      {{- if .Values.openvpn.conf }}
-{{ indent 6 .Values.openvpn.conf }}
+      {{- if .Values.openvpn.commonConf }}
+{{ indent 6 .Values.openvpn.commonConf }}
+      {{- end -}}
+      {{- if .Values.openvpn.serverConf }}
+{{ indent 6 .Values.openvpn.serverConf }}
       {{- end -}}

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -47,7 +47,14 @@ openvpn:
   OVPN_K8S_POD_NETWORK: "10.0.0.0"
   # Kubernetes pod network subnet (optional).
   OVPN_K8S_POD_SUBNET: "255.0.0.0"
-  # Arbitrary lines appended to the end of the server configuration file
-  # conf: |
-  #  max-clients 100
-  #  client-to-client
+  # Arbitrary lines appended to the end of the client and server configuration files
+  # Place here common config options  such as: auth,cipher,compression algo
+  commonConf: |
+    ## commonConfig
+    cipher AES-256-CBC
+    comp-lzo
+  # Arbitrary lines appended to the end of the server configuration file (after commonConf)
+  serverConf: |
+    ## serverConf
+    #max-clients 100
+    #client-to-client


### PR DESCRIPTION
Russian censorship agency (RKN) going crazy this week and blocked 16M of ip addresses. 
But anyone can setup openvpn server in kubernetes cluster. 

**LOG
By default server configured with obsoleted cryptography algo so
client complains about weak security:
 "WARNING: INSECURE cipher with block size less than 128 bit (64 bit). 
 This allows attacks like SWEET32.  Mitigate by using a --cipher with
 a larger block size (e.g. AES-256-CBC)."

Let's use AES-256-CBC by default so deployment becomes more secure out of box.