### PR TITLE
[stable/mysql] Add fullnameOverride

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.5.0
+version: 0.6.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/templates/_helpers.tpl
+++ b/stable/mysql/templates/_helpers.tpl
@@ -9,8 +9,17 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "mysql.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `fullnameOverride`, as seen in other charts, to the template helpers.

Also, update the conditional logic in the `mysql.fullname` template to more closely mirror the behaviour of other charts, i.e. if no `fullnameOverride` is specified and the release name contains the chart name, use it as the full name.