### PR TITLE
[stable/stolon] Leave secret in place as it's used by the keepers

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,5 +1,5 @@
 name: stolon
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.10.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/templates/secret.yaml
+++ b/stable/stolon/templates/secret.yaml
@@ -1,4 +1,3 @@
-{{ if .Release.IsInstall }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,5 +20,3 @@ data:
   {{ else }}
   pg_repl_password: {{ randAlphaNum 40 | b64enc | quote }}
   {{ end }}
-
-{{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
It ensures the stolon chart can be used in `helm upgrade` w/o breaking the setup.

**Which issue this PR fixes**
At the moment, it's not possible to use `helm upgrade` on this chart as the secret gets removed. So when the keeper-pods are restarted, they won't start anymore because the secret is missing.