### PR TITLE
[stable/datadog] Allow skipping Secret creation

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.17.0
+version: 0.18.0
 appVersion: 6.3.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `deployment.tolerations`    | List of node taints to tolerate    | `[]`                                      |
 | `kube-state-metrics.rbac.create`| If true, create & use RBAC resources for kube-state-metrics | `true`       |
 | `kube-state-metrics.rbac.serviceAccount` | existing ServiceAccount to use (ignored if rbac.create=true) for kube-state-metrics | `default` |
-| `secret.create`             | If true, create a Secret | `true` |
+| `existingSecret`             | If set, use the secret with providen name instead of creating a new one |`nil` |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
@@ -97,8 +97,8 @@ Datadog offers a multitude of [tags](https://hub.docker.com/r/datadog/docker-dd-
 By default installs Datadog agent inside a DaemonSet. You may also use Datadog agent inside a Deployment, if you want to collect Kubernetes API events or send custom metrics to DogStatsD endpoint.
 
 ### Secret
-By default, this Chart creates a Secret and puts an API key in that Secret. However, this behavior can be disabled when `secret.create` is set to false.
-You can use this in cases where you want to manually create a Secret instead. 
+By default, this Chart creates a Secret and puts an API key in that Secret.
+However, you can use manually created secret by setting `existingSecret` value.
 
 ### confd and checksd
 

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -97,8 +97,8 @@ Datadog offers a multitude of [tags](https://hub.docker.com/r/datadog/docker-dd-
 By default installs Datadog agent inside a DaemonSet. You may also use Datadog agent inside a Deployment, if you want to collect Kubernetes API events or send custom metrics to DogStatsD endpoint.
 
 ### Secret
-By default chart creates Secret and puts API key to that Secret. If disabled (via `secret.create`) skips a creation of
-Secret and disables an API key presence check, so DaemonSet and/or Deployment will be created anyway, and will expect a Secret to be present. 
+By default, this Chart creates a Secret and puts an API key in that Secret. However, this behavior can be disabled when `secret.create` is set to false.
+You can use this in cases where you want to manually create a Secret instead. 
 
 ### confd and checksd
 

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `deployment.tolerations`    | List of node taints to tolerate    | `[]`                                      |
 | `kube-state-metrics.rbac.create`| If true, create & use RBAC resources for kube-state-metrics | `true`       |
 | `kube-state-metrics.rbac.serviceAccount` | existing ServiceAccount to use (ignored if rbac.create=true) for kube-state-metrics | `default` |
-
+| `secret.create`             | If true, create a Secret | `true` |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
@@ -95,6 +95,10 @@ Datadog offers a multitude of [tags](https://hub.docker.com/r/datadog/docker-dd-
 
 ### DaemonSet and Deployment
 By default installs Datadog agent inside a DaemonSet. You may also use Datadog agent inside a Deployment, if you want to collect Kubernetes API events or send custom metrics to DogStatsD endpoint.
+
+### Secret
+By default chart creates Secret and puts API key to that Secret. If disabled (via `secret.create`) skips a creation of
+Secret and disables an API key presence check, so DaemonSet and/or Deployment will be created anyway, and will expect a Secret to be present. 
 
 ### confd and checksd
 

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 |             Parameter       |            Description             |                    Default                |
 |-----------------------------|------------------------------------|-------------------------------------------|
 | `datadog.apiKey`            | Your Datadog API key               |  `Nil` You must provide your own key      |
+| `datadog.apiKeyExistingSecret` | If set, use the secret with a provided name instead of creating a new one |`nil` |
 | `image.repository`          | The image repository to pull from  | `datadog/agent`                           |
 | `image.tag`                 | The image tag to pull              | `6.2.1`                                   |
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
@@ -72,7 +73,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `deployment.tolerations`    | List of node taints to tolerate    | `[]`                                      |
 | `kube-state-metrics.rbac.create`| If true, create & use RBAC resources for kube-state-metrics | `true`       |
 | `kube-state-metrics.rbac.serviceAccount` | existing ServiceAccount to use (ignored if rbac.create=true) for kube-state-metrics | `default` |
-| `existingSecret`             | If set, use the secret with providen name instead of creating a new one |`nil` |
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
@@ -98,7 +99,7 @@ By default installs Datadog agent inside a DaemonSet. You may also use Datadog a
 
 ### Secret
 By default, this Chart creates a Secret and puts an API key in that Secret.
-However, you can use manually created secret by setting `existingSecret` value.
+However, you can use manually created secret by setting `datadog.apiKeyExistingSecret` value.
 
 ### confd and checksd
 

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -1,11 +1,14 @@
-{{- if .Values.datadog.apiKey -}}
+{{- if (or (not .Values.secret.create) (.Values.datadog.apiKey)) }}
 DataDog agents are spinning up on each node in your cluster. After a few
 minutes, you should see your agents starting in your event stream:
 
     https://app.datadoghq.com/event/stream
-
+{{ if (and (.Values.secret.create) (.Values.datadog.apiKey)) }}
 No further action should be required.
-
+{{- else if (not .Values.secret.create) }}
+You disabled creation of Secret containing API key, therefore it is expected
+you create Secret named '{{ template "datadog.fullname" . }}' including a key 'api-key'.
+{{ end }}
 {{- else -}}
 ##############################################################################
 ####               ERROR: You did not set a datadog.apiKey.               ####

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -1,11 +1,11 @@
-{{- if (or (.Values.existingSecret) (.Values.datadog.apiKey)) }}
+{{- if (or (.Values.datadog.apiKeyExistingSecret) (.Values.datadog.apiKey)) }}
 DataDog agents are spinning up on each node in your cluster. After a few
 minutes, you should see your agents starting in your event stream:
 
     https://app.datadoghq.com/event/stream
-{{ if .Values.existingSecret }}
+{{ if .Values.datadog.apiKeyExistingSecret }}
 You disabled creation of Secret containing API key, therefore it is expected
-that you create Secret named '{{ .Values.existingSecret }}' which includes a key called 'api-key', which actually contains the API key.
+that you create Secret named '{{ .Values.datadog.apiKeyExistingSecret }}' which includes a key called 'api-key', which actually contains the API key.
 {{ else if (.Values.datadog.apiKey) }}
 No further action should be required.
 {{ end }}

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -1,13 +1,13 @@
-{{- if (or (not .Values.secret.create) (.Values.datadog.apiKey)) }}
+{{- if (or (.Values.existingSecret) (.Values.datadog.apiKey)) }}
 DataDog agents are spinning up on each node in your cluster. After a few
 minutes, you should see your agents starting in your event stream:
 
     https://app.datadoghq.com/event/stream
-{{ if (and (.Values.secret.create) (.Values.datadog.apiKey)) }}
-No further action should be required.
-{{- else if (not .Values.secret.create) }}
+{{ if .Values.existingSecret }}
 You disabled creation of Secret containing API key, therefore it is expected
-that you create Secret named '{{ template "datadog.fullname" . }}' which includes a key called 'api-key', which actually contains the API key.
+that you create Secret named '{{ .Values.existingSecret }}' which includes a key called 'api-key', which actually contains the API key.
+{{ else if (.Values.datadog.apiKey) }}
+No further action should be required.
 {{ end }}
 {{- else -}}
 ##############################################################################

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -7,7 +7,7 @@ minutes, you should see your agents starting in your event stream:
 No further action should be required.
 {{- else if (not .Values.secret.create) }}
 You disabled creation of Secret containing API key, therefore it is expected
-you create Secret named '{{ template "datadog.fullname" . }}' including a key 'api-key'.
+that you create Secret named '{{ template "datadog.fullname" . }}' which includes a key called 'api-key', which actually contains the API key.
 {{ end }}
 {{- else -}}
 ##############################################################################

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -16,6 +16,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Return secret name to be used based on provided values.
+*/}}
+{{- define "apiSecretName" -}}
+{{- $fullName := include "datadog.fullname" . -}}
+{{- default $fullName .Values.existingSecret | quote -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified confd name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -18,7 +18,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Return secret name to be used based on provided values.
 */}}
-{{- define "apiSecretName" -}}
+{{- define "datadog.apiSecretName" -}}
 {{- $fullName := include "datadog.fullname" . -}}
 {{- default $fullName .Values.datadog.apiKeyExistingSecret | quote -}}
 {{- end -}}

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -20,7 +20,7 @@ Return secret name to be used based on provided values.
 */}}
 {{- define "apiSecretName" -}}
 {{- $fullName := include "datadog.fullname" . -}}
