### PR TITLE
Adding HTTPS using AWS ACM with whitelisting option to the concourse chart

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.5.2
+version: 1.6.0
 appVersion: 3.10.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.5.1
+version: 1.5.2
 appVersion: 3.10.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -110,6 +110,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.tolerations` | Tolerations for the web nodes | `[]` |
 | `web.service.type` | Concourse Web service type | `ClusterIP` |
 | `web.service.annotations` | Concourse Web Service annotations | `nil` |
+| `web.service.loadBalancerSourceRanges` | Concourse Web Service Load Balancer Source IP ranges | `nil` |
 | `web.service.atcNodePort` | Sets the nodePort for atc when using `NodePort` | `nil` |
 | `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |
 | `web.ingress.enabled` | Enable Concourse Web Ingress | `false` |

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -17,6 +17,12 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.web.service.type }}
+  {{- if .Values.web.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range .Values.web.service.loadBalancerSourceRanges }}
+    - {{ . }}
+    {{- end }}
+  {{ end }}
   ports:
     - name: atc
       port: {{ .Values.concourse.atcPort }}

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.web.service.type }}
-  {{- if .Values.web.service.loadBalancerSourceRanges }}
+  {{ if  .Values.web.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range .Values.web.service.loadBalancerSourceRanges }}
     - {{ . }}

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.web.service.type }}
-  {{ if  .Values.web.service.loadBalancerSourceRanges }}
+  {{ if .Values.web.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range .Values.web.service.loadBalancerSourceRanges }}
     - {{ . }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -237,6 +237,16 @@ web:
     # annotations:
     #   prometheus.io/probe: "true"
     #   prometheus.io/probe_path: "/"
+    #
+    #   ## When using web.service.type: LoadBalancer, enable HTTPS with an ACM cert
+    #   service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:123456789:certificate/abc123-abc123-abc123-abc123"
+    #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+    #   service.beta.kubernetes.io/aws-load-balancer-backend-port: "atc"
+    #   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    #
+    # ## When using web.service.type: LoadBalancer, whitelist the load balancer to particular IPs
+    # loadBalancerSourceRanges:
+    #   - 192.168.1.10/32
 
   # When using web.service.type: NodePort, sets the nodePort for atc
   #  atcNodePort: 30150


### PR DESCRIPTION
**What this PR does / why we need it**:

* Provides a way to whitelist the spawned AWS load balancer when service type is set to LoadBalancer.
* Provides a way to run concourse over HTTPS with an existing AWS ACM certificate when using service type LoadBalancer.

**Special notes for your reviewer**:
Tested successfully on a kops managed cluster with the following versions
```
$ helm version
Client: &version.Version{SemVer:"v2.8.2", GitCommit:"a80231648a1473929271764b920a8e346f6de844", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.8.2", GitCommit:"a80231648a1473929271764b920a8e346f6de844", GitTreeState:"clean"}
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.1", GitCommit:"d4ab47518836c750f9949b9e0d387f20fb92260b", GitTreeState:"clean", BuildDate:"2018-04-13T22:27:55Z", GoVersion:"go1.9.5", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.3", GitCommit:"d2835416544f298c919e2ead3be3d0864b52323b", GitTreeState:"clean", BuildDate:"2018-02-07T11:55:20Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
```