### PR TITLE
[stable/external-dns] Update externaldns chart to 0.5.0

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.5.4
-appVersion: 0.4.8
+version: 0.5.5
+appVersion: 0.5.0
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
 - https://github.com/kubernetes-incubator/external-dns

--- a/stable/external-dns/templates/clusterrole.yaml
+++ b/stable/external-dns/templates/clusterrole.yaml
@@ -12,6 +12,7 @@ rules:
     resources:
       - ingresses
       - services
+      - pods
     verbs:
       - get
       - list

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -1,7 +1,7 @@
 ## Details about the image to be pulled.
 image:
   name: registry.opensource.zalan.do/teapot/external-dns
-  tag: v0.4.8
+  tag: v0.5.0
   pullSecrets: []
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Upgrades the version of ExternalDNS installed by the `external-dns` chart to `v0.5.0`

**Special notes for your reviewer**:
Added the pod permission into the RBAC authorization as per https://github.com/kubernetes-incubator/external-dns/pull/538

I updated the patch version of the chart to make the minimal required version change, if this should be considered semver-minor, I can change it to that.

