### PR TITLE
Allow Ghost to be installed on a subdirectory

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 3.1.2
+version: 3.1.3
 appVersion: 1.22.7
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -47,12 +47,13 @@ The following table lists the configurable parameters of the Ghost chart and the
 
 | Parameter                     | Description                                                   | Default                                                  |
 |-------------------------------|---------------------------------------------------------------|----------------------------------------------------------|
-| `image.registry`              | Ghost image registry                                          | `docker.io`                                             |
-| `image.repository`            | Ghost Image name                                              | `bitnami/ghost`                                      |
-| `image.tag`                   | Ghost Image tag                                               | `{VERSION}`                                             |
-| `image.pullPolicy`            | Image pull policy                                             | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `image.pullSecrets`           | Specify image pull secrets                                    | `nil`                                                   |
+| `image.registry`              | Ghost image registry                                          | `docker.io`                                              |
+| `image.repository`            | Ghost Image name                                              | `bitnami/ghost`                                          |
+| `image.tag`                   | Ghost Image tag                                               | `{VERSION}`                                              |
+| `image.pullPolicy`            | Image pull policy                                             | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
+| `image.pullSecrets`           | Specify image pull secrets                                    | `nil`                                                    |
 | `ghostHost`                   | Ghost host to create application URLs                         | `nil`                                                    |
+| `ghostPath`                   | Ghost path to create application URLs                         | `nil`                                                    |
 | `ghostPort`                   | Ghost port to create application URLs along with host         | `80`                                                     |
 | `ghostLoadBalancerIP`         | `loadBalancerIP` for the Ghost Service                        | `nil`                                                    |
 | `ghostUsername`               | User of the application                                       | `user@example.com`                                       |

--- a/stable/ghost/requirements.lock
+++ b/stable/ghost/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
-generated: 2017-11-27T16:40:56.867665764Z
+  version: 2.1.1
+digest: sha256:b8e3e6de1e41b1af5cad8decf6f3345af26d850c11dcbb2e2efa4d118c51a573
+generated: 2018-05-11T15:39:45.730914147+02:00

--- a/stable/ghost/requirements.yaml
+++ b/stable/ghost/requirements.yaml
@@ -1,5 +1,7 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
+  version: 2.1.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
+  tags:
+    - ghost-database

--- a/stable/ghost/templates/NOTES.txt
+++ b/stable/ghost/templates/NOTES.txt
@@ -30,21 +30,21 @@ host. To configure Ghost with the URL of your service:
 {{- if eq .Values.serviceType "ClusterIP" }}
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ghost.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo Blog URL  :  http://127.0.0.1:{{ default "80" .Values.ghostPort }}/
-  echo Admin URL : http://127.0.0.1:{{ default "80" .Values.ghostPort }}/ghost
+  echo Blog URL  : http://127.0.0.1:{{ default "80" .Values.ghostPort }}{{ .Values.ghostPath }}
+  echo Admin URL : http://127.0.0.1:{{ default "80" .Values.ghostPort }}{{ .Values.ghostPath }}ghost
   kubectl port-forward $POD_NAME {{ default "80" .Values.ghostPort }}:2368
 
 {{- else if eq .Values.serviceType "NodePort" }}
   export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   export APP_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ghost.fullname" . }})
 
-  echo Blog URL  : http://$APP_HOST:$APP_PORT/
-  echo Admin URL : http://$APP_HOST:$APP_PORT/ghost
+  echo Blog URL  : http://$APP_HOST:$APP_PORT{{ .Values.ghostPath }}
+  echo Admin URL : http://$APP_HOST:$APP_PORT{{ .Values.ghostPath }}ghost
 
 {{- else }}
 
-  echo Blog URL  : http://{{ include "ghost.host" . }}/
-  echo Admin URL : http://{{ include "ghost.host" . }}/ghost
+  echo Blog URL  : http://{{ include "ghost.host" . }}
+  echo Admin URL : http://{{ include "ghost.host" . }}ghost
 {{- end }}
 
 2. Get your Ghost login credentials by running:

--- a/stable/ghost/templates/_helpers.tpl
+++ b/stable/ghost/templates/_helpers.tpl
@@ -49,7 +49,7 @@ Gets the host to be used for this application.
 If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
 */}}
 {{- define "ghost.host" -}}
-{{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
+{{- $host := printf "%s%s" .Values.ghostHost .Values.ghostPath | default "" -}}
 {{- default (include "ghost.serviceIP" .) $host -}}
 {{- end -}}
 

--- a/stable/ghost/templates/_helpers.tpl
+++ b/stable/ghost/templates/_helpers.tpl
@@ -49,8 +49,12 @@ Gets the host to be used for this application.
 If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
 */}}
 {{- define "ghost.host" -}}
-{{- $host := printf "%s%s" .Values.ghostHost .Values.ghostPath | default "" -}}
+{{- if .Values.ghostHost -}}
+{{- $host := printf "%s%s" .Values.ghostHost .Values.ghostPath -}}
 {{- default (include "ghost.serviceIP" .) $host -}}
