### PR TITLE
Concourse: Add miscellaneous concourse atc flags.

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 name: concourse
-version: 1.4.0
-appVersion: 3.10.0
+version: 1.5.0
+appVersion: 3.13.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -36,6 +36,12 @@ spec:
             - "--aws-ssm-region"
             - "$(CONCOURSE_AWS_SSM_REGION)"
             {{- end }}
+            {{- if .Values.web.cookieSecure }}
+            - "--cookie-secure"
+            {{- end }}
+            {{- if .Values.web.logging.logDBQueries }}
+            - "--log-db-queries"
+            {{- end }}
           env:
             - name: CONCOURSE_TSA_HOST_KEY
               value: "/concourse-keys/host_key"
@@ -255,6 +261,18 @@ spec:
               value: "0.0.0.0"
             - name: CONCOURSE_PROMETHEUS_BIND_PORT
               value: {{ .Values.web.metrics.prometheus.port | quote }}
+            {{- end }}
+            {{- if .Values.web.xFrameOptions }}
+            - name: CONCOURSE_X_FRAME_OPTIONS
+              value: {{ .Values.web.xFrameOptions | quote }}
+            {{- end }}
+            {{- if .Values.web.interceptIdleTimeout }}
+            - name: CONCOURSE_INTERCEPT_IDLE_TIMEOUT
+              value: {{ .Values.web.interceptIdleTimeout | quote }}
+            {{- end }}
+            {{- if .Values.web.logging.level }}
+            - name: CONCOURSE_LOG_LEVEL
+              value: {{ .Values.web.logging.logLevel | quote }}
             {{- end }}
           ports:
             - name: atc

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -274,6 +274,14 @@ spec:
             - name: CONCOURSE_LOG_LEVEL
               value: {{ .Values.web.logging.logLevel | quote }}
             {{- end }}
+            {{- if .Values.web.defaultBuildLogsToRetain }}
+            - name: CONCOURSE_DEFAULT_BUILD_LOGS_TO_RETAIN
+              value: {{ .Values.web.defaultBuildLogsToRetain | quote }}
+            {{- end }}
+            {{- if .Values.web.maxBuildLogsToRetain }}
+            - name: CONCOURSE_MAX_BUILD_LOGS_TO_RETAIN
+              value: {{ .Values.web.maxBuildLogsToRetain | quote }}
+            {{- end }}
           ports:
             - name: atc
               containerPort: {{ .Values.concourse.atcPort }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -101,6 +101,9 @@ spec:
 {{- if .Values.worker.env }}
 {{ toYaml .Values.worker.env | indent 12 }}
 {{- end }}
+          ports:
+            - name: worker
+              containerPort: 7799
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
           securityContext:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -13,7 +13,7 @@ image: concourse/concourse
 ## Concourse image version.
 ## ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "3.11.0"
+imageTag: "3.13.0"
 
 ## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
 ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -301,6 +301,14 @@ web:
     ## Log database queries
     ###
     logDBQueries: false
+
+  ## Default build logs to retain, 0 means all
+  ##
+  # defaultBuildLogsToRetain:
+
+  ## Maximum build logs to retain, 0 means not specified. Will override values configured in jobs
+  ##
+  # maxBuildLogsToRetain:
 
 ## Configuration values for Concourse Worker components.
 ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -13,7 +13,7 @@ image: concourse/concourse
 ## Concourse image version.
 ## ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "3.10.0"
+imageTag: "3.11.0"
 
 ## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
 ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -278,6 +278,29 @@ web:
     prometheus:
       enabled: false
       port: 9391
+
+  ## Set secure flag on auth cookies
+  ##
+  cookieSecure: false
+
+  ## The value to set for X-Frame-Options
+  ##
+  xFrameOptions: ""
+
+  ## Length of time for a intercepted session to be idle before terminating, in Go duration format
+  ##
+  interceptIdleTimeout: ""
+
+  ## Logging configuration
+  logging:
+
+    ## The log level for the ATC
+    ##
+    level: ""
+
+    ## Log database queries
+    ###
+    logDBQueries: false
 
 ## Configuration values for Concourse Worker components.
 ##


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a few missing configuration options to the concourse atc, mostly useful to us for compliance purposes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

@frodenas @william-tran 