### PR TITLE
[stable/redis] Use string instead of int in the tag

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.3.3
+version: 3.3.4
 appVersion: 4.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/_helpers.tpl
+++ b/stable/redis/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Return the proper image name
 {{- define "redis.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | quote | trimAll "\"" -}}
+{{- $tag := .Values.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
@@ -58,7 +58,7 @@ Return the proper image name (for the metrics image)
 {{- define "metrics.image" -}}
 {{- $registryName :=  .Values.metrics.image.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag | quote | trimAll "\"" -}}
+{{- $tag := .Values.metrics.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 

--- a/stable/redis/templates/_helpers.tpl
+++ b/stable/redis/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Return the proper image name
 {{- define "redis.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag -}}
+{{- $tag := .Values.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
@@ -58,11 +58,11 @@ Return the proper image name (for the metrics image)
 {{- define "metrics.image" -}}
 {{- $registryName :=  .Values.metrics.image.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag -}}
+{{- $tag := .Values.metrics.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
-{{/* 
+{{/*
 Return slave readiness probe
 */}}
 {{- define "redis.slave.readinessProbe" -}}

--- a/stable/redis/templates/_helpers.tpl
+++ b/stable/redis/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Return the proper image name
 {{- define "redis.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
+{{- $tag := .Values.image.tag | quote | trimAll "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
@@ -58,7 +58,7 @@ Return the proper image name (for the metrics image)
 {{- define "metrics.image" -}}
 {{- $registryName :=  .Values.metrics.image.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
+{{- $tag := .Values.metrics.image.tag | quote | trimAll "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 


### PR DESCRIPTION
Test fails because the image name is not correct after it is renderer by the template:
```
{{/*
Return the proper image name
*/}}
{{- define "redis.image" -}}
{{- $registryName :=  .Values.image.registry -}}
{{- $repositoryName := .Values.image.repository -}}
{{- $tag := .Values.image.tag -}}
{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
{{- end -}}
```
The issue:
```
$ k get pods
NAME                                            READY     STATUS                       RESTARTS   AGE
anxious-greyhound-redis-7bc55fff4c-5s2hl   0/1       InvalidImageName
```
```
Image:          docker.io/bitnami/redis:%!s(float64=4)
```