### PR TITLE
Feature/add extra labels and annotations locust

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 name: locust
 description: A modern load testing framework
-version: 0.2.4
+version: 0.2.0
 appVersion: 0.7.5
 maintainers:
   - name: Vincent De Smet

--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 name: locust
 description: A modern load testing framework
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.7.5
 maintainers:
   - name: Vincent De Smet

--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,6 +1,6 @@
 name: locust
 description: A modern load testing framework
-version: 0.1.5
+version: 0.2.4
 appVersion: 0.7.5
 maintainers:
   - name: Vincent De Smet

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -32,7 +32,7 @@ helm install -n locust-nymph --set master.config.target-host=http://site.example
 | `service.type`               | k8s service type exposing master   | `NodePort`                                            |
 | `service.nodePort`           | Port on cluster to expose master   | `0`                                                   |
 | `service.annotations`        | KV containing custom annotations   | `{}`                                                    |
-| `service.extra_labels`       | KV containing extra labels         | `{}`                                                    |
+| `service.extraLabels`        | KV containing extra labels         | `{}`                                                    |
 | `master.config.target-host`  | locust target host                 | `http://site.example.com`                             |
 | `worker.config.locust-script`| locust script to run               | `/locust-tasks/tasks.py`                              |
 | `worker.replicaCount`        | Number of workers to run           | `2`                                                   |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -31,6 +31,8 @@ helm install -n locust-nymph --set master.config.target-host=http://site.example
 | `image.tag`                  | Locust Container image tag         | `0.7.5`                                               |
 | `service.type`               | k8s service type exposing master   | `NodePort`                                            |
 | `service.nodePort`           | Port on cluster to expose master   | `0`                                                   |
+| `service.annotations`        | KV containing custom annotations   | `{}`                                                    |
+| `service.extra_labels`       | KV containing extra labels         | `{}`                                                    |
 | `master.config.target-host`  | locust target host                 | `http://site.example.com`                             |
 | `worker.config.locust-script`| locust script to run               | `/locust-tasks/tasks.py`                              |
 | `worker.replicaCount`        | Number of workers to run           | `2`                                                   |

--- a/stable/locust/templates/master-svc.yaml
+++ b/stable/locust/templates/master-svc.yaml
@@ -9,9 +9,7 @@ metadata:
     app: {{ template "locust.fullname" . }}
     component: "master"
     {{- range $key, $value :=  .Values.service.extra_labels }}
-    - name: {{ $key }}
-      value: {{ $value | quote }}
-    {{- end }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.service.annotations }}
   annotations:

--- a/stable/locust/templates/master-svc.yaml
+++ b/stable/locust/templates/master-svc.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "locust.fullname" . }}
     component: "master"
-    {{- range $key, $value :=  .Values.service.extra_labels }}
+    {{- range $key, $value :=  .Values.service.extraLabels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.service.annotations }}

--- a/stable/locust/templates/master-svc.yaml
+++ b/stable/locust/templates/master-svc.yaml
@@ -14,8 +14,7 @@ metadata:
   {{- if .Values.service.annotations }}
   annotations:
   {{- range $key, $value :=  .Values.service.annotations }}
-  - name: {{ $key }}
-    value: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- end }}
 spec:

--- a/stable/locust/templates/master-svc.yaml
+++ b/stable/locust/templates/master-svc.yaml
@@ -8,6 +8,18 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: {{ template "locust.fullname" . }}
     component: "master"
+    {{- range $key, $value :=  .Values.service.extra_labels }}
+    - name: {{ $key }}
+      value: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.service.annotations }}
+  annotations:
+  {{- range $key, $value :=  .Values.service.annotations }}
+  - name: {{ $key }}
+    value: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -11,8 +11,6 @@ service:
   externalPort: 8089
   internalPort: 8089
   nodePort: 0
-  annotations: {}
-  extra_labels: {}
 master:
   config:
     target-host: https://site.example.com

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -12,7 +12,7 @@ service:
   internalPort: 8089
   nodePort: 0
   annotations: {}
-  extra_labels: {}
+  extraLabels: {}
 master:
   config:
     target-host: https://site.example.com

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -11,6 +11,8 @@ service:
   externalPort: 8089
   internalPort: 8089
   nodePort: 0
+  annotations: {}
+  extra_labels: {}
 master:
   config:
     target-host: https://site.example.com


### PR DESCRIPTION
This PR allows people to customize labels and annotations. This is primarily usefull for people who have kubernetes plugins that rely on custom annotations and/or labels to find resources throught the api.