### PR TITLE
[stable/buildkite] typo fix: [want to xxtra env] -> [want extra env]

### DIFF
--- a/stable/buildkite/Chart.yaml
+++ b/stable/buildkite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Agent for Buildkite
 name: buildkite
-version: 0.2.2
+version: 0.2.3
 appVersion: 3.0
 icon: https://github.com/buildkite/media/blob/master/marks/Buildkite%20-%20Mark%20-%20colour.png
 keywords:

--- a/stable/buildkite/values.yaml
+++ b/stable/buildkite/values.yaml
@@ -17,7 +17,7 @@ agent:
   meta: "role=agent"
 
 # Extra env vars to be passed
-# If you do want to xxtra env vars to pass to agent, uncomment the following
+# If you do want extra env vars to pass to agent, uncomment the following
 # lines, adjust them as necessary.
 #
 # extraEnv:


### PR DESCRIPTION

It's difficult to read this sentence: "If you do want to xxtra env vars to pass to agent", even I know what it wants to describe.
Suggestion: If you do want extra env vars to pass to agent.