### PR TITLE
only install daemonset if collectorUrl is set

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,6 @@
 name: sumologic-fluentd
-version: 0.3.1
+version: 0.3.2
+appVersion: v1.6
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/ci/no-url-values.yaml
+++ b/stable/sumologic-fluentd/ci/no-url-values.yaml
@@ -1,0 +1,3 @@
+sumologic:
+  collectorUrl: https://endpoint1.collection.us2.sumologic.com/receiver/v1/http/1234
+  excludePath: "[\"/mnt/log/*.log\", \"/var/log/*.log\", \"/mnt/log/*/*.log\"]"

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sumologic.collectorUrl -}}
 # Sumologic collector URL is required
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -190,3 +191,4 @@ spec:
     {{- end }}
   updateStrategy:
     type: "{{ .Values.updateStrategy }}"
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now we are unable to merge other PRs as the testing installs the Daemonset without the sumologic.collectorUrl being provided.  This causes the image to fail and is also preventing us from merging other changes.  

In an ideal world, we would have a Sumo account we could send data too, which we can do. But that means that all the logs from all the containers running in the k8s cluster would be sent to sumo.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

This will unblock #4539 from test failures.

**Special notes for your reviewer**: