### PR TITLE
Bump imageTag to 4.0.1 to match values.yaml

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,7 +1,7 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.3.2
-appVersion: 4.0.0
+version: 0.3.3
+appVersion: 4.0.1
 keywords:
   - confluent
   - kafka

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -62,7 +62,7 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image` | The `SchemaRegistry` image repository | `confluentinc/cp-schema-registry` |
-| `imageTag` | The `SchemaRegistry` image tag | `4.0.0` |
+| `imageTag` | The `SchemaRegistry` image tag | `4.0.1` |
 | `imagePullPolicy` | Image Pull Policy | `IfNotPresent` |
 | `replicaCount` | The number of `SchemaRegistry` Pods in the Deployment | `1` |
 | `configurationOverrides` | `SchemaRegistry` [configuration setting](https://github.com/confluentinc/schema-registry/blob/master/docs/config.rst#configuration-options) overrides in the dictionary format `setting.name: value` | `{}` |


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: The `imageTag` in `values.yaml` is 4.0.1. This PR updates the `Chart.yaml` and `README.md` to reflect this default.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: n/a

**Special notes for your reviewer**: @benjigoldberg 
