### PR TITLE
Update Secret.yaml

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.4
-version: 1.5.0
+version: 1.5.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/secret.yaml
+++ b/stable/rabbitmq-ha/templates/secret.yaml
@@ -16,7 +16,7 @@ data:
   {{ if .Values.rabbitmqPassword }}
   rabbitmq-password: {{ .Values.rabbitmqPassword | b64enc | quote }}
   {{ else }}
-  rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}
+  rabbitmq-password: {{ randAscii 24 | nospace | b64enc | quote }}
   {{ end }}
   {{ if .Values.rabbitmqErlangCookie }}
   rabbitmq-erlang-cookie: {{ .Values.rabbitmqErlangCookie | b64enc | quote }}


### PR DESCRIPTION
Increase rabbitmq password complexity

**What this PR does / why we need it**:
There are two reasons found while using in production:

0. Passing custom password via **--set=** stores the password in shell history (plain).
1. Password generated by default in **Secret.yaml** does not contain special characters and has 10 symbols length which affects it's strength.

I assume it would be more suitable if a stront password is generated when using rabbitmq-ha out of of the box. 