### PR TITLE
[stable/mediawiki] Allow configuration of svc spec.loadBalancerIP

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 1.0.2
+version: 1.0.3
 appVersion: 1.30.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation
   that uses PHP to process and display data stored in a database.

--- a/stable/mediawiki/templates/svc.yaml
+++ b/stable/mediawiki/templates/svc.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.serviceType }}
+  {{ if .Values.serviceLoadBalancerIP -}}
+  loadBalancerIP: {{ .Values.serviceLoadBalancerIP }}
+  {{ end -}}
   ports:
   - name: http
     port: 80

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -117,7 +117,11 @@ mariadb:
 ## Kubernetes configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##
+## Use serviceLoadBalancerIP to request a specific static IP,
+## otherwise leave blank
+##
 serviceType: LoadBalancer
+# serviceLoadBalancerIP:
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
@bitnami-bot 

**What this PR does / why we need it**:
Enables a chart user to configure spec.loadBalancerIP in mediawiki service to use a static public IP
(as per step 2(b) in the following tutorial: https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip)

**Which issue this PR fixes** N/A

**Special notes for your reviewer**: N/A
