### PR TITLE
[incubator/kubeless] Adding Kafka Trigger

### DIFF
--- a/incubator/kubeless/Chart.yaml
+++ b/incubator/kubeless/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubeless
-version: 1.0.3
+version: 1.0.4
 appVersion: v1.0.0-alpha.3
 description: Kubeless is a Kubernetes-native serverless framework. It runs on top of your Kubernetes cluster and allows you to deploy small unit of code without having to build container images.
 icon: https://cloud.githubusercontent.com/assets/4056725/25480209/1d5bf83c-2b48-11e7-8db8-bcd650f31297.png

--- a/incubator/kubeless/README.md
+++ b/incubator/kubeless/README.md
@@ -43,37 +43,47 @@ $ helm delete my-release
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Kafka Trigger
+
+Kubeless supports triggering functions via kafka events. More info here: https://kubeless.io/docs/use-existing-kafka/.
+To support this `rbac.create: true`, `kafkaTrigger.enabled: true`, `kafkaTrigger.env.kafkaBrokers: <your_kafka_brokers>` must be set.
+
 ## Configuration
 
 The following table lists the configurable parameters of the Kubeless chart and their default values.
 
-|                Parameter                 |          Description                       |            Default                    |
-|------------------------------------------|--------------------------------------------|---------------------------------------|
-| `config.builderImage`                    | Function builder image                     | `kubeless/function-image-builder`     |
-| `config.builderImagePullSecret`          | Secret to pull builder image               | ""                                    |
-| `config.builderImage`                    | Provision image                            | `kubeless/unzip`                      |
-| `config.builderImagePullSecret`          | Secret to pull provision image             | ""                                    |
-| `config.deploymentTemplate`              | Deployment template for functions          | `{}`                                  |
-| `config.enableBuildStep`                 | Enable builder functionality               | `false`                               |
-| `config.functionRegistryTLSVerify`       | Enable TLS verification for image registry | `{}`                                  |
-| `config.runtimeImages`                   | Runtimes available                         | python, nodejs, ruby, php and go      |
-| `controller.deployment.image.repository` | Controller image                           | `bitnami/kubeless-controller-manager` |
-| `controller.deployment.image.pullPolicy` | Controller image pull policy               | `IfNotPresent`                        |
-| `controller.deployment.replicaCount`     | Number of replicas                         | `1`                                   |
-| `ui.enabled`                             | Kubeless UI component                      | `false`                               |
-| `ui.deployment.ui.image.repository`      | Kubeless UI image                          | `bitnami/kubeless-ui`                 |
-| `ui.deployment.ui.image.pullPolicy`      | Kubeless UI image pull policy              | `IfNotPresent`                        |
-| `ui.deployment.proxy.image.repository`   | Proxy image                                | `kelseyhightower/kubectl`             |
-| `ui.deployment.proxy.image.pullPolicy`   | Proxy image pull policy                    | `IfNotPresent`                        |
-| `ui.deployment.replicaCount`             | Number of replicas                         | `1`                                   |
-| `ui.service.name`                        | Service name                               | `ui-port`                             |
-| `ui.service.type`                        | Kubernetes service name                    | `NodePort`                            |
-| `ui.service.externalPort`                | Service external port                      | `3000`                                |
-| `ui.ingress.enabled`                     | Kubeless UI ingress switch                 | `false`                               |
-| `ui.ingress.annotations`                 | Kubeless UI ingress annotations            | `{}`                                  |
-| `ui.ingress.path`                        | Kubeless UI ingress path                   | `{}`                                  |
-| `ui.ingress.hosts`                       | Kubeless UI ingress hosts                  | `[chart-example.local]`               |
-| `ui.ingress.tls`                         | Kubeless UI ingress TLS                    | `[]`                                  |
+|                Parameter                       |          Description                       |            Default                    |
+|------------------------------------------------|--------------------------------------------|---------------------------------------|
+| `config.builderImage`                          | Function builder image                     | `kubeless/function-image-builder`     |
+| `config.builderImagePullSecret`                | Secret to pull builder image               | ""                                    |
+| `config.builderImage`                          | Provision image                            | `kubeless/unzip`                      |
+| `config.builderImagePullSecret`                | Secret to pull provision image             | ""                                    |
+| `config.deploymentTemplate`                    | Deployment template for functions          | `{}`                                  |
+| `config.enableBuildStep`                       | Enable builder functionality               | `false`                               |
+| `config.functionRegistryTLSVerify`             | Enable TLS verification for image registry | `{}`                                  |
+| `config.runtimeImages`                         | Runtimes available                         | python, nodejs, ruby, php and go      |
+| `controller.deployment.image.repository`       | Controller image                           | `bitnami/kubeless-controller-manager` |
+| `controller.deployment.image.pullPolicy`       | Controller image pull policy               | `IfNotPresent`                        |
+| `controller.deployment.replicaCount`           | Number of replicas                         | `1`                                   |
+| `ui.enabled`                                   | Kubeless UI component                      | `false`                               |
+| `ui.deployment.ui.image.repository`            | Kubeless UI image                          | `bitnami/kubeless-ui`                 |
+| `ui.deployment.ui.image.pullPolicy`            | Kubeless UI image pull policy              | `IfNotPresent`                        |
+| `ui.deployment.proxy.image.repository`         | Proxy image                                | `kelseyhightower/kubectl`             |
+| `ui.deployment.proxy.image.pullPolicy`         | Proxy image pull policy                    | `IfNotPresent`                        |
+| `ui.deployment.replicaCount`                   | Number of replicas                         | `1`                                   |
+| `ui.service.name`                              | Service name                               | `ui-port`                             |
+| `ui.service.type`                              | Kubernetes service name                    | `NodePort`                            |
+| `ui.service.externalPort`                      | Service external port                      | `3000`                                |
+| `ui.ingress.enabled`                           | Kubeless UI ingress switch                 | `false`                               |
+| `ui.ingress.annotations`                       | Kubeless UI ingress annotations            | `{}`                                  |
+| `ui.ingress.path`                              | Kubeless UI ingress path                   | `{}`                                  |
+| `ui.ingress.hosts`                             | Kubeless UI ingress hosts                  | `[chart-example.local]`               |
+| `ui.ingress.tls`                               | Kubeless UI ingress TLS                    | `[]`                                  |
+| `kafkaTrigger.enabled`                         | Kubeless Kafka Trigger                     | `false`                               |
+| `kafkaTrigger.env.kafkaBrokers`                | Kafka Brokers Environment Variable         | `localhost:9092`                      |
+| `kafkaTrigger.deployment.ui.image.repository`  | Kubeless Kafka Trigger image               | `bitnami/kubeless-ui`                 |
+| `kafkaTrigger.deployment.ui.image.pullPolicy`  | Kubeless Kafka Trigger image pull policy   | `IfNotPresent`                        |
+| `kafkaTrigger.deployment.ui.image.tag`         | Kubeless Kafka Trigger image tag           | `v1.0.0-alpha.3`                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/incubator/kubeless/README.md
+++ b/incubator/kubeless/README.md
@@ -45,8 +45,9 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Kafka Trigger
 
-Kubeless supports triggering functions via kafka events. More info here: https://kubeless.io/docs/use-existing-kafka/.
-To support this `rbac.create: true`, `kafkaTrigger.enabled: true`, `kafkaTrigger.env.kafkaBrokers: <your_kafka_brokers>` must be set.
+Kubeless supports triggering functions via Kafka events. More info here: https://kubeless.io/docs/use-existing-kafka/.
+An existing Kafka cluster needs to be accessible to kubeless -- if you like, you may look into setting Kafka up via the [Kafka chart](https://github.com/kubernetes/charts/tree/master/incubator/kafka). Once Kafka is running,
+to enable the Kafka trigger you must congifure the following values: `rbac.create: true`, `kafkaTrigger.enabled: true`, `kafkaTrigger.env.kafkaBrokers: <your_kafka_brokers>`.
 
 ## Configuration
 

--- a/incubator/kubeless/templates/cluster-role.yaml
+++ b/incubator/kubeless/templates/cluster-role.yaml
@@ -51,9 +51,7 @@ rules:
   - functions
   - httptriggers
   - cronjobtriggers
-  {{-if .Values.kafkaTrigger.enabled }
-  - kafkatriggers
-  {{- end }}
+  {{ if .Values.kafkaTrigger.enabled }}- kafkatriggers {{ end }}
   verbs:
   - get
   - list

--- a/incubator/kubeless/templates/cluster-role.yaml
+++ b/incubator/kubeless/templates/cluster-role.yaml
@@ -51,6 +51,9 @@ rules:
   - functions
   - httptriggers
   - cronjobtriggers
+  {{-if .Values.kafkaTrigger.enabled }
+  - kafkatriggers
+  {{- end }}
   verbs:
   - get
   - list

--- a/incubator/kubeless/templates/cluster-role.yaml
+++ b/incubator/kubeless/templates/cluster-role.yaml
@@ -51,7 +51,6 @@ rules:
   - functions
   - httptriggers
   - cronjobtriggers
-  {{ if .Values.kafkaTrigger.enabled }}- kafkatriggers {{ end }}
   verbs:
   - get
   - list

--- a/incubator/kubeless/templates/kafka-controller-cluster-role-binding.yaml
+++ b/incubator/kubeless/templates/kafka-controller-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-controller-deployer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kafka-controller-deployer
+subjects:
+- kind: ServiceAccount
+  name: controller-acct
+  namespace: {{ .Release.Namespace }}

--- a/incubator/kubeless/templates/kafka-controller-cluster-role.yaml
+++ b/incubator/kubeless/templates/kafka-controller-cluster-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.kafkaTrigger.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kafka-controller-deployer
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kubeless.io
+  resources:
+  - functions
+  - kafkatriggers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+{{- end }}

--- a/incubator/kubeless/templates/kafka-controller-deployment.yaml
+++ b/incubator/kubeless/templates/kafka-controller-deployment.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.kafkaTrigger.enabled }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    kubeless: kafka-trigger-controller
+  name: kafka-trigger-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      kubeless: kafka-trigger-controller
+  template:
+    metadata:
+      labels:
+        kubeless: kafka-trigger-controller
+    spec:
+      containers:
+      - image: "{{ .Values.kafkaTrigger.deployment.image.repository }}:{{ .Values.kafkaTrigger.deployment.image.tag }}"
+        imagePullPolicy: {{ .Values.kafkaTrigger.deployment.image.pullPolicy }}
+        name: kafka-trigger-controller
+        env:
+        - name: KAFKA_BROKERS
+          value: {{ .Values.kafkaTrigger.env.kafkaBrokers }}
+      serviceAccountName: controller-acct
+{{- end }}

--- a/incubator/kubeless/templates/kafka-trigger-type-crd.yaml
+++ b/incubator/kubeless/templates/kafka-trigger-type-crd.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.kafkaTrigger.enabled }}
+apiVersion: apiextensions.k8s.io/v1beta1
+description: CRD object for Kafka trigger type
+kind: CustomResourceDefinition
+metadata:
+  name: kafkatriggers.kubeless.io
+spec:
+  group: kubeless.io
+  names:
+    kind: KafkaTrigger
+    plural: kafkatriggers
+    singular: kafkatrigger
+  scope: Namespaced
+  version: v1beta1
+{{- end }}

--- a/incubator/kubeless/values.yaml
+++ b/incubator/kubeless/values.yaml
@@ -185,3 +185,13 @@ ui:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+
+## Kafka Trigger configuration Configuration
+kafkaTrigger:
+  enabled: false
+  deployment:
+    image:
+      repository: bitnami/kafka-trigger-controller
+      tag: v1.0.0-alpha.3
+      pullPolicy: IfNotPresent
+  kafkaBrokers: localhost:9092


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The upstream project supports having a kafka trigger send events to kubeless (see https://kubeless.io/docs/use-existing-kafka/). The configuration modifications allow us to enable this when installing kubeless via helm

**Which issue this PR fixes** N/A

**Special notes for your reviewer**:

In order to function as currently implemented, `rbac.create = true` must be set. I don't know if we want this to be explicit, or add an or statement around some of the rbac conditionals to enable it when `kafkaTrigger.enabled` is true also.

Note, does not enable spinning up a kafka cluster.

None of the rbac values were documented in the README, is this by design?