### PR TITLE
Fix stable/grafana chart

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.9.0
+version: 1.9.1
 appVersion: 5.1.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
 {{- end }}
           {{- if .Values.envFromSecret }}
           envFrom:
-            - secretKeyRef:
+            - secretRef:
                 name: {{ .Values.envFromSecret }}
           {{- end }}
           livenessProbe:


### PR DESCRIPTION
Use `secretRef` instead of `secretKeyRef`, because `secretKeyRef` is not
a valid key for `envFrom`.

Here are the relevant
[docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#envfromsource-v1-core).

**What this PR does / why we need it**:
Fix `stable/grafana` chart.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5549 

