### PR TITLE
add annotation values to the elasticsearch curator chart

### DIFF
--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.4.1"
 description: A Helm chart for Elasticseach Curator
 name: elasticsearch-curator
-version: 0.2.0
+version: 0.2.1
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/incubator/elasticsearch-curator/README.md
+++ b/incubator/elasticsearch-curator/README.md
@@ -34,6 +34,8 @@ their default values.
 | `image.repository`           | Container image to use                                | `quay.io/pires/docker-elasticsearch-curator` |
 | `image.tag`                  | Container image tag to deploy                         | `5.4.1`                                      |
 | `cronjob.schedule`           | Schedule for the CronJob                              | `0 1 * * *`                                  |
+| `cronjob.annotations`        | Annotations to add to the cronjob                     | {}                                           |
+| `pod.annotations`            | Annotations to add to the pod                         | {}                                           |
 | `config.elasticsearch.hosts` | Array of Elasticsearch hosts to curate                | - CHANGEME.host                              |
 | `config.elasticsearch.port`  | Elasticsearch port to connect too                     | 9200                                         |
 | `configMaps.action_file_yml` | Contents of the Curator action_file.yml               | See values.yaml                              |

--- a/incubator/elasticsearch-curator/templates/cronjob.yaml
+++ b/incubator/elasticsearch-curator/templates/cronjob.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ template "elasticsearch-curator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations: 
+{{ toYaml .Values.cronjob.annotations | indent 4 }}
 spec:
   schedule: "{{ .Values.cronjob.schedule }}"
   jobTemplate:
@@ -16,6 +18,8 @@ spec:
           labels:
             app: {{ template "elasticsearch-curator.name" . }}
             release: {{ .Release.Name }}
+          annotations: 
+{{ toYaml .Values.pod.annotations | indent 12 }}
         spec:
           volumes:
             - name: config-volume

--- a/incubator/elasticsearch-curator/values.yaml
+++ b/incubator/elasticsearch-curator/values.yaml
@@ -5,6 +5,10 @@
 cronjob:
   # At 01:00 every day
   schedule: "0 1 * * *"
+  annotations: {}
+
+pod:
+  annotations: {}
 
 image:
   repository: quay.io/pires/docker-elasticsearch-curator


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables you to add annotations to both cronjob and pod resources. This is needed for things such as kube2iam allowing you to run curator with an AWS IAM role that has access rights to your AWS ES cluster.

**Special notes for your reviewer**:
Please review @tmestdagh @gianrubio 