### PR TITLE
[stable/redis] references correct slave service annotation from values.yaml

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.3.5
+version: 3.3.6
 appVersion: 4.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-slave-svc.yaml
+++ b/stable/redis/templates/redis-slave-svc.yaml
@@ -9,8 +9,8 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-{{- if .Values.master.service.annotations }}
-{{ toYaml .Values.master.service.annotations | indent 4 }}
+{{- if .Values.slave.service.annotations }}
+{{ toYaml .Values.slave.service.annotations | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.slave.service.type }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The current slave service references annotations from the master service values.  This is especially problematic when attempting to annotate redis slaves.  E.g.,:

```
  master:
    service:
      annotations:
        external-dns.alpha.kubernetes.io/hostname: 'redis-master.foobar.com'
      type: LoadBalancer
  slave:
    service:
      annotations:
        external-dns.alpha.kubernetes.io/hostname: 'redis-slave.foobar.com'
      type: LoadBalancer
```

In this scenario, the slave service will inherit service annotations from `.Values.master.service` resulting in `redis-master.foobar.com` aliasing both the master and slave services.
