### PR TITLE
[stable/gcloud-sqlproxy] optional secret creation

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-sqlproxy
-version: 0.3.5
+version: 0.3.6
 appVersion: 1.11
 description: Google Cloud SQL Proxy
 keywords:

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -62,10 +62,9 @@ The following table lists the configurable parameters of the Drupal chart and th
 | `imageTag`                        | SQLProxy image tag                      | `1.11`                                                                                      |
 | `imagePullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
 | `replicasCount`                   | Replicas count                          | `1`                                                                                         |
-| `serviceAccountKey`               | Service account key JSON file           | Must be provided and base64 encoded when `secret.create == true`                            |
-| `secret.create`                   | Create a secret storing the credentials | `true`                                                                                      |
-| `secret.name`                     | The name of the secret to use           | `{{ template "gcloud-sqlproxy.fullname" . }}`                                               |
-| `secret.key`                      | The key to use in the provided secret   | `credentials.json`                                                                          |
+| `serviceAccountKey`               | Service account key JSON file           | Must be provided and base64 encoded when no existing secret is used, in this case a new secret will be created holding this service account |
+| `existingSecret`                  | Name of an existing secret to be used for the cloud-sql credentials | `""`                                                            |
+| `existingSecretKey`               | The key to use in the provided existing secret   | `""`                                                                               |
 | `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
 | `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
 | `nodeSelector`                    | Node Selector                           |                                                                                             |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the Drupal chart and th
 | Parameter                         | Description                             | Default                                                                                     |
 | --------------------------------- | --------------------------------------  | ---------------------------------------------------------                                   |
 | `image`                           | SQLProxy image                          | `b.gcr.io/cloudsql-docker/gce-proxy`                                                        |
-| `imageTag`                        | SQLProxy image tag                      | `1.09`                                                                                      |
+| `imageTag`                        | SQLProxy image tag                      | `1.11`                                                                                      |
 | `imagePullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
 | `replicasCount`                   | Replicas count                          | `1`                                                                                         |
 | `serviceAccountKey`               | Service account key JSON file           | Must be provided and base64 encoded when `secret.create == true`                            |

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -56,17 +56,20 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Drupal chart and their default values.
 
