### PR TITLE
[stable/concourse] Add missing release labels to pods

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.4.0
+version: 1.4.1
 appVersion: 3.10.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: {{ template "concourse.web.fullname" . }}
+        release: "{{ .Release.Name }}"
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "concourse.web.fullname" . }}{{ else }}{{ .Values.rbac.webServiceAccountName }}{{ end }}
       tolerations:

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: {{ template "concourse.worker.fullname" . }}
+        release: "{{ .Release.Name }}"
       annotations:
         {{- range $key, $value := .Values.worker.annotations }}
         {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
This fixes worker podAntiAffinity which was selecting on the missing release label.