### PR TITLE
Bump MongoDB dependency chart version to latest including Mongo 3.6.x

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,5 +1,5 @@
 name: parse
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.7.4
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/requirements.lock
+++ b/stable/parse/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.4.15
-digest: sha256:1a4e23d283ae090cf7595d7e255a0804b66a20f94620a4063b1271b2aa8b0879
-generated: 2017-09-03T14:24:36.800583401-04:00
+  version: 0.4.24
+digest: sha256:13691f4fa1d39a912a1a47710bd95e2442584e6d50a75b222412087ba46770c7
+generated: 2018-04-30T10:49:23.667014102+02:00

--- a/stable/parse/requirements.yaml
+++ b/stable/parse/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mongodb
-  version: 0.4.15
+  version: 0.4.24
   repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
**What this PR does / why we need it**:

The current MongoDB chart version included as a dependency is 0.4.15, which uses MongoDB 3.4.7. Parse currently supports MongoDB 3.6 and the latest MongoDB chart with that version is 0.4.24, which includes MongoDB 3.6.2.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
