### PR TITLE
fix postgres chart

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.14.1
+version: 0.14.2
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -83,18 +83,18 @@ spec:
             - sh
             - -c
             - exec pg_isready --host $POD_IP
-          initialDelaySeconds: {{ .Values.probes.liveness.initialDelay | quote }}
-          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds | quote }}
-          failureThreshold: {{ .Values.probes.liveness.failureThreshold | quote }}
+          initialDelaySeconds: {{ .Values.probes.liveness.initialDelay }}
+          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
         readinessProbe:
           exec:
             command:
             - sh
             - -c
             - exec pg_isready --host $POD_IP
-          initialDelaySeconds: {{ .Values.probes.readiness.initialDelay | quote }}
-          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds | quote }}
-          periodSeconds: {{ .Values.probes.readiness.periodSeconds | quote }}
+          initialDelaySeconds: {{ .Values.probes.readiness.initialDelay }}
+          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -132,13 +132,13 @@ affinity: {}
 # Override default liveness & readiness probes
 probes:
   liveness:
-    initialDelay: "60"
-    timeoutSeconds: "5"
-    failureThreshold: "6"
+    initialDelay: 60
+    timeoutSeconds: 5
+    failureThreshold: 6
   readiness:
-    initialDelay: "5"
-    timeoutSeconds: "3"
-    failureThreshold: "5"
+    initialDelay: 5
+    timeoutSeconds: 3
+    failureThreshold: 5
 ## Annotations for the deployment and nodes.
 deploymentAnnotations: {}
 podAnnotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:  currenrt postgresql chart is broken. see https://github.com/kubernetes/charts/pull/2957#issuecomment-397903485

**Special notes for your reviewer**:

Currently a deployment of the postgresql chart results in : 
```
Error: release geared-mouse failed: Deployment in version "v1beta1" cannot be handled as a Deployment: v1beta1.Deployment: Spec: v1beta1.DeploymentSpec: Template: v1.PodTemplateSpec: Spec: v1.PodSpec: Containers: []v1.Container: v1.Container: LivenessProbe: v1.Probe: FailureThreshold: readUint32: unexpected character: �, error found in #10 byte of ...|reshold":"6","initia|..., bigger context ...| pg_isready --host $POD_IP"]},"failureThreshold":"6","initialDelaySeconds":"60","timeoutSeconds":"5"|...
```
@adamcharnock, @unguiculus  reason is that the values for `failureThreshold`, `initialDelaySeconds`,  `timeoutSeconds` have to be ints not strings.


