### PR TITLE
[stable/keel] Add support for SLACK_BOT_NAME

### DIFF
--- a/stable/keel/Chart.yaml
+++ b/stable/keel/Chart.yaml
@@ -2,18 +2,20 @@ apiVersion: v1
 name: keel
 description: Open source, tool for automating Kubernetes deployment updates. Keel
   is stateless, robust and lightweight.
-version: 0.2.2
-appVersion: 0.4.7
+version: 0.3.0
+appVersion: 0.8.3
 keywords:
 - kubernetes deployment
 - helm release
 - continuous deployment
 home: https://keel.sh
 sources:
-- https://github.com/rusenask/keel
+- https://github.com/keel-hq/keel
 maintainers:
 - name: rimusz
   email: rmocius@gmail.com
 - name: rusenask
   email: karolis.rusenas@gmail.com
+- name: archifleks
+  email: lefevre.kevin@gmail.com
 engine: gotpl

--- a/stable/keel/README.md
+++ b/stable/keel/README.md
@@ -99,6 +99,7 @@ The following table lists has the main configurable parameters (polling, trigger
 | `slack.enabled`                   | Enable/disable Slack Notification      | `false`                                                   |
 | `slack.token`                     | Slack token                            |                                                           |
 | `slack.channel`                   | Slack channel                          |                                                           |
+| `slack.botName`                   | Slack Bot name                         |                                                           |
 | `service.enable`                  | Enable/disable Keel service            | `false`                                                   |
 | `service.type`                    | Keel service type                      | `LoadBalancer`                                            |
 | `service.externalPort`            | Keel service port                      | `9300`                                                    |

--- a/stable/keel/templates/deployment.yaml
+++ b/stable/keel/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: "{{ .Values.slack.token }}"
             - name: SLACK_CHANNELS
               value: "{{ .Values.slack.channel }}"
+            - name: SLACK_BOT_NAME
+              value: "{{ .Values.slack.botName }}"
 {{- end }}
           ports:
             - containerPort: 9300

--- a/stable/keel/values.yaml
+++ b/stable/keel/values.yaml
@@ -35,6 +35,7 @@ slack:
   enabled: false
   token: ""
   channel: ""
+  botName: ""
 
 # Keel service
 # Enable to receive webhooks from Docker registries

--- a/stable/keel/values.yaml
+++ b/stable/keel/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: karolisr/keel
-  tag: 0.4.7
+  repository: keelhq/keel
+  tag: 0.8.3
   pullPolicy: IfNotPresent
 
 # Polling is enabled by default,
@@ -56,7 +56,7 @@ webhookRelay:
   # webhookrelay docker image
   image:
     repository: webhookrelay/webhookrelayd
-    tag: 0.2.7
+    tag: 0.6.3
     pullPolicy: IfNotPresent
 
 # Keel self-update


### PR DESCRIPTION
Allow to specify a Bot name different from the default "keel".