### PR TITLE
[incubator/fluentd-cloudwatch] fixed incorrect AWS secrets because a newline was appended during Files.Glob

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-cloudwatch
-version: 0.5.1
+version: 0.5.2
 appVersion: v0.12.43-cloudwatch
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/templates/secrets.yaml
+++ b/incubator/fluentd-cloudwatch/templates/secrets.yaml
@@ -10,5 +10,6 @@ metadata:
     release: {{ .Release.Name }}
 type: Opaque
 data:
-{{ (.Files.Glob "secrets/*").AsSecrets | indent 2 }}
+  aws_access_key_id: {{ .Files.Get "secrets/aws_access_key_id" | trimSuffix "\n" | b64enc }}
+  aws_secret_access_key: {{ .Files.Get "secrets/aws_secret_access_key" | trimSuffix "\n" | b64enc }}
 {{- end }}


### PR DESCRIPTION
This is related to the issue https://github.com/kubernetes/helm/issues/3410

fixed https://github.com/kubernetes/charts/issues/5810

