### PR TITLE
[kube2iam] Add node flag to limit relevant pods

### DIFF
--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.8.8
+version: 0.9.0
 appVersion: 0.10.0
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/Chart.yaml
+++ b/stable/kube2iam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube2iam
-version: 0.8.7
+version: 0.8.8
 appVersion: 0.10.0
 description: Provide IAM credentials to pods based on annotations.
 keywords:

--- a/stable/kube2iam/templates/daemonset.yaml
+++ b/stable/kube2iam/templates/daemonset.yaml
@@ -27,6 +27,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           args:
             - --host-interface={{ .Values.host.interface }}
+            - --node=$(NODE_NAME)
           {{- if .Values.host.iptables }}
             - --host-ip={{ .Values.host.ip }}
           {{- end }}
@@ -47,6 +48,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           {{- if and .Values.aws.secret_key .Values.aws.access_key }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
## what

kube2iam 0.10 introduced a new CLI arg `--node` that instructs it to only monitor pods on the same node. This PR enables this flag

## why

I enabled the flag by default because I can see no reason to not have it enabled, and kube2iam documents it as the recommended default behavior

See https://github.com/jtblin/kube2iam/pull/108