### PR TITLE
Allow specifying DaemonSet API version in NewRelic Infrastructure chart

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.0.19
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/README.md
+++ b/stable/newrelic-infrastructure/README.md
@@ -6,19 +6,20 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 
 ## Configuration
 
-| Parameter          | Description                                                  | Default                    |
-| ------------------ | ------------------------------------------------------------ | -------------------------- |
-| `cluster`          | The cluster name for the Kubernetes cluster.                 | ``                         |
-| `config`           | A `newrelic.yml` file if you wish to provide.                | ` `                        |
-| `image.name`       | The container to pull.                                       | `newrelic/infrastructure`  |
-| `image.pullPolicy` | The pull policy.                                             | `IfNotPresent`             |
-| `image.tag`        | The version of the container to pull.                        | `1.0.0-beta1.0`            |
-| `licenseKey`       | The license key for your New Relic Account.                  | ``                         |
-| `resources`        | Any resources you wish to assign to the pod.                 | See Resources below        |
-| `verboseLog`       | Should the agent log verbosely. (Boolean)                    | `false`                    |
-| `nodeSelector`     | Node label to use for scheduling                             | `nil`                      |
-| `tolerations`      | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`                      |
-| `updateStrategy`   | Strategy for DaemonSet updates (requires Kubernetes >= 1.6)  | `RollingUpdate`            |
+| Parameter               | Description                                                  | Default                    |
+| ----------------------- | ------------------------------------------------------------ | -------------------------- |
+| `cluster`               | The cluster name for the Kubernetes cluster.                 | ``                         |
+| `config`                | A `newrelic.yml` file if you wish to provide.                | ` `                        |
+| `image.name`            | The container to pull.                                       | `newrelic/infrastructure`  |
+| `image.pullPolicy`      | The pull policy.                                             | `IfNotPresent`             |
+| `image.tag`             | The version of the container to pull.                        | `1.0.0-beta1.0`            |
+| `licenseKey`            | The license key for your New Relic Account.                  | ``                         |
+| `resources`             | Any resources you wish to assign to the pod.                 | See Resources below        |
+| `verboseLog`            | Should the agent log verbosely. (Boolean)                    | `false`                    |
+| `nodeSelector`          | Node label to use for scheduling                             | `nil`                      |
+| `tolerations`           | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`                      |
+| `updateStrategy`        | Strategy for DaemonSet updates (requires Kubernetes >= 1.6)  | `RollingUpdate`            |
+| `daemonSetApiVersion`   | API Version used for DaemonSet (change for Kubernetes <=1.8) | `apps/v1`                  |
 
 ## Resources
 

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.licenseKey .Values.cluster }}
-apiVersion: apps/v1
+apiVersion: {{ .Values.daemonSetApiVersion }}
 kind: DaemonSet
 metadata:
   labels: {{ include "newrelic.labels" . | indent 4 }}

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -85,3 +85,6 @@ nodeSelector: {}
 tolerations: []
 
 updateStrategy: RollingUpdate
+
+# Use extensions/v1beta1 here when using Kubernetes 1.8 or older
+daemonSetApiVersion: apps/v1


### PR DESCRIPTION
Hey @rk295, thanks for all your work on this chart. When I was attempting to install this chart in a Kubernetes 1.8 cluster I realized that the default DaemonSet API version used by this chart is not supported in that Kubernetes version. I'd imagine this is also an issue for anyone running an earlier version of Kubernetes. 