### PR TITLE
[incubator/drone] typo fix: afinity->affinity

### DIFF
--- a/incubator/drone/Chart.yaml
+++ b/incubator/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 1.0.2
+version: 1.0.3
 appVersion: 0.8.4
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -55,13 +55,13 @@ The following table lists the configurable parameters of the drone charts and th
 | `server.annotations`        | Drone **server** annotations                                                                  | `{}`                        |
 | `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
 | `server.schedulerName`      | Drone **server** alternate scheduler name                                                     | `nil`                       |
-| `server.afinity`            | Drone **server** scheduling preferences                                                       | `{}`                        |
+| `server.affinity`            | Drone **server** scheduling preferences                                                       | `{}`                        |
 | `agent.env`                 | Drone **agent** environment variables                                                         | `(default values)`          |
 | `agent.replicas`            | Drone **agent** replicas                                                                      | `1`                         |
 | `agent.annotations`         | Drone **agent** annotations                                                                   | `{}`                        |
 | `agent.resources`           | Drone **agent** pod resource requests & limits                                                | `{}`                        |
 | `agent.schedulerName`       | Drone **agent** alternate scheduler name                                                      | `nil`                       |
-| `agent.afinity`             | Drone **agent** scheduling preferences                                                        | `{}`                        |
+| `agent.affinity`             | Drone **agent** scheduling preferences                                                        | `{}`                        |
 | `dind.enabled`              | Enable or disable **DinD**                                                                    | `true`                      |
 | `dind.driver`               | **DinD** storage driver                                                                       | `overlay2`                  |
 | `dind.resources`            | **DinD** pod resource requests & limits                                                       | `{}`                        |

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -55,7 +55,7 @@ The following table lists the configurable parameters of the drone charts and th
 | `server.annotations`        | Drone **server** annotations                                                                  | `{}`                        |
 | `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
 | `server.schedulerName`      | Drone **server** alternate scheduler name                                                     | `nil`                       |
-| `server.affinity`            | Drone **server** scheduling preferences                                                       | `{}`                        |
+| `server.affinity`           | Drone **server** scheduling preferences                                                       | `{}`                        |
 | `agent.env`                 | Drone **agent** environment variables                                                         | `(default values)`          |
 | `agent.replicas`            | Drone **agent** replicas                                                                      | `1`                         |
 | `agent.annotations`         | Drone **agent** annotations                                                                   | `{}`                        |

--- a/incubator/drone/README.md
+++ b/incubator/drone/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the drone charts and th
 | `agent.annotations`         | Drone **agent** annotations                                                                   | `{}`                        |
 | `agent.resources`           | Drone **agent** pod resource requests & limits                                                | `{}`                        |
 | `agent.schedulerName`       | Drone **agent** alternate scheduler name                                                      | `nil`                       |
-| `agent.affinity`             | Drone **agent** scheduling preferences                                                        | `{}`                        |
+| `agent.affinity`            | Drone **agent** scheduling preferences                                                        | `{}`                        |
 | `dind.enabled`              | Enable or disable **DinD**                                                                    | `true`                      |
 | `dind.driver`               | **DinD** storage driver                                                                       | `overlay2`                  |
 | `dind.resources`            | **DinD** pod resource requests & limits                                                       | `{}`                        |


### PR DESCRIPTION
Typo in the parameter lists:
afinity->affinity
I checked the values.yaml, the "affinity" parameters for server and agent are defined, not "afinity".