### PR TITLE
Fixed Kafka-Exporter annotations typo

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.6.0
+version: 0.6.1
 appVersion: 4.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/kafka-exporter.yaml
+++ b/incubator/kafka/templates/kafka-exporter.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-{{- if and .Values.prometheus.jmx.enabled  (not .Values.prometheus.operator.enabled) }}
+{{- if and .Values.prometheus.kafka.enabled  (not .Values.prometheus.operator.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.kafka.port | quote }}
 {{- end }}


### PR DESCRIPTION
Kafka exporter should check for the value of `.Values.prometheus.kafka.enabled` instead of the jmx value (`.Values.prometheus.jmx.enabled`)

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
