### PR TITLE
OpenVPN NOTES.txt - Fix label key in the pod status command

### DIFF
--- a/stable/openvpn/templates/NOTES.txt
+++ b/stable/openvpn/templates/NOTES.txt
@@ -4,7 +4,7 @@ Please be aware that certificate generation is variable and may take some time (
 
 Check pod status with the command:
 
-  POD_NAME=$(kubectl get pods -l type=openvpn -o jsonpath='{ .items[0].metadata.name }') && kubectl log $POD_NAME --follow
+  POD_NAME=$(kubectl get pods -l app=openvpn -o jsonpath='{ .items[0].metadata.name }') && kubectl log $POD_NAME --follow
 
 LoadBalancer ingress creation can take some time as well. Check service status with the command:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In `NOTES.txt`, the command to follow the pod's log has a label filter with the old `type` label key instead of the new `app` key.

