### PR TITLE
[stable/jenkins] Inherit existing plugins from Jenkins image

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.15.1
+version: 0.16.0
 appVersion: 2.107
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -167,9 +167,12 @@ data:
     cp -n /var/jenkins_config/config.xml /var/jenkins_home;
     cp -n /var/jenkins_config/jenkins.CLI.xml /var/jenkins_home;
 {{- if .Values.Master.InstallPlugins }}
+    # Install missing plugins
     cp /var/jenkins_config/plugins.txt /var/jenkins_home;
     rm -rf /usr/share/jenkins/ref/plugins/*.lock
     /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+    # Copy plugins to shared volume
+    cp -n /usr/share/jenkins/ref/plugins/* /var/jenkins_plugins;
 {{- end }}
 {{- if .Values.Master.ScriptApproval }}
     cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -79,9 +79,11 @@ spec:
               name: jenkins-jobs
               readOnly: true
             {{- end }}
+            {{- if .Values.Master.InstallPlugins }}
             -
-              mountPath: /usr/share/jenkins/ref/plugins/
+              mountPath: /var/jenkins_plugins
               name: plugin-dir
+            {{- end }}
             -
               mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
@@ -169,10 +171,12 @@ spec:
               name: jenkins-jobs
               readOnly: true
             {{- end }}
+            {{- if .Values.Master.InstallPlugins }}
             -
               mountPath: /usr/share/jenkins/ref/plugins/
               name: plugin-dir
               readOnly: false
+            {{- end }}
             -
               mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
@@ -199,8 +203,10 @@ spec:
         configMap:
           name: {{ template "jenkins.fullname" . }}-jobs
       {{- end }}
+      {{- if .Values.Master.InstallPlugins }}
       - name: plugin-dir
         emptyDir: {}
+      {{- end }}
       - name: secrets-dir
         emptyDir: {}
       - name: jenkins-home


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This allows us to inherit plugins that are pre-installed in the base docker image, as documented here:
https://github.com/jenkinsci/docker#preinstalling-plugins

This provides several benefits:
- init times are improved (if a plugin is already installed, it won't be re-downloaded)
- customized master images can be deployed behind a firewall with no access to internet
- pre-installed plugins allow for more deterministic chart deployments

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This is a breaking change.  For users who are currently overriding the default Jenkins configmap, an additional instruction is needed in order to copy plugins installed by the init container to the shared plugin volume.

Testing:
```bash
helm install ./stable/jenkins \
  --set Master.Image=quay.io/jlegrone/jenkins \
  --set Master.ImageTag=latest \
  --set Master.InstallPlugins={}
```
These plugins should be installed:
https://github.com/jlegrone/jenkins-master/blob/master/src/plugins.txt