### PR TITLE
add GCP CloudSQL support

### DIFF
--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.2.1
+version: 7.2.2
 appVersion: 6.0.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/requirements.lock
+++ b/stable/artifactory/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.8.7
-digest: sha256:02e9e88b9a147c956d857fb8874f16257b90fc980522b329f3257979811af7f7
-generated: 2018-05-18T16:12:27.72899131-07:00
+- name: gcloud-sqlproxy
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.3.5
+digest: sha256:22e9150be9293edeb7edeaea9e3fa8d3cd25a7a110af875a40a691fedc72f7d9
+generated: 2018-06-22T15:57:51.515788+02:00

--- a/stable/artifactory/requirements.yaml
+++ b/stable/artifactory/requirements.yaml
@@ -3,3 +3,7 @@ dependencies:
     version: 0.8.7
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled
+  - name: gcloud-sqlproxy
+    version: 0.3.5
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: database.cloudsql

--- a/stable/artifactory/templates/artifactory-deployment.yaml
+++ b/stable/artifactory/templates/artifactory-deployment.yaml
@@ -40,7 +40,9 @@ spec:
         - >
       {{- if .Values.postgresql.enabled }}
           until nc -z -w 2 {{ .Release.Name }}-postgresql {{ .Values.postgresql.service.port }} && echo database ok; do
-      {{- else }}
+      {{- else if .Values.database.cloudsql }}
+          until nc -z -w 2 {{ .Release.Name }}-gcloud-sqlproxy {{ .Values.postgresql.service.port }} && echo database ok; do
+      {{- else }} 
           until nc -z -w 2 {{ .Values.database.host }} {{ .Values.database.port }} && echo database ok; do
       {{- end }}
             sleep 2;
@@ -79,7 +81,7 @@ spec:
         - name: DB_TYPE
           value: 'postgresql'
         - name: DB_USER
-          value: {{.Values.postgresql.postgresUser | quote }}
+          value: {{ .Values.postgresql.postgresUser | quote }}
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -90,8 +92,13 @@ spec:
         {{- else }}
         - name: DB_TYPE
           value: '{{ .Values.database.type }}'
+          {{- if .Values.database.cloudsql }}
+        - name: DB_HOST
+          value: {{ .Release.Name }}-gcloud-sqlproxy
+          {{- else }}
         - name: DB_HOST
           value: '{{ .Values.database.host }}'
+          {{- end }}
         - name: DB_PORT
           value: '{{ .Values.database.port }}'
         - name: DB_USER
@@ -186,7 +193,7 @@ spec:
       - name: bootstrap-config
         configMap:
           name: {{ .Values.artifactory.configMapName }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.artifactory.license.secret }}
       - name: artifactory-license
         secret:

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -201,9 +201,19 @@ postgresql:
 
 ## If NOT using the PostgreSQL in this chart (postgresql.enabled=false),
 ## you must specify the following database details
+## You don't need to set the 'host' in case of cloudsql: true
 database:
-  type:
-  host:
-  port:
-  user:
-  password:
+  type: 
+  port: 
+  user: 
+  password: 
+  cloudsql: false
+
+gcloud-sqlproxy:
+  cloudsql:
+    serviceAccountKey:
+    instances:
+    - instance: 
+      project: 
+      region: 
+      port: 

--- a/stable/artifactory/values.yaml
+++ b/stable/artifactory/values.yaml
@@ -203,17 +203,17 @@ postgresql:
 ## you must specify the following database details
 ## You don't need to set the 'host' in case of cloudsql: true
 database:
-  type: 
-  port: 
-  user: 
-  password: 
+  type:
+  port:
+  user:
+  password:
   cloudsql: false
 
 gcloud-sqlproxy:
   cloudsql:
     serviceAccountKey:
     instances:
-    - instance: 
-      project: 
-      region: 
-      port: 
+    - instance:
+      project:
+      region:
+      port:


### PR DESCRIPTION
Hello guys!

From my experience running postgresql db in the GCP k8s isn't the best idea from the availability point of view, so I decided to try run artifactory db in the cloudSQL. 

Looking forward for you reply!  