-| Parameter                         | Description                            | Default                                                                                     |
-| --------------------------------- | -------------------------------------- | ---------------------------------------------------------                                   |
-| `image`                           | SQLProxy image                         | `b.gcr.io/cloudsql-docker/gce-proxy`                                                        |
-| `imageTag`                        | SQLProxy image tag                     | `1.09`                                                                                      |
-| `imagePullPolicy`                 | Image pull policy                      | `IfNotPresent`                                                                              |
-| `replicasCount`                   | Replicas count                         | `1`                                                                                         |
-| `serviceAccountKey`               | Service account key JSON file          | Must be provided and base64 encoded                                                         |
-| `cloudsql.instances`              | List of PostgreSQL/MySQL instances     | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
-| `resources`                       | CPU/Memory resource requests/limits    | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
-| `nodeSelector`                    | Node Selector                          |                                                                                             |
-| `rbac.create`                     | Create RBAC configuration w/ SA        | `false`                                                                                     |
+| Parameter                         | Description                             | Default                                                                                     |
+| --------------------------------- | --------------------------------------  | ---------------------------------------------------------                                   |
+| `image`                           | SQLProxy image                          | `b.gcr.io/cloudsql-docker/gce-proxy`                                                        |
+| `imageTag`                        | SQLProxy image tag                      | `1.09`                                                                                      |
+| `imagePullPolicy`                 | Image pull policy                       | `IfNotPresent`                                                                              |
+| `replicasCount`                   | Replicas count                          | `1`                                                                                         |
+| `serviceAccountKey`               | Service account key JSON file           | Must be provided and base64 encoded when `secret.create == true`                            |
+| `secret.create`                   | Create a secret storing the credentials | `true`                                                                                      |
+| `secret.name`                     | The name of the secret to use           | `{{ template "gcloud-sqlproxy.fullname" . }}`                                               |
+| `secret.key`                      | The key to use in the provided secret   | `credentials.json`                                                                          |
+| `cloudsql.instances`              | List of PostgreSQL/MySQL instances      | [{instance: `instance`, project: `project`, region: `region`, port: 5432}] must be provided |
+| `resources`                       | CPU/Memory resource requests/limits     | Memory: `100/150Mi`, CPU: `100/150m`                                                        |
+| `nodeSelector`                    | Node Selector                           |                                                                                             |
+| `rbac.create`                     | Create RBAC configuration w/ SA         | `false`                                                                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -75,6 +78,7 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 $ helm install --name my-release -f values.yaml stable/gcloud-sqlproxy
 ```
+
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## Documentation

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccountKey (ne (index .Values.cloudsql.instances 0).instance "instance") }}
+{{- if and (or .Values.serviceAccountKey (not .Values.secret.create)) (ne (index .Values.cloudsql.instances 0).instance "instance") }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -28,7 +28,7 @@ spec:
                   "-instances={{- range .Values.cloudsql.instances -}}
                                 {{ .project }}:{{ .region }}:{{ .instance }}=tcp:0.0.0.0:{{ .port }},
                               {{- end }}",
-                  "-credential_file=/secrets/cloudsql/credentials.json"]
+                  "-credential_file=/secrets/cloudsql/{{.Values.secret.key}}"]
         ports:
         {{- range .Values.cloudsql.instances }}
         - name: {{ .instanceShortName | default (.instance | trunc 15) }}
@@ -42,7 +42,11 @@ spec:
       volumes:
       - name: cloudsql-oauth-credentials
         secret:
+          {{ if (not .Values.secret.name) -}}
           secretName: {{ template "gcloud-sqlproxy.fullname" . }}
+          {{- else -}}
+          secretName: {{ .Values.secret.name }}
+          {{- end }}
       - name: cloudsql
         emptyDir: {}
       nodeSelector:

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.serviceAccountKey (not .Values.secret.create)) (ne (index .Values.cloudsql.instances 0).instance "instance") }}
+{{- if and (or .Values.serviceAccountKey .Values.existingSecret) (ne (index .Values.cloudsql.instances 0).instance "instance") }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -28,7 +28,7 @@ spec:
                   "-instances={{- range .Values.cloudsql.instances -}}
                                 {{ .project }}:{{ .region }}:{{ .instance }}=tcp:0.0.0.0:{{ .port }},
                               {{- end }}",
-                  "-credential_file=/secrets/cloudsql/{{.Values.secret.key}}"]
+                  "-credential_file=/secrets/cloudsql/{{- if .Values.existingSecret -}} {{ .Values.existingSecretKey }} {{- else -}} credentials.json {{- end -}}"]
         ports:
         {{- range .Values.cloudsql.instances }}
         - name: {{ .instanceShortName | default (.instance | trunc 15) }}
@@ -42,10 +42,10 @@ spec:
       volumes:
       - name: cloudsql-oauth-credentials
         secret:
-          {{ if (not .Values.secret.name) -}}
+          {{ if (not .Values.existingSecret) -}}
           secretName: {{ template "gcloud-sqlproxy.fullname" . }}
           {{- else -}}
-          secretName: {{ .Values.secret.name }}
+          secretName: {{ .Values.existingSecret }}
           {{- end }}
       - name: cloudsql
         emptyDir: {}

--- a/stable/gcloud-sqlproxy/templates/secrets.yaml
+++ b/stable/gcloud-sqlproxy/templates/secrets.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.secret.create -}}
+{{- if not .Values.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secret.name | default ( include "gcloud-sqlproxy.fullname" . )}}
+  name: {{ template "gcloud-sqlproxy.fullname" . }}
   labels:
     app: {{ template "gcloud-sqlproxy.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -10,6 +10,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  {{ .Values.secret.key }}: |-
+  credentials.json: |-
     {{ .Values.serviceAccountKey }}
 {{- end -}}

--- a/stable/gcloud-sqlproxy/templates/secrets.yaml
+++ b/stable/gcloud-sqlproxy/templates/secrets.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.secret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "gcloud-sqlproxy.fullname" . }}
+  name: {{ .Values.secret.name | default ( include "gcloud-sqlproxy.fullname" . )}}
   labels:
     app: {{ template "gcloud-sqlproxy.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -9,5 +10,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  credentials.json: |-
+  {{ .Values.secret.key }}: |-
     {{ .Values.serviceAccountKey }}
+{{- end -}}

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -20,6 +20,15 @@ replicasCount: 1
 ##
 serviceAccountKey: ""
 
+## Instance credentials secret configuration
+secret:
+  ## Should a secret be generated
+  create: true
+  ## The name of the secret to use/create, defaults to chart fullname if not set
+  name: ""
+  ## The key to use within the secret
+  key: credentials.json
+
 ## SQL connection settings
 ##
 cloudsql:
@@ -42,13 +51,12 @@ cloudsql:
     # Port number for the proxy to expose for this instance.
     port: 5432
 
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
-
 rbac:
   create: false
 
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
 resources:
   requests:
     cpu: 100m

--- a/stable/gcloud-sqlproxy/values.yaml
+++ b/stable/gcloud-sqlproxy/values.yaml
@@ -17,17 +17,15 @@ replicasCount: 1
 ## Service account has access be set to Cloud SQL instances
 ## the key must be encoded with base64
 ## e.g. `cat service-account.json | base64`
+## only used if no existing secret is specified
 ##
 serviceAccountKey: ""
 
-## Instance credentials secret configuration
-secret:
-  ## Should a secret be generated
-  create: true
-  ## The name of the secret to use/create, defaults to chart fullname if not set
-  name: ""
-  ## The key to use within the secret
-  key: credentials.json
+## Specify an existing secret holding the cloud-sql service account credentials
+existingSecret: ""
+## The key in the existing secret that stores the credenials
+existingSecretKey: ""
+
 
 ## SQL connection settings
 ##


### PR DESCRIPTION
**What this PR does / why we need it**: 
This PR makes it possible for users to specify an existing secret where the credentials for the cloud-sql proxy are stored. By doing so we allow users to make use of additional tooling e.g. [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) which converts encrypted secrets to regular secrets when entering the cluster.

**Which issue this PR fixes**: 
none

**Special notes for your reviewer**:
