### PR TITLE
[stable/cert-manager] add extraEnv

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.10
+version: 0.2.11
 appVersion: 0.2.5
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `createCustomResource` | Create CRD/TPR with this release | `true` |
 | `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |
 | `extraArgs` | Optional flags for cert-manager | `[]` |
+| `extraEnv` | Optional environment variables for cert-manager (eg. `VAULT_CAPATH`) | `[]` |
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`
 | `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        {{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 10 }}
+        {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.ingressShim.enabled }}

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -28,6 +28,9 @@ extraArgs: []
   # Use this flag to set a namespace that cert-manager will use to store
   # supporting resources required for each ClusterIssuer (default is kube-system)
   # - --cluster-resource-namespace=kube-system
+extraEnv: []
+# - name: VAULT_CAPATH
+#   value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 
 resources: {}
   # requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows configuring environment variables for the `cert-manager`.
For example it enables configuring `Vault` client to accept connections with kubernetes Certificate Authority:
```yaml
extraEnv:
- name: VAULT_CAPATH
  value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
added extraEnv
```
