### PR TITLE
Adds tolerations labels for Jaeger pods

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.6.1
+version: 0.7.0
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -150,6 +150,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `agent.service.compactPort`              | jaeger.thrift over compact thrift   |  6831                                  |
 | `agent.service.zipkinThriftPort`         | zipkin.thrift over compact thrift   |  5775                                  |
 | `agent.useHostNetwork`                   | Enable hostNetwork for agents       |  false                                 |
+| `agent.tolerations`                      | Node Tolerations                    | `[]`                                   |
 | `cassandra.config.cluster_name`          | Cluster name                        |  jaeger                                |
 | `cassandra.config.dc_name`               | Datacenter name                     |  dc1                                   |
 | `cassandra.config.endpoint_snitch`       | Node discovery method               |  GossipingPropertyFileSnitch           |
@@ -163,6 +164,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.service.annotations`          | Annotations for Collector SVC       |  nil                                   |
 | `collector.image`                        | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
 | `collector.pullPolicy`                   | Collector image pullPolicy          |  IfNotPresent                          |
+| `collector.tolerations`                  | Node Tolerations                    | `[]`                                   |
 | `collector.service.annotations`          | Annotations for Collector SVC       |  nil                                   |
 | `collector.service.httpPort`             | Client port for HTTP thrift         |  14268                                 |
 | `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`   |
@@ -183,6 +185,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `query.ingress.enabled`                  | Allow external traffic access       |  false                                 |
 | `query.podAnnotations`                   | Annotations for Query pod           |  nil                                   |
 | `query.pullPolicy`                       | Query UI image pullPolicy           |  IfNotPresent                          |
+| `query.tolerations`                      | Node Tolerations                    | `[]`                                   |
 | `query.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`       |
 | `query.service.queryPort`                | External accessible port            |  80                                    |
 | `query.service.targetPort`               | Internal Query UI port              |  16686                                 |
@@ -198,6 +201,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `spark.successfulJobsHistoryLimit`       | Cron job successfulJobsHistoryLimit |  5                                     |
 | `spark.failedJobsHistoryLimit`           | Cron job failedJobsHistoryLimit     |  5                                     |
 | `spark.tag`                              | Tag of the dependencies job image   |  latest                                |
+| `spark.tolerations`                      | Node Tolerations                    | `[]`                                   |
 | `storage.cassandra.host`                 | Provisioned cassandra host          |  cassandra                             |
 | `storage.cassandra.password`             | Provisioned cassandra password      |  password                              |
 | `storage.cassandra.port`                 | Provisioned cassandra port          |  9042                                  |

--- a/incubator/jaeger/templates/agent-ds.yaml
+++ b/incubator/jaeger/templates/agent-ds.yaml
@@ -36,6 +36,10 @@ spec:
       dnsPolicy: {{ .Values.agent.dnsPolicy }}
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}
+{{- if .Values.agent.tolerations }}
+      tolerations:
+{{ toYaml .Values.agent.tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: {{ template "jaeger.agent.name" . }}
         image: {{ .Values.agent.image }}:{{ .Values.tag }}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -35,6 +35,10 @@ spec:
     spec:
       nodeSelector:
 {{ toYaml .Values.collector.nodeSelector | indent 8 }}
+{{- if .Values.collector.tolerations }}
+      tolerations:
+{{ toYaml .Values.collector.tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: {{ template "jaeger.collector.name" . }}
         image: {{ .Values.collector.image }}:{{ .Values.tag }}

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -35,6 +35,10 @@ spec:
     spec:
       nodeSelector:
 {{ toYaml .Values.query.nodeSelector | indent 8 }}
+{{- if .Values.query.tolerations }}
+      tolerations:
+{{ toYaml .Values.query.tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: {{ template "jaeger.query.name" . }}
         image: {{ .Values.query.image }}:{{ .Values.tag }}

--- a/incubator/jaeger/templates/spark-cronjob.yaml
+++ b/incubator/jaeger/templates/spark-cronjob.yaml
@@ -34,6 +34,10 @@ spec:
         spec:
           nodeSelector:
 {{ toYaml .Values.spark.nodeSelector | indent 12 }}
+{{- if .Values.spark.tolerations }}
+      tolerations:
+{{ toYaml .Values.spark.tolerations | indent 8 }}
+{{- end }}
           containers:
           - name: {{ template "jaeger.fullname" . }}-spark
             image: {{ .Values.spark.image }}:{{ .Values.spark.tag }}

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -110,6 +110,9 @@ agent:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  ## Allow the scheduling on tainted nodes (requires Kubernetes >= 1.6)
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
   useHostNetwork: false
   dnsPolicy: ClusterFirst
 
@@ -145,6 +148,9 @@ collector:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  ## Allow the scheduling on tainted nodes (requires Kubernetes >= 1.6)
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
 
 query:
   enabled: true
@@ -190,6 +196,9 @@ query:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  ## Allow the scheduling on tainted nodes (requires Kubernetes >= 1.6)
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
 
 spark:
   enabled: false
@@ -211,6 +220,9 @@ spark:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  ## Allow the scheduling on tainted nodes (requires Kubernetes >= 1.6)
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
 # End: Default values for the various components of Jaeger
 
 hotrod:


### PR DESCRIPTION
Hi Jaeger Chart maintainers! I work in a cluster which has GPU nodes that we manage with node taints. We use (and love) this Jaeger chart -- but we cant use the agent daemonset without tolerations on these nodes. 

While I was modifying the agent to allow toleration specification, I also added it to the other deploys (collectors, query, spark) in case future users might need to specify tolerations for those pods.