### PR TITLE
Allow setting env vars on concourse web

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.5.1
+version: 1.6.0
 appVersion: 3.10.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -105,6 +105,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.nameOverride` | Override the Concourse Web components name | `nil` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |
+| `web.env` | Configure additional environment variables for the web container(s) | `[]` |
 | `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
 | `web.annotations`| Concourse Web deployment annotations | `nil` |
 | `web.tolerations` | Tolerations for the web nodes | `[]` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -259,6 +259,9 @@ spec:
             - name: CONCOURSE_PROMETHEUS_BIND_PORT
               value: {{ .Values.web.metrics.prometheus.port | quote }}
             {{- end }}
+{{- if .Values.web.env }}
+{{ toYaml .Values.web.env | indent 12 }}
+{{- end }}
           ports:
             - name: atc
               containerPort: {{ .Values.concourse.atcPort }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -194,6 +194,12 @@ web:
       cpu: "100m"
       memory: "128Mi"
 
+  ## Configure additional environment variables for the
+  ## web container(s)
+  # env:
+  #   - name: CONCOURSE_LOG_LEVEL
+  #     value: fatal
+
   ## Additional affinities to add to the web pods.
   ##
   # additionalAffinities:


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously it was only possible to set additional env vars on the
`worker` pod. Its conceivable that a user would also want to set
additional env vars on the `web` pod.

I tested this by uncommenting the added configuration in `values.yaml`,
running `helm install .` and verifying `kubectl exec -t WEB_POD_NAME env | grep CONCOURSE_LOG_LEVEL`
returned a result.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5597 
