### PR TITLE
[stable/apm-server] Elastic APM Server

### DIFF
--- a/stable/apm-server/.helmignore
+++ b/stable/apm-server/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/apm-server/Chart.yaml
+++ b/stable/apm-server/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+description: The server receives data from the Elastic APM agents and stores the data into a datastore like Elasticsearch
+icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
+name: apm-server
+version: 0.1.0
+appVersion: 6.2.4
+home: https://www.elastic.co/solutions/apm
+sources:
+- https://www.elastic.co/guide/en/apm/get-started/current/index.html
+maintainers:
+- name: mumoshu
+  email: ykuoka@gmail.com

--- a/stable/apm-server/README.md
+++ b/stable/apm-server/README.md
@@ -1,0 +1,71 @@
+# apm-server
+
+[apm-server](https://www.elastic.co/guide/en/beats/apm-server/current/index.html)  is the server receives data from the Elastic APM agents and stores the data into a datastore like Elasticsearch.
+
+## Introduction
+
+This chart deploys apm-server agents to all the nodes in your cluster via a DaemonSet.
+
+By default this chart only ships a single output to a file on the local system.  Users should set config.output.file.enabled=false and configure their own outputs as [documented](https://www.elastic.co/guide/en/apm/get-started/current/install-and-run.html)
+
+## Prerequisites
+
+- Kubernetes 1.9+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`, run:
+
+```bash
+$ helm install --name my-release stable/apm-server
+```
+
+After a few minutes, you should see service statuses being written to the configured output, which is a log file inside the apm-server container.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the apm-server chart and their default values.
+
+|             Parameter               |            Description             |                    Default                |
+|-------------------------------------|------------------------------------|-------------------------------------------|
+| `image.repository`                  | The image repository to pull from  | `docker.elastic.co/apm/apm-server`        |
+| `image.tag`                         | The image tag to pull              | `6.2.4`                                   |
+| `image.pullPolicy`                  | Image pull policy                  | `IfNotPresent`                            |
+| `rbac.create`                       | If true, create & use RBAC resources | `true`                                  |
+| `rbac.serviceAccount`               | existing ServiceAccount to use (ignored if rbac.create=true) | `default`       |
+| `config`                            | The content of the configuration file consumed by apm-server. See the [apm-server documentation](https://www.elastic.co/guide/en/beats/apm-server/current/apm-server-reference-yml.html) for full details |
+| `plugins`                           | List of beat plugins                                                           |
+| `extraVars`                         | A map of additional environment variables |                                    |
+| `extraVolumes`, `extraVolumeMounts` | Additional volumes and mounts, for example to provide other configuration files | |
+| `resources.requests.cpu`            | CPU resource requests              |                                           |
+| `resources.limits.cpu`              | CPU resource limits                |                                           |
+| `resources.requests.memory`         | Memory resource requests           |                                           |
+| `resources.limits.memory`           | Memory resource limits             |                                           |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+    --set rbac.create=true \
+    stable/apm-server
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/apm-server
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/apm-server/templates/NOTES.txt
+++ b/stable/apm-server/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that apm-server has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "apm-server.name" . }},release={{ .Release.Name }}"

--- a/stable/apm-server/templates/_helpers.tpl
+++ b/stable/apm-server/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apm-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "apm-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "apm-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "apm-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "apm-server.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/apm-server/templates/clusterrole.yaml
+++ b/stable/apm-server/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "apm-server.fullname" . }}
+  labels:
+    app: {{ template "apm-server.name" . }}
+    chart: {{ template "apm-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/stable/apm-server/templates/clusterrolebinding.yaml
+++ b/stable/apm-server/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "apm-server.fullname" . }}
+  labels:
+    app: {{ template "apm-server.name" . }}
+    chart: {{ template "apm-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "apm-server.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "apm-server.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/stable/apm-server/templates/daemonset.yaml
+++ b/stable/apm-server/templates/daemonset.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "apm-server.fullname" . }}
+  labels:
+    app: {{ template "apm-server.name" . }}
+    chart: {{ template "apm-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "apm-server.name" . }}
+      release: {{ .Release.Name }}
+  minReadySeconds: 10
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "apm-server.name" . }}
+        release: {{ .Release.Name }}
+        {{-  range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+      annotations:
+        checksum/secret: {{ toYaml .Values.config | sha256sum }}
+        {{-  range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - "-e"
+{{- if .Values.plugins }}
+        - "--plugin"
+        - {{ .Values.plugins | join "," | quote }}
+{{- end }}
+{{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 8 }}
+{{- end }}
+        env:
+{{- range $key, $value := .Values.extraVars }}
+        - name: {{ $key }}
+          value: {{ $value }}
+{{- end }}
+        ports:
+          - containerPort: 8200
+        securityContext:
+          runAsUser: 0
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: apm-server-config
+          mountPath: /usr/share/apm-server/apm-server.yml
+          readOnly: true
+          subPath: apm-server.yml
+        - name: data
+          mountPath: /usr/share/apm-server/data
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+      - name: apm-server-config
+        secret:
+          secretName: {{ template "apm-server.fullname" . }}
+      - name: data
+        hostPath:
+          path: /var/lib/apm-server
+          type: DirectoryOrCreate
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: {{ template "apm-server.serviceAccountName" . }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}

--- a/stable/apm-server/templates/secret.yaml
+++ b/stable/apm-server/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "apm-server.fullname" . }}
+  labels:
+    app: {{ template "apm-server.name" . }}
+    chart: {{ template "apm-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  apm-server.yml: {{ toYaml .Values.config | indent 4 | b64enc }}

--- a/stable/apm-server/templates/serviceaccount.yaml
+++ b/stable/apm-server/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "apm-server.serviceAccountName" . }}
+  labels:
+    app: {{ template "apm-server.name" . }}
+    chart: {{ template "apm-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/stable/apm-server/values.yaml
+++ b/stable/apm-server/values.yaml
@@ -1,0 +1,126 @@
+image:
+  repository: docker.elastic.co/apm/apm-server
+  tag: 6.2.4
+  pullPolicy: IfNotPresent
+
+config:
+  apm-server: {}
+    ### Defines the host and port the server is listening on
+    # host: "localhost:8200"
+
+    ## Maximum permitted size in bytes of an unzipped request accepted by the server to be processed.
+    # max_unzipped_size: 52428800
+    ## Maximum permitted size in bytes of a request's header accepted by the server to be processed.
+    # max_header_size: 1048576
+
+    ## Maximum permitted duration in seconds for reading an entire request.
+    # read_timeout: 2s
+    ## Maximum permitted duration in seconds for writing a response.
+    # write_timeout: 2s
+
+    ## Maximum duration in seconds before releasing resources when shutting down the server.
+    # shutdown_timeout: 5s
+
+    ## Maximum number of requests permitted to be sent to the server concurrently.
+    # concurrent_requests: 40
+
+    ## Authorization token to be checked. If a token is set here the agents must
+    ## send their token in the following format: Authorization: Bearer <secret-token>.
+    ## It is recommended to use an authorization token in combination with SSL enabled.
+    # secret_token:
+    # ssl.enabled: false
+    # ssl.certificate : "path/to/cert"
+    # ssl.key : "path/to/private_key"
+
+  queue: {}
+    ## Queue type by name (default 'mem')
+    ## The memory queue will present all available events (up to the outputs
+    ## bulk_max_size) to the output, the moment the output is ready to server
+    ## another batch of events.
+    # mem:
+      ## Max number of events the queue can buffer.
+      # events: 4096
+
+      ## Hints the minimum number of events stored in the queue,
+      ## before providing a batch of events to the outputs.
+      ## A value of 0 (the default) ensures events are immediately available
+      ## to be sent to the outputs.
+      # flush.min_events: 2048
+
+      ## Maximum duration after which events are available to the outputs,
+      ## if the number of events stored in the queue is < min_flush_events.
+      # flush.timeout: 1s
+
+  # When a key contains a period, use this format for setting values on the command line:
+  # --set config."output\.file".enabled=false
+  output.file:
+    path: "/usr/share/apm-server/data"
+    filename: apm-server
+    rotate_every_kb: 10000
+    number_of_files: 5
+
+  # output.elasticsearch:
+  #  hosts: ["elasticsearch:9200"]
+  #  protocol: "https"
+  #  username: "elastic"
+  #  password: "changeme"
+
+# List of beat plugins
+plugins: []
+  # - kinesis.so
+
+# Additional container arguments
+extraArgs: []
+  # - -d
+  # - *
+
+# A map of additional environment variables
+extraVars: {}
+  # test1: "test2"
+
+# Add additional volumes and mounts, for example to read other log files on the host
+extraVolumes: []
+  # - hostPath:
+  #     path: /var/log
+  #   name: varlog
+extraVolumeMounts: []
+  # - name: varlog
+  #   mountPath: /host/var/log
+  #   readOnly: true
+
+## Labels to be added to pods
+podLabels: {}
+
+## Annotations to be added to pods
+podAnnotations: {}
+
+resources: {}
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 200Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 100Mi
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+nodeSelector: {}
+
+## Affinity configuration for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+affinity: {}
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
[Elastic APM](https://www.elastic.co/guide/en/apm/get-started/current/overview.html) is an application performance monitoring system built on the Elastic Stack. This chart is to install the server part of the system.

See the official documentation to setup the agent part of the system.

Even though apm-server is built by the Elastic team, it supports alternative outputs other than Elasticsearch via built-in beat output plugins and community plugins. For example, [awsbeats](https://github.com/s12v/awsbeats) enables apm-server to write collected application traces to AWS Kinesis Streams.