### PR TITLE
cert-manager: fast-forward to upstream 1e606b3e

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: 0.2.10
-appVersion: 0.2.5
+version: v0.3.0
+appVersion: v0.3.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -54,10 +54,12 @@ The following table lists the configurable parameters of the cert-manager chart 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.2.5` |
+| `image.tag` | Image tag | `v0.3.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |
+| `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
+| `leaderElection.Namespace` | Override the namespace used to store the ConfigMap for leader election | Same namespace as cert-manager pod
 | `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |
 | `extraArgs` | Optional flags for cert-manager | `[]` |
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
@@ -67,13 +69,12 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |
-| `ingressShim.enabled` | Enable ingress-shim for automatic ingress integration | `true`|
-| `ingressShim.extraArgs` | Optional flags for ingress-shim | `[]` |
-| `ingressShim.resources` | CPU/memory resource requests/limits for ingress-shim | `requests: {cpu: 10m, memory: 32Mi}` |
-| `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
-| `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
-| `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
+| `ingressShim.defaultIssuerName` | Optional default issuer to use for ingress resources |  |
+| `ingressShim.defaultIssuerKind` | Optional default issuer kind to use for ingress resources |  |
+| `ingressShim.defaultACMEChallengeType` | Optional default challenge type to use for ingresses using ACME issuers |  |
+| `ingressShim.defaultACMEDNS01ChallengeProvider` | Optional default DNS01 challenge provider to use for ingresses using ACME issuers with DNS01 |  |
 | `podAnnotations` | Annotations to add to the cert-manager pod | `{}` |
+| `podLabels` | Labels to add to the cert-manager pod | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -83,3 +84,7 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 $ helm install --name my-release -f values.yaml .
 ```
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Contributing
+
+This chart is maintained at [github.com/jetstack/cert-manager](https://github.com/jetstack/cert-manager/tree/master/contrib/charts/cert-manager).

--- a/stable/cert-manager/templates/00-namespace.yaml
+++ b/stable/cert-manager/templates/00-namespace.yaml
@@ -1,0 +1,6 @@
+{{ if .Values.createNamespaceResource }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/stable/cert-manager/templates/NOTES.txt
+++ b/stable/cert-manager/templates/NOTES.txt
@@ -6,10 +6,10 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
+http://cert-manager.readthedocs.io/en/latest/reference/issuers.html
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
+http://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: {{ template "cert-manager.name" . }}
         release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
       annotations:
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -30,14 +33,33 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-          # This is currently commented out until the 0.3 release of
-          # cert-manager, as it results in a breaking change (users will need
-          # to move credentials/acme private keys from kube-system into the
-          # same namespace cert-manager is deployed into.
-          # - --cluster-resource-namespace=$(POD_NAMESPACE)
+        {{- if .Values.clusterResourceNamespace }}
+          - --cluster-resource-namespace={{ .Values.clusterResourceNamespace }}
+        {{- else }}
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+        {{- end }}
+        {{- if .Values.leaderElection.namespace }}
+          - --leader-election-namespace={{ .Values.leaderElection.namespace }}
+        {{- else }}
+          - --leader-election-namespace=$(POD_NAMESPACE)
+        {{- end }}
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 10 }}
         {{- end }}
+          {{- with .Values.ingressShim }}
+          {{- if .defaultIssuerName }}
+          - --default-issuer-name={{ .defaultIssuerName }}
+          {{- end }}
+          {{- if .defaultIssuerKind }}
+          - --default-issuer-kind={{ .defaultIssuerKind }}
+          {{- end }}
+          {{- if .defaultACMEChallengeType }}
+          - --default-acme-issuer-challenge-type={{ .defaultACMEChallengeType }}
+          {{- end }}
+          {{- if .defaultACMEDNS01ChallengeProvider }}
+          - --default-acme-issuer-dns01-provider-name={{ .defaultACMEDNS01ChallengeProvider }}
+          {{- end }}
+          {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -45,17 +67,6 @@ spec:
                 fieldPath: metadata.namespace
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-{{- if .Values.ingressShim.enabled }}
-        - name: ingress-shim
-          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
-        {{- if .Values.ingressShim.extraArgs }}
-          args:
-{{ toYaml .Values.ingressShim.extraArgs | indent 10 }}
-        {{- end }}
-          resources:
-{{ toYaml .Values.ingressShim.resources | indent 12 }}
-{{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -5,10 +5,19 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.2.5
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 createCustomResource: true
+
+# Override the namespace used to store DNS provider credentials etc. for ClusterIssuer
+# resources. By default, the same namespace as cert-manager is deployed within is
+# used. This namespace will not be automatically created by the Helm chart.
+clusterResourceNamespace: ""
+
+leaderElection:
+  # Override the namespace used to store the ConfigMap for leader election
+  namespace: ""
 
 certificateResourceShortNames: ["cert", "certs"]
 
@@ -36,31 +45,15 @@ resources: {}
 
 podAnnotations: {}
 
+podLabels: {}
+
 nodeSelector: {}
 
-ingressShim:
-  enabled: true
-
-  # Optional additional arguments for ingress-shim
-  extraArgs: []
-    # Use these flags to specify the default Issuer/ClusterIssuer
-    # (IMPORTANT: You need to create this Issuer/ClusterIssuer resource yourself)
-    # - --default-issuer-name=letsencrypt-prod
-    # - --default-issuer-kind=ClusterIssuer
-
-  resources: {}
-    # requests:
-    #   cpu: 10m
-    #   memory: 32Mi
-
-  image:
-    repository: quay.io/jetstack/cert-manager-ingress-shim
-
-    # Defaults to image.tag.
-    # You should only change this if you know what you are doing!
-    # tag: v0.2.5
-
-    pullPolicy: IfNotPresent
+ingressShim: {}
+  # defaultIssuerName: ""
+  # defaultIssuerKind: ""
+  # defaultACMEChallengeType: ""
+  # defaultACMEDNS01ChallengeProvider: ""
 
 # This is used by the static manifest generator in order to create a static
 # namespace manifest for the namespace that cert-manager is being installed


### PR DESCRIPTION
* Bump chart and manifests for v0.3.0 release (jetstack/cert-manager#575)
* add pod labels (jetstack/cert-manager#563)
* Add leaderElection.namespace option to helm chart (jetstack/cert-manager#548)
* Add clusterResourceNamespace option to Helm chart (jetstack/cert-manager#547)
* Fix ingress-shim cli flags (jetstack/cert-manager#526)
* Create chart OWNERS (jetstack/cert-manager#528)
* Link ingress-shim into main controller binary (jetstack/cert-manager#502)
* readthedocs documentation rewrite (jetstack/cert-manager#428)
* add selector, as otherwise it fails on GKE k8s v1.9.x (jetstack/cert-manager#440)
* Add podAnnotations (jetstack/cert-manager#387)
* Document common ingressShim.extraArgs use case in chart (jetstack/cert-manager#382)
* Helm Chart: Add support for affinity and tolerations (jetstack/cert-manager#350)
* Set default cluster resource namespace to current pod namespace (jetstack/cert-manager#329)
* Create a Namespace resource as part of the static manifest bundle (jetstack/cert-manager#340)
* Add default shortNames to certificates CRD (jetstack/cert-manager#312)
* fix: Use ConfigMaps for leaderelection (jetstack/cert-manager#327)

/cc @kragniz @simonswine 