### PR TITLE
[incubator/vault] add PDB, make HA + TLS + Consul work together

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.12.0
-appVersion: 0.10.1
+version: 0.13.0
+appVersion: 0.10.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
 sources:

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -110,3 +110,80 @@ $ kubectl port-forward vault-pod 8200
 $ export VAULT_ADDR=http://127.0.0.1:8200
 $ vault status
 ```
+
+### TLS config
+
+This is example of running Vault with Kubernetes generated TLS certificate:
+
+1. Create `CertificateSigningRequest` according to [documentation](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/),
+    some useful hosts entries to add:
+   - `127.0.0.1` for running Vault commands inside the pod,
+   - `*.<namespace>.pod.cluster.local` for direct Pod to Pod communication,
+   - `<release>.<namespace>.svc.cluster.local` for communication within cluster,
+
+1. Create `Secret` holding certificate and private key PEM:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: vault-tls
+data:
+  tls.crt: ${BASE64_ENCODED_CRT}
+  tls.key: ${BASE64_ENCODED_PRIVATE_KEY}
+```
+
+1. Example TLS `values.yml` (note: you should replace `{{ ... }}` entries):
+
+```yaml
+replicaCount: {{ .Cur.replicas }}
+
+vault:
+  dev: false
+  extraEnv:
+  - name: VAULT_CAPATH
+    value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  config:
+    ui: "true"
+    storage:
+      consul:
+        address: {{ .Cur.consul_addr | quote }}
+        path: {{ .Cur.name | quote }}
+    listener:
+      tcp:
+        tls_disable: false
+        tls_cert_file: /vault/tls/tls.crt
+        tls_key_file: /vault/tls/tls.key
+  customSecrets:
+  - secretName: {{ .Cur.tls_secret | quote }}
+    mountPath: /vault/tls
+
+ingress:
+  enabled: true
+  hosts:
+  - {{ .Cur.domain | quote }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Cur.ingress_class | quote }}
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/load-balance: "round_robin"
+  tls:
+  - hosts:
+    - {{ .Cur.domain | quote }}
+```
+
+### HA unseal script
+
+Script for easier HA mode Vault unsealing:
+```bash
+#!/bin/sh
+set -e
+release=$1
+namespace=$(helm status vault -o json | jq -r '.namespace')
+read -rsp 'Vault Unseal Key: ' key
+echo
+for pod in $(kubectl -n ${namespace} get pods -l release=${release},app=vault -o json | jq -r '.items[] | select(.status.phase == "Running" and (.status.containerStatuses | any(.name == "vault" and (.ready | not)))) | .metadata.name')
+do
+    kubectl -n ${namespace} exec -ti ${pod} -c vault vault operator unseal "${key}"
+done
+```

--- a/incubator/vault/templates/NOTES.txt
+++ b/incubator/vault/templates/NOTES.txt
@@ -9,9 +9,9 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "vault.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "vault.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo http://$SERVICE_IP:8200
 {{- else if contains "ClusterIP"  .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "vault.name" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Use http://127.0.0.1:8200 as the Vault address after forwarding."
-  kubectl port-forward --namespace {{ .Release.Namespace }}  $POD_NAME 8200:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }}  $POD_NAME 8200:{{ .Values.service.externalPort }}
 {{- end }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
-      subdomain: vault
+      subdomain: "{{ template "consul.fullname" . }}"
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -83,11 +83,11 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: VAULT_ADDR
-            value: "{{ $scheme }}://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8200"
+            value: "{{ $scheme }}://$(POD_NAME).{{ template "consul.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8200"
           - name: VAULT_API_ADDR
-            value: "{{ $scheme }}://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8200"
+            value: "{{ $scheme }}://$(POD_NAME).{{ template "consul.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8200"
           - name: VAULT_CLUSTER_ADDR
-            value: "{{ $scheme }}://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8201"
+            value: "{{ $scheme }}://$(POD_NAME).{{ template "consul.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8201"
           - name: VAULT_LOG_LEVEL
             value: "{{ .Values.vault.logLevel }}"
         {{- if .Values.vault.extraEnv }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -14,7 +14,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: {{ .Values.maxUnavailable }}
+      maxSurge: {{ .Values.maxSurge }}
   template:
     metadata:
       labels:
@@ -23,57 +24,79 @@ spec:
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
+      subdomain: vault
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.vault.dev }}
-        command: ["vault", "server", "-dev", "-dev-listen-address", "[::]:8200"]
+        command:
+          - "vault"
+          - "server"
+          - "-dev"
+          - "-dev-listen-address"
+          - "[::]:8200"
         {{- else }}
-        command: ["vault", "server", "-config", "/vault/config/config.json"]
+        command:
+          - "vault"
+          - "server"
+          - "-config"
+          - "/vault/config/config.json"
         {{- end }}
         {{- if .Values.lifecycle }}
         lifecycle:
 {{ tpl .Values.lifecycle . | indent 10 }}
         {{- end }}
         ports:
-        - containerPort: {{ .Values.service.port }}
+        - containerPort: 8200
           name: api
         - containerPort: 8201
-          name: cluster-address
+          name: cluster
         livenessProbe:
           # Alive if it is listening for clustering traffic
-          tcpSocket:
-            port: {{ .Values.service.port }}
+          httpGet:
+            path: /v1/sys/health?standbycode=200&sealedcode=200&uninitcode=200
+            port: 8200
+            {{- if not .Values.vault.config.listener.tcp.tls_disable }}
+            scheme: HTTPS
+            {{- end }}
         readinessProbe:
           # Ready depends on preference
           httpGet:
-            path: /v1/sys/health?
-              {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
-              {{- if .Values.vault.readiness.readyIfStandby -}}standbycode=204&{{- end }}
-              {{- if .Values.vault.readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
-            port: {{ .Values.service.port }}
-            scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
+            path: "/v1/sys/health?
+            {{- range $key, $value := .Values.vault.readinessParams -}}
+              {{ $key }}={{ $value }}&
+            {{- end -}}"
+            port: 8200
+            {{- if not .Values.vault.config.listener.tcp.tls_disable }}
+            scheme: HTTPS
+            {{- end }}
         securityContext:
           readOnlyRootFilesystem: true
           capabilities:
             add:
             - IPC_LOCK
         env:
-          - name: POD_IP
+          - name: POD_NAME
             valueFrom:
               fieldRef:
-                fieldPath: status.podIP
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: VAULT_API_ADDR
+            value: "https://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8200"
           - name: VAULT_CLUSTER_ADDR
-            value: "https://$(POD_IP):8201"
+            value: "https://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8201"
+          - name: VAULT_LOG_LEVEL
+            value: "{{ .Values.vault.logLevel }}"
         {{- if .Values.vault.extraEnv }}
 {{ toYaml .Values.vault.extraEnv | indent 10 }}
         {{- end }}
         volumeMounts:
         - name: vault-config
           mountPath: /vault/config/
-        - name: vault-root
-          mountPath: /root/
         {{- range .Values.vault.customSecrets }}
         - name: {{ .secretName }}
           mountPath: {{ .mountPath }}
@@ -84,7 +107,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.affinity }}
-      {{- if .Values.consulAgent.join }}
+        {{- if .Values.consulAgent.join }}
       - name: {{ .Chart.Name }}-consul-agent
         image: "{{ .Values.consulAgent.repository }}:{{ .Values.consulAgent.tag }}"
         imagePullPolicy: {{ .Values.consulAgent.pullPolicy }}
@@ -113,7 +136,7 @@ spec:
               $GOSSIP_KEY \
               -join={{- .Values.consulAgent.join }} \
               -data-dir=/etc/consul
-      {{- end }}
+        {{- end }}
       affinity:
 {{ tpl .Values.affinity . | indent 8 }}
       {{- end }}
@@ -121,16 +144,14 @@ spec:
         - name: vault-config
           configMap:
             name: "{{ template "vault.fullname" . }}-config"
-        - name: vault-root
-          emptyDir: {}
         {{- range .Values.vault.customSecrets }}
         - name: {{ .secretName }}
           secret:
             secretName: {{ .secretName }}
         {{- end }}
-{{- if .Values.vault.extraVolumes }}
+        {{- if .Values.vault.extraVolumes }}
 {{ toYaml .Values.vault.extraVolumes | indent 8}}
-{{- end }}
+        {{- end }}
         {{- if .Values.consulAgent.join }}
         - name: consul-data
           emptyDir: {}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
-      subdomain: "{{ template "consul.fullname" . }}"
+      subdomain: "{{ template "vault.fullname" . }}"
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $scheme := coalesce (and (eq .Values.vault.config.listener.tcp.tls_disable false) "https") "http" -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -56,10 +57,8 @@ spec:
           # Alive if it is listening for clustering traffic
           httpGet:
             path: /v1/sys/health?standbycode=200&sealedcode=200&uninitcode=200
-            port: 8200
-            {{- if not .Values.vault.config.listener.tcp.tls_disable }}
-            scheme: HTTPS
-            {{- end }}
+            port: api
+            scheme: {{ $scheme | upper }}
         readinessProbe:
           # Ready depends on preference
           httpGet:
@@ -67,10 +66,8 @@ spec:
             {{- range $key, $value := .Values.vault.readinessParams -}}
               {{ $key }}={{ $value }}&
             {{- end -}}"
-            port: 8200
-            {{- if not .Values.vault.config.listener.tcp.tls_disable }}
-            scheme: HTTPS
-            {{- end }}
+            port: api
+            scheme: {{ $scheme | upper }}
         securityContext:
           readOnlyRootFilesystem: true
           capabilities:
@@ -85,10 +82,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: VAULT_ADDR
+            value: "{{ $scheme }}://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8200"
           - name: VAULT_API_ADDR
-            value: "https://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8200"
+            value: "{{ $scheme }}://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8200"
           - name: VAULT_CLUSTER_ADDR
-            value: "https://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8201"
+            value: "{{ $scheme }}://$(POD_NAME).vault.$(POD_NAMESPACE).svc.cluster.local:8201"
           - name: VAULT_LOG_LEVEL
             value: "{{ .Values.vault.logLevel }}"
         {{- if .Values.vault.extraEnv }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -83,11 +83,11 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: VAULT_ADDR
-            value: "{{ $scheme }}://$(POD_NAME).{{ template "consul.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8200"
+            value: "{{ $scheme }}://$(POD_NAME).{{ template "vault.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8200"
           - name: VAULT_API_ADDR
-            value: "{{ $scheme }}://$(POD_NAME).{{ template "consul.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8200"
+            value: "{{ $scheme }}://$(POD_NAME).{{ template "vault.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8200"
           - name: VAULT_CLUSTER_ADDR
-            value: "{{ $scheme }}://$(POD_NAME).{{ template "consul.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8201"
+            value: "{{ $scheme }}://$(POD_NAME).{{ template "vault.fullname" . }}.$(POD_NAMESPACE).svc.cluster.local:8201"
           - name: VAULT_LOG_LEVEL
             value: "{{ .Values.vault.logLevel }}"
         {{- if .Values.vault.extraEnv }}

--- a/incubator/vault/templates/ingress.yaml
+++ b/incubator/vault/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
-{{- $servicePort := .Values.service.port -}}
+{{- $servicePort := .Values.service.externalPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/incubator/vault/templates/poddisruptionbudget.yaml
+++ b/incubator/vault/templates/poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}
 spec:
-  maxUnavailable: 1
+  maxUnavailable: {{ .Values.vault.maxUnavailable }}
   selector:
     matchLabels:
       app: {{ template "vault.name" . }}

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -25,7 +25,7 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     protocol: TCP
-    targetPort: {{ .Values.service.port }}
+    targetPort: api
     name: api
   selector:
     app: {{ template "vault.name" . }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -1,12 +1,15 @@
 # Default values for vault.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 3
 ## The name of the secret to use if pulling images from a private registry.
 # imagePullSecret:
+replicaCount: 3
+maxUnavailable: 1
+# Allow to create all missing pods at once
+maxSurge: "100%"
 image:
   repository: vault
-  tag: 0.10.1
+  tag: 0.10.2
   pullPolicy: IfNotPresent
 
 consulAgent:
@@ -32,11 +35,7 @@ service:
   #  - 10.0.0.0/8
   #  - 130.211.204.2/32
   externalPort: 8200
-  port: 8200
   # clusterIP: None
-  annotations: {}
-  #   cloud.google.com/load-balancer-type: "Internal"
-  #
   # An example using type:loadbalancer and AWS internal ELB on kops
   # type: LoadBalancer
   # annotations:
@@ -100,6 +99,7 @@ vault:
   # https://www.vaultproject.io/intro/getting-started/dev-server.html for more
   # information.
   dev: true
+  logLevel: info
   # Allows the mounting of various custom secrets th enable production vault
   # configurations. The comments show an example usage for mounting a TLS
   # secret. The two fields required are a secretName indicating the name of
@@ -125,10 +125,14 @@ vault:
   # - name: extra-volume
   #   secret:
   #     secretName: some-secret
-  readiness:
-    readyIfSealed: false
-    readyIfStandby: true
-    readyIfUninitialized: true
+  readinessParams:
+    # https://www.vaultproject.io/api/system/health.html
+    standbycode: "200"
+    #  standbyok: "false"
+    #  activecode: "200"
+    #  standbycode: "429"
+    #  sealedcode: "503"
+    #  uninitcode: "501"
   config:
     # A YAML representation of a final vault config.json file.
     # See https://www.vaultproject.io/docs/configuration/ for more information.


### PR DESCRIPTION
reworked #4968 

**What this PR does / why we need it**:
We need this PR to make it possible to run High Availability Vault with TLS enabled and request forwarding working (behind LoadBalancer/Ingress).

This PR adds following:
- changes `livenessProbe` to `httpGet` always returning `200`,
- makes `readinessProbe` customization map more directly to GET parameters,
- adds HA & TLS examples to `README.md`,
- sets `VAULT_CLUSTER_ADDR` and `VAULT_API_ADDR` to wildcard-able DNS names (using `PodSpec.subdomain`),
- dropped `service.port` in favor of customizing just `externalPort` (should not need that customization),
- adds `maxSurge` and `maxUnavailable` customization for scheduling, then unsealing all missing pods at once,