### PR TITLE
[stable/sonatype-nexus] Fix resources not applied + allow env var

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.0.2
+version: 1.0.3
 appVersion: 3.10.0-04
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -66,7 +66,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.imageName`                           | Nexus image                         | `quay.io/travelaudience/docker-nexus`   |
 | `nexus.imageTag`                            | Version of Nexus                    | `3.9.0`                                 |
 | `nexus.imagePullPolicy`                     | Nexus image pull policy             | `IfNotPresent`                          |
-| `nexus.env.install4jAddVmParams`            | JVM options                         | `-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap`  |
+| `nexus.env`                                 | Nexus environment variables         | `[{install4jAddVmParams: -Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap}]` |
 | `nexus.resources`                           | Nexus resource requests and limits  | `{}`                                    |
 | `nexus.dockerPort`                          | Port to access docker               | `5003`                                  |
 | `nexus.nexusPort`                           | Internal port for Nexus service     | `8081`                                  |

--- a/stable/sonatype-nexus/templates/deployment.yaml
+++ b/stable/sonatype-nexus/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           env:
 {{ toYaml .Values.nexus.env | indent 12 }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.nexus.resources | indent 12 }}
           ports:
             - containerPort: {{ .Values.nexus.dockerPort }}
               name: nexus-docker-g

--- a/stable/sonatype-nexus/templates/deployment.yaml
+++ b/stable/sonatype-nexus/templates/deployment.yaml
@@ -25,8 +25,7 @@ spec:
           image: {{ .Values.nexus.imageName }}:{{ .Values.nexus.imageTag }}
           imagePullPolicy: {{ .Values.nexus.imagePullPolicy }}
           env:
-            - name: INSTALL4J_ADD_VM_PARAMS
-              value: {{ .Values.nexus.env.install4jAddVmParams | quote }}
+{{ toYaml .Values.nexus.env | indent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -5,7 +5,8 @@ nexus:
   imageTag: 3.9.0
   imagePullPolicy: IfNotPresent
   env:
-    install4jAddVmParams: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+    - name: install4jAddVmParams
+      value: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
   # nodeSelector:
   #   cloud.google.com/gke-nodepool: default-pool
   resources: {}


### PR DESCRIPTION
This PR does two things (If two separate PR are required, I can do, but I thought that for these two small changes one PR would do fine):
* Fix a typo:  `.Values.resources` does not exist in `values.yaml`, the key is `.Values.nexus.resources`.
* Add the possibility to add env variables ( for `INSTALL4J_ADD_VM_PARAMS`, it will use the default value from the chart's `values.yaml` overwritten by the user's `values.yaml` or via CLI).
