### PR TITLE
[stable/consul] Fix service name declaration in the ingress template when using nameOverride (resubmit)

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 1.3.5
+version: 1.3.6
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/consul-ingress.yaml
+++ b/stable/consul/templates/consul-ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.uiIngress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $servicePort := .Values.HttpPort -}}
+{{- $serviceName := printf "%s-%s" (include "consul.fullname" .) "ui" -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +22,7 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ printf "%s-%s" $releaseName "consul-ui" | trunc 63 }}
+              serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
   {{- end -}}
   {{- if .Values.uiIngress.tls }}

--- a/stable/consul/templates/consul-ingress.yaml
+++ b/stable/consul/templates/consul-ingress.yaml
@@ -22,7 +22,7 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ printf "%s-%s" $releaseName $consulFullName | trunc 63 | trimSuffix "-" }}-ui
+              serviceName: {{ printf "%s-%s" $releaseName $consulFullName | trunc 60 | trimSuffix "-" }}-ui
               servicePort: {{ $servicePort }}
   {{- end -}}
   {{- if .Values.uiIngress.tls }}

--- a/stable/consul/templates/consul-ingress.yaml
+++ b/stable/consul/templates/consul-ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.uiIngress.enabled -}}
 {{- $releaseName := .Release.Name -}}
 {{- $servicePort := .Values.HttpPort -}}
+{{- $consulFullName := default .Chart.Name .Values.nameOverride -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -21,7 +22,7 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ printf "%s-%s" $releaseName "consul-ui" | trunc 63 }}
+              serviceName: {{ printf "%s-%s" $releaseName $consulFullName | trunc 63 | trimSuffix "-" }}-ui
               servicePort: {{ $servicePort }}
   {{- end -}}
   {{- if .Values.uiIngress.tls }}


### PR DESCRIPTION
Sorry about the resubmit, but my rebase didn't really work..

At the moment if you use `nameOverride` with the ingress configuration enabled, the service name declared in the ingress is wrong. This PR fix this

### At the moment:

```
$ cat test-values.yaml
antiAffinity: soft
nameOverride: "this-is-a-test"
uiIngress:
  enabled: true
  hosts: ["www.example.com"]

$ helm install --name consul-test stable/consul -f test-values.yaml
NAME:   consul-test
LAST DEPLOYED: Wed Apr 18 10:49:39 2018
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1beta1/PodDisruptionBudget
NAME                            MIN AVAILABLE  MAX UNAVAILABLE  ALLOWED DISRUPTIONS  AGE
consul-test-this-is-a-test-pdb  N/A            1                0                    0s

==> v1/Pod(related)
NAME                          READY  STATUS             RESTARTS  AGE
consul-test-this-is-a-test-0  0/1    ContainerCreating  0         0s

==> v1/Secret
NAME                                   TYPE    DATA  AGE
consul-test-this-is-a-test-gossip-key  Opaque  1     0s

==> v1/ConfigMap
NAME                              DATA  AGE
consul-test-this-is-a-test-tests  1     0s

==> v1/Service
NAME                           TYPE       CLUSTER-IP    EXTERNAL-IP  PORT(S)                                                                           AGE
consul-test-this-is-a-test     ClusterIP  None          <none>       8500/TCP,8400/TCP,8301/TCP,8301/UDP,8302/TCP,8302/UDP,8300/TCP,8600/TCP,8600/UDP  0s
consul-test-this-is-a-test-ui  NodePort   10.99.85.156  <none>       8500:31869/TCP                                                                    0s

==> v1beta1/StatefulSet
NAME                        DESIRED  CURRENT  AGE
consul-test-this-is-a-test  3        1        0s

==> v1beta1/Ingress
NAME                           HOSTS            ADDRESS  PORTS  AGE
consul-test-this-is-a-test-ui  www.example.com  80       0s


NOTES:
1. Watch all cluster members come up.
  $ kubectl get pods --namespace=default -w
2. Test cluster health using Helm test.
  $ helm test consul-test
3. (Optional) Manually confirm consul cluster is healthy.
  $ kubectl exec consul-test-consul-0 consul members --namespace=default | grep server

$ kubectl get ingress consul-test-this-is-a-test-ui -o yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  creationTimestamp: 2018-04-18T14:49:39Z
  generation: 1
  labels:
    chart: consul-1.3.5
    component: consul-test-consul
    heritage: Tiller
    release: consul-test
  name: consul-test-this-is-a-test-ui
  namespace: default
  resourceVersion: "11467"
  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/consul-test-this-is-a-test-ui
  uid: b8ab84d5-4317-11e8-b3db-025000000001
spec:
  rules:
  - host: www.example.com
    http:
      paths:
      - backend:
          serviceName: consul-test-consul-ui
          servicePort: 8500
status:
  loadBalancer: {}
```

### After the modification in this PR:

```
$ cat test-values.yaml
antiAffinity: soft
nameOverride: "this-is-a-test"
uiIngress:
  enabled: true
  hosts: ["www.example.com"]
  
$ helm install --name consul-new-template . -f test-values.yaml
NAME:   consul-new-template
LAST DEPLOYED: Wed Apr 18 12:35:04 2018
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Pod(related)
NAME                                  READY  STATUS             RESTARTS  AGE
consul-new-template-this-is-a-test-0  0/1    ContainerCreating  0         0s

==> v1/Secret
NAME                                           TYPE    DATA  AGE
consul-new-template-this-is-a-test-gossip-key  Opaque  1     0s

==> v1/ConfigMap
NAME                                      DATA  AGE
consul-new-template-this-is-a-test-tests  1     0s

==> v1/Service
NAME                                   TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)                                                                           AGE
consul-new-template-this-is-a-test     ClusterIP  None           <none>       8500/TCP,8400/TCP,8301/TCP,8301/UDP,8302/TCP,8302/UDP,8300/TCP,8600/TCP,8600/UDP  0s
consul-new-template-this-is-a-test-ui  NodePort   10.111.54.246  <none>       8500:30481/TCP                                                                    0s

==> v1beta1/StatefulSet
NAME                                DESIRED  CURRENT  AGE
consul-new-template-this-is-a-test  3        1        0s

==> v1beta1/Ingress
NAME                                   HOSTS            ADDRESS  PORTS  AGE
consul-new-template-this-is-a-test-ui  www.example.com  80       0s

==> v1beta1/PodDisruptionBudget
NAME                                    MIN AVAILABLE  MAX UNAVAILABLE  ALLOWED DISRUPTIONS  AGE
consul-new-template-this-is-a-test-pdb  N/A            1                0                    0s


NOTES:
1. Watch all cluster members come up.
  $ kubectl get pods --namespace=default -w
2. Test cluster health using Helm test.
  $ helm test consul-new-template
3. (Optional) Manually confirm consul cluster is healthy.
  $ kubectl exec consul-new-template-consul-0 consul members --namespace=default | grep server

$ kubectl get ing consul-new-template-this-is-a-test-ui -o yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  creationTimestamp: 2018-04-18T16:35:04Z
  generation: 1
  labels:
    chart: consul-1.3.6
    component: consul-new-template-consul
    heritage: Tiller
    release: consul-new-template
  name: consul-new-template-this-is-a-test-ui
  namespace: default
  resourceVersion: "19039"
  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/consul-new-template-this-is-a-test-ui
  uid: 72b76e7f-4326-11e8-b3db-025000000001
spec:
  rules:
  - host: www.example.com
    http:
      paths:
      - backend:
          serviceName: consul-new-template-this-is-a-test-ui
          servicePort: 8500
status:
  loadBalancer: {}
```