### PR TITLE
[cluster-autoscaler] Add support for `hostNetwork`.

### DIFF
--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -96,6 +96,9 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
+    {{- if .Values.hostNetwork }}
+      hostNetwork: true
+    {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -67,6 +67,9 @@ podDisruptionBudget: |
   maxUnavailable: 1
   # minAvailable: 2
 
+## Whether to use the hostNetwork (e.g., to utliize an AWS IAM instance profile for credentials)
+hostNetwork: false
+
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR adds support for the Cluster Autoscaler to run with `hostNetwork: true`. On AWS & GCE, it may be desirable to run the autoscaler on the host network, e.g., to provide access to IAM profile/GCE service account credentials via the hypervisor-local metadata service. In some environments, such credentials may be provided via `kube2iam`/`kiam`, in other environments creds may be provided statically (e.g., via env vars with values from a Secret). In my context, I wanted the Cluster Autoscaler to utilize the host's role/service account via the `hostNetwork`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

There is no existing issue for the absence of `hostNetwork` support in the Cluster Autoscaler chart.

**Special notes for your reviewer**:

None.