### PR TITLE
[stable/mariadb] Use string instead of int in the tag

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 4.2.0
+version: 4.2.1
 appVersion: 10.1.33
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Return the proper image name
 {{- define "mariadb.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
+{{- $tag := .Values.image.tag | quote | trimAll "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
@@ -48,6 +48,6 @@ Return the proper image name
 {{- define "metrics.image" -}}
 {{- $registryName :=  .Values.metrics.mage.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
+{{- $tag := .Values.metrics.image.tag | quote | trimAll "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Return the proper image name
 {{- define "mariadb.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | quote | trimAll "\"" -}}
+{{- $tag := .Values.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
@@ -48,6 +48,6 @@ Return the proper image name
 {{- define "metrics.image" -}}
 {{- $registryName :=  .Values.metrics.mage.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag | quote | trimAll "\"" -}}
+{{- $tag := .Values.metrics.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -38,7 +38,7 @@ Return the proper image name
 {{- define "mariadb.image" -}}
 {{- $registryName :=  .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag -}}
+{{- $tag := .Values.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
@@ -48,6 +48,6 @@ Return the proper image name
 {{- define "metrics.image" -}}
 {{- $registryName :=  .Values.metrics.mage.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
-{{- $tag := .Values.metrics.image.tag -}}
+{{- $tag := .Values.metrics.image.tag | quote | trimPrefix "\"" | trimSuffix "\"" -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}


### PR DESCRIPTION
Test fails because the image name is not correct after it is renderer by the template:
```
{{/*
Return the proper image name
*/}}
{{- define "mariadb.image" -}}
{{- $registryName :=  .Values.image.registry -}}
{{- $repositoryName := .Values.image.repository -}}
{{- $tag := .Values.image.tag -}}
{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
{{- end -}}
```
The issue:
```
$ k get pods
NAME                                            READY     STATUS                       RESTARTS   AGE
anxious-greyhound-mariadb-7bc55fff4c-5s2hl   0/1       InvalidImageName
```
```
Image:          docker.io/bitnami/mariadb:%!s(float64=4)
```