### PR TITLE
Fix to make busybox and bats registries templatable for mongodb-replicaset chart

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.4.1
+version: 3.4.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -34,7 +34,8 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
         - name: copy-config
-          image: busybox
+          image: "{{ .Values.initContainers.busybox.repository }}"
+          imagePullPolicy: "{{ .Values.initContainers.busybox.pullPolicy }}"
           command:
             - "sh"
           args:

--- a/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
+++ b/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   initContainers:
     - name: test-framework
-      image: dduportal/bats:0.4.0
+      image: "{{ .Values.testImage.repository }}:{{ .Values.testImage.tag }}"
       command:
         - bash
         - -c

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -27,6 +27,21 @@ image:
   tag: 3.6
   pullPolicy: IfNotPresent
 
+# Specs for busybox image
+
+initContainers:
+  busybox:
+    repository: busybox
+    pullPolicy: IfNotPresent
+
+# Specs for test image
+testImage:
+  repository: dduportal/bats
+  tag: 0.4.0
+  pullPolicy: IfNotPresent
+
+
+#      image: 
 # Additional environment variables to be set in the container
 extraVars: {}
 # - name: TCMALLOC_AGGRESSIVE_DECOMMIT

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -40,8 +40,7 @@ testImage:
   tag: 0.4.0
   pullPolicy: IfNotPresent
 
-
-#      image: 
+#      image:
 # Additional environment variables to be set in the container
 extraVars: {}
 # - name: TCMALLOC_AGGRESSIVE_DECOMMIT


### PR DESCRIPTION
**Fix for hardcoded busybox and bats registries in mongodb-replicaset chart
