### PR TITLE
[stable/jenkins] Make jenkins master pod security context optional

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.5
+version: 0.16.6
 appVersion: 2.121.1
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -41,6 +41,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.resources`                | Resources allocation (Requests and Limits) | `{requests: {cpu: 50m, memory: 256Mi}, limits: {cpu: 2000m, memory: 2048Mi}}`|
 | `Master.InitContainerEnv`         | Environment variables for Init Container                                 | Not set                                  |
 | `Master.ContainerEnv`             | Environment variables for Jenkins Container                              | Not set                                  |
+| `Master.UsePodSecurityContext`    | Enable pod security context (must be `true` if `RunAsUser` or `FsGroup` are set) | `true`                           |
 | `Master.RunAsUser`                | uid that jenkins runs with           | `0`                                                                          |
 | `Master.FsGroup`                  | uid that will be used for persistent volume | `0`                                                                   |
 | `Master.ServiceAnnotations`       | Service annotations                  | `{}`                                                                         |

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -40,11 +40,13 @@ spec:
       affinity:
 {{ toYaml .Values.Master.Affinity | indent 8 }}
       {{- end }}
+{{- if .Values.Master.UsePodSecurityContext }}
       securityContext:
         runAsUser: {{ default 0 .Values.Master.RunAsUser }}
 {{- if and (.Values.Master.RunAsUser) (.Values.Master.FsGroup) }}
 {{- if not (eq .Values.Master.RunAsUser 0.0) }}
         fsGroup: {{ .Values.Master.FsGroup }}
+{{- end }}
 {{- end }}
 {{- end }}
       serviceAccountName: {{ if .Values.rbac.install }}{{ template "jenkins.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -36,6 +36,8 @@ Master:
   # JavaOpts: "-Xms512m -Xmx512m"
   # JenkinsOpts: ""
   # JenkinsUriPrefix: "/jenkins"
+  # Enable pod security context (must be `true` if RunAsUser or FsGroup are set)
+  UsePodSecurityContext: true
   # Set RunAsUser to 1000 to let Jenkins run as non-root user 'jenkins' which exists in 'jenkins/jenkins' docker image.
   # When setting RunAsUser to a different value than 0 also set FsGroup to the same value:
   # RunAsUser: <defaults to 0>


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Adding the ability to remove pod security context configuration makes deploying the Jenkins chart on OpenShift clusters with the ["restricted" security context constraint enabled](https://docs.openshift.com/container-platform/3.9/admin_guide/manage_scc.html#example-security-context-constraints) much less hassle.

If a pod security context is not provided, OpenShift will apply a valid security context during admission. This is preferable since OpenShift also rejects pods that attempt to run as users outside of a uid range that can vary on a per-namespace basis.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:

If testing in OpenShift, you will need a Jenkins image with "anyuid" enabled in order to do git checkouts from the Jenkins master:

```bash
helm install ./stable/jenkins \
  --set Master.Image=quay.io/skookum/jenkins \
  --set Master.ImageTag=latest \
  --set Master.InstallPlugins={} \
  --set Master.UsePodSecurityContext=false
```

This PR duplicates https://github.com/kubernetes/charts/pull/6014. I'm reopening now that I've done some additional validation of these changes in an OpenShift 3.9 cluster.