### PR TITLE
[stable/telegraf] Remove influxDB dependency

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,5 +1,5 @@
 name: telegraf
-version: 0.3.3
+version: 0.3.4
 appVersion: 1.5
 deprecated: true
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/stable/telegraf/templates/NOTES.txt
+++ b/stable/telegraf/templates/NOTES.txt
@@ -12,14 +12,3 @@ To watch for the LoadBalancer IP run the following
 
 - kubectl get svc -w --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }}
 {{- end }}
-
-{{- if empty .Values.single.config.outputs.influxdb.urls }}
-{{- if empty .Values.daemonset.config.outputs.influxdb.urls }}
-
-Need to set an InfluxDB url for either single or daemonset to deploy this instance:
-
-.Values.daemonset.config.outputs.influxdb.urls
-.Values.single.config.outputs.influxdb.urls
-
-{{- end }}
-{{- end }}

--- a/stable/telegraf/templates/configmap-ds.yaml
+++ b/stable/telegraf/templates/configmap-ds.yaml
@@ -1,4 +1,3 @@
-{{- if gt (len .Values.daemonset.config.outputs.influxdb.urls) 0 }}
 {{- if .Values.daemonset.enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -15,5 +14,4 @@ data:
     {{ template "agent" .Values.daemonset.config.agent }}
     {{ template "outputs" .Values.daemonset.config.outputs }}
     {{ template "inputs" .Values.daemonset.config.inputs -}}
-{{- end -}}
 {{- end -}}

--- a/stable/telegraf/templates/configmap-s.yaml
+++ b/stable/telegraf/templates/configmap-s.yaml
@@ -1,4 +1,3 @@
-{{- if gt (len .Values.single.config.outputs.influxdb.urls) 0 }}
 {{- if .Values.single.enabled -}}
 apiVersion: v1
 kind: ConfigMap
@@ -15,5 +14,4 @@ data:
     {{ template "agent" .Values.single.config.agent }}
     {{ template "outputs" .Values.single.config.outputs }}
     {{ template "inputs" .Values.single.config.inputs -}}
-{{- end -}}
 {{- end -}}

--- a/stable/telegraf/templates/daemonset.yaml
+++ b/stable/telegraf/templates/daemonset.yaml
@@ -1,4 +1,3 @@
-{{- if gt (len .Values.daemonset.config.outputs.influxdb.urls) 0 }}
 {{- if .Values.daemonset.enabled -}}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -11,6 +10,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-ds.yaml") . | sha256sum }}
       labels:
         app: {{ template "fullname" . }}-ds
     spec:
@@ -60,5 +61,4 @@ spec:
       - name: config
         configMap:
           name: {{ template "fullname" . }}-ds
-{{- end -}}
 {{- end -}}

--- a/stable/telegraf/templates/deployment.yaml
+++ b/stable/telegraf/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if gt (len .Values.single.config.outputs.influxdb.urls) 0 }}
 {{- if .Values.single.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -12,6 +11,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-s.yaml") . | sha256sum }}
       labels:
         app: {{ template "fullname" . }}-s
     spec:
@@ -28,5 +29,4 @@ spec:
       - name: config
         configMap:
           name: {{ template "fullname" . }}-s
-{{- end -}}
 {{- end -}}

--- a/stable/telegraf/templates/service.yaml
+++ b/stable/telegraf/templates/service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}-s
   labels:
+    app: {{ template "fullname" . }}-s
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   type: {{ .Values.single.service.type }}
@@ -34,6 +35,13 @@ spec:
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "webhooks"
+    {{- end }}
+  {{- end }}
+  {{- range $key, $value := .Values.single.config.outputs }}
+    {{- if eq $key "prometheus_client" }}
+  - port: {{ trimPrefix ":" $value.listen | int64 }}
+    targetPort: {{ trimPrefix ":" $value.listen | int64 }}
+    name: "prometheus"
     {{- end }}
   {{- end }}
   selector:

--- a/stable/telegraf/values.yaml
+++ b/stable/telegraf/values.yaml
@@ -38,11 +38,11 @@ daemonset:
       logfile: ""
       hostname: "$HOSTNAME"
       omit_hostname: false
-    outputs:
-      influxdb:
-        urls: []
+    outputs: {}
+##      influxdb:
+##        urls: []
           # - "http://influxdb-influxdb.tick:8086"
-        database: "telegraf"
+##        database: "telegraf"
 ##        retention_policy: ""
 ##        write_consistency: "any"
 ##        timeout: "5s"
@@ -106,6 +106,9 @@ daemonset:
 ##        server: "localhost:4150"
 ##        topic: "telegraf"
 ##        data_format: "influx"
+##      prometheus_client:
+##        listen: ":9273"
+##        path: "/metrics"
     inputs:
       cpu:
         percpu: true
@@ -169,11 +172,11 @@ single:
       logfile: ""
       hostname: "telegraf-polling-service"
       omit_hostname: false
-    outputs:
-      influxdb:
-        urls: []
+    outputs: {}
+##      influxdb:
+##        urls: []
           # - "http://influxdb-influxdb.tick:8086"
-        database: "telegraf"
+##        database: "telegraf"
 ##        retention_policy: ""
 ##        write_consistency: "any"
 ##        timeout: "5s"
@@ -237,11 +240,14 @@ single:
 ##        server: "localhost:4150"
 ##        topic: "telegraf"
 ##        data_format: "influx"
-    inputs:
-      cpu:
-        percpu: false
-        totalcpu: true
-      system:
+##      prometheus_client:
+##        listen: ":9273"
+##        path: "/metrics"
+    inputs: {}
+##      cpu:
+##        percpu: false
+##        totalcpu: true
+##      system:
 ##      aerospike:
 ##        servers:
 ##          - "localhost:3000"
@@ -333,10 +339,10 @@ single:
 ##      haproxy:
 ##        servers:
 ##          - "http://myhaproxy.com:1936/haproxy?stats"
-      influxdb:
-        urls:
-          - "http://influxdb-influxdb.tick:8086/debug/vars"
-        timeout: "5s"
+##      influxdb:
+##        urls:
+##          - "http://influxdb-influxdb.tick:8086/debug/vars"
+##        timeout: "5s"
 ##      lustre2:
 ##        ost_procfiles:
 ##          - "/proc/fs/lustre/obdfilter/*/stats"
@@ -430,12 +436,12 @@ single:
 ##        databases:
 ##          - "app_production"
 ##          - "testing"
-      prometheus:
-        urls:
-          - "https://kubernetes.default:443/metrics"
-        name_prefix: "prom_"
-        bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        insecure_skip_verify: true
+##      prometheus:
+##        urls:
+##          - "https://kubernetes.default:443/metrics"
+##        name_prefix: "prom_"
+##        bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+##        insecure_skip_verify: true
 ##        ssl_ca: /path/to/cafile
 ##        ssl_cert: /path/to/certfile
 ##        ssl_key: /path/to/keyfile
@@ -480,12 +486,12 @@ single:
 ##        write_timeout: "10s"
 ##        max_body_size: 0
 ##        max_line_size: 0
-      statsd:
-        service_address: ":8125"
-        percentiles:
-          - 50
-          - 95
-          - 99
-        metric_separator: "_"
-        allowed_pending_messages: 10000
-        percentile_limit: 1000
+##      statsd:
+##        service_address: ":8125"
+##        percentiles:
+##          - 50
+##          - 95
+##          - 99
+##        metric_separator: "_"
+##        allowed_pending_messages: 10000
+##        percentile_limit: 1000


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The actual chart makes hard to disable unwanted inputs and outputs. It adds an implicit dependency on InfluxDB as output plugin (introduced by https://github.com/kubernetes/charts/commit/71945766294b7eb10a550d94fc0d731611cabf0f) which makes very hard to disable it when not needed.

This PR removes the default dependency on InfluxDB for Telegraf and adds a configuration examples to use the prometheus_client as output plugin.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
