### PR TITLE
[incubator/kafka] If RBAC is enabled in the cluster, the init container needs permissions

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.6.2
+version: 0.7.0
 appVersion: 4.0.1
 keywords:
 - kafka

--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.6.1
+version: 0.6.2
 appVersion: 4.0.1
 keywords:
 - kafka

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -71,6 +71,7 @@ following configurable parameters:
 | `external.firstListenerPort`   | TCP port which is added pod index number to arrive at the port used for NodePort and external listener port.    | '31090'                                                    |
 | `external.domain`              | Domain in which to advertise Kafka external listeners.                                                          | `cluster.local`                                            |
 | `external.init`                | External init container settings.                                                                               | (see `values.yaml`)                                        |
+| `rbac.enabled`                 | Enable a service account and role for the init container to use in an RBAC enabled cluster                      | `false`                                                    |
 | `configurationOverrides`       | `Kafka ` [configuration setting][brokerconfigs] overrides in the dictionary format                              | `{ offsets.topic.replication.factor: 3 }`                  |
 | `additionalPorts`              | Additional ports to expose on brokers.  Useful when the image exposes metrics (like prometheus, etc.) through a javaagent instead of a sidecar   | `{}`                                 |
 | `readinessProbe.initialDelaySeconds` | Number of seconds before probe is initiated.                                                              | `30`                                                       |

--- a/incubator/kafka/templates/rbac.yaml
+++ b/incubator/kafka/templates/rbac.yaml
@@ -1,0 +1,36 @@
+{{- if  .Values.rbac.enabled  }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ .Release.Name }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -19,6 +19,7 @@ metadata:
     chart: "{{ $root.Chart.Name }}-{{ $root.Chart.Version }}"
     release: {{ $root.Release.Name | quote }}
     heritage: {{ $root.Release.Service | quote }}
+    pod: {{ $responsiblePod | quote }}
 spec:
   type: NodePort
   ports:

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -28,6 +28,9 @@ spec:
 {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
+{{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ .Release.Name }}
+{{- end }}
     {{- if .Values.external.enabled }}
       ## ref: https://github.com/Yolean/kubernetes-kafka/blob/master/kafka/50kafka.yml
       initContainers:

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -35,6 +35,11 @@ updateStrategy:
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
 podManagementPolicy: OrderedReady
 
+## If RBAC is enabled on the cluster, the Kafka init container needs a service account
+## with permissisions sufficient to apply pod labels
+rbac:
+  enabled: false
+
 ## The name of the storage class which the cluster should use.
 # storageClass: default
 


### PR DESCRIPTION
@benjigoldberg

**What this PR does / why we need it**:

This optionally creates a service account with needed permissions for the Kafka init container. On an RBAC enabled cluster the expose remote is not able to complete due to permissions needed. 

**Special notes for your reviewer**:

In addition to RBAC which is most of the PR, this also adds an additional label to the services created. We have a custom ingress solution and need to be able to identify which service is tied to a pod since our ingress selects only on services. In order to minimize changes, I reused the same logic that the pod is labeled with. If there's a desire to not label a service with 'pod' I'm happy to adjust this label, but in this case the service will always be a 1:1 mapping to a pod, so it seemed to make sense.