### PR TITLE
[Incubator/mysqlha] rechedule fails with persistent disks

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysqlha
-version: 0.2.0
+version: 0.2.1
 appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -23,12 +23,14 @@ spec:
           - "-c"
           - |
             set -ex
-            # Skip the clone if data already exists.
-            [[ -d /var/lib/mysql/mysql ]] && exit 0
             # Skip the clone on master (ordinal index 0).
             [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
             ordinal=${BASH_REMATCH[1]}
             [[ $ordinal -eq 0 ]] && exit 0
+
+            # If data aleready exists, delete and proceed to clone.
+            [[ -d /var/lib/mysql/mysql ]] && rm -fr /var/lib/mysql/*
+
             # Clone data from previous peer.
             ncat --recv-only {{ template "fullname" . }}-$(($ordinal-1)).{{ template "fullname" . }} 3307 | xbstream -x -C /var/lib/mysql
             # Prepare the backup.

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -191,6 +191,7 @@ spec:
             # In case of container restart, attempt this at-most-once.
             cp change_master_to.sql.in change_master_to.sql.orig
             mysql -h 127.0.0.1 --verbose<<EOF
+            STOP SLAVE IO_THREAD;
             $(<change_master_to.sql.orig),
             MASTER_HOST='{{ template "fullname" . }}-0.{{ template "fullname" . }}',
             MASTER_USER='${MYSQL_REPLICATION_USER}',

--- a/incubator/mysqlha/templates/statefulset.yaml
+++ b/incubator/mysqlha/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
             ordinal=${BASH_REMATCH[1]}
             [[ $ordinal -eq 0 ]] && exit 0
 
-            # If data aleready exists, delete and proceed to clone.
+            # If data already exists, delete and proceed to clone.
             [[ -d /var/lib/mysql/mysql ]] && rm -fr /var/lib/mysql/*
 
             # Clone data from previous peer.


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR allow pods using persistent volumed to be rescheduled and restarted without replication failure or data inconsistency

**Which issue this PR fixes**:
fixes #5522 

**Special notes for your reviewer**:
This scenario has been tested on gcloud