### PR TITLE
Ianb/datadog deploy only

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.16.0
+version: 0.16.1
 appVersion: 6.2.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -126,6 +126,12 @@ datadog:
       instances:
         - host: "outside-k8s.example.com"
           port: 6379
+  deploy_confd:
+    http_check.yaml: |-
+      init_config:
+      instances:
+        - host: "public-site.example.com"
+          port: 80
 ```
 
 ### Leader election

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -50,6 +50,8 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.autoconf`          | Additional Datadog service discovery configurations | `nil`                    |
 | `datadog.checksd`           | Additional Datadog service checks  | `nil`                                     |
 | `datadog.confd`             | Additional Datadog service configurations | `nil`                              |
+| `datadog.deploy_checksd`    | Additional Datadog service checks specific to kind:Deployment. Overrides `datadog.checksd` if set. | `nil`                                     |
+| `datadog.deploy_confd`      | Additional Datadog service configurations specific to kind:Deployment. Overrides `datadog.confd` if set. | `nil`                              |
 | `datadog.volumes`           | Additional volumes for the daemonset or deployment | `nil`                     |
 | `datadog.volumeMounts`      | Additional volumeMounts for the daemonset or deployment | `nil`                |
 | `resources.requests.cpu`    | CPU resource requests              | `100m`                                    |

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -16,14 +16,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Create a default fully qualified confd name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-*/}}
-{{- define "datadog.confd.fullname" -}}
-{{- printf "%s-datadog-confd" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
 Create a default fully qualified autoconf name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -32,11 +24,27 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default fully qualified confd name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "datadog.confd.fullname" -}}
+{{- printf "%s-datadog-confd" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "datadog.deploy_confd.fullname" -}}
+{{- printf "%s-datadog-deploy-confd" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified checksd name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "datadog.checksd.fullname" -}}
 {{- printf "%s-datadog-checksd" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "datadog.deploy_checksd.fullname" -}}
