### PR TITLE
[CI] Update Helm to v2.9.1

### DIFF
--- a/test/changed.sh
+++ b/test/changed.sh
@@ -136,7 +136,7 @@ fi
 
 # Install and initialize helm/tiller
 readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
-readonly HELM_TARBALL=helm-v2.8.2-linux-amd64.tar.gz
+readonly HELM_TARBALL=helm-v2.9.1-linux-amd64.tar.gz
 readonly INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 
 pushd /opt

--- a/test/circle/install.sh
+++ b/test/circle/install.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Install Helm
-HELM_LATEST_VERSION="v2.8.2"
+HELM_LATEST_VERSION="v2.9.1"
 
 wget http://storage.googleapis.com/kubernetes-helm/helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz
 tar -xvf helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz

--- a/test/helm-test-e2e.sh
+++ b/test/helm-test-e2e.sh
@@ -7,7 +7,7 @@ set -o xtrace
 
 # Install and initialize helm/tiller
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.8.2-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.9.1-linux-amd64.tar.gz
 
 wget -q ${HELM_URL}/${HELM_TARBALL} -P ${WORKSPACE}
 tar xzfv ${WORKSPACE}/${HELM_TARBALL} -C ${WORKSPACE}

--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -15,7 +15,7 @@
 
 # Setup Helm
 HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.8.2-linux-amd64.tar.gz
+HELM_TARBALL=helm-v2.9.1-linux-amd64.tar.gz
 STABLE_REPO_URL=https://kubernetes-charts.storage.googleapis.com/
 INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
 wget -q ${HELM_URL}/${HELM_TARBALL}


### PR DESCRIPTION
**What this PR does / why we need it**:

Update Helm to v2.9.1 as discussed in today's charts call.

cc @kubernetes/charts-maintainers 