### PR TITLE
added podAntiAffinity rule on sentinel and server deployments

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 2.1.2
+version: 2.1.3
 appVersion: 4.0.8-r0
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-sentinel-deployment.yaml
+++ b/stable/redis-ha/templates/redis-sentinel-deployment.yaml
@@ -14,6 +14,16 @@ spec:
         component: sentinel
         name: {{ template "redis-ha.fullname" . }}-sentinel
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - {{ template "redis-ha.fullname" . }}-sentinel
+            topologyKey: "kubernetes.io/hostname"
       serviceAccountName: {{ template "redis-ha.serviceAccountName" . }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/stable/redis-ha/templates/redis-server-deployment.yaml
+++ b/stable/redis-ha/templates/redis-server-deployment.yaml
@@ -18,6 +18,16 @@ spec:
         name: {{ template "redis-ha.fullname" . }}-server
         redis-node: "true"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: redis-role
+                operator: In
+                values:
+                - slave
+            topologyKey: "kubernetes.io/hostname"
       serviceAccountName: {{ template "redis-ha.serviceAccountName" . }}
       {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to add podAntiAffinity rule both on sentinel and server deployments in order to these pods don't get scheduled all on same nodes.
The podAntiAffinity for sentinel is to not schedule a sentinel pod on same node with another sentinel pod already scheduled/running.
The podAntiAffinity for server is to not schedule a slave pod on same node with another slave pod already scheduled/running.
It is ok to schedule a master with a slave, but it will be truth if there is at least 2 slaves.

**Which issue this PR fixes** 
fixes #5453

**Special notes for your reviewer**: