### PR TITLE
[traefik] Add a README header for basic auth

### DIFF
--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -182,6 +182,8 @@ Currently it is possible to specify the number of `replicas` but the implementat
 
 It is heavily advised to not set a value for `replicas` if you also have Let's Encrypt configured. While setting `replicas` will work for many cases, since no leader is elected it has the consequence that each node will end up requesting Let's Encrypt certificates if this is also configured. This will quickly cut into the very modest rate limit that Let's Encrypt enforces. Also, if using challenges, the challenges may fail, as the challenge request may hit a pod without the challenge certificate.
 
+### Dashboard Basic Auth
+
 [Basic auth](https://docs.traefik.io/toml/#api-backend) can be specified via `dashboard.auth.basic` as a map of usernames to passwords as below.
 See the linked Traefik documentation for accepted passwords encodings.
 It is advised to single quote passwords to avoid issues with special characters:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Traefik's basic auth instructions seemed to be incorrectly part of the Clustering section. This adds a new header to the README to differentiate them.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: