### PR TITLE
[stable/traefik] adding support for traefik wildcard certificates

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.34.0
+version: 1.35.0
 appVersion: 1.6.2
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -121,6 +121,9 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `acme.email`                    | Email address to be used in certificates obtained from Let's Encrypt | `admin@example.com`                       |
 | `acme.staging`                  | Whether to get certs from Let's Encrypt's staging environment        | `true`                                    |
 | `acme.logging`                  | Display debug log messages from the ACME client library              | `false`                                   |
+| `acme.domains.enabled`          | Enable certificate creation by default for specific domain           | `false`                                   |
+| `acme.domains.main`             | Main domain name of the generated certificate                        | `*.example.com`                           |
+| `acme.domains.sans`             | List of alternative subject name to give to the certificate          | `[]`                                      |
 | `acme.persistence.enabled`      | Create a volume to store ACME certs (if ACME is enabled)             | `true`                                    |
 | `acme.persistence.annotations`  | PVC annotations                                                      | `{}`                                      |
 | `acme.persistence.storageClass` | Type of `StorageClass` to request-- will be cluster-specific         | `nil` (uses alpha storage class annotation) |
@@ -220,6 +223,26 @@ acme:
     name:  # name of the dns provider to use
     $name: # the configuration of the dns provider. See the following section for an example
       # variables that the specific dns provider requires
+```
+
+### Let's Encrypt wildcard certificate
+
+To obtain an ACME (Let's Encrypt) wildcard certificate you must use a DNS challenge as explained above.
+Then you need to specify the wildcard domain name in the `acme.domains` section like this :
+
+```yaml
+acme:
+  enabled: true
+  challengeType: "dns-01"
+  dnsProvider:
+    name:  # name of the dns provider to use
+    $name: # the configuration of the dns provider. See the following section for an example
+      # variables that the specific dns provider requires
+  domains:
+    enabled: true
+    main: "*.example.com" # name of the wildcard domain name for the certificate
+    sans:
+      - "example.com" # OPTIONAL: Alternative name(s) for the certificate, if you want the same certificate for the root of the domain name for example
 ```
 
 #### Example: AWS Route 53

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -122,8 +122,9 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `acme.staging`                  | Whether to get certs from Let's Encrypt's staging environment        | `true`                                    |
 | `acme.logging`                  | Display debug log messages from the ACME client library              | `false`                                   |
 | `acme.domains.enabled`          | Enable certificate creation by default for specific domain           | `false`                                   |
-| `acme.domains.main`             | Main domain name of the generated certificate                        | `*.example.com`                           |
-| `acme.domains.sans`             | List of alternative subject name to give to the certificate          | `[]`                                      |
+| `acme.domains.domainList`       | List of domains & (optional) subject names                           | `[]`                                      |
+| `acme.domains.domainList.main`  | Main domain name of the generated certificate                        | *.example.com                             |
+| `acme.domains.domainList.sans`  | optional list of alternative subject names to give to the certificate | `[]`                                     |
 | `acme.persistence.enabled`      | Create a volume to store ACME certs (if ACME is enabled)             | `true`                                    |
 | `acme.persistence.annotations`  | PVC annotations                                                      | `{}`                                      |
 | `acme.persistence.storageClass` | Type of `StorageClass` to request-- will be cluster-specific         | `nil` (uses alpha storage class annotation) |
@@ -240,9 +241,11 @@ acme:
       # variables that the specific dns provider requires
   domains:
     enabled: true
-    main: "*.example.com" # name of the wildcard domain name for the certificate
-    sans:
-      - "example.com" # OPTIONAL: Alternative name(s) for the certificate, if you want the same certificate for the root of the domain name for example
+    domainsList:
+      - main: "*.example.com" # name of the wildcard domain name for the certificate
+      - sans:
+        - "example.com" # OPTIONAL: Alternative name(s) for the certificate, if you want the same certificate for the root of the domain name for example
+      - main: "*.example2.com" # name of the wildcard domain name for the certificate
 ```
 
 #### Example: AWS Route 53

--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -49,3 +49,15 @@ Create the block for whiteListSourceRange.
 	   {{- end -}}
          ]
 {{- end -}}
+
+{{/*
+Create the block for acme.domains.sans.
+*/}}
+{{- define "traefik.acme.domains.sans" -}}
+       sans = [
+	   {{- range $idx, $domains := .Values.acme.domains.sans }}
+	     {{- if $idx }}, {{ end }}
+	     {{- $domains | quote }}
+	   {{- end -}}
+         ]
+{{- end -}}

--- a/stable/traefik/templates/_helpers.tpl
+++ b/stable/traefik/templates/_helpers.tpl
@@ -51,13 +51,21 @@ Create the block for whiteListSourceRange.
 {{- end -}}
 
 {{/*
-Create the block for acme.domains.sans.
+Create the block for acme.domains.
 */}}
