### PR TITLE
[incubator/mysqlha] STOP SLAVE IO_THREAD before changing master 

### DIFF
--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -191,6 +191,7 @@ spec:
             # In case of container restart, attempt this at-most-once.
             cp change_master_to.sql.in change_master_to.sql.orig
             mysql -h 127.0.0.1 --verbose<<EOF
+            STOP SLAVE IO_THREAD;
             $(<change_master_to.sql.orig),
             MASTER_HOST='{{ template "fullname" . }}-0.{{ template "fullname" . }}',
             MASTER_USER='${MYSQL_REPLICATION_USER}',


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
In case a slave pod is rescheduled replication fails with the following error:
`ERROR 3021 (HY000) at line 1: This operation cannot be performed with a running slave io thread; run STOP SLAVE IO_THREAD FOR CHANNEL '' first.`
Slave IO_THREAD needs to be stopped before changing master.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
