### PR TITLE
Mediawiki - Several Improvements

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,15 +1,17 @@
 name: mediawiki
-version: 1.0.4
+version: 2.0.0
 appVersion: 1.30.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation
   that uses PHP to process and display data stored in a database.
+home: http://www.mediawiki.org/
+icon: https://bitnami.com/assets/stacks/mediawiki/img/mediawiki-stack-220x234.png
 keywords:
 - mediawiki
 - wiki
 - http
+- web
+- application
 - php
-home: http://www.mediawiki.org/
-icon: https://bitnami.com/assets/stacks/mediawiki/img/mediawiki-stack-220x234.png
 sources:
 - https://github.com/bitnami/bitnami-docker-mediawiki
 maintainers:

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -45,41 +45,66 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the MediaWiki chart and their default values.
 
-|              Parameter               |               Description                |                         Default                         |
-|--------------------------------------|------------------------------------------|---------------------------------------------------------|
-| `image.registry`                     | MediaWiki image registry                 | `docker.io`                                             |
-| `image.repository`                   | MwdiaWiki Image name                     | `bitnami/mediawiki`                                     |
-| `image.tag`                          | MediaWiki Image tag                      | `{VERSION}`                                             |
-| `image.pullPolicy`                   | Image pull policy                        | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `image.pullSecrets`                  | Specify image pull secrets               | `nil`                                                   |
-| `mediawikiUser`                      | User of the application                  | `user`                                                  |
-| `mediawikiPassword`                  | Application password                     | _random 10 character long alphanumeric string_          |
-| `mediawikiEmail`                     | Admin email                              | `user@example.com`                                      |
-| `mediawikiName`                      | Name for the wiki                        | `My Wiki`                                               |
-| `allowEmptyPassword`                 | Allow DB blank passwords                 | `yes`                                                   |
-| `smtpHost`                           | SMTP host                                | `nil`                                                   |
-| `smtpPort`                           | SMTP port                                | `nil`                                                   |
-| `smtpHostID`                         | SMTP host ID                             | `nil`                                                   |
-| `smtpUser`                           | SMTP user                                | `nil`                                                   |
-| `smtpPassword`                       | SMTP password                            | `nil`                                                   |
-| `externalDatabase.host`              | Host of the external database            | `nil`                                                   |
-| `externalDatabase.user`              | Existing username in the external db     | `bn_mediawiki`                                          |
-| `externalDatabase.password`          | Password for the above username          | `nil`                                                   |
-| `externalDatabase.database`          | Name of the existing database             | `bitnami_mediawiki`                                     |
-| `mariadb.enabled`                    | Use or not the mariadb chart             | `true`                                                  |
-| `mariadb.mariadbRootPassword`        | MariaDB admin password                   | `nil`                                                   |
-| `mariadb.mariadbDatabase`            | Database name to create                  | `bitnami_mediawiki`                                     |
-| `mariadb.mariadbUser`                | Database user to create                  | `bn_mediawiki`                                          |
-| `mariadb.mariadbPassword`            | Password for the database                | _random 10 character long alphanumeric string_          |
-| `serviceType`                        | Kubernetes Service type                  | `LoadBalancer`                                          |
-| `persistence.enabled`                | Enable persistence using PVC             | `true`                                                  |
-| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume      | `nil` (uses alpha storage class annotation)             |
-| `persistence.apache.accessMode`      | PVC Access Mode for Apache volume        | `ReadWriteOnce`                                         |
-| `persistence.apache.size`            | PVC Storage Request for Apache volume    | `1Gi`                                                   |
-| `persistence.mediawiki.storageClass` | PVC Storage Class for MediaWiki volume   | `nil` (uses alpha storage class annotation)   |
-| `persistence.mediawiki.accessMode`   | PVC Access Mode for MediaWiki volume     | `ReadWriteOnce`                                         |
-| `persistence.mediawiki.size`         | PVC Storage Request for MediaWiki volume | `8Gi`                                                   |
-| `resources`                          | CPU/Memory resource requests/limits      | Memory: `512Mi`, CPU: `300m`                            |
+|              Parameter               |               Description                                   |                         Default                         |
+|--------------------------------------|-------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                     | MediaWiki image registry                                    | `docker.io`                                             |
+| `image.repository`                   | MwdiaWiki Image name                                        | `bitnami/mediawiki`                                     |
+| `image.tag`                          | MediaWiki Image tag                                         | `{VERSION}`                                             |
+| `image.pullPolicy`                   | Image pull policy                                           | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullSecrets`                  | Specify image pull secrets                                  | `nil`                                                   |
+| `mediawikiUser`                      | User of the application                                     | `user`                                                  |
+| `mediawikiPassword`                  | Application password                                        | _random 10 character long alphanumeric string_          |
+| `mediawikiEmail`                     | Admin email                                                 | `user@example.com`                                      |
+| `mediawikiName`                      | Name for the wiki                                           | `My Wiki`                                               |
+| `allowEmptyPassword`                 | Allow DB blank passwords                                    | `yes`                                                   |
+| `smtpHost`                           | SMTP host                                                   | `nil`                                                   |
+| `smtpPort`                           | SMTP port                                                   | `nil`                                                   |
+| `smtpHostID`                         | SMTP host ID                                                | `nil`                                                   |
+| `smtpUser`                           | SMTP user                                                   | `nil`                                                   |
+| `smtpPassword`                       | SMTP password                                               | `nil`                                                   |
+| `externalDatabase.host`              | Host of the external database                               | `nil`                                                   |
+| `externalDatabase.user`              | Existing username in the external db                        | `bn_mediawiki`                                          |
+| `externalDatabase.password`          | Password for the above username                             | `nil`                                                   |
+| `externalDatabase.database`          | Name of the existing database                               | `bitnami_mediawiki`                                     |
+| `mariadb.enabled`                    | Use or not the mariadb chart                                | `true`                                                  |
+| `mariadb.mariadbRootPassword`        | MariaDB admin password                                      | `nil`                                                   |
+| `mariadb.mariadbDatabase`            | Database name to create                                     | `bitnami_mediawiki`                                     |
+| `mariadb.mariadbUser`                | Database user to create                                     | `bn_mediawiki`                                          |
+| `mariadb.mariadbPassword`            | Password for the database                                   | _random 10 character long alphanumeric string_          |
+| `service.type`                       | Kubernetes Service type                                     | `LoadBalancer`                                          |
+| `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                        | `nil`                                                   |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Local`                                                 |
+| `service.nodePorts.http`             | Kubernetes http node port                                   | `""`                                                    |
+| `service.nodePorts.https`            | Kubernetes https node port                                  | `""`                                                    |
+| `ingress.enabled`                    | Enable ingress controller resource                          | `false`                                                 |
+| `ingress.hosts[0].name`              | Hostname to your Mediawiki installation                     | `mediawiki.local`                                       |
+| `ingress.hosts[0].path`              | Path within the url structure                               | `/`                                                     |
+| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                              | `false`                                                 |
+| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                   | `mediawiki.local-tls-secret`                            |
+| `ingress.hosts[0].annotations`       | Annotations for this host's ingress record                  | `[]`                                                    |
+| `ingress.secrets[0].name`            | TLS Secret Name                                             | `nil`                                                   |
+| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                      | `nil`                                                   |
+| `ingress.secrets[0].key`             | TLS Secret Key                                              | `nil`                                                   |
+| `persistence.enabled`                | Enable persistence using PVC                                | `true`                                                  |
+| `persistence.apache.storageClass`    | PVC Storage Class for Apache volume                         | `nil` (uses alpha storage class annotation)             |
+| `persistence.apache.accessMode`      | PVC Access Mode for Apache volume                           | `ReadWriteOnce`                                         |
+| `persistence.apache.size`            | PVC Storage Request for Apache volume                       | `1Gi`                                                   |
+| `persistence.mediawiki.storageClass` | PVC Storage Class for MediaWiki volume                      | `nil` (uses alpha storage class annotation)             |
+| `persistence.mediawiki.accessMode`   | PVC Access Mode for MediaWiki volume                        | `ReadWriteOnce`                                         |
+| `persistence.mediawiki.size`         | PVC Storage Request for MediaWiki volume                    | `8Gi`                                                   |
+| `resources`                          | CPU/Memory resource requests/limits                         | Memory: `512Mi`, CPU: `300m`                            |
+| `livenessProbe.enabled`              | Enable/disable the liveness probe (ingest nodes pod)        | `true`                                                  |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated (ingest nodes pod) | 120                                                     |
+| `livenessProbe.periodSeconds`        | How often to perform the probe (ingest nodes pod)           | 10                                                      |
+| `livenessProbe.timeoutSeconds`       | When the probe times out (ingest nodes pod)                 | 5                                                       |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures to be considered failed        | 6                                                       |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes to be considered successful   | 1                                                       |
+| `readinessProbe.enabled`             | would you like a readinessProbe to be enabled               | `true`                                                  |
+| `readinessProbe.initialDelaySeconds` | Delay before readinessProbe is initiated (ingest nodes pod) | 30                                                      |
+| `readinessProbe.periodSeconds   `    | How often to perform the probe (ingest nodes pod)           | 10                                                      |
+| `readinessProbe.timeoutSeconds`      | When the probe times out (ingest nodes pod)                 | 5                                                       |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures to be considered failed        | 6                                                       |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes to be considered successful   | 1                                                       |
 
 The above parameters map to the env variables defined in [bitnami/mediawiki](http://github.com/bitnami/bitnami-docker-mediawiki). For more information please refer to the [bitnami/mediawiki](http://github.com/bitnami/bitnami-docker-mediawiki) image documentation.
 

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -50,7 +50,7 @@ The following table lists the configurable parameters of the MediaWiki chart and
 | `image.registry`                     | MediaWiki image registry                                    | `docker.io`                                             |
 | `image.repository`                   | MwdiaWiki Image name                                        | `bitnami/mediawiki`                                     |
 | `image.tag`                          | MediaWiki Image tag                                         | `{VERSION}`                                             |
-| `image.pullPolicy`                   | Image pull policy                                           | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullPolicy`                   | Image pull policy                                           | `Always`                                                |
 | `image.pullSecrets`                  | Specify image pull secrets                                  | `nil`                                                   |
 | `mediawikiUser`                      | User of the application                                     | `user`                                                  |
 | `mediawikiPassword`                  | Application password                                        | _random 10 character long alphanumeric string_          |

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:f59f68030aa5c50b9e776b813804875fac911f91c2aa384e991f37a795c5ae34
-generated: 2017-12-05T17:16:36.715765+01:00
+  version: 2.1.18
+digest: sha256:51ac4cf1a5969bb18ccc8958791d7a70b7c5f38ffcde3d959051d32a07070656
+generated: 2018-05-31T12:29:09.473261802+02:00

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.1.18
-digest: sha256:51ac4cf1a5969bb18ccc8958791d7a70b7c5f38ffcde3d959051d32a07070656
-generated: 2018-05-31T12:29:09.473261802+02:00
+digest: sha256:fb5da9866e8795f850a6f4f2473dc4d7a4aa8b804a784b71f54b1aca67a16bf6
+generated: 2018-06-04T17:57:19.543696212+02:00

