### PR TITLE
[stable/redis] Update redis supported versions

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.3.1
+version: 3.3.2
 appVersion: 4.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -20,7 +20,7 @@ This chart bootstraps a [Redis](https://github.com/bitnami/bitnami-docker-redis)
 
 ## Prerequisites
 
-- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.8+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous information around supported k8s versions in the `redis`
chart was incorrect. It said this chart could be used with k8s 1.4+ with
the beta APIs enabled. However, the `statefulset` utilized
`apps/v1beta2`, which is only available in 1.8+. Supporting 1.8+
corresponds with the overall Charts policy of supporting the current and
previous minor release (in this case, 1.10 and 1.9).

**Special notes for your reviewer**:

@timstoop this is the alternative diff I mentioned in place of #5673 .
