### PR TITLE
[stable/grafana] extraSecretMounts support

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.9.2
+version: 1.10.0
 appVersion: 5.1.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.9.1
+version: 1.9.2
 appVersion: 5.1.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -59,6 +59,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `schedulerName`            | Alternate scheduler name | `nil` |
 | `env`                      | Extra environment variables passed to pods | `{}` |
 | `envFromSecret`            | The name of a Kubenretes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |
+| `extraSecretMounts`        | Additional grafana server secret mounts | `[]` |
 | `datasource`               | Configure grafana datasources | `{}` |
 | `dashboardProviders`       | Configure grafana dashboard providers | `{}` |
 | `dashboards`               | Dashboards to import | `{}` |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
             - name: storage
               mountPath: "/var/lib/grafana"
               subPath: {{ .Values.persistence.subPath }}
+          {{- range .Values.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
 {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -182,4 +187,9 @@ spec:
       {{- else }}
           emptyDir: {}
       {{- end -}}
+      {{- range .Values.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+      {{- end }}
 

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -107,6 +107,14 @@ env: {}
 ## This can be useful for auth tokens, etc
 envFromSecret: ""
 
+## Additional grafana server secret mounts
+# Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+extraSecretMounts: []
+  # - name: secret-files
+  #   mountPath: /etc/secrets
+  #   secretName: grafana-secret-files
+  #   readOnly: true
+
 # Pass the plugins you want installed as a comma separated list.
 # plugins: "digrich-bubblechart-panel,grafana-clock-panel"
 plugins: ""


### PR DESCRIPTION
This allows users to specify secret files to mount into volumes. For example, a user may want to mount a tls certificate and set the `cert_file` / `cert_key` values in the configuration to serve grafana via TLS.

This PR is essentially identical to the one for prometheus in https://github.com/kubernetes/charts/commit/28faaf8da04dab9cc646c9994f6bcaa45d3fbd6b#diff-608253559307288b55a9f2a76abe4cd7 but applys it to grafana.