### PR TITLE
Fix data types (from string to int).

### DIFF
--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -83,18 +83,18 @@ spec:
             - sh
             - -c
             - exec pg_isready --host $POD_IP
-          initialDelaySeconds: {{ .Values.probes.liveness.initialDelay | quote }}
-          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds | quote }}
-          failureThreshold: {{ .Values.probes.liveness.failureThreshold | quote }}
+          initialDelaySeconds: {{ .Values.probes.liveness.initialDelay }}
+          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
         readinessProbe:
           exec:
             command:
             - sh
             - -c
             - exec pg_isready --host $POD_IP
-          initialDelaySeconds: {{ .Values.probes.readiness.initialDelay | quote }}
-          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds | quote }}
-          periodSeconds: {{ .Values.probes.readiness.periodSeconds | quote }}
+          initialDelaySeconds: {{ .Values.probes.readiness.initialDelay }}
+          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -132,13 +132,13 @@ affinity: {}
 # Override default liveness & readiness probes
 probes:
   liveness:
-    initialDelay: "60"
-    timeoutSeconds: "5"
-    failureThreshold: "6"
+    initialDelay: 60
+    timeoutSeconds: 5
+    failureThreshold: 6
   readiness:
-    initialDelay: "5"
-    timeoutSeconds: "3"
-    failureThreshold: "5"
+    initialDelay: 5
+    timeoutSeconds: 3
+    failureThreshold: 5
 ## Annotations for the deployment and nodes.
 deploymentAnnotations: {}
 podAnnotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixed a bug with the liveness and readiness probes, whose default values were set as strings, not as integers, and hence didn't work.