### PR TITLE
[stable/prometheus-redis-exporter] add RBAC resources

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.16.0
+appVersion: 0.17.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
 version: 0.1.2

--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.17.0
+appVersion: 0.16.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 0.1.2
+version: 0.2.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -51,6 +51,10 @@ The following table lists the configurable parameters and their default values.
 | `service.port`         | service external port                               | `9121`                    |
 | `redisAddress`         | address of one or more redis nodes, comma separated | `redis://myredis:6379`    |
 | `annotations`          | pod annotations for easier discovery                | {}                        |
+| `rbac.create`           | Specifies whether RBAC resources should be created.| `true` |
+| `rbac.pspEnabled`       | Specifies whether a PodSecurityPolicy should be created.| `true` |
+| `serviceAccount.create` | Specifies whether a service account should be created.| `true` |
+| `serviceAccount.name`   | Name of the service account.|        |
 
 For more information please refer to the [redis_exporter](https://github.com/oliver006/redis_exporter) documentation.
 

--- a/stable/prometheus-redis-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-redis-exporter/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "prometheus-redis-exporter.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-redis-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "prometheus-redis-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app: {{ template "prometheus-redis-exporter.name" . }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
+++ b/stable/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/stable/prometheus-redis-exporter/templates/role.yaml
+++ b/stable/prometheus-redis-exporter/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.rbac.pspEnabled }}
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "prometheus-redis-exporter.fullname" . }}]
+{{- end }}
+{{- end }}

--- a/stable/prometheus-redis-exporter/templates/rolebinding.yaml
+++ b/stable/prometheus-redis-exporter/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
+{{- end -}}

--- a/stable/prometheus-redis-exporter/templates/serviceaccount.yaml
+++ b/stable/prometheus-redis-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ template "prometheus-redis-exporter.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end -}}

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -1,3 +1,15 @@
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  # Specifies whether a PodSecurityPolicy should be created
+  pspEnabled: true
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
 replicaCount: 1
 image:
   repository: oliver006/redis_exporter


### PR DESCRIPTION
**What this PR does / why we need it**:

For clusters with a PodSecurityPolicy admission controller, every pod
must have an associated PodSecurityPolicy to be scheduled.