### PR TITLE
adding pod antiaffinity to slave pods

### DIFF
--- a/stable/redis/templates/redis-slave-deployment.yaml
+++ b/stable/redis/templates/redis-slave-deployment.yaml
@@ -26,6 +26,20 @@ spec:
 {{ toYaml (.Values.slave.podAnnotations | default .Values.master.podAnnotations) | indent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.slave.podAntiAffinity }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "redis.name" . }}
+              topologyKey: kubernetes.io/hostname
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.pullSecrets }}
@@ -33,7 +47,7 @@ spec:
         {{- end}}
       {{- end}}
       {{- /* Include master securityContext if slave securityContext not defined */ -}}
-      {{ include "redis.slave.securityContext" . | indent 6 }}  
+      {{ include "redis.slave.securityContext" . | indent 6 }}
       {{- if (.Values.slave.nodeSelector | default .Values.master.nodeSelector) }}
       nodeSelector:
 {{ toYaml (.Values.slave.nodeSelector | default .Values.master.nodeSelector) | indent 8 }}
@@ -92,9 +106,9 @@ spec:
         - name: redis
           containerPort: {{ .Values.slave.port | default .Values.master.port }}
         {{- /* Include master livenessProbe if slave livenessProbe not defined */ -}}
-        {{ include "redis.slave.livenessProbe" . | indent 8 }}  
+        {{ include "redis.slave.livenessProbe" . | indent 8 }}
         {{- /* Include master readinessProbe if slave readinessProbe not defined */ -}}
-        {{ include "redis.slave.readinessProbe" . | indent 8 }}  
+        {{ include "redis.slave.readinessProbe" . | indent 8 }}
         resources:
 {{ toYaml (.Values.slave.resources | default .Values.master.resources) | indent 10 }}
 {{- end }}

--- a/stable/redis/values-production.yaml
+++ b/stable/redis/values-production.yaml
@@ -179,6 +179,7 @@ master:
 ## The rest of the parameters, if undefined, will inherit those declared in Redis Master
 ##
 slave:
+  podAntiAffinity: true
   ## Slave Service properties
   service:
     ## Redis Slave Service type


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Add the option for pod antiaffinity for redis slaves to redis charts. Helps ensure pods are not concentrated on one node ensuring high availability. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5249

**Special notes for your reviewer**:
