### PR TITLE
[stable/grafana] Fix readme storageClass/storageClassName description

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.3.0
+version: 1.3.1
 appVersion: 5.0.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -51,7 +51,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.enabled`      | Use persistent volume to store data | `false` |
 | `persistence.size`         | Size of persistent volume claim | `10Gi` |
 | `persistence.existingClaim`| Use an existing PVC to persist data | `nil` |
-| `persistence.storageClass` | Type of persistent volume claim | `generic` |
+| `persistence.storageClassName` | Type of persistent volume claim | `nil` |
 | `persistence.accessModes`  | Persistence access modes | `[]` |
 | `persistence.subPath`      | Mount a sub directory of the persistent volume if set | `""` |
 | `env`                      | Extra environment variables passed to pods | `{}` |


### PR DESCRIPTION
**What this PR does / why we need it**: The description of `persistence.storageClass` in the README is incorrect.

It should be `persistence.storageClassName`: https://github.com/kubernetes/charts/blob/0011b17cfffea8154b5d34fa28fbbf6454a2e448/stable/grafana/templates/pvc.yaml#L23