### PR TITLE
[stable/rabbitmq] disable rbac by default

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 0.8.1
+version: 1.0.0
 appVersion: 3.7.4
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -24,7 +24,7 @@ image:
   #   - myRegistrKeySecretName
 
 ## does your cluster have rbac enabled? assume yes by default
-rbacEnabled: true
+rbacEnabled: false
 
 ## section of specific values for rabbitmq
 rabbitmq:


### PR DESCRIPTION
By default, we should not create RBAC resources unless using the values-production.yaml.