### PR TITLE
Run Minecraft as correct user

### DIFF
--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: {{ template "minecraft.fullname" . }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"


### PR DESCRIPTION
A recent change to the Minecraft server container now runs Minecraft
as user/group 1000 instead of root. When the persistent volume (/data)
is mounted, it's not readable by this user unless we specify an
appropriate securityContext, which will ensure that the persistent
volume is mounted with the appropriate uid/gid.

@gtaylor 
