### PR TITLE
[elasticsearch-curator] Add extra volumes & mounts

### DIFF
--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.4.1"
 description: A Helm chart for Elasticseach Curator
 name: elasticsearch-curator
-version: 0.1.2
+version: 0.2.0
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.4.1"
 description: A Helm chart for Elasticseach Curator
 name: elasticsearch-curator
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/incubator/elasticsearch-curator/README.md
+++ b/incubator/elasticsearch-curator/README.md
@@ -39,6 +39,8 @@ their default values.
 | `configMaps.action_file_yml` | Contents of the Curator action_file.yml               | See values.yaml                              |
 | `configMaps.config_yml`      | Contents of the Curator config.yml (overrides config) | See values.yaml                              |
 | `resources`                  | Resource requests and limits                          | {}                                           |
+| `extraVolumeMounts`          | Mount extra volume(s),                                |                                              |
+| `extraVolumes`               | Extra volumes                                         |                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/incubator/elasticsearch-curator/templates/cronjob.yaml
+++ b/incubator/elasticsearch-curator/templates/cronjob.yaml
@@ -21,6 +21,9 @@ spec:
             - name: config-volume
               configMap:
                 name: curator-config
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 12 }}
+{{- end }}
           restartPolicy: Never
           containers:
             - name: {{ .Chart.Name }}
@@ -29,6 +32,9 @@ spec:
               volumeMounts:
                 - name: config-volume
                   mountPath: /etc/es-curator
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 16 }}
+{{- end }}
               command: [ "curator" ]
               args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
               resources:

--- a/incubator/elasticsearch-curator/values.yaml
+++ b/incubator/elasticsearch-curator/values.yaml
@@ -75,3 +75,15 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+# extraVolumes and extraVolumeMounts allows you to mount other volumes
+# Example Use Case: mount ssl certificates when elasticsearch has tls enabled
+# extraVolumes:
+#   - name: es-certs
+#     secret:
+#       defaultMode: 420
+#       secretName: es-certs
+# extraVolumeMounts:
+#   - name: es-certs
+#     mountPath: /certs
+#     readOnly: true


### PR DESCRIPTION
Similar to the fluentd-elasticsearch chart where one
would like to mount extra volumes for things like TLS,
this commit adds the same thing for this chart.
Example Use Case: Need to mount certificate authority
file so the curator can talk to a elasticsearch cluster
where HTTPS is enforced

CC the maintainers: @gianrubio @tmestdagh 


**Special notes for your reviewer**:
Reference the similar logic in the fluentd-elasticsearch chart: https://github.com/kubernetes/charts/tree/master/incubator/fluentd-elasticsearch
