### PR TITLE
Added support for private certs

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.1
+version: 0.17.0
 appVersion: 2.107
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -64,6 +64,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
+| `Master.CACerts`                  | Collection of private certs          | `{}`                                                                         |
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
 | `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
 | `Master.Jobs`                     | Jenkins XML job configs              | Not set                                                                      |
@@ -202,6 +203,8 @@ jenkins:
     RunAsUser: 1000
     FsGroup: 1000
 ```
+
+**Note:** Running Jenkins as a non-root user will break the ability to add private certs to the OS and Java cert stores. At the moment the only way to handle this is to rebuild the Jenkins container from a base image that already has the private certs applied to the cert stores. Inspection of the `initcacert.groovy` script in the `templates/config.yaml` file can provide more information on adding private certs to the cert stores.
 
 Docs taken from https://github.com/jenkinsci/docker/blob/master/Dockerfile:
 _Jenkins is run with user `jenkins`, uid = 1000. If you bind mount a volume from the host or a data container,ensure you use the same uid_

--- a/stable/jenkins/templates/cacerts-configmap.yaml
+++ b/stable/jenkins/templates/cacerts-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.Master.CACerts }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}-cacerts
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Master.Name }}"
+data:
+{{ toYaml .Values.Master.CACerts | indent 2 }}
+{{- end }}

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -177,10 +177,8 @@ data:
 {{- if .Values.Master.ScriptApproval }}
     cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
 {{- end }}
-{{- if .Values.Master.InitScripts }}
     mkdir -p /var/jenkins_home/init.groovy.d/;
     cp -n /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/
-{{- end }}
 {{- if .Values.Master.CredentialsXmlSecret }}
     cp -n /var/jenkins_credentials/credentials.xml /var/jenkins_home;
 {{- end }}
@@ -197,6 +195,39 @@ data:
   init{{ $key }}.groovy: |-
 {{ $val | indent 4 }}
 {{- end }}
+  initcacert.groovy: |-
+    def env = System.getenv()
+    def (JAVA_HOME, JENKINS_HOME) = [env["JAVA_HOME"], env["JENKINS_HOME"]]
+    def keystore_dir = JENKINS_HOME + '/.keystore'
+
+    // Test for keystore directory
+    def keystore_fh = new File(keystore_dir)
+    if (! keystore_fh.isDirectory()) {
+      keystore_fh.mkdir()
+    }
+    println "initcacert: Copying Java keystore to ${JENKINS_HOME}/.keystore"
+    "cp ${JAVA_HOME}/jre/lib/security/cacerts ${JENKINS_HOME}/.keystore".execute()
+    "chmod 644 ${JENKINS_HOME}/.keystore".execute()
+
+    def add_certs_fh = new File("/usr/share/ca-certificates/additional")
+    def cert_conf_fh = new File("/etc/ca-certificates.conf")
+    if (add_certs_fh.isDirectory()) {
+      add_certs_fh.eachFile() { cert ->
+        if (cert.isFile()) {
+          def basename = cert.name.replaceFirst(~/\.[^\.]+$/, '')
+          def filename = cert.name.replaceFirst(/^.*\//, '')
+          println "initcacert: Adding ${basename} to local Java keystore"
+          println "${JAVA_HOME}/bin/keytool -import -keystore ${JENKINS_HOME}/.keystore/cacerts -alias ${basename} -file ${cert} -storepass changeit -noprompt"
+          "${JAVA_HOME}/bin/keytool -import -keystore ${JENKINS_HOME}/.keystore/cacerts -alias ${basename} -file ${cert} -storepass changeit -noprompt".execute()
+
+          cert_conf_fh.append("\nadditional/${filename}\n")
+        }
+      }
+      println "initcacert: Adding additional certs to OS certificate store"
+      "/usr/sbin/update-ca-certificates".execute()
+    }
+
+
   plugins.txt: |-
 {{- if .Values.Master.InstallPlugins }}
 {{- range $index, $val := .Values.Master.InstallPlugins }}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -92,7 +92,7 @@ spec:
           image: "{{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}"
           imagePullPolicy: "{{ .Values.Master.ImagePullPolicy }}"
           {{- if .Values.Master.UseSecurity }}
-          args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]
+          args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin", "-Djavax.net.ssl.trustStore=$JENKINS_HOME/.keystore/cacerts" ]
           {{- end }}
           env:
             - name: JAVA_OPTS
@@ -181,6 +181,12 @@ spec:
               mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
               readOnly: false
+            {{- if .Values.Master.CACerts }}
+            -
+              mountPath: /usr/share/ca-certificates/additional
+              name: cacerts-dir
+              readOnly: true
+            {{- end }}
       volumes:
 {{- if .Values.Persistence.volumes }}
 {{ toYaml .Values.Persistence.volumes | indent 6 }}
@@ -216,6 +222,11 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end -}}
+      {{- if .Values.Master.CACerts }}
+      - name: cacerts-dir
+        configMap:
+          name: {{ template "jenkins.fullname" . }}-cacerts
+      {{- end }}
 {{- if .Values.Master.ImagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.Master.ImagePullSecret }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -101,6 +101,16 @@ Master:
   #   test: |-
   #     <<xml here>>
   CustomConfigMap: false
+
+  CACerts: {}
+# Add a series of CA certificate the certificate stores. This is a dictionary so
+# you can add multiple certs here. Each cert is stored as a unique file based on
+# the dictionary key. Certs are added to both the OS cert store and the Java
+# cert store. 
+#
+#  <filename>: |
+#      <cert contents>
+
   # Node labels and tolerations for pod assignment
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -106,7 +106,7 @@ Master:
 # Add a series of CA certificate the certificate stores. This is a dictionary so
 # you can add multiple certs here. Each cert is stored as a unique file based on
 # the dictionary key. Certs are added to both the OS cert store and the Java
-# cert store. 
+# cert store.
 #
 #  <filename>: |
 #      <cert contents>


### PR DESCRIPTION
**What this PR does / why we need it**: This PR give the Jenkins chart the ability to include additional CA certificates (private, self-signed or not distributed with OS/Java cert stores) and place them in all the appropriate places to be recognized by OS and Java applications. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: @lachie83, @viglesiasce This change now caused the Groovy init scripts to always run. 
