### PR TITLE
[stable/mongodb] Use string instead of int in the tag

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 2.0.6
+version: 2.0.7
 appVersion: 3.6.5
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -21,6 +21,6 @@ Return the proper image name
 {{- define "mongodb.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag -}}
+{{- $tag := .Values.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -21,6 +21,6 @@ Return the proper image name
 {{- define "mongodb.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
+{{- $tag := .Values.image.tag | quote | trimAll "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -21,6 +21,6 @@ Return the proper image name
 {{- define "mongodb.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | quote | trimAll "\"" -}}
+{{- $tag := .Values.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}


### PR DESCRIPTION
Test fails because the image name is not correct after it is renderer by the template:
```
{{/*
Return the proper image name
*/}}
{{- define "mongodb.image" -}}
{{- $registryName :=  .Values.image.registry -}}
{{- $repositoryName := .Values.image.repository -}}
{{- $tag := .Values.image.tag -}}
{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
{{- end -}}
```
The issue:
```
$ k get pods
NAME                                            READY     STATUS                       RESTARTS   AGE
anxious-greyhound-mongodb-7bc55fff4c-5s2hl   0/1       InvalidImageName
```
```
Image:          docker.io/bitnami/mongodb:%!s(float64=4)
```