### PR TITLE
[stable/mongodb-replicaset] Add templating for busybox and bats registry images

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.4.2
+version: 3.5.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.5.1
+version: 3.5.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.4.1
+version: 3.4.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -34,8 +34,8 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
         - name: copy-config
-          image: "{{ .Values.copyConfigImage.busybox.repository }}"
-          imagePullPolicy: "{{ .Values.copyConfigImage.busybox.pullPolicy }}"
+          image: "{{ .Values.copyConfigImage.repository }}"
+          imagePullPolicy: "{{ .Values.copyConfigImage.pullPolicy }}"
           command:
             - "sh"
           args:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -34,8 +34,8 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
         - name: copy-config
-          image: "{{ .Values.initContainers.busybox.repository }}"
-          imagePullPolicy: "{{ .Values.initContainers.busybox.pullPolicy }}"
+          image: "{{ .Values.copyConfigImage.busybox.repository }}"
+          imagePullPolicy: "{{ .Values.copyConfigImage.busybox.pullPolicy }}"
           command:
             - "sh"
           args:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -34,7 +34,8 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
         - name: copy-config
-          image: busybox
+          image: "{{ .Values.initContainers.busybox.repository }}"
+          imagePullPolicy: "{{ .Values.initContainers.busybox.pullPolicy }}"
           command:
             - "sh"
           args:

--- a/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
+++ b/stable/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   initContainers:
     - name: test-framework
-      image: dduportal/bats:0.4.0
+      image: "{{ .Values.testImage.repository }}:{{ .Values.testImage.tag }}"
       command:
         - bash
         - -c

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -29,9 +29,10 @@ image:
 
 # Specs for busybox image
 
-initContainers:
+copyConfigImage:
   busybox:
     repository: busybox
+    tag: latest
     pullPolicy: IfNotPresent
 
 # Specs for test image

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -30,10 +30,9 @@ image:
 # Specs for busybox image
 
 copyConfigImage:
-  busybox:
-    repository: busybox
-    tag: 1.28.4
-    pullPolicy: IfNotPresent
+  repository: busybox
+  tag: 1.28.4
+  pullPolicy: IfNotPresent
 
 # Specs for test image
 testImage:

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -32,7 +32,7 @@ image:
 copyConfigImage:
   busybox:
     repository: busybox
-    tag: latest
+    tag: 1.28.4
     pullPolicy: IfNotPresent
 
 # Specs for test image

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -27,6 +27,20 @@ image:
   tag: 3.6
   pullPolicy: IfNotPresent
 
+# Specs for busybox image
+
+initContainers:
+  busybox:
+    repository: busybox
+    pullPolicy: IfNotPresent
+
+# Specs for test image
+testImage:
+  repository: dduportal/bats
+  tag: 0.4.0
+  pullPolicy: IfNotPresent
+
+#      image:
 # Additional environment variables to be set in the container
 extraVars: {}
 # - name: TCMALLOC_AGGRESSIVE_DECOMMIT


### PR DESCRIPTION
**Replace busybox and bats hardcoded registry entries with templates**:

It's important tho have this option to run with isolated from inet cluster.