### PR TITLE
Adding optional sidecar containers and volumes

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 2.1.1
+version: 2.2.0
 appVersion: 1.5.6
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -11,6 +11,6 @@ icon: https://upload.wikimedia.org/wikipedia/en/thumb/2/27/Memcached.svg/1024px-
 sources:
 - https://github.com/docker-library/memcached
 maintainers:
-- name: Greg Taylor
+- name: gtaylor
   email: gtaylor@gc-taylor.com
 engine: gotpl

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `imagePullPolicy`         | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
 | `memcached.verbosity`     | Verbosity level (v, vv, or vvv) | Un-set.                                                 |
 | `memcached.maxItemMemory` | Max memory for items (in MB)    | `64`                                                    |
-| `sidecars`                | Container sidecar definition(s) as string | Un-set                                        |
+| `extraContainers`         | Container sidecar definition(s) as string | Un-set                                        |
 | `additionalVolumes`       | Volume definitions to add as string | Un-set                                              |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `memcached.verbosity`     | Verbosity level (v, vv, or vvv) | Un-set.                                                 |
 | `memcached.maxItemMemory` | Max memory for items (in MB)    | `64`                                                    |
 | `extraContainers`         | Container sidecar definition(s) as string | Un-set                                        |
-| `additionalVolumes`       | Volume definitions to add as string | Un-set                                              |
+| `extraVolumes`            | Volume definitions to add as string | Un-set                                              |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).
 

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -46,6 +46,8 @@ The following table lists the configurable parameters of the Memcached chart and
 | `imagePullPolicy`         | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
 | `memcached.verbosity`     | Verbosity level (v, vv, or vvv) | Un-set.                                                 |
 | `memcached.maxItemMemory` | Max memory for items (in MB)    | `64`                                                    |
+| `sidecars`                | Container sidecar definition(s) as string | Un-set                                        |
+| `additionalVolumes`       | Volume definitions to add as string | Un-set                                              |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).
 

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -66,3 +66,10 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- with .Values.sidecars }}
+{{ tpl . $ | indent 6 }}
+{{- end }}
+{{- with .Values.additionalVolumes }}
+      volumes:
+{{ tpl . $ | indent 6 }}
+{{- end }}

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 6 }}
 {{- end }}
-{{- with .Values.additionalVolumes }}
+{{- with .Values.extraVolumes }}
       volumes:
 {{ tpl . $ | indent 6 }}
 {{- end }}

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-{{- with .Values.sidecars }}
+{{- with .Values.extraContainers }}
 {{ tpl . $ | indent 6 }}
 {{- end }}
 {{- with .Values.additionalVolumes }}

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -35,6 +35,6 @@ resources:
     memory: 64Mi
     cpu: 50m
 
-extraContainers:
+extraContainers: |
 
-extraVolumes:
+extraVolumes: |

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -35,6 +35,6 @@ resources:
     memory: 64Mi
     cpu: 50m
 
-sidecars:
+extraContainers:
 
 additionalVolumes:

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -34,3 +34,7 @@ resources:
   requests:
     memory: 64Mi
     cpu: 50m
+
+sidecars:
+
+additionalVolumes:

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -37,4 +37,4 @@ resources:
 
 extraContainers:
 
-additionalVolumes:
+extraVolumes:


### PR DESCRIPTION
This allows the use of optional sidecar containers to be added to the memcache deployment to handle things like metric collection or ssl termination.
