### PR TITLE
[stable/traefik] Ability to add arbitrary Secrets and ConfigMaps

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.61.1
+version: 1.62.0
 appVersion: 1.7.9
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -133,7 +133,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `acme.challengeType`                   | Type of ACME challenge to perform domain validation. `tls-sni-01` (deprecated), `tls-alpn-01` (recommended), `http-01` or `dns-01` | `tls-sni-01`                                |
 | `acme.delayBeforeCheck`         | By default, the provider will verify the TXT DNS challenge record before letting ACME verify. If delayBeforeCheck is greater than zero, this check is delayed for the configured duration in seconds. Useful when Traefik cannot resolve external DNS queries. | `0` |
 | `acme.dnsProvider.name`                | Which DNS provider to use. See [here](https://github.com/xenolf/lego/tree/master/providers/dns) for the list of possible values. | `nil`                                         |
-| `acme.dnsProvider.$name`               | The configuration environment variables (encoded as a secret) needed for the DNS provider to do DNS challenge. See [here](#example-aws-route-53). | `{}`                         |
+| `acme.dnsProvider.$name`               | The configuration environment variables (encoded as a secret) needed for the DNS provider to do DNS challenge. Example configuration: [AWS Route 53](#example-aws-route-53), [Google Cloud DNS](#example-gcloud). | `{}` |
 | `acme.email`                           | Email address to be used in certificates obtained from Let's Encrypt                                                         | `admin@example.com`                               |
 | `acme.onHostRule`                      | Whether to generate a certificate for each frontend with Host rule                                                           | `true`                                            |
 | `acme.staging`                         | Whether to get certs from Let's Encrypt's staging environment                                                                | `true`                                            |
@@ -219,6 +219,8 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `tracing.datadog.debug`                | Enables Datadog debugging                                                                                                    | `false`                                           |
 | `tracing.datadog.globalTag`            | Apply shared tag in a form of Key:Value to all the traces                                                                    | `""`                                           |
 | `autoscaling`                          | HorizontalPodAutoscaler for the traefik Deployment                                                                           | `{}`                                           |
+| `configFiles`                          | Config files to make available in the deployment. key=filename, value=file contents                                          | `{}`                                              |
+| `secretFiles`                          | Secret files to make available in the deployment. key=filename, value=file contents                                          | `{}`                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
@@ -354,12 +356,12 @@ acme:
 
 #### Example: AWS Route 53
 
-Route 53 requires the [following configuration variables to be set](values.yaml#L98-L101):
+Using `route53` as DNS provider requires the following configuration variables to be set:
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_REGION`
 
-The configuration for the DNS provider would look like this:
+The configuration would look like this:
 
 ```yaml
 acme:
@@ -370,6 +372,28 @@ acme:
       AWS_ACCESS_KEY_ID: ...
       AWS_SECRET_ACCESS_KEY: ...
       AWS_REGION: us-east-1
+```
+
+#### Example: Google Cloud DNS
+
+Using `gcloud` as DNS provider requires the following configuration variables to be set:
+- `GCE_PROJECT`
+- `GCE_SERVICE_ACCOUNT_FILE`
+
+The configuration would look like this:
+
+```yaml
+
+secretFiles:
+  gcloud-credentials.json: '{"type":"service_account","project_id":"<projectName>","private_key_id":"<hash>",...}'
+
+acme:
+  enabled: true
+  dnsProvider:
+    name: gcloud
+    gcloud:
+      GCE_PROJECT: <projectName>
+      GCE_SERVICE_ACCOUNT_FILE: /secrets/gcloud-credentials.json
 ```
 
 ### Proxy Protocol

--- a/stable/traefik/templates/config-files.yaml
+++ b/stable/traefik/templates/config-files.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.configFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "traefik.fullname" . }}-configs
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{- range $filename, $fileContents := .Values.configFiles }}
+  {{ $filename }}: |-
+{{ $fileContents | indent 4 }}
+{{- end }}
+{{- end }}

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -114,6 +114,14 @@ spec:
         - mountPath: /acme
           name: acme
         {{- end }}
+        {{- if .Values.configFiles }}
+        - mountPath: /configs
+          name: {{ template "traefik.fullname" $ }}-configs
+        {{ end }}
+        {{- if .Values.secretFiles }}
+        - mountPath: /secrets
+          name: {{ template "traefik.fullname" $ }}-secrets
+        {{- end }}
         ports:
         - name: http
           containerPort: 80
@@ -161,6 +169,16 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
+      {{- end }}
+      {{- if .Values.configFiles }}
+      - name: {{ template "traefik.fullname" $ }}-configs
+        configMap:
+          name: {{ template "traefik.fullname" $ }}-configs
+      {{ end }}
+      {{- if .Values.secretFiles }}
+      - name: {{ template "traefik.fullname" $ }}-secrets
+        secret:
+          secretName: {{ template "traefik.fullname" $ }}-secrets
       {{- end }}
       {{- if and (.Values.tolerations) (semverCompare "^1.6-0" .Capabilities.KubeVersion.GitVersion) }}
       tolerations:

--- a/stable/traefik/templates/secret-files.yaml
+++ b/stable/traefik/templates/secret-files.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secretFiles }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "traefik.fullname" . }}-secrets
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+{{- range $filename, $fileContents := .Values.secretFiles }}
+  {{ $filename }}: {{ $fileContents | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -63,6 +63,22 @@ forwardedHeaders:
   # trustedIPs is required when enabled
   trustedIPs: []
   # - 10.0.0.0/8
+
+## Add arbitrary ConfigMaps to deployment
+## Will be mounted to /configs/, i.e. myconfig.json would
+## be mounted to /configs/myconfig.json.
+configFiles: {}
+  # myconfig.json: |
+  #   filecontents...
+
+## Add arbitrary Secrets to deployment
+## Will be mounted to /secrets/, i.e. file.name would
+## be mounted to /secrets/mysecret.txt.
+## The contents will be base64 encoded when added
+secretFiles: {}
+  # mysecret.txt: |
+  #   filecontents...
+
 ssl:
   enabled: false
   enforced: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Google Cloud DNS is configured differently from all other ACME DNS providers in that it expects a file to be available inside the container (because of how the underlying `lego` library is set up). This didn’t map well to how helm packages are expected to be provided with configuration/secrets.

To support this the ability to add any number of Secrets and ConfigMaps has been added.

~Implementation details:~
~The contents of `GCE_SERVICE_ACCOUNT_FILE_DATA` will be made available in a file inside the container and its path will be set as the value of environment variable `GCE_SERVICE_ACCOUNT_FILE`, which the [underlying ACME library](https://github.com/xenolf/lego) looks for.~

~That means that any value set manually to `GCE_SERVICE_ACCOUNT_FILE` will be ignored with this change. My general understanding of k8s/helm is quite fresh so I'm not sure if anyone's been able to use the setting at all before without resorting to something like what @Azuka suggested in https://github.com/kubernetes/charts/pull/1299#issuecomment-361450527.~

**Which issue this PR fixes**: fixes #5617

@krancour @emilevauge @dtomcej @ldez