### PR TITLE
[datadog] make the agent pod part of the Guaranteed QoS class

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.11.3
+version: 0.12.3
 appVersion: 6.2.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -150,16 +150,17 @@ datadog:
   # checksd:
   #   service.py: |-
 
-  ## dd-agent resource requests and limits
+  ## datadog-agent resource requests and limits
+  ## Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 200m
+      memory: 256Mi
     limits:
-      cpu: 256m
-      memory: 512Mi
+      cpu: 200m
+      memory: 256Mi
 
 rbac:
   ## If true, create & use RBAC resources


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Make the agent pod part of the Guaranteed QoS class. This prevents useless scheduling back and forth where the kubelet will evict the agent because it's only `Burstable`, but then relaunch it because it's a daemon set.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
