### PR TITLE
[stable/postgresql] Add pod/deployment annotations

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.12.0
+version: 0.13.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -81,6 +81,8 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `nodeSelector`             | Node labels for pod assignment                  | {}                                                         |
 | `affinity`                 | Affinity settings for pod assignment            | {}                                                         |
 | `tolerations`              | Toleration labels for pod assignment            | []                                                         |
+| `podAnnotations`           | Annotations for the postgresql pod              | {}                                                         |
+| `deploymentAnnotations`    | Annotations for the postgresql deployment       | {}                                                         |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "postgresql.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   template:
   selector:
@@ -18,6 +22,10 @@ spec:
       labels:
         app: {{ template "postgresql.name" . }}
         release: {{ .Release.Name }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.affinity }}
       affinity:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -128,3 +128,7 @@ networkPolicy:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+## Annotations for the deployment and nodes.
+deploymentAnnotations: {}
+podAnnotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the ability to specify pod/deployment annotations through
`values.yml`.

I tested this works without any custom annotations, and also tested
specifying custom annotations and verifying they are included in the
existing pod/deployment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4418 

