### PR TITLE
[incubator/patroni] Correct default zookeeper host to be compatible with zk charts

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.8.0
+version: 0.8.1
 appVersion: 1.4-p7
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -53,7 +53,7 @@ spec:
         {{- else if .Values.zookeeper.enable }}
         {{- if .Values.zookeeper.deployChart }}
         - name: ZOOKEEPER_HOSTS
-          value: {{(printf "'zk-%s-headless:2181'" .Release.Name | trunc 63)}}
+          value: {{(printf "'%s-zookeeper-headless:2181'" .Release.Name | trunc 63)}}
         {{- else }}
         - name: ZOOKEEPER_HOSTS
           value: {{ .Values.zookeeper.hosts | quote }}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

* Update default `ZOOKEEPER_HOSTS` to be equal services name deployed by zookeeper charts.