### PR TITLE
[stable/fluent-bit]: Allow exposing of metrics

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -76,6 +76,9 @@ The following tables lists the configurable parameters of the Fluent-Bit chart a
 | `resources.requests.memory`        | Memory request                             | `200Mi`                                           |
 | `tolerations`                      | Optional daemonset tolerations             | `NULL`                                            |
 | `nodeSelector`                     | Node labels for fluent-bit pod assignment  | `NULL`                                            |
+| `metrics.enabled`                  | Specifies whether a service for metrics should be exposed | `false`                            |
+| `metrics.service.port`             | Port on where metrics should be exposed    | `2020`                                            |
+| `metrics.service.type`             | Service type for metrics                   | `ClusterIP`                                       |
 | | | |
 
 

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -12,6 +12,11 @@ data:
         Daemon       Off
         Log_Level    info
         Parsers_File parsers.conf
+{{- if .Values.metrics.enabled }}
+        HTTP_Server  On
+        HTTP_Listen  0.0.0.0
+        HTTP_Port    2020
+{{- end }}
 
     [INPUT]
         Name             tail

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -26,6 +26,12 @@ spec:
 {{ toYaml .Values.env | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.metrics.enabled }}
+        ports:
+          - name: metrics
+            containerPort: 2020
+            protocol: TCP
+{{- end }}
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/stable/fluent-bit/templates/service.yaml
+++ b/stable/fluent-bit/templates/service.yaml
@@ -11,6 +11,7 @@ spec:
   ports:
   - port: {{ .Values.metrics.service.port }}
     targetPort: metrics
+    name: metrics
   selector:
     app: {{ template "fluent-bit.fullname" . }}
 {{- end }}

--- a/stable/fluent-bit/templates/service.yaml
+++ b/stable/fluent-bit/templates/service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}-metrics
+  labels:
+    app: {{ template "fluent-bit.fullname" . }}
+spec:
+  type: {{ .Values.metrics.service.type}}
+  sessionAffinity: None
+  ports:
+  - port: {{ .Values.metrics.service.port }}
+    targetPort: metrics
+  selector:
+    app: {{ template "fluent-bit.fullname" . }}
+{{- end }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -8,6 +8,13 @@ image:
     tag: 0.13.0
   pullPolicy: Always
 
+# When enabled, exposes json and prometheus metrics on {{ .Release.Name }}-metrics service
+metrics:
+  enabled: false
+  service:
+    port: 2020
+    type: ClusterIP
+
 backend:
   type: forward
   forward:


### PR DESCRIPTION
By setting `metrics.enabled` to `true` `fluent-bit` will start a http
server, exposing metrics as described in [Monitoring](https://fluentbit.io/documentation/0.13/configuration/monitoring.html)

@kfox1111 @edsiper 