### PR TITLE
[stable/keycloak] Documentation fixes

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 3.0.0
+version: 3.0.1
 appVersion: 4.0.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -272,7 +272,7 @@ keycloak:
 
   persistence:
     deployPostgres: false
-    dbVendor: POSTGRES
+    dbVendor: postgres
     dbName: postgres
     dbHost: 127.0.0.1
     dbPort: 5432

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -258,7 +258,7 @@ keycloak:
       command:
         - /cloud_sql_proxy
       args:
-        - -instances={{ .Values.cloudsql.project }}:{{ .Values.cloudsql.region }}:{{ .Values.cloudsql.instance }}=tcp:5432=tcp:5432
+        - -instances={{ .Values.cloudsql.project }}:{{ .Values.cloudsql.region }}:{{ .Values.cloudsql.instance }}=tcp:5432
         - -credential_file=/secrets/cloudsql/credentials.json
       volumeMounts:
         - name: cloudsql-creds

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -188,7 +188,7 @@ In combination with an `emptyDir` that is shared with the Keycloak container, co
 
 ```yaml
 keycloak:
-  extraInitContainers:
+  extraInitContainers: |
     - name: theme-provider
       image: myuser/mytheme:1
       imagePullPolicy: IfNotPresent
@@ -203,11 +203,11 @@ keycloak:
         - name: theme
           mountPath: /theme
 
-  extraVolumeMounts:
+  extraVolumeMounts: |
     - name: theme
       mountPath: /opt/jboss/keycloak/themes/mytheme
 
-  extraVolumes:
+  extraVolumes: |
     - name: theme
       emptyDir: {}
 ```


### PR DESCRIPTION
Various doc fixes:

## Cloud SQL Example:

1. Since the configmap has the condition:

`{{- if and $highAvailability (eq $.Values.keycloak.persistence.dbVendor "postgres") }}`

to bootstrap jgroupsping for HA, the dbVendor value is actually case-sensitive.

2. the port string is duplicated

## Theme Example:

all tpl args should be strings.

