### PR TITLE
[incubator/kafka] add RBAC for init container

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.6.1
+version: 0.6.2
 appVersion: 4.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/rbac.yaml
+++ b/incubator/kafka/templates/rbac.yaml
@@ -1,0 +1,37 @@
+{{- if  .Values.rbac.enabled  }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ .Release.Name }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -34,6 +34,9 @@ spec:
       - name: init-ext
         image: "{{ .Values.external.init.image }}:{{ .Values.external.init.imageTag }}"
         imagePullPolicy: "{{ .Values.external.init.imagePullPolicy }}"
+        {{- if .Values.rbac.enabled }}
+        serviceAccountName: {{ .Release.Name }}
+        {{- end }}
         command:
           - sh
           - -euxc

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -276,3 +276,6 @@ zookeeper:
   ## If the Zookeeper Chart is disabled a URL and port are required to connect
   url: ""
   port: 2181
+
+rbac:
+  enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support to Kafka chart for RBAC. Without the service account, the init container for exposing externally will fail.
