### PR TITLE
[stable/redis] Fallback to proper apis on redis

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.3.0
+version: 3.3.1
 appVersion: 4.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "apps/v1beta2" }}
 apiVersion: apps/v1beta2
+{{- else }}
+apiVersion: apps/v1beta1
+{{- end }}
 kind: StatefulSet
 metadata:
   name: {{ template "redis.fullname" . }}-master


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the README for this chart advertises it working on Kubernetes
1.4+ with Beta APIs enabled. However, that was not the case, as the
`statefulset` specified `apps/v1beta2`, which did not exist until 1.8.
Update the `redis-master-statefulset.yaml` so it uses `apps/v1beta2` if
its available, and fallback to `apps/v1beta1` if it is not.

I verified this change works by installing my branch on a 1.6 Kubernetes
cluster (and also verifying the master install did not work on a 1.6
cluster).

Basing my discussion of versions on [this documentation](https://kubernetes.io/docs/reference/workloads-18-19/).
