### PR TITLE
Fix formatting in drone README

### DIFF
--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.8.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the drone charts and th
 | `ingress.tls`               | Ingress TLS configuration                                                                     | `[]`                        |
 | `server.host`               | Drone **server** scheme and hostname                                                          | `(internal hostname)`       |
 | `server.env`                | Drone **server** environment variables                                                        | `(default values)`          |
-| `server.envSecrets          | Drone **server** secret environment variables                                                 | `(default values)`          |
+| `server.envSecrets`         | Drone **server** secret environment variables                                                 | `(default values)`          |
 | `server.annotations`        | Drone **server** annotations                                                                  | `{}`                        |
 | `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
 | `server.schedulerName`      | Drone **server** alternate scheduler name                                                     | `nil`                       |


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a issue in README file, where the `server.envSecrets` variable miss the closing ` ` ` char

**Which issue this PR fixes**

None

**Special notes for your reviewer**:

cc/ @christian-roggia