### PR TITLE
[stable/datadog] add nodePort value in datadog template

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.15.1
+version: 0.16.0
 appVersion: 6.2.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.15.0
+version: 0.15.1
 appVersion: 6.2.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -16,14 +16,14 @@ spec:
   - port: 8125
     name: dogstatsdport
     protocol: UDP
-  {{- if .Values.deplyment.dogstatsdNodePort }}
+  {{- if .Values.deployment.dogstatsdNodePort }}
     nodePort: {{ .Values.deployment.dogstatsdNodePort }}
   {{- end }}
   {{- if .Values.datadog.apmEnabled }}
   - port: 8126
     name: traceport
     protocol: TCP
-  {{- if .Values.deplyment.traceNodePort }}
+  {{- if .Values.deployment.traceNodePort }}
     nodePort: {{ .Values.deployment.traceNodePort }}
   {{- end }}
   {{- end }}

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
   - port: 8125
     name: dogstatsdport
     protocol: UDP
+  {{- if .Values.dogstatsd.nodePort }}
+    nodePort: {{ .Values.dogstatsd.nodePort }}
+  {{- end }}
   {{- if .Values.datadog.apmEnabled }}
   - port: 8126
     name: traceport

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -16,12 +16,15 @@ spec:
   - port: 8125
     name: dogstatsdport
     protocol: UDP
-  {{- if .Values.dogstatsd.nodePort }}
-    nodePort: {{ .Values.dogstatsd.nodePort }}
+  {{- if .Values.deplyment.dogstatsdNodePort }}
+    nodePort: {{ .Values.deployment.dogstatsdNodePort }}
   {{- end }}
   {{- if .Values.datadog.apmEnabled }}
   - port: 8126
     name: traceport
     protocol: TCP
+  {{- if .Values.deplyment.traceNodePort }}
+    nodePort: {{ .Values.deployment.traceNodePort }}
+  {{- end }}
   {{- end }}
 {{ end }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -62,10 +62,8 @@ deployment:
   # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
-  # You'll need to set dogstatsd node port.
+  # If you're using a NodePort-type service and need a fixed port, set this parameter.
   # dogstatsdNodePort: 8125
-  #
-  # You'll need to set trace (APM) node port.
   # traceNodePort: 8126
 
 ## deploy the kube-state-metrics deployment

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -62,6 +62,12 @@ deployment:
   # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
+  # You'll need to set dogstatsd node port.
+  # dogstatsdNodePort: 8125
+  #
+  # You'll need to set trace (APM) node port.
+  # traceNodePort: 8126
+
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
 ##


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
helm user become able to set fixed dogstatsd nodePort.

if using `type: NodePort` service, I want to use fixed nodePort.
But, NodePort is random when `nodePort` is blank. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

in datadog service template, add `dogstatsd.nodePort` template value.
helm user become able to set fixed port.

**Special notes for your reviewer**:
This PR don't mention `traceport`. Because, user need to set `.Values.datadog.apmEnabled` value when user want to enable traceport. 