### PR TITLE
Whitespace issue in prometheus/server-configmap.yaml  in issues 5425

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 6.5.0
+version: 6.5.1
 appVersion: 2.2.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -15,7 +15,7 @@ data:
   {{ $key }}: |
 {{ toYaml $value | default "{}" | indent 4 }}
 {{- if eq $key "prometheus.yml" -}}
-{{- if $root.Values.alertmanager.enabled }}
+{{ if $root.Values.alertmanager.enabled }}
     alerting:
       alertmanagers:
       - kubernetes_sd_configs:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Is this a BUG REPORT

server-configmap.yaml:

```
{{- if (empty .Values.server.configMapOverrideName) -}}
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    app: {{ template "prometheus.name" . }}
    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
    component: "{{ .Values.server.name }}"
    heritage: {{ .Release.Service }}
    release: {{ .Release.Name }}
  name: {{ template "prometheus.server.fullname" . }}
data:
{{- $root := . -}}
{{- range $key, $value := .Values.serverFiles }}
  {{ $key }}: |
{{ toYaml $value | default "{}" | indent 4 }}
{{- if eq $key "prometheus.yml" -}}
{{- if $root.Values.alertmanager.enabled -}}
    alerting:
      alertmanagers:
```
Line 18: `{{- if $root.Values.alertmanager.enabled -}}`

Should be` {{ if $root.Values.alertmanager.enabled }}`
So that the whitespace is correct in the configmap once its generated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

`fixes #<5425>(, fixes #<5425>, )`

https://github.com/kubernetes/charts/issues/5425

**Special notes for your reviewer**:
