### PR TITLE
[stable/prometheus-rabbitmq-exporter] Add container configuration env variables

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.1.3
+version: 0.1.4
 appVersion: v0.28.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.1.4
+version: 0.2.0
 appVersion: v0.28.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/README.md
+++ b/stable/prometheus-rabbitmq-exporter/README.md
@@ -40,24 +40,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters and their default values.
 
-| Parameter                | Description                                                            | Default                   |
-| ------------------------ | ---------------------------------------------------------------------- | ------------------------- |
-| `replicaCount`           | desired number of prometheus-rabbitmq-exporter pods                    | `1`                       |
-| `image.repository`       | prometheus-rabbitmq-exporter image repository                          | `kbudde/rabbitmq-exporter`|
-| `image.tag`              | prometheus-rabbitmq-exporter image tag                                 | `v0.28.0`                 |
-| `image.pullPolicy`       | image pull policy                                                      | `IfNotPresent`            |
-| `service.type`           | desired service type                                                   | `ClusterIP`               |
-| `service.internalport`   | service listening port                                                 | `9121`                    |
-| `service.externalPort`   | public service port                                                    | `9419`                    |
-| `resources`              | cpu/memory resource requests/limits                                    | {}                        |
-| `loglevel`               | exporter log level                                                     | {}                        |
-| `rabbitmq.url`           | rabbitm management url                                                  | `http://myrabbit:15672`   |
-| `rabbitmq.user`          | rabbitm user login                                                     | `guest`                   |
-| `rabbitmq.password`      | rabbitm password login                                                 | `guest`                   |
-| `rabbitmq.capabilities`  | comma-separated list of capabilities supported by the RabbitMQ server  | `bert,no_sort`            |
-| `rabbitmq.include_queues`| regex queue filter. just matching names are exported                   | `.*`                      |
-| `rabbitmq.skip_queues`   | regex, matching queue names are not exported                           | `.*`                      |
-| `annotation`             | pod annotations for easier discovery                                   | {}                        |
+| Parameter                    | Description                                                             | Default                        |
+| ---------------------------- | ----------------------------------------------------------------------- | ------------------------------ |
+| `replicaCount`               | desired number of prometheus-rabbitmq-exporter pods                     | `1`                            |
+| `image.repository`           | prometheus-rabbitmq-exporter image repository                           | `kbudde/rabbitmq-exporter`     |
+| `image.tag`                  | prometheus-rabbitmq-exporter image tag                                  | `v0.28.0`                      |
+| `image.pullPolicy`           | image pull policy                                                       | `IfNotPresent`                 |
+| `service.type`               | desired service type                                                    | `ClusterIP`                    |
+| `service.internalport`       | service listening port                                                  | `9121`                         |
+| `service.externalPort`       | public service port                                                     | `9419`                         |
+| `resources`                  | cpu/memory resource requests/limits                                     | {}                             |
+| `loglevel`                   | exporter log level                                                      | {}                             |
+| `rabbitmq.url`               | rabbitm management url                                                  | `http://myrabbit:15672`        |
+| `rabbitmq.user`              | rabbitm user login                                                      | `guest`                        |
+| `rabbitmq.password`          | rabbitm password login                                                  | `guest`                        |
+| `rabbitmq.capabilities`      | comma-separated list of capabilities supported by the RabbitMQ server   | `bert,no_sort`                 |
+| `rabbitmq.include_queues`    | regex queue filter. just matching names are exported                    | `.*`                           |
+| `rabbitmq.skip_queues`       | regex, matching queue names are not exported                            | `.*`                           |
+| `rabbitmq.rabbitmq_exporter` | list of enabled exporters. only "connections" is not enabled by default | `exchange,node,overview,queue` |
+| `rabbitmq.skipverify`        | set to true to ignore certificate errors from the management plugin     | `false`                        |
+| `annotation`                 | pod annotations for easier discovery                                    | {}                             |
 
 For more information please refer to the [rabbitmq_exporter](https://github.com/kbudde/rabbitmq_exporter) documentation.
 

--- a/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
               value: "{{ .Values.rabbitmq.include_queues }}"
             - name: SKIP_QUEUES
               value: "{{ .Values.rabbitmq.skip_queues }}"
+            - name: RABBIT_EXPORTERS
+              value: "{{ .Values.rabbitmq.rabbit_exporters }}"
+            - name: SKIPVERIFY
+              value: "{{ .Values.rabbitmq.skipverify }}"
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           livenessProbe:

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -36,6 +36,8 @@ rabbitmq:
   capabilities: bert,no_sort
   include_queues: ".*"
   skip_queues: "^$"
+  rabbit_exporters: exchange,node,overview,queue
+  skipverify: false
 
 annotation: {}
 #  prometheus.io/scrape: "true"


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Add container configuration env vars as documented [here](https://github.com/kbudde/rabbitmq_exporter):
- `rabbitmq.rabbit_exporters`: list of enabled exporters. only `connections` is not enabled by default
- `rabbitmq.skipverify`: set to `true` to ignore certificate errors from the management plugin

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:
