### PR TITLE
[stable/keycloak] option to run kcadm cli commands

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 2.0.0
+version: 2.1.0
 appVersion: 3.4.3.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -242,7 +242,7 @@ Keycloak can be configured using the kcadm cli. For example, SSL for master real
       /opt/jboss/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE --no-config --server http://localhost:8080/auth --realm master --user admin --password admin &>> /opt/jboss/postStartLog;
       echo Stopping postStartScript >> /opt/jboss/postStartLog;
 ```
-Here the keycloak admin user is admin/admin. The sleep is necessary as hook can be executed before keycloak is fully started, in which case kcadm will error with 'Connection refused'. In this example the script logs could be checked by doing 'kubectl exec -it <pod> -- /bin/bash' for the pod and 'more postStartLog'. 
+Here the keycloak admin user is admin/admin. The sleep is necessary as hook can be executed before keycloak is fully started, in which case kcadm will error with `Connection refused`. In this example the script logs could be checked by doing `kubectl exec -it <pod> -- /bin/bash` for the pod and `more postStartLog`. 
 
 ### Using Google Cloud SQL Proxy
 

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -246,7 +246,7 @@ Here the keycloak admin user is admin/admin. The sleep is necessary as hook can 
 
 This approach can also be used to set redirectUris or webOrigins for a client. Get the json configuration for the client from an export, create a secret for it and mount it using `extraVolumes` and `extraVolumeMounts`. Then the client can be updated with:
 
-`/opt/jboss/keycloak/bin/kcadm.sh update clients/<ID> -f /client/activiti-client.json -s 'redirectUris=[URLs]' -s 'webOrigins=[<URLs>] --server http://localhost:8080/auth --realm master --user admin --password admin`
+`/opt/jboss/keycloak/bin/kcadm.sh update clients/<ID> -f /client/activiti-client.json -s 'redirectUris=[URLs]' -s 'webOrigins=[<URLs>] --server http://localhost:8080/auth --realm <realm> --user <user> --password <password>`
 
 Here <ID> is the client's ID (a generated UUID) and <URLs> are double-quoted, comma-separated URLs. See the [documentation](https://www.keycloak.org/docs/3.3/server_admin/topics/admin-cli.html) for more admin cli commands. 
 

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -242,7 +242,13 @@ Keycloak can be configured using the kcadm cli. For example, SSL for master real
       /opt/jboss/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE --no-config --server http://localhost:8080/auth --realm master --user admin --password admin &>> /opt/jboss/postStartLog;
       echo Stopping postStartScript >> /opt/jboss/postStartLog;
 ```
-Here the keycloak admin user is admin/admin. The sleep is necessary as hook can be executed before keycloak is fully started, in which case kcadm will error with `Connection refused`. In this example the script logs could be checked by doing `kubectl exec -it <pod> -- /bin/bash` for the pod and `more postStartLog`. 
+Here the keycloak admin user is admin/admin. The sleep is necessary as hook can be executed before keycloak is fully started, in which case kcadm will error with `Connection refused`. In this example the script logs could be checked by doing `kubectl exec -it <pod> -- /bin/bash` for the pod and `more postStartLog`.
+
+This approach can also be used to set redirectUris or webOrigins for a client. Get the json configuration for the client from an export, create a secret for it and mount it using `extraVolumes` and `extraVolumeMounts`. Then the client can be updated with:
+
+`/opt/jboss/keycloak/bin/kcadm.sh update clients/<ID> -f /client/activiti-client.json -s 'redirectUris=[URLs]' -s 'webOrigins=[<URLs>] --server http://localhost:8080/auth --realm master --user admin --password admin`
+
+Here <ID> is the client's ID (a generated UUID) and <URLs> are double-quoted, comma-separated URLs. See the [documentation](https://www.keycloak.org/docs/3.3/server_admin/topics/admin-cli.html) for more admin cli commands. 
 
 ### Using Google Cloud SQL Proxy
 

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -62,6 +62,7 @@ Parameter | Description | Default
 `keycloak.tolerations` | Node taints to tolerate | `[]`
 `keycloak.securityContext` | Security context for the pod | `{runAsUser: 1000, fsGroup: 1000, runAsNonRoot: true}`
 `keycloak.preStartScript` | Custom script to run before Keycloak starts up | ``
