### PR TITLE
[stable/magento] increase initialDelaySeconds for magento

### DIFF
--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -1,5 +1,5 @@
 name: magento
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.2.4
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/templates/deployment.yaml
+++ b/stable/magento/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             httpHeaders:
             - name: Host
               value: {{ include "magento.host" . | quote }}
-          initialDelaySeconds: 420
+          initialDelaySeconds: 1000
           timeoutSeconds: 5
           failureThreshold: 6
         readinessProbe:


### PR DESCRIPTION
In some Kubernetes environments, we have experienced that the livenessProbe kills the Magento container while it is still initializing the application. Magento takes some time to initialize due to the number of files that needs to adjust the permissions.