### PR TITLE
Fix path on docker-registry

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.4.1
+version: 1.4.2
 appVersion: 2.6.2
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/templates/ingress.yaml
+++ b/stable/docker-registry/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "docker-registry.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
+{{- $path := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -20,7 +21,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ $path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}


### PR DESCRIPTION
The range in another merge caused .Values.ingress.path to be executed in the wrong context. This fixes it.