### PR TITLE
Remove checksum annotations

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.16.1
+version: 0.17.1
 appVersion: 0.13.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -17,9 +17,8 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   template:
     metadata:
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
       {{- if .Values.controller.podAnnotations }}
+      annotations:
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
       {{- end }}
       labels:


### PR DESCRIPTION
This annotation cause unnecessary restart on nginx ingress pods, the controller has a configmap watcher that will take care of any configuration change. 