### PR TITLE
[incubator/vault] Add ability to define sidecar containers

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.11.0
+version: 0.12.0
 appVersion: 0.10.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the Vault chart and the
 | `annotations`                     | Annotations for deployment               | `{}`                                |
 | `ingress.labels`                  | Labels for ingress                       | `{}`                                |
 | `podAnnotations`                  | Annotations for pods                     | `{}`                                |
+| `sidecarContainers`               | Additional container that should be added to the vault pod   | `[]`            |
 | `consulAgent.join`                | If set, start start a consul agent       | `nil`                               |
 | `consulAgent.repository`          | Container image for consul agent         | `consul`                            |
 | `consulAgent.tag`                 | Container image tag for consul agent     | `1.0.7`                             |

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -65,7 +65,8 @@ The following table lists the configurable parameters of the Vault chart and the
 | `annotations`                     | Annotations for deployment               | `{}`                                |
 | `ingress.labels`                  | Labels for ingress                       | `{}`                                |
 | `podAnnotations`                  | Annotations for pods                     | `{}`                                |
-| `sidecarContainers`               | Additional container that should be added to the vault pod   | `[]`            |
+| `sidecarContainer`                | Additional container that should be added to the vault pod   | `disabled`      |
+| `sidecarContainer.customSecrets`  | Custom secrets available in the sidecar  | `[]`                                |
 | `consulAgent.join`                | If set, start start a consul agent       | `nil`                               |
 | `consulAgent.repository`          | Container image for consul agent         | `consul`                            |
 | `consulAgent.tag`                 | Container image tag for consul agent     | `1.0.7`                             |

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -54,6 +54,8 @@ The following table lists the configurable parameters of the Vault chart and the
 | `image.tag`                       | Container image tag to deploy            | `0.10.1`                            |
 | `vault.dev`                       | Use Vault in dev mode                    | true (set to false in production)   |
 | `vault.extraEnv`                  | Extra env vars for Vault pods            | `{}`                                |
+| `vault.extraContainers`           | Sidecar containers to add to the vault pod | `{}`                              |
+| `vault.extraVolumes`              | Additional volumes to the controller pod | `{}`                                |
 | `vault.customSecrets`             | Custom secrets available to Vault        | `[]`                                |
 | `vault.config`                    | Vault configuration                      | No default backend                  |
 | `replicaCount`                    | k8s replicas                             | `3`                                 |
@@ -65,8 +67,6 @@ The following table lists the configurable parameters of the Vault chart and the
 | `annotations`                     | Annotations for deployment               | `{}`                                |
 | `ingress.labels`                  | Labels for ingress                       | `{}`                                |
 | `podAnnotations`                  | Annotations for pods                     | `{}`                                |
-| `sidecarContainer`                | Additional container that should be added to the vault pod   | `disabled`      |
-| `sidecarContainer.customSecrets`  | Custom secrets available in the sidecar  | `[]`                                |
 | `consulAgent.join`                | If set, start start a consul agent       | `nil`                               |
 | `consulAgent.repository`          | Container image for consul agent         | `consul`                            |
 | `consulAgent.tag`                 | Container image tag for consul agent     | `1.0.7`                             |

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
         - name: {{ .secretName }}
           mountPath: {{ .mountPath }}
         {{- end }}
+{{- if .Values.sidecarContainers }}
+{{ toYaml .Values.sidecarContainers | indent 6 }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.affinity }}
@@ -114,9 +117,6 @@ spec:
       affinity:
 {{ tpl .Values.affinity . | indent 8 }}
       {{- end }}
-{{- if .Values.sidecarContainers }}
-{{ toYaml .Values.sidecarContainers | indent 6 }}
-{{- end }}
       volumes:
         - name: vault-config
           configMap:

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -78,9 +78,15 @@ spec:
         - name: {{ .secretName }}
           mountPath: {{ .mountPath }}
         {{- end }}
-{{- if .Values.sidecarContainers }}
-{{ toYaml .Values.sidecarContainers | indent 6 }}
-{{- end }}
+      {{- if .Values.sidecarContainer.enabled }}
+      - name: {{ .name }}
+        image: {{ .image }}
+        volumeMounts:
+        {{- range .Values.sidecarContainer.customSecrets }}
+        - name: {{ .secretName }}
+          mountPath: {{ .mountPath }}
+        {{- end }}        
+      {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.affinity }}
@@ -124,6 +130,11 @@ spec:
         - name: vault-root
           emptyDir: {}
         {{- range .Values.vault.customSecrets }}
