### PR TITLE
[stable/dask] bump version to 0.17.4

### DIFF
--- a/stable/dask/Chart.yaml
+++ b/stable/dask/Chart.yaml
@@ -1,6 +1,6 @@
 name: dask
-version: 1.0.3
-appVersion: 0.17.1
+version: 1.0.4
+appVersion: 0.17.4
 description: Distributed computation in Python with task scheduling
 home: https://dask.pydata.org
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200

--- a/stable/dask/README.md
+++ b/stable/dask/README.md
@@ -50,7 +50,7 @@ The following tables list the configurable parameters of the Dask chart and thei
 | -----------------------      | ---------------------------------| ---------------|
 | `worker.name`                | Dask worker name                 | `worker`       |
 | `worker.image`               | Container image name             | `daskdev/dask` |
-| `worker.imageTag`            | Container image tag              | `0.17.1`       |
+| `worker.imageTag`            | Container image tag              | `0.17.4`       |
 | `worker.replicas`            | k8s hpa and deployment replicas  | `3`            |
 | `worker.resources`           | Container resources              | `{}`           |
 |
@@ -62,7 +62,7 @@ The following tables list the configurable parameters of the Dask chart and thei
 | `jupyter.name`          | Jupyter name                     | `jupyter`                |
 | `jupyter.enabled`       | Include optional Jupyter server  | `true`                   |
 | `jupyter.image`         | Container image name             | `daskdev/dask-notebook`  |
-| `jupyter.imageTag`      | Container image tag              | `0.17.1`                 |
+| `jupyter.imageTag`      | Container image tag              | `0.17.4`                 |
 | `jupyter.replicas`      | k8s deployment replicas          | `1`                      |
 | `jupyter.servicePort`   | k8s service port                 | `80`                     |
 | `jupyter.resources`     | Container resources              | `{}`                     |

--- a/stable/dask/values.yaml
+++ b/stable/dask/values.yaml
@@ -5,7 +5,7 @@ scheduler:
   name: scheduler
   image:
     repository: "daskdev/dask"
-    tag: "0.17.1"
+    tag: "0.17.4"
     pullPolicy: IfNotPresent
   replicas: 1
   serviceType: "LoadBalancer"
@@ -26,7 +26,7 @@ worker:
   name: worker
   image:
     repository: "daskdev/dask"
-    tag: "0.17.1"
+    tag: "0.17.4"
     pullPolicy: IfNotPresent
   replicas: 3
   aptPackages: >-
@@ -51,7 +51,7 @@ jupyter:
   enabled: true
   image:
     repository: "daskdev/dask-notebook"
-    tag: "0.17.1"
+    tag: "0.17.4"
     pullPolicy: IfNotPresent
   replicas: 1
   serviceType: "LoadBalancer"


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the chart to point to a newer docker image by default that includes an updated version of some of the libraries used within the chart.

**Special notes for your reviewer**:

I'm also curious if there is a best practice how how to keep the helm chart in line with an evolving software project.