### PR TITLE
Adding 'usePassword' parameter to allow deploying the chart without a…

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 2.0.1
+version: 2.0.2
 appVersion: 3.7.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -43,35 +43,36 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the MongoDB chart and their default values.
 
-|         Parameter                   |             Description                    |                         Default                          |
-|----------------------------         |-------------------------------------       |----------------------------------------------------------|
-| `image.registry`                    | MongoDB image registry                     | `docker.io`                                              |
-| `image.repository`                  | MongoDB Image name                         | `bitnami/mongodb`                                        |
-| `image.tag`                         | MongoDB Image tag                          | `{VERSION}`                                              |
-| `image.pullPolicy`                  | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
-| `image.pullSecrets`                 | Specify image pull secrets                 | `nil`                                                    |
-| `mongodbRootPassword`               | MongoDB admin password                     | `random alhpanumeric string (10)`                        |
-| `mongodbUsername`                   | MongoDB custom user                        | `nil`                                                    |
-| `mongodbPassword`                   | MongoDB custom user password               | `random alhpanumeric string (10)`                        |
-| `mongodbDatabase`                   | Database to create                         | `nil`                                                    |
-| `mongodbExtraFlags`                 | MongoDB additional command line flags      | []                                                       |
-| `service.type`                      | Kubernetes Service type                    | `ClusterIP`                                              |
-| `service.nodePort`                  | Port to bind to for NodePort service type  | `nil`                                                    |
-| `persistence.enabled`               | Use a PVC to persist data                  | `true`                                                   |
-| `persistence.storageClass`          | Storage class of backing PVC               | `nil` (uses alpha storage class annotation)              |
-| `persistence.accessMode`            | Use volume as ReadOnly or ReadWrite        | `ReadWriteOnce`                                          |
-| `persistence.size`                  | Size of data volume                        | `8Gi`                                                    |
-| `nodeSelector`                      | Node labels for pod assignment             | {}                                                       |
-| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated   | 30                                                       |
-| `livenessProbe.periodSeconds`       | How often to perform the probe             | 10                                                       |
-| `livenessProbe.timeoutSeconds`      | When the probe times out                   | 5                                                        |
-| `livenessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.     |  1 |
-| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.       |  6 |
-| `readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated                                                        |  5 |
-| `readinessProbe.periodSeconds`      | How often to perform the probe                                                                   | 10 |
-| `readinessProbe.timeoutSeconds`     | When the probe times out                                                                         |  5 |
-| `readinessProbe.successThreshold`   | Minimum consecutive successes for the probe to be considered successful after having failed.     |  1 |
-| `readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe to be considered failed after having succeeded.       |  6 |
+|         Parameter                   |             Description                                                                      |                         Default                          |
+|-------------------------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| `image.registry`                    | MongoDB image registry                                                                       | `docker.io`                                              |
+| `image.repository`                  | MongoDB Image name                                                                           | `bitnami/mongodb`                                        |
+| `image.tag`                         | MongoDB Image tag                                                                            | `{VERSION}`                                              |
+| `image.pullPolicy`                  | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
+| `image.pullSecrets`                 | Specify image pull secrets                                                                   | `nil`                                                    |
+| `usePassword`                       | Enable password authentication                                                               | `true`                                                   |
+| `mongodbRootPassword`               | MongoDB admin password                                                                       | `random alhpanumeric string (10)`                        |
+| `mongodbUsername`                   | MongoDB custom user                                                                          | `nil`                                                    |
+| `mongodbPassword`                   | MongoDB custom user password                                                                 | `random alhpanumeric string (10)`                        |
+| `mongodbDatabase`                   | Database to create                                                                           | `nil`                                                    |
+| `mongodbExtraFlags`                 | MongoDB additional command line flags                                                        | []                                                       |
+| `service.type`                      | Kubernetes Service type                                                                      | `ClusterIP`                                              |
+| `service.nodePort`                  | Port to bind to for NodePort service type                                                    | `nil`                                                    |
+| `persistence.enabled`               | Use a PVC to persist data                                                                    | `true`                                                   |
+| `persistence.storageClass`          | Storage class of backing PVC                                                                 | `nil` (uses alpha storage class annotation)              |
+| `persistence.accessMode`            | Use volume as ReadOnly or ReadWrite                                                          | `ReadWriteOnce`                                          |
+| `persistence.size`                  | Size of data volume                                                                          | `8Gi`                                                    |
+| `nodeSelector`                      | Node labels for pod assignment                                                               | {}                                                       |
+| `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated                                                     | 30                                                       |
+| `livenessProbe.periodSeconds`       | How often to perform the probe                                                               | 10                                                       |
+| `livenessProbe.timeoutSeconds`      | When the probe times out                                                                     | 5                                                        |
+| `livenessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                        |
+| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                        |
+| `readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated                                                    | 5                                                        |
+| `readinessProbe.periodSeconds`      | How often to perform the probe                                                               | 10                                                       |
+| `readinessProbe.timeoutSeconds`     | When the probe times out                                                                     | 5                                                        |
+| `readinessProbe.successThreshold`   | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                        |
+| `readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                        |
 
 The above parameters map to the env variables defined in [bitnami/mongodb](http://github.com/bitnami/bitnami-docker-mongodb). For more information please refer to the [bitnami/mongodb](http://github.com/bitnami/bitnami-docker-mongodb) image documentation.
 

--- a/stable/mongodb/templates/NOTES.txt
+++ b/stable/mongodb/templates/NOTES.txt
@@ -21,9 +21,26 @@ MongoDB can be accessed via port 27017 on the following DNS name from within you
 
     {{ template "mongodb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
+{{ if .Values.usePassword -}}
+
+To get the root password run:
+
+    export MONGODB_ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mongodb.fullname" . }} -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
+
+{{- end }}
+{{- if and .Values.mongodbUsername .Values.mongodbDatabase }}
+{{- if .Values.mongodbPassword }}
+
+To get the password for "{{ .Values.mongodbUsername }}" run:
+
+    export MONGODB_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mongodb.fullname" . }} -o jsonpath="{.data.mongodb-password}" | base64 --decode)
+
+{{- end }}
+{{- end }}
+
 To connect to your database run the following command:
 
-    kubectl run {{ template "mongodb.fullname" . }}-client --rm --tty -i --image bitnami/mongodb --command -- mongo --host {{ template "mongodb.fullname" . }} {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end }}
+    kubectl run {{ template "mongodb.fullname" . }}-client --rm --tty -i --image bitnami/mongodb --command -- mongo --host {{ template "mongodb.fullname" . }} {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
 
 To connect to your database from outside the cluster execute the following commands:
 
@@ -31,7 +48,7 @@ To connect to your database from outside the cluster execute the following comma
 
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mongodb.fullname" . }})
-    mongo --host $NODE_IP --port $NODE_PORT {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end }}
+    mongo --host $NODE_IP --port $NODE_PORT {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
@@ -39,12 +56,12 @@ To connect to your database from outside the cluster execute the following comma
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "mongodb.fullname" . }}'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mongodb.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    mongo --host $SERVICE_IP --port {{ .Values.service.nodePort }} {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end }}
+    mongo --host $SERVICE_IP --port {{ .Values.service.nodePort }} {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mongodb.name" . }}" -o jsonpath="{.items[0].metadata.name}")
     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 27017:27017 &
-    mongo --host 127.0.0.1 {{- if .Values.mongodbRootPassword }} -p {{ .Values.mongodbRootPassword }}{{- end }}
+    mongo --host 127.0.0.1 {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
 
 {{- end }}

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -14,3 +14,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the proper image name
+*/}}
+{{- define "mongodb.image" -}}
+{{- $registryName :=  default .Values.image.registry "docker.io" -}}
+{{- $tag := .Values.image.tag | default "latest" -}}
+{{- printf "%s/%s:%s" $registryName .Values.image.repository $tag -}}
+{{- end -}}

--- a/stable/mongodb/templates/deployment.yaml
+++ b/stable/mongodb/templates/deployment.yaml
@@ -25,23 +25,25 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "mongodb.fullname" . }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ template "mongodb.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        {{- if .Values.usePassword }}
         - name: MONGODB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mongodb.fullname" . }}
               key: mongodb-root-password
+        {{- end }}
         - name: MONGODB_USERNAME
           value: {{ default "" .Values.mongodbUsername | quote }}
-        {{ if and .Values.mongodbUsername .Values.mongodbDatabase }}
+        {{- if and .Values.mongodbUsername .Values.mongodbDatabase }}
         - name: MONGODB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mongodb.fullname" . }}
               key: mongodb-password
-        {{ end }}
+        {{- end }}
         - name: MONGODB_DATABASE
           value: {{ default "" .Values.mongodbDatabase | quote }}
         - name: MONGODB_EXTRA_FLAGS

--- a/stable/mongodb/templates/pvc.yaml
+++ b/stable/mongodb/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{ if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/stable/mongodb/templates/secrets.yaml
+++ b/stable/mongodb/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{ if or .Values.usePassword .Values.mongodbPassword -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,15 +10,18 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  {{ if .Values.mongodbRootPassword }}
+  {{- if .Values.usePassword }}
+  {{- if .Values.mongodbRootPassword }}
   mongodb-root-password:  {{ .Values.mongodbRootPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   mongodb-root-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
-  {{ if and .Values.mongodbUsername .Values.mongodbDatabase }}
-  {{ if .Values.mongodbPassword }}
+  {{- end }}
+  {{- end }}
+  {{- if and .Values.mongodbUsername .Values.mongodbDatabase }}
+  {{- if .Values.mongodbPassword }}
   mongodb-password:  {{ .Values.mongodbPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   mongodb-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
-  {{ end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -17,6 +17,11 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+## Enable authentication
+## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
+#
+usePassword: true
+
 ## MongoDB admin password
 ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
 ##


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows the user to setup the MongoDB deployment without authentication.

It also does some improvements on `_helpers.tpl` and `README.md`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes issue https://github.com/bitnami/bitnami-docker-mongodb/issues/93

**Special notes for your reviewer**:
