### PR TITLE
[stable/grafana] Allow overriding deployment strategy

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.6.0
+version: 1.7.0
 appVersion: 5.0.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -33,6 +33,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `replicas`                 | Number of nodes | `1` |
+| `deploymentStrategy`       | Deployment strategy | `RollingUpdate` |
 | `image.repository`         | Image repository | `grafana/grafana` |
 | `image.tag`                | Image tag. (`Must be >= 5.0.0`) Possible values listed [here](https://hub.docker.com/r/grafana/grafana/tags/).| `5.0.4`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
     matchLabels:
       app: {{ template "grafana.name" . }}
       release: {{ .Release.Name }}
+  strategy:
+    type: {{ .Values.deploymentStrategy }}
   template:
     metadata:
       labels:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -1,5 +1,7 @@
 replicas: 1
 
+deploymentStrategy: RollingUpdate
+
 image:
   repository: grafana/grafana
   tag: 5.0.4


### PR DESCRIPTION
We've hit an issue with the stable/grafana chart where - if we enable persistence - we're unable to do updates of the deployment. The new replicaset managed by the Grafana deployment will have it's pods waiting for the PVCs to be released from the previous replicaset due to the rolling update on the deployment, leaving them hanging indefinitely. We're seeing this issue on GKE, if that's relevant.

With this change, we'll be able to override the deployment strategy of the Grafana deployment, optionally setting this to `Recreate` instead of the default `RollingUpdate` - solving our issue.