### PR TITLE
[stable/grafana] Fixed a typo in clusterrolebinding.yaml.

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.11.3
+version: 1.11.4
 appVersion: 5.1.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/clusterrolebinding.yaml
+++ b/stable/grafana/templates/clusterrolebinding.yaml
@@ -15,7 +15,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "grafana.serviceAccountName" . }}
-    namespace: {{ .Release.namespace }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ template "grafana.fullname" . }}-clusterrole


### PR DESCRIPTION
Quick typo fix `Namespace` instead of `namespace`. 