### PR TITLE
[stable/rabbitmq-ha] - Use the serviceAccount name from the template helper for consistency

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.4
-version: 1.6.1
+version: 1.6.2
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/rolebinding.yaml
+++ b/stable/rabbitmq-ha/templates/rolebinding.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "rabbitmq-ha.fullname" . }}
+    name: {{ template "rabbitmq-ha.serviceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a broken cluster - the nodes fail on startup when attempting to connect to the kubernetes api server - `Failed to get nodes from k8s - (403)`.

@etiennetremel @coreypobrien - Please review! thank you!