### PR TITLE
stable/metallb: bump binary version to v0.6.1.

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-version: 0.4.0
+version: 0.5.0
 
 name: metallb
-appVersion: 0.5.0
+appVersion: 0.6.1
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
 home: https://metallb.universe.tf

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -39,10 +39,6 @@ spec:
         - --port=7472
         - --config={{ template "metallb.configMapName" . }}
         env:
-        - name: METALLB_NODE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
         - name: METALLB_NODE_NAME
           valueFrom:
             fieldRef:

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -53,7 +53,7 @@ serviceAccounts:
 controller:
   image:
     repository: metallb/controller
-    tag: v0.5.0
+    tag: v0.6.1
     pullPolicy: IfNotPresent
   resources:
     # limits:
@@ -65,7 +65,7 @@ controller:
 speaker:
   image:
     repository: metallb/speaker
-    tag: v0.5.0
+    tag: v0.6.1
     pullPolicy: IfNotPresent
   resources:
     # limits:


### PR DESCRIPTION
Also removes an environment variable that is no longer needed in MetalLB 0.6.