### PR TITLE
[stable/acs-engine-autoscaler] Fix the failure links and little change in format

### DIFF
--- a/stable/acs-engine-autoscaler/Chart.yaml
+++ b/stable/acs-engine-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within agent pools
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: acs-engine-autoscaler
-version: 2.1.4
+version: 2.1.5
 appVersion: 2.1.1
 home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
 sources:

--- a/stable/acs-engine-autoscaler/README.md
+++ b/stable/acs-engine-autoscaler/README.md
@@ -116,7 +116,8 @@ Parameter | Description | Default
 `spareagents`| [OPTIONAL] Number of agents per pool that should always remain up. | 1
 `idlethreshold`| [OPTIONAL] Maximum duration (in seconds) an agent can stay idle before being deleted. | 1800 (30 minutes)
 `overprovision`| [OPTIONAL] Number of extra agents to create when scaling out. | 0
-Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section.
+
+Specify each parameter you'd like to override using a YAML file as described above in the [installation](#installing-the-chart) section.
 
 
 ## Credentials


### PR DESCRIPTION
1) Fix failure links:
[installation](#Installing the Chart) --> [installation](#installing-the-chart)

2) Line 119 should not be put into the table.