### PR TITLE
Use configuration options to bind to all interfaces

### DIFF
--- a/stable/hadoop/Chart.yaml
+++ b/stable/hadoop/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: The Apache Hadoop software library is a framework that allows for the distributed processing of large data sets across clusters of computers using simple programming models.
 name: hadoop
-version: 1.0.5
+version: 1.0.6
 appVersion: 2.7.3
 home: https://hadoop.apache.org/
 sources:

--- a/stable/hadoop/templates/hadoop-configmap.yaml
+++ b/stable/hadoop/templates/hadoop-configmap.yaml
@@ -35,7 +35,6 @@ data:
     if [[ "${HOSTNAME}" =~ "hdfs-nn" ]]; then
       mkdir -p /root/hdfs/namenode
       $HADOOP_PREFIX/bin/hdfs namenode -format -force -nonInteractive
-      sed -i s/{{ template "hadoop.fullname" . }}-hdfs-nn/0.0.0.0/ /usr/local/hadoop/etc/hadoop/core-site.xml
       $HADOOP_PREFIX/sbin/hadoop-daemon.sh start namenode
     fi
 
@@ -50,7 +49,6 @@ data:
     fi
 
     if [[ "${HOSTNAME}" =~ "yarn-rm" ]]; then
-      sed -i s/{{ template "hadoop.fullname" . }}-yarn-rm/0.0.0.0/ $HADOOP_PREFIX/etc/hadoop/yarn-site.xml
       cp ${CONFIG_DIR}/start-yarn-rm.sh $HADOOP_PREFIX/sbin/
       cd $HADOOP_PREFIX/sbin
       chmod +x start-yarn-rm.sh
@@ -138,6 +136,18 @@ data:
         <name>dfs.namenode.datanode.registration.ip-hostname-check</name>
         <value>false</value>
       </property>
+
+      <!-- Bind to all interfaces -->
+      <property>
+        <name>dfs.namenode.rpc-bind-host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <property>
+        <name>dfs.namenode.servicerpc-bind-host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <!-- /Bind to all interfaces -->
+      
     </configuration>
 
   mapred-site.xml: |
@@ -245,6 +255,21 @@ data:
         <name>yarn.resourcemanager.hostname</name>
         <value>{{ template "hadoop.fullname" . }}-yarn-rm</value>
       </property>
+
+      <!-- Bind to all interfaces -->
+      <property>
+        <name>yarn.resourcemanager.bind-host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <property>
+        <name>yarn.nodemanager.bind-host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <property>
+        <name>yarn.timeline-service.bind-host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <!-- /Bind to all interfaces -->
 
       <property>
         <name>yarn.nodemanager.vmem-check-enabled</name>


### PR DESCRIPTION
**What this PR does / why we need it**:

It changes the configuration to use native Hadoop configuration options (cf. options for [yarn](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-common/yarn-default.xml) and [dfs](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)) to bind to all interfaces instead of replacing the hostname with `0.0.0.0` using `sed`. 

This avoids issues with webhdfs and URLs being generated that contain `...&namenoderpcaddress=0.0.0.0:9000&...` instead of the hostname of the name node (e.g., `...&namenoderpcaddress=myrelease-hadoop-hdfs-nn:9000&...`).

**Special notes for your reviewer**:

@danisla: I've tested this on a 4-node Kubernetes cluster without issues. I have deployed an instance of Apache Knox that exposes the webhdfs RESTful API for users outside of the cluster. After applying this fix, webhdfs access works.
