### PR TITLE
Let the preconfigure script not fail if the API calls to GoCD server fail.

### DIFF
--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.0.6
+version: 1.0.7
 appVersion: 18.3.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -92,6 +92,7 @@ The following tables list the configurable parameters of the GoCD chart and thei
 Based on the information available about the Kubernetes cluster, the [Kubernetes elastic agent](https://github.com/gocd/kubernetes-elastic-agents) plugin settings can be configured. A default elastic agent profile too is created so that users can concentrate on building their CD pipeline.
 A simple first pipeline is created in order to bootstrap the getting started experience for users. 
 
+An attempt at preconfiguring the GoCD server is made if `server.shouldPreconfigure` is set to true. This means that there are cases when this attempt will fail. These cases are listed below. However, in all cases, the GoCD server will be available for users to configure. 
 If you are comfortable with GoCD and feel that there is no need to preconfigure the server, then you can override `server.shouldPreconfigure` to be false. 
 
 **Note: If the GoCD server is started with an existing config from a persistent volume, set the value of `server.shouldPreconfigure` to `false`.** 
@@ -125,7 +126,7 @@ This command provides the information on how to access the GoCD server.
 The cases when the attempt to preconfigure the GoCD server fails:
 
 1. The service account token mounted as a secret for the GoCD server pod does not have sufficient permissions. The API call to configure the plugin settings will fail.
-2. If the GoCD server is started with an existing configuration with security configured, then the API calls in the preconfigure script will fail. 
+2. If the GoCD server is started with an existing configuration with security configured, then the API calls in the preconfigure script will fail, but the GoCD server will come up. This is to accommodate the fact the the preconfigure script will fail in case a `helm upgrade` happens. 
 
 ### GoCD Agent
 

--- a/stable/gocd/templates/configmap.yaml
+++ b/stable/gocd/templates/configmap.yaml
@@ -23,8 +23,6 @@ data:
       sleep 10
     done
 
-    set -e
-
     echo "Trying to create an elastic profile now." >> /godata/logs/preconfigure.log
 
     (curl --fail -i 'http://localhost:8153/go/api/elastic/profiles' \


### PR DESCRIPTION
* This is so that the GoCD server will always be available for users.
* helm upgrade will not fail now.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
