### PR TITLE
[stable/grafana] Correct secretRef for envFromSecret

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.9.0
+version: 1.9.1
 appVersion: 5.1.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
 {{- end }}
           {{- if .Values.envFromSecret }}
           envFrom:
-            - secretKeyRef:
+            - secretRef:
                 name: {{ .Values.envFromSecret }}
           {{- end }}
           livenessProbe:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The current implementation uses a `secretKeyRef` to map in `.Values.envFromSecret`. `secretKeyRef`s require a secret name and a key, which is not provided. This generates an error when setting the `.Values.envFromSecret` to anything other than empty. A `secretRef` maps all of the keys from the secret name provided, which I believe was the original intent (and actually works).


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5279 

**Special notes for your reviewer**:
