### PR TITLE
Support for session affinity configuration

### DIFF
--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -31,6 +31,11 @@ spec:
 {{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.service.externalTrafficPolicy) }}
   externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
 {{- end }}
+{{- if .Values.controller.service.sessionAffinity }}
+  sessionAffinity: "{{ .Values.controller.service.sessionAffinity }}"
+{{- end }}
+  sessionAffinityConfig:
+{{ toYaml .Values.controller.service.sessionAffinityConfig | indent 4 }}
 {{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.service.healthCheckNodePort) }}
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
 {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -171,6 +171,11 @@ controller:
 
     healthCheckNodePort: 0
 
+    # Configure LB session Affinity (None | ClientIP)
+    sessionAffinity: "None"
+    sessionAffinityConfig: {}
+    #  clientIP.timeoutSeconds: 10800
+
     targetPorts:
       http: http
       https: https


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Currently there is no session affinity support. When you do an SSL stripping in nginx ingress, SSL resumption requires session affinity (like GCE ClientIP) between LB and ingress controller, otherwise connection might be routed to a different controller and cache miss.