### PR TITLE
[stable/jenkins] Wait for up to 2 minutes before failing liveness check

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.14.5
+version: 0.14.6
 appVersion: 2.107
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -50,6 +50,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.NodePort`                 | k8s node port                        | Not set                                                                      |
 | `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `true`                                                                   |
 | `Master.HealthProbesTimeout`      | Set the timeout for the liveness and readiness probes | `120`                                                       |
+| `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
 | `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
 | `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -127,6 +127,8 @@ spec:
               path: /login
               port: http
             initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout }}
+            timeoutSeconds: 5
+            failureThreshold: {{ .Values.Master.HealthProbeLivenessFailureThreshold }}
           readinessProbe:
             httpGet:
               path: /login

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -49,6 +49,8 @@ Master:
   # Enable Kubernetes Liveness and Readiness Probes
   HealthProbes: true
   HealthProbesTimeout: 60
+  # ~2 minutes to allow Jenkins to restart when upgrading plugins
+  HealthProbeLivenessFailureThreshold: 12
   SlaveListenerPort: 50000
   # Kubernetes service type for the JNLP slave service
   # SETTING THIS TO "LoadBalancer" IS A HUGE SECURITY RISK: https://github.com/kubernetes/charts/issues/1341


### PR DESCRIPTION
Otherwise a plugin installation causes 2 restarts

@lachie83 @viglesiasce 