### PR TITLE
[stable/gocd] Use the gocd-agent-docker-dind image of the tag same as  of GoCD app version

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.1.3
+
+* [3df661cc](https://github.com/kubernetes/charts/commit/3df661cc):  Use the gocd-agent-docker-dind image of the tag same as of GoCD app version
+
+### 1.1.2
+
+* [ec6474b9](https://github.com/kubernetes/charts/commit/ec6474b9):  Fix heath check->health check (#6269)
+
 ### 1.1.1
 
 * [ccd0a08d](https://github.com/kubernetes/charts/commit/ccd0a08d): Do not perform preconfigure_server script if server has already been configured

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.1.2
+version: 1.1.3
 appVersion: 18.6.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/templates/configmap.yaml
+++ b/stable/gocd/templates/configmap.yaml
@@ -46,7 +46,7 @@ data:
         "properties": [
           {
             "key": "Image",
-            "value": "gocd/gocd-agent-docker-dind:v18.2.0"
+            "value": "gocd/gocd-agent-docker-dind:v{{ .Chart.AppVersion }}"
           },
           {
             "key": "PodConfiguration",


### PR DESCRIPTION
![screen shot 2018-06-18 at 11 47 34 am](https://user-images.githubusercontent.com/15275847/41520886-8261183c-72ed-11e8-8e6d-9c6abf415091.png)
