### PR TITLE
[incubator/vault] add PDB, make HA + TLS + Consul work together

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.14.0
+version: 0.14.1
 appVersion: 0.11.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/README.md
+++ b/incubator/vault/README.md
@@ -116,8 +116,7 @@ $ vault status
 This is example of running Vault with Kubernetes generated TLS certificate:
 
 1. Create `CertificateSigningRequest` according to [documentation](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/),
-    some useful hosts entries to add:
-   - `127.0.0.1` for running Vault commands inside the pod,
+    mandatory entries to add:
    - `*.<namespace>.pod.cluster.local` for direct Pod to Pod communication,
    - `<release>.<namespace>.svc.cluster.local` for communication within cluster,
 

--- a/incubator/vault/templates/NOTES.txt
+++ b/incubator/vault/templates/NOTES.txt
@@ -9,9 +9,9 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "vault.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "vault.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo http://$SERVICE_IP:8200
 {{- else if contains "ClusterIP"  .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "vault.name" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Use http://127.0.0.1:8200 as the Vault address after forwarding."
-  kubectl port-forward --namespace {{ .Release.Namespace }}  $POD_NAME 8200:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }}  $POD_NAME 8200:{{ .Values.service.externalPort }}
 {{- end }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             export VAULT_API_ADDR="${VAULT_SCHEME}://${POD_DNS}:8200"
             export VAULT_CLUSTER_ADDR="${VAULT_SCHEME}://${POD_DNS}:8201"
         {{- if .Values.vault.dev }}
-            exec vault server -dev -dev-listen-address [::]:8200
+            exec vault server -dev -dev-listen-address '[::]:8200'
         {{- else }}
             exec vault server -config /vault/config/config.json
         {{- end }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -1,4 +1,5 @@
-apiVersion: extensions/v1beta1
+{{- $scheme := coalesce (and (eq .Values.vault.config.listener.tcp.tls_disable false) "https") "http" -}}
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "vault.fullname" . }}
@@ -14,7 +15,12 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: {{ .Values.maxUnavailable }}
+      maxSurge: {{ .Values.maxSurge }}
+  selector:
+    matchLabels:
+      app: {{ template "vault.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
@@ -23,37 +29,48 @@ spec:
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
+      subdomain: "{{ template "vault.fullname" . }}"
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - sh
+          - "-c"
+          - |
+            export POD_DNS="${POD_IP//./-}.${POD_NAMESPACE}.pod.cluster.local"
+            export VAULT_ADDR="${VAULT_SCHEME}://${POD_DNS}:8200"
+            export VAULT_API_ADDR="${VAULT_SCHEME}://${POD_DNS}:8200"
+            export VAULT_CLUSTER_ADDR="${VAULT_SCHEME}://${POD_DNS}:8201"
         {{- if .Values.vault.dev }}
-        command: ["vault", "server", "-dev", "-dev-listen-address", "[::]:8200"]
+            exec vault server -dev -dev-listen-address [::]:8200
         {{- else }}
-        command: ["vault", "server", "-config", "/vault/config/config.json"]
+            exec vault server -config /vault/config/config.json
         {{- end }}
         {{- if .Values.lifecycle }}
         lifecycle:
 {{ tpl .Values.lifecycle . | indent 10 }}
         {{- end }}
         ports:
-        - containerPort: {{ .Values.service.port }}
+        - containerPort: 8200
           name: api
         - containerPort: 8201
-          name: cluster-address
+          name: cluster
         livenessProbe:
           # Alive if it is listening for clustering traffic
-          tcpSocket:
-            port: {{ .Values.service.port }}
+          httpGet:
+            path: /v1/sys/health?standbycode=200&sealedcode=200&uninitcode=200
+            port: api
+            scheme: {{ $scheme | upper }}
         readinessProbe:
           # Ready depends on preference
           httpGet:
-            path: /v1/sys/health?
-              {{- if .Values.vault.readiness.readyIfSealed -}}sealedcode=204&{{- end }}
-              {{- if .Values.vault.readiness.readyIfStandby -}}standbycode=204&{{- end }}
-              {{- if .Values.vault.readiness.readyIfUninitialized -}}uninitcode=204&{{- end }}
-            port: {{ .Values.service.port }}
-            scheme: {{ if .Values.vault.config.listener.tcp.tls_disable -}}HTTP{{- else -}}HTTPS{{- end }}
+            path: "/v1/sys/health?
+            {{- range $key, $value := .Values.vault.readinessParams -}}
+              {{ $key }}={{ $value }}&
+            {{- end -}}"
+            port: api
+            scheme: {{ $scheme | upper }}
         securityContext:
           readOnlyRootFilesystem: true
           capabilities:
@@ -64,8 +81,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          - name: VAULT_CLUSTER_ADDR
-            value: "https://$(POD_IP):8201"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: VAULT_SCHEME
+            value: {{ $scheme | quote }}
           - name: VAULT_LOG_LEVEL
             value: {{ .Values.vault.logLevel | quote }}
         {{- if .Values.vault.extraEnv }}
@@ -86,7 +107,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.affinity }}
-      {{- if .Values.consulAgent.join }}
+        {{- if .Values.consulAgent.join }}
       - name: {{ .Chart.Name }}-consul-agent
         image: "{{ .Values.consulAgent.repository }}:{{ .Values.consulAgent.tag }}"
         imagePullPolicy: {{ .Values.consulAgent.pullPolicy }}
@@ -115,7 +136,7 @@ spec:
               $GOSSIP_KEY \
               -join={{- .Values.consulAgent.join }} \
               -data-dir=/etc/consul
