### PR TITLE
[stable/mongodb-replicaset] Prometheus Metrics export

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,12 +1,13 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.5.1
+version: 3.5.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.
 icon: https://webassets.mongodb.com/_com_assets/cms/mongodb-logo-rgb-j6w271g1xn.jpg
 sources:
   - https://github.com/mongodb/mongo
+  - https://github.com/percona/mongodb_exporter
 maintainers:
   - name: foxish
     email: ramanathana@google.com

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `tls.enabled`                       | Enable MongoDB TLS support including authentication                       | `false`                                             |
 | `tls.cacert`                        | The CA certificate used for the members                                   | Our self signed CA certificate                      |
 | `tls.cakey`                         | The CA key used for the members                                           | Our key for the self signed CA certificate          |
+| `metrics.enabled`                   | Enable Prometheus compatible metrics for pods and replicasets             | `false`                                             |
 | `auth.enabled`                      | If `true`, keyfile access control is enabled                              | `false`                                             |
 | `auth.key`                          | Key for internal authentication                                           | ``                                                  |
 | `auth.existingKeySecret`            | If set, an existing secret with this name for the key is used             | ``                                                  |
@@ -160,6 +161,26 @@ mongodb with your `mongo.pem` certificate:
 ```console
 $ mongo --ssl --sslCAFile=ca.crt --sslPEMKeyFile=mongo.pem --eval "db.adminCommand('ping')"
 ```
+
+## Promethus metrics
+Enabling the metrics as follows will allow for each replicaset pod to export Prometheus compatible metrics
+on server status, individual replicaset information, replication oplogs, and storage engine.
+
+```yaml
+metrics:
+  enabled: true
+  image: ssalaues/mongodb-exporter
+  imageTag: 0.5
+  imagePullPolicy: IfNotPresent
+  resources: {}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9216"
+    prometheus.io/path: "/metrics"
+```
+
+More information on [MongoDB Exporter](https://github.com/percona/mongodb_exporter) metrics available.
+
 ## Readiness probe
 The default values for the readiness probe are:
 

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -172,11 +172,9 @@ metrics:
   image: ssalaues/mongodb-exporter
   imageTag: 0.5
   imagePullPolicy: IfNotPresent
+  port: 9216
+  path: "/metrics"
   resources: {}
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9216"
-    prometheus.io/path: "/metrics"
 ```
 
 More information on [MongoDB Exporter](https://github.com/percona/mongodb_exporter) metrics available.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -52,11 +52,21 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `tls.cacert`                        | The CA certificate used for the members                                   | Our self signed CA certificate                      |
 | `tls.cakey`                         | The CA key used for the members                                           | Our key for the self signed CA certificate          |
 | `metrics.enabled`                   | Enable Prometheus compatible metrics for pods and replicasets             | `false`                                             |
+| `metrics.image.repository           | Image name for metrics exporter                                           | `ssalaues/mongodb-exporter`                         |
+| `metrics.image.tag                  | Image tag for metrics exporter                                            | `0.6.1`                                             |
+| `metrics.image.pullPolicy           | Image pull policy for metrics exporter                                    | `IfNotPresent`                                      |
+| `metrics.port                       | Port for metrics exporter                                                 | `9216`                                              |
+| `metrics.path                       | URL Path to expose metics                                                 | `/metrics`                                          |
+| `metrics.socketTimeout              | Time to wait for a non-responding socket                                  | `3s`                                                |
+| `metrics.syncTimeout                | Time an operation with this session will wait before returning an error   | `1m0s`                                              |
+| `metrics.prometheusServiceDiscovery | Adds annotations for Prometheus ServiceDiscovery                          | `true`                                              |
 | `auth.enabled`                      | If `true`, keyfile access control is enabled                              | `false`                                             |
 | `auth.key`                          | Key for internal authentication                                           | ``                                                  |
 | `auth.existingKeySecret`            | If set, an existing secret with this name for the key is used             | ``                                                  |
 | `auth.adminUser`                    | MongoDB admin user                                                        | ``                                                  |
 | `auth.adminPassword`                | MongoDB admin password                                                    | ``                                                  |
+| `auth.metricsUser`                  | MongoDB clusterMonitor user                                               | ``                                                  |
+| `auth.metricsPassword`              | MongoDB clusterMonitor password                                           | ``                                                  |
 | `auth.existingAdminSecret`          | If set, and existing secret with this name is used for the admin user     | ``                                                  |
 | `serviceAnnotations`                | Annotations to be added to the service                                    | `{}`                                                |
 | `configmap`                         | Content of the MongoDB config file                                        | ``                                                  |
@@ -169,9 +179,10 @@ on server status, individual replicaset information, replication oplogs, and sto
 ```yaml
 metrics:
   enabled: true
-  image: ssalaues/mongodb-exporter
-  imageTag: 0.5
-  imagePullPolicy: IfNotPresent
+    image:
+      repository: ssalaues/mongodb-exporter
+      tag: 0.6.1
+      pullPolicy: IfNotPresent
   port: 9216
   path: "/metrics"
   resources: {}

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -58,7 +58,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `metrics.port                       | Port for metrics exporter                                                 | `9216`                                              |
 | `metrics.path                       | URL Path to expose metics                                                 | `/metrics`                                          |
 | `metrics.socketTimeout              | Time to wait for a non-responding socket                                  | `3s`                                                |
-| `metrics.syncTimeout                | Time an operation with this session will wait before returning an error   | `1m0s`                                              |
+| `metrics.syncTimeout                | Time an operation with this session will wait before returning an error   | `1m`                                                |
 | `metrics.prometheusServiceDiscovery | Adds annotations for Prometheus ServiceDiscovery                          | `true`                                              |
 | `auth.enabled`                      | If `true`, keyfile access control is enabled                              | `false`                                             |
 | `auth.key`                          | Key for internal authentication                                           | ``                                                  |
@@ -179,12 +179,15 @@ on server status, individual replicaset information, replication oplogs, and sto
 ```yaml
 metrics:
   enabled: true
-    image:
-      repository: ssalaues/mongodb-exporter
-      tag: 0.6.1
-      pullPolicy: IfNotPresent
+  image:
+    repository: ssalaues/mongodb-exporter
+    tag: 0.6.1
+    pullPolicy: IfNotPresent
   port: 9216
   path: "/metrics"
+  socketTimeout: 3s
+  syncTimeout: 1m
+  prometheusServiceDiscovery: true
   resources: {}
 ```
 

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -66,6 +66,9 @@ if [ -f "$ca_crt"  ]; then
     pem=/work-dir/mongo.pem
     ssl_args=(--ssl --sslCAFile "$ca_crt" --sslPEMKeyFile "$pem")
 
+# Move into /work-dir
+pushd /work-dir
+
 cat >openssl.cnf <<EOL
 [req]
 req_extensions = v3_req

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -21,6 +21,11 @@ if [[ "$AUTH" == "true" ]]; then
     admin_user="$ADMIN_USER"
     admin_password="$ADMIN_PASSWORD"
     admin_creds=(-u "$admin_user" -p "$admin_password")
+    if [[ "$METRICS" == "true" ]]; then
+        metrics_user="$METRICS_USER"
+        metrics_password="$METRICS_PASSWORD"
+        monitor_creds=(-u "$monitor_user" -p "$admin_password")
+    fi
     auth_args=(--auth --keyFile=/data/configdb/key.txt)
 fi
 
@@ -143,6 +148,10 @@ if mongo "${ssl_args[@]}" --eval "rs.status()" | grep "no replset config has bee
     if [[ "$AUTH" == "true" ]]; then
         log "Creating admin user..."
         mongo admin "${ssl_args[@]}" --eval "db.createUser({user: '$admin_user', pwd: '$admin_password', roles: [{role: 'root', db: 'admin'}]})"
+        if [[ "$METRICS" == "true" ]]; then
+            log "Creating cluterMonitor user..."
+            mongo admin "${ssl_args[@]}" --eval "db.auth('$admin_user', '$admin_password'); db.createUser({user: '$metrics_user', pwd: '$metrics_password', roles: [{role: 'clusterMonitor', db: 'admin'}]})"
+        fi
     fi
 
     log "Done."

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -153,7 +153,7 @@ if mongo "${ssl_args[@]}" --eval "rs.status()" | grep "no replset config has bee
         mongo admin "${ssl_args[@]}" --eval "db.createUser({user: '$admin_user', pwd: '$admin_password', roles: [{role: 'root', db: 'admin'}]})"
         if [[ "$METRICS" == "true" ]]; then
             log "Creating cluterMonitor user..."
-            mongo admin "${ssl_args[@]}" --eval "db.auth('$admin_user', '$admin_password'); db.createUser({user: '$metrics_user', pwd: '$metrics_password', roles: [{role: 'clusterMonitor', db: 'admin'}]})"
+            mongo admin "${ssl_args[@]}" --eval "db.auth('$admin_user', '$admin_password'); db.createUser({user: '$metrics_user', pwd: '$metrics_password', roles: [{role: 'clusterMonitor', db: 'admin'}, {role: 'read', db: 'local'}]})"
         fi
     fi
 

--- a/stable/mongodb-replicaset/templates/_helpers.tpl
+++ b/stable/mongodb-replicaset/templates/_helpers.tpl
@@ -42,6 +42,15 @@ Create the name for the admin secret.
     {{- end -}}
 {{- end -}}
 
+{{- define "mongodb-replicaset.metricsSecret" -}}
+    {{- if .Values.auth.existingMetricsSecret -}}
+        {{- .Values.auth.existingMetricsSecret -}}
+    {{- else -}}
+        {{- template "mongodb-replicaset.fullname" . -}}-metrics
+    {{- end -}}
+{{- end -}}
+
+
 {{/*
 Create the name for the key secret.
 */}}

--- a/stable/mongodb-replicaset/templates/mongodb-metrics-secret.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-metrics-secret.yaml
@@ -1,0 +1,18 @@
+{{- if and (.Values.auth.enabled) (not .Values.auth.existingAdminSecret) (.Values.metrics.enabled) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ template "mongodb-replicaset.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+  name: {{ template "mongodb-replicaset.metricsSecret" . }}
+type: Opaque
+data:
+  user: {{ .Values.auth.metricsUser | b64enc }}
+  password: {{ .Values.auth.metricsPassword | b64enc }}
+{{- end -}}

--- a/stable/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service.yaml
@@ -4,6 +4,9 @@ kind: Service
 metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  {{- if .Values.metrics.enabled }}
+{{ toYaml .Values.metrics.annotations | indent 4 }}
+  {{- end }}
   {{- if .Values.serviceAnnotations }}
 {{ toYaml .Values.serviceAnnotations | indent 4 }}
   {{- end }}
@@ -22,6 +25,11 @@ spec:
   ports:
     - name: peer
       port: {{ .Values.port }}
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ index .Values "metrics" "annotations" "prometheus.io/port" }}
+      targetPort: metrics
+    {{- end }}
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
     release: {{ .Release.Name }}

--- a/stable/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service.yaml
@@ -22,11 +22,11 @@ spec:
   ports:
     - name: peer
       port: {{ .Values.port }}
-    {{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.enabled }}
     - name: metrics
       port: {{ .Values.metrics.port }}
       targetPort: metrics
-    {{- end }}
+{{- end }}
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
     release: {{ .Release.Name }}

--- a/stable/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service.yaml
@@ -4,9 +4,6 @@ kind: Service
 metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-  {{- if .Values.metrics.enabled }}
-{{ toYaml .Values.metrics.annotations | indent 4 }}
-  {{- end }}
   {{- if .Values.serviceAnnotations }}
 {{ toYaml .Values.serviceAnnotations | indent 4 }}
   {{- end }}
@@ -27,7 +24,7 @@ spec:
       port: {{ .Values.port }}
     {{- if .Values.metrics.enabled }}
     - name: metrics
-      port: {{ index .Values "metrics" "annotations" "prometheus.io/port" }}
+      port: {{ .Values.metrics.port }}
       targetPort: metrics
     {{- end }}
   selector:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -258,18 +258,19 @@ spec:
               command:
                 - sh
                 - -ec
+                - |-
                 {{- if .Values.auth.enabled }}
-                - export MONGODB_URL=mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }};
+                  export MONGODB_URL=mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }};
                 {{- else }}
