### PR TITLE
[stable/kibana] Add fullnameOverride

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.4.1
+version: 0.5.0
 appVersion: 6.0.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/templates/_helpers.tpl
+++ b/stable/kibana/templates/_helpers.tpl
@@ -9,12 +9,17 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "kibana.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if ne $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `fullnameOverride`, as seen in other charts, to the template helpers.

Also, update the conditional logic in the `kibana.fullname` template to more closely mirror the behaviour of other charts, i.e. if no `fullnameOverride` is specified, and the release name contains the chart name, use it as the full name.