### PR TITLE
datadog: api key: make api key optional value in chart

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.11.3
+version: 0.11.4
 appVersion: 6.2.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -8,10 +8,10 @@ No further action should be required.
 
 {{- else -}}
 ##############################################################################
-####               ERROR: You did not set a datadog.apiKey.               ####
+####               WARN: You did not set a datadog.apiKey.               ####
 ##############################################################################
 
-This deployment will be incomplete until you get your API key from Datadog. 
+This deployment will be incomplete until you get your API key from Datadog.
 One can sign up for a free Datadog trial at https://app.datadoghq.com/signup
 
 Once registered you can request an API key at:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.daemonset.enabled }}
-{{- if .Values.datadog.apiKey }}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -172,5 +171,4 @@ spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
   updateStrategy:
     type: {{ default "OnDelete" .Values.daemonset.updateStrategy | quote }}
-{{ end }}
 {{ end }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.deployment.enabled }}
-{{- if .Values.datadog.apiKey }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -136,5 +135,4 @@ spec:
 {{ toYaml .Values.datadog.volumes | indent 8 }}
 {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
-{{ end }}
 {{ end }}


### PR DESCRIPTION
it can provided in many different ways. one way we do it is using the
user data scripts on system creation on aws, which pulls the key from a
authorized bucket. hardcoding this requirement reduces the flexibility
of this chart.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Making the api key in datadog chart optional. There are many ways the key can be provided at runtime. One way is to provide it during machine install time in AWS as a user-data script, which pulls it down from a authenticated repo. This makes the chart flexible and reduces hard dependency on the api key. This will to enable people on the team to spin up machines with datadog installed and working, and not have to worry about the api key, which currently has to be shared with everyone on the team.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: Hopefully this change makes sense to be implemented. Thanks for taking the time to review this change.
