### PR TITLE
[stable/redis] references correct slave service annotation from values.yaml

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.3.5
+version: 3.3.6
 appVersion: 4.0.9
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-slave-svc.yaml
+++ b/stable/redis/templates/redis-slave-svc.yaml
@@ -9,8 +9,8 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-{{- if .Values.master.service.annotations }}
-{{ toYaml .Values.master.service.annotations | indent 4 }}
+{{- if .Values.slave.service.annotations }}
+{{ toYaml .Values.slave.service.annotations | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.slave.service.type }}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

The current slave service references annotations from the master service values. This is especially problematic when attempting to annotate redis slaves. E.g.,:

```
  master:
    service:
      annotations:
        external-dns.alpha.kubernetes.io/hostname: 'redis-master.foobar.com'
      type: LoadBalancer
  slave:
    service:
      annotations:
        external-dns.alpha.kubernetes.io/hostname: 'redis-slave.foobar.com'
      type: LoadBalancer
```

In this scenario, the slave service will inherit service annotations from `.Values.master.service` resulting in `redis-master.foobar.com` aliasing both the master and slave services.