### PR TITLE
[stable/postgresql] Add ability to use foreign secret for postgresPassword

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.11.0
+version: 0.12.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -93,6 +93,8 @@ $ helm install --name my-release \
 
 The above command creates a PostgreSQL user named `my-user` with password `secretpassword`. Additionally it creates a database named `my-database`.
 
+`postgresPassword` can alternatively be provided as map containing the name of an external `Secret` and key which contains this password.
+
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -3,7 +3,7 @@ PostgreSQL can be accessed via port 5432 on the following DNS name from within y
 
 To get your user password run:
 
-    PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }} -o jsonpath="{.data.postgres-password}" | base64 --decode; echo)
+    PGPASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "postgresql.password.secret" . }} -o jsonpath="{.data.{{ template "postgresql.password.key" }}}" | base64 --decode; echo)
 
 To connect to your database run the following command (using the env variable from above):
 

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -41,3 +41,25 @@ Create chart name and version as used by the chart label.
 {{- define "postgresql.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate name of the secret containing password
+*/}}
+{{- define "postgresql.password.secret" -}}
+{{- if typeIs "map[string]interface {}" .Values.postgresPassword -}}
+{{-   printf "%s"  .Values.postgresPassword.secret -}}
+{{- else -}}
+{{-   include "postgresql.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate name of the key in secret containing password
+*/}}
+{{- define "postgresql.password.key" -}}
+{{- if typeIs "map[string]interface {}" .Values.postgresPassword -}}
+{{-   default "postgres-password" .Values.postgresPassword.key -}}
+{{- else -}}
+{{-   printf "postgres-password" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -62,8 +62,8 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "postgresql.fullname" . }}
-              key: postgres-password
+              name: {{ template "postgresql.password.secret" . }}
+              key: {{ template "postgresql.password.key" . }}
         {{- end }}
         - name: POD_IP
           valueFrom: { fieldRef: { fieldPath: status.podIP } }
@@ -138,9 +138,9 @@ spec:
       {{- if .Values.usePasswordFile }}
       - name: password-file
         secret:
-          secretName: {{ template "postgresql.fullname" . }}
+          secretName: {{ template "postgresql.password.secret" . }}
           items:
-            - key: postgres-password
+            - key: {{ template "postgresql.password.key" . }}
               path: postgres-password
       {{- end }}
       {{- if .Values.imagePullSecrets }}

--- a/stable/postgresql/templates/secrets.yaml
+++ b/stable/postgresql/templates/secrets.yaml
@@ -9,11 +9,11 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  {{ if .Values.postgresPassword }}
+  {{- if typeIs "string" .Values.postgresPassword }}
   postgres-password:  {{ .Values.postgresPassword | b64enc | quote }}
-  {{ else }}
+  {{- else if typeIs "<nil>" .Values.postgresPassword }}
   postgres-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
+  {{- end }}
   {{- if .Values.metrics.customMetrics }}
   custom-metrics.yaml: {{ toYaml .Values.metrics.customMetrics | b64enc | quote }}
   {{- end }}

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -21,6 +21,9 @@ imageTag: "9.6.2"
 # postgresUser:
 ## Default: random 10 character string
 # postgresPassword:
+## Alternately, can be provided a map of a Secret name, and key.
+#   secret: # defaults to `postgresql.fullname` template.
+#   key: # defaults to `postgres-password`, used only when `secret` is provided.
 
 ## Inject postgresPassword via a volume mount instead of environment variable
 usePasswordFile: false


### PR DESCRIPTION
**What this PR does**:

Introduce the ability to provide and use a foreign `Secret` as the `postgresPassword` value, while maintaining backwards compatibility.

This is implemented in such a way that backwards compatbility is maintained:
- nil: random string, encoded in secret template for this chart
- string: value encoded in secret template for this chart
- map: values will be templated based on these values, via _helpers.tpl

Valid examples:

```
postgresPassword: # nil

postgresPassword: sekrit #string

postgresPassword: # map[string]
  secret: external-secret
  key: some-other-key #optional
```

**Why we need it**:

At GitLab, we're [using this pattern](https://gitlab.com/charts/gitlab/tree/master/doc/development/#passwords) for [our next generation of charts](https://gitlab.com/charts/gitlab). @coreypobrien [previously submitted PR 5013](https://github.com/kubernetes/charts/pull/5013) so that we can observe our decision to [never put sensitive information in ENV](https://gitlab.com/charts/gitlab/blob/master/doc/architecture/decisions.md#preference-of-secrets-in-initcontainer-over-environment). This completes the process of removing the secret content from the environment, as well as removing it from the properties of the deployment itself. Secrets not pre-provisioned are then [automatically generated as a Job](https://gitlab.com/charts/gitlab/tree/master/charts/gitlab/charts/shared-secrets) within our charts.

I did not remove this chart's Secret template because `custom-metrics.yaml` is placed there. I'll admit I don't understand why it is in a Secret instead of the ConfigMap, but as that would be a change unrelated to this proposal, I have not altered it.


**Which issue this PR fixes**:

Relates to/alternative to https://github.com/kubernetes/charts/pull/3393

Due to the previously mentioned [decision regarding ENV](https://gitlab.com/charts/gitlab/blob/master/doc/architecture/decisions.md#preference-of-secrets-in-initcontainer-over-environment), **3393**s `secretKeyRefs` implementation is not acceptable for us.

**Special notes for your reviewer**:

I don't immediately see a method of providing `ci/*-values.yaml` for the CI to run tests in multiple modes, as this change requires a pre-existing secret, or secret provided from outside the chart. I manually ran the following, and verified expectations were met in this charts Secret and Deployment template output.
- `helm template . --set postgresPassword=derp`
- `helm template . --set postgresPassword.secret=external`
- `helm template . --set postgresPassword.secret=external --set postgresPassword.key=other`

cc @databus23 