+{{- printf "%s-datadog-deploy-checksd" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/datadog/templates/deploy-checksd-configmap.yaml
+++ b/stable/datadog/templates/deploy-checksd-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "datadog.deploy_checksd.fullname" . }}
+  labels:
+    app: {{ template "datadog.deploy_checksd.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    checksum/checksd-config: {{ toYaml .Values.datadog.deploy_checksd | sha256sum }}
+data:
+{{- if .Values.datadog.deploy_checksd }}
+{{ toYaml .Values.datadog.deploy_checksd | indent 2 }}
+{{- end -}}

--- a/stable/datadog/templates/deploy-confd-configmap.yaml
+++ b/stable/datadog/templates/deploy-confd-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "datadog.deploy_confd.fullname" . }}
+  labels:
+    app: {{ template "datadog.deploy_confd.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    checksum/confd-config: {{ toYaml .Values.datadog.deploy_confd | sha256sum }}
+data:
+{{- if .Values.datadog.deploy_confd }}
+{{ toYaml .Values.datadog.deploy_confd | indent 2 }}
+{{- end -}}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -83,8 +83,16 @@ spec:
           - name: confd
             mountPath: /conf.d
             readOnly: true
+          {{- else if .Values.datadog.confd }}
+          - name: confd
+            mountPath: /conf.d
+            readOnly: true
           {{- end }}
-          {{- if .Values.datadog.deploy_checksd  }}
+          {{- if .Values.datadog.deploy_checksd }}
+          - name: checksd
+            mountPath: /checks.d
+            readOnly: true
+          {{- else if .Values.datadog.checksd }}
           - name: checksd
             mountPath: /checks.d
             readOnly: true
@@ -117,15 +125,23 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        {{- if .Values.datadog.deploy_confd  }}
+        {{- if .Values.datadog.deploy_confd }}
         - name: confd
           configMap:
-            name: {{ if .Values.datadog.deploy_confd }}{{ template "datadog.deploy_confd.fullname" . }}{{ else }}{{ template "datadog.confd.fullname" . }}{{ end }}
+            name: {{ template "datadog.deploy_confd.fullname" . }}
+        {{- else if .Values.datadog.confd }}
+        - name: confd
+          configMap:
+            name: {{ template "datadog.confd.fullname" . }}
         {{- end }}
-        {{- if .Values.datadog.deploy_checksd  }}
+        {{- if .Values.datadog.deploy_checksd }}
         - name: checksd
           configMap:
-            name: {{ if .Values.datadog.deploy_checksd }}{{ template "datadog.deploy_checksd.fullname" . }}{{ else }}{{ template "datadog.checksd.fullname" . }}{{ end }}
+            name: {{ template "datadog.deploy_checksd.fullname" . }}
+        {{- else if .Values.datadog.checksd }}
+        - name: checksd
+          configMap:
+            name: {{ template "datadog.checksd.fullname" . }}
         {{- end }}
         {{- if .Values.datadog.autoconf }}
         - name: autoconf

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -16,8 +16,8 @@ spec:
       name: {{ template "datadog.fullname" . }}
       annotations:
         checksum/autoconf-config: {{ toYaml .Values.datadog.autoconf | sha256sum }}
-        checksum/confd-config: {{ toYaml .Values.datadog.confd | sha256sum }}
-        checksum/checksd-config: {{ toYaml .Values.datadog.checksd | sha256sum }}
+        checksum/confd-config: {{ if .Values.datadog.deploy_confd }}{{ toYaml .Values.datadog.deploy_confd | sha256sum }}{{ else }}{{ toYaml .Values.datadog.confd | sha256sum }}{{ end }}
+        checksum/checksd-config: {{ if .Values.datadog.deploy_checksd }}{{ toYaml .Values.datadog.deploy_checksd | sha256sum }}{{ else }}{{ toYaml .Values.datadog.checksd | sha256sum }}{{ end }}
     spec:
       containers:
       - name: {{ .Chart.Name }}
@@ -79,12 +79,12 @@ spec:
           - name: cgroups
             mountPath: /host/sys/fs/cgroup
             readOnly: true
-          {{- if .Values.datadog.confd }}
+          {{- if .Values.datadog.deploy_confd }}
           - name: confd
             mountPath: /conf.d
             readOnly: true
           {{- end }}
-          {{- if .Values.datadog.checksd }}
+          {{- if .Values.datadog.deploy_checksd  }}
           - name: checksd
             mountPath: /checks.d
             readOnly: true
@@ -117,15 +117,15 @@ spec:
         - hostPath:
             path: /sys/fs/cgroup
           name: cgroups
-        {{- if .Values.datadog.confd }}
+        {{- if .Values.datadog.deploy_confd  }}
         - name: confd
           configMap:
-            name: {{ template "datadog.confd.fullname" . }}
+            name: {{ if .Values.datadog.deploy_confd }}{{ template "datadog.deploy_confd.fullname" . }}{{ else }}{{ template "datadog.confd.fullname" . }}{{ end }}
         {{- end }}
-        {{- if .Values.datadog.checksd }}
+        {{- if .Values.datadog.deploy_checksd  }}
         - name: checksd
           configMap:
-            name: {{ template "datadog.checksd.fullname" . }}
+            name: {{ if .Values.datadog.deploy_checksd }}{{ template "datadog.deploy_checksd.fullname" . }}{{ else }}{{ template "datadog.checksd.fullname" . }}{{ end }}
         {{- end }}
         {{- if .Values.datadog.autoconf }}
         - name: autoconf

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -160,12 +160,26 @@ datadog:
   #     instances:
   #       - host: "name"
   #         port: "6379"
+  
+  ## If set, below will be applied to a kind:Deployment instead of above.
+  ##
+  # deploy_confd:
+  #   redisdb.yaml: |-
+  #     init_config:
+  #     instances:
+  #       - host: "name2"
+  #         port: "6379"
 
   ## Provide additional service checks
   ## Each key will become a file in /checks.d
   ## ref: https://github.com/DataDog/docker-dd-agent#configuration-files
   ##
   # checksd:
+  #   service.py: |-
+  
+  ## If set, below will be applied to a kind:Deployment instead of above.
+  ##
+  # deploy_checksd:
   #   service.py: |-
 
   ## datadog-agent resource requests and limits


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
Lint OK: https://cl.ly/0F3G3q3W2G2H

* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds an option to include a Deployment-only confd (`datadog.deploy_confd`) and checksd (`datadog.deploy_checksd`).  Currently, the both are inherited by the daemonset and deployment kinds, resulting to duplicated checks and metrics if checking an external endpoint e.g. http_check

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
- not sure re versioning
- will link this to a card.
@hkaj @xvello @irabinovitch 