### PR TITLE
Create configmap just if there is any config

### DIFF
--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -84,12 +84,14 @@ spec:
         - name: host-root
           hostPath:
               path: /
+        {{- if .Values.config }}
         - name: config
           configMap:
             name: {{ template "newrelic.fullname" . }}
             items:
             - key: newrelic-infra.yml
               path: newrelic-infra.yml
+         {{- end }}
       {{- if $.Values.nodeSelector }}
       nodeSelector:
 {{ toYaml $.Values.nodeSelector | indent 8 }}


### PR DESCRIPTION
The daemonset tries to use the configmap but the [confimap](https://github.com/kubernetes/charts/blob/master/stable/newrelic-infrastructure/templates/configmap.yaml#L1)  won't be created if there's nothing in the 
[values.yaml](https://github.com/kubernetes/charts/blob/master/stable/newrelic-infrastructure/values.yaml#L45).

That lead to an error in the pod creation.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Check if there're configurations before using the configmap in the deamonset.yaml

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
