### PR TITLE
[stable/rabbitmq] Update rabbitmq supported ver.

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 1.1.2
+version: 1.1.3
 appVersion: 3.7.5
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a [RabbitMQ](https://github.com/bitnami/bitnami-docker-rab
 
 ## Prerequisites
 
-- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.8+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous information around supported k8s versions in the rabbitmq
chart was incorrect. It said this chart could be used with k8s 1.4+ with
the beta APIs enabled. However, the statefulset utilized
apps/v1beta2, which is only available in 1.8+. Supporting 1.8+
corresponds with the overall Charts policy of supporting the current and
previous minor release (in this case, 1.10 and 1.9).)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5388 

