### PR TITLE
[stable/concourse] Add optional datadog metrics config

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 name: concourse
-version: 1.6.0
-appVersion: 3.10.0
+version: 1.7.0
+appVersion: 3.13.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -119,6 +119,11 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.ingress.tls` | Concourse Web Ingress TLS configuration | `[]` |
 | `web.metrics.prometheus.enabled` | Enable Prometheus metrics exporter | `false` |
 | `web.metrics.prometheus.port` | Port for exporting Prometheus metrics | `9391` |
+| `web.metrics.datadog.enabled` | Enable datadog metrics exporter | `false` |
+| `web.metrics.datadog.agentHost` | Host to export Datadog metrics to | `127.0.0.1` |
+| `web.metrics.datadog.agentHostUseHostIP` | Use node's IP as host to export Datadog metrics to. Overrides `web.metrics.datadog.agentHost` | `127.0.0.1` |
+| `web.metrics.datadog.agentPort` | Port to export Datadog metrics to | `8125` |
+| `web.metrics.datadog.prefix` | prefix for all Datadog metrics to easily find them in Datadog | `nil` |
 | `worker.nameOverride` | Override the Concourse Worker components name | `nil` |
 | `worker.replicas` | Number of Concourse Worker replicas | `2` |
 | `worker.minAvailable` | Minimum number of workers available after an eviction | `1` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -39,6 +39,16 @@ spec:
             - "--aws-ssm-region"
             - "$(CONCOURSE_AWS_SSM_REGION)"
             {{- end }}
+            {{- if .Values.web.metrics.datadog.enabled }}
+            - "--datadog-agent-host"
+            - "$(CONCOURSE_DATADOG_AGENT_HOST)"
+            - "--datadog-agent-port"
+            - "$(CONCOURSE_DATADOG_AGENT_PORT)"
+            {{- if .Values.web.metrics.datadog.prefix }}
+            - "--datadog-prefix"
+            - {{ .Values.web.metrics.datadog.prefix }}
+            {{- end }}
+            {{- end }}
           env:
             - name: CONCOURSE_TSA_HOST_KEY
               value: "/concourse-keys/host_key"
@@ -258,6 +268,18 @@ spec:
               value: "0.0.0.0"
             - name: CONCOURSE_PROMETHEUS_BIND_PORT
               value: {{ .Values.web.metrics.prometheus.port | quote }}
+            {{- end }}
+            {{- if .Values.web.metrics.datadog.enabled }}
+            - name: CONCOURSE_DATADOG_AGENT_HOST
+            {{- if .Values.web.metrics.datadog.agentHostUseHostIP }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- else }}
+              value: {{ .Values.web.metrics.datadog.agentHost | quote }}
+            {{- end }}
+            - name: CONCOURSE_DATADOG_AGENT_PORT
+              value: {{ .Values.web.metrics.datadog.agentPort | quote }}
             {{- end }}
           ports:
             - name: atc

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -13,7 +13,7 @@ image: concourse/concourse
 ## Concourse image version.
 ## ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "3.10.0"
+imageTag: "3.13.0"
 
 ## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
 ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -295,6 +295,23 @@ web:
     prometheus:
       enabled: false
       port: 9391
+
+    ## Enable the datadog metrics?
+    ##
+    datadog:
+      enabled: false
+
+      ## Datadog agent host to expose metrics
+      agentHost: 127.0.0.1
+
+      ## Use IP of node the pod is scheduled on, overrides `agentHost`
+      agentHostUseHostIP: false
+
+      ## Datadog agent port to expose metrics
+      agentPort: 8125
+
+      ## Optional prefix for all metrics to easily find them in Datadog
+      # prefix: concoursedev
 
 ## Configuration values for Concourse Worker components.
 ##


### PR DESCRIPTION
**What this PR does / why we need it**:
Concourse 3.13.0 adds support for exporting metrics to Datadog (see concourse/atc#269). This adds support for the new flags, and bumps the Concourse version.
