### PR TITLE
Kong, Cassandra, and PostgreSQL version bump

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.2.5
-appVersion: 0.13.0
+version: 0.2.6
+appVersion: 0.13.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -51,7 +51,7 @@ and their default values.
 | Parameter                         | Description                                                            | Default               |
 | ------------------------------    | --------------------------------------------------------------------   | -------------------   |
 | image.repository                  | Kong image                                                             | `kong`                |
-| image.tag                         | Kong image version                                                     | `0.12.2`              |
+| image.tag                         | Kong image version                                                     | `0.13.1`              |
 | image.pullPolicy                  | Image pull policy                                                      | `IfNotPresent`        |
 | replicaCount                      | Kong instance count                                                    | `1`                   |
 | admin.useTLS                      | Secure Admin traffic                                                   | `true`                |

--- a/stable/kong/requirements.lock
+++ b/stable/kong/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.10.0
+- name: cassandra
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 0.2.6
+digest: sha256:391605d7f63ec34018a29b4369637cdc72372d2192a9c9112940b0b26ad9c730
+generated: 2018-05-02T09:44:40.383381-07:00

--- a/stable/kong/requirements.lock
+++ b/stable/kong/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.10.0
-- name: cassandra
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.2.6
-digest: sha256:260f7cb6e0ada4190711d6bd8bff23a97bdcab3e1f0f2802270513644dd96172
-generated: 2017-12-25T22:52:53.50321-08:00

--- a/stable/kong/requirements.lock
+++ b/stable/kong/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.8.5
+  version: 0.10.0
 - name: cassandra
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.1.9
+  version: 0.2.6
 digest: sha256:260f7cb6e0ada4190711d6bd8bff23a97bdcab3e1f0f2802270513644dd96172
 generated: 2017-12-25T22:52:53.50321-08:00

--- a/stable/kong/requirements.yaml
+++ b/stable/kong/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  version: ~0.8.3
+  version: ~0.10.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: cassandra
-  version: ~0.1.6
+  version: ~0.2.6
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: cassandra.enabled

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: kong
-  tag: 0.13.0
+  tag: 0.13.1
   pullPolicy: IfNotPresent
 
 # Specify Kong admin and proxy services configurations


### PR DESCRIPTION
- Kong version bumped to 0.13.1
- Cassandra chart version bumped to 0.2.6
- PostgreSQL chart bumped to 0.10.0