### PR TITLE
[incubator/vault] Enable for passing additional env variables and add AWS/LoadBalancer examples

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.9.0
+version: 0.10.0
 appVersion: 0.10.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -50,8 +50,9 @@ The following table lists the configurable parameters of the Vault chart and the
 |-----------------------------------|------------------------------------------|-------------------------------------|
 | `image.pullPolicy`                | Container pull policy                    | `IfNotPresent`                      |
 | `image.repository`                | Container image to use                   | `vault`                             |
-| `image.tag`                       | Container image tag to deploy            | `0.9.0`                             |
+| `image.tag`                       | Container image tag to deploy            | `0.10.1`                            |
 | `vault.dev`                       | Use Vault in dev mode                    | true (set to false in production)   |
+| `vault.extraEnv`                  | Extra env vars for Vault pods            | `{}`                                |
 | `vault.customSecrets`             | Custom secrets available to Vault        | `[]`                                |
 | `vault.config`                    | Vault configuration                      | No default backend                  |
 | `replicaCount`                    | k8s replicas                             | `3`                                 |

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
                 fieldPath: status.podIP
           - name: VAULT_CLUSTER_ADDR
             value: "https://$(POD_IP):8201"
+        {{- if .Values.vault.env }}
+{{ toYaml .Values.vault.env | indent 10 }}
+        {{- end }}
         volumeMounts:
         - name: vault-config
           mountPath: /vault/config/

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -66,8 +66,8 @@ spec:
                 fieldPath: status.podIP
           - name: VAULT_CLUSTER_ADDR
             value: "https://$(POD_IP):8201"
-        {{- if .Values.vault.env }}
-{{ toYaml .Values.vault.env | indent 10 }}
+        {{- if .Values.vault.extraEnv }}
+{{ toYaml .Values.vault.extraEnv | indent 10 }}
         {{- end }}
         volumeMounts:
         - name: vault-config

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -33,10 +33,10 @@ service:
   #   cloud.google.com/load-balancer-type: "Internal"
   #
   # An example using type:loadbalancer and AWS internal ELB on kops
+  # type: LoadBalancer
   # annotations:
   #   dns.alpha.kubernetes.io/internal: vault.internal.domain.name
   #   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-  # type: LoadBalancer
 ingress:
   enabled: false
   labels: {}
@@ -105,8 +105,7 @@ vault:
     #   mountPath: /vault/tls
   #
   # Configure additional environment variables for the Vault containers
-  #
-  # env:
+  # extraEnv:
   #   - name: VAULT_API_ADDR
   #     value: "https://vault.internal.domain.name:8200"
   readiness:

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -97,6 +97,12 @@ vault:
   customSecrets: []
     # - secretName: vault-tls
     #   mountPath: /vault/tls
+  #
+  # Configure additional environment variables for the Vault containers  
+  #
+  #env: 
+  #  - name: VAULT_API_ADDR
+  #    value: "https://my-svc.my-namespace.svc.cluster.local:8200"
   readiness:
     readyIfSealed: false
     readyIfStandby: true

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -34,7 +34,7 @@ service:
   #
   # An example using type:loadbalancer and AWS internal ELB on kops
   # annotations:
-  #   dns.alpha.kubernetes.io/internal: vault.internal.cqd.k8s.janusz.io
+  #   dns.alpha.kubernetes.io/internal: vault.internal.domain.name
   #   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
   #type: LoadBalancer
 ingress:
@@ -108,7 +108,7 @@ vault:
   #
   #env: 
   #  - name: VAULT_API_ADDR
-  #    value: "https://my-svc.my-namespace.svc.cluster.local:8200"
+  #    value: "https://vault.internal.domain.name:8200"
   readiness:
     readyIfSealed: false
     readyIfStandby: true

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -105,7 +105,7 @@ vault:
     #   mountPath: /vault/tls
   #
   # Configure additional environment variables for the Vault containers
-  # extraEnv:
+  extraEnv: {}
   #   - name: VAULT_API_ADDR
   #     value: "https://vault.internal.domain.name:8200"
   readiness:

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -31,6 +31,12 @@ service:
   # clusterIP: None
   annotations: {}
   #   cloud.google.com/load-balancer-type: "Internal"
+  #
+  # An example using type:loadbalancer and AWS internal ELB on kops
+  # annotations:
+  #   dns.alpha.kubernetes.io/internal: vault.internal.cqd.k8s.janusz.io
+  #   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+  #type: LoadBalancer
 ingress:
   enabled: false
   labels: {}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -36,7 +36,7 @@ service:
   # annotations:
   #   dns.alpha.kubernetes.io/internal: vault.internal.domain.name
   #   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-  #type: LoadBalancer
+  # type: LoadBalancer
 ingress:
   enabled: false
   labels: {}
@@ -104,11 +104,11 @@ vault:
     # - secretName: vault-tls
     #   mountPath: /vault/tls
   #
-  # Configure additional environment variables for the Vault containers  
+  # Configure additional environment variables for the Vault containers
   #
-  #env: 
-  #  - name: VAULT_API_ADDR
-  #    value: "https://vault.internal.domain.name:8200"
+  # env:
+  #   - name: VAULT_API_ADDR
+  #     value: "https://vault.internal.domain.name:8200"
   readiness:
     readyIfSealed: false
     readyIfStandby: true


### PR DESCRIPTION
**What this PR does / why we need it**:

- Allows for passing additional `env` values to the Vault containers. As an example, this is required in a situation where `VAULT_CLUSTER_ADDR` needs to be defined manually when dealing with backends other than Consul. When deploying a cluster backed by DynamoDB, vault returns an error, `api_addr not set`.

- Add an example of how to use type:loadbalancer and AWS ELB when working with a `kops` kubernetes cluster on AWS. Also shows how to use the `dns-controller` annotation to have the controller automatically provision the route 53 records.

- Add an example of how to pass the `VAULT_API_ADDR` as an environment variable to the vault containers.