### PR TITLE
Add podAnnotations value for setting annotations on pods

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.5.0
+version: 0.6.0
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -142,6 +142,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `agent.service.binaryPort`               | jaeger.thrift over binary thrift    |  6832                                  |
 | `agent.service.compactPort`              | jaeger.thrift over compact thrift   |  6831                                  |
 | `agent.image`                            | Image for Jaeger Agent              |  jaegertracing/jaeger-agent            |
+| `agent.podAnnotations`                   | Annotations for Agent pod           |  nil                                   |
 | `agent.pullPolicy`                       | Agent image pullPolicy              |  IfNotPresent                          |
 | `agent.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`       |
 | `agent.service.annotations`              | Annotations for Agent SVC           |  nil                                   |
@@ -156,8 +157,8 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `cassandra.config.seed_size`             | Seed size                           |  1                                     |
 | `cassandra.image.tag`                    | The image tag/version               |  3.11                                  |
 | `cassandra.persistence.enabled`          | To enable storage persistence       |  false (Highly recommended to enable)  |
-| `collector.annotationsPod`               | Annotations for Collector           |  nil                                   |
 | `collector.cmdlineParams`                | Additional command line parameters  |  nil                                   |
+| `collector.podAnnotations`               | Annotations for Collector pod       |  nil                                   |
 | `collector.service.httpPort`             | Client port for HTTP thrift         |  14268                                 |
 | `collector.service.annotations`          | Annotations for Collector SVC       |  nil                                   |
 | `collector.image`                        | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
@@ -176,11 +177,11 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `hotrod.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`      |
 | `provisionDataStore.cassandra`           | Provision Cassandra Data Store      |  true                                  |
 | `provisionDataStore.elasticsearch`       | Provision Elasticsearch Data Store  |  false                                 |
-| `query.annotationsPod`                   | Annotations for Query UI            |  nil                                   |
 | `query.service.annotations`              | Annotations for Query SVC           |  nil                                   |
 | `query.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
 | `query.image`                            | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
 | `query.ingress.enabled`                  | Allow external traffic access       |  false                                 |
+| `query.podAnnotations`                   | Annotations for Query pod           |  nil                                   |
 | `query.pullPolicy`                       | Query UI image pullPolicy           |  IfNotPresent                          |
 | `query.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`       |
 | `query.service.queryPort`                | External accessible port            |  80                                    |

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -17,6 +17,10 @@ metadata:
 spec:
   template:
     metadata:
+{{- if .Values.agent.podAnnotations }}
+      annotations:
+{{ toYaml .Values.agent.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "jaeger.name" . }}
         component: agent

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -20,6 +20,10 @@ spec:
     type: Recreate
   template:
     metadata:
+{{- if .Values.collector.podAnnotations }}
+      annotations:
+{{ toYaml .Values.collector.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "jaeger.name" . }}
         component: collector

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -20,6 +20,10 @@ spec:
     type: Recreate
   template:
     metadata:
+{{- if .Values.query.podAnnotations }}
+      annotations:
+{{ toYaml .Values.query.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "jaeger.name" . }}
         component: query

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -106,6 +106,7 @@ agent:
     #   cpu: 256m
     #   memory: 128Mi
   nodeSelector: {}
+  podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
@@ -140,6 +141,7 @@ collector:
     #   cpu: 500m
     #   memory: 512Mi
   nodeSelector: {}
+  podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
@@ -184,6 +186,7 @@ query:
     #    cpu: 256m
     #    memory: 128Mi
   nodeSelector: {}
+  podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}


### PR DESCRIPTION
Also, remove "annotationsPod" settings documented in README. They did
nothing.  The naming was inconsistent with other charts, so that is
changed as well.

**What this PR does / why we need it**: This allows us to add some annotations to the pods so that we can hook up a datadog integration (but it could allow any other pod annotation as well).