-                - export MONGODB_URL=mongodb://localhost:{{ .Values.port }};
+                  export MONGODB_URL=mongodb://localhost:{{ .Values.port }};
                 {{- end }}
-                - /bin/mongodb_exporter
+                  /bin/mongodb_exporter
                 {{- if .Values.tls.enabled }}
-                - -mongodb.tls
-                - -mongodb.tls-ca=/ca/tls.crt
-                - -mongodb.tls-cert=/work-dir/mongo.pem
+                  -mongodb.tls
+                  -mongodb.tls-ca=/ca/tls.crt
+                  -mongodb.tls-cert=/work-dir/mongo.pem
                 {{- end }}
-                - -test
+                  -test
               initialDelaySeconds: 30
               periodSeconds: 10
 {{ end }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -211,7 +211,7 @@ spec:
           command:
             - sh
             - -ec
-            - |-
+            - >-
             {{- if .Values.auth.enabled }}
               export MONGODB_URL=mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }};
             {{- else }}
@@ -258,7 +258,7 @@ spec:
               command:
                 - sh
                 - -ec
-                - |-
+                - >-
                 {{- if .Values.auth.enabled }}
                   export MONGODB_URL=mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }};
                 {{- else }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -26,7 +26,7 @@ spec:
 {{ toYaml .Values.extraLabels | indent 8 }}
 {{- end }}
       annotations:
-      {{- if .Values.metrics.enabled }}
+      {{- if .Values.metrics.prometheusServiceDiscovery }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.metrics.port | quote }}
         prometheus.io/path: {{ .Values.metrics.path | quote }}
