### PR TITLE
Redis slave deployment: fix affinity -> slave.affinity

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.5.0
+version: 3.6.0
 appVersion: 4.0.10
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-slave-deployment.yaml
+++ b/stable/redis/templates/redis-slave-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- if .Values.slave.schedulerName }}
       schedulerName: "{{ .Values.slave.schedulerName }}"
       {{- end }}
-    {{- with .Values.affinity }}
+    {{- with .Values.slave.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}


### PR DESCRIPTION
/!\ Breaking change

Documentation talks about `slave.affinity` parameter, but slave affinity is actually set by `affinity` parameter.