### PR TITLE
[stable/coredns] Make CoreDNS chart more configurable

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 name: coredns
-version: 0.9.1
-appVersion: 1.0.6
+version: 0.10.0
+appVersion: 1.1.3
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:
 - coredns
@@ -15,3 +15,5 @@ maintainers:
   email: hello@acale.ph
 - name: shashidharatd
   email: shashidhara.huawei@gmail.com
+- name: andor44
+  email: andor44@gmail.com

--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,6 +1,6 @@
 name: coredns
 version: 0.10.0
-appVersion: 1.1.3
+appVersion: 1.2.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:
 - coredns

--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 0.10.0
+version: 1.0.0
 appVersion: 1.2.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/README.md
+++ b/stable/coredns/README.md
@@ -17,19 +17,7 @@ This chart bootstraps a [CoreDNS](https://github.com/coredns/coredns) deployment
 
  - CoreDNS as a cluster dns service and a drop-in replacement for Kube/SkyDNS. This is the default mode and CoreDNS is deployed as cluster-service in kube-system namespace. This mode is chosen by setting `isClusterService` to true.
  - CoreDNS as an external dns service. In this mode CoreDNS is deployed as any kubernetes app in user specified namespace. The CoreDNS service can be exposed outside the cluster by using using either the NodePort or LoadBalancer type of service. This mode is chosen by setting `isClusterService` to false.
- - CoreDNS as an external dns provider for kubernetes federation. This is a sub case of 'external dns service' which uses etcd plugin for CoreDNS backend. This deployment mode as a dependency on `etcd-operator` chart, which needs to be pre-installed. To use this deployment mode use below configuration file to override default values.
-```
-isClusterService: false
-   serviceType: "NodePort"
-   plugins:
-     kubernetes:
-       enabled: false
-     etcd:
-       enabled: true
-       zones:
-       - "<example.io>"
-       endpoint: "http://<etcd-cluster>:2379"
-```
+ - CoreDNS as an external dns provider for kubernetes federation. This is a sub case of 'external dns service' which uses etcd plugin for CoreDNS backend. This deployment mode as a dependency on `etcd-operator` chart, which needs to be pre-installed.
 
 Prerequisites
 -------------
@@ -67,11 +55,11 @@ See `values.yaml` for configuration notes. Specify each parameter using the `--s
 
 ```console
 $ helm install --name coredns \
-  --set plugins.prometheus.enabled=false \
+  --set rbac.create=false \
     stable/coredns
 ```
 
-The above command disables the Prometheus plugin.
+The above command disables automatic creation of RBAC rules.
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
@@ -85,9 +73,11 @@ $ helm install --name coredns -f values.yaml stable/coredns
 Caveats
 -------
 
-CoreDNS service, by default is deployed to listen on both "TCP" and "UDP".
+The chart will automatically determine which protocols to listen on based on
+the protocols you define in your zones. This means that you could potentially
+use both "TCP" and "UDP" on a single port.
 Some cloud environments like "GCE" or "Azure container service" cannot
 create external loadbalancers with both "TCP" and "UDP" protocols. So
 When deploying CoreDNS with `serviceType="LoadBalancer"` on such cloud
-environments, it is preferred to use either "TCP" or "UDP" by setting
-`serviceProtocol` parameter.
+environments, make sure you do not attempt to use both protocols at the same
+time.

--- a/stable/coredns/templates/_helpers.tpl
+++ b/stable/coredns/templates/_helpers.tpl
@@ -14,3 +14,111 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Generate the list of ports automatically from the server definitions
+*/}}
+{{- define "coredns.servicePorts" -}}
+    {{/* Set ports to be an empty dict */}}
+    {{- $ports := dict -}}
+    {{/* Iterate through each of the server blocks */}}
+    {{- range .Values.servers -}}
+        {{/* Capture port to avoid scoping awkwardness */}}
+        {{- $port := toString .port -}}
+
+        {{/* If none of the server blocks has mentioned this port yet take note of it */}}
+        {{- if not (hasKey $ports $port) -}}
+            {{- $ports := set $ports $port (dict "istcp" false "isudp" false) -}}
+        {{- end -}}
+        {{/* Retrieve the inner dict that holds the protocols for a given port */}}
+        {{- $innerdict := index $ports $port -}}
+
+        {{/*
+        Look at each of the zones and check which protocol they serve
+        At the moment the following are supported by CoreDNS:
+        UDP: dns://
+        TCP: tls://, grpc://
+        */}}
+        {{- range .zones -}}
+            {{- if has (default "" .scheme) (list "dns://") -}}
+                {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- end -}}
+
+            {{- if has (default "" .scheme) (list "tls://" "grpc://") -}}
+                {{- $innerdict := set $innerdict "istcp" true -}}
+            {{- end -}}
+        {{- end -}}
+
+        {{/* If none of the zones specify scheme, default to UDP (CoreDNS defaults to dns://) */}}
+        {{- if and (not (index $innerdict "istcp")) (not (index $innerdict "isudp")) -}}
+            {{- $innerdict := set $innerdict "isudp" true -}}
+        {{- end -}}
+
+        {{/* Write the dict back into the outer dict */}}
+        {{- $ports := set $ports $port $innerdict -}}
+    {{- end -}}
+
+    {{/* Write out the ports according to the info collected above */}}
+    {{- range $port, $innerdict := $ports -}}
+        {{- if index $innerdict "isudp" -}}
+            {{- printf "- {port: %v, protocol: UDP}\n" $port -}}
+        {{- end -}}
+        {{- if index $innerdict "istcp" -}}
+            {{- printf "- {port: %v, protocol: TCP}\n" $port -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Generate the list of ports automatically from the server definitions
+*/}}
+{{- define "coredns.containerPorts" -}}
+    {{/* Set ports to be an empty dict */}}
+    {{- $ports := dict -}}
+    {{/* Iterate through each of the server blocks */}}
+    {{- range .Values.servers -}}
+        {{/* Capture port to avoid scoping awkwardness */}}
+        {{- $port := toString .port -}}
+
+        {{/* If none of the server blocks has mentioned this port yet take note of it */}}
+        {{- if not (hasKey $ports $port) -}}
+            {{- $ports := set $ports $port (dict "istcp" false "isudp" false) -}}
+        {{- end -}}
+        {{/* Retrieve the inner dict that holds the protocols for a given port */}}
+        {{- $innerdict := index $ports $port -}}
+
+        {{/*
+        Look at each of the zones and check which protocol they serve
+        At the moment the following are supported by CoreDNS:
+        UDP: dns://
+        TCP: tls://, grpc://
+        */}}
+        {{- range .zones -}}
+            {{- if has (default "" .scheme) (list "dns://") -}}
+                {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- end -}}
+
+            {{- if has (default "" .scheme) (list "tls://" "grpc://") -}}
+                {{- $innerdict := set $innerdict "istcp" true -}}
+            {{- end -}}
+        {{- end -}}
+
+        {{/* If none of the zones specify scheme, default to UDP (CoreDNS defaults to dns://) */}}
+        {{- if and (not (index $innerdict "istcp")) (not (index $innerdict "isudp")) -}}
+            {{- $innerdict := set $innerdict "isudp" true -}}
+        {{- end -}}
+
+        {{/* Write the dict back into the outer dict */}}
+        {{- $ports := set $ports $port $innerdict -}}
+    {{- end -}}
+
+    {{/* Write out the ports according to the info collected above */}}
+    {{- range $port, $innerdict := $ports -}}
+        {{- if index $innerdict "isudp" -}}
+            {{- printf "- {containerPort: %v, protocol: UDP}\n" $port -}}
+        {{- end -}}
+        {{- if index $innerdict "istcp" -}}
+            {{- printf "- {containerPort: %v, protocol: TCP}\n" $port -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -4,45 +4,17 @@ metadata:
   name: {{ template "coredns.fullname" . }}
 data:
   Corefile: |-
-    .:53 {
-      {{- range $key, $plugin := .Values.plugins }}
-      {{- if $plugin.enabled }}
-      {{- if eq "kubernetes" $key }}
-        kubernetes {{ $plugin.clusterDomain }} {{ $plugin.clusterCidr }}
-      {{- end }}
-      {{- if eq "etcd" $key }}
-        etcd {{ range $plugin.zones }}{{ . }} {{ end }}{
-          {{ if $plugin.path }}path {{ $plugin.path }}{{ end }}
-          endpoint {{ $plugin.endpoint }}
-        }
-      {{- end }}
-      {{- if eq "loadbalance" $key }}
-        loadbalance {{ default "round_robin" $plugin.policy }}
-      {{- end }}
-      {{- if eq "log" $key }}
-        log
-      {{- end }}
-      {{- if eq "errors" $key }}
-        errors
-      {{- end }}
-      {{- if eq "health" $key }}
-        health
-      {{- end }}
-      {{- if eq "prometheus" $key }}
-        prometheus 0.0.0.0:{{ $plugin.port }}
-      {{- end }}
-      {{- if eq "proxy" $key }}
-        proxy . /etc/resolv.conf
-      {{- end }}
-      {{- if eq "cache" $key }}
-        cache 30
-      {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- range .Values.zoneFiles }}
-        file /etc/coredns/{{ .filename }} {{ .domain }}
+    {{ range .Values.servers }}
+    {{- range $idx, $zone := .zones }}{{ if $idx }} {{ else }}{{ end }}{{ default "" $zone.scheme }}{{ default "." $zone.zone }}{{ else }}.{{ end -}}
+    {{- if .port }}:{{ .port }} {{ end -}}
+    {
+      {{- range .plugins }}
+        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} {
+{{ .configBlock | indent 12 }}
+        }{{ end }}
       {{- end }}
     }
+    {{ end }}
   {{- range .Values.zoneFiles }}
   {{ .filename }}: {{ toYaml .contents | indent 4 }}
   {{- end }}

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
         {{- end }}
     spec:
-      {{- if .Values.plugins.kubernetes.enabled }}
+      {{- if or .Values.rbac.create .Values.rbac.serviceAccountName }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "coredns.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       {{- end }}
       {{- if .Values.isClusterService }}
@@ -63,21 +63,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
-        {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "UDP") }}
-        - containerPort: 53
-          name: dns
-          protocol: UDP
-        {{- end }}
-        {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "TCP") }}
-        - containerPort: 53
-          name: dns-tcp
-          protocol: TCP
-        {{- end }}
-        {{- if .Values.plugins.prometheus.enabled }}
-        - containerPort: {{ .Values.plugins.prometheus.port }}
-          name: metrics
-          protocol: TCP
-        {{- end }}
+{{ include "coredns.containerPorts" . | indent 8 }}
         livenessProbe:
           httpGet:
             path: /health

--- a/stable/coredns/templates/rbac.yaml
+++ b/stable/coredns/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.plugins.kubernetes.enabled .Values.rbac.create }}
+{{- if .Values.rbac.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -14,10 +14,7 @@ metadata:
     app: {{ template "coredns.fullname" . }}
     {{- end }}
   annotations:
-    {{- if .Values.plugins.prometheus.enabled }}
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.plugins.prometheus.port | quote }}
-    {{- end }}
+{{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   selector:
   {{- if .Values.isClusterService }}
@@ -25,23 +22,9 @@ spec:
   {{- else }}
     app: {{ template "coredns.fullname" . }}
   {{- end }}
-  {{- if .Values.clusterIP }}
-  clusterIP: {{ .Values.clusterIP }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   ports:
-  {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "UDP") }}
-  - name: dns
-    port: 53
-    protocol: UDP
-  {{- end }}
-  {{- if or (eq .Values.serviceProtocol "UDPNTCP") (eq .Values.serviceProtocol "TCP") }}
-  - name: dns-tcp
-    port: 53
-    protocol: TCP
-  {{- end }}
-  {{- if .Values.plugins.prometheus.enabled }}
-  - name: metrics
-    port: {{ .Values.plugins.prometheus.port }}
-    protocol: TCP
-  {{- end }}
+{{ include "coredns.servicePorts" . | indent 2 -}}
   type: {{ default "ClusterIP" .Values.serviceType }}

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: coredns/coredns
-  tag: "1.1.3"
+  tag: "1.2.0"
   pullPolicy: IfNotPresent
 
 resources:

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: coredns/coredns
-  tag: "1.0.6"
+  tag: "1.1.3"
   pullPolicy: IfNotPresent
 
 resources:
@@ -17,6 +17,13 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+service:
+  type: "ClusterIP"
+# clusterIP: ""
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9153"
+
 rbac:
   # If true, create & use RBAC resources
   create: false
@@ -26,15 +33,35 @@ rbac:
 # isClusterService specifies whether chart should be deployed as cluster-service or normal k8s app.
 isClusterService: true
 
-# serviceType specifies type of service to be created for this chart.
-serviceType: "ClusterIP"
+servers:
+- zones:
+  - zone: .
+  port: 53
+  plugins:
+  - name: cache
+    parameters: 30
+  - name: errors
+  - name: health
+  - name: kubernetes
+    parameters: cluster.local
+  - name: loadbalance
+    parameters: round_robin
+  - name: prometheus
+    parameters: 0.0.0.0:9153
+  - name: proxy
+    parameters: . /etc/resolv.conf
 
-# cluster IP to use
-# clusterIP: ""
-
-# serviceProtocol specifies the protocol on which to expose the CoreDNS service.
-# Can be one of three options: "UDPNTCP" (default), "UDP" or "TCP"
-serviceProtocol: "UDPNTCP"
+# Complete example with all the options:
+# - zones:                 # the `zones` block can be left out entirely, defaults to "."
+#   - zone: hello.world.   # optional, defaults to "."
+#     scheme: tls://       # optional, defaults to "" (which equals "dns://" in CoreDNS)
+#   port: 12345            # optional, defaults to "" (which equals 53 in CoreDNS)
+#   plugins:               # the plugins to use for this server block
+#   - name: kubernetes     # name of plugin, if used multiple times ensure that the plugin supports it!
+#     parameters: foo bar  # list of parameters after the plugin
+#     configBlock: |-      # if the plugin supports extra block style config, supply it here
+#       hello world
+#       foo bar
 
 # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
 # for example:
@@ -58,37 +85,6 @@ affinity: {}
 #     effect: NoSchedule
 tolerations: []
 
-# plugn configuration of CoreDNS refer to https://github.com/coredns/coredns/tree/master/plugin
-# for all specific details. set enabled to true/false to enable/disable a plugin.
-plugins:
-  kubernetes:
-    enabled: true
-    clusterCidr: "10.3.0.0/24"
-    clusterDomain: "cluster.local"
-    clusterIP:
-  prometheus:
-    enabled: true
-    port: "9153"
-  errors:
-    enabled: true
-    file: "stdout"
-  log:
-    enabled: false
-  health:
-    enabled: true
-  proxy:
-    enabled: true
-  cache:
-    enabled: true
-  loadbalance:
-    enabled: true
-    policy: "round_robin"
-  etcd:
-    enabled: false
-    zones:
-      - "k8s.io"
-    path: "/skydns"
-    endpoint: "http://localhost:2379"
 # configure custom zone files as per https://coredns.io/2017/05/08/custom-dns-entries-for-kubernetes/
 zoneFiles: []
 #  - filename: example.db


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes CoreDNS more configurable. Currently, the chart defines a single server block with a fixed zone, and a fixed set of plugins. Now you can define as many server zones as you want, with any number of zones and plugins.

**Special notes for your reviewer**:
This flexibility of course comes at a tradeoff. The chart is not as hands-off anymore, as the plugins aren't known beforehand. That being said, the supplied `values.yaml` produces an almost-identical default `Corefile`, the only difference being that I didn't hardcode the reverse zone for the k8s plugin.
Additionally, I made the chart "smart" by making it automatically derive the ports for the service and the containers based on the server blocks and zones defined. The caveat is that I tried passing an extra argument to my template helpers to determine whether it's templating the service (use key `port`) or the container (use key `containerPort`), but this did not work for reasons described on Slack, to which I didn't receive any answers. Therefore the template helper is essentially repeated twice, with the only difference being a single line.

**edit**: In terms of what I tried to avoid duplication of the port templates see [here](https://kubernetes.slack.com/archives/C0NH30761/p1528477432000391). If somebody knows of a way to avoid duplication I'm more than happy to update the PR.