### PR TITLE
kube-state-metrics: Update tag to 1.3.1

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -11,5 +11,5 @@ home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/
 maintainers:
-- name: Jose Armesto
+- name: fiunchinho
   email: jose@armesto.net

--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.7.1
-appVersion: 1.2.0
+version: 0.7.2
+appVersion: 1.3.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:
 - https://github.com/kubernetes/kube-state-metrics/

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: k8s.gcr.io/kube-state-metrics
-  tag: v1.2.0
+  tag: v1.3.1
   pullPolicy: IfNotPresent
 service:
   port: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps kube-state-metrics default tag from 1.2.0 to 1.3.1. This gets us additional metrics that we'd like. Also fixes a few bugs.

**Special notes for your reviewer**:

See the full [release notes](https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md).