+`keycloak.postStartScript` | Custom script to run after Keycloak starts up | ``
 `keycloak.extraArgs` | Additional arguments to the start command | ``
 `keycloak.livenessProbe.initialDelaySeconds` | Liveness Probe `initialDelaySeconds` | `120`
 `keycloak.livenessProbe.timeoutSeconds` | Liveness Probe `timeoutSeconds` | `5`
@@ -229,6 +230,19 @@ keycloak:
 Alternatively, the file could be added to a custom image (set in `keycloak.image`) and then referenced by `-Dkeycloak.import`.
 
 After startup the web admin console for the realm should be available on the path /auth/admin/\<realm name>/console/.
+
+### Using kcadm cli with postStartScript
+
+Keycloak can be configured using the kcadm cli. For example, SSL for master realm is enabled by default but can be disabled with:
+
+```yaml
+  postStartScript: |
+      echo Starting postStartScript and sleeping 30 >> /opt/jboss/postStartLog;
+      sleep 30;
+      /opt/jboss/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE --no-config --server http://localhost:8080/auth --realm master --user admin --password admin &>> /opt/jboss/postStartLog;
+      echo Stopping postStartScript >> /opt/jboss/postStartLog;
+```
+Here the keycloak admin user is admin/admin. The sleep is necessary as hook can be executed before keycloak is fully started, in which case kcadm will error with 'Connection refused'. In this example the script logs could be checked by doing 'kubectl exec -it <pod> -- /bin/bash' for the pod and 'more postStartLog'. 
 
 ### Using Google Cloud SQL Proxy
 

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -51,6 +51,16 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag }}"
           imagePullPolicy: {{ .Values.keycloak.image.pullPolicy }}
+          {{- with .Values.keycloak.postStartScript }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - '/bin/sh'
+                - '-c'
+                - >
+{{ . | indent 18 }}
+{{- end }}
           command:
             - /scripts/keycloak.sh
           env:

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -34,11 +34,7 @@ keycloak:
   preStartScript:
 
   ## Custom script that is run after Keycloak is started
-  postStartScript: |
-      echo Starting postStartScript and sleeping 30 >> /opt/jboss/postStartLog;
-      sleep 30;
-      /opt/jboss/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE --no-config --server http://localhost:8080/auth --realm master --user admin --password admin &>> /opt/jboss/postStartLog;
-      echo Stopping postStartScript >> /opt/jboss/postStartLog;
+  postStartScript:
 
   ## Additional arguments to start command e.g. -Dkeycloak.import= to load a realm
   extraArgs:

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -33,6 +33,13 @@ keycloak:
   ## Custom script that is run before Keycloak is started.
   preStartScript:
 
+  ## Custom script that is run after Keycloak is started
+  postStartScript: |
+      echo Starting postStartScript and sleeping 30 >> /opt/jboss/postStartLog;
+      sleep 30;
+      /opt/jboss/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE --no-config --server http://localhost:8080/auth --realm master --user admin --password admin &>> /opt/jboss/postStartLog;
+      echo Stopping postStartScript >> /opt/jboss/postStartLog;
+
   ## Additional arguments to start command e.g. -Dkeycloak.import= to load a realm
   extraArgs:
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/charts/issues/6107

Using [postStart lifecycle handler](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/) following suggestion from @unguiculus . The [documentation](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/) cautions that "there is no guarantee... that the postStart handler is called before the Container’s entrypoint is called". This likely explains why I found that I get connection refused if I don't start the script with a sleep so have made this point explicit in the example provided in the README.