### PR TITLE
Remove duplicate updateStrategy declaration

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.16.0
+version: 0.16.1
 appVersion: 0.13.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -185,6 +185,4 @@ spec:
 {{- if .Values.controller.extraVolumes }}
 {{ toYaml .Values.controller.extraVolumes | indent 6}}
 {{- end }}
-  updateStrategy:
-{{ toYaml .Values.controller.updateStrategy | indent 4 }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: `updateStrategy` is [already declared in the file](https://github.com/hobti01/charts/blob/f49dbe37107ec09b6e9baf27e3d7ef08e4c32ee4/stable/nginx-ingress/templates/controller-daemonset.yaml#L14), this removes the duplicate declaration
