### PR TITLE
Add namespace support to signalfx-agent helm chart

### DIFF
--- a/stable/signalfx-agent/Chart.yaml
+++ b/stable/signalfx-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The SignalFx Kubernetes agent
 name: signalfx-agent
 appVersion: 3.1.9
-version: 0.1.2
+version: 0.2.0
 keywords:
 - monitoring
 - alerting

--- a/stable/signalfx-agent/Chart.yaml
+++ b/stable/signalfx-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The SignalFx Kubernetes agent
 name: signalfx-agent
 appVersion: 3.1.9
-version: 0.1.1
+version: 0.1.2
 keywords:
 - monitoring
 - alerting

--- a/stable/signalfx-agent/templates/_helpers.tpl
+++ b/stable/signalfx-agent/templates/_helpers.tpl
@@ -41,3 +41,10 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get namespace to deploy agent and its dependencies.
+*/}}
+{{- define "signalfx-agent.namespace" -}}
+    {{- default .Release.Namespace .Values.namespace -}}
+{{- end -}}

--- a/stable/signalfx-agent/templates/clusterrolebinding.yaml
+++ b/stable/signalfx-agent/templates/clusterrolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "signalfx-agent.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
 {{- end -}}

--- a/stable/signalfx-agent/templates/configmap.yaml
+++ b/stable/signalfx-agent/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "signalfx-agent.fullname" . }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
   labels:
     app: {{ template "signalfx-agent.name" . }}
     heritage: {{ .Release.Service }}

--- a/stable/signalfx-agent/templates/daemonset.yaml
+++ b/stable/signalfx-agent/templates/daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: {{ template "signalfx-agent.fullname" . }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
   labels:
     app: {{ template "signalfx-agent.name" . }}
     version: {{ .Values.agentVersion }}

--- a/stable/signalfx-agent/templates/secrets.yaml
+++ b/stable/signalfx-agent/templates/secrets.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "signalfx-agent.fullname" . }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
   labels:
     app: {{ template "signalfx-agent.name" . }}
     chart: {{ template "signalfx-agent.chart" . }}

--- a/stable/signalfx-agent/templates/serviceaccount.yaml
+++ b/stable/signalfx-agent/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "signalfx-agent.serviceAccountName" . }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
 {{- end -}}

--- a/stable/signalfx-agent/values.yaml
+++ b/stable/signalfx-agent/values.yaml
@@ -20,6 +20,9 @@ image:
 # version of the agent
 rollingUpdateMaxUnavailable: 1
 
+# Namespace to deploy agent in (Optional: Will default to release namespace)
+namespace:
+
 # RBAC config for the agent
 rbac:
   create: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a values option to specify the namespace you want the signalfx-agent to run under.
This is particularly useful if the agent is deployed as a dependency in your master chart.

Namespace in values.yaml is optional. If its not specified, the behavior of this chart
will be the same as it is now.

**Special notes for your reviewer**:
Tested by deploying signalfx-agent with and without namespace option specified. Confirmed agent was working as expected.