### PR TITLE
Adds support for RBAC for CloudSQL Proxy

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -13,6 +13,6 @@ home: https://cloud.google.com/sql/docs/postgres/sql-proxy
 sources:
 - https://github.com/rimusz/charts
 maintainers:
-- name: Rimas Mocevicius
+- name: rimusz
   email: rmocius@gmail.com
 engine: gotpl

--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-sqlproxy
-version: 0.3.4
+version: 0.3.5
 appVersion: 1.11
 description: Google Cloud SQL Proxy
 keywords:

--- a/stable/gcloud-sqlproxy/OWNERS
+++ b/stable/gcloud-sqlproxy/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- rimusz
+- unguiculus
+- lachie83
+reviewers:
+- rimusz
+- unguiculus
+- lachie83

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -56,16 +56,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Drupal chart and their default values.
 
-| Parameter                         | Description                            | Default                                                   |
-| --------------------------------- | -------------------------------------- | --------------------------------------------------------- |
-| `image`                           | SQLProxy image                         | `b.gcr.io/cloudsql-docker/gce-proxy`                      |
-| `imageTag`                        | SQLProxy image tag                     | `1.09`                                                    |
-| `imagePullPolicy`                 | Image pull policy                      | `IfNotPresent`                                            |
-| `replicasCount`                   | Replicas count                         | `1`                                                       |
-| `serviceAccountKey`               | Service account key JSON file          | Must be provided and base64 encoded                       |
-| `cloudsql.instances`              | List of PostgreSQL/MySQL instances     | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided                |
-| `resources`                       | CPU/Memory resource requests/limits    | Memory: `100/150Mi`, CPU: `100/150m`                      |
-| `nodeSelector`                    | Node Selector                          |                                                           |
+| Parameter                         | Description                            | Default                                                                                     |
+| --------------------------------- | -------------------------------------- | ---------------------------------------------------------                                   |
+| `image`                           | SQLProxy image                         | `b.gcr.io/cloudsql-docker/gce-proxy`                                                        |
+| `imageTag`                        | SQLProxy image tag                     | `1.09`                                                                                      |
+| `imagePullPolicy`                 | Image pull policy                      | `IfNotPresent`                                                                              |
+| `replicasCount`                   | Replicas count                         | `1`                                                                                         |
+| `serviceAccountKey`               | Service account key JSON file          | Must be provided and base64 encoded                                                         |
+| `cloudsql.instances`              | List of PostgreSQL/MySQL instances     | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
+| `resources`                       | CPU/Memory resource requests/limits    | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
+| `nodeSelector`                    | Node Selector                          |                                                                                             |
+| `rbac.create`                     | Create RBAC configuration w/ SA        | `false`                                                                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: {{ template "gcloud-sqlproxy.fullname" . }}
     spec:
+      {{- if .Values.rbac.create }}
+      serviceAccountName: {{ template "gcloud-sqlproxy.fullname" . }}
+      {{- end }}
       containers:
       - name: sqlproxy
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"

--- a/stable/gcloud-sqlproxy/templates/role.yaml
+++ b/stable/gcloud-sqlproxy/templates/role.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "gcloud-sqlproxy.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "gcloud-sqlproxy.fullname" . }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+{{- end }}

--- a/stable/gcloud-sqlproxy/templates/rolebinding.yaml
+++ b/stable/gcloud-sqlproxy/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "gcloud-sqlproxy.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "gcloud-sqlproxy.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "gcloud-sqlproxy.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
+++ b/stable/gcloud-sqlproxy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "gcloud-sqlproxy.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "gcloud-sqlproxy.fullname" . }}
+{{- end }}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -45,6 +45,10 @@ cloudsql:
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
+
+rbac:
+  create: false
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it**:

This Pull Requests adds support for RBAC in the CloudSQL Proxy. This feature is disabled by default. To enable the feature, use `--set rbac.create=true`.

**Special notes for your reviewer**:

Ping - @rimusz. This adds the RBAC support as discussed. 