### PR TITLE
[CI] Refactor repo sync

### DIFF
--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -29,18 +29,12 @@ main() {
     setup_helm_client
     authenticate
 
-    local exit_code=0
-
     if ! sync_repo stable "$GCS_BUCKET_STABLE"; then
         log_error "Not all stable charts could be packaged and synced!"
-        exit_code=1
     fi
     if ! sync_repo incubator "$GCS_BUCKET_INCUBATOR"; then
         log_error "Not all incubator charts could be packaged and synced!"
-        exit_code=1
     fi
-
-    return "$exit_code"
 }
 
 setup_helm_client() {

--- a/test/repo-sync.sh
+++ b/test/repo-sync.sh
@@ -1,11 +1,12 @@
-#!/bin/bash
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,82 +14,92 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Setup Helm
-HELM_URL=https://storage.googleapis.com/kubernetes-helm
-HELM_TARBALL=helm-v2.9.1-linux-amd64.tar.gz
-STABLE_REPO_URL=https://kubernetes-charts.storage.googleapis.com/
-INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
-apt-get install -y wget
-wget --user-agent=wget-ci-sync -q ${HELM_URL}/${HELM_TARBALL}
-tar xzfv ${HELM_TARBALL}
-PATH=`pwd`/linux-amd64/:$PATH
-helm init --client-only
-helm repo add incubator ${INCUBATOR_REPO_URL}
+set -o errexit
+set -o nounset
+set -o pipefail
 
-# Authenticate before uploading to Google Cloud Storage
-SERVICE_ACCOUNT_JSON=$(echo $SYNC_CREDS | base64 --decode)
-cat > sa.json <<EOF
-$SERVICE_ACCOUNT_JSON
-EOF
-gcloud auth activate-service-account --key-file sa.json
+readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
+readonly HELM_TARBALL=helm-v2.9.1-linux-amd64.tar.gz
+readonly STABLE_REPO_URL=https://kubernetes-charts.storage.googleapis.com/
+readonly INCUBATOR_REPO_URL=https://kubernetes-charts-incubator.storage.googleapis.com/
+readonly GCS_BUCKET=gs://kubernetes-charts
 
-# Create the stable repository
-STABLE_REPO_DIR=stable-repo
-mkdir -p ${STABLE_REPO_DIR}
-cd ${STABLE_REPO_DIR}
-  gsutil cp gs://kubernetes-charts/index.yaml .
-  ret=$?
-  if [ $ret -ne 0 ]; then
-    echo "Exiting because unable to copy index locally. Not safe to proceed."
-    exit 1
-  fi
+main() {
+    setup_helm_client
+    authenticate
 
-  for dir in `ls ../stable`;do
-    echo "Building and packaging ${dir}"
-    helm dep build ../stable/$dir
-    ret=$?
-    if [ $ret -ne 0 ]; then
-      echo "Problem building dependencies. Skipping packaging of ${dir}"
-    else
-      helm package ../stable/$dir
+    local exit_code=0
+
+    if ! sync_repo stable; then
+        log_error "Not all stable charts could be packaged and synced!"
+        exit_code=1
     fi
-  done
-  helm repo index --url ${STABLE_REPO_URL} --merge ./index.yaml .
-  ret=$?
-  if [ $ret -ne 0 ]; then
-    echo "Exiting because unable to update index. Not safe to push update."
-    exit 1
-  fi
-  gsutil -m rsync ./ gs://kubernetes-charts/
-cd ..
-ls -l ${STABLE_REPO_DIR}
-
-# Create the incubator repository
-INCUBATOR_REPO_DIR=incubator-repo
-mkdir -p ${INCUBATOR_REPO_DIR}
-cd ${INCUBATOR_REPO_DIR}
-  gsutil cp gs://kubernetes-charts-incubator/index.yaml .
-  ret=$?
-  if [ $ret -ne 0 ]; then
-    echo "Exiting because unable to copy index locally. Not safe to proceed."
-    exit 1
-  fi
-  for dir in `ls ../incubator`;do
-    echo "Building and packaging ${dir}"
-    helm dep build ../incubator/$dir
-    ret=$?
-    if [ $ret -ne 0 ]; then
-      echo "Problem building dependencies. Skipping packaging of ${dir}"
-    else
-      helm package ../incubator/$dir
+    if ! sync_repo incubator; then
+        log_error "Not all incubator charts could be packaged and synced!"
+        exit_code=1
     fi
-  done
-  helm repo index --url ${INCUBATOR_REPO_URL} --merge ./index.yaml .
-  ret=$?
-  if [ $ret -ne 0 ]; then
-    echo "Exiting because unable to update index. Not safe to push update."
-    exit 1
-  fi
-  gsutil -m rsync ./ gs://kubernetes-charts-incubator/
-cd ..
-ls -l ${INCUBATOR_REPO_DIR}
+
+    return "$exit_code"
+}
+
+setup_helm_client() {
+    echo "Setting up Helm client..."
+
+    curl --user-agent curl-ci-sync -sSL -o "$HELM_TARBALL" "$HELM_URL/$HELM_TARBALL"
+    tar xzfv "$HELM_TARBALL"
+
+    PATH="$(pwd)/linux-amd64/:$PATH"
+
+    helm init --client-only
+    helm repo add incubator "$INCUBATOR_REPO_URL"
+}
+
+authenticate() {
+    echo "Authenticating with Google Cloud..."
+    gcloud auth activate-service-account --key-file <(base64 --decode <<< "$SYNC_CREDS")
+}
+
+sync_repo() {
+    local repo_dir="${1?Specify repo dir}"
+    local sync_dir="${repo_dir}-sync"
+    local index_dir="${repo_dir}-index"
+
+    echo "Syncing repo '$repo_dir'..."
+
+    mkdir -p "$sync_dir"
+    if ! gsutil cp "$GCS_BUCKET/index.yaml" "$index_dir/index.yaml"; then
+        log_error "Exiting because unable to copy index locally. Not safe to proceed."
+        exit 1
+    fi
+
+    local exit_code=0
+
+    for dir in "$repo_dir"/*; do
+        if helm dependency build "$dir"; then
+            helm package --destination "$sync_dir" "$dir"
+        else
+            log_error "Problem building dependencies. Skipping packaging of '$dir'."
+            exit_code=1
+        fi
+    done
+
+    if helm repo index --url "$sync_dir" --merge "$index_dir/index.yaml" "$sync_dir"; then
+        gsutil -m rsync "$sync_dir" "$GCS_BUCKET"
+
+        # Make sure index.yaml is synced last
+        gsutil cp "$index_dir/index.yaml" "$GCS_BUCKET"
+    else
+        log_error "Exiting because unable to update index. Not safe to push update."
+        exit 1
+    fi
+
+    ls -l "$sync_dir"
+
+    return "$exit_code"
+}
+
+log_error() {
+    printf '\e[31mERROR: %s\n\e[39m' "$1" >&2
+}
+
+main


### PR DESCRIPTION
With the upcoming refactoring of the chart testing, Shellcheck is added
to CircleCI for shell scripts. In order to prepare for this, several
adjustments are necessary so it passes. On top of that, the script is
refactored as follows:

* Reorganize code into several functions for better readability and to
  eliminate code redundancies
* Use curl instead of wget for intalling Helm because it's already
  available in the Docker image
* Treat index.yaml separately and copy it to the bucket after syncing
  charts in order to avoid chart fetch errors
