### PR TITLE
Add home key and typo fix in vaultingkube

### DIFF
--- a/incubator/vaultingkube/Chart.yaml
+++ b/incubator/vaultingkube/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.1.0
 home: https://github.com/sunshinekitty/vaultingkube
 description: vaultingkube takes config maps and secrets stored inside Hashicorp Vault and syncs them to your Kubernetes cluster.
 name: vaultingkube
-version: 0.1.0
+version: 0.1.1

--- a/incubator/vaultingkube/Chart.yaml
+++ b/incubator/vaultingkube/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 appVersion: 0.1.0
+home: https://github.com/sunshinekitty/vaultingkube
 description: vaultingkube takes config maps and secrets stored inside Hashicorp Vault and syncs them to your Kubernetes cluster.
 name: vaultingkube
 version: 0.1.0

--- a/incubator/vaultingkube/README.md
+++ b/incubator/vaultingkube/README.md
@@ -31,7 +31,7 @@ chart and deletes the release.
 
 ## Configuration
 
-The following tables lists the configurable parameters of the vaultingkube chart and their default values.
+The following table lists the configurable parameters of the vaultingkube chart and their default values.
 
 | Parameter               | Description                                                                                                                   | Default                                                 |
 |-------------------------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|


### PR DESCRIPTION
Home key is missed in chart.yaml.
Typo fix in README.md: tables lists-> table lists
