### PR TITLE
[incubator/elasticsearch] Adding support for nodeSelector

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -11,7 +11,7 @@ sources:
 - https://github.com/giantswarm/kubernetes-elastic-stack
 - https://github.com/GoogleCloudPlatform/elasticsearch-docker
 maintainers:
-- name: Christian Simon
+- name: simonswine
   email: christian@jetstack.io
-- name: Michael Haselton
+- name: icereval
   email: michael.haselton@gmail.com

--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.4.10
+version: 0.5.0
 appVersion: 5.4
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.4.9
+version: 0.4.10
 appVersion: 5.4
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.resources`                   | Client node resources requests & limits                             | `{} - cpu limit must be an integer`  |
 | `client.heapSize`                    | Client node heap size                                               | `512m`                               |
 | `client.podAnnotations`              | Client Deployment annotations                                       | `{}`                                 |
+| `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                 |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                          |
 | `master.exposeHttp`                 | Expose http port 9200 on master Pods for monitoring, etc           | `false`                              |
@@ -74,6 +75,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.replicas`                    | Master node replicas (deployment)                                   | `2`                                  |
 | `master.resources`                   | Master node resources requests & limits                             | `{} - cpu limit must be an integer`  |
 | `master.podAnnotations`              | Master Deployment annotations                                       | `{}`                                 |
+| `master.nodeSelector`                | Node labels for master pod assignment                               | `{}`                                 |
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
@@ -91,6 +93,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.persistence.storageClass`      | Data persistent volume Class                                        | `nil`                                |
 | `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |
 | `data.podAnnotations`                | Data StatefulSet annotations                                        | `{}`                                 |
+| `data.nodeSelector`                  | Node labels for data pod assignment                                 | `{}`                                 |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
 | `rbac.create`                        | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                              |

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -45,6 +45,10 @@ spec:
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.client.name }}"
       {{- end }}
+{{- if .Values.client.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.client.nodeSelector | indent 8 }}
+{{- end }}
       initContainers:
       # see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
       # and https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#mlockall

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -46,6 +46,10 @@ spec:
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.data.name }}"
       {{- end }}
+{{- if .Values.data.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.data.nodeSelector | indent 8 }}
+{{- end }}
       initContainers:
       # see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
       # and https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#mlockall

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -46,6 +46,10 @@ spec:
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.master.name }}"
       {{- end }}
+{{- if .Values.master.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.master.nodeSelector | indent 8 }}
+{{- end }}
       initContainers:
       # see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
       # and https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration-memory.html#mlockall

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -28,6 +28,7 @@ client:
 
   heapSize: "512m"
   antiAffinity: "soft"
+  nodeSelector: {}
   resources:
     limits:
       cpu: "1"
@@ -52,6 +53,7 @@ master:
     size: "4Gi"
     # storageClass: "ssd"
   antiAffinity: "soft"
+  nodeSelector: {}
   resources:
     limits:
       cpu: "1"
@@ -77,6 +79,7 @@ data:
     # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"
+  nodeSelector: {}
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds `nodeSelector` to all deployments to allow forcing ES to run on a certain node pool within the cluster if needed.

This is a duplicate of https://github.com/kubernetes/charts/pull/5053 with some README tweaks in order to pass approval.