### PR TITLE
[stable/etcd-operator] Applied pre-install hooks to deployments

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.7.7
-appVersion: 0.7.0
+version: 0.8.0
+appVersion: 0.9.2
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png
 sources:

--- a/stable/etcd-operator/templates/backup-etcd-crd.yaml
+++ b/stable/etcd-operator/templates/backup-etcd-crd.yaml
@@ -9,7 +9,9 @@ metadata:
     app: {{ template "etcd-backup-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   clusterName: {{ .Values.etcdCluster.name }}
 {{ toYaml .Values.backupOperator.spec | indent 2 }}

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deployments.backupOperator }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "etcd-backup-operator.fullname" . }}
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "etcd-backup-operator.fullname" . }}
+      release: {{ .Release.Name }}
   replicas: {{ .Values.backupOperator.replicaCount }}
   template:
     metadata:

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deployments.backupOperator }}
 ---
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "etcd-backup-operator.fullname" . }}
@@ -9,6 +9,8 @@ metadata:
     app: {{ template "etcd-backup-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "pre-install"
 spec:
   replicas: {{ .Values.backupOperator.replicaCount }}
   template:

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -9,8 +9,6 @@ metadata:
     app: {{ template "etcd-backup-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  annotations:
-    "helm.sh/hook": "pre-install"
 spec:
   replicas: {{ .Values.backupOperator.replicaCount }}
   template:

--- a/stable/etcd-operator/templates/etcd-cluster-crd.yaml
+++ b/stable/etcd-operator/templates/etcd-cluster-crd.yaml
@@ -9,6 +9,9 @@ metadata:
     app: {{ template "etcd-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   size: {{ .Values.etcdCluster.size }}
   version: "{{ .Values.etcdCluster.version }}"

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deployments.etcdOperator }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "etcd-operator.fullname" . }}
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "etcd-operator.fullname" . }}
+      release: {{ .Release.Name }}
   replicas: {{ .Values.etcdOperator.replicaCount }}
   template:
     metadata:

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -9,8 +9,6 @@ metadata:
     app: {{ template "etcd-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  annotations:
-    "helm.sh/hook": "pre-install"
 spec:
   replicas: {{ .Values.etcdOperator.replicaCount }}
   template:

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deployments.etcdOperator }}
 ---
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "etcd-operator.fullname" . }}
@@ -9,6 +9,8 @@ metadata:
     app: {{ template "etcd-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "pre-install"
 spec:
   replicas: {{ .Values.etcdOperator.replicaCount }}
   template:

--- a/stable/etcd-operator/templates/restore-etcd-crd.yaml
+++ b/stable/etcd-operator/templates/restore-etcd-crd.yaml
@@ -10,6 +10,9 @@ metadata:
     app: {{ template "etcd-restore-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   clusterSpec:
     size: {{ .Values.etcdCluster.size }}

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deployments.restoreOperator }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "etcd-restore-operator.fullname" . }}
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "etcd-restore-operator.name" . }}
+      release: {{ .Release.Name }}
   replicas: {{ .Values.restoreOperator.replicaCount }}
   template:
     metadata:

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -9,8 +9,6 @@ metadata:
     app: {{ template "etcd-restore-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  annotations:
-    "helm.sh/hook": "pre-install"
 spec:
   replicas: {{ .Values.restoreOperator.replicaCount }}
   template:

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.deployments.restoreOperator }}
 ---
-apiVersion: apps/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "etcd-restore-operator.fullname" . }}
@@ -9,6 +9,8 @@ metadata:
     app: {{ template "etcd-restore-operator.name" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "pre-install"
 spec:
   replicas: {{ .Values.restoreOperator.replicaCount }}
   template:

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -43,7 +43,7 @@ etcdOperator:
   replicaCount: 1
   image:
     repository: quay.io/coreos/etcd-operator
-    tag: v0.7.0
+    tag: v0.9.2
     pullPolicy: Always
   resources:
     cpu: 100m
@@ -75,7 +75,7 @@ backupOperator:
   replicaCount: 1
   image:
     repository: quay.io/coreos/etcd-operator
-    tag: v0.7.0
+    tag: v0.9.2
     pullPolicy: Always
   resources:
     cpu: 100m
@@ -98,7 +98,7 @@ restoreOperator:
   replicaCount: 1
   image:
     repository: quay.io/coreos/etcd-operator
-    tag: v0.7.0
+    tag: v0.9.2
     pullPolicy: Always
   port: 19999
   resources:
@@ -121,10 +121,10 @@ restoreOperator:
 etcdCluster:
   name: etcd-cluster
   size: 3
-  version: 3.2.10
+  version: 3.2.13
   image:
     repository: quay.io/coreos/etcd
-    tag: v3.2.10
+    tag: v3.2.13
     pullPolicy: Always
   enableTLS: false
   # TLS configs


### PR DESCRIPTION
 to allow for operators to deploy and register custom resources before creating a crd and avoid having helm push an error indicating as much.

**What this PR does / why we need it**: Should resolve issue where helm complains that it cannot deploy a crd whose kind doesnt exist currently in the cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5328

**Special notes for your reviewer**: Includes a few additional small changes to versions being used to keep up to date with current state of coreos/etcd-operator.
