### PR TITLE
[stable/fluent-bit]: Track tail offsets across restarts

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.5.2
+version: 0.5.3
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.5.3
+version: 0.6.0
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `metrics.enabled`                  | Specifies whether a service for metrics should be exposed | `false`                            |
 | `metrics.service.port`             | Port on where metrics should be exposed    | `2020`                                            |
 | `metrics.service.type`             | Service type for metrics                   | `ClusterIP`                                       |
+| `trackOffsets`                     | Specify whether to track the file offsets for tailing docker logs. This allows fluent-bit to pick up where it left after pod restarts but requires access to a `hostPath` | `false` |
 | | | |
 
 

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -26,6 +26,10 @@ data:
         Refresh_Interval 5
         Mem_Buf_Limit    5MB
         Skip_Long_Lines  On
+{{- if .Values.trackOffsets }}
+        DB               /tail-db/tail-containers-state.db
+        DB.Sync          Normal
+{{- end }}
 
     [FILTER]
         Name                kubernetes

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -46,6 +46,10 @@ spec:
           mountPath: /secure/es-tls-ca.crt
           subPath: es-tls-ca.crt
 {{- end }}
+{{- if .Values.trackOffsets }}
+        - name: tail-db
+          mountPath: /tail-db
+{{- end }}
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
@@ -74,6 +78,12 @@ spec:
       - name: es-tls-secret
         secret:
           secretName: "{{ template "fluent-bit.fullname" . }}-es-tls-secret"
+{{- end }}
+{{- if .Values.trackOffsets }}
+      - name: tail-db
+        hostPath:
+          path: /var/lib/fluent-bit
+          type: DirectoryOrCreate
 {{- end }}
       - name: config
         configMap:

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -15,6 +15,9 @@ metrics:
     port: 2020
     type: ClusterIP
 
+# When enabled, fluent-bit will keep track of tailing offsets across pod restarts.
+trackOffsets: false
+
 backend:
   type: forward
   forward:


### PR DESCRIPTION
This enables the `DB` feature of the input for docker logs and will
persist the offsets of tracked files, allowing the plugin to pick
up where it left the file across restarts.

@kfox1111 @edsiper 
