### PR TITLE
Whitelist files that don't require semver bump

### DIFF
--- a/test/semvercompare.sh
+++ b/test/semvercompare.sh
@@ -16,6 +16,8 @@
 semvercompareOldVer=""
 semvercompareNewVer=""
 
+semverIgnoreRegex="(README\.md)"
+
 # Verify that the semver for the chart was increased
 semvercompare() {
   printf "\nChecking the Chart version has increased for the chart at ${1}\n"
@@ -28,6 +30,14 @@ semvercompare() {
   ## If the chart is new git cannot checkout the chart. In that case return
   if [ $? -ne 0 ]; then
     echo "Unable to find Chart on master. New chart detected."
+    return
+  fi
+
+  # If the only files change are files we've whitelisted to allow changes
+  # without a semver bump, then return.
+  local non_whitelist_files=$(git diff HEAD~1 --name-only | grep -Ev "$semverIgnoreRegex" | wc -l)
+  if [ "$non_whitelist_files" -eq 0 ]; then
+    echo "No semver change required."
     return
   fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, if any file in the chart is changed, there must be a
corresponding increase in semver. Specifically, I'm not sure this policy
makes sense for the README.md. I'm not sure updating (or correcting)
documentation should require a semver bump.

This diff updates `test/semvercompare.sh` so that if the only changes in
a directory are in a set of whitelisted files (which at this point only
contains README.md), a semver bump is not required by the linter.
