### PR TITLE
[stable/sonarqube] Add MySQL database support to Sonarqube

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.6.1
+version: 0.7.0
 appVersion: 6.7.3
 keywords:
   - coverage

--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.6.0
+version: 0.6.1
 appVersion: 6.7.3
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -52,12 +52,19 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `persistence.accessMode`                    | Volumes access mode to be set             | `ReadWriteOnce`                            |
 | `persistence.size`                          | Size of the volume                        | `10Gi`                                     |
 | `sonarProperties`                           | Custom `sonar.properties` file            | None                                       |
-| `postgresql.enabled`                        | Set to `false` to use external server     | `true`                                     |
+| `database.type`                             |Set to "mysql" to use mysql database       | `postgresql`|
+| `postgresql.enabled`                        | Set to `false` to use external server / mysql database     | `true`                                     |
 | `postgresql.postgresServer`                 | Hostname of the external Postgresql server| `null`                                     |
 | `postgresql.postgresUser`                   | Postgresql database user                  | `sonarUser`                                |
 | `postgresql.postgresPassword`               | Postgresql database password              | `sonarPass`                                |
 | `postgresql.postgresDatabase`               | Postgresql database name                  | `sonarDB`                                  |
-| `postgresql.service.port`                | Postgresql port                              | `5432`                                     |
+| `postgresql.service.port`                   | Postgresql port                           | `5432`                                     |
+| `mysql.enabled`                             | Set to `false` to use external server / postgresql database        | `false`                                     |
+| `mysql.mysqlServer`                         | Hostname of the external Mysql server     | `null`                                     |
+| `mysql.mysqlUser`                           | Mysql database user                       | `sonarUser`                                |
+| `mysql.mysqlPassword`                       | Mysql database password                   | `sonarPass`                                |
+| `mysql.mysqlDatabase`                       | Mysql database name                       | `sonarDB`                                  |
+| `mysql.service.port`                        | Mysql port                                | `3306`                                     |
 | `resources`                                 | Sonarqube Pod resource requests & limits  | `{}`                                       |
 | `affinity`                                  | Node / Pod affinities                     | `{}`                                       |
 | `nodeSelector`                              | Node labels for pod assignment            | `{}`                                       |
@@ -65,6 +72,6 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `plugins.install`                           | List of plugins to install                | `[]`                                       |
 | `plugins.resources`                         | Plugin Pod resource requests & limits     | `{}`                                       |
 
-You can also configure values for the PostgreSQL database via the Postgresql [README.md](https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md).
+You can also configure values for the PostgreSQL / MySQL database via the Postgresql [README.md](https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md) / MySQL [README.md](https://github.com/kubernetes/charts/blob/master/stable/mysql/README.md)
 
 For overriding variables see: [Customizing the chart](https://docs.helm.sh/using_helm/#customizing-the-chart-before-installing)

--- a/stable/sonarqube/requirements.lock
+++ b/stable/sonarqube/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.8.3
-digest: sha256:7669c2dcb2741e52c61240019803c5a8a0061e51195060b2bd3b8176648faa63
-generated: 2018-04-19T13:47:45.089773+02:00
+- name: mysql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.6.0
+digest: sha256:2e9888ddfac13a780385a8c40f720b7248914986f4afbe0dce143ba7fecb9313
+generated: 2018-05-28T12:47:06.012847582+02:00

--- a/stable/sonarqube/requirements.yaml
+++ b/stable/sonarqube/requirements.yaml
@@ -3,3 +3,7 @@ dependencies:
     version: 0.8.3
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled
+  - name: mysql
+    version: 0.6.0
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: mysql.enabled

--- a/stable/sonarqube/templates/_helpers.tpl
+++ b/stable/sonarqube/templates/_helpers.tpl
@@ -16,20 +16,34 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-  Create a default fully qualified postgresql name.
+  Create a default fully qualified mysql/postgresql name.
   We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "postgresql.fullname" -}}
 {{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- define "mysql.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" -}}
+{{- end}}
 
 {{/*
-  Determine the hostname to use for PostgreSQL.
+  Determine the hostname to use for PostgreSQL/mySQL.
 */}}
 {{- define "postgresql.hostname" -}}
