### PR TITLE
Update jaeger version to 1.4.1, but use a single value for all 4 imag…

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.4.1
+version: 0.4.2
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.2.0
+appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 version: 0.4.1
@@ -8,7 +8,7 @@ keywords:
   - opentracing
   - tracing
   - instrumentation
-home: https://github.com/uber/jaeger
+home: https://jaegertracing.io
 icon: https://camo.githubusercontent.com/afa87494e0753b4b1f5719a2f35aa5263859dffb/687474703a2f2f6a61656765722e72656164746865646f63732e696f2f656e2f6c61746573742f696d616765732f6a61656765722d766563746f722e737667
 sources:
   - https://hub.docker.com/u/jaegertracing/

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.4.2
+version: 0.5.0
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -144,7 +144,6 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `agent.image`                            | Image for Jaeger Agent              |  jaegertracing/jaeger-agent            |
 | `agent.pullPolicy`                       | Agent image pullPolicy              |  IfNotPresent                          |
 | `agent.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`       |
-| `agent.tag`                              | Image tag/version                   |  0.6                                   |
 | `agent.service.annotations`              | Annotations for Agent SVC           |  nil                                   |
 | `agent.service.binaryPort`               | jaeger.thrift over binary thrift    |  6832                                  |
 | `agent.service.compactPort`              | jaeger.thrift over compact thrift   |  6831                                  |
@@ -169,7 +168,6 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.service.tchannelPort`         | Jaeger Agent port for thrift        |  14267                                 |
 | `collector.service.type`                 | Service type                        |  ClusterIP                             |
 | `collector.service.zipkinPort`           | Zipkin port for JSON/thrift HTTP    |  9411                                  |
-| `collector.tag`                          | Image tag/version                   |  0.6                                   |
 | `elasticsearch.cluster.name`             | Elasticsearch cluster name          |  "tracing"                             |
 | `elasticsearch.data.persistence.enabled` | To enable storage persistence       |  false (Highly recommended to enable)  |
 | `elasticsearch.image.tag`                | Elasticsearch image tag             |  "5.4"                                 |
@@ -188,12 +186,10 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `query.service.queryPort`                | External accessible port            |  80                                    |
 | `query.service.targetPort`               | Internal Query UI port              |  16686                                 |
 | `query.service.type`                     | Service type                        |  ClusterIP                             |
-| `query.tag`                              | Image tag/version                   |  0.6                                   |
 | `schema.annotations`                     | Annotations for the schema job      |  nil                                   |
 | `schema.image`                           | Image to setup cassandra schema     |  jaegertracing/jaeger-cassandra-schema |
 | `schema.mode`                            | Schema mode (prod or test)          |  prod                                  |
 | `schema.pullPolicy`                      | Schema image pullPolicy             |  IfNotPresent                          |
-| `schema.tag`                             | Image tag/version                   |  0.6                                   |
 | `spark.enabled`                          | Enables the dependencies job        |  false                                 |
 | `spark.image`                            | Image for the dependencies job      |  jaegertracing/spark-dependencies      |
 | `spark.pullPolicy`                       | Image pull policy of the deps image |  Always                                |
@@ -212,6 +208,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.elasticsearch.user`             | Provisioned elasticsearch user      |  elastic                               |
 | `storage.elasticsearch.nodesWanOnly`     | Only access specified es host       |  false                                 |
 | `storage.type`                           | Storage type (ES or Cassandra)      |  cassandra                             |
+| `tag`                                    | Image tag/version                   |  1.4.1                                 |
 
 For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
 

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -34,7 +34,7 @@ spec:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}
       containers:
       - name: {{ template "jaeger.agent.name" . }}
-        image: {{ .Values.agent.image }}:{{ .Values.agent.tag }}
+        image: {{ .Values.agent.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         env:
         - name: COLLECTOR_HOST_PORT

--- a/incubator/jaeger/templates/cassandra-schema-job.yaml
+++ b/incubator/jaeger/templates/cassandra-schema-job.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: {{ template "jaeger.fullname" . }}-cassandra-schema
-        image: {{ .Values.schema.image }}:{{ .Values.schema.tag }}
+        image: {{ .Values.schema.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
         env:
         - name: CQLSH_HOST

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -33,7 +33,7 @@ spec:
 {{ toYaml .Values.collector.nodeSelector | indent 8 }}
       containers:
       - name: {{ template "jaeger.collector.name" . }}
-        image: {{ .Values.collector.image }}:{{ .Values.collector.tag }}
+        image: {{ .Values.collector.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         env:
           - name: SPAN_STORAGE_TYPE

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -33,7 +33,7 @@ spec:
 {{ toYaml .Values.query.nodeSelector | indent 8 }}
       containers:
       - name: {{ template "jaeger.query.name" . }}
-        image: {{ .Values.query.image }}:{{ .Values.query.tag }}
+        image: {{ .Values.query.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         env:
           - name: SPAN_STORAGE_TYPE

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -6,6 +6,8 @@ provisionDataStore:
   cassandra: true
   elasticsearch: false
 
+tag: 1.4.1
+
 storage:
   # allowed values (cassandra, elasticsearch)
   type: cassandra
@@ -46,7 +48,6 @@ cassandra:
 schema:
   annotations: {}
   image: jaegertracing/jaeger-cassandra-schema
-  tag: 1.2.0
   pullPolicy: IfNotPresent
   # Acceptable values are test and prod. Default is for production use.
   mode: prod
@@ -77,7 +78,6 @@ agent:
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-agent
-  tag: 1.2.0
   pullPolicy: IfNotPresent
   collector:
     host: null
@@ -116,7 +116,6 @@ collector:
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-collector
-  tag: 1.2.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
@@ -149,7 +148,6 @@ query:
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-query
-  tag: 1.2.0
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the jaeger version, but does this by consolidating the properties in the values.yaml into a single property, to make it easier to maintain and users override.

**Special notes for your reviewer**:

The change affects the way that the jaeger version can be overridden, but ideally all four images should be using the same version, which would mean a user having to override four separate values properties currently.

cc @dvonthenen @mikelorant @pavelnikolov