### PR TITLE
[stable/jenkins] Add different Deployment Strategies based on persistence

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.22
+version: 0.16.23
 appVersion: 2.121.3
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: {{ if .Values.Persistence.Enabled }}Recreate{{ else }}RollingUpdate{{ end }}
   selector:
     matchLabels:
       component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"


### PR DESCRIPTION
RollingUpdate isn't supported when using persistence, since it doesn't support sharing a RWO PV.

PR add supports for having Recreate as a strategy if persistence is enabled, as opposed to the default RollingUpdate

**What this PR does / why we need it**:

Fixes https://github.com/kubernetes/charts/issues/3154

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
From OpenShift docs (https://docs.openshift.com/container-platform/3.6/dev_guide/deployments/deployment_strategies.html):
`When to Use a Recreate Deployment [...]
When you want to use a RWO volume, which is not supported being shared between multiple replicas.`

Signed-off-by: Tore S. Lønøy <tore.lonoy@gmail.com>