### PR TITLE
[stable/keycloak] Add option to specify extra init containers

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 1.0.0
+version: 1.1.0
 appVersion: 3.4.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -29,8 +29,9 @@ spec:
         - name: {{ . }}
       {{- end}}
     {{- end }}
-    {{- if .Values.keycloak.persistence.deployPostgres }}
+    {{- if or .Values.keycloak.persistence.deployPostgres .Values.keycloak.extraInitContainers }}
       initContainers:
+      {{- if .Values.keycloak.persistence.deployPostgres }}
         - name: wait-for-postgresql
           image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
           imagePullPolicy: {{ .Values.init.image.pullPolicy }}
@@ -43,6 +44,10 @@ spec:
               done;
 
               echo 'PostgreSQL OK ✓'
+      {{- end }}
+      {{- if .Values.keycloak.extraInitContainers }}
+{{ toYaml .Values.keycloak.extraInitContainers | indent 8 }}
+      {{- end }}
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -23,6 +23,9 @@ keycloak:
     fsGroup: 1000
     runAsNonRoot: true
 
+  ## Additional init containers, e. g. for providing custom themes
+  extraInitContainers: []
+
   ## Custom script that is run before Keycloak is started.
   preStartScript:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the option to configure extra init containers which could be used as providers for installing additional components such as themes.

**Which issue this PR fixes**:

Fixes #4633

