### PR TITLE
Grafana: Prepare chart for 5.1.x

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.10.0
+version: 1.10.1
 appVersion: 5.1.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -33,8 +33,19 @@ spec:
 {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
-{{- if .Values.dashboards }}
       initContainers:
+{{- /* Since grafana 5.1.0 the files need to be owned by user id 472 */ -}}
+{{- /* http://docs.grafana.org/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later */ -}}
+{{- if semverCompare ">= 5.1.0" .Values.image.tag }}
+        - name: chown
+          image: "{{ .Values.chownImage.repository }}:{{ .Values.chownImage.tag }}"
+          command: ["chown", "-R", "472:472", "/var/lib/grafana"]
+          volumeMounts:
+          - name: storage
+            mountPath: "/var/lib/grafana"
+            subPath: {{ .Values.persistence.subPath }}
+{{- end }}
+{{- if .Values.dashboards }}
         - name: download-dashboards
           image: "{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}"
           imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -21,6 +21,11 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+chownImage:
+  repository: busybox
+  tag: latest
+  pullPolicy: IfNotPresent
+
 downloadDashboardsImage:
   repository: appropriate/curl
   tag: latest


### PR DESCRIPTION
When upgrading to 5.1.x we need to chown the whole /var/lib/grafana dir in order to comply with the new grafana user id used in the latest docker image.
