### PR TITLE
[stable/grafana] Fix a bug in clusterrolebinding for grafana sidecars

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.11.1
+version: 1.11.2
 appVersion: 5.1.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/clusterrolebinding.yaml
+++ b/stable/grafana/templates/clusterrolebinding.yaml
@@ -15,7 +15,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "grafana.serviceAccountName" . }}
-    namespace: default
+    namespace: {{ .Release.Namespace }} 
 roleRef:
   kind: ClusterRole
   name: {{ template "grafana.fullname" . }}-clusterrole


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a bug, in ./templates/clusterrolebindings.yaml.  The subjects namespace is set to `default`.
This will not allow the grafana dashboard and datasource sidecars to watch for changes in 
configmaps. In namespaces other than the default.   

```
subjects:
  - kind: ServiceAccount
    name: {{ template "grafana.serviceAccountName" . }}
    namespace: default
```
A simple change to 

```
subjects:
  - kind: ServiceAccount
    name: {{ template "grafana.serviceAccountName" . }}
    namespace: {{ .Release.Namespace }}
``` 
Fixes the problem. 