### PR TITLE
[stable/mongo] Use stable mongodb version in the chart

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb
-version: 2.0.3
-appVersion: 3.7.3
+version: 2.0.4
+appVersion: 3.6.4
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:
 - mongodb

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: bitnami/mongodb
-  tag: 3.7.3
+  tag: 3.6.4
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
We should be using mongodb 3.6.x as it is the stable version and not 3.7.x that is the development one.