### PR TITLE
[stable/openvpn] service label selector match pod

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.0.0
+version: 3.0.1
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/templates/openvpn-service.yaml
+++ b/stable/openvpn/templates/openvpn-service.yaml
@@ -17,5 +17,6 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
 {{- end }}
   selector:
-    app: {{ template "openvpn.fullname" . }}
+    app: {{ template "openvpn.name" . }}
+    release: {{ .Release.Name }}
   type: {{ .Values.service.type }}


### PR DESCRIPTION
**What this PR does / why we need it**:

OpenVPN service label selector didn't match the pod labels, so didn't always select the pod. This brings them in sync.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5455