### PR TITLE
[stable/openvpn] Configurable update strategy

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.5.1
+version: 3.6.0
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -54,6 +54,7 @@ and can be overwritten via the helm `--set` flag.
 Parameter | Description | Default
 ---                            | ---                                                                  | ---
 `replicaCount`                 | amount of parallel openvpn replicas to be started                    | `1`
+`updateStrategy`               | update strategy for deployment                                       | `{}`
 `image.repository`             | `openvpn` image repository                                           | `jfelten/openvpn-docker`
 `image.tag`                    | `openvpn` image tag                                                  | `1.1.0`
 `image.pullPolicy`             | Image pull policy                                                    | `IfNotPresent`

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+{{- if .Values.updateStrategy }}
+  strategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "openvpn.name" . }}

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -2,6 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
+
+updateStrategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+
 image:
   repository: jfelten/openvpn-docker
   tag: 1.1.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows configuration of update strategy, for example when using a PersistentVolumeClaim to store certificates and needing a strategy of `recreate`.