### PR TITLE
[stable/minio] Bring back config map support

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 1.3.4
-appVersion: RELEASE.2018-06-09T03-43-35Z
+version: 1.4.0
+appVersion: RELEASE.2018-07-10T01-42-11Z
 keywords:
 - storage
 - object-storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -76,7 +76,7 @@ The following table lists the configurable parameters of the Minio chart and the
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository                    | `minio/minio`                                           |
-| `image.tag`                | Minio image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).| `RELEASE.2018-06-09T03-43-35Z`|
+| `image.tag`                | Minio image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).| `RELEASE.2018-07-10T01-42-11Z`|
 | `image.pullPolicy`         | Image pull policy                   | `IfNotPresent`                                          |
 | `mcImage.repository`       | Client image repository             | `minio/mc`                                              |
 | `mcImage.tag`              | mc image tag. Possible values listed [here](https://hub.docker.com/r/minio/mc/tags/).| `RELEASE.2018-06-09T02-18-09Z`|
@@ -85,7 +85,7 @@ The following table lists the configurable parameters of the Minio chart and the
 | `ingress.annotations`      | Ingress annotations                 | `{}`                                                    |
 | `ingress.hosts`            | Ingress accepted hostnames          | `[]`                                                    |
 | `ingress.tls`              | Ingress TLS configuration           | `[]`                                                    |
-| `mode`                     | Minio server mode (`standalone`, `shared` or `distributed`)| `standalone`                     |
+| `mode`                     | Minio server mode (`standalone` or `distributed`)| `standalone`                               |
 | `replicas`                 | Number of nodes (applicable only for Minio distributed mode). Should be 4 <= x <= 32 | `4`    |
 | `accessKey`                | Default access key (5 to 20 characters) | `AKIAIOSFODNN7EXAMPLE`                              |
 | `secretKey`                | Default secret key (8 to 40 characters) | `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`          |
@@ -112,6 +112,8 @@ The following table lists the configurable parameters of the Minio chart and the
 | `gcsgateway.enabled`       | Use minio as a [Google Cloud Storage gateway](https://docs.minio.io/docs/minio-gateway-for-gcs)| `false` |
 | `gcsgateway.gcsKeyJson`    | credential json file of service account key | `""` |
 | `gcsgateway.projectId`     | Google cloud project id             | `""` |
+| `nasgateway.enabled`       | Use minio as a [NAS gateway](https://docs.minio.io/docs/minio-gateway-for-nas)             | `false` |
+| `nasgateway.replicas`      | Number of NAS gateway instances to be run in parallel on a PV            | `4` |
 
 Some of the parameters above map to the env variables defined in the [Minio DockerHub image](https://hub.docker.com/r/minio/minio/).
 
@@ -155,29 +157,29 @@ This provisions Minio server in distributed mode with 8 nodes. Note that the `re
 1. StatefulSets need persistent storage, so the `persistence.enabled` flag is ignored when `mode` is set to `distributed`.
 2. When uninstalling a distributed Minio release, you'll need to manually delete volumes associated with the StatefulSet.
 
-Shared Minio
+NAS Gateway
 -----------
 
 ### Prerequisites
 
-Minio shared mode deployment creates multiple Minio server instances backed by single PV in `ReadWriteMany` mode. Currently few [Kubernetes volume plugins](https://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes) support `ReadWriteMany` mode. To deploy Minio shared mode you'll need to have a Persistent Volume running with one of the supported volume plugins. [This document](https://kubernetes.io/docs/user-guide/volumes/#nfs)
+Minio in [NAS gateway mode](https://docs.minio.io/docs/minio-gateway-for-nas) can be used to create multiple Minio instances backed by single PV in `ReadWriteMany` mode. Currently few [Kubernetes volume plugins](https://kubernetes.io/docs/user-guide/persistent-volumes/#access-modes) support `ReadWriteMany` mode. To deploy Minio NAS gateway with Helm chart you'll need to have a Persistent Volume running with one of the supported volume plugins. [This document](https://kubernetes.io/docs/user-guide/volumes/#nfs)
 outlines steps to create a NFS PV in Kubernetes cluster.
 
-### Provision Shared Minio instances
+### Provision NAS Gateway Minio instances
 
-To provision Minio servers in [shared mode](https://github.com/minio/minio/blob/master/docs/shared-backend/README.md), set the `mode` field to `shared`,
-
-```bash
-$ helm install --set mode=shared stable/minio
-```
-
-This provisions 4 Minio server nodes backed by single storage. To change the number of nodes in your shared Minio deployment, set the `replicas` field,
+To provision Minio servers in [NAS gateway mode](https://docs.minio.io/docs/minio-gateway-for-nas), set the `nasgateway.enabled` field to `true`,
 
 ```bash
-$ helm install --set mode=shared,replicas=8 stable/minio
+$ helm install --set nasgateway.enabled=true stable/minio
 ```
 
-This provisions Minio server in shared mode with 8 nodes.
+This provisions 4 Minio NAS gateway instances backed by single storage. To change the number of instances in your Minio deployment, set the `replicas` field,
+
+```bash
+$ helm install --set nasgateway.enabled=true,nasgateway.replicas=8 stable/minio
+```
+
+This provisions Minio NAS gateway with 8 instances.
 
 Persistence
 -----------

--- a/stable/minio/templates/configmap.yaml
+++ b/stable/minio/templates/configmap.yaml
@@ -10,3 +10,131 @@ metadata:
 data:
   initialize: |-
 {{ include (print $.Template.BasePath "/_helper_create_bucket.txt") . | indent 4 }}
+  config.json: |-
+    {
+      "version": "26",
+      "credential": {
+        "accessKey": {{ .Values.accessKey | quote }},
+        "secretKey": {{ .Values.secretKey | quote }}
+      },
+      "region": {{ .Values.minioConfig.region | quote }},
+      "browser": {{ .Values.minioConfig.browser | quote }},
+      "worm": {{ .Values.minioConfig.worm | quote }},
+      "domain": {{ .Values.minioConfig.domain | quote }},
+      "storageclass": {
+        "standard": {{ .Values.minioConfig.storageClass.standardStorageClass | quote }},
+        "rrs": {{ .Values.minioConfig.storageClass.reducedRedundancyStorageClass | quote }}
+      },
+      "cache": {
+        "drives": {{ .Values.minioConfig.cache.drives }},
+        "expiry": {{ .Values.minioConfig.cache.expiry | int }},
+        "maxuse": {{ .Values.minioConfig.cache.maxuse | int }},
+        "exclude": {{ .Values.minioConfig.cache.exclude }}
+      },
+      "notify": {
+        "amqp": {
+          "1": {
+            "enable": {{ .Values.minioConfig.aqmp.enable }},
+            "url": {{ .Values.minioConfig.aqmp.url | quote }},
+            "exchange": {{ .Values.minioConfig.aqmp.exchange | quote }},
+            "routingKey": {{ .Values.minioConfig.aqmp.routingKey | quote }},
+            "exchangeType": {{ .Values.minioConfig.aqmp.exchangeType | quote }},
+            "deliveryMode": {{ .Values.minioConfig.aqmp.deliveryMode }},
+            "mandatory": {{ .Values.minioConfig.aqmp.mandatory }},
+            "immediate": {{ .Values.minioConfig.aqmp.immediate }},
+            "durable": {{ .Values.minioConfig.aqmp.durable }},
+            "internal": {{ .Values.minioConfig.aqmp.internal }},
+            "noWait": {{ .Values.minioConfig.aqmp.noWait }},
+            "autoDeleted": {{ .Values.minioConfig.aqmp.autoDeleted }}
+          }
+        },
+        "nats": {
+          "1": {
+            "enable": {{ .Values.minioConfig.nats.enable }},
+            "address": {{ .Values.minioConfig.nats.address | quote }},
+            "subject": {{ .Values.minioConfig.nats.subject | quote }},
+            "username": {{ .Values.minioConfig.nats.username | quote }},
+            "password": {{ .Values.minioConfig.nats.password | quote }},
+            "token": {{ .Values.minioConfig.nats.token | quote }},
+            "secure": {{ .Values.minioConfig.nats.secure }},
+            "pingInterval": {{ .Values.minioConfig.nats.pingInterval | int64 }},
+            "streaming": {
+              "enable": {{ .Values.minioConfig.nats.enableStreaming }},
+              "clusterID": {{ .Values.minioConfig.nats.clusterID | quote }},
+              "clientID": {{ .Values.minioConfig.nats.clientID | quote }},
+              "async": {{ .Values.minioConfig.nats.async }},
+              "maxPubAcksInflight": {{ .Values.minioConfig.nats.maxPubAcksInflight | int }}
+            }
+          }
+        },
+        "elasticsearch": {
+          "1": {
+            "enable": {{ .Values.minioConfig.elasticsearch.enable }},
+            "format": {{ .Values.minioConfig.elasticsearch.format | quote }},
+            "url": {{ .Values.minioConfig.elasticsearch.url | quote }},
+            "index": {{ .Values.minioConfig.elasticsearch.index | quote }}
+          }
+        },
+        "redis": {
+          "1": {
+            "enable": {{ .Values.minioConfig.redis.enable }},
+            "format": {{ .Values.minioConfig.redis.format | quote }},
+            "address": {{ .Values.minioConfig.redis.address | quote }},
+            "password": {{ .Values.minioConfig.redis.password | quote }},
+            "key": {{ .Values.minioConfig.redis.key | quote }}
+          }
+        },
+        "postgresql": {
+          "1": {
+            "enable": {{ .Values.minioConfig.postgresql.enable }},
+            "format": {{ .Values.minioConfig.postgresql.format | quote }},
+            "connectionString": {{ .Values.minioConfig.postgresql.connectionString | quote }},
+            "table": {{ .Values.minioConfig.postgresql.table | quote }},
+            "host": {{ .Values.minioConfig.postgresql.host | quote }},
+            "port": {{ .Values.minioConfig.postgresql.port | quote }},
+            "user": {{ .Values.minioConfig.postgresql.user | quote }},
+            "password": {{ .Values.minioConfig.postgresql.password | quote }},
+            "database": {{ .Values.minioConfig.postgresql.database | quote }}
+          }
+        },
+        "kafka": {
+          "1": {
+            "enable": {{ .Values.minioConfig.kafka.enable }},
+            "brokers": {{ .Values.minioConfig.kafka.brokers }},
+            "topic": {{ .Values.minioConfig.kafka.topic | quote }}
+          }
+        },
+        "webhook": {
+          "1": {
+            "enable": {{ .Values.minioConfig.webhook.enable }},
+            "endpoint": {{ .Values.minioConfig.webhook.endpoint | quote }}
+          }
+        },
+        "mysql": {
+          "1": {
+            "enable": {{ .Values.minioConfig.mysql.enable }},
+            "format": {{ .Values.minioConfig.mysql.format | quote }},
+            "dsnString": {{ .Values.minioConfig.mysql.dsnString | quote }},
+            "table": {{ .Values.minioConfig.mysql.table | quote }},
+            "host": {{ .Values.minioConfig.mysql.host | quote }},
+            "port": {{ .Values.minioConfig.mysql.port | quote }},
+            "user": {{ .Values.minioConfig.mysql.user | quote }},
+            "password": {{ .Values.minioConfig.mysql.password | quote }},
+            "database": {{ .Values.minioConfig.mysql.database | quote }}
+          }
+        },
+        "mqtt": {
+          "1": {
+            "enable": {{ .Values.minioConfig.mqtt.enable }},
+            "broker": {{ .Values.minioConfig.mqtt.broker | quote }},
+            "topic": {{ .Values.minioConfig.mqtt.topic | quote }},
+            "qos": {{ .Values.minioConfig.mqtt.qos | int }},
+            "clientId": {{ .Values.minioConfig.mqtt.clientId | quote }},
+            "username": {{ .Values.minioConfig.mqtt.username | quote }},
+            "password": {{ .Values.minioConfig.mqtt.password | quote }},
+            "reconnectInterval": {{ .Values.minioConfig.mqtt.reconnectInterval | int }},
+            "keepAliveInterval": {{ .Values.minioConfig.mqtt.keepAliveInterval | int }}
+          }
+        }
+      }
+    }

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.mode "standalone" "shared" }}
+{{- if eq .Values.mode "standalone" }}
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -9,8 +9,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  {{- if eq .Values.mode "shared" }}
-  replicas: {{ .Values.replicas }}
+  {{- if .Values.nasgateway.enabled }}
+  replicas: {{ .Values.nasgateway.replicas }}
   {{- end }}
   selector:
     matchLabels:
@@ -28,15 +28,27 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.azuregateway.enabled }}
-          args: ["gateway", "azure"]
+          command: [ "/bin/sh", 
+          "-ce", 
+          "cp /tmp/config.json {{ .Values.configPath }} && 
+          /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway azure"]
           {{- else }}
           {{- if .Values.gcsgateway.enabled }}
-          args: ["gateway", "gcs", "{{ .Values.gcsgateway.projectId }}"]
+          command: [ "/bin/sh", 
+          "-ce", 
+          "cp /tmp/config.json {{ .Values.configPath }} && 
+          /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway gcs {{ .Values.gcsgateway.projectId }}"]
           {{- else }}
-          {{- if .Values.configPath }}
-          args: ["-C", "{{ .Values.configPath }}", "server", "{{ .Values.mountPath }}"]
+          {{- if .Values.nasgateway.enabled }}
+          command: [ "/bin/sh", 
+          "-ce", 
+          "cp /tmp/config.json {{ .Values.configPath }} && 
+          /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} gateway nas {{ .Values.mountPath }}"]
           {{- else }}
-          args: ["server", "{{ .Values.mountPath }}"]
+          command: [ "/bin/sh", 
+          "-ce", 
+          "cp /tmp/config.json {{ .Values.configPath }} && 
+          /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} server {{ .Values.mountPath }}" ]
           {{- end }}
           {{- end }}
           {{- end }}
@@ -51,6 +63,11 @@ spec:
               mountPath: "/etc/credentials"
               readOnly: true
             {{- end }}
+            - name: minio-server-config
+              mountPath: "/tmp/config.json"
+              subPath: config.json
+            - name: minio-config-dir
+              mountPath: {{ .Values.configPath }}
           ports:
             - name: service
               containerPort: 9000
@@ -95,7 +112,12 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+        - name: minio-server-config
+          configMap:
+            name: {{ template "minio.fullname" . }}
         - name: minio-user
           secret:
             secretName: {{ template "minio.fullname" . }}
+        - name: minio-config-dir
+          emptyDir: {}
 {{- end }}

--- a/stable/minio/templates/pvc.yaml
+++ b/stable/minio/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.mode "standalone" "shared" }}
+{{- if eq .Values.mode "standalone" }}
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -10,21 +10,18 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+{{- if .Values.nasgateway.enabled }}
+  selector:
+    matchLabels:
+      pv: {{ .Values.nasgateway.pv | quote }}
+{{- end }}
   accessModes:
-    {{- if eq .Values.mode "shared" }}
-    - ReadWriteMany
-    {{- else }}
     - {{ .Values.persistence.accessMode | quote }}
-    {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
 {{- if .Values.persistence.storageClass }}
-{{- if (eq "-" .Values.persistence.storageClass) }}
-  storageClassName: ""
-{{- else }}
-  storageClassName: "{{ .Values.persistence.storageClass }}"
-{{- end }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -27,22 +27,24 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.configPath }}
-          args:
-            - -C {{ .Values.configPath }} server
-          {{- else }}
-          args:
-            - server
-            {{- range $i := until $nodeCount }}
-            - http://{{ template "minio.fullname" $ }}-{{ $i }}.{{ template "minio.fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local{{ $.Values.mountPath }}
-            {{- end }}
-            {{- end }}
+          command: [ "/bin/sh", 
+          "-ce", 
+          "cp /tmp/config.json {{ .Values.configPath }} &&
+          /usr/bin/docker-entrypoint.sh minio -C {{ .Values.configPath }} server
+          {{- range $i := until $nodeCount }}
+          http://{{ template `minio.fullname` $ }}-{{ $i }}.{{ template `minio.fullname` $ }}.{{ $.Release.Namespace }}.svc.cluster.local{{ $.Values.mountPath }}
+          {{- end }}" ]
           volumeMounts:
             - name: export
               mountPath: {{ .Values.mountPath }}
               {{- if and .Values.persistence.enabled .Values.persistence.subPath }}
               subPath: "{{ .Values.persistence.subPath }}"
               {{- end }}
+            - name: minio-server-config
+              mountPath: "/tmp/config.json"
+              subPath: config.json
+            - name: minio-config-dir
+              mountPath: {{ .Values.configPath }}
           ports:
             - name: service
               containerPort: 9000
@@ -75,6 +77,11 @@ spec:
         - name: minio-user
           secret:
             secretName: {{ template "minio.fullname" . }}
+        - name: minio-server-config
+          configMap:
+            name: {{ template "minio.fullname" . }}
+        - name: minio-config-dir
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: export

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: minio/minio
-  tag: RELEASE.2018-06-09T03-43-35Z
+  tag: RELEASE.2018-07-10T01-42-11Z
   pullPolicy: IfNotPresent
 
 ## Set default image, imageTag, and imagePullPolicy for the `mc` (the minio
@@ -24,7 +24,7 @@ mode: standalone
 ##
 accessKey: "AKIAIOSFODNN7EXAMPLE"
 secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-configPath: ""
+configPath: "/root/.minio/"
 mountPath: "/export"
 replicas: 4
 
@@ -46,7 +46,9 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: "-"
+  ## Storage class of PV to bind. By default it looks for standard storage class.
+  ## If the PV uses a different storage class, specify that here.
+  storageClass: standard
   accessMode: ReadWriteOnce
   size: 10Gi
 
@@ -123,14 +125,32 @@ gcsgateway:
   # Google cloud project-id
   projectId: ""
 
+## Use minio on NAS backend
+## https://docs.minio.io/docs/minio-gateway-for-nas
+
+nasgateway:
+  enabled: false
+  # Number of parallel instances
+  replicas: 4
+  # Generally for NAS Gateway, you'd like to bind the PVC to a specific PV. To ensure that happens, PV to bind to should have
+  # a label like "pv: <value>", use value here.
+  pv: ""
+
 ## https://docs.minio.io/docs/minio-bucket-notification-guide
-##
+## https://github.com/minio/minio/blob/master/docs/config
 minioConfig:
   region: "us-east-1"
   browser: "on"
   domain: ""
-  standardStorageClass: ""
-  reducedRedundancyStorageClass: ""
+  worm: "off"
+  storageClass:
+    standardStorageClass: ""
+    reducedRedundancyStorageClass: ""
+  cache:
+    drives: []
+    expiry: 90
+    maxuse: 80
+    exclude: []
   aqmp:
     enable: false
     url: ""
@@ -204,6 +224,8 @@ minioConfig:
     clientId: ""
     username: ""
     password: ""
+    reconnectInterval: 0
+    keepAliveInterval: 0
 networkPolicy:
   enabled: false
   allowExternal: true


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Brings back ConfigMap support to Minio chart

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
