### PR TITLE
[stable/drone] Improve ability to use private Docker images

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 1.2.0
+version: 1.3.0
 appVersion: 0.8.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -31,50 +31,53 @@ chart and deletes the release.
 
 The following table lists the configurable parameters of the drone charts and their default values.
 
-| Parameter                   | Description                                                                                   | Default                     |
-|-----------------------------|-----------------------------------------------------------------------------------------------|-----------------------------|
-| `images.server.repository`  | Drone **server** image                                                                        | `docker.io/drone/drone`     |
-| `images.server.tag`         | Drone **server** image tag                                                                    | `0.8.5`                     |
-| `images.server.pullPolicy`  | Drone **server** image pull policy                                                            | `IfNotPresent`              |
-| `images.agent.repository`   | Drone **agent** image                                                                         | `docker.io/drone/agent`     |
-| `images.agent.tag`          | Drone **agent** image tag                                                                     | `0.8.5`                     |
-| `images.agent.pullPolicy`   | Drone **agent** image pull policy                                                             | `IfNotPresent`              |
-| `images.dind.repository`    | Docker **dind** image                                                                         | `docker.io/library/docker`  |
-| `images.dind.tag`           | Docker **dind** image tag                                                                     | `17.12.0-ce-dind`           |
-| `images.dind.pullPolicy`    | Docker **dind** image pull policy                                                             | `IfNotPresent`              |
-| `service.httpPort`          | Drone's Web GUI HTTP port                                                                     | `80`                        |
-| `service.nodePort`          | If `service.type` is `NodePort` and this is non-empty, sets the http node port of the service | `32015`                     |
-| `service.type`              | Service type (ClusterIP, NodePort or LoadBalancer)                                            | `ClusterIP`                 |
-| `ingress.enabled`           | Enables Ingress for Drone                                                                     | `false`                     |
-| `ingress.annotations`       | Ingress annotations                                                                           | `{}`                        |
-| `ingress.hosts`             | Ingress accepted hostnames                                                                    | `nil`                       |
-| `ingress.tls`               | Ingress TLS configuration                                                                     | `[]`                        |
-| `server.host`               | Drone **server** scheme and hostname                                                          | `(internal hostname)`       |
-| `server.env`                | Drone **server** environment variables                                                        | `(default values)`          |
-| `server.envSecrets`         | Drone **server** secret environment variables                                                 | `(default values)`          |
-| `server.annotations`        | Drone **server** annotations                                                                  | `{}`                        |
-| `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
-| `server.schedulerName`      | Drone **server** alternate scheduler name                                                     | `nil`                       |
-| `server.affinity`           | Drone **server** scheduling preferences                                                       | `{}`                        |
-| `agent.env`                 | Drone **agent** environment variables                                                         | `(default values)`          |
-| `agent.replicas`            | Drone **agent** replicas                                                                      | `1`                         |
-| `agent.annotations`         | Drone **agent** annotations                                                                   | `{}`                        |
-| `agent.resources`           | Drone **agent** pod resource requests & limits                                                | `{}`                        |
-| `agent.schedulerName`       | Drone **agent** alternate scheduler name                                                      | `nil`                       |
-| `agent.affinity`            | Drone **agent** scheduling preferences                                                        | `{}`                        |
-| `dind.enabled`              | Enable or disable **DinD**                                                                    | `true`                      |
-| `dind.driver`               | **DinD** storage driver                                                                       | `overlay2`                  |
-| `dind.resources`            | **DinD** pod resource requests & limits                                                       | `{}`                        |
-| `dind.env`                  | **DinD** environment variables                                                                | `nil`                       |
-| `dind.command`              | **DinD** custom command instead of default entry point                                        | `nil`                       |
-| `dind.args`                 | **DinD** arguments for custom command or entry point                                          | `nil`                       |
-| `persistence.enabled`       | Use a PVC to persist data                                                                     | `true`                      |
-| `persistence.existingClaim` | Use an existing PVC to persist data                                                           | `nil`                       |
-| `persistence.storageClass`  | Storage class of backing PVC                                                                  | `nil`                       |
-| `persistence.accessMode`    | Use volume as ReadOnly or ReadWrite                                                           | `ReadWriteOnce`             |
-| `persistence.size`          | Size of data volume                                                                           | `1Gi`                       |
-| `sharedSecret`              | Drone server and agent shared secret (Note: The Default random value changes on every `helm upgrade` causing a rolling update of server and agents) | `(random value)`            |
-| `rbac.create`               | Specifies whether RBAC resources should be created.                                           | `true`                      |
-| `rbac.apiVersion`           | RBAC API version                                                                              | `v1`                        |
-| `serviceAccount.create`     | Specifies whether a ServiceAccount should be created.                                         | `true`                      |
-| `serviceAccount.name`       | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template. | `(fullname template)` |
+| Parameter                      | Description                                                                                   | Default                     |
+|--------------------------------|-----------------------------------------------------------------------------------------------|-----------------------------|
+| `images.server.repository`     | Drone **server** image                                                                        | `docker.io/drone/drone`     |
+| `images.server.tag`            | Drone **server** image tag                                                                    | `0.8.5`                     |
+| `images.server.pullPolicy`     | Drone **server** image pull policy                                                            | `IfNotPresent`              |
+| `images.agent.repository`      | Drone **agent** image                                                                         | `docker.io/drone/agent`     |
+| `images.agent.tag`             | Drone **agent** image tag                                                                     | `0.8.5`                     |
+| `images.agent.pullPolicy`      | Drone **agent** image pull policy                                                             | `IfNotPresent`              |
+| `images.dind.repository`       | Docker **dind** image                                                                         | `docker.io/library/docker`  |
+| `images.dind.tag`              | Docker **dind** image tag                                                                     | `17.12.0-ce-dind`           |
+| `images.dind.pullPolicy`       | Docker **dind** image pull policy                                                             | `IfNotPresent`              |
+| `images.pullSecrets`           | Docker image pull secret names as an array                                                    | `nil`                       |
+| `service.httpPort`             | Drone's Web GUI HTTP port                                                                     | `80`                        |
+| `service.nodePort`             | If `service.type` is `NodePort` and this is non-empty, sets the http node port of the service | `32015`                     |
+| `service.type`                 | Service type (ClusterIP, NodePort or LoadBalancer)                                            | `ClusterIP`                 |
+| `ingress.enabled`              | Enables Ingress for Drone                                                                     | `false`                     |
+| `ingress.annotations`          | Ingress annotations                                                                           | `{}`                        |
+| `ingress.hosts`                | Ingress accepted hostnames                                                                    | `nil`                       |
+| `ingress.tls`                  | Ingress TLS configuration                                                                     | `[]`                        |
+| `server.host`                  | Drone **server** scheme and hostname                                                          | `(internal hostname)`       |
+| `server.env`                   | Drone **server** environment variables                                                        | `(default values)`          |
+| `server.envSecrets`            | Drone **server** secret environment variables                                                 | `(default values)`          |
+| `server.annotations`           | Drone **server** annotations                                                                  | `{}`                        |
+| `server.resources`             | Drone **server** pod resource requests & limits                                               | `{}`                        |
+| `server.schedulerName`         | Drone **server** alternate scheduler name                                                     | `nil`                       |
+| `server.affinity`              | Drone **server** scheduling preferences                                                       | `{}`                        |
+| `agent.env`                    | Drone **agent** environment variables                                                         | `(default values)`          |
+| `agent.replicas`               | Drone **agent** replicas                                                                      | `1`                         |
+| `agent.annotations`            | Drone **agent** annotations                                                                   | `{}`                        |
+| `agent.resources`              | Drone **agent** pod resource requests & limits                                                | `{}`                        |
+| `agent.schedulerName`          | Drone **agent** alternate scheduler name                                                      | `nil`                       |
+| `agent.affinity`               | Drone **agent** scheduling preferences                                                        | `{}`                        |
+| `dind.enabled`                 | Enable or disable **DinD**                                                                    | `true`                      |
+| `dind.env`                     | **DinD** environment variables                                                                | `nil`                       |
+| `dind.dockerConfig.secretName` | **DinD** name of existing secret containing Docker config.json file                           | `nil`                       |
+| `dind.dockerConfig.items`      | **DinD** optional ability to change the secret key (filename) projected target path inside the mounted volume, from e.g. `.dockerconfigjson` to `config.json` | `nil`                       |
+| `dind.command`                 | **DinD** custom command instead of default entry point                                        | `nil`                       |
+| `dind.args`                    | **DinD** arguments for custom command or entry point                                          | `nil`                       |
+| `dind.driver`                  | **DinD** storage driver                                                                       | `overlay2`                  |
+| `dind.resources`               | **DinD** pod resource requests & limits                                                       | `{}`                        |
+| `persistence.enabled`          | Use a PVC to persist data                                                                     | `true`                      |
+| `persistence.existingClaim`    | Use an existing PVC to persist data                                                           | `nil`                       |
+| `persistence.storageClass`     | Storage class of backing PVC                                                                  | `nil`                       |
+| `persistence.accessMode`       | Use volume as ReadOnly or ReadWrite                                                           | `ReadWriteOnce`             |
+| `persistence.size`             | Size of data volume                                                                           | `1Gi`                       |
+| `sharedSecret`                 | Drone server and agent shared secret (Note: The Default random value changes on every `helm upgrade` causing a rolling update of server and agents) | `(random value)`            |
+| `rbac.create`                  | Specifies whether RBAC resources should be created.                                           | `true`                      |
+| `rbac.apiVersion`              | RBAC API version                                                                              | `v1`                        |
+| `serviceAccount.create`        | Specifies whether a ServiceAccount should be created.                                         | `true`                      |
+| `serviceAccount.name`          | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template. | `(fullname template)` |

--- a/stable/drone/templates/deployment-agent.yaml
+++ b/stable/drone/templates/deployment-agent.yaml
@@ -92,7 +92,16 @@ spec:
         volumeMounts:
           - name: docker-graph-storage
             mountPath: /var/lib/docker
+{{- if .Values.dind.dockerConfig }}
+          - name: docker-config
+            mountPath: "/root/.docker"
+{{- end }}
       volumes:
       - name: docker-graph-storage
         emptyDir: {}
+{{- if .Values.dind.dockerConfig }}
+      - name: docker-config
+        secret:
+{{ toYaml .Values.dind.dockerConfig | indent 10 }}
+{{- end }}
 {{- end }}

--- a/stable/drone/templates/deployment-agent.yaml
+++ b/stable/drone/templates/deployment-agent.yaml
@@ -30,6 +30,12 @@ spec:
 {{ toYaml .Values.agent.affinity | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "drone.serviceAccountName" . }}
+      {{- if .Values.images.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.images.pullSecrets }}
+        - name: {{ . }}
+        {{- end}}
+      {{- end}}
       containers:
       - name: {{ template "drone.fullname" . }}-agent
         image: "{{ .Values.images.agent.repository }}:{{ .Values.images.agent.tag }}"

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -31,6 +31,12 @@ spec:
 {{ toYaml .Values.server.affinity | indent 8 }}
 {{- end }}
       serviceAccountName: {{ template "drone.serviceAccountName" . }}
+      {{- if .Values.images.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.images.pullSecrets }}
+        - name: {{ . }}
+        {{- end}}
+      {{- end}}
       containers:
       - name: {{ template "drone.fullname" . }}-server
         image: "{{ .Values.images.server.repository }}:{{ .Values.images.server.tag }}"

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -25,6 +25,13 @@ images:
     tag: 17.12.0-ce-dind
     pullPolicy: IfNotPresent
 
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
 service:
   httpPort: 80
 

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -30,7 +30,7 @@ images:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
   # pullSecrets:
-  #   - myRegistrKeySecretName
+  #   - myRegistryPullSecretName
 
 service:
   httpPort: 80
@@ -226,7 +226,7 @@ persistence:
   ## If defined, PVC must be created manually before volume will be bound
   # existingClaim:
 
-  ## rabbitmq data Persistent Volume Storage Class
+  ## Drone data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -178,6 +178,21 @@ dind:
   #  env:
   #    DRONE_DEBUG: "false"
 
+  ## Optionally specify a Docker config.json secret
+  ## Secret must be manually created in the namespace.
+  ## ref: https://docs.docker.com/engine/reference/commandline/cli/#configuration-files
+  ##      https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-using-kubectl-create-secret
+  ##
+  # dockerConfig:
+  #   secretName: myDockerConfigSecret
+
+  #   ## Set items[] field to change target path of projected secret key in the volume:
+  #   ## ref: https://kubernetes.io/docs/concepts/configuration/secret/
+  #   ##
+  #   items:
+  #   - key: .dockerconfigjson
+  #     path: config.json
+
   ## Allowing custom command and args to DinD
   ## ref: https://discourse.drone.io/t/docker-mtu-problem/1207
   ##

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -175,8 +175,8 @@ dind:
   ## Values in here get injected as environment variables to DinD.
   ## ref: http://readme.drone.io/admin/installation-reference
   ##
-  #  env:
-  #    DRONE_DEBUG: "false"
+  # env:
+  #   DRONE_DEBUG: "false"
 
   ## Optionally specify a Docker config.json secret
   ## Secret must be manually created in the namespace.
@@ -196,8 +196,8 @@ dind:
   ## Allowing custom command and args to DinD
   ## ref: https://discourse.drone.io/t/docker-mtu-problem/1207
   ##
-  #  command: '["/bin/sh"]'
-  #  args: '["-c", "dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --mtu=1350"]'
+  # command: '["/bin/sh"]'
+  # args: '["-c", "dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --mtu=1350"]'
 
   ## Docker storage driver.
   ## Your DinD instance should be using the same driver as your host.


### PR DESCRIPTION
In some companies, pulling images straight from the Docker Hub won't be allowed. They might need to be mirrored or cached in private Artifactory registries first (for security scanning all company dependencies for example).

**What this PR does / why we need it**:

• Adds the ability to specify Kubernetes image pull secrets for pulling from private registries: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

• Adds the ability to mount custom Docker config.json or image pull secrets inside the DinD container for pulling private Drone plugin images