### PR TITLE
[stable/prestashop] - Expose readiness/liveness probes to values.yaml

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 1.0.5
+version: 1.0.6
 appVersion: 1.7.3-2
 description: A popular open source ecommerce solution. Professional tools are easily
   accessible to increase online sales including instant guest checkout, abandoned

--- a/stable/prestashop/README.md
+++ b/stable/prestashop/README.md
@@ -45,45 +45,55 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the PrestaShop chart and their default values.
 
-|               Parameter               |                 Description                 |                         Default                          |
-|---------------------------------------|---------------------------------------------|----------------------------------------------------------|
-| `image.registry`                      | PrestaShop image registry                   | `docker.io`                                              |
-| `image.repository`                    | PrestaShop image name                       | `bitnami/prestashop`                                     |
-| `image.tag`                           | PrestaShop image tag                        | `{VERSION}`                                              |
-| `image.pullPolicy`                    | Image pull policy                           | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
-| `image.pullSecrets`                   | Specify image pull secrets                  | `nil`                                                    |
-| `prestashopHost`                      | PrestaShop host to create application URLs  | `nil`                                                    |
-| `prestashopLoadBalancerIP`            | `loadBalancerIP` for the PrestaShop Service | `nil`                                                    |
-| `prestashopUsername`                  | User of the application                     | `user@example.com`                                       |
-| `prestashopPassword`                  | Application password                        | _random 10 character long alphanumeric string_           |
-| `prestashopEmail`                     | Admin email                                 | `user@example.com`                                       |
-| `prestashopFirstName`                 | First Name                                  | `Bitnami`                                                |
-| `prestashopLastName`                  | Last Name                                   | `Name`                                                   |
-| `smtpHost`                            | SMTP host                                   | `nil`                                                    |
-| `smtpPort`                            | SMTP port                                   | `nil`                                                    |
-| `smtpUser`                            | SMTP user                                   | `nil`                                                    |
-| `smtpPassword`                        | SMTP password                               | `nil`                                                    |
-| `smtpProtocol`                        | SMTP protocol [`ssl`, `tls`]                | `nil`                                                    |
-| `allowEmptyPassword`                  | Allow DB blank passwords                    | `yes`                                                    |
-| `externalDatabase.host`               | Host of the external database               | `nil`                                                    |
-| `externalDatabase.port`               | SMTP protocol [`ssl`, `none`]               | `3306`                                                   |
-| `externalDatabase.user`               | Existing username in the external db        | `bn_prestashop`                                          |
-| `externalDatabase.password`           | Password for the above username             | `nil`                                                    |
-| `externalDatabase.database`           | Name of the existing database               | `bitnami_prestashop`                                     |
-| `mariadb.enabled`                     | Whether to use the MariaDB chart            | `true`                                                   |
-| `mariadb.mariadbDatabase`             | Database name to create                     | `bitnami_prestashop`                                     |
-| `mariadb.mariadbUser`                 | Database user to create                     | `bn_prestashop`                                          |
-| `mariadb.mariadbPassword`             | Password for the database                   | `nil`                                                    |
-| `mariadb.mariadbRootPassword`         | MariaDB admin password                      | `nil`                                                    |
-| `serviceType`                         | Kubernetes Service type                     | `LoadBalancer`                                           |
-| `persistence.enabled`                 | Enable persistence using PVC                | `true`                                                   |
-| `persistence.apache.storageClass`     | PVC Storage Class for Apache volume         | `nil` (uses alpha storage class annotation)              |
-| `persistence.apache.accessMode`       | PVC Access Mode for Apache volume           | `ReadWriteOnce`                                          |
-| `persistence.apache.size`             | PVC Storage Request for Apache volume       | `1Gi`                                                    |
-| `persistence.prestashop.storageClass` | PVC Storage Class for PrestaShop volume     | `nil` (uses alpha storage class annotation)              |
-| `persistence.prestashop.accessMode`   | PVC Access Mode for PrestaShop volume       | `ReadWriteOnce`                                          |
-| `persistence.prestashop.size`         | PVC Storage Request for PrestaShop volume   | `8Gi`                                                    |
-| `resources`                           | CPU/Memory resource requests/limits         | Memory: `512Mi`, CPU: `300m`                             |
+|               Parameter               |                                        Description                                           |                         Default                          |
+|---------------------------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| `image.registry`                      | PrestaShop image registry                                                                    | `docker.io`                                              |
+| `image.repository`                    | PrestaShop image name                                                                        | `bitnami/prestashop`                                     |
+| `image.tag`                           | PrestaShop image tag                                                                         | `{VERSION}`                                              |
+| `image.pullPolicy`                    | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
+| `image.pullSecrets`                   | Specify image pull secrets                                                                   | `nil`                                                    |
+| `prestashopHost`                      | PrestaShop host to create application URLs                                                   | `nil`                                                    |
+| `prestashopLoadBalancerIP`            | `loadBalancerIP` for the PrestaShop Service                                                  | `nil`                                                    |
+| `prestashopUsername`                  | User of the application                                                                      | `user@example.com`                                       |
+| `prestashopPassword`                  | Application password                                                                         | _random 10 character long alphanumeric string_           |
+| `prestashopEmail`                     | Admin email                                                                                  | `user@example.com`                                       |
+| `prestashopFirstName`                 | First Name                                                                                   | `Bitnami`                                                |
+| `prestashopLastName`                  | Last Name                                                                                    | `Name`                                                   |
+| `smtpHost`                            | SMTP host                                                                                    | `nil`                                                    |
+| `smtpPort`                            | SMTP port                                                                                    | `nil`                                                    |
+| `smtpUser`                            | SMTP user                                                                                    | `nil`                                                    |
+| `smtpPassword`                        | SMTP password                                                                                | `nil`                                                    |
+| `smtpProtocol`                        | SMTP protocol [`ssl`, `tls`]                                                                 | `nil`                                                    |
+| `allowEmptyPassword`                  | Allow DB blank passwords                                                                     | `yes`                                                    |
+| `externalDatabase.host`               | Host of the external database                                                                | `nil`                                                    |
+| `externalDatabase.port`               | SMTP protocol [`ssl`, `none`]                                                                | `3306`                                                   |
+| `externalDatabase.user`               | Existing username in the external db                                                         | `bn_prestashop`                                          |
+| `externalDatabase.password`           | Password for the above username                                                              | `nil`                                                    |
+| `externalDatabase.database`           | Name of the existing database                                                                | `bitnami_prestashop`                                     |
+| `mariadb.enabled`                     | Whether to use the MariaDB chart                                                             | `true`                                                   |
+| `mariadb.mariadbDatabase`             | Database name to create                                                                      | `bitnami_prestashop`                                     |
+| `mariadb.mariadbUser`                 | Database user to create                                                                      | `bn_prestashop`                                          |
+| `mariadb.mariadbPassword`             | Password for the database                                                                    | `nil`                                                    |
+| `mariadb.mariadbRootPassword`         | MariaDB admin password                                                                       | `nil`                                                    |
+| `serviceType`                         | Kubernetes Service type                                                                      | `LoadBalancer`                                           |
+| `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                                   |
+| `persistence.apache.storageClass`     | PVC Storage Class for Apache volume                                                          | `nil` (uses alpha storage class annotation)              |
+| `persistence.apache.accessMode`       | PVC Access Mode for Apache volume                                                            | `ReadWriteOnce`                                          |
+| `persistence.apache.size`             | PVC Storage Request for Apache volume                                                        | `1Gi`                                                    |
+| `persistence.prestashop.storageClass` | PVC Storage Class for PrestaShop volume                                                      | `nil` (uses alpha storage class annotation)              |
+| `persistence.prestashop.accessMode`   | PVC Access Mode for PrestaShop volume                                                        | `ReadWriteOnce`                                          |
+| `persistence.prestashop.size`         | PVC Storage Request for PrestaShop volume                                                    | `8Gi`                                                    |
+| `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                             |
+| `livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                     | 600                                                     |
+| `livenessProbe.periodSeconds`         | How often to perform the probe                                                               | 3                                                       |
+| `livenessProbe.timeoutSeconds`        | When the probe times out                                                                     | 5                                                       |
+| `livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                       |
+| `livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                       |
+| `readinessProbe.initialDelaySeconds`  | Delay before readiness probe is initiated                                                    | 30                                                      |
+| `readinessProbe.periodSeconds`        | How often to perform the probe                                                               | 3                                                       |
+| `readinessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                                       |
+| `readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                       |
+| `readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                       |
 
 The above parameters map to the env variables defined in [bitnami/prestashop](http://github.com/bitnami/bitnami-docker-prestashop). For more information please refer to the [bitnami/prestashop](http://github.com/bitnami/bitnami-docker-prestashop) image documentation.
 

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.0.3
-digest: sha256:dc59582a7eae0d957afb9b3acf6e90d95857592ee30229aa5f6294d5862c080d
-generated: 2018-05-24T11:06:42.276639277+02:00
+  version: 0.7.0
+digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
+generated: 2018-05-24T18:07:27.111407018+02:00

--- a/stable/prestashop/requirements.lock
+++ b/stable/prestashop/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
-generated: 2018-03-15T17:02:26.357827+01:00
+  version: 3.0.3
+digest: sha256:dc59582a7eae0d957afb9b3acf6e90d95857592ee30229aa5f6294d5862c080d
+generated: 2018-05-24T11:06:42.276639277+02:00

--- a/stable/prestashop/requirements.yaml
+++ b/stable/prestashop/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
+  version: 3.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/stable/prestashop/requirements.yaml
+++ b/stable/prestashop/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 3.x.x
+  version: 0.7.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -89,6 +89,7 @@ spec:
           containerPort: 80
         - name: https
           containerPort: 443
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /login
@@ -96,9 +97,13 @@ spec:
             httpHeaders:
             - name: Host
               value: {{ include "prestashop.host" . | quote }}
-          initialDelaySeconds: 120
-          timeoutSeconds: 5
-          failureThreshold: 6
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /login
@@ -106,9 +111,12 @@ spec:
             httpHeaders:
             - name: Host
               value: {{ include "prestashop.host" . | quote }}
-          initialDelaySeconds: 30
-          timeoutSeconds: 3
-          periodSeconds: 5
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -169,3 +169,19 @@ resources:
   requests:
     memory: 512Mi
     cpu: 300m
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  initialDelaySeconds: 600
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 6
+  successThreshold: 1
+  

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -184,4 +184,3 @@ readinessProbe:
   timeoutSeconds: 3
   failureThreshold: 6
   successThreshold: 1
-  


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR expose the configuration of Prestashop liveness and readiness probes to the values.yaml.
It also updates the MariaDB dependency as it was quite old.
