### PR TITLE
[stable/phpmyadmin] Use string instead of int in the tag

### DIFF
--- a/stable/phpmyadmin/Chart.yaml
+++ b/stable/phpmyadmin/Chart.yaml
@@ -1,5 +1,5 @@
 name: phpmyadmin
-version: 0.1.4
+version: 0.1.5
 appVersion: 4.8.0
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/stable/phpmyadmin/templates/_helpers.tpl
+++ b/stable/phpmyadmin/templates/_helpers.tpl
@@ -45,6 +45,6 @@ Return the proper image name
 {{- define "phpmyadmin.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag -}}
+{{- $tag := .Values.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}

--- a/stable/phpmyadmin/templates/_helpers.tpl
+++ b/stable/phpmyadmin/templates/_helpers.tpl
@@ -45,6 +45,6 @@ Return the proper image name
 {{- define "phpmyadmin.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | quote | trimAll "\"" -}}
+{{- $tag := .Values.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}

--- a/stable/phpmyadmin/templates/_helpers.tpl
+++ b/stable/phpmyadmin/templates/_helpers.tpl
@@ -45,6 +45,6 @@ Return the proper image name
 {{- define "phpmyadmin.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
+{{- $tag := .Values.image.tag | quote | trimAll "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}


### PR DESCRIPTION
Test fails because the image name is not correct after it is renderer by the template:
```
{{/*
Return the proper image name
*/}}
{{- define "phpmyadmin.image" -}}
{{- $registryName :=  .Values.image.registry -}}
{{- $repositoryName := .Values.image.repository -}}
{{- $tag := .Values.image.tag -}}
{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
{{- end -}}
```
The issue:
```
$ k get pods
NAME                                            READY     STATUS                       RESTARTS   AGE
anxious-greyhound-phpmyadmin-7bc55fff4c-5s2hl   0/1       InvalidImageName
```
```
Image:          docker.io/bitnami/phpmyadmin:%!s(float64=4)
```