### PR TITLE
[stable/minio] Add `minio/mc` tag

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Distributed object storage server built for cloud applications and devops.
 name: minio
-version: 1.3.0
+version: 1.3.1
 appVersion: RELEASE.2018-04-27T23-33-52Z
 keywords:
 - storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -77,6 +77,9 @@ The following table lists the configurable parameters of the Minio chart and the
 | `image.repository`         | Image repository                    | `minio/minio`                                           |
 | `image.tag`                | Minio image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).| `RELEASE.2018-04-27T23-33-52Z`|
 | `image.pullPolicy`         | Image pull policy                   | `IfNotPresent`                                          |
+| `mcImage.repository`       | Client image repository             | `minio/mc`                                              |
+| `mcImage.tag`              | mc image tag. Possible values listed [here](https://hub.docker.com/r/minio/mc/tags/).| `RELEASE.2018-04-28T00-08-20Z`|
+| `mcImage.pullPolicy`       | mc Image pull policy                | `IfNotPresent`                                          |
 | `ingress.enabled`          | Enables Ingress                     | `false`                                                 |
 | `ingress.annotations`      | Ingress annotations                 | `{}`                                                    |
 | `ingress.hosts`            | Ingress accepted hostnames          | `[]`                                                    |

--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -31,7 +31,8 @@ spec:
                 name: {{ template "minio.fullname" . }}
       containers:
       - name: minio-mc
-        image: minio/mc
+        image: "{{ .Values.mcImage.repository }}:{{ .Values.mcImage.tag }}"
+        imagePullPolicy: {{ .Values.mcImage.pullPolicy }}
         command: ["/bin/sh", "/config/initialize"]
         env:
           - name: MINIO_ENDPOINT

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -1,12 +1,21 @@
 ## Set default image, imageTag, and imagePullPolicy. mode is used to indicate the
-## minio server mode, i.e. standalone or distributed.
-## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
 ##
 image:
   repository: minio/minio
   tag: RELEASE.2018-04-27T23-33-52Z
   pullPolicy: IfNotPresent
 
+## Set default image, imageTag, and imagePullPolicy for the `mc` (the minio
+## client used to create a default bucket).
+##
+mcImage:
+  repository: minio/mc
+  tag: RELEASE.2018-04-28T00-08-20Z
+  pullPolicy: IfNotPresent
+
+## minio server mode, i.e. standalone or distributed.
+## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
+##
 mode: standalone
 
 ## Set default accesskey, secretkey, Minio config file path, volume mount path and


### PR DESCRIPTION
**What this PR does / why we need it**:,

The `post-install-create-bucket-job` uses the `minio/mc` image to create
a bucket. Previously, it just specified `minio/mc`. We want to set a
default image tag, and also allow users to configure a different image
tag should they need it. Add this configuration under the `mcImage` key.