+{{- if eq .Values.database.type "postgresql" -}}
 {{- if .Values.postgresql.enabled -}}
 {{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" .Values.postgresql.postgresServer -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- define "mysql.hostname" -}}
+{{- if eq .Values.database.type "mysql" -}}
+{{- if .Values.mysql.enabled -}}
+{{- printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" .Values.mysql.mysqlServer -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -74,14 +74,27 @@ spec:
               value: {{ $value }}
             {{- end }}
             - name: SONARQUBE_JDBC_USERNAME
-              value: {{.Values.postgresql.postgresUser | quote }}
+              {{- if eq .Values.database.type "postgresql" }}
+              value: {{ .Values.postgresql.postgresUser | quote }}
+              {{- else if eq .Values.database.type "mysql" }}
+              value: {{ .Values.mysql.mysqlUser | quote }}
+              {{- end }}
             - name: SONARQUBE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{- if eq .Values.database.type "postgresql" }}
                   name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
                   key: postgres-password
+                  {{- else if eq .Values.database.type "mysql" }}
+                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ template "sonarqube.fullname" . }} {{- end }}
+                  key: mysql-password
+                  {{- end }}
             - name: SONARQUBE_JDBC_URL
+              {{- if eq .Values.database.type "postgresql" }}
               value: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.postgresDatabase -}}"
+              {{- else if eq .Values.database.type "mysql" }}
+              value: "jdbc:mysql://{{ .Release.Name }}-mysql:{{ .Values.mysql.service.port }}/{{ .Values.mysql.mysqlDatabase }}?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true"
+              {{- end }}
           livenessProbe:
             httpGet:
               path: /sessions/new

--- a/stable/sonarqube/templates/secret.yaml
+++ b/stable/sonarqube/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.database.type "postgresql" -}}
 {{- if eq .Values.postgresql.enabled false -}}
 apiVersion: v1
 kind: Secret
@@ -12,6 +13,8 @@ type: Opaque
 data:
   postgres-password: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
 {{- end -}}
+{{- end -}}
+{{- if eq .Values.database.type "mysql" -}}
 {{- if eq .Values.mysql.enabled false -}}
 apiVersion: v1
 kind: Secret
@@ -24,6 +27,7 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  postgres-password: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
+  mysql-password: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
+{{- end -}}
 {{- end -}}
 

--- a/stable/sonarqube/templates/secret.yaml
+++ b/stable/sonarqube/templates/secret.yaml
@@ -12,3 +12,18 @@ type: Opaque
 data:
   postgres-password: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
 {{- end -}}
+{{- if eq .Values.mysql.enabled false -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sonarqube.fullname" . }}
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  postgres-password: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
+{{- end -}}
+

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -97,7 +97,7 @@ plugins:
 
 ## Configuration value to select database type
 ## Option to use "postgresql" or "mysql" database type, by default "postgresql" is choosen
-## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select 
+## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select
 database:
   type: "postgresql"
 

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -96,8 +96,8 @@ plugins:
 #   ldap.url=ldaps://organization.com
 
 ## Configuration value to select database type
-## Option to use "postgresql" or "mysql" database , by default "postgresql" is choosen
-## set the enabled to false to the database type you're not selecting and true to the one you select 
+## Option to use "postgresql" or "mysql" database type, by default "postgresql" is choosen
+## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select 
 database:
   type: "postgresql"
 

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -95,9 +95,14 @@ plugins:
 #   sonar.security.realm=LDAP
 #   ldap.url=ldaps://organization.com
 
-## Configuration values for the postgresql dependency
+## Configuration value to select database type
+## Option to use "postgresql" or "mysql" database , by default "postgresql" is choosen
+## set the enabled to false to the database type you're not selecting and true to the one you select 
+database:
+  type: "postgresql"
+
+## Configuration values for postgresql dependency
 ## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
-##
 postgresql:
   # Enable to deploy the PostgreSQL chart
   enabled: true
@@ -110,3 +115,19 @@ postgresql:
   # Specify the TCP port that PostgreSQL should use
   service:
     port: 5432
+
+## Configuration values for the mysql dependency
+## ref: https://github.com/kubernetes/charts/blob/master/stable/mysql/README.md
+##
+mysql:
+  # Enable to deploy the mySQL chart
+  enabled: false
+  # To use an external mySQL instance, set enabled to false and uncomment
+  # the line below:
+  # mysqlServer: ""
+  mysqlUser: "sonarUser"
+  mysqlPassword: "sonarPass"
+  mysqlDatabase: "sonarDB"
+  # Specify the TCP port that mySQL should use
+  service:
+    port: 3306


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds `MySQL` database support to Sonarqube. Currently Sonarqube has only`Postgresql` support to store the data. It has the relevant changes to the template files and README.md for the new MySQL database support

**Which issue this PR fixes** *
fixes #5654 

**Special notes for your reviewer**:
`/assign`  @rjkernick 