### PR TITLE
Chartmuseum svc account

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 1.4.0
+version: 1.5.0
 appVersion: 0.7.0
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -64,6 +64,7 @@ their default values. See values.yaml for all available options.
 | `resources.requests.memory`            | Container requested memory                  | `64Mi`                                              |
 | `serviceAccount.create`                | If true, create the service account         | `false`                                             |
 | `serviceAccount.name`                  | Name of the serviceAccount to create or use | `{{ chartmuseum.fullname }}`                        |
+| `securityContext`                      | Map of securityContext for the pod          | `{}`                                                |
 | `nodeSelector`                         | Map of node labels for pod assignment       | `{}`                                                |
 | `tolerations`                          | List of node taints to tolerate             | `[]`                                                |
 | `affinity`                             | Map of node/pod affinities                  | `{}`                                                |

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -62,6 +62,8 @@ their default values. See values.yaml for all available options.
 | `resources.limits.memory`              | Container maximum memory                    | `128Mi`                                             |
 | `resources.requests.cpu`               | Container requested CPU                     | `80m`                                               |
 | `resources.requests.memory`            | Container requested memory                  | `64Mi`                                              |
+| `serviceAccount.create`                | If true, create the service account         | `false`                                             |
+| `serviceAccount.name`                  | Name of the serviceAccount to create or use | `{{ chartmuseum.fullname }}`                        |
 | `nodeSelector`                         | Map of node labels for pod assignment       | `{}`                                                |
 | `tolerations`                          | List of node taints to tolerate             | `[]`                                                |
 | `affinity`                             | Map of node/pod affinities                  | `{}`                                                |

--- a/stable/chartmuseum/templates/_helpers.tpl
+++ b/stable/chartmuseum/templates/_helpers.tpl
@@ -82,3 +82,14 @@ chartmuseum-0.4.5
 {{- define "chartmuseum.chartref" -}}
 {{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chartmuseum.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "chartmuseum.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/chartmuseum/templates/_helpers.tpl
+++ b/stable/chartmuseum/templates/_helpers.tpl
@@ -82,14 +82,3 @@ chartmuseum-0.4.5
 {{- define "chartmuseum.chartref" -}}
 {{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
 {{- end -}}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "chartmuseum.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "chartmuseum.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -92,6 +92,10 @@ spec:
     {{- if or .Values.serviceAccount.name .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "chartmuseum.serviceAccountName" .) }}
     {{- end }}
+    {{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
       - name: storage-volume
       {{- if .Values.persistence.enabled }}

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -89,8 +89,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if or .Values.serviceAccount.name .Values.serviceAccount.create }}
-      serviceAccountName: {{ .Values.serviceAccount.name | default (include "chartmuseum.serviceAccountName" .) }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "chartmuseum.fullname" . }}
+    {{- else if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
     {{- end }}
     {{- with .Values.securityContext }}
       securityContext:

--- a/stable/chartmuseum/templates/deployment.yaml
+++ b/stable/chartmuseum/templates/deployment.yaml
@@ -89,7 +89,9 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-
+    {{- if or .Values.serviceAccount.name .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "chartmuseum.serviceAccountName" .) }}
+    {{- end }}
       volumes:
       - name: storage-volume
       {{- if .Values.persistence.enabled }}

--- a/stable/chartmuseum/templates/serviceaccount.yaml
+++ b/stable/chartmuseum/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "chartmuseum.serviceAccountName" . }}
+  name: {{ include "chartmuseum.fullname" . }}
   labels:
 {{ include "chartmuseum.labels.standard" . | indent 4 }}
 {{- end -}}

--- a/stable/chartmuseum/templates/serviceaccount.yaml
+++ b/stable/chartmuseum/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "chartmuseum.serviceAccountName" . }}
+  labels:
+{{ include "chartmuseum.labels.standard" . | indent 4 }}
+{{- end -}}

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -128,6 +128,8 @@ serviceAccount:
   create: false
   # name:
 
+securityContext: {}
+
 nodeSelector: {}
 
 tolerations: []

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -124,6 +124,9 @@ probes:
     successThreshold: 1
     failureThreshold: 3
 
+serviceAccount:
+  create: false
+  # name:
 
 nodeSelector: {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

This PR adds support for ServiceAccount creation / use and for pod securityContext; none will be set by default.
On clusters with PSP enabled and a bit tightened, this chart might fail since `system:serviceaccount:{{ namespace }}:default` will likely be unable to run a container as root (image default)  