@@ -206,8 +206,8 @@ spec:
               mountPath: /work-dir
 {{ if .Values.metrics.enabled }}
         - name: metrics
-          image: "{{ .Values.metrics.repository }}:{{ .Values.metrics.tag }}"
-          imagePullPolicy: {{ .Values.metrics.imagePullPolicy | quote }}
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           command:
             - sh
             - -ec
@@ -223,6 +223,8 @@ spec:
               -mongodb.tls-ca=/ca/tls.crt
               -mongodb.tls-cert=/work-dir/mongo.pem
             {{- end }}
+              -mongodb.socket-timeout={{ .Values.metrics.socketTimeout }}
+              -mongodb.sync-timeout={{ .Values.metrics.syncTimeout }}
               -web.metrics-path={{ .Values.metrics.path }}
               -web.listen-address=:{{ .Values.metrics.port }}
           volumeMounts:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -26,6 +26,11 @@ spec:
 {{ toYaml .Values.extraLabels | indent 8 }}
 {{- end }}
       annotations:
+      {{- if .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+        prometheus.io/path: {{ .Values.metrics.path | quote }}
+      {{- end }}
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
@@ -218,8 +223,8 @@ spec:
               -mongodb.tls-ca=/ca/tls.crt
               -mongodb.tls-cert=/work-dir/mongo.pem
             {{- end }}
-              -web.metrics-path={{ index .Values "metrics" "annotations" "prometheus.io/path" }}
-              -web.listen-address=:{{ index .Values "metrics" "annotations" "prometheus.io/port" }}
+              -web.metrics-path={{ .Values.metrics.path }}
+              -web.listen-address=:{{ .Values.metrics.port }}
           volumeMounts:
           {{- if and (.Values.tls.enabled) }}
             - name: ca
@@ -244,7 +249,7 @@ spec:
           {{- end }}
           ports:
             - name: metrics
-              containerPort: {{ index .Values "metrics" "annotations" "prometheus.io/port" }}
+              containerPort: {{ .Values.metrics.port  }}
           resources: {{ toYaml .Values.metrics.resources | indent 12 }}
           livenessProbe:
             exec:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -106,6 +106,20 @@ spec:
                 secretKeyRef:
                   name: "{{ template "mongodb-replicaset.adminSecret" . }}"
                   key: password
+          {{- if .Values.metrics.enabled }}
+            - name: METRICS
+              value: "true"
+            - name: METRICS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "mongodb-replicaset.metricsSecret" . }}"
+                  key: user
+            - name: METRICS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "mongodb-replicaset.metricsSecret" . }}"
+                  key: password
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: workdir
@@ -185,7 +199,74 @@ spec:
               mountPath: /data/configdb
             - name: workdir
               mountPath: /work-dir
