### PR TITLE
[stable/nginx-ingress] Enable custom hostports

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.20.3
+version: 0.20.4
 appVersion: 0.14.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -64,6 +64,8 @@ Parameter | Description | Default
 `controller.extraArgs` | Additional controller container arguments | `{}`
 `controller.kind` | install as Deployment or DaemonSet | `Deployment`
 `controller.daemonset.useHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for TCP/80 and TCP/443 | false
+`controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"80"`
+`controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"443"`
 `controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `controller.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -102,13 +102,13 @@ spec:
               containerPort: 80
               protocol: TCP
               {{- if .Values.controller.daemonset.useHostPort }}
-              hostPort: 80
+              hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
               {{- end }}
             - name: https
               containerPort: 443
               protocol: TCP
               {{- if .Values.controller.daemonset.useHostPort }}
-              hostPort: 443
+              hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
               {{- end }}
           {{- if .Values.controller.stats.enabled }}
             - name: stats

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -26,6 +26,10 @@ controller:
   daemonset:
     useHostPort: false
 
+    hostPorts:
+      http: 80
+      https: 443
+
   ## Required only if defaultBackend.enabled = false
   ## Must be <namespace>/<service_name>
   ##


### PR DESCRIPTION
**What this PR does / why we need it**: This PR makes hostPorts configurable, and it allows you to change the default ports in case of a port conflict. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Custom host port won't work when the hostNetwork is enabled and Kubernetes already warns about that. Not sure if I need to add a warning about this here. 