### PR TITLE
[incubator/vault] Add loadBalancerSourceRanges for service type LoadBalancer

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.10.0
+version: 0.11.0
 appVersion: 0.10.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `resources.limits.cpu`            | Container requested CPU                  | `nil`                               |
 | `resources.limits.memory`         | Container requested memory               | `nil`                               |
 | `affinity`                        | Affinity settings                        | See values.yaml                     |
+| `service.loadBalancerSourceRanges`| IP whitelist for service type loadbalancer   | `[]`                            |
 | `service.annotations`             | Annotations for service                  | `{}`                                |
 | `annotations`                     | Annotations for deployment               | `{}`                                |
 | `ingress.labels`                  | Labels for ingress                       | `{}`                                |

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -16,6 +16,12 @@ spec:
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range .Values.service.loadBalancerSourceRanges }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
   ports:
   - port: {{ .Values.service.externalPort }}
     protocol: TCP

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
-  {{- if .Values.service.loadBalancerSourceRanges }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerSourceRanges:
     {{- range .Values.service.loadBalancerSourceRanges }}
     - {{ . }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -29,9 +29,9 @@ service:
   name: vault
   type: ClusterIP
   # type: LoadBalancer
-  # loadBalancerSourceRanges:
-  #   - 10.0.0.0/8
-  #   - 130.211.204.2/32
+  loadBalancerSourceRanges: []
+  #  - 10.0.0.0/8
+  #  - 130.211.204.2/32
   externalPort: 8200
   port: 8200
   # clusterIP: None

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -28,6 +28,10 @@ consulAgent:
 service:
   name: vault
   type: ClusterIP
+  # type: LoadBalancer
+  # loadBalancerSourceRanges:
+  #   - 10.0.0.0/8
+  #   - 130.211.204.2/32
   externalPort: 8200
   port: 8200
   # clusterIP: None


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR gives the option to add `spec.loadBalancerSourceRanges` when service type is set to "LoadBalancer". This enables IP whitelisting on the ELB as described here:

https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/

This is a necessity when configuring Vault with service type LoadBalancer on the different cloud providers where IP whitelisting might be desired when the service is exposed using an internal or external ELBs.

Example: AWS Inbound Rules for a specific list of IP CIDRs specified under `loadBalancerSourceRanges`:

<img width="1155" alt="loadbalancer_secgroup" src="https://user-images.githubusercontent.com/6475833/40384501-bf093778-5dd1-11e8-9b6e-af0f4465b335.png">
