### PR TITLE
[stable/grafana] configure session provider from secret

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.3.0
+version: 1.4.0
 appVersion: 5.0.4
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -63,4 +63,4 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ldap.config  `            | Grafana's LDAP configuration    | `""` |
 | `annotations`              | Deployment annotations | `{}` |
 | `podAnnotations`           | Pod annotations | `{}` |
-
+| `session.existingSecret`   | The name of an existing secret containing the session provider configuration, this must have the key `provider_config`. Must match the session `provider` configured in grafana.ini. Possible values listed [here](http://docs.grafana.org/installation/configuration/#provider-config) | `""` |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -105,6 +105,13 @@ spec:
                   name: {{ template "grafana.fullname" . }}
                   key: plugins
             {{- end }}
+            {{- if .Values.session.existingSecret }}
+            - name: GF_SESSION_PROVIDER_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.session.existingSecret }}
+                  key: provider_config
+            {{- end }}
 {{- range $key, $value := .Values.env }}
             - name: "{{ $key }}"
               value: "{{ $value }}"
@@ -147,7 +154,7 @@ spec:
             {{- if .Values.ldap.existingSecret }}
             secretName: {{ .Values.ldap.existingSecret }}
             {{- else }}
-            secretName: {{ template "grafana.fullname" . }}            
+            secretName: {{ template "grafana.fullname" . }}
             {{- end }}
             items:
               - key: ldap-toml
@@ -159,4 +166,4 @@ spec:
       {{- else }}
           emptyDir: {}
       {{- end -}}
-        
+

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -180,3 +180,11 @@ ldap:
   #   start_tls = false
   #   ssl_skip_verify = false
   #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+
+## Grafana's session configuration
+## ref: http://docs.grafana.org/installation/configuration/#session
+session:
+  # `existingSecret` is a reference to an existing secret containing the session provider_config
+  # for Grafana in a key `provider_config`.
+  # ref: http://docs.grafana.org/installation/configuration/#provider-config
+  existingSecret: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows session provider to be configured from a pre-existing secret.
