### PR TITLE
[incubator/kafka] Fix heapOptions template reference

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.7.2
+version: 0.7.3
 appVersion: 4.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -134,7 +134,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         - name: KAFKA_HEAP_OPTS
-          value: {{ .Values.heapOptions }}
+          value: {{ .Values.kafkaHeapOptions }}
         {{- if not (hasKey .Values.configurationOverrides "zookeeper.connect") }}
         - name: KAFKA_ZOOKEEPER_CONNECT
           value: {{ include "zookeeper.url" . | quote }}


### PR DESCRIPTION
* Change template reference in templates/statfulset.yaml
* Ran with helm install --dry-run --debug to see that new options are
added.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Fix incorrect reference to `kafkaHeapOptions` in `templates/statefulset.yaml`

fixes: https://github.com/kubernetes/charts/issues/5466

As mentioned in the issue you should be able to run
`helm install --dry-run --debug`
`kafkaHeapOptions` should be set
