### PR TITLE
[stable/nginx-ingress] Add hide-headers option to nginx-ingress.

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.20.3
+version: 0.20.4
 appVersion: 0.14.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -119,6 +119,7 @@ Parameter | Description | Default
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
+`controller.hideHeaders` | configMap string containing the [hide-headers](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#hide-headers) for Nginx | `""`
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend`

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -13,6 +13,9 @@ data:
 {{- if .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
 {{- end }}
+{{- if .Values.controller.hideHeaders }}
+  hide-headers: {{ .Values.controller.hideHeaders }}
+{{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}
 {{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -12,6 +12,9 @@ controller:
   # Will add custom header to Nginx https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers
   headers: {}
 
+  # Will hide header from Nginx https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#hide-headers
+  hideHeaders: ""
+
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
   # is merged


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR adds the [hide-headers](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#hide-headers) option to the `controller-configmap.yaml` for nginx-ingress.

**Special notes for your reviewer**:
N.A.

**For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file**:

@jackzampolin 
@mgoodness 
@chancez 
