### PR TITLE
Add ExternalDNS configuration docs to nginx-ingress chart

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.18.0
+version: 0.18.1
 appVersion: 0.14.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -193,6 +193,15 @@ spec:
 ```
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+## ExternalDNS Service configuration
+
+Add an [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) annotation to the LoadBalancer service:
+
+```yaml
+annotations:
+  external-dns.alpha.kubernetes.io/hostname: kubernetes-example.com.
+```
+
 ## AWS L7 ELB with SSL Termination
 
 Annotate the controller as shown in the [nginx-ingress l7 patch](https://github.com/kubernetes/ingress-nginx/blob/master/deploy/provider/aws/service-l7.yaml):


### PR DESCRIPTION
**What this PR does / why we need it**:

I wanted to update the docs to show how to configure [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) with the nginx-ingress controller service. 

[I previously added](https://github.com/kubernetes/charts/pull/5035) docs for route53-mapper config but route53-mapper is now being deprecated in favour of ExternalDNS, so I wanted to keep the docs up-to-date.

**Which issue this PR fixes**

None

**Special notes for your reviewer**:
