### PR TITLE
Fix cockroachdb not abiding by resources limits

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 1.1.0
+version: 1.1.1
 appVersion: 2.0.0
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -249,7 +249,7 @@ spec:
           periodSeconds: 5
           failureThreshold: 2
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.Resources | indent 10 }}
         env:
         - name: STATEFULSET_NAME
           value: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -12,10 +12,12 @@ MaxUnavailable: 1
 Component: "cockroachdb"
 GrpcPort: 26257
 HttpPort: 8080
-Resources:
-  requests:
-    cpu: "100m"
-    memory: "512Mi"
+# Uncomment the following resources definitions or pass them from command line
+# to control the cpu and memory resources allocated by the Kubernetes cluster
+Resources: {}
+  # requests:
+  #   cpu: "100m"
+  #   memory: "512Mi"
 Storage: "1Gi"
 ## Persistent Volume Storage Class for database data
 ## If defined, storageClassName: <StorageClass>


### PR DESCRIPTION
**What this PR does / why we need it**:
The containers in the stateful set were ignoring the resource limits
specified in `values.yaml`.

I verified this is working by running `kubectl describe pod POD | grep
cpu` on one of the created pods on the fix branch. It returned `cpu:
"100m"`. On the master branch, the same command returned nothing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5628 

**Special notes for your reviewer**:
