### PR TITLE
Update kube-lego to latest version

### DIFF
--- a/stable/kube-lego/Chart.yaml
+++ b/stable/kube-lego/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: DEPRECATED Automatically requests certificates from Let's Encrypt
 name: kube-lego
-version: 0.4.1
-appVersion: v0.1.5
+version: 0.4.2
+appVersion: v0.1.6
 # The kube-lego chart is deprecated and no longer maintained.
 deprecated: true
 keywords:

--- a/stable/kube-lego/values.yaml
+++ b/stable/kube-lego/values.yaml
@@ -34,7 +34,7 @@ config:
 ##
 image:
   repository: jetstack/kube-lego
-  tag: 0.1.5
+  tag: 0.1.6
   pullPolicy: IfNotPresent
 
 ## Node labels for pod assignment


### PR DESCRIPTION
Update to final release of kube-lego to alleviate excessing requests on LetsEncrypt. https://github.com/jetstack/kube-lego/releases/tag/0.1.6