--- a/stable/mediawiki/requirements.yaml
+++ b/stable/mediawiki/requirements.yaml
@@ -1,5 +1,7 @@
 dependencies:
 - name: mariadb
-  version: 0.7.0
+  version: 2.1.18
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
+  tags:
+    - mediawiki-database

--- a/stable/mediawiki/requirements.yaml
+++ b/stable/mediawiki/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  version: 2.1.18
+  version: 2.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled
   tags:

--- a/stable/mediawiki/templates/NOTES.txt
+++ b/stable/mediawiki/templates/NOTES.txt
@@ -2,20 +2,20 @@
 
 1. Get the MediaWiki URL by running:
 
-{{- if contains "NodePort" .Values.serviceType }}
+{{- if contains "NodePort" .Values.service.type }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mediawiki.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT/
 
-{{- else if contains "LoadBalancer" .Values.serviceType }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "mediawiki.fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mediawiki.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP/
-{{- else if contains "ClusterIP"  .Values.serviceType }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mediawiki.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8080/
@@ -39,6 +39,6 @@ host. To configure MediaWiki to use and external database host:
 
 1. Complete your MediaWiki deployment by running:
 
-  helm upgrade {{ .Release.Name }} --set serviceType={{ .Values.serviceType }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/mediawiki
+  helm upgrade {{ .Release.Name }} --set service.type={{ .Values.service.type }},mariadb.enabled=false,externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST stable/mediawiki
 
 {{- end}}

--- a/stable/mediawiki/templates/_helpers.tpl
+++ b/stable/mediawiki/templates/_helpers.tpl
@@ -26,7 +26,8 @@ Create chart name and version as used by the chart label.
 Return the proper Mediawiki image name
 */}}
 {{- define "mediawiki.image" -}}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
 {{- end -}}
 
 {{/*

--- a/stable/mediawiki/templates/_helpers.tpl
+++ b/stable/mediawiki/templates/_helpers.tpl
@@ -16,6 +16,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mediawiki.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper Mediawiki image name
+*/}}
+{{- define "mediawiki.image" -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/mediawiki/templates/apache-pvc.yaml
+++ b/stable/mediawiki/templates/apache-pvc.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ template "mediawiki.fullname" . }}-apache
   labels:
     app: {{ template "mediawiki.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: {{ template "mediawiki.chart" . }}
+    release: {{ $.Release.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}
@@ -18,7 +18,7 @@ spec:
 {{- if (eq "-" .Values.persistence.apache.storageClass) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.persistence.apache.storageClass }}"
+  storageClassName: {{ .Values.persistence.apache.storageClass | quote }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/stable/mediawiki/templates/apache-pvc.yaml
+++ b/stable/mediawiki/templates/apache-pvc.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "mediawiki.fullname" . }}
     chart: {{ template "mediawiki.chart" . }}
-    release: {{ $.Release.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.apache.accessMode | quote }}

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ template "mediawiki.fullname" . }}
   labels:
     app: {{ template "mediawiki.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: {{ template "mediawiki.chart" . }}
+    release: {{ $.Release.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
 spec:
   replicas: 1
   template:
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "mediawiki.fullname" . }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ template "mediawiki.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
@@ -73,19 +73,29 @@ spec:
           value: {{ .Values.mediawikiEmail | quote }}
         - name: MEDIAWIKI_WIKI_NAME
           value: {{ .Values.mediawikiName | quote }}
+        {{- if .Values.smtpHostID }}
         - name: SMTP_HOST_ID
           value: {{ .Values.smtpHostID | quote }}
+        {{- end }}
+        {{- if .Values.smtpHost }}
         - name: SMTP_HOST
           value: {{ .Values.smtpHost | quote }}
+        {{- end }}
+        {{- if .Values.smtpPort }}
         - name: SMTP_PORT
           value: {{ .Values.smtpPort | quote }}
+        {{- end }}
+        {{- if .Values.smtpUser }}
         - name: SMTP_USER
           value: {{ .Values.smtpUser | quote }}
+        {{- end }}
+        {{- if .Values.smtpPassword }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mediawiki.fullname" . }}
               key: smtp-password
+        {{- end }}
         ports:
         - name: http
           containerPort: 80
@@ -95,12 +105,12 @@ spec:
           httpGet:
             path: /index.php
             port: http
-          initialDelaySeconds: 120
+{{ toYaml .Values.livenessProbe | indent 10 }}
         readinessProbe:
           httpGet:
             path: /index.php
             port: http
-          initialDelaySeconds: 30
+{{ toYaml .Values.readinessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "mediawiki.fullname" . }}
     chart: {{ template "mediawiki.chart" . }}
-    release: {{ $.Release.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   replicas: 1
   template:
@@ -101,18 +101,30 @@ spec:
           containerPort: 80
         - name: https
           containerPort: 443
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /index.php
             port: http
-{{ toYaml .Values.livenessProbe | indent 10 }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /index.php
             port: http
-{{ toYaml .Values.readinessProbe | indent 10 }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- end }}
         volumeMounts:
         - name: mediawiki-data
           mountPath: /bitnami/mediawiki

--- a/stable/mediawiki/templates/externaldb-secrets.yaml
+++ b/stable/mediawiki/templates/externaldb-secrets.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
   labels:
     app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: {{ template "mediawiki.chart" . }}
+    release: {{ $.Release.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
 type: Opaque
 data:
   db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}

--- a/stable/mediawiki/templates/externaldb-secrets.yaml
+++ b/stable/mediawiki/templates/externaldb-secrets.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
     chart: {{ template "mediawiki.chart" . }}
-    release: {{ $.Release.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
   db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}

--- a/stable/mediawiki/templates/ingress.yaml
+++ b/stable/mediawiki/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
+  labels:
+    app: {{ template "mediawiki.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: {{ $.Release.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
+  annotations:
+    {{- if .tls }}
+    ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "mediawiki.fullname" $ }}
+            servicePort: 80
+{{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/stable/mediawiki/templates/mediawiki-pvc.yaml
+++ b/stable/mediawiki/templates/mediawiki-pvc.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ template "mediawiki.fullname" . }}-mediawiki
   labels:
     app: {{ template "mediawiki.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: {{ template "mediawiki.chart" . }}
+    release: {{ $.Release.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.mediawiki.accessMode | quote }}
@@ -18,7 +18,7 @@ spec:
 {{- if (eq "-" .Values.persistence.mediawiki.storageClass) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.persistence.mediawiki.storageClass }}"
+  storageClassName: {{ .Values.persistence.mediawiki.storageClass | quote }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/stable/mediawiki/templates/mediawiki-pvc.yaml
+++ b/stable/mediawiki/templates/mediawiki-pvc.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "mediawiki.fullname" . }}
     chart: {{ template "mediawiki.chart" . }}
-    release: {{ $.Release.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.mediawiki.accessMode | quote }}

--- a/stable/mediawiki/templates/secrets.yaml
+++ b/stable/mediawiki/templates/secrets.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ template "mediawiki.fullname" . }}
   labels:
     app: {{ template "mediawiki.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: {{ template "mediawiki.chart" . }}
+    release: {{ $.Release.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
 type: Opaque
 data:
   {{ if .Values.mediawikiPassword }}
@@ -14,4 +14,6 @@ data:
   {{ else }}
   mediawiki-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
-  smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
+  {{ if .Values.smtpPassword }}
+  smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
+  {{ end }}

--- a/stable/mediawiki/templates/secrets.yaml
+++ b/stable/mediawiki/templates/secrets.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app: {{ template "mediawiki.fullname" . }}
     chart: {{ template "mediawiki.chart" . }}
-    release: {{ $.Release.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
   {{ if .Values.mediawikiPassword }}

--- a/stable/mediawiki/templates/svc.yaml
+++ b/stable/mediawiki/templates/svc.yaml
@@ -5,19 +5,28 @@ metadata:
   labels:
     app: {{ template "mediawiki.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
-  type: {{ .Values.serviceType }}
-  {{ if .Values.serviceLoadBalancerIP -}}
-  loadBalancerIP: {{ .Values.serviceLoadBalancerIP }}
-  {{ end -}}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
   ports:
   - name: http
     port: 80
     targetPort: http
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.http)))}}
+    nodePort: {{ .Values.service.nodePorts.http }}
+    {{- end }}
   - name: https
     port: 443
     targetPort: https
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePorts.https)))}}
+    nodePort: {{ .Values.service.nodePorts.https }}
+    {{- end }}
   selector:
     app: {{ template "mediawiki.fullname" . }}

--- a/stable/mediawiki/templates/tls-secrets.yaml
+++ b/stable/mediawiki/templates/tls-secrets.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     app: {{ template "mediawiki.fullname" . }}
     chart: {{ template "mediawiki.chart" . }}
-    release: {{ $.Release.Name | quote }}
-    heritage: {{ $.Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}

--- a/stable/mediawiki/templates/tls-secrets.yaml
+++ b/stable/mediawiki/templates/tls-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "mediawiki.fullname" . }}
+    chart: {{ template "mediawiki.chart" . }}
+    release: {{ $.Release.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -9,7 +9,7 @@ image:
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -114,14 +114,79 @@ mariadb:
     accessMode: ReadWriteOnce
     size: 8Gi
 
-## Kubernetes configuration
+## Kubernetes svc configuration
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer
 ##
 ## Use serviceLoadBalancerIP to request a specific static IP,
 ## otherwise leave blank
 ##
-serviceType: LoadBalancer
-# serviceLoadBalancerIP:
+service:
+  ## Kubernetes svc type
+  ## For minikube, set this to NodePort, elsewhere use LoadBalancer
+  ##
+  type: LoadBalancer
+  ## Use serviceLoadBalancerIP to request a specific static IP,
+  ## otherwise leave blank
+  ##
+  # loadBalancerIP:
+  ## Use nodePorts to requets some specific ports when usin NodePort
+  ## nodePorts:
+  ##   http: <to set explicitly, choose port between 30000-32767>
+  ##   https: <to set explicitly, choose port between 30000-32767>
+  ##
+  nodePorts:
+    http: ""
+    https: ""
+  ## Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Local
+
+## Configure the ingress resource that allows you to access the
+## Mediawiki installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  enabled: false
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: mediawiki.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    ## A side effect of this will be that the backend mediawiki service will be connected at port 443
+    tls: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: mediawiki.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## If you're using kube-lego, you will want to add:
+    ## kubernetes.io/tls-acme: true
+    ##
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+    #  kubernetes.io/tls-acme: true
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: mediawiki.local-tls
+  #   key:
+  #   certificate:
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -129,7 +194,7 @@ serviceType: LoadBalancer
 persistence:
   enabled: true
   apache:
-    ## apache data Persistent Volume Storage Class
+    ## Apache data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
     ## If undefined (the default) or set to null, no storageClassName spec is
@@ -140,7 +205,7 @@ persistence:
     accessMode: ReadWriteOnce
     size: 1Gi
   mediawiki:
-    ## mediawiki data Persistent Volume Storage Class
+    ## Mediawiki data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
     ## If undefined (the default) or set to null, no storageClassName spec is
@@ -158,3 +223,18 @@ resources:
   requests:
     memory: 512Mi
     cpu: 300m
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR provides several improvements to Mediawiki Helm Chart:

 - Add Ingress and TLS Secret to allow the user configure a Ingress Rule for Mediawiki
 - Improve configurable parameters for services, readiness/liveness probes, etc.
 - Improve README.md file and helpers
 - Update MariaDB requirement.
