### PR TITLE
[incubator/common] more logical port

### DIFF
--- a/incubator/common/Chart.yaml
+++ b/incubator/common/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 description: Common chartbuilding components and helpers
 name: common
 version: 0.0.3
+appVersion: 0.0.3
 home: https://helm.sh
 maintainers:
 - name: technosophos

--- a/incubator/common/Chart.yaml
+++ b/incubator/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Common chartbuilding components and helpers
 name: common
-version: 0.0.2
+version: 0.0.3
 home: https://helm.sh
 maintainers:
 - name: technosophos

--- a/incubator/common/README.md
+++ b/incubator/common/README.md
@@ -79,8 +79,8 @@ metadata:
 spec:
   ports:                                        # composes the `ports` section of the service definition.
   - name: smtp
-    port: 22
-    targetPort: 22
+    port: 25
+    targetPort: 25
   - name: imaps
     port: 993
     targetPort: 993
@@ -124,8 +124,8 @@ metadata:
 spec:
   ports:
   - name: smtp
-    port: 22
-    targetPort: 22
+    port: 25
+    targetPort: 25
   - name: imaps
     port: 993
     targetPort: 993


### PR DESCRIPTION
Have a more sensible port in the docs as smtp is 25, and ssh is 22.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/charts/6292)
<!-- Reviewable:end -->
