### PR TITLE
[stable/cert-manager] Properly pass params for ingressShim.image.tag default

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.10
+version: 0.2.11
 appVersion: 0.2.5
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.ingressShim.enabled }}
         - name: ingress-shim
-          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag .Values.image.tag }}"
+          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.image.tag .Values.ingressShim.image.tag }}"
           imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
         {{- if .Values.ingressShim.extraArgs }}
           args:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

The docs for the `cert-manager` chart indicate that the `ingressShim` image tag defaults to `image.tag`, but the params for default are supposed to be in the format `default DEFAULT_VALUE GIVEN_VALUE` (as per https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/functions_and_pipelines.md#using-the-default-function).

The current chart does the opposite - it tries to use `image.tag` (which is _always_ present) and then defaults to `ingressShim.image.tag` if `image.tag` is not present).

This makes it impossible to update the base `image.tag` without having an exact matching tag for the ingressShim container.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
