### PR TITLE
[stable/consul] Rework affinity settings

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 2.0.1
+version: 3.0.0
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/README.md
+++ b/stable/consul/README.md
@@ -49,7 +49,7 @@ The following table lists the configurable parameters of the consul chart and th
 | `SerfwanUdpPort`        | Container serf wan UDP listening port | `8302`                                                     |
 | `ServerPort`            | Container server listening port       | `8300`                                                     |
 | `ConsulDnsPort`         | Container dns listening port          | `8600`                                                     |
-| `antiAffinity`          | Consul pod anti-affinity setting      | `hard`                                                     |
+| `affinity`              | Consul affinity settings              | `see values.yaml`                                                     |
 | `maxUnavailable`        | Pod disruption Budget maxUnavailable  | `1`                                                        |
 | `ui.enabled`            | Enable Consul Web UI                  | `true`                                                    |
 | `uiService.enabled`     | Create dedicated Consul Web UI svc    | `true`                                                    |

--- a/stable/consul/templates/consul-statefulset.yaml
+++ b/stable/consul/templates/consul-statefulset.yaml
@@ -27,39 +27,10 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
-      {{- if eq .Values.antiAffinity "hard" }}
+    {{- if .Values.affinity }}
       affinity:
-        {{- if .Values.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml .Values.nodeAffinity | indent 10 }}
-        {{- end }}
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: component
-                operator: In
-                values:
-                - "{{ .Release.Name }}-{{ .Values.Component }}"
-            topologyKey: kubernetes.io/hostname
-      {{- else if eq .Values.antiAffinity "soft" }}
-      affinity:
-        {{- if .Values.nodeAffinity }}
-        nodeAffinity:
-{{ toYaml .Values.nodeAffinity | indent 10 }}
-        {{- end }}
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                - key: component
-                  operator: In
-                  values:
-                  - "{{ .Release.Name }}-{{ .Values.Component }}"
-      {{- end }}
+{{ tpl .Values.affinity . | indent 8 }}
+    {{- end }}
       containers:
       - name: "{{ template "consul.fullname" . }}"
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -78,12 +78,19 @@ maxUnavailable: 1
 #         values:
 #         - true
 
-## Anti-Affinity setting. The default "hard" will use pod anti-affinity that is
-## requiredDuringSchedulingIgnoredDuringExecution to ensure 2 services don't
-## end up on the same node. Setting this to "soft" will use
-## preferredDuringSchedulingIgnoredDuringExecution. If set to anything else,
-## no anti-affinity rules will be configured.
-antiAffinity: "hard"
+## Affinity settings
+affinity: |
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 1
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+          - key: component
+            operator: In
+            values:
+            - "{{ .Release.Name }}-{{ .Values.Component }}"
 
 ## Enable Consul Web UI
 ##


### PR DESCRIPTION
Rework affinity settings to follow Helm best practices.

* I followed the same pattern as in the Vault Helm chart in order to allow setting a sane default in values.yaml (not completely the same as a default helm create template due to the need to template inside of values.yaml).
* Bumped Chart as a breaking change as this might break people's use of nodeAffinity?