### PR TITLE
Added prometheus scrape annotations

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.16.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -50,6 +50,7 @@ The following tables lists the configurable parameters and their default values.
 | `service.type`         | desired service type                                | `ClusterIP`               |
 | `service.port`         | service external port                               | `9121`                    |
 | `redisAddress`         | address of one or more redis nodes, comma separated | `redis://myredis:6379`    |
+| `annotation`           | pod annotations for easier discovery                | {}                        |
 
 For more information please refer to the [redis_exporter](https://github.com/oliver006/redis_exporter) documentation.
 

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -50,7 +50,7 @@ The following tables lists the configurable parameters and their default values.
 | `service.type`         | desired service type                                | `ClusterIP`               |
 | `service.port`         | service external port                               | `9121`                    |
 | `redisAddress`         | address of one or more redis nodes, comma separated | `redis://myredis:6379`    |
-| `annotation`           | pod annotations for easier discovery                | {}                        |
+| `annotations`          | pod annotations for easier discovery                | {}                        |
 
 For more information please refer to the [redis_exporter](https://github.com/oliver006/redis_exporter) documentation.
 

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9121"
+        prometheus.io/scrape: "true"
       labels:
         app: {{ template "prometheus-redis-exporter.name" . }}
         release: {{ .Release.Name }}

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -16,9 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "9121"
-        prometheus.io/scrape: "true"
+{{ toYaml .Values.annotations | indent 8 }}
       labels:
         app: {{ template "prometheus-redis-exporter.name" . }}
         release: {{ .Release.Name }}

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -9,3 +9,7 @@ service:
   annotations: {}
 resources: {}
 redisAddress: redis://myredis:6379
+annotations: {}
+#  prometheus.io/path: /metrics
+#  prometheus.io/port: "9121"
+#  prometheus.io/scrape: "true"


### PR DESCRIPTION

**What this PR does / why we need it**:
I added the anotations to the deployment so that the prometheus server find the service without any config.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
I'm not aware if ther is issue regarding this.

**Special notes for your reviewer**:

Hey @acondrat small change to avoid having to configure the exporter on prometheus server. 