-      {{- end }}
+        {{- end }}
       affinity:
 {{ tpl .Values.affinity . | indent 8 }}
       {{- end }}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -38,10 +38,12 @@ spec:
           - sh
           - "-c"
           - |
+            # hyphenate $(POD_IP).$(POD_NAMESPACE).pod.cluster.local
             export POD_DNS="${POD_IP//./-}.${POD_NAMESPACE}.pod.cluster.local"
-            export VAULT_ADDR="${VAULT_SCHEME}://${POD_DNS}:8200"
-            export VAULT_API_ADDR="${VAULT_SCHEME}://${POD_DNS}:8200"
-            export VAULT_CLUSTER_ADDR="${VAULT_SCHEME}://${POD_DNS}:8201"
+            # replace addresses with hyphenated versions
+            export VAULT_ADDR="${VAULT_ADDR//${POD_IP}.${POD_NAMESPACE}.pod.cluster.local/${POD_DNS}}"
+            export VAULT_API_ADDR="${VAULT_API_ADDR//${POD_IP}.${POD_NAMESPACE}.pod.cluster.local/${POD_DNS}}"
+            export VAULT_CLUSTER_ADDR="${VAULT_CLUSTER_ADDR//${POD_IP}.${POD_NAMESPACE}.pod.cluster.local/${POD_DNS}}"
         {{- if .Values.vault.dev }}
             exec vault server -dev -dev-listen-address '[::]:8200'
         {{- else }}
@@ -85,6 +87,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: LISTENER_SCHEME
+            value: "{{ $scheme }}"
+          - name: VAULT_ADDR
+            value: "{{ .Values.vault.addr }}"
+          - name: VAULT_API_ADDR
+            value: "{{ .Values.vault.api_addr }}"
+          - name: VAULT_CLUSTER_ADDR
+            value: "{{ .Values.vault.cluster_addr }}"
           - name: VAULT_SCHEME
             value: {{ $scheme | quote }}
           - name: VAULT_LOG_LEVEL

--- a/incubator/vault/templates/ingress.yaml
+++ b/incubator/vault/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
-{{- $servicePort := .Values.service.port -}}
+{{- $servicePort := .Values.service.externalPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/incubator/vault/templates/poddisruptionbudget.yaml
+++ b/incubator/vault/templates/poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}
 spec:
-  maxUnavailable: 1
+  maxUnavailable: {{ .Values.vault.maxUnavailable }}
   selector:
     matchLabels:
       app: {{ template "vault.name" . }}

--- a/incubator/vault/templates/service.yaml
+++ b/incubator/vault/templates/service.yaml
@@ -25,7 +25,7 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     protocol: TCP
-    targetPort: {{ .Values.service.port }}
+    targetPort: api
     name: api
   selector:
     app: {{ template "vault.name" . }}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -1,9 +1,12 @@
 # Default values for vault.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 3
 ## The name of the secret to use if pulling images from a private registry.
 # imagePullSecret:
+replicaCount: 1
+maxUnavailable: 0
+# Allow to create all missing pods at once
+maxSurge: "100%"
 image:
   repository: vault
   tag: 0.11.1
@@ -32,7 +35,6 @@ service:
   #  - 10.0.0.0/8
   #  - 130.211.204.2/32
   externalPort: 8200
-  port: 8200
   # clusterIP: None
   annotations: {}
   #   cloud.google.com/load-balancer-type: "Internal"
@@ -128,10 +130,14 @@ vault:
   # - name: extra-volume
   #   secret:
   #     secretName: some-secret
-  readiness:
-    readyIfSealed: false
-    readyIfStandby: true
-    readyIfUninitialized: true
+  readinessParams:
+    # https://www.vaultproject.io/api/system/health.html
+    standbycode: "200"
+    #  standbyok: "false"
+    #  activecode: "200"
+    #  standbycode: "429"
+    #  sealedcode: "503"
+    #  uninitcode: "501"
   config:
     # A YAML representation of a final vault config.json file.
     # See https://www.vaultproject.io/docs/configuration/ for more information.

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -97,6 +97,12 @@ podAnnotations: {}
 #       command: ["./unseal -s my-unseal-keys"]
 
 vault:
+  # Vault addresses to use
+  # $(POD_IP).$(POD_NAMESPACE).pod.cluster.local gets hyphenated automatically
+  # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-records-1
+  addr: '$(LISTENER_SCHEME)://$(POD_IP).$(POD_NAMESPACE).pod.cluster.local:8200'
+  api_addr: '$(LISTENER_SCHEME)://$(POD_IP).$(POD_NAMESPACE).pod.cluster.local:8200'
+  cluster_addr: '$(LISTENER_SCHEME)://$(POD_IP).$(POD_NAMESPACE).pod.cluster.local:8201'
   # Only used to enable dev mode. When in dev mode, the rest of this config
   # section below is not used to configure Vault. See
   # https://www.vaultproject.io/intro/getting-started/dev-server.html for more


### PR DESCRIPTION
reworked #4968 

**What this PR does / why we need it**:
We need this PR to make it possible to run High Availability Vault with TLS enabled and request forwarding working (behind LoadBalancer/Ingress).

This PR adds following:
- changes `livenessProbe` to `httpGet` always returning `200`,
- makes `readinessProbe` customization map more directly to GET parameters,
- adds HA & TLS examples to `README.md`,
- replacing `$(POD_IP).$(POD_NAMESPACE).pod.cluster.local` with hyphenated version,
- dropped `service.port` in favor of customizing just `externalPort` (should not need that customization),
- adds `maxSurge` and `maxUnavailable` customization for scheduling, then unsealing all missing pods at once,