### PR TITLE
[stable/redis] Check API version capability

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.0.5
+version: 3.0.6
 appVersion: 4.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/_helpers.tpl
+++ b/stable/redis/templates/_helpers.tpl
@@ -32,17 +32,6 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for networkpolicy.
-*/}}
-{{- define "networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return the proper image name
 */}}
 {{- define "redis.image" -}}
@@ -114,4 +103,15 @@ securityContext:
   runAsUser: {{ $securityContext.runAsUser | default .Values.master.securityContext.runAsUser }}
 {{- end }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Return the appropriate version for the 'apps' API.
+*/}}
+{{- define "apps.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1" -}}
+"apps/v1"
+{{- else -}}
+"apps/v1beta2"
+{{- end -}}
 {{- end -}}

--- a/stable/redis/templates/metrics-deployment.yaml
+++ b/stable/redis/templates/metrics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.metrics.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "apps.apiVersion" $ }}
 kind: Deployment
 metadata:
   name: {{ template "redis.fullname" . }}-metrics

--- a/stable/redis/templates/networkpolicy.yaml
+++ b/stable/redis/templates/networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
 kind: NetworkPolicy
-apiVersion: {{ template "networkPolicy.apiVersion" . }}
+apiVersion: "networking.k8s.io/v1"
 metadata:
   name: "{{ template "redis.fullname" . }}"
   labels:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: {{ template "apps.apiVersion" $ }}
 kind: StatefulSet
 metadata:
   name: {{ template "redis.fullname" . }}-master

--- a/stable/redis/templates/redis-slave-deployment.yaml
+++ b/stable/redis/templates/redis-slave-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cluster.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ template "apps.apiVersion" $ }}
 kind: Deployment
 metadata:
   name: {{ template "redis.fullname" . }}-slave


### PR DESCRIPTION
**What this PR does / why we need it**:
Use dynamic API version based on cluster capability instead of hard-coded API version which fails for some versions of Kubernetes.
