### PR TITLE
[stable/datadog] enable logging support

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.16.0
+version: 0.16.1
 appVersion: 6.2.1
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -63,6 +63,9 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `daemonset.affinity`        | Node affinities                    | `nil`                                     |
 | `daemonset.useHostNetwork`  | If true, use the host's network    | `nil`                                     |
 | `daemonset.useHostPort`     | If true, use the same ports for both host and container  | `nil`               |
+| `daemonset.logs.enabled`    | If true, enable log collection from the node | `false`                         |
+| `daemonset.logs.collect_all_containers` | If true, collect logs from all containers on the node | `true`     |
+| `daemonset.logs.manage_pointer_directory` | If true, set `type` to `DirectoryOrCreate` otherwise `type` is `Directory` | `true`     |
 | `datadog.leaderElection`    | Adds the leader Election feature   | `false`                                   |
 | `datadog.leaderLeaseDuration`| The duration for which a leader stays elected.| `nil`                         |
 | `deployment.affinity`       | Node / Pod affinities              | `{}`                                      |

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -64,8 +64,8 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `daemonset.useHostNetwork`  | If true, use the host's network    | `nil`                                     |
 | `daemonset.useHostPort`     | If true, use the same ports for both host and container  | `nil`               |
 | `daemonset.logs.enabled`    | If true, enable log collection from the node | `false`                         |
-| `daemonset.logs.collect_all_containers` | If true, collect logs from all containers on the node | `true`     |
-| `daemonset.logs.manage_pointer_directory` | If true, set `type` to `DirectoryOrCreate` otherwise `type` is `Directory` | `true`     |
+| `daemonset.logs.collectAllContainers` | If true, collect logs from all containers on the node | `true`     |
+| `daemonset.logs.managePointerDirectory` | If true, set `type` to `DirectoryOrCreate` otherwise `type` is `Directory` | `false`     |
 | `datadog.leaderElection`    | Adds the leader Election feature   | `false`                                   |
 | `datadog.leaderLeaseDuration`| The duration for which a leader stays elected.| `nil`                         |
 | `deployment.affinity`       | Node / Pod affinities              | `{}`                                      |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -95,6 +95,12 @@ spec:
               fieldRef:
                 fieldPath: status.hostIP
           {{- end }}
+          {{- if .Values.daemonset.logs.enabled }}
+          - name: DD_LOGS_ENABLED
+            value: "true"
+          - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
+            value: {{ .Values.daemonset.logs.collectAllContainers | quote }}
+          {{- end }}
 
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}
@@ -128,6 +134,12 @@ spec:
             {{- end }}
             readOnly: true
           {{- end }}
+          {{- if .Values.daemonset.logs.enabled }}
+          - name: pointerdir
+            mountPath: /opt/datadog-agent/run
+            readOnly: false
+          {{- end }}
+
 {{- if .Values.datadog.volumeMounts }}
 {{ toYaml .Values.datadog.volumeMounts | indent 10 }}
 {{- end }}
@@ -161,6 +173,12 @@ spec:
         - name: autoconf
           configMap:
             name: {{ template "datadog.autoconf.fullname" . }}
+        {{- end }}
+        {{- if .Values.daemonset.logs.enabled }}
+        - name: pointerdir
+          hostPath:
+            path: /opt/datadog-agent/run
+            type: "{{ if .Values.daemonset.logs.managePointerDirectory }}DirectoryOrCreate{{ else }}Directory{{ end }}"
         {{- end }}
 {{- if .Values.datadog.volumes }}
 {{ toYaml .Values.datadog.volumes | indent 8 }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -48,6 +48,16 @@ daemonset:
   ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   # updateStrategy: RollingUpdate
 
+  ## Allow datadog to collect logs from containers
+  ## ref: https://docs.datadoghq.com/logs/log_collection/docker/
+  logs:
+    enabled: false
+    collectAllContainers: true
+    ## If set to false, operator is responsible for managing /opt/datadog-agent/run
+    ## on the node. If set to true, kubernetes will manage the directory
+    ## requires Kubernetes >=1.8
+    managePointerDirectory: false
+
 # Apart from DaemonSet, deploy Datadog agent pods and related service for
 # applications that want to send custom metrics. Provides DogStasD service.
 #


### PR DESCRIPTION
@hkaj @irabinovitch @xvello 

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Add support for datadog logging

**Special notes for your reviewer**:

* Followed recommendations from https://docs.datadoghq.com/logs/log_collection/docker/
* I only enabled this for daemonsets, because it seemed trying to settle possible contentions between the deployments and daemonsets would get tricky 