### PR TITLE
fix for itzg/minecraft-server image change

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,5 +1,5 @@
 name: minecraft
-version: 0.2.1
+version: 0.2.2
 appVersion: 1.12.2
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/templates/deployment.yaml
+++ b/stable/minecraft/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: {{ template "minecraft.fullname" . }}
     spec:
+      securityContext:
+        runAsUser: {{ .Values.secContext.runAsUser }}
+        fsGroup: {{ .Values.secContext.fsGroup }}
       containers:
       - name: {{ template "minecraft.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -10,6 +10,10 @@ resources:
     memory: 512Mi
     cpu: 500m
 
+secContext:
+  #Securiyt context settings
+  runAsUser: 1000
+  fsGroup: 2000
 # Most of these map to environment variables. See Minecraft for details:
 # https://hub.docker.com/r/itzg/minecraft-server/
 minecraftServer:
@@ -73,6 +77,7 @@ minecraftServer:
   jvmOpts: "-Xmx512M -Xms512M"
   serviceType: LoadBalancer
 
+  
   rcon:
     # If you enable this, make SURE to change your password below.
     enabled: false
@@ -93,3 +98,4 @@ persistence:
     # Set this to false if you don't care to persist state between restarts.
     enabled: true
     Size: 1Gi
+

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -10,7 +10,7 @@ resources:
     memory: 512Mi
     cpu: 500m
 secContext:
-  #Securiyt context settings
+  # Security context settings
   runAsUser: 1000
   fsGroup: 2000
 # Most of these map to environment variables. See Minecraft for details:

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -9,7 +9,6 @@ resources:
   requests:
     memory: 512Mi
     cpu: 500m
-
 secContext:
   #Securiyt context settings
   runAsUser: 1000
@@ -77,7 +76,6 @@ minecraftServer:
   jvmOpts: "-Xmx512M -Xms512M"
   serviceType: LoadBalancer
 
-  
   rcon:
     # If you enable this, make SURE to change your password below.
     enabled: false
@@ -98,4 +96,3 @@ persistence:
     # Set this to false if you don't care to persist state between restarts.
     enabled: true
     Size: 1Gi
-


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The docker image used in the chart stable/minecraft no longer runs its startup as root. When a volume is mapped for persistence the directory ends up being owned by root. Causing the startup script to fail with permission denied. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I added security context to the values.yaml and the deployment.yaml template. This allows the pod to run as not root and also the fsGroup allows the user to write to the mounted directory at /data

