### PR TITLE
[stable/postgresql] PostgreSQL metrics need the right username

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.11.1
+version: 0.11.2
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.11.0
+version: 0.11.1
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         imagePullPolicy: {{ default "" .Values.metrics.imagePullPolicy | quote }}
         env:
         - name: DATA_SOURCE_NAME
-          value: postgresql://postgres@127.0.0.1:5432?sslmode=disable
+          value: postgresql://{{ default "postgres" .Values.postgresUser }}@127.0.0.1:5432?sslmode=disable
         ports:
         - name: metrics
           containerPort: 9187


### PR DESCRIPTION
**What this PR does / why we need it**:

If we use `POSTGERS_USER` = `sonar`, metrics go boom. So, let's use the same user for metrics as we created when we setup PostgreSQL!

**Which issue this PR fixes**:

N/A (PR as fix)

**Special notes for your reviewer**:

Easy, right?!