### PR TITLE
[stable/kube-lego] Update link to migration guide

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 description: DEPRECATED Automatically requests certificates from Let's Encrypt
 name: kube-lego
 version: 0.4.1
+appVersion: v0.1.5
 # The kube-lego chart is deprecated and no longer maintained.
 deprecated: true
 keywords:

--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: DEPRECATED Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.4.0
+version: 0.4.1
 # The kube-lego chart is deprecated and no longer maintained.
 deprecated: true
 keywords:

--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -7,6 +7,7 @@ deprecated: true
 keywords:
 - kube-lego
 - letsencrypt
+home: https://github.com/jetstack/kube-lego
 sources:
 - https://github.com/jetstack/kube-lego/tree/master/examples/nginx
 engine: gotpl

--- a/stable/kube-lego/README.md
+++ b/stable/kube-lego/README.md
@@ -8,7 +8,7 @@
 >  features. The latest Kubernetes release that kube-lego officially supports
 >  is **1.8**.  The officially endorsed successor is **[cert-manager](https://hub.kubeapps.com/charts/stable/cert-manager)**.
 >
->  If you are a current user of kube-lego, you can find a migration guide [here](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/migrating-from-kube-lego.md).
+>  If you are a current user of kube-lego, you can find a migration guide [here](https://cert-manager.readthedocs.io/en/latest/tutorials/acme/migrating-from-kube-lego.html).
 >
 >  :warning:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The docs of cert-manager are moved from the repo to readthedocs.io. The current link to migration guide in readme is dead.