### PR TITLE
[stable/prometheus] more careful conditional deployment behaviour 

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 6.2.2
+version: 6.3.1
 appVersion: 2.2.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 6.2.1
+version: 6.2.2
 appVersion: 2.2.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -200,6 +200,7 @@ Parameter | Description | Default
 `pushgateway.service.servicePort` | pushgateway service port | `9091`
 `pushgateway.service.type` | type of pushgateway service to create | `ClusterIP`
 `rbac.create` | If true, create & use RBAC resources | `true`
+`server.enabled` | If true, create Prometheus server | `true`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
 `server.image.tag` | Prometheus server container image tag | `v2.1.0`

--- a/stable/prometheus/templates/alertmanager-networkpolicy.yaml
+++ b/stable/prometheus/templates/alertmanager-networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.alertmanager.enabled .Values.networkPolicy.enabled }}
 apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:

--- a/stable/prometheus/templates/alertmanager-serviceaccount.yaml
+++ b/stable/prometheus/templates/alertmanager-serviceaccount.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.alertmanager.enabled }}
-{{- if .Values.serviceAccounts.alertmanager.create }}
+{{- if and .Values.alertmanager.enabled .Values.serviceAccounts.alertmanager.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,5 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/alertmanager-serviceaccount.yaml
+++ b/stable/prometheus/templates/alertmanager-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled }}
 {{- if .Values.serviceAccounts.alertmanager.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.kubeStateMetrics.enabled }}
-{{- if .Values.rbac.create }}
+{{- if and .Values.kubeStateMetrics.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -60,5 +59,4 @@ rules:
     verbs:
       - list
       - watch
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubeStateMetrics.enabled }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -59,4 +60,5 @@ rules:
     verbs:
       - list
       - watch
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.kubeStateMetrics.enabled }}
-{{- if .Values.rbac.create }}
+{{- if and .Values.kubeStateMetrics.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -18,5 +17,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubeStateMetrics.enabled }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -17,4 +18,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-networkpolicy.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-networkpolicy.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.kubeStateMetrics.enabled }}
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.kubeStateMetrics.enabled .Values.networkPolicy.enabled }}
 apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
