### PR TITLE
[stable/msoms] support custom tolerations

### DIFF
--- a/stable/msoms/Chart.yaml
+++ b/stable/msoms/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: msoms
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.0.0-30
 description: A chart for deploying omsagent as a daemonset Kubernetes
 keywords:

--- a/stable/msoms/Chart.yaml
+++ b/stable/msoms/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: msoms
-version: 0.1.4
+version: 0.2.0
 appVersion: 1.0.0-30
 description: A chart for deploying omsagent as a daemonset Kubernetes
 keywords:

--- a/stable/msoms/templates/omsagent-daemonset.yaml
+++ b/stable/msoms/templates/omsagent-daemonset.yaml
@@ -74,4 +74,8 @@ spec:
       operator: "Equal"
       value: "true"
       effect: "NoSchedule"
+{{- if .Values.tolerations }}       
+{{ toYaml .Values.tolerations | indent 4 }}     
+{{- end }}       
+
 {{- end }}               

--- a/stable/msoms/values.yaml
+++ b/stable/msoms/values.yaml
@@ -32,3 +32,7 @@ resources:
 # Node selector - default to Linux as cannot deploy OMS agent container to Windows nodes
 nodeSelector:
   beta.kubernetes.io/os: linux
+
+# optional tolerations to handle custom taints
+# tolerations:
+# - operator: "Exists"

--- a/stable/msoms/values.yaml
+++ b/stable/msoms/values.yaml
@@ -34,5 +34,4 @@ nodeSelector:
   beta.kubernetes.io/os: linux
 
 # optional tolerations to handle custom taints
-# tolerations:
-# - operator: "Exists"
+tolerations: []


### PR DESCRIPTION
I have taints in my cluster, but I still want the OMS DaemonSet to run on all nodes. This allows for custom tolerations to be added, similar to the custom nodeSelector option.

cc @keikhara