### PR TITLE
[stable/minio] Use variable for kubernetes cluster name

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Distributed object storage server built for cloud applications and devops.
 name: minio
-version: 1.3.3
+version: 1.3.4
 appVersion: RELEASE.2018-04-27T23-33-52Z
 keywords:
 - storage

--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Distributed object storage server built for cloud applications and devops.
 name: minio
-version: 1.3.4
+version: 1.4.0
 appVersion: RELEASE.2018-04-27T23-33-52Z
 keywords:
 - storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -84,6 +84,7 @@ The following table lists the configurable parameters of the Minio chart and the
 | `ingress.annotations`      | Ingress annotations                 | `{}`                                                    |
 | `ingress.hosts`            | Ingress accepted hostnames          | `[]`                                                    |
 | `ingress.tls`              | Ingress TLS configuration           | `[]`                                                    |
+| `kubernetesClusterName`    | Name of the Kubernetes cluster      | `cluster.local`                                         |
 | `mode`                     | Minio server mode (`standalone`, `shared` or `distributed`)| `standalone`                     |
 | `replicas`                 | Number of nodes (applicable only for Minio distributed mode). Should be 4 <= x <= 16 | `4`    |
 | `accessKey`                | Default access key (5 to 20 characters) | `AKIAIOSFODNN7EXAMPLE`                              |

--- a/stable/minio/templates/NOTES.txt
+++ b/stable/minio/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{- if eq .Values.service.type "ClusterIP" "NodePort" }}
 Minio can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
-{{ template "minio.fullname" . }}-svc.{{ .Release.Namespace }}.svc.{{ .Values.kubernetes_cluster_name }}
+{{ template "minio.fullname" . }}-svc.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterName }}
 
 To access Minio from localhost, run the below commands:
 

--- a/stable/minio/templates/NOTES.txt
+++ b/stable/minio/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{- if eq .Values.service.type "ClusterIP" "NodePort" }}
 Minio can be accessed via port {{ .Values.service.port }} on the following DNS name from within your cluster:
-{{ template "minio.fullname" . }}-svc.{{ .Release.Namespace }}.svc.cluster.local
+{{ template "minio.fullname" . }}-svc.{{ .Release.Namespace }}.svc.{{ .Values.kubernetes_cluster_name }}
 
 To access Minio from localhost, run the below commands:
 

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - server
             {{- range $i := until $nodeCount }}
-            - http://{{ template "minio.fullname" $ }}-{{ $i }}.{{ template "minio.fullname" $ }}.{{ $.Release.Namespace }}.svc.{{ .Values.kubernetes_cluster_name }}{{ $.Values.mountPath }}
+            - http://{{ template "minio.fullname" $ }}-{{ $i }}.{{ template "minio.fullname" $ }}.{{ $.Release.Namespace }}.svc.{{ .Values.kubernetesClusterName }}{{ $.Values.mountPath }}
             {{- end }}
             {{- end }}
           volumeMounts:

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - server
             {{- range $i := until $nodeCount }}
-            - http://{{ template "minio.fullname" $ }}-{{ $i }}.{{ template "minio.fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local{{ $.Values.mountPath }}
+            - http://{{ template "minio.fullname" $ }}-{{ $i }}.{{ template "minio.fullname" $ }}.{{ $.Release.Namespace }}.svc.{{ .Values.kubernetes_cluster_name }}{{ $.Values.mountPath }}
             {{- end }}
             {{- end }}
           volumeMounts:

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -20,7 +20,7 @@ mode: standalone
 
 ## Kubernetes cluster name
 ##
-kubernetes_cluster_name: cluster.local
+kubernetesClusterName: cluster.local
 
 ## Set default accesskey, secretkey, Minio config file path, volume mount path and
 ## number of nodes (only used for Minio distributed mode)

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -18,6 +18,10 @@ mcImage:
 ##
 mode: standalone
 
+## Kubernetes cluster name
+##
+kubernetes_cluster_name: cluster.local
+
 ## Set default accesskey, secretkey, Minio config file path, volume mount path and
 ## number of nodes (only used for Minio distributed mode)
 ## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: This PR adds a variable for kubernetes cluster name, instead of always using `cluster.local`

**Which issue this PR fixes**: fixes #5797 
