### PR TITLE
[ stable/concourse ] HostPath can now be used as working dir for workers

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.9.0
+version: 1.9.1
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -147,6 +147,7 @@ spec:
               - key: worker-key-pub
                 path: worker_key.pub
   {{- if .Values.persistence.enabled }}
+    {{- if (eq "volumeclaim" .Values.persistence.worker.type) }}
   volumeClaimTemplates:
     - metadata:
         name: concourse-work-dir
@@ -163,6 +164,12 @@ spec:
         storageClassName: "{{ .Values.persistence.worker.storageClass }}"
       {{- end }}
       {{- end }}
+    {{- else if (eq "hostpath" .Values.persistence.worker.type) }}
+        - name: concourse-work-dir
+          hostPath:
+            path: {{ .Values.persistence.worker.path }}
+            type: {{ .Values.persistence.worker.pathType }}
+    {{- end }}
   {{- else }}
         - name: concourse-work-dir
           emptyDir: {}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -443,6 +443,20 @@ persistence:
   ## Worker Persistence configuration.
   ##
   worker:
+    ## concourse data Persistent type
+    ## If set to "hostpath", concourse-work-dir will use a hostPath volume for persistence
+    ## If set to "volumeclaim" (the default), concourse-work-dir will use a PVC for persistence
+    type: "volumeclaim"
+
+    ## concourse data Persistent Host Path path
+    ##
+    path: ""
+
+    ## concourse data Persistent Host Path type
+    ##
+    pathType: Directory
+
+
     ## concourse data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
**What this PR does / why we need it**:

Amazon supports NVME drives, which now can be mapped as concourse working dir using `hostPath` volumes.

**Special notes for your reviewer**: The goal is to be able to use NVME for baggage claim, if you have a better implementation, I'm all ears. This just seemed the fasted/less complicated way of doing it since baggage claim is set within the working directory.