### PR TITLE
Fix sentry-kubernetes

### DIFF
--- a/incubator/sentry-kubernetes/Chart.yaml
+++ b/incubator/sentry-kubernetes/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for sentry-kubernetes (https://github.com/getsentry/sentry-kubernetes)
 name: sentry-kubernetes
-version: 0.1.5
+version: 0.1.6
 appVersion: latest
 home: https://github.com/getsentry/sentry-kubernetes
 sources:

--- a/incubator/sentry-kubernetes/README.md
+++ b/incubator/sentry-kubernetes/README.md
@@ -16,6 +16,7 @@ The following table lists the configurable parameters of the sentry-kubernetes c
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
 | `sentry.dsn`            | Sentry dsn                                                                                                                  | Empty                         |
 | `sentry.environment`    | Sentry environment                                                                                                          | Empty                         |
+| `sentry.release`        | Sentry release                                                                                                              | Empty                         |
 | `image.repository`      | Container image name                                                                                                        | `getsentry/sentry-kubernetes` |
 | `image.tag`             | Container image tag                                                                                                         | `latest`                      |
 | `rbac.create`           | If `true`, create and use RBAC resources                                                                                    | `true`                        |

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -26,8 +26,14 @@ spec:
               secretKeyRef:
                 name: {{ template "sentry-kubernetes.fullname" . }}
                 key: sentry.dsn
+          {{ if .Values.sentry.environment }}
           - name: ENVIRONMENT
             value: {{ .Values.sentry.environment }}
+          {{ end }}
+          {{ if .Values.sentry.release }}
+          - name: RELEASE 
+            value: {{ .Values.sentry.release }}
+          {{ end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}

--- a/incubator/sentry-kubernetes/templates/deployment.yaml
+++ b/incubator/sentry-kubernetes/templates/deployment.yaml
@@ -28,11 +28,6 @@ spec:
                 key: sentry.dsn
           - name: ENVIRONMENT
             value: {{ .Values.sentry.environment }}
-          - name: RELEASE
-            valueFrom:
-              resourceFieldRef:
-                containerName: {{ .Chart.Name }}
-                resource: image
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}


### PR DESCRIPTION
in #5952 I added sentry.environment and sentry.release values, but for
sentry.values, we used to use the k8s metadata information to fill this value. Unfortunately this causes an error when deploying the chart, *I think* this value isn't available until the chart is deployed? Anyway upon further reflection I can't think of a good usecase for passing the RELEASE value. (Atleast its not required for my usecase)

So this just removes the problem value set

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
