### PR TITLE
Allow setting node port for NodePort typed service

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.7.6
+version: 0.7.7
 appVersion: 3.7.4
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/svc.yaml
+++ b/stable/rabbitmq/templates/svc.yaml
@@ -16,6 +16,9 @@ spec:
   - name: amqp
     port: {{ .Values.rabbitmq.nodePort }}
     targetPort: amqp
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.rabbitmq.nodePort))) }}
+    nodePort: {{ .Values.rabbitmq.nodePort }}
+    {{- end }}
   - name: dist
     port: {{ .Values.rabbitmq.nodePort | add 20000 }}
     targetPort: dist

--- a/stable/rabbitmq/templates/svc.yaml
+++ b/stable/rabbitmq/templates/svc.yaml
@@ -16,7 +16,7 @@ spec:
   - name: amqp
     port: {{ .Values.rabbitmq.nodePort }}
     targetPort: amqp
-    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.rabbitmq.nodePort))) }}
+    {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.rabbitmq.nodePort))) }}
     nodePort: {{ .Values.rabbitmq.nodePort }}
     {{- end }}
   - name: dist


### PR DESCRIPTION
If the service type is set to NodePort, k8s creates a random port if the nodePort property isn't set. This isn't usefull if RabbitMq should be accessible from outside of the cluster