### PR TITLE
[incubator/elasticsearch] add client ingress and fix some issues

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.1.0
+version: 1.2.0
 appVersion: 6.1.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                 |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                          |
+| `client.ingress` | Client ingress | `{ enabled: false }` |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.replicas`                    | Master node replicas (deployment)                                   | `2`                                  |
 | `master.resources`                   | Master node resources requests & limits                             | `{} - cpu limit must be an integer`  |

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -79,7 +79,6 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                 |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                          |
-| `master.exposeHttp`                  | Expose http port 9200 on master Pods for monitoring, etc            | `false`                              |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.replicas`                    | Master node replicas (deployment)                                   | `2`                                  |
 | `master.resources`                   | Master node resources requests & limits                             | `{} - cpu limit must be an integer`  |
@@ -92,7 +91,6 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.persistence.size`            | Master persistent volume size                                       | `4Gi`                                |
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
-| `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                              |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `3`                                  |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |

--- a/incubator/elasticsearch/templates/client-ingress.yaml
+++ b/incubator/elasticsearch/templates/client-ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.client.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.client.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "elasticsearch.client.fullname" . }}
+{{- if .Values.client.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.client.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: {{ .Values.client.ingress.path | quote }}
+        backend:
+          serviceName: {{ template "elasticsearch.client.fullname" . }}
+          servicePort: 9200
+    {{- if .Values.client.ingress.host }}
+    host: {{ .Values.client.ingress.host | quote }}
+    {{- end }}
+{{- if .Values.client.ingress.tls }}
+  tls:
+{{ toYaml .Values.client.ingress.tls | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
 spec:
   serviceName: {{ template "elasticsearch.data.fullname" . }}
   replicas: {{ .Values.data.replicas }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "7") }}
+  podManagementPolicy: Parallel
+{{- end }}
   template:
     metadata:
       labels:

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -98,10 +98,8 @@ spec:
         ports:
         - containerPort: 9300
           name: transport
-{{ if .Values.data.exposeHttp }}
         - containerPort: 9200
           name: http
-{{ end }}
         resources:
 {{ toYaml .Values.data.resources | indent 12 }}
         readinessProbe:

--- a/incubator/elasticsearch/templates/data-svc.yaml
+++ b/incubator/elasticsearch/templates/data-svc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.data.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "elasticsearch.data.fullname" . }}
+{{- if .Values.data.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.data.serviceAnnotations | indent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  ports:
+    - name: transport
+      port: 9300
+      targetPort: transport
+    - name: http
+      port: 9200
+      targetPort: http
+  selector:
+    app: {{ template "elasticsearch.name" . }}
+    component: "{{ .Values.data.name }}"
+    release: {{ .Release.Name }}
+  type: {{ .Values.data.serviceType }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -109,10 +109,8 @@ spec:
         ports:
         - containerPort: 9300
           name: transport
-{{ if .Values.master.exposeHttp }}
         - containerPort: 9200
           name: http
-{{ end }}
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
 spec:
   serviceName: {{ template "elasticsearch.master.fullname" . }}
   replicas: {{ .Values.master.replicas }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (ge .Capabilities.KubeVersion.Minor "7") }}
+  podManagementPolicy: Parallel
+{{- end }}
   template:
     metadata:
       labels:

--- a/incubator/elasticsearch/templates/master-svc.yaml
+++ b/incubator/elasticsearch/templates/master-svc.yaml
@@ -11,8 +11,12 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: 9300
+    - name: transport
+      port: 9300
       targetPort: transport
+    - name: http
+      port: 9200
+      targetPort: http
   selector:
     app: {{ template "elasticsearch.name" . }}
     component: "{{ .Values.master.name }}"

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -45,6 +45,13 @@ client:
   # podAnnotations:
   #   example: client-foo
 
+  ingress:
+    enabled: false
+    # host: ""
+    path: "/"
+    # annotations: {}
+    # tls: {}
+
 master:
   name: master
   replicas: 3

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -47,7 +47,6 @@ client:
 
 master:
   name: master
-  exposeHttp: false
   replicas: 3
   heapSize: "512m"
   persistence:
@@ -72,7 +71,6 @@ master:
 
 data:
   name: data
-  exposeHttp: false
   replicas: 2
   heapSize: "1536m"
   persistence:


### PR DESCRIPTION
This PR improves incubator/elasticsearch with the following:
- It adds an ingress for the client service
- It removes `*. exposeHttp`, as it neither has an actual effect on the container port nor is it desired to close the ports, because the probes require it
- adds `podManagementPolicy: Parallel` for stateful sets, if the kubernetes version supports it
- adds a missing headless service for the data nodes