### PR TITLE
[elastalert] Add flag to use_ssl when connecting to elasticsearch

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,6 +1,6 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.1.29
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,6 +1,6 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.1.5
+version: 0.2.0
 appVersion: 0.1.29
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -30,16 +30,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-|        Parameter        |                    Description                    |             Default             |
-| ----------------------- | ------------------------------------------------- | ------------------------------- |
-| `image.repository`      | docker image                                      | jertel/elastalert-docker        |
-| `image.tag`             | docker image tag                                  | 0.1.29                          |
-| `image.pullPolicy`      | image pull policy                                 | IfNotPresent                    |
-| `replicaCount`          | number of replicas to run                         | 1                               |
-| `elasticsearch.host`    | elasticsearch endpoint to use                     | elasticsearch                   |
-| `elasticsearch.port`    | elasticsearch port to use                         | 80                              |
-| `elasticsearch.use_ssl` | whether or not to connect to es_host using TLS    | False                           |
-| `resources`             | Container resource requests and limits            | {}                              |
-| `rules`                 | Rule and alert configuration for Elastalert       | {} example shown in values.yaml |
-| `runIntervalMins`       | Default interval between alert checks, in minutes | 1                               |
-| `bufferTimeMins`        | Default rule buffer time, in minutes              | 15                              |
+|       Parameter        |                    Description                    |             Default             |
+| ---------------------- | ------------------------------------------------- | ------------------------------- |
+| `image.repository`     | docker image                                      | jertel/elastalert-docker        |
+| `image.tag`            | docker image tag                                  | 0.1.29                          |
+| `image.pullPolicy`     | image pull policy                                 | IfNotPresent                    |
+| `replicaCount`         | number of replicas to run                         | 1                               |
+| `elasticsearch.host`   | elasticsearch endpoint to use                     | elasticsearch                   |
+| `elasticsearch.port`   | elasticsearch port to use                         | 80                              |
+| `elasticsearch.useSsl` | whether or not to connect to es_host using SSL    | False                           |
+| `resources`            | Container resource requests and limits            | {}                              |
+| `rules`                | Rule and alert configuration for Elastalert       | {} example shown in values.yaml |
+| `runIntervalMins`      | Default interval between alert checks, in minutes | 1                               |
+| `bufferTimeMins`       | Default rule buffer time, in minutes              | 15                              |

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -30,15 +30,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-| Parameter                 | Description                                         | Default                           |
-|---------------------------|-----------------------------------------------------|-----------------------------------|
-| `image.repository`        | docker image                                        | jertel/elastalert-docker    |
-| `image.tag`               | docker image tag                                    | 0.1.29                            |
-| `image.pullPolicy`        | image pull policy                                   | IfNotPresent                      |
-| `replicaCount`            | number of replicas to run                           | 1                                 |
-| `elasticsearch.host`      | elasticsearch endpoint to use                       | elasticsearch                     |
-| `elasticsearch.port`      | elasticsearch port to use                           | 80                                |
-| `resources`               |  Container resource requests and limits             | {}                                |
-| `rules`                   | Rule and alert configuration for Elastalert         | {} example shown in values.yaml   |
-| `runIntervalMins`         | Default interval between alert checks, in minutes   | 1                                 |
-| `bufferTimeMins`          | Default rule buffer time, in minutes                | 15                                |
+|        Parameter        |                    Description                    |             Default             |
+| ----------------------- | ------------------------------------------------- | ------------------------------- |
+| `image.repository`      | docker image                                      | jertel/elastalert-docker        |
+| `image.tag`             | docker image tag                                  | 0.1.29                          |
+| `image.pullPolicy`      | image pull policy                                 | IfNotPresent                    |
+| `replicaCount`          | number of replicas to run                         | 1                               |
+| `elasticsearch.host`    | elasticsearch endpoint to use                     | elasticsearch                   |
+| `elasticsearch.port`    | elasticsearch port to use                         | 80                              |
+| `elasticsearch.use_ssl` | whether or not to connect to es_host using TLS    | False                           |
+| `resources`             | Container resource requests and limits            | {}                              |
+| `rules`                 | Rule and alert configuration for Elastalert       | {} example shown in values.yaml |
+| `runIntervalMins`       | Default interval between alert checks, in minutes | 1                               |
+| `bufferTimeMins`        | Default rule buffer time, in minutes              | 15                              |

--- a/stable/elastalert/templates/config.yaml
+++ b/stable/elastalert/templates/config.yaml
@@ -19,6 +19,6 @@ data:
     es_host: {{ .Values.elasticsearch.host }}
     es_port: {{ .Values.elasticsearch.port }}
     writeback_index: elastalert_status
-    use_ssl: {{ .Values.elasticsearch.use_ssl }}
+    use_ssl: {{ .Values.elasticsearch.useSsl }}
     alert_time_limit:
       days: 2

--- a/stable/elastalert/templates/config.yaml
+++ b/stable/elastalert/templates/config.yaml
@@ -19,5 +19,6 @@ data:
     es_host: {{ .Values.elasticsearch.host }}
     es_port: {{ .Values.elasticsearch.port }}
     writeback_index: elastalert_status
+    use_ssl: {{ .Values.elasticsearch.use_ssl }}
     alert_time_limit:
       days: 2

--- a/stable/elastalert/templates/deployment.yaml
+++ b/stable/elastalert/templates/deployment.yaml
@@ -13,6 +13,9 @@ spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        checksum/rules: {{ include (print $.Template.BasePath "/rules.yaml") . | sha256sum }}
       labels:
         name: {{ template "elastalert.fullname" . }}-elastalert
         app: {{ template "elastalert.name" . }}

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -22,6 +22,8 @@ elasticsearch:
   host: ""
   # elasticsearch port
   port: 80
+  # whether or not to connect to es_host using TLS
+  use_ssl: False
 
 # rule configurations e.g. (http://elastalert.readthedocs.io/en/latest/)
 rules: {}

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -23,7 +23,7 @@ elasticsearch:
   # elasticsearch port
   port: 80
   # whether or not to connect to es_host using TLS
-  use_ssl: False
+  useSsl: False
 
 # rule configurations e.g. (http://elastalert.readthedocs.io/en/latest/)
 rules: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use ssl connection when talking to a es server with tls enabled
