### PR TITLE
add default for probes.readiness.periodSeconds

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.14.2
+version: 0.14.3
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -139,6 +139,7 @@ probes:
     initialDelay: 5
     timeoutSeconds: 3
     failureThreshold: 5
+    periodSeconds: 5
 ## Annotations for the deployment and nodes.
 deploymentAnnotations: {}
 podAnnotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
When I tried to fix the postgress chart in https://github.com/kubernetes/charts/pull/6179 it seems that even though I tested this there is a problem with different versions of kubernetes / kubectl, as other others experience a problem that I did not see. see #6225 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes  #6225

**Special notes for your reviewer**:

when I do a helm install --debug now I see 
```
        readinessProbe:
          exec:
            command:
            - sh
            - -c
            - exec pg_isready --host $POD_IP
          initialDelaySeconds: 5
          timeoutSeconds: 3
          periodSeconds: 5
```

unfortunately as I was not experiencing the problem with my k8s version this is the only way how I could test.