### PR TITLE
Split Jenkins readiness and liveness probe periods

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.2
+version: 0.16.3
 appVersion: 2.107
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.1
+version: 0.16.2
 appVersion: 2.107
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -49,7 +49,8 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.ServicePort`              | k8s service port                     | `8080`                                                                       |
 | `Master.NodePort`                 | k8s node port                        | Not set                                                                      |
 | `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `true`                                                                   |
-| `Master.HealthProbesTimeout`      | Set the timeout for the liveness and readiness probes | `120`                                                       |
+| `Master.HealthProbesTimeout`      | Set the timeout for the liveness probe | `120`                                                       |
+| `Master.HealthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                                                       |
 | `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
 | `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
 | `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -49,7 +49,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.ServicePort`              | k8s service port                     | `8080`                                                                       |
 | `Master.NodePort`                 | k8s node port                        | Not set                                                                      |
 | `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `true`                                                                   |
-| `Master.HealthProbesTimeout`      | Set the timeout for the liveness probe | `120`                                                       |
+| `Master.HealthProbesLivenessTimeout`      | Set the timeout for the liveness probe | `120`                                                       |
 | `Master.HealthProbesReadinessTimeout` | Set the timeout for the readiness probe | `60`                                                       |
 | `Master.HealthProbeLivenessFailureThreshold` | Set the failure threshold for the liveness probe | `12`                                                       |
 | `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -128,7 +128,7 @@ spec:
             httpGet:
               path: /login
               port: http
-            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout }}
+            initialDelaySeconds: {{ .Values.Master.HealthProbesLivenessTimeout }}
             timeoutSeconds: 5
             failureThreshold: {{ .Values.Master.HealthProbeLivenessFailureThreshold }}
           readinessProbe:

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -135,7 +135,7 @@ spec:
             httpGet:
               path: /login
               port: http
-            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout }}
+            initialDelaySeconds: {{ .Values.Master.HealthProbesReadinessTimeout }}
 {{- end }}
           resources:
             requests:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -49,7 +49,7 @@ Master:
   # Enable Kubernetes Liveness and Readiness Probes
   # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
   HealthProbes: true
-  HealthProbesTimeout: 90
+  HealthProbesLivenessTimeout: 90
   HealthProbesReadinessTimeout: 60
   HealthProbeLivenessFailureThreshold: 12
   SlaveListenerPort: 50000

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -47,7 +47,7 @@ Master:
   # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
   # Enable Kubernetes Liveness and Readiness Probes
-  # ~2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout. 
+  # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout. 
   HealthProbes: true
   HealthProbesTimeout: 90
   HealthProbesReadinessTimeout: 60

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -47,9 +47,10 @@ Master:
   # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
   # Enable Kubernetes Liveness and Readiness Probes
+  # ~2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout. 
   HealthProbes: true
-  HealthProbesTimeout: 60
-  # ~2 minutes to allow Jenkins to restart when upgrading plugins
+  HealthProbesTimeout: 90
+  HealthProbesReadinessTimeout: 60
   HealthProbeLivenessFailureThreshold: 12
   SlaveListenerPort: 50000
   DisabledAgentProtocols:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -47,7 +47,7 @@ Master:
   # NodePort: <to set explicitly, choose port between 30000-32767
   ContainerPort: 8080
   # Enable Kubernetes Liveness and Readiness Probes
-  # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout. 
+  # ~ 2 minutes to allow Jenkins to restart when upgrading plugins. Set ReadinessTimeout to be shorter than LivenessTimeout.
   HealthProbes: true
   HealthProbesTimeout: 90
   HealthProbesReadinessTimeout: 60


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: ReadinessProbe and LivenessProbe times were set to the same period. This PR splits the two into separate values. We need readiness to be shorter than liveness to ensure that Jenkins starts reliably without being repeatedly killed in our environment. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: Please squash and merge, or nudge me to rebase/squash my commits - thank you. 