### PR TITLE
[stable/coredns] use .name in app label, not fullname

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.2.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -2,6 +2,17 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "coredns.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- else }}
+    app: {{ template "coredns.name" . }}
+    {{- end }}
 data:
   Corefile: |-
     {{ range .Values.servers }}

--- a/stable/coredns/templates/configmap.yaml
+++ b/stable/coredns/templates/configmap.yaml
@@ -10,9 +10,8 @@ metadata:
     k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    {{- else }}
-    app: {{ template "coredns.name" . }}
     {{- end }}
+    app: {{ template "coredns.name" . }}
 data:
   Corefile: |-
     {{ range .Values.servers }}

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -11,16 +11,17 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     {{- else }}
-    app: {{ template "coredns.fullname" . }}
+    app: {{ template "coredns.name" . }}
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
+      release: {{ .Release.Name | quote }}
       {{- if .Values.isClusterService }}
       k8s-app: {{ .Chart.Name | quote }}
       {{- else }}
-      app: {{ template "coredns.fullname" . }}
+      app: {{ template "coredns.name" . }}
       {{- end }}
   template:
     metadata:

--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -10,9 +10,8 @@ metadata:
     k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    {{- else }}
-    app: {{ template "coredns.name" . }}
     {{- end }}
+    app: {{ template "coredns.name" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -20,17 +19,15 @@ spec:
       release: {{ .Release.Name | quote }}
       {{- if .Values.isClusterService }}
       k8s-app: {{ .Chart.Name | quote }}
-      {{- else }}
-      app: {{ template "coredns.name" . }}
       {{- end }}
+      app: {{ template "coredns.name" . }}
   template:
     metadata:
       labels:
         {{- if .Values.isClusterService }}
         k8s-app: {{ .Chart.Name | quote }}
-        {{- else }}
-        app: {{ template "coredns.fullname" . }}
         {{- end }}
+        app: {{ template "coredns.fullname" . }}
         release: {{ .Release.Name | quote }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}

--- a/stable/coredns/templates/rbac.yaml
+++ b/stable/coredns/templates/rbac.yaml
@@ -12,7 +12,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     {{- else }}
-    app: {{ template "coredns.fullname" . }}
+    app: {{ template "coredns.name" . }}
     {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -28,7 +28,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     {{- else }}
-    app: {{ template "coredns.fullname" . }}
+    app: {{ template "coredns.name" . }}
     {{- end }}
 rules:
 - apiGroups:
@@ -55,7 +55,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     {{- else }}
-    app: {{ template "coredns.fullname" . }}
+    app: {{ template "coredns.name" . }}
     {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/coredns/templates/rbac.yaml
+++ b/stable/coredns/templates/rbac.yaml
@@ -11,9 +11,8 @@ metadata:
     k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    {{- else }}
-    app: {{ template "coredns.name" . }}
     {{- end }}
+    app: {{ template "coredns.name" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -27,9 +26,8 @@ metadata:
     k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    {{- else }}
-    app: {{ template "coredns.name" . }}
     {{- end }}
+    app: {{ template "coredns.name" . }}
 rules:
 - apiGroups:
   - ""
@@ -54,9 +52,8 @@ metadata:
     k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    {{- else }}
-    app: {{ template "coredns.name" . }}
     {{- end }}
+    app: {{ template "coredns.name" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     {{- else }}
-    app: {{ template "coredns.fullname" . }}
+    app: {{ template "coredns.name" . }}
     {{- end }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
@@ -20,7 +20,7 @@ spec:
   {{- if .Values.isClusterService }}
     k8s-app: {{ .Chart.Name | quote }}
   {{- else }}
-    app: {{ template "coredns.fullname" . }}
+    app: {{ template "coredns.name" . }}
   {{- end }}
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -17,6 +17,7 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   selector:
+    release: {{ .Release.Name | quote }}
   {{- if .Values.isClusterService }}
     k8s-app: {{ .Chart.Name | quote }}
   {{- else }}

--- a/stable/coredns/templates/service.yaml
+++ b/stable/coredns/templates/service.yaml
@@ -10,19 +10,17 @@ metadata:
     k8s-app: {{ .Chart.Name | quote }}
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    {{- else }}
-    app: {{ template "coredns.name" . }}
     {{- end }}
+    app: {{ template "coredns.name" . }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   selector:
     release: {{ .Release.Name | quote }}
-  {{- if .Values.isClusterService }}
+    {{- if .Values.isClusterService }}
     k8s-app: {{ .Chart.Name | quote }}
-  {{- else }}
+    {{- end }}
     app: {{ template "coredns.name" . }}
-  {{- end }}
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}


### PR DESCRIPTION

**What this PR does / why we need it**:

Follow conventions in other charts, labeling best practices where the deployment name is not part of app label. Result: `app: coredns`, not `app: mydeployment-coredns`.

cc @ShashidharaTD