+{{- else -}}
+{{- default (include "ghost.serviceIP" .) "" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       initContainers:
       - name: volume-permissions
         image: "{{ .Values.volumePermissions.image.name }}:{{ .Values.volumePermissions.image.tag }}"
-        imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
+        imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
         command: ['sh', '-c', 'chmod -R g+rwX /bitnami']
         volumeMounts:
         - mountPath: /bitnami
@@ -44,21 +44,21 @@ spec:
         {{- if .Values.mariadb.enabled }}
           value: {{ template "ghost.mariadb.fullname" . }}
         {{- else }}
-          value: {{ default "" .Values.externalDatabase.host | quote }}
+          value: {{ .Values.externalDatabase.host | quote }}
         {{- end }}
         - name: MARIADB_PORT_NUMBER
           value: "3306"
         - name: GHOST_DATABASE_NAME
         {{- if .Values.mariadb.enabled }}
-          value: {{ default "" .Values.mariadb.mariadbDatabase | quote }}
+          value: {{ .Values.mariadb.mariadbDatabase | quote }}
         {{- else }}
-          value: {{ default "" .Values.externalDatabase.database | quote }}
+          value: {{ .Values.externalDatabase.database | quote }}
         {{- end }}
         - name: GHOST_DATABASE_USER
         {{- if .Values.mariadb.enabled }}
-          value: {{ default "" .Values.mariadb.mariadbUser | quote }}
+          value: {{ .Values.mariadb.mariadbUser | quote }}
         {{- else }}
-          value: {{ default "" .Values.externalDatabase.user | quote }}
+          value: {{ .Values.externalDatabase.user | quote }}
         {{- end }}
         - name: GHOST_DATABASE_PASSWORD
         {{- if .Values.mariadb.enabled }}
@@ -67,42 +67,42 @@ spec:
               name: {{ template "ghost.mariadb.fullname" . }}
               key: mariadb-password
         {{- else }}
-          value: {{ default "" .Values.externalDatabase.password | quote }}
+          value: {{ .Values.externalDatabase.password | quote }}
         {{- end }}
         - name: GHOST_HOST
           value: {{ include "ghost.host" . | quote }}
         - name: GHOST_PORT_NUMBER
-          value: {{ default "80" .Values.ghostPort | quote }}
+          value: {{ .Values.ghostPort | quote }}
         - name: GHOST_USERNAME
-          value: {{ default "" .Values.ghostUsername | quote }}
+          value: {{ .Values.ghostUsername | quote }}
         - name: GHOST_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "ghost.fullname" . }}
               key: ghost-password
         - name: GHOST_EMAIL
-          value: {{ default "" .Values.ghostEmail | quote }}
+          value: {{ .Values.ghostEmail | quote }}
         - name: BLOG_TITLE
-          value: {{ default "" .Values.ghostBlogTitle | quote }}
+          value: {{ .Values.ghostBlogTitle | quote }}
         - name: SMTP_HOST
-          value: {{ default "" .Values.smtpHost | quote }}
+          value: {{ .Values.smtpHost | quote }}
         - name: SMTP_PORT
-          value: {{ default "" .Values.smtpPort | quote }}
+          value: {{ .Values.smtpPort | quote }}
         - name: SMTP_USER
-          value: {{ default "" .Values.smtpUser | quote }}
+          value: {{ .Values.smtpUser | quote }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "ghost.fullname" . }}
               key: smtp-password
         - name: SMTP_SERVICE
-          value: {{ default "" .Values.smtpService | quote }}
+          value: {{ .Values.smtpService | quote }}
         ports:
         - name: http
           containerPort: 2368
         livenessProbe:
           httpGet:
-            path: /ghost
+            path: {{ .Values.ghostPath }}
             port: http
             httpHeaders:
             - name: Host
@@ -112,7 +112,7 @@ spec:
           failureThreshold: 6
         readinessProbe:
           httpGet:
-            path: /ghost
+            path: {{ .Values.ghostPath }}
             port: http
             httpHeaders:
             - name: Host

--- a/stable/ghost/templates/svc.yaml
+++ b/stable/ghost/templates/svc.yaml
@@ -10,11 +10,11 @@ metadata:
 spec:
   type: {{ .Values.serviceType }}
   {{- if eq .Values.serviceType "LoadBalancer" }}
-  loadBalancerIP: {{ default "" .Values.ghostLoadBalancerIP }}
+  loadBalancerIP: {{ .Values.ghostLoadBalancerIP }}
   {{- end }}
   ports:
   - name: http
-    port: {{ default "80" .Values.ghostPort }}
+    port: {{ .Values.ghostPort }}
     targetPort: http
   selector:
     app: {{ template "ghost.fullname" . }}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -39,7 +39,7 @@ ghostPort: 80
 ## loadBalancerIP for the Ghost Service (optional, cloud specific)
 ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
 ##
-# ghostLoadBalancerIP:
+ghostLoadBalancerIP: ""
 
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-ghost#configuration

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -22,13 +22,14 @@ image:
 volumePermissions:
   image:
     name: busybox
-    tag: 1.27.1
+    tag: 1.28.3
 #    pullPolicy:
 
-## Ghost host to create application URLs
+## Ghost host and path to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-ghost#configuration
 ##
 # ghostHost:
+ghostPath: /
 
 ## Ghost port to create application URLs along with host.
 ## ref: https://github.com/bitnami/bitnami-docker-ghost#configuration


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the possibility of running Ghost on a custom subdirectory instead of installing it on `/`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5513

Add functionality not supported as reported by @BenderV 

**Special notes for your reviewer**:
