### PR TITLE
[stable/wordpress] Add custom labels on wordpress ingress

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 1.0.5
+version: 1.0.6
 appVersion: 4.9.5
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -86,6 +86,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `ingress.hosts[0].tls`               | Utilize TLS backend in ingress             | `false`                                                    |
 | `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                  | `wordpress.local-tls-secret`                               |
 | `ingress.hosts[0].annotations`       | Annotations for this host's ingress record | `[]`                                                       |
+| `ingress.hosts[0].labels`            | Labels for this host's ingress records     | `{}`                                                       |
 | `ingress.secrets[0].name`            | TLS Secret Name                            | `nil`                                                      |
 | `ingress.secrets[0].certificate`     | TLS Secret Certificate                     | `nil`                                                      |
 | `ingress.secrets[0].key`             | TLS Secret Key                             | `nil`                                                      |

--- a/stable/wordpress/templates/ingress.yaml
+++ b/stable/wordpress/templates/ingress.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
+    {{- if .labels }}
+{{ toYaml .labels | indent 4 }}
+    {{- end }}
   annotations:
     {{- if .tls }}
     ingress.kubernetes.io/secure-backends: "true"

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -195,6 +195,8 @@ ingress:
     #  kubernetes.io/ingress.class: nginx
     #  kubernetes.io/tls-acme: true
 
+    labels: {}
+
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or


### PR DESCRIPTION
What this PR does: Implement custom labels on wordpress ingress, following the per host implementation.