### PR TITLE
added ability to use loadBalancerSourceRanges in weave-scope

### DIFF
--- a/stable/weave-scope/charts/weave-scope-frontend/templates/service.yaml
+++ b/stable/weave-scope/charts/weave-scope-frontend/templates/service.yaml
@@ -19,4 +19,10 @@ spec:
     release: {{ .Release.Name }}
     component: frontend
   type: {{ .Values.global.service.type }}
+  {{- if .Values.global.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+  {{- range .Values.global.service.loadBalancerSourceRanges }}
+  - {{ . }}
+  {{- end }}
+  {{- end -}}
 {{- end -}}

--- a/stable/weave-scope/values.yaml
+++ b/stable/weave-scope/values.yaml
@@ -19,6 +19,9 @@ global:
     # global.service.type: (required if frontend.enabled == true) the type of the frontend service -- must be ClusterIP, NodePort or LoadBalancer
     # global.service.type is a global to keep it with the other values for configuring the frontend service
     type: "ClusterIP"
+    # global.service.loadBalancerSourceRanges: lets you limit the load balancer to a specific network range/s
+    # global.service.loadBalancerSourceRanges: [198.40.126.0/21,215.140.110.2/32]
+
 
 # weave-scope-frontend.* controls how the Scope frontend is installed
 weave-scope-frontend:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds load balancer source ranges functionality to weave-scope helm chart.
This is needed to allow limiting the loadbalancer to be exposed on specific network ranges.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

It currently does not fix an issue, it just adds functionality

**Special notes for your reviewer**:
This feature has been tested and is working, use this repo to test the chart https://raw.githubusercontent.com/rmccomb-bnet/helmrepocustom/master