### PR TITLE
[incubator/mysqlha] Allow configuration of MySQL master and slaves from values.yaml

### DIFF
--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 home: https://www.mysql.com/
 icon: https://www.mysql.com/common/logos/logo-mysql-170x115.png
 maintainers:
-  - name: Jason Poon
+  - name: jpoon
     email: jason.poon@microsoft.com
-  - name: Jon Hoare
+  - name: jonhoare
     email: jon.bitbucket@livewire-uk.co.uk

--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysqlha
-version: 0.2.2
+version: 0.3.0
 appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:

--- a/incubator/mysqlha/Chart.yaml
+++ b/incubator/mysqlha/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysqlha
-version: 0.2.1
+version: 0.2.2
 appVersion: 5.7.13
 description: MySQL cluster with a single master and zero or more slave replicas
 keywords:

--- a/incubator/mysqlha/README.md
+++ b/incubator/mysqlha/README.md
@@ -43,8 +43,10 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `mysqlPassword`            | Password for the new user.          | Randomly generated                     |
 | `mysqlReplicationUser`     | Username for replication user       | `repl`                                 |
 | `mysqlReplicationPassword` | Password for replication user.      | Randomly generated                     |
-| `mysqlDatabase`            | Name of the new Database to create  | `nil`                                  | 
-| `persistence.enabled`      | Create a volume to store data       | true                                   | 
+| `mysqlDatabase`            | Name of the new Database to create  | `nil`                                  |
+| `configFiles.master.cnf`   | Master configuration file           | See `values.yaml`                      |
+| `configFiles.slave.cnf`    | Slave configuration file            | See `values.yaml`                      |
+| `persistence.enabled`      | Create a volume to store data       | true                                   |
 | `persistence.size`         | Size of persistent volume claim     | 10Gi                                   |
 | `persistence.storageClass` | Type of persistent volume claim     | `nil`                                  |
 | `persistence.accessModes`  | Persistent volume access modes      | `[ReadWriteOnce]`                      |

--- a/incubator/mysqlha/templates/configmap.yaml
+++ b/incubator/mysqlha/templates/configmap.yaml
@@ -8,16 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  master.cnf: |
-    # Apply this config only on the master.
-    [mysqld]
-    log-bin
-    skip_name_resolve
-  slave.cnf: |
-    # Apply this config only on slaves.
-    [mysqld]
-    super-read-only
-    skip_name_resolve
+{{ toYaml .Values.mysqlha.configFiles | indent 2 }}
   server-id.cnf: |
     [mysqld]
     server-id=@@SERVER_ID@@

--- a/incubator/mysqlha/values.yaml
+++ b/incubator/mysqlha/values.yaml
@@ -29,6 +29,20 @@ mysqlha:
   ## Create database with name and grant all permissions to user on startup, if needed
   # mysqlDatabase:
 
+  ## Configuration files for the master and slaves
+  ##
+  configFiles:
+    master.cnf: |
+      # Apply this config only on the master.
+      [mysqld]
+      log-bin
+      skip_name_resolve
+    slave.cnf: |
+      # Apply this config only on slaves.
+      [mysqld]
+      super-read-only
+      skip_name_resolve
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
**What this PR does / why we need it**:

I found myself needing to make tweaks to the configuration (e.g. setting `max_connections`). This allows that by moving the setting of the master/slave configuration files into values.yaml.

**Special notes for your reviewer**:

Please let me know if there is a different way you'd like me to go about this.
