### PR TITLE
Use defaults in values.yaml (stable/mongodb)

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 2.0.2
+version: 2.0.3
 appVersion: 3.7.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -19,7 +19,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the proper image name
 */}}
 {{- define "mongodb.image" -}}
-{{- $registryName :=  default .Values.image.registry "docker.io" -}}
-{{- $tag := .Values.image.tag | default "latest" -}}
-{{- printf "%s/%s:%s" $registryName .Values.image.repository $tag -}}
+{{- $registryName :=  .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Currently, when using the `stable/mongodb` chart, it's not possible to set an alternate value for `image.registry`, because the arguments supplied to `default` in `_helpers.tpl` are in the wrong order. This prevents use with OpenShift, because it relies on images being available in a local cluster repository via image streams.

In this PR, I've removed the reliance on `default` altogether, as the default values are already available in the `values.yaml` file and there's no need to store these values twice.
