### PR TITLE
[stable/openvpn] Update resource labels to latest best practices

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 2.0.4
+version: 3.0.0
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/templates/NOTES.txt
+++ b/stable/openvpn/templates/NOTES.txt
@@ -14,8 +14,8 @@ You set the service type to NodePort, port {{ .Values.service.nodePort }} will b
 {{ end }}
 Once the external IP is available and all the server certificates are generated create client key .ovpn files by pasting the following into a shell:
 
-  POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l type=openvpn -o jsonpath='{ .items[0].metadata.name }')
-  SERVICE_NAME=$(kubectl get svc --namespace {{ .Release.Namespace }} -l type=openvpn  -o jsonpath='{ .items[0].metadata.name }')
+  POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "openvpn.name" . }},release={{ .Release.Name }}" -o jsonpath='{ .items[0].metadata.name }')
+  SERVICE_NAME=$(kubectl get svc --namespace {{ .Release.Namespace }} -l "app={{ template "openvpn.name" . }},release={{ .Release.Name }}" -o jsonpath='{ .items[0].metadata.name }')
   SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} $SERVICE_NAME {{"-o go-template='{{ range $k, $v := (index .status.loadBalancer.ingress 0)}}{{ $v }}{{end}}'"}})
   KEY_NAME=kubeVPN
   kubectl --namespace {{ .Release.Namespace }} exec -it $POD_NAME /etc/openvpn/setup/newClientCert.sh $KEY_NAME $SERVICE_IP

--- a/stable/openvpn/templates/_helpers.tpl
+++ b/stable/openvpn/templates/_helpers.tpl
@@ -8,9 +8,25 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-Truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "openvpn.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openvpn.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/openvpn/templates/certs-pvc.yaml
+++ b/stable/openvpn/templates/certs-pvc.yaml
@@ -3,12 +3,11 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "openvpn.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "openvpn.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/openvpn/templates/config-openvpn.yaml
+++ b/stable/openvpn/templates/config-openvpn.yaml
@@ -2,7 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "openvpn.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
   setup-certs.sh: |-
     #!/bin/bash

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -1,23 +1,23 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "openvpn.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "openvpn.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "openvpn.fullname" . }}
-        type: openvpn
-        heritage: {{ .Release.Service | quote }}
-        release: {{ .Release.Name | quote }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        app: {{ template "openvpn.name" . }}
+        release: {{ .Release.Name }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/stable/openvpn/templates/openvpn-service.yaml
+++ b/stable/openvpn/templates/openvpn-service.yaml
@@ -2,10 +2,11 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "openvpn.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    type: openvpn
+    app: {{ template "openvpn.name" . }}
+    chart: {{ template "openvpn.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   ports:
     - name: openvpn


### PR DESCRIPTION
**What this PR does / why we need it**:
- All resources directly created have `app`, `chart`, `release`, and `heritage`
- Because deployment pod selectors are immutable in API version apps/v1,
  openvpn deployment pods no longer have chart version in `chart` to
  allow updating.