-    {{- with .Values.nodeSelector }}
+{{ if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.repository }}:{{ .Values.metrics.tag }}"
+          imagePullPolicy: {{ .Values.metrics.imagePullPolicy | quote }}
+          command:
+            - sh
+            - -ec
+            - |-
+            {{- if .Values.auth.enabled }}
+              export MONGODB_URL=mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }};
+            {{- else }}
+              export MONGODB_URL=mongodb://localhost:{{ .Values.port }};
+            {{- end }}
+              /bin/mongodb_exporter
+            {{- if .Values.tls.enabled }}
+              -mongodb.tls
+              -mongodb.tls-ca=/ca/tls.crt
+              -mongodb.tls-cert=/work-dir/mongo.pem
+            {{- end }}
+              -web.metrics-path={{ index .Values "metrics" "annotations" "prometheus.io/path" }}
+              -web.listen-address=:{{ index .Values "metrics" "annotations" "prometheus.io/port" }}
+          volumeMounts:
+          {{- if and (.Values.tls.enabled) }}
+            - name: ca
+              mountPath: /ca
+              readOnly: true
+          {{- end }}
+            - name: workdir
+              mountPath: /work-dir
+              readOnly: true
+          env:
+          {{- if .Values.auth.enabled }}
+            - name: METRICS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "mongodb-replicaset.metricsSecret" . }}"
+                  key: user
+            - name: METRICS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "mongodb-replicaset.metricsSecret" . }}"
+                  key: password
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ index .Values "metrics" "annotations" "prometheus.io/port" }}
+          resources: {{ toYaml .Values.metrics.resources | indent 12 }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                {{- if .Values.auth.enabled }}
+                - export MONGODB_URL=mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }};
+                {{- else }}
+                - export MONGODB_URL=mongodb://localhost:{{ .Values.port }};
+                {{- end }}
+                - /bin/mongodb_exporter
+                {{- if .Values.tls.enabled }}
+                - -mongodb.tls
+                - -mongodb.tls-ca=/ca/tls.crt
+                - -mongodb.tls-cert=/work-dir/mongo.pem
+                {{- end }}
+                - -test
+              initialDelaySeconds: 30
+              periodSeconds: 10
+{{ end }}
+   {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -156,7 +156,7 @@ spec:
             - --keyFile=/data/configdb/key.txt
           {{- end }}
           {{- if .Values.tls.enabled }}
-            - --ssl
+            - --sslMode=requireSSL
             - --sslCAFile=/data/configdb/tls.crt
             - --sslPEMKeyFile=/work-dir/mongo.pem
           {{- end }}

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -41,12 +41,9 @@ metrics:
   # repository: ssalaues/mongodb-exporter
   # tag: 0.5
   # imagePullPolicy: IfNotPresent
+  # port: 9216
+  # path: "/metrics"
   # resources: {}
-  # Prometheus annotations not necessary with prometheus-operator
-  # annotations:
-  #   prometheus.io/scrape: "true"
-  #   prometheus.io/port: "9216"
-  #   prometheus.io/path: "/metrics"
 
 # Annotations to be added to MongoDB pods
 podAnnotations: {}

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -38,11 +38,15 @@ extraVars: {}
 # Prometheus Metrics Exporter
 metrics:
   enabled: false
-  # repository: ssalaues/mongodb-exporter
-  # tag: 0.5
-  # imagePullPolicy: IfNotPresent
+  # image:
+  #   repository: ssalaues/mongodb-exporter
+  #   tag: 0.6.1
+  #   pullPolicy: IfNotPresent
   # port: 9216
   # path: "/metrics"
+  # socketTimeout: 3s
+  # syncTimeout: 1m
+  # prometheusServiceDiscovery: true
   # resources: {}
 
 # Annotations to be added to MongoDB pods

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -11,9 +11,12 @@ auth:
   enabled: false
   # adminUser: username
   # adminPassword: password
+  # metricsUser: metrics
+  # metricsPassword: password
   # key: keycontent
   # existingKeySecret:
   # existingAdminSecret:
+  # exisitingMetricsSecret:
 
 # Specs for the Docker image for the init container that establishes the replica set
 installImage:
@@ -31,6 +34,19 @@ image:
 extraVars: {}
 # - name: TCMALLOC_AGGRESSIVE_DECOMMIT
 #   value: "true"
+
+# Prometheus Metrics Exporter
+metrics:
+  enabled: false
+  # repository: ssalaues/mongodb-exporter
+  # tag: 0.5
+  # imagePullPolicy: IfNotPresent
+  # resources: {}
+  # Prometheus annotations not necessary with prometheus-operator
+  # annotations:
+  #   prometheus.io/scrape: "true"
+  #   prometheus.io/port: "9216"
+  #   prometheus.io/path: "/metrics"
 
 # Annotations to be added to MongoDB pods
 podAnnotations: {}

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -38,16 +38,16 @@ extraVars: {}
 # Prometheus Metrics Exporter
 metrics:
   enabled: false
-  # image:
-  #   repository: ssalaues/mongodb-exporter
-  #   tag: 0.6.1
-  #   pullPolicy: IfNotPresent
-  # port: 9216
-  # path: "/metrics"
-  # socketTimeout: 3s
-  # syncTimeout: 1m
-  # prometheusServiceDiscovery: true
-  # resources: {}
+  image:
+    repository: ssalaues/mongodb-exporter
+    tag: 0.6.1
+    pullPolicy: IfNotPresent
+  port: 9216
+  path: "/metrics"
+  socketTimeout: 3s
+  syncTimeout: 1m
+  prometheusServiceDiscovery: true
+  resources: {}
 
 # Annotations to be added to MongoDB pods
 podAnnotations: {}


### PR DESCRIPTION
Original PR #5874

**What this PR does / why we need it**:
Adds Prometheus metrics to the mongodb-replicaset chart using the a readonly clusterMonitor mongodb account for metrics authentication.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Fixes from the previous PR
- Uses clusterMonitor role for authenticating the metrics exporter into the replicaset
- Fixes best practices for specifying images
- Removed makefile (was originally intending for the Dockerfile to be hosted here but not necessary)

Need clarification on the Prometheus annotations.
- Since I am using the annotations to also define the exporter port and path, should I leave those defined in the metrics container definition? Or would it be preferred to create separate values not tied to the annotations?