### PR TITLE
 Add loadBalancerIP/loadBalancerSourceRanges

### DIFF
--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -1,7 +1,14 @@
 # Elasticsearch Helm Chart
 
-This chart is based on the [centerforopenscience/elasticsearch](https://hub.docker.com/r/centerforopenscience/elasticsearch/) image which comes with Fabric8's great [kubernetes discovery plugin](https://github.com/fabric8io/elasticsearch-cloud-kubernetes) for Elasticsearch.
- 
+This chart uses a standard Docker image of Elasticsearch (hub.docker.com/r/blacktop/elasticsearch) and uses a service pointing to the master's transport port for service discovery.
+Elasticsearch does not communicate with the Kubernetes API, hence no need for RBAC permissions.
+
+## Warning for previous users
+If you are currently using an earlier version of this Chart you will need to redeploy your Elasticsearch clusters. The discovery method used here is incompatible with using RBAC.
+If you are upgrading to Elasticsearch 6 from the 5.5 version used in this chart before, please note that your cluster needs to do a full cluster restart.
+The simplest way to do that is to delete the installation (keep the PVs) and install this chart again with the new version.
+If you want to avoid doing that upgrade to Elasticsearch 5.6 first before moving on to Elasticsearch 6.0.
+
 ## Prerequisites Details
 
 * Kubernetes 1.6+
@@ -51,15 +58,17 @@ $ kubectl delete pvc -l release=my-release,component=data
 
 ## Configuration
 
-The following tables lists the configurable parameters of the elasticsearch chart and their default values.
+The following table lists the configurable parameters of the elasticsearch chart and their default values.
 
 |              Parameter               |                             Description                             |               Default                |
 | ------------------------------------ | ------------------------------------------------------------------- | ------------------------------------ |
-| `appVersion`                         | Application Version (Elasticsearch)                                 | `5.4`                                |
-| `image.repository`                   | Container image name                                                | `centerforopenscience/elasticsearch` |
-| `image.tag`                          | Container image tag                                                 | `5.4`                                |
+| `appVersion`                         | Application Version (Elasticsearch)                                 | `6.1.1`                              |
+| `image.repository`                   | Container image name                                                | `docker.elastic.co/elasticsearch/elasticsearch-oss` |
+| `image.tag`                          | Container image tag                                                 | `6.1.1`                                |
 | `image.pullPolicy`                   | Container pull policy                                               | `Always`                             |
 | `cluster.name`                       | Cluster name                                                        | `elasticsearch`                      |
+| `cluster.kubernetesDomain`           | Kubernetes cluster domain name                                      | `cluster.local`                      |
+| `cluster.xpackEnable`                | Writes the X-Pack configuration options to the configuration file   | `false`                              |
 | `cluster.config`                     | Additional cluster config appended                                  | `{}`                                 |
 | `cluster.env`                        | Cluster environment variables                                       | `{}`                                 |
 | `client.name`                        | Client component name                                               | `client`                             |
@@ -67,13 +76,17 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `client.resources`                   | Client node resources requests & limits                             | `{} - cpu limit must be an integer`  |
 | `client.heapSize`                    | Client node heap size                                               | `512m`                               |
 | `client.podAnnotations`              | Client Deployment annotations                                       | `{}`                                 |
+| `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                 |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                          |
-| `master.exposeHttp`                 | Expose http port 9200 on master Pods for monitoring, etc           | `false`                              |
+| `client.loadBalancerIP`                 | Client loadBalancerIP                                                 | `nil`                          |
+| `client.loadBalancerSourceRanges`                 | Client loadBalancerSourceRanges                                                 | `nil`                          |
+| `master.exposeHttp`                  | Expose http port 9200 on master Pods for monitoring, etc            | `false`                              |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.replicas`                    | Master node replicas (deployment)                                   | `2`                                  |
 | `master.resources`                   | Master node resources requests & limits                             | `{} - cpu limit must be an integer`  |
 | `master.podAnnotations`              | Master Deployment annotations                                       | `{}`                                 |
+| `master.nodeSelector`                | Node labels for master pod assignment                               | `{}`                                 |
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
@@ -81,7 +94,7 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `master.persistence.size`            | Master persistent volume size                                       | `4Gi`                                |
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
-| `data.exposeHttp`                   | Expose http port 9200 on data Pods for monitoring, etc              | `false`                              |
+| `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                              |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `3`                                  |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |
@@ -91,9 +104,9 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `data.persistence.storageClass`      | Data persistent volume Class                                        | `nil`                                |
 | `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |
 | `data.podAnnotations`                | Data StatefulSet annotations                                        | `{}`                                 |
+| `data.nodeSelector`                  | Node labels for data pod assignment                                 | `{}`                                 |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
-| `rbac.create`                        | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/elasticsearch/templates/client-svc.yaml
+++ b/incubator/elasticsearch/templates/client-svc.yaml
@@ -18,11 +18,17 @@ spec:
     - name: http
       port: 9200
       targetPort: http
-    - name: transport
-      port: 9300
-      targetPort: transport
   selector:
     app: {{ template "elasticsearch.name" . }}
     component: "{{ .Values.client.name }}"
     release: {{ .Release.Name }}
   type: {{ .Values.client.serviceType }}
+{{- if .Values.client.loadBalancerIP}}
+  loadBalancerIP: {{.Values.client.loadBalancerIP}}
+{{- end}}
+{{- if .Values.client.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+    {{range $rangeList := .Values.client.loadBalancerSourceRanges}}
+    - {{ $rangeList }}
+    {{end}}
+{{end}}

--- a/incubator/elasticsearch/templates/client-svc.yaml
+++ b/incubator/elasticsearch/templates/client-svc.yaml
@@ -31,4 +31,4 @@ spec:
     {{range $rangeList := .Values.client.loadBalancerSourceRanges}}
     - {{ $rangeList }}
     {{end}}
-{{end}}
+{{- end}}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         component: "{{ .Values.server.name }}"
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 2000
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "prometheus.server.fullname" . }}{{ else }}"{{ .Values.server.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ template "prometheus.name" . }}-{{ .Values.server.name }}-{{ .Values.configmapReload.name }}
@@ -35,6 +38,8 @@ spec:
             - --webhook-url=http://localhost:9090{{ .Values.server.prefixURL }}/-/reload
           resources:
 {{ toYaml .Values.configmapReload.resources | indent 12 }}
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
@@ -44,9 +49,6 @@ spec:
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
           args:
-          {{- if or .Values.alertmanager.enabled .Values.server.alertmanagerURL }}
-            - --alertmanager.url={{- if .Values.alertmanager.enabled }}http://{{ template "prometheus.alertmanager.fullname" . }}:{{ .Values.alertmanager.service.servicePort }}{{ .Values.alertmanager.prefixURL }}{{- else }}{{ .Values.server.alertmanagerURL }}{{- end }}
-          {{- end }}
           {{- if .Values.server.retention }}
             - --storage.local.retention={{ .Values.server.retention }}
           {{- end }}


### PR DESCRIPTION
Hi there,

In my actual enterprise sometimes I had to edit the client-svc.yaml in order to add these parameters when we need to expose ES serivce with an internal IP like 10.x.x.x.x with this annotation:
- cloud.google.com/load-balancer-type: "Internal"
or with a public IP firewalled (LoabalancerSourceRanges).

So it's better to feed with the community :)

Cheers.