### PR TITLE
[stable/redis] Fix README password typo

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.0.2
+version: 3.0.3
 appVersion: 4.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.0.3
+version: 3.0.4
 appVersion: 4.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -138,7 +138,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```bash
 $ helm install --name my-release \
-  --set redisPassword=secretpassword \
+  --set password=secretpassword \
     stable/redis
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a small typo fix on `stable/redis` README. We have `--set redisPassword=..` instead of `--set password=..`

