### PR TITLE
README: Add persistence.existingClaim

### DIFF
--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `service.loadBalancerSourceRanges`          | Kubernetes service LB Allowed inbound IP addresses | 0.0.0.0/0                            |
 | `service.loadBalancerIP`                    | Kubernetes service LB Optional fixed external IP   | None                                       |
 | `persistence.enabled`                       | Flag for enabling persistent storage      | false                                      |
+| `persistence.existingClaim`	                | Name of existing PersistentVolumeClaim	  | `nil`                                      |
 | `persistence.storageClass`                  | Storage class to be used                  | "-"                                        |
 | `persistence.accessMode`                    | Volumes access mode to be set             | `ReadWriteOnce`                            |
 | `persistence.size`                          | Size of the volume                        | `10Gi`                                     |


### PR DESCRIPTION
**What this PR does / why we need it**:

Add persistence.existingClaim to configuration table in README so users are aware of it without looking through the templates.