### PR TITLE
[stable/rabbitmq] Fix hardcoded service account name

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.7.5
+version: 0.7.6
 appVersion: 3.7.4
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/rolebinding.yaml
+++ b/stable/rabbitmq/templates/rolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 subjects:
 - kind: ServiceAccount
-  name: rabbitmq
+  name: {{ template "rabbitmq.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
**What this PR does / why we need it**:
The service account name in rolebinding.yaml is currently hardcoded to rabbitmq while the actual service account name is set to {{ template "rabbitmq.fullname" . }}. This means if {{ template "rabbitmq.fullname" . }} does not evaluate to "rabbitmq", the permissions are not assigned to the service account.

This change simply sets the referenced service account name in the rolebinding.yaml file to {{ template "rabbitmq.fullname" . }} as well.
