### PR TITLE
Specifying hostPort when apmEnabled is set to true

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.17.0
+version: 0.17.1
 appVersion: 6.3.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
           protocol: UDP
         {{- if .Values.datadog.apmEnabled }}
         - containerPort: 8126
+          hostPort: 8126
           name: traceport
           protocol: TCP
         {{- end }}


### PR DESCRIPTION
Hey @hkaj, @irabinovitch, and @xvello, thanks for all your work on this chart! When I was trying to use APM with this chart, I realized that the chart does not set `hostPort` when the `apmEnabled` flag is true. Using [this guide](https://www.datadoghq.com/blog/monitor-google-kubernetes-engine/#integrate-distributed-tracing-with-apm) as a reference that seems like a requirement for APM integration. Making this change locally worked for me. 
