### PR TITLE
Stable/unbound/add tcp port + minor fixes

### DIFF
--- a/stable/unbound/Chart.yaml
+++ b/stable/unbound/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Unbound is a fast caching DNS resolver
 home: https://www.unbound.net/
 name: unbound
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.6.7
 sources:
 - http://unbound.nlnetlabs.nl/svn/

--- a/stable/unbound/templates/deployment.yaml
+++ b/stable/unbound/templates/deployment.yaml
@@ -72,16 +72,16 @@ spec:
       - name: "unbound-conf"
         configMap:
           name: {{ template "unbound.fullname" . }}
-    {{- with .Values.nodeSelector }}
+{{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
-    {{- end }}
+{{- end }}
 

--- a/stable/unbound/templates/deployment.yaml
+++ b/stable/unbound/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
         - name: "dns-udp"
           containerPort: {{ .Values.unbound.serverPort }}
           protocol: "UDP"
+        - name: "dns-tcp"
+          containerPort: {{ .Values.unbound.serverPort }}
+          protocol: "TCP"
         volumeMounts:
         - name: "unbound-conf"
           mountPath: "/etc/unbound/"
@@ -49,7 +52,6 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 2
         readinessProbe:
-          exec:
           httpGet:
             path: "/healthz"
             port: 8080

--- a/stable/unbound/templates/deployment.yaml
+++ b/stable/unbound/templates/deployment.yaml
@@ -32,8 +32,10 @@ spec:
       - name: "unbound"
         image: {{ .Values.unbound.image.repository }}:{{ .Values.unbound.image.tag }}
         imagePullPolicy: {{ .Values.unbound.image.pullPolicy | quote }}
+{{- with .Values.resources }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml . | indent 10 }}
+{{- end }}
         ports:
         - name: "dns-udp"
           containerPort: {{ .Values.unbound.serverPort }}

--- a/stable/unbound/templates/service.yaml
+++ b/stable/unbound/templates/service.yaml
@@ -16,3 +16,7 @@ spec:
     protocol: UDP
     port: {{ .Values.unbound.serverPort }}
     targetPort: dns-udp
+  - name: dns-tcp
+    protocol: TCP
+    port: {{ .Values.unbound.serverPort }}
+    targetPort: dns-tcp


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

- Updates stable/unbound to add explicit tcp support. 
- Removes spurious `exec:` from unbound readiness probe.
- Wraps resources in with block to prevent rendering when empty
- Unindents with blocks to left margin for readability
- Increments chart version

**Which issue this PR fixes**: 

N/A

**Special notes for your reviewer**:

None
