### PR TITLE
fix gogs service ssh targetPort

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.5.2
+version: 0.5.3
 appVersion: 0.11.29
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/incubator/gogs/templates/deployment.yaml
+++ b/incubator/gogs/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - containerPort: 3000
-            - containerPort: {{ .Values.service.sshPort | int }}
+            - containerPort: 22
           livenessProbe:
             httpGet:
               path: /

--- a/incubator/gogs/templates/service.yaml
+++ b/incubator/gogs/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
     targetPort: 3000
     name: {{ default "gogs" .Values.service.nameOverride }}-http
   - port: {{ .Values.service.sshPort | int }}
-    targetPort:  {{ .Values.service.sshPort | int }}
+    targetPort: 22
     name: {{ default "gogs" .Values.service.nameOverride }}-ssh
   selector:
     app: {{ template "gogs.fullname" . }}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: This pr fixes gogs k8s service targetPort value. Because the exposed ssh port (targetPort) is hard code in gogs docker image equals to port 22. So if we don't do changes in gogs repo, we need change the mapping value.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2704

**Special notes for your reviewer**:
Accoring to https://github.com/gogits/gogs/issues/1788 and https://github.com/gogits/gogs/blob/master/docker/sshd_config, sshd in gogs docker image exposes port 22, and the field **SSH_PORT** is just for git ssh URL and will not affect the inner sshd port.