### PR TITLE
Fix the missing "-cert" suffix when applying SSL certificates in `rabbitmq-ha` chart

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.4
-version: 1.6.0
+version: 1.6.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/_helpers.tpl
+++ b/stable/rabbitmq-ha/templates/_helpers.tpl
@@ -46,5 +46,5 @@ Generate chart secret name
 Generate chart ssl secret name
 */}}
 {{- define "rabbitmq-ha.certSecretName" -}}
-{{ default (include "rabbitmq-ha.fullname" .) .Values.rabbitmqCert.existingSecret }}
+{{ default (print (include "rabbitmq-ha.fullname" .) "-cert") .Values.rabbitmqCert.existingSecret }}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

https://github.com/kubernetes/charts/blob/master/stable/rabbitmq-ha `rabbitmq-ha` chart does not use the certificates and keys set up in `rabbitmqCert` section. This PR fixes the missing certificate `-cert` suffix.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

There is no existing issue for this PR.

**Special notes for your reviewer**:

cc @etiennetremel

This change has been tested in my local environment.