### PR TITLE
[stable/traefik] bump version to 1.6.2

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
 version: 1.31.1
-appVersion: 1.6.1
+appVersion: 1.6.2
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.31.0
-appVersion: 1.6.0
+version: 1.31.1
+appVersion: 1.6.1
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -87,7 +87,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
 | `fullnameOverride`              | Override the full resource names                                     | `{release-name}-traefik (or traefik if release-name is traefik`|
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
-| `imageTag`                      | The version of the official Traefik image to use                     | `1.6.0`                                  |
+| `imageTag`                      | The version of the official Traefik image to use                     | `1.6.1`                                   |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
 | `loadBalancerSourceRanges`      | List of IP CIDRs allowed access to load balancer (if supported)      | None                                      |

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -87,7 +87,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | ------------------------------- | -------------------------------------------------------------------- | ----------------------------------------- |
 | `fullnameOverride`              | Override the full resource names                                     | `{release-name}-traefik (or traefik if release-name is traefik`|
 | `image`                         | Traefik image name                                                   | `traefik`                                 |
-| `imageTag`                      | The version of the official Traefik image to use                     | `1.6.1`                                   |
+| `imageTag`                      | The version of the official Traefik image to use                     | `1.6.2`                                   |
 | `serviceType`                   | A valid Kubernetes service type                                      | `LoadBalancer`                            |
 | `loadBalancerIP`                | An available static IP you have reserved on your cloud platform      | None                                      |
 | `loadBalancerSourceRanges`      | List of IP CIDRs allowed access to load balancer (if supported)      | None                                      |

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 ## Default values for Traefik
 image: traefik
-imageTag: 1.6.1
+imageTag: 1.6.2
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
 loadBalancerIP:

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 ## Default values for Traefik
 image: traefik
-imageTag: 1.6.0
+imageTag: 1.6.1
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
 loadBalancerIP:


### PR DESCRIPTION
**What this PR does / why we need it**:

 - Update traefik to 1.6.2
 - Bump version as required

cc/ @krancour @emilevauge @dtomcej @ldez