-{{- define "traefik.acme.domains.sans" -}}
+{{- define "traefik.acme.domains" -}}
+{{- range $idx, $value := .Values.acme.domains.domainsList }}
+    {{- if $value.main }}
+    [[acme.domains]]
+       main = {{- range $mainIdx, $mainValue := $value }} {{ $mainValue | quote }}{{- end -}}
+    {{- end -}}
+{{- if $value.sans }}
        sans = [
-	   {{- range $idx, $domains := .Values.acme.domains.sans }}
-	     {{- if $idx }}, {{ end }}
+  {{- range $sansIdx, $domains := $value.sans }}
+			 {{- if $sansIdx }}, {{ end }}
 	     {{- $domains | quote }}
-	   {{- end -}}
-         ]
+  {{- end -}}
+	     ]
+	{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -111,6 +111,13 @@ data:
       [acme.httpChallenge]
       entryPoint = "http"
     {{- end }}
+    {{- if .Values.acme.domains.enabled }}
+    [[acme.domains]]
+      main = "{{ .Values.acme.domains.main }}"
+      {{- if .Values.acme.domains.sans }}
+      {{ template "traefik.acme.domains.sans" . }}
+      {{- end }}
+    {{- end }}
     {{- end }}
     {{- if or .Values.dashboard.enabled .Values.metrics.prometheus.enabled .Values.metrics.statsd.enabled .Values.metrics.datadog.enabled }}
     [web]

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -112,11 +112,7 @@ data:
       entryPoint = "http"
     {{- end }}
     {{- if .Values.acme.domains.enabled }}
-    [[acme.domains]]
-      main = "{{ .Values.acme.domains.main }}"
-      {{- if .Values.acme.domains.sans }}
-      {{ template "traefik.acme.domains.sans" . }}
-      {{- end }}
+    {{- if .Values.acme.domains.domainsList }}{{ template "traefik.acme.domains" . }}{{- end }}
     {{- end }}
     {{- end }}
     {{- if or .Values.dashboard.enabled .Values.metrics.prometheus.enabled .Values.metrics.statsd.enabled .Values.metrics.datadog.enabled }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -63,12 +63,13 @@ acme:
   # This is the only way to request wildcard certificates (works only with dns challenge).
   domains:
     enabled: false
-    # Main domain the certificate should be generated for.
-    main: "*.example.com"
-    # Alternative domain names this certificate can have.
-    sans:
-      # - "test1.example.com"
-      # - "test2.example.com"
+    # List of sets of main and (optional) SANs to generate for
+    # for wildcard certificates see https://docs.traefik.io/configuration/acme/#wildcard-domains
+    domainsList:
+      - main: "*.example.com"
+      - sans: ["example.com"]
+      - main: "*.example2.com"
+      - sans: ["test1.example2.com", "test2.example2.com"]
   ## ACME challenge type: "tls-sni-01", "http-01" or "dns-01"
   ## Note the chart's default of tls-sni-01 has been DEPRECATED and (except in
   ## certain circumstances) DISABLED by Let's Encrypt. It remains as a default

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -67,9 +67,12 @@ acme:
     # for wildcard certificates see https://docs.traefik.io/configuration/acme/#wildcard-domains
     domainsList:
       - main: "*.example.com"
-      - sans: ["example.com"]
+      - sans:
+        - "example.com"
       - main: "*.example2.com"
-      - sans: ["test1.example2.com", "test2.example2.com"]
+      - sans:
+        - "test1.example2.com"
+        - "test2.example2.com"
   ## ACME challenge type: "tls-sni-01", "http-01" or "dns-01"
   ## Note the chart's default of tls-sni-01 has been DEPRECATED and (except in
   ## certain circumstances) DISABLED by Let's Encrypt. It remains as a default

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -59,6 +59,16 @@ acme:
   email: admin@example.com
   staging: true
   logging: false
+  # Configure a Let's Encrypt certificate to be managed by default.
+  # This is the only way to request wildcard certificates (works only with dns challenge).
+  domains:
+    enabled: false
+    # Main domain the certificate should be generated for.
+    main: "*.example.com"
+    # Alternative domain names this certificate can have.
+    sans:
+      # - "test1.example.com"
+      # - "test2.example.com"
   ## ACME challenge type: "tls-sni-01", "http-01" or "dns-01"
   ## Note the chart's default of tls-sni-01 has been DEPRECATED and (except in
   ## certain circumstances) DISABLED by Let's Encrypt. It remains as a default

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -66,13 +66,13 @@ acme:
     # List of sets of main and (optional) SANs to generate for
     # for wildcard certificates see https://docs.traefik.io/configuration/acme/#wildcard-domains
     domainsList:
-      - main: "*.example.com"
-      - sans:
-        - "example.com"
-      - main: "*.example2.com"
-      - sans:
-        - "test1.example2.com"
-        - "test2.example2.com"
+      # - main: "*.example.com"
+      # - sans:
+      #   - "example.com"
+      # - main: "*.example2.com"
+      # - sans:
+      #   - "test1.example2.com"
+      #   - "test2.example2.com"
   ## ACME challenge type: "tls-sni-01", "http-01" or "dns-01"
   ## Note the chart's default of tls-sni-01 has been DEPRECATED and (except in
   ## certain circumstances) DISABLED by Let's Encrypt. It remains as a default


### PR DESCRIPTION
**What this PR does / why we need it**:  This PR is to include wildcard certificate support for the traefik chart.  See https://docs.traefik.io/configuration/acme/#wildcard-domains for more details on this capability.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5379

**Special notes for your reviewer**: Based on the original work provided by @farfeduc

