### PR TITLE
[stable/nginx-ingress] Align RBAC with current best practices

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.19.2
+version: 0.20.0
 appVersion: 0.14.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -137,8 +137,9 @@ Parameter | Description | Default
 `defaultBackend.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
 `imagePullSecrets` | name of Secret resource containing private registry credentials | `nil`
-`rbac.create` | If true, create & use RBAC resources | `false`
-`rbac.serviceAccountName` | ServiceAccount to be used (ignored if rbac.create=true) | `default`
+`rbac.create` | if `true`, create & use RBAC resources | `true`
+`serviceAccount.create` | if `true`, create a service account | ``
+`serviceAccount.name` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template. | ``
 `revisionHistoryLimit` | The number of old history to retain to allow rollback. | `10`
 `tcp` | TCP service key:value pairs | `{}`
 `udp` | UDP service key:value pairs | `{}`

--- a/stable/nginx-ingress/templates/_helpers.tpl
+++ b/stable/nginx-ingress/templates/_helpers.tpl
@@ -59,3 +59,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nginx-ingress.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "nginx-ingress.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/nginx-ingress/templates/clusterrole.yaml
+++ b/stable/nginx-ingress/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rbac.create .Values.rbac.createClusterRole -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/stable/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rbac.create .Values.rbac.createClusterRole -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -14,6 +14,6 @@ roleRef:
   name: {{ template "nginx-ingress.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.fullname" . }}
+    name: {{ template "nginx-ingress.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -169,7 +169,7 @@ spec:
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if or .Values.rbac.create .Values.rbac.createRole .Values.rbac.createClusterRole }}{{ template "nginx-ingress.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
       terminationGracePeriodSeconds: 60
 {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumes) }}
       volumes:

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -163,7 +163,7 @@ spec:
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
     {{- end }}
-      serviceAccountName: {{ if or .Values.rbac.create .Values.rbac.createRole .Values.rbac.createClusterRole }}{{ template "nginx-ingress.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      serviceAccountName: {{ template "nginx-ingress.serviceAccountName" . }}
       terminationGracePeriodSeconds: 60
 {{- if (or .Values.controller.customTemplate.configMapName .Values.controller.extraVolumes) }}
       volumes:

--- a/stable/nginx-ingress/templates/role.yaml
+++ b/stable/nginx-ingress/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rbac.create .Values.rbac.createRole -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/stable/nginx-ingress/templates/rolebinding.yaml
+++ b/stable/nginx-ingress/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rbac.create .Values.rbac.createRole -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
@@ -14,6 +14,6 @@ roleRef:
   name: {{ template "nginx-ingress.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "nginx-ingress.fullname" . }}
+    name: {{ template "nginx-ingress.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/stable/nginx-ingress/templates/serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rbac.create .Values.rbac.createRole .Values.rbac.createClusterRole -}}
+{{- if or .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,5 +7,5 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "nginx-ingress.fullname" . }}
+  name: {{ template "nginx-ingress.serviceAccountName" . }}
 {{- end -}}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -332,9 +332,10 @@ defaultBackend:
 ## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
 rbac:
   create: true
-  createRole: true
-  createClusterRole: true
-  serviceAccountName: default
+
+serviceAccount:
+  create: true
+  name:
 
 ## Optional array of imagePullSecrets containing private registry credentials
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
**What this PR does / why we need it**:

Aligns RBAC with current best practices. RBAC was recently enabled by default which cause some trouble for users running without RBAC (#5559).

**Which issue this PR fixes** 

Fixes #5559