### PR TITLE
[stable/jenkins] Add cpu and memory limit for jenkins master

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.3
-appVersion: 2.107
+version: 0.16.4
+appVersion: 2.121.1
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
   projects as well as arbitrary scripts.

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -39,7 +39,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
 | `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
 | `Master.Cpu`                      | Master requested cpu                 | `200m`                                                                       |
+| `Master.CpuLimit`                 | Master cpu limit                     | `1000m`                                                                      |
 | `Master.Memory`                   | Master requested memory              | `256Mi`                                                                      |
+| `Master.MemoryLimit`              | Master memory limit                  | `1024Mi`                                                                     |
 | `Master.InitContainerEnv`         | Environment variables for Init Container                                 | Not set                                  |
 | `Master.ContainerEnv`             | Environment variables for Jenkins Container                              | Not set                                  |
 | `Master.RunAsUser`                | uid that jenkins runs with           | `0`                                                                          |

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -141,6 +141,9 @@ spec:
             requests:
               cpu: "{{ .Values.Master.Cpu }}"
               memory: "{{ .Values.Master.Memory }}"
+            limits:
+              cpu: "{{ .Values.Master.CpuLimit }}"
+              memory: "{{ .Values.Master.MemoryLimit }}"
           volumeMounts:
 {{- if .Values.Persistence.mounts }}
 {{ toYaml .Values.Persistence.mounts | indent 12 }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -19,7 +19,9 @@ Master:
   AdminUser: admin
   # AdminPassword: <defaults to random>
   Cpu: "200m"
+  CpuLimit: "1000m"
   Memory: "256Mi"
+  MemoryLimit: "1024Mi"
   # Environment variables that get added to the init container (useful for e.g. http_proxy)
   # InitContainerEnv:
   #   - name: http_proxy


### PR DESCRIPTION
**What this PR does / why we need it**:
- This PR makes it possible to configure cpu and memory limits for jenkins master. In some environments it is not possible to launch jenkins without these values provided.
- This PR bumps `version` to 0.16.4 and `appVersion` to reflect the current LTS version of Jenkins (see https://jenkins.io/changelog-stable).