### PR TITLE
[incubator/fluentd-elasticseatch] Add release label to fluentd-elasticsearch DaemonSet

### DIFF
--- a/incubator/fluentd-elasticsearch/Chart.yaml
+++ b/incubator/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 0.6.1
+version: 0.6.2
 appVersion: 2.0.4
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/incubator/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/incubator/fluentd-elasticsearch/templates/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
         heritage: "{{ .Release.Service }}"
         kubernetes.io/cluster-service: "true"
         version: {{ .Values.image.tag }}
+        release: "{{ .Release.Name }}"
       # This annotation ensures that fluentd does not get evicted if the node
       # supports critical pod annotation based priority scheme.
       # Note that this does not guarantee admission on the nodes (#40573).
@@ -67,15 +68,15 @@ spec:
           readOnly: true
         - name: config-volume-{{ template "fluentd-elasticsearch.fullname" . }}
           mountPath: /etc/fluent/config.d
-        ports:          
+        ports:
 {{- range $port := .Values.service.ports }}
           - name: {{ $port.name }}
             containerPort: {{ $port.port }}
-{{- end }}          
+{{- end }}
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
-{{- if .Values.livenessProbe.enabled }}       
+{{- if .Values.livenessProbe.enabled }}
         # Liveness probe is aimed to help in situarions where fluentd
         # silently hangs for no apparent reasons until manual restart.
         # The idea of this probe is that if fluentd is not queueing or
@@ -108,7 +109,7 @@ spec:
               then
                 exit 1;
               fi;
-{{- end }}              
+{{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
Fix for kubernetes/charts#5569
The DaemonSet was missing a release label so the new service wasn't matching anything.
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
