### PR TITLE
[stable/spinnaker] Fix for k8s 1.9.4 or upper version

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 0.4.0
+version: 0.4.1
 appVersion: 1.6.0
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/requirements.lock
+++ b/stable/spinnaker/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.1.6
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.4.3
+  version: 1.1.1
 - name: jenkins
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.13.3
-digest: sha256:5cdbf5aa7fa2f1fab477b75cbe931bb053e261c4437413af3c8d8a39b119924c
-generated: 2018-02-25T13:11:01.017154568-08:00
+digest: sha256:c41d8c94dd87eccc61df25f2cdea2fd35e370a89d2c6742028585c7998339c41
+generated: 2018-04-25T10:53:14.553461816+09:00

--- a/stable/spinnaker/requirements.yaml
+++ b/stable/spinnaker/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
   version: 1.1.6
   repository: https://kubernetes-charts.storage.googleapis.com/
 - name: minio
-  version: 0.4.3
+  version: 1.1.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: minio.enabled
 - name: jenkins

--- a/stable/spinnaker/templates/configmap/spinnaker-config.yaml
+++ b/stable/spinnaker/templates/configmap/spinnaker-config.yaml
@@ -355,7 +355,7 @@ data:
           enabled: false
         s3:
           enabled: true
-          endpoint: http://{{ .Release.Name }}-minio-svc:9000
+          endpoint: http://{{ .Release.Name }}-minio:9000
         {{ end }}
       gate:
         host: {{ template "fullname" . }}-gate

--- a/stable/spinnaker/templates/hooks/create-bucket.yaml
+++ b/stable/spinnaker/templates/hooks/create-bucket.yaml
@@ -22,9 +22,9 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: post-install-job
-        image: "viglesiasce/minio-client:v0.4.0"
+        image: "minio/mc:RELEASE.2018-03-25T01-22-22Z"
         command:
         - sh
         - -c
-        - "mc config host add {{.Release.Name}}-minio http://{{.Release.Name}}-minio:9000 {{ .Values.minio.accessKey }} {{ .Values.minio.secretKey }} S3v4 &&  mc mb {{.Release.Name}}-minio/spinnaker"
+        - "mc config host add {{.Release.Name}}-minio http://{{.Release.Name}}-minio:9000 {{ .Values.minio.accessKey }} {{ .Values.minio.secretKey }} S3v4 && mc mb -p {{.Release.Name}}-minio/spinnaker"
 {{- end }}

--- a/stable/spinnaker/templates/hooks/create-bucket.yaml
+++ b/stable/spinnaker/templates/hooks/create-bucket.yaml
@@ -26,5 +26,5 @@ spec:
         command:
         - sh
         - -c
-        - "mc config host add {{.Release.Name}}-minio http://{{.Release.Name}}-minio-svc:9000 {{ .Values.minio.accessKey }} {{ .Values.minio.secretKey }} S3v4 &&  mc mb {{.Release.Name}}-minio/spinnaker"
+        - "mc config host add {{.Release.Name}}-minio http://{{.Release.Name}}-minio:9000 {{ .Values.minio.accessKey }} {{ .Values.minio.secretKey }} S3v4 &&  mc mb {{.Release.Name}}-minio/spinnaker"
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

stable/spinnaker chart version 0.4.0 does not work on Kubernetes version 1.9.4 or higher.
It will work with the following fixes.

1. Update minio version in requirements.yaml
2. Change minio endpoints in spinnaker-config.yaml and create-bucketyaml
3. Change minio client image in create-bucket.yaml, and add command option

***1. Update minio version in requirements.yaml***:

maybe, in k8s 1.9.4 or higher version, minio 0.4.3 is not working.

update stable/minio 0.4.3 -> 1.1.1

Please refer to this: <https://github.com/minio/minio/issues/5725>

***2. Change minio endpoints in spinnaker-config.yaml and create-bucketyaml***:

in minio chart version 1.0.0 or higher, service name(endpoint) is "http://{{ .Release.Name }}-minio:9000"
(in 0.4.0, endpoint is "http://{{ .Release.Name }}-minio-__svc__:9000")

***3. Change minio client image in create-bucket.yaml, and add command option***:

Sometimes, "create bucket" job container goes into crash loop.

```
Your previous request to create the named bucket succeeded and you already own it.
```

to avoid this, update mc version and use `mc mb -p`. "-p" option is like `mkdir -p`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

no issue.

**Special notes for your reviewer**:

tested on k8s 1.9.6 and 1.10.0