+        - name: {{ .secretName }}
+          secret:
+            secretName: {{ .secretName }}
+        {{- end }}
+        {{- range .Values.sidecarContainer.customSecrets }}
         - name: {{ .secretName }}
           secret:
             secretName: {{ .secretName }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -114,6 +114,9 @@ spec:
       affinity:
 {{ tpl .Values.affinity . | indent 8 }}
       {{- end }}
+{{- if .Values.sidecarContainers }}
+{{ toYaml .Values.sidecarContainers | indent 6 }}
+{{- end }}
       volumes:
         - name: vault-config
           configMap:

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -78,15 +78,9 @@ spec:
         - name: {{ .secretName }}
           mountPath: {{ .mountPath }}
         {{- end }}
-      {{- if .Values.sidecarContainer.enabled }}
-      - name: {{ .name }}
-        image: {{ .image }}
-        volumeMounts:
-        {{- range .Values.sidecarContainer.customSecrets }}
-        - name: {{ .secretName }}
-          mountPath: {{ .mountPath }}
-        {{- end }}        
-      {{- end }}
+{{- if .Values.vault.extraContainers }}
+{{ toYaml .Values.vault.extraContainers | indent 6}}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.affinity }}
@@ -134,11 +128,9 @@ spec:
           secret:
             secretName: {{ .secretName }}
         {{- end }}
-        {{- range .Values.sidecarContainer.customSecrets }}
-        - name: {{ .secretName }}
-          secret:
-            secretName: {{ .secretName }}
-        {{- end }}
+{{- if .Values.vault.extraVolumes }}
+{{ toYaml .Values.vault.extraVolumes | indent 8}}
+{{- end }}
         {{- if .Values.consulAgent.join }}
         - name: consul-data
           emptyDir: {}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -24,16 +24,6 @@ consulAgent:
   #
   # Optionally override the agent's http port
   HttpPort: 8500
-
-sidecarContainer:
-  # enabled: true
-  ## Additional container to be added to the Vault pod
-  # - name: vault-unsealer
-  #   image: vault-unsealer:latest
-  customSecrets: []
-    # - secretName: unseal-keys
-    #   mountPath: /vault/keys
-
 service:
   name: vault
   type: ClusterIP
@@ -123,6 +113,18 @@ vault:
   extraEnv: {}
   #   - name: VAULT_API_ADDR
   #     value: "https://vault.internal.domain.name:8200"
+  extraContainers: {}
+  ## Additional containers to be added to the Vault pod
+  # - name: vault-sidecar
+  #   image: vault-sidecar:latest
+  #   volumeMounts:
+  #   - name: some-mount
+  #     mountPath: /some/path
+  extraVolumes: {}
+  ## Additional volumes to the vault pod.
+  # - name: extra-volume
+  #   secret:
+  #     secretName: some-secret
   readiness:
     readyIfSealed: false
     readyIfStandby: true

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -25,6 +25,11 @@ consulAgent:
   # Optionally override the agent's http port
   HttpPort: 8500
 
+sidecarContainers: []
+  ## Additional containers to be added to the Vault pod
+  # - name: vault-unsealer
+  #   image: vault-unsealer:latest
+
 service:
   name: vault
   type: ClusterIP

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -26,7 +26,7 @@ consulAgent:
   HttpPort: 8500
 
 sidecarContainer:
-  #enabled: true
+  # enabled: true
   ## Additional container to be added to the Vault pod
   # - name: vault-unsealer
   #   image: vault-unsealer:latest

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -25,10 +25,14 @@ consulAgent:
   # Optionally override the agent's http port
   HttpPort: 8500
 
-sidecarContainers: []
-  ## Additional containers to be added to the Vault pod
+sidecarContainer:
+  #enabled: true
+  ## Additional container to be added to the Vault pod
   # - name: vault-unsealer
   #   image: vault-unsealer:latest
+  customSecrets: []
+    # - secretName: unseal-keys
+    #   mountPath: /vault/keys
 
 service:
   name: vault


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables the addition of a sidecar container to the vault pod, `sidecarContainer.enabled`. A use for a sidecar container could include an `unsealer`, where any unseal logic can be done in a separate container that lives outside of the official vault image. This allows for separation of concerns where tasks that don't necessarily belong in the vault container could live along side in the same pod and share the same network layer. 

Custom secrets for the sidecar can also be specified using `sidecarContainer.customSecrets: []`
