### PR TITLE
[stable/heartbeat] Add Heartbeat to check status of your services

### DIFF
--- a/stable/heartbeat/.helmignore
+++ b/stable/heartbeat/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/heartbeat/Chart.yaml
+++ b/stable/heartbeat/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+description: A Helm chart to periodically check the status of your services with heartbeat
+icon: https://www.elastic.co/jp/assets/blt75e7956191e1bd55/icon-heartbeat-bb.svg
+name: heartbeat
+version: 0.1.0
+appVersion: 6.2.4
+home: https://www.elastic.co/products/beats/heartbeat
+sources:
+- https://www.elastic.co/guide/en/beats/heartbeat/current/index.html
+maintainers:
+- name: mumoshu
+  email: ykuoka@gmail.com

--- a/stable/heartbeat/README.md
+++ b/stable/heartbeat/README.md
@@ -1,0 +1,71 @@
+# heartbeat
+
+[heartbeat](https://www.elastic.co/guide/en/beats/heartbeat/current/index.html) is a lightweight daemon that periodically check the status of your services and determine whether they are available.
+
+## Introduction
+
+This chart deploys heartbeat agents to all the nodes in your cluster via a DaemonSet.
+
+By default this chart only ships a single output to a file on the local system.  Users should set config.output.file.enabled=false and configure their own outputs as [documented](https://www.elastic.co/guide/en/beats/heartbeat/current/configuring-output.html)
+
+## Prerequisites
+
+- Kubernetes 1.9+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`, run:
+
+```bash
+$ helm install --name my-release stable/heartbeat
+```
+
+After a few minutes, you should see service statuses being written to the configured output, which is a log file inside the heartbeat container.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the heartbeat chart and their default values.
+
+|             Parameter               |            Description             |                    Default                |
+|-------------------------------------|------------------------------------|-------------------------------------------|
+| `image.repository`                  | The image repository to pull from  | `docker.elastic.co/beats/heartbeat`       |
+| `image.tag`                         | The image tag to pull              | `6.2.4`                                   |
+| `image.pullPolicy`                  | Image pull policy                  | `IfNotPresent`                            |
+| `rbac.create`                       | If true, create & use RBAC resources | `true`                                  |
+| `rbac.serviceAccount`               | existing ServiceAccount to use (ignored if rbac.create=true) | `default`       |
+| `config`                            | The content of the configuration file consumed by heartbeat. See the [heartbeat documentation](https://www.elastic.co/guide/en/beats/heartbeat/current/heartbeat-reference-yml.html) for full details |
+| `plugins`                           | List of beat plugins                                                           |
+| `extraVars`                         | A map of additional environment variables |                                    |
+| `extraVolumes`, `extraVolumeMounts` | Additional volumes and mounts, for example to provide other configuration files | |
+| `resources.requests.cpu`            | CPU resource requests              |                                           |
+| `resources.limits.cpu`              | CPU resource limits                |                                           |
+| `resources.requests.memory`         | Memory resource requests           |                                           |
+| `resources.limits.memory`           | Memory resource limits             |                                           |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set rbac.create=true \
+    stable/heartbeat
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/heartbeat
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/heartbeat/templates/NOTES.txt
+++ b/stable/heartbeat/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that heartbeat has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "heartbeat.name" . }},release={{ .Release.Name }}"

--- a/stable/heartbeat/templates/_helpers.tpl
+++ b/stable/heartbeat/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "heartbeat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "heartbeat.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "heartbeat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "heartbeat.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "heartbeat.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/heartbeat/templates/clusterrole.yaml
+++ b/stable/heartbeat/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "heartbeat.fullname" . }}
+  labels:
+    app: {{ template "heartbeat.name" . }}
+    chart: {{ template "heartbeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/stable/heartbeat/templates/clusterrolebinding.yaml
+++ b/stable/heartbeat/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "heartbeat.fullname" . }}
+  labels:
+    app: {{ template "heartbeat.name" . }}
+    chart: {{ template "heartbeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "heartbeat.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "heartbeat.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/heartbeat/templates/daemonset.yaml
+++ b/stable/heartbeat/templates/daemonset.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "heartbeat.fullname" . }}
+  labels:
+    app: {{ template "heartbeat.name" . }}
+    chart: {{ template "heartbeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "heartbeat.name" . }}
+      release: {{ .Release.Name }}
+  minReadySeconds: 10
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "heartbeat.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        checksum/secret: {{ toYaml .Values.config | sha256sum }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - "-e"
+{{- if .Values.plugins }}
+        - "--plugin"
+        - {{ .Values.plugins | join "," | quote }}
+{{- end }}
+        env:
+{{- range $key, $value := .Values.extraVars }}
+        - name: {{ $key }}
+          value: {{ $value }}
+{{- end }}
+        securityContext:
+          runAsUser: 0
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: heartbeat-config
+          mountPath: /usr/share/heartbeat/heartbeat.yml
+          readOnly: true
+          subPath: heartbeat.yml
+        - name: data
+          mountPath: /usr/share/heartbeat/data
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+      - name: heartbeat-config
+        secret:
+          secretName: {{ template "heartbeat.fullname" . }}
+      - name: data
+        hostPath:
+          path: /var/lib/heartbeat
+          type: DirectoryOrCreate
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: {{ template "heartbeat.serviceAccountName" . }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}

--- a/stable/heartbeat/templates/secret.yaml
+++ b/stable/heartbeat/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "heartbeat.fullname" . }}
+  labels:
+    app: {{ template "heartbeat.name" . }}
+    chart: {{ template "heartbeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  heartbeat.yml: {{ toYaml .Values.config | indent 4 | b64enc }}

--- a/stable/heartbeat/templates/serviceaccount.yaml
+++ b/stable/heartbeat/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "heartbeat.serviceAccountName" . }}
+  labels:
+    app: {{ template "heartbeat.name" . }}
+    chart: {{ template "heartbeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/stable/heartbeat/values.yaml
+++ b/stable/heartbeat/values.yaml
@@ -1,0 +1,70 @@
+image:
+  repository: docker.elastic.co/beats/heartbeat
+  tag: 6.2.4
+  pullPolicy: IfNotPresent
+
+config:
+  # See https://www.elastic.co/guide/en/beats/heartbeat/current/heartbeat-reference-yml.html for reference
+  heartbeat.monitors:
+  - type: icmp
+    schedule: '*/5 * * * * * *'
+    hosts: ["localhost"]
+    ipv4: true
+    timeout: 16s
+    wait: 1s
+
+  processors:
+  - add_cloud_metadata:
+
+  output.file:
+    path: "/usr/share/heartbeat/data"
+    filename: heartbeat
+    rotate_every_kb: 10000
+    number_of_files: 5
+
+  # output.elasticsearch:
+  #   hosts: ["elasticsearch:9200"]
+  #   protocol: "https"
+  #   username: "elastic"
+  #   password: "changeme"
+
+# List of beat plugins
+plugins: []
+  # - kinesis.so
+
+# A map of additional environment variables
+extraVars: {}
+  # test1: "test2"
+
+# Add additional volumes and mounts, for example to read other log files on the host
+extraVolumes: []
+  # - hostPath:
+  #     path: /var/log
+  #   name: varlog
+extraVolumeMounts: []
+  # - name: varlog
+  #   mountPath: /host/var/log
+  #   readOnly: true
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 200Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 100Mi
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
Manually verified to work by installing it like `helm install ~/charts/stable/heartbeat --name hb --namespace hb` and then reading logs:

```console
$ stern --namespace hb heart
+ hb-heartbeat-zljn2 › heartbeat
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:17.531ZINFOinstance/beat.go:468Home path: [/usr/share/heartbeat] Config path: [/usr/share/heartbeat] Data path: [/usr/share/heartbeat/data] Logs path: [/usr/share/heartbeat/logs]
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:17.532ZINFOinstance/beat.go:475Beat UUID: cc04f1e7-c1a2-4e9c-beca-009539becd87
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:17.532ZINFOinstance/beat.go:213Setup Beat: heartbeat; Version: 6.2.4
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:20.534ZINFOadd_cloud_metadata/add_cloud_metadata.go:297add_cloud_metadata: hosting provider type not detected.
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:20.534ZINFOfileout/file.go:76Initialized file output. path=/usr/share/heartbeat/data/heartbeat max_size_bytes=10240000 max_backups=5 permissions=-rw-------
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:20.535ZINFOpipeline/module.go:76Beat name: hb-heartbeat-zljn2
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:20.535ZWARNbeater/heartbeat.go:24Beta: Heartbeat is beta software
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:20.535ZINFObeater/manager.go:110Select (active) monitor icmp
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:20.537ZINFO[monitoring]log/log.go:97Starting metrics logging every 30s
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:20.538ZINFOinstance/beat.go:301heartbeat start running.
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:20.538ZINFObeater/heartbeat.go:56heartbeat is running! Hit CTRL-C to stop it.
hb-heartbeat-zljn2 heartbeat 2018-05-25T09:07:50.538ZINFO[monitoring]log/log.go:124Non-zero metrics in the last 30s{"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":40,"time":40},"total":{"ticks":70,"time":74,"value":70},"user":{"ticks":30,"time":34}},"info":{"ephemeral_id":"23539714-a27c-40bb-a124-805b7e009958","uptime":{"ms":33026}},"memstats":{"gc_next":4194304,"memory_alloc":2423104,"memory_total":4047776,"rss":22454272}},"libbeat":{"config":{"module":{"running":0}},"output":{"events":{"acked":5,"batches":5,"total":5},"type":"file","write":{"bytes":2306}},"pipeline":{"clients":1,"events":{"active":1,"published":6,"total":6},"queue":{"acked":5}}},"system":{"cpu":{"cores":2},"load":{"1":0.75,"15":0.38,"5":0.55,"norm":{"1":0.375,"15":0.19,"5":0.275}}}}}}
```

Templates and values.yaml is mostly similar to stable/filebeat's.
The main difference is `config:` in values.yaml, which directly reflects heartbeat's own configuration file.