### PR TITLE
feat(filebeat): Add support for beat plugins

### DIFF
--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 0.2.0
+version: 0.2.1
 appVersion: 6.2.3
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/Chart.yaml
+++ b/stable/filebeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with filebeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: filebeat
-version: 0.2.1
+version: 0.3.0
 appVersion: 6.2.3
 home: https://www.elastic.co/products/beats/filebeat
 sources:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -31,6 +31,10 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - "-e"
+{{- if .Values.plugins }}
+        - "--plugin"
+        - {{ .Values.plugins | join "," | quote }}
+{{- end }}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/stable/filebeat/values.yaml
+++ b/stable/filebeat/values.yaml
@@ -45,6 +45,10 @@ config:
   http.enabled: false
   http.port: 5066
 
+# List of beat plugins
+plugins: []
+  # - kinesis.so
+
 # A map of additional environment variables
 extraVars: {}
   # test1: "test2"


### PR DESCRIPTION
A use-case for this feature is to specify `--plugin foo.so,bar.so` in order to enable a beat plugin like awsbeats.
A more complete instructions from building a custom filebeat to installing the helm chart with the new setting can be seen in [README of my awsbeats fork](https://github.com/kube-aws/awsbeats#running-on-a-kubernetes-cluster).