### PR TITLE
Orangehrm password

### DIFF
--- a/stable/orangehrm/Chart.yaml
+++ b/stable/orangehrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: orangehrm
-version: 1.0.5
+version: 1.0.6
 appVersion: 4.0.0
 description: OrangeHRM is a free HR management system that offers a wealth of modules
   to suit the needs of your business.

--- a/stable/orangehrm/requirements.lock
+++ b/stable/orangehrm/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
-generated: 2018-03-15T15:46:51.001597+01:00
+  version: 3.0.3
+digest: sha256:cbb7adf99b46d1821f835c8f7783d600d0609d876fb6e117d5ecd3a35335ead8
+generated: 2018-05-08T11:22:56.937244223+02:00

--- a/stable/orangehrm/requirements.yaml
+++ b/stable/orangehrm/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
+  version: 3.0.3
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/stable/orangehrm/templates/secrets.yaml
+++ b/stable/orangehrm/templates/secrets.yaml
@@ -12,6 +12,6 @@ data:
   {{ if .Values.orangehrmPassword }}
   orangehrm-password: {{ default "" .Values.orangehrmPassword | b64enc | quote }}
   {{ else }}
-  orangehrm-password: {{ randAlphaNum 10 | b64enc | quote }}
+  orangehrm-password: {{ list (lower (randAlpha 3)) (randNumeric 2) (upper (randAlpha 3)) | join "_" | b64enc | quote }}
   {{ end }}
   smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Latest OrangeHRM version requires a password which contains letters, numbers and symbols. This PR ensures the password randomly generated had every character kind. 

The way to ensure this password is a little hacky. I created the issue https://github.com/Masterminds/sprig/issues/99 on Sprig to have a proper way to generate this kind of passwords.

It also updates the MariaDB requirement.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
