### PR TITLE
issue_5600: Fix README.md for Kubeless

### DIFF
--- a/incubator/kubeless/Chart.yaml
+++ b/incubator/kubeless/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubeless
-version: 1.0.0
+version: 1.0.1
 appVersion: v1.0.0-alpha.2
 description: Kubeless is a Kubernetes-native serverless framework. It runs on top of your Kubernetes cluster and allows you to deploy small unit of code without having to build container images.
 icon: https://cloud.githubusercontent.com/assets/4056725/25480209/1d5bf83c-2b48-11e7-8db8-bcd650f31297.png

--- a/incubator/kubeless/README.md
+++ b/incubator/kubeless/README.md
@@ -16,7 +16,6 @@ This chart bootstraps a [Kubeless](https://github.com/kubeless/kubeless) and a [
 ## Prerequisites
 
 - Kubernetes 1.7+ with Beta APIs enabled
-- PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
 
@@ -94,7 +93,3 @@ The [Kubeless UI](https://github.com/kubeless/kubeless-ui) component is disabled
 ```bash
 $ helm install --name my-release --set ui.enabled=true --namespace kubeless incubator/kubeless
 ```
-
-## Persistence
-
-The Kafka and Zookeeper images stores the data and configurations at the `/bitnami/kafka` and `/bitnami/zookeeper` path of the container.


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubeless has been updated but still references Kafka/Zookeeper, which are no longer used, as well as Persistent Volumes, which are also gone (with K & Z).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Improved documentation.

**Special notes for your reviewer**:

N/A