### PR TITLE
[incubator/elasticsearch] Readme update to reflect latest default values.

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.0.0
+version: 1.0.1
 appVersion: 6.1.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -63,8 +63,8 @@ The following table lists the configurable parameters of the elasticsearch chart
 |              Parameter               |                             Description                             |               Default                |
 | ------------------------------------ | ------------------------------------------------------------------- | ------------------------------------ |
 | `appVersion`                         | Application Version (Elasticsearch)                                 | `6.1.1`                              |
-| `image.repository`                   | Container image name                                                | `centerforopenscience/elasticsearch` |
-| `image.tag`                          | Container image tag                                                 | `5.4`                                |
+| `image.repository`                   | Container image name                                                | `docker.elastic.co/elasticsearch/elasticsearch-oss` |
+| `image.tag`                          | Container image tag                                                 | `6.1.1`                                |
 | `image.pullPolicy`                   | Container pull policy                                               | `Always`                             |
 | `cluster.name`                       | Cluster name                                                        | `elasticsearch`                      |
 | `cluster.kubernetesDomain`           | Kubernetes cluster domain name                                      | `cluster.local`                      |


### PR DESCRIPTION
**What this PR does / why we need it**: 
To reflect latest default chart values

**Which issue this PR fixes** 
Update to https://github.com/kubernetes/charts/pull/5663

@simonswine @icereval @rendhalver