### PR TITLE
Add resource policy annotation to InfluxDB pvc

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 0.9.1
+version: 0.9.2
 appVersion: 1.4
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/pvc.yaml
+++ b/stable/influxdb/templates/pvc.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- if .Values.persistence.keep }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -38,6 +38,8 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: "-"
+  ## If true, the PVC will not be deleted when chart is deleted
+  # keep: false
   accessMode: ReadWriteOnce
   size: 8Gi
 


### PR DESCRIPTION
- Add value `persistence.keep` to provide the option to keep pvc after deletes.
- Add conditional `resource-policy` annotation to pvc template

**What this PR does / why we need it**:
This provides an option to retain the pvc used by InfluxDB across chart deletes