-{{- default $fullName .Values.existingSecret | quote -}}
+{{- default $fullName .Values.datadog.apiKeyExistingSecret | quote -}}
 {{- end -}}
 
 {{/*

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.daemonset.enabled }}
-{{- if (or (.Values.existingSecret) (.Values.datadog.apiKey)) }}
+{{- if (or (.Values.datadog.apiKeyExistingSecret) (.Values.datadog.apiKey)) }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
           - name: DD_API_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ template "apiSecretName" . }}
+                name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.daemonset.enabled }}
-{{- if (or (not .Values.secret.create) (.Values.datadog.apiKey)) }}
+{{- if (or (.Values.existingSecret) (.Values.datadog.apiKey)) }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -54,7 +54,7 @@ spec:
           - name: DD_API_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ template "datadog.fullname" . }}
+                name: {{ template "apiSecretName" . }}
                 key: api-key
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.daemonset.enabled }}
-{{- if .Values.datadog.apiKey }}
+{{- if (or (not .Values.secret.create) (.Values.datadog.apiKey)) }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           - name: DD_API_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ template "apiSecretName" . }}
+                name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.enabled }}
-{{- if (or (.Values.existingSecret) (.Values.datadog.apiKey)) }}
+{{- if (or (.Values.datadog.apiKeyExistingSecret) (.Values.datadog.apiKey)) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.enabled }}
-{{- if .Values.datadog.apiKey }}
+{{- if (or (not .Values.secret.create) (.Values.datadog.apiKey)) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.enabled }}
-{{- if (or (not .Values.secret.create) (.Values.datadog.apiKey)) }}
+{{- if (or (.Values.existingSecret) (.Values.datadog.apiKey)) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -38,7 +38,7 @@ spec:
           - name: DD_API_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ template "datadog.fullname" . }}
+                name: {{ template "apiSecretName" . }}
                 key: api-key
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.secret.create }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +12,5 @@ metadata:
 type: Opaque
 data:
   api-key: {{ default "MISSING" .Values.datadog.apiKey | b64enc | quote }}
+
+{{- end }}

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret.create }}
+{{- if not .Values.existingSecret }}
 
 apiVersion: v1
 kind: Secret

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.existingSecret }}
+{{- if not .Values.datadog.apiKeyExistingSecret }}
 
 apiVersion: v1
 kind: Secret

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -70,9 +70,6 @@ deployment:
   # dogstatsdNodePort: 8125
   # traceNodePort: 8126
 
-# Use existing Secret which stores API key instead of creating a new one
-# existingSecret:
-
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
 ##
@@ -84,6 +81,9 @@ datadog:
   ## ref: https://app.datadoghq.com/account/settings#agent/kubernetes
   ##
   # apiKey:
+
+  ## Use existing Secret which stores API key instead of creating a new one
+  # apiKeyExistingSecret:
 
   ## dd-agent container name
   ##

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -70,6 +70,9 @@ deployment:
   # dogstatsdNodePort: 8125
   # traceNodePort: 8126
 
+secret:
+  create: true
+
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
 ##

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -70,8 +70,8 @@ deployment:
   # dogstatsdNodePort: 8125
   # traceNodePort: 8126
 
-secret:
-  create: true
+# Use existing Secret which stores API key instead of creating a new one
+# existingSecret:
 
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics


### PR DESCRIPTION
Allow skipping Secret creation since there are situations where one may not want create Secret automatically.

In order to determine if chart need to create DaemonSet and/or Deployment logical expression has been changed to be a logical implication, which means it doesn't create DaemonSet and/or Deployment only if `secret.create` is `true` and `datedog.apiKey` is missing.