### PR TITLE
Sonarqube chart: Make PostgreSQL requirement optional

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.5.1
+version: 0.5.2
 appVersion: 6.7.3
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -49,9 +49,12 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `persistence.accessMode`                    | Volumes access mode to be set             | `ReadWriteOnce`                            |
 | `persistence.size`                          | Size of the volume                        | `10Gi`                                     |
 | `sonarProperties`                           | Custom `sonar.properties` file            | None                                       |
+| `postgresql.enabled`                        | Set to `false` to use external server     | `true`                                     |
+| `postgresql.postgresServer`                 | Hostname of the external Postgresql server| `null`                                     |
 | `postgresql.postgresUser`                   | Postgresql database user                  | `sonarUser`                                |
 | `postgresql.postgresPassword`               | Postgresql database password              | `sonarPass`                                |
 | `postgresql.postgresDatabase`               | Postgresql database name                  | `sonarDB`                                  |
+| `postgresql.service.port`                | Postgresql port                              | `5432`                                     |
 | `resources`                                 | Sonarqube Pod resource requests & limits  | `{}`                                       |
 | `affintiy`                                  | Node / Pod affinities                     | `{}`                                       |
 | `nodeSelector`                              | Node labels for pod assignment            | `{}`                                       |

--- a/stable/sonarqube/requirements.lock
+++ b/stable/sonarqube/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.8.3
-digest: sha256:b67c843d95aa0a2e7684abb787b22913e54baa92f45a450a3c3bcb7f3e068748
-generated: 2017-11-15T14:43:21.132299+01:00
+digest: sha256:7669c2dcb2741e52c61240019803c5a8a0061e51195060b2bd3b8176648faa63
+generated: 2018-04-19T13:47:45.089773+02:00

--- a/stable/sonarqube/requirements.yaml
+++ b/stable/sonarqube/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
   - name: postgresql
     version: 0.8.3
     repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: postgresql.enabled

--- a/stable/sonarqube/templates/_helpers.tpl
+++ b/stable/sonarqube/templates/_helpers.tpl
@@ -22,3 +22,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "postgresql.fullname" -}}
 {{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+  Determine the hostname to use for PostgreSQL.
+*/}}
+{{- define "postgresql.hostname" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" .Values.postgresql.postgresServer -}}
+{{- end -}}
+{{- end -}}

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
                   name: {{ template "postgresql.fullname" .}}
                   key: postgres-password
             - name: SONARQUBE_JDBC_URL
-              value: "jdbc:postgresql://{{ template "postgresql.fullname" .}}:5432/{{.Values.postgresql.postgresDatabase}}"
+              value: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.postgresDatabase -}}"
           livenessProbe:
             httpGet:
               path: /

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -93,9 +93,17 @@ plugins:
 #   ldap.url=ldaps://organization.com
 
 ## Configuration values for the postgresql dependency
-## ref: https://github.com/kubernetes/charts/blob/master/stable/postgressql/README.md
+## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
 ##
 postgresql:
+  # Enable to deploy the PostgreSQL chart
+  enabled: true
+  # To use an external PostgreSQL instance, set enabled to false and uncomment
+  # the line below:
+  # postgresServer: ""
   postgresUser: "sonarUser"
   postgresPassword: "sonarPass"
   postgresDatabase: "sonarDB"
+  # Specify the TCP port that PostgreSQL should use
+  service:
+    port: 5432


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

@rjkernick

**What this PR does / why we need it**:
The changes in this PR allow the use of an external PostgreSQL database server instead of using the PostgreSQL chart. The default behaviour of this chart is unchanged: using an external PostgreSQL server requires additional configuration.

The behaviour is controlled by a newly introduced value `postgresql.enabled` (defaults to `true`). If set to false, the chart expects a user to specify the hostname of the external database server via the `postgresql.postgresServer` value.

To improve flexibility and robustness, the database port is no longer hardcoded in the deployment, but taken from the `postgresql.service.port` property. That property is also used by the PostgreSQL chart to determine the configure the service port.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
