### PR TITLE
[stable/rabbitmq] enable RBAC by default

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.7.7
+version: 0.8.0
 appVersion: 3.7.4
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/configuration.yaml
+++ b/stable/rabbitmq/templates/configuration.yaml
@@ -15,3 +15,4 @@ data:
     default_user={{.Values.rabbitmq.username}}
     default_pass=CHANGEME
 {{ .Values.rabbitmq.configuration | indent 4 }}
+

--- a/stable/rabbitmq/templates/configuration.yaml
+++ b/stable/rabbitmq/templates/configuration.yaml
@@ -15,5 +15,3 @@ data:
     default_user={{.Values.rabbitmq.username}}
     default_pass=CHANGEME
 {{ .Values.rabbitmq.configuration | indent 4 }}
-
-      

--- a/stable/rabbitmq/templates/serviceaccount.yaml
+++ b/stable/rabbitmq/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "rabbitmq.fullname" . }} 
+  name: {{ template "rabbitmq.fullname" . }}
   labels:
     app: {{ template "rabbitmq.name" . }}
     chart: {{ template "rabbitmq.chart" .  }}

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end}}
       {{- end }}
       {{- if .Values.rbacEnabled}}
-      serviceAccountName: {{ template "rabbitmq.fullname" . }} 
+      serviceAccountName: {{ template "rabbitmq.fullname" . }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity:
@@ -42,7 +42,7 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 10
-      containers:        
+      containers:
       - name: {{ template "rabbitmq.fullname" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
@@ -52,7 +52,7 @@ spec:
          - |
             #create the var/lib/rabbitmq directory under the bitnami folder
             mkdir -p /opt/bitnami/rabbitmq/var/lib/rabbitmq/
-            
+
             #persist the erlang cookie in both places for server and cli tools
             echo $RABBITMQ_ERL_COOKIE > /opt/bitnami/rabbitmq/var/lib/rabbitmq/.erlang.cookie
             cp /opt/bitnami/rabbitmq/var/lib/rabbitmq/.erlang.cookie /root
@@ -127,7 +127,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ template "rabbitmq.fullname" . }}
-                key: rabbitmq-erlang-cookie 
+                key: rabbitmq-erlang-cookie
           - name: RABBITMQ_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -135,7 +135,7 @@ spec:
                 key: rabbitmq-password
       volumes:
         - name: config-volume
-          configMap: 
+          configMap:
             name: {{ template "rabbitmq.fullname" . }}-config
             items:
             - key: rabbitmq.conf
@@ -149,4 +149,3 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end -}}
-       

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -10,18 +10,18 @@ image:
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
   pullPolicy: IfNotPresent
-  
+
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb
-  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging 
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
   debug: false
-  
+
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
   # pullSecrets:
-  #   - myRegistrKeySecretName 
+  #   - myRegistrKeySecretName
 
 
 ## does your cluster have rbac enabled?
@@ -64,11 +64,11 @@ rabbitmq:
   ## ref: https://www.rabbitmq.com/disk-alarms.html
   ##
   diskFreeLimit: '"6GiB"'
-  
+
   ## Plugins to enable
   plugins: |-
       [rabbitmq_management,rabbitmq_peer_discovery_k8s].
-  
+
   ## Configution file content
   configuration: |-
       ## Clustering
@@ -78,10 +78,11 @@ rabbitmq:
       cluster_formation.node_cleanup.interval = 10
       cluster_formation.node_cleanup.only_log_warning = false
       cluster_partition_handling = autoheal
-      ## queue master locator 
+      ## queue master locator
       queue_master_locator=min-masters
-      ## enable guest user  
+      ## enable guest user
       loopback_users.guest = false
+
 ## Kubernetes service type
 serviceType: ClusterIP
 
@@ -120,7 +121,7 @@ replicas: 3
 ## Node labels and tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
-nodeSelector: 
+nodeSelector:
   beta.kubernetes.io/arch: amd64
 tolerations: []
 affinity: {}

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -23,7 +23,7 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## does your cluster have rbac enabled? assume no by default
+## does your cluster have rbac enabled? assume yes by default
 rbacEnabled: true
 
 ## section of specific values for rabbitmq

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -24,7 +24,7 @@ image:
   #   - myRegistrKeySecretName
 
 ## does your cluster have rbac enabled? assume no by default
-rbacEnabled: false
+rbacEnabled: true
 
 ## section of specific values for rabbitmq
 rabbitmq:
@@ -66,17 +66,17 @@ rabbitmq:
 
   ## Plugins to enable
   plugins: |-
-      [rabbitmq_management,rabbitmq_peer_discovery_k8s].
+      [rabbitmq_management].
 
   ## Configution file content
   configuration: |-
       ## Clustering
-      cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
-      cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
-      cluster_formation.k8s.address_type = ip
-      cluster_formation.node_cleanup.interval = 10
-      cluster_formation.node_cleanup.only_log_warning = false
-      cluster_partition_handling = autoheal
+      # cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
+      # cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+      # cluster_formation.k8s.address_type = ip
+      # cluster_formation.node_cleanup.interval = 10
+      # cluster_formation.node_cleanup.only_log_warning = false
+      # cluster_partition_handling = autoheal
       ## queue master locator
       queue_master_locator=min-masters
       ## enable guest user

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -66,17 +66,17 @@ rabbitmq:
 
   ## Plugins to enable
   plugins: |-
-      [rabbitmq_management].
+      [rabbitmq_management, rabbitmq_peer_discovery_k8s].
 
   ## Configution file content
   configuration: |-
       ## Clustering
-      # cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
-      # cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
-      # cluster_formation.k8s.address_type = ip
-      # cluster_formation.node_cleanup.interval = 10
-      # cluster_formation.node_cleanup.only_log_warning = false
-      # cluster_partition_handling = autoheal
+      cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
+      cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+      cluster_formation.k8s.address_type = ip
+      cluster_formation.node_cleanup.interval = 10
+      cluster_formation.node_cleanup.only_log_warning = false
+      cluster_partition_handling = autoheal
       ## queue master locator
       queue_master_locator=min-masters
       ## enable guest user


### PR DESCRIPTION
**What this PR does / why we need it**:

It's not possible to use the current `values.yaml` to install RabbitMQ chart since it does not enable RBAC but it includes the K8s plugin on the list of plugins to install. That plugin requires RBAC configuration and, therefore, you can't install the chart simply running: `helm instal stable/rabbitmq`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes

Issue reported at: 

https://github.com/bitnami/bitnami-docker-rabbitmq/issues/60