### PR TITLE
Add support for default certificate

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.0.3
+version: 1.1.0
 appVersion: 3.10.0-04
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -107,7 +107,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
 | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{}`                          |
 | `ingress.tls.enabled`                       | Enable TLS                          | `false`                                 |
-| `ingress.tls.secretName`                    | Name of the secret storing TLS cert | `nexus-tls`                             |
+| `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
 
 If `nexusProxy.env.cloudIamAuthEnabled` is set to `true` the following variables need to be configured
 

--- a/stable/sonatype-nexus/templates/ingress.yaml
+++ b/stable/sonatype-nexus/templates/ingress.yaml
@@ -30,6 +30,8 @@ spec:
     - hosts:
         - {{ .Values.nexusProxy.env.nexusDockerHost }}
         - {{ .Values.nexusProxy.env.nexusHttpHost }}
+      {{- if .Values.ingress.tls.secretName }}
       secretName: {{ .Values.ingress.tls.secretName | quote }}
+      {{- end }}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for using the default TLS Secret provided by the ingress controller.

**Special notes for your reviewer**:
`secretName` is optional for `Ingress`, for instance if you use `--default-ssl-certificate`in the ingress-nginx and have a wildcard certificate, you do not need to specify the default secret every time.