### PR TITLE
[stable/openvpn] Remove old README config for chart values

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.5.0
+version: 3.5.1
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -79,6 +79,7 @@ Parameter | Description | Default
 `openvpn.OVPN_K8S_POD_SUBNET`  | Kubernetes pod network subnet (optional)                             | `255.0.0.0`
 `openvpn.dhcpOptionDomain`     | Push a `dhcp-option DOMAIN` config                                   | `true`
 `openvpn.conf`                 | Arbitrary lines appended to the end of the server configuration file | `nil`
+`openvpn.redirectGateway`      | Redirect all client traffic through VPN                              | `true`
 
 This chart has been engineered to use kube-dns and route all network traffic to kubernetes pods and services,
 to disable this behaviour set `openvpn.OVPN_K8S_POD_NETWORK` and `openvpn.OVPN_K8S_POD_SUBNET` to `null`.
@@ -90,19 +91,3 @@ to disable this behaviour set `openvpn.OVPN_K8S_POD_NETWORK` and `openvpn.OVPN_K
 New certificates are generated with each deployment.
 If persistence is enabled certificate data will be persisted across pod restarts.
 Otherwise new client certs will be needed after each deployment or pod restart.
-
-### Important values
-* service.externalPort: 443 - external LoadBalancer port
-* service.internalPort: 443 - port of openVPN port
-* service.nodePort: 32085 - certain node port for NodePort service type
-* openvpn.OVPN_NETWORK: 10.240.0.0 - Network allocated for openvpn clients (default: 10.240.0.0).
-* openvpn.OVPN_SUBNET:  255.255.0.0 - Network subnet allocated for openvpn client (default: 255.255.0.0).
-* openvpn.OVPN_PROTO: tcp - Protocol used by openvpn tcp or udp (default: tcp).
-* openvpn.OVPN_K8S_POD_NETWORK: "10.0.0.0" - Kubernetes pod network (optional).
-* openvpn.OVPN_K8S_POD_SUBNET: "255.0.0.0" - Kubernetes pod network subnet (optional).
-* openvpn.dhcpOptionDomain: true - Push a `dhcp-option DOMAIN` config
-* openvpn.redirectGateway: true - Redirect all client traffic through VPN
-* openvpn.conf: "" - Arbitrary lines appended to the end of the server configuration file
-
-#### Note: As configured the chart will create a route for a large 10.0.0.0/8 network that may cause issues if that is your local network.  If so tweak this value to something more restrictive.  This route is added, because GKE generates pods with IPs in this range.
-


### PR DESCRIPTION
**What this PR does / why we need it**:
When #5174 was merged, it brought back parts of the README that were changed in #5489, resulting in unintentional duplicate documentation of chart values. This PR removes that duplication and adds the `openvpn.redirectGateway` documentation to the main values block.