### PR TITLE
GoCD - Add extra volumes and volumeMounts options on server and agents

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,12 +1,18 @@
+### 1.4.3
+
+* [52120886](https://github.com/kubernetes/charts/commit/52120886): Add extra volumes and volumeMounts options on the server and agents
+
 ### 1.4.2
 
 * [499fddf9](https://github.com/kubernetes/charts/commit/499fddf9): Add agent.env.extraEnvVars
 
 ### 1.4.1
+
 * [15c77caf](https://github.com/kubernetes/charts/commit/15c77caf):
   - Bump up GoCD app version to 18.9.0
 
 ### 1.4.0
+
 * [f5249551](https://github.com/kubernetes/charts/commit/f5249551):  
   - Bump up GoCD app version to 18.8.0
   - Updated kubernetes elastic agent plugin version to 1.0.2

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.4.2
+version: 1.4.3
 appVersion: 18.9.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -229,30 +229,70 @@ The value pvSelector must be specified so that the right persistence volume will
 $ helm install --name gocd-app --set server.persistence.existingClaim=PVC_NAME stable/gocd
 ```
 
+#### Additional Volumes
+
+Additional volumes, such as `ConfigMaps` and `secrets`, can be mounted on the server and agent deployments.
+
+To mount a `secret`:
+```
+  persistence:
+    enabled: true
+    extraVolumeMounts:
+      - name: github-key
+        mountPath: /etc/config/keys/
+        readOnly: true
+    extraVolumes:
+      - name: github-key
+        secret:
+          secretName: github-key
+          defaultMode: 0744
+```
+
+To mount a `ConfigMap` containing `/docker-entrypoint.d/` scripts:
+```
+  persistence:
+    enabled: true
+    name:
+      dockerEntryPoint: gocd-init-scripts
+    subpath:
+      dockerEntryPoint: ""
+    extraVolumes:
+      - name: gocd-init-scripts
+        configMap:
+          name: gocd-init-scripts
+          defaultMode: 0755
+```
+
 ### Server persistence Values
 
-| Parameter                                     | Description                                         | Default              |
-| --------------------------------------------- | --------------------------------------------------- | -------------------- |
-| `server.persistence.enabled`                  | Enable the use of a GoCD server PVC                 | `true`              |
-| `server.persistence.accessMode`               | The PVC access mode                                 | `ReadWriteOnce`      |
-| `server.persistence.size`                     | The size of the PVC                                 | `2Gi`                |
-| `server.persistence.storageClass`             | The PVC storage class name                          | `nil`                |
-| `server.persistence.pvSelector`               | The godata Persistence Volume Selectors             | `nil`                |
-| `server.persistence.subpath.godata`           | The /godata path on Persistence Volume              | `godata`             |
-| `server.persistence.subpath.homego`           | The /home/go path on Persistence Volume             | `homego`             |
-| `server.persistence.subpath.dockerEntryPoint` | The /docker-entrypoint.d path on Persistence Volume | `scripts`            |
+| Parameter                                     | Description                                             | Default              |
+| --------------------------------------------- | ------------------------------------------------------- | -------------------- |
+| `server.persistence.enabled`                  | Enable the use of a GoCD server PVC                     | `true`               |
+| `server.persistence.accessMode`               | The PVC access mode                                     | `ReadWriteOnce`      |
+| `server.persistence.size`                     | The size of the PVC                                     | `2Gi`                |
+| `server.persistence.storageClass`             | The PVC storage class name                              | `nil`                |
+| `server.persistence.pvSelector`               | The godata Persistence Volume Selectors                 | `nil`                |
+| `server.persistence.name.dockerEntryPoint`    | The Persitence Volume to mount at /docker-entrypoint.d/ | `goserver-vol`       |
+| `server.persistence.subpath.godata`           | The /godata path on Persistence Volume                  | `godata`             |
+| `server.persistence.subpath.homego`           | The /home/go path on Persistence Volume                 | `homego`             |
+| `server.persistence.subpath.dockerEntryPoint` | The /docker-entrypoint.d path on Persistence Volume     | `scripts`            |
+| `server.persistence.extraVolumes`             | Additional server volumes                               | `[]`                 |
+| `server.persistence.extraVolumeMounts`        | Additional server volumeMounts                          | `[]`                 |
 
 ### Agent persistence Values
 
-| Parameter                                     | Description                                          | Default              |
-| --------------------------------------------- | ---------------------------------------------------- | -------------------- |
-| `agent.persistence.enabled`                   | Enable the use of a GoCD agent PVC                   | `false`              |
-| `agent.persistence.accessMode`                | The PVC access mode                                  | `ReadWriteOnce`      |
-| `agent.persistence.size`                      | The size of the PVC                                  | `1Gi`                |
-| `agent.persistence.storageClass`              | The PVC storage class name                           | `nil`                |
-| `agent.persistence.pvSelector`                | The godata Persistence Volume Selectors              | `nil`                |
-| `agent.persistence.subpath.homego`            | The /home/go path on Persistence Volume              | `homego`             |
-| `agent.persistence.subpath.dockerEntryPoint`  | The /docker-entrypoint.d path on Persistence Volume  | `scripts`            |
+| Parameter                                     | Description                                             | Default              |
+| --------------------------------------------- | ------------------------------------------------------- | -------------------- |
+| `agent.persistence.enabled`                   | Enable the use of a GoCD agent PVC                      | `false`              |
+| `agent.persistence.accessMode`                | The PVC access mode                                     | `ReadWriteOnce`      |
+| `agent.persistence.size`                      | The size of the PVC                                     | `1Gi`                |
+| `agent.persistence.storageClass`              | The PVC storage class name                              | `nil`                |
+| `agent.persistence.pvSelector`                | The godata Persistence Volume Selectors                 | `nil`                |
+| `agent.persistence.name.dockerEntryPoint`     | The Persitence Volume to mount at /docker-entrypoint.d/ | `goagent-vol`        |
+| `agent.persistence.subpath.homego`            | The /home/go path on Persistence Volume                 | `homego`             |
+| `agent.persistence.subpath.dockerEntryPoint`  | The /docker-entrypoint.d path on Persistence Volume     | `scripts`            |
+| `agent.persistence.extraVolumes`              | Additional agent volumes                                | `[]`                 |
+| `agent.persistence.extraVolumeMounts`         | Additional agent volumeMounts                           | `[]`                 |
 
 ##### Note:
 

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -29,6 +29,9 @@ spec:
         - name: goagent-vol
           persistentVolumeClaim:
             claimName: {{ .Values.agent.persistence.existingClaim | default (printf "%s-%s" (include "gocd.fullname" .) "agent")  }}
+        {{- if ne (len .Values.agent.persistence.extraVolumes) 0 }}
+{{ toYaml .Values.agent.persistence.extraVolumes | indent 8 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.agent.security.ssh.enabled }}
         - name: ssh-secrets
@@ -105,9 +108,12 @@ spec:
             - name: goagent-vol
               mountPath: /home/go
               subPath: {{ .Values.agent.persistence.subpath.homego }}
-            - name: goagent-vol
+            - name: {{ .Values.agent.persistence.name.dockerEntryPoint }}
               mountPath: /docker-entrypoint.d
               subPath: {{ .Values.agent.persistence.subpath.dockerEntryPoint }}
+            {{- if ne (len .Values.agent.persistence.extraVolumeMounts) 0 }}
+{{ toYaml .Values.agent.persistence.extraVolumeMounts | indent 12 }}
+            {{- end }}
           {{- end }}
           {{- if .Values.agent.security.ssh.enabled }}
             - name: ssh-secrets

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         - name: config-vol
           configMap:
             name: {{ template "gocd.fullname" . }}
+        {{- if ne (len .Values.server.persistence.extraVolumes) 0 }}
+{{ toYaml .Values.server.persistence.extraVolumes | indent 8 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.server.security.ssh.enabled }}
         - name: ssh-secrets
@@ -85,12 +88,15 @@ spec:
             - name: goserver-vol
               mountPath: /home/go
               subPath: {{ .Values.server.persistence.subpath.homego }}
-            - name: goserver-vol
+            - name: {{ .Values.server.persistence.name.dockerEntryPoint }}
               mountPath: /docker-entrypoint.d
               subPath: {{ .Values.server.persistence.subpath.dockerEntryPoint }}
             - name: config-vol
               mountPath: /preconfigure_server.sh
               subPath: preconfigure_server.sh
+            {{- if ne (len .Values.server.persistence.extraVolumeMounts) 0 }}
+{{ toYaml .Values.server.persistence.extraVolumeMounts | indent 12 }}
+            {{- end }}
           {{- end }}
           {{- if .Values.server.security.ssh.enabled }}
             - name: ssh-secrets

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -121,6 +121,10 @@ server:
     pvSelector:
 #      matchLabels:
 #        volume-type: ssd
+    name:
+      # server.persistence.name.dockerEntryPoint name of the volume mounted at /docker-entrypoint.d/ on the server
+      dockerEntryPoint: goserver-vol
+      # "" for the volume root
     subpath:
       # godata is where the config, db, plugins are stored
       godata: godata
@@ -128,6 +132,24 @@ server:
       homego: homego
       # custom entrypoint scripts that should be run before starting the GoCD server inside the container.
       dockerEntryPoint: scripts
+    # server.persistence.extraVolumes additional server volumes
+    extraVolumes: []
+    # - name: gocd-server-init-scripts
+    #   configMap:
+    #      name: gocd-server-init-scripts
+    #      defaultMode: 0755
+    # - name: github-key
+    #   secret:
+    #     secretName: github-key
+    #     defaultMode: 0744
+
+    # server.persistence.extraVolumeMounts additional server volumeMounts
+    extraVolumeMounts: []
+    # - name: github-key
+    #   mountPath: /etc/config/keys/
+    #   readOnly: true
+    # - name: gocd-server-init-scripts
+    #   mountPath: /docker-entrypoint.d/
 
   # server.hostAliases allows the modification of the hosts file inside a container
   hostAliases:
@@ -190,9 +212,31 @@ agent:
     pvSelector:
 #      matchLabels:
 #        app: godata-gocd-agent
+    name:
+      # agent.persistence.name.dockerEntryPoint name of the volume mounted at /docker-entrypoint.d/ on the agent
+      dockerEntryPoint: goagent-vol
+    # "" for the volume root
     subpath:
       homego: homego
       dockerEntryPoint: scripts
+    # agent.persistence.extraVolumes additional agent volumes
+    extraVolumes: []
+    # - name: gocd-agent-init-scripts
+    #   configMap:
+    #      name: gocd-agent-init-scripts
+    #      defaultMode: 0755
+    # - name: github-key
+    #   secret:
+    #     secretName: github-key
+    #     defaultMode: 0744
+
+    # agent.persistence.extraVolumeMounts additional agent volumeMounts
+    extraVolumeMounts: []
+    # - name: github-key
+    #   mountPath: /etc/config/keys/
+    #   readOnly: true
+    # - name: gocd-agent-init-scripts
+    #   mountPath: /docker-entrypoint.d/
 
   # agent.privileged is needed for running Docker-in-Docker (DinD) agents
   privileged: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows mounting of arbitrary additional volumes on the GoCD server or agent.

This is needed to mount additional secrets, ConfigMaps, or regular volumes which the server or agent might need.

This also allows overriding the volume name to mount at `/docker-entrypoint.d/`, in case the user wants to mount an additional volume there.

The use cases I have at present are:

- Mounting secrets such a keys.
- Mounting scripts to be run during container init.
- Mounting arbitrary additional volumes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

One possible drawback of this config is that you have to enable persistence in order to mount the additional volumes, which may or may not be correct. To me this seems reasonable and keeps the template cleaner but I can shift around if this might be an issue.