@@ -24,5 +23,4 @@ spec:
           component: "{{ .Values.server.name }}"
   - ports:
     - port: 8080
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-networkpolicy.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubeStateMetrics.enabled }}
 {{- if .Values.networkPolicy.enabled }}
 apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -23,4 +24,5 @@ spec:
           component: "{{ .Values.server.name }}"
   - ports:
     - port: 8080
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kubeStateMetrics.enabled }}
 {{- if .Values.serviceAccounts.kubeStateMetrics.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.kubeStateMetrics" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.kubeStateMetrics.enabled }}
-{{- if .Values.serviceAccounts.kubeStateMetrics.create }}
+{{- if and .Values.kubeStateMetrics.enabled .Values.serviceAccounts.kubeStateMetrics.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,5 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.kubeStateMetrics" . }}
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/node-exporter-serviceaccount.yaml
+++ b/stable/prometheus/templates/node-exporter-serviceaccount.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.nodeExporter.enabled }}
-{{- if .Values.serviceAccounts.nodeExporter.create }}
+{{- if and .Values.nodeExporter.enabled .Values.serviceAccounts.nodeExporter.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,5 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/node-exporter-serviceaccount.yaml
+++ b/stable/prometheus/templates/node-exporter-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nodeExporter.enabled }}
 {{- if .Values.serviceAccounts.nodeExporter.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/pushgateway-serviceaccount.yaml
+++ b/stable/prometheus/templates/pushgateway-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.pushgateway.enabled }}
 {{- if .Values.serviceAccounts.pushgateway.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/pushgateway-serviceaccount.yaml
+++ b/stable/prometheus/templates/pushgateway-serviceaccount.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.pushgateway.enabled }}
-{{- if .Values.serviceAccounts.pushgateway.create }}
+{{- if and .Values.pushgateway.enabled .Values.serviceAccounts.pushgateway.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,5 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -42,4 +43,5 @@ rules:
       - "/metrics"
     verbs:
       - get
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled }}
-{{- if .Values.rbac.create }}
+{{- if and .Values.server.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -43,5 +42,4 @@ rules:
       - "/metrics"
     verbs:
       - get
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/server-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -17,4 +18,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "prometheus.server.fullname" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/server-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled }}
-{{- if .Values.rbac.create }}
+{{- if and .Values.server.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -18,5 +17,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "prometheus.server.fullname" . }}
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 {{- if (empty .Values.server.configMapOverrideName) -}}
 apiVersion: v1
 kind: ConfigMap
@@ -39,6 +40,7 @@ data:
         - source_labels: [__meta_kubernetes_pod_container_port_number]
           regex:
           action: drop
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled }}
-{{- if (empty .Values.server.configMapOverrideName) -}}
+{{- if and .Values.server.enabled (empty .Values.server.configMapOverrideName) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -40,7 +39,6 @@ data:
         - source_labels: [__meta_kubernetes_pod_container_port_number]
           regex:
           action: drop
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -166,3 +167,4 @@ spec:
           configMap:
             name: {{ .configMap }}
       {{- end }}
+{{- end }}

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 {{- if .Values.server.ingress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.server.fullname" . }}
@@ -32,4 +33,5 @@ spec:
   tls:
 {{ toYaml .Values.server.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled }}
-{{- if .Values.server.ingress.enabled -}}
+{{- if and .Values.server.enabled .Values.server.ingress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.server.fullname" . }}
 {{- $servicePort := .Values.server.service.servicePort -}}
@@ -33,5 +32,4 @@ spec:
   tls:
 {{ toYaml .Values.server.ingress.tls | indent 4 }}
   {{- end -}}
-{{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-networkpolicy.yaml
+++ b/stable/prometheus/templates/server-networkpolicy.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled }}
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.server.enabled .Values.networkPolicy.enabled }}
 apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
@@ -19,5 +18,4 @@ spec:
   ingress:
     - ports:
       - port: 9090
-{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-networkpolicy.yaml
+++ b/stable/prometheus/templates/server-networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 {{- if .Values.networkPolicy.enabled }}
 apiVersion: {{ template "prometheus.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -18,4 +19,5 @@ spec:
   ingress:
     - ports:
       - port: 9090
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled }}
-{{- if .Values.server.persistentVolume.enabled -}}
+{{- if and .Values.server.enabled .Values.server.persistentVolume.enabled -}}
 {{- if not .Values.server.persistentVolume.existingClaim -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -28,6 +27,5 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.server.persistentVolume.size }}"
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 {{- if .Values.server.persistentVolume.enabled -}}
 {{- if not .Values.server.persistentVolume.existingClaim -}}
 apiVersion: v1
@@ -27,5 +28,6 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.server.persistentVolume.size }}"
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,3 +46,4 @@ spec:
     component: "{{ .Values.server.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.server.service.type }}"
+{{- end }}

--- a/stable/prometheus/templates/server-serviceaccount.yaml
+++ b/stable/prometheus/templates/server-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 {{- if .Values.serviceAccounts.server.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
+{{- end }}
 {{- end }}

--- a/stable/prometheus/templates/server-serviceaccount.yaml
+++ b/stable/prometheus/templates/server-serviceaccount.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.server.enabled }}
-{{- if .Values.serviceAccounts.server.create }}
+{{- if and .Values.server.enabled .Values.serviceAccounts.server.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,5 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
-{{- end }}
 {{- end }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -403,6 +403,10 @@ nodeExporter:
     type: ClusterIP
 
 server:
+  ## If false, Prometheus server will not be installed
+  ##
+  enabled: true
+
   ## Prometheus server container name
   ##
   name: server


### PR DESCRIPTION
**What this PR does / why we need it**:

I wanted to deploy the node exporter and kube-state-metrics separately to the
rest of Prometheus and discovered that there was no conditional deployment
setting in `values.yaml` for that.

While making these changes I also noticed that deploying individual components
would still generate RBAC resources for the other components, so I fixed that too.

I think this should not introduce any chart default behaviour changes, or release
upgrade issues for users of earlier revisions of the chart, as `server.enabled`
defaults to `true`.

**Special notes for your reviewer**:

Tested on Kubernetes 1.10.

(ping @mgoodness — Thanks for maintaining this chart!)