### PR TITLE
[incubator/etcd] Prevent removal of data from INITIAL_CLUSTER_SIZE pods

### DIFF
--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.4.0
+version: 0.4.1
 appVersion: 2.2.5
 description: Distributed reliable key-value store for the most critical data of a
   distributed system.

--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -8,5 +8,5 @@ icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal
 sources:
 - https://github.com/coreos/etcd
 maintainers:
-- name: Lachlan Evenson
+- name: lachie83
   email: lachlan@deis.com

--- a/incubator/etcd/templates/statefulset.yaml
+++ b/incubator/etcd/templates/statefulset.yaml
@@ -68,12 +68,15 @@ spec:
                       etcdctl member list | grep http://${HOSTNAME}.${SET_NAME}:2380 | cut -d':' -f1 | cut -d'[' -f1
                   }
 
-                  echo "Removing ${HOSTNAME} from etcd cluster"
+                  SET_ID=${HOSTNAME##*[^0-9]}
 
-                  ETCDCTL_ENDPOINT=${EPS} etcdctl member remove $(member_hash)
-                  if [ $? -eq 0 ]; then
-                      # Remove everything otherwise the cluster will no longer scale-up
-                      rm -rf /var/run/etcd/*
+                  if [ "${SET_ID}" -ge ${INITIAL_CLUSTER_SIZE} ]; then
+                      echo "Removing ${HOSTNAME} from etcd cluster"
+                      ETCDCTL_ENDPOINT=${EPS} etcdctl member remove $(member_hash)
+                      if [ $? -eq 0 ]; then
+                          # Remove everything otherwise the cluster will no longer scale-up
+                          rm -rf /var/run/etcd/*
+                      fi
                   fi
         command:
           - "/bin/sh"
@@ -115,7 +118,7 @@ spec:
             fi
 
             # etcd-SET_ID
-            SET_ID=${HOSTNAME:5:${#HOSTNAME}}
+            SET_ID=${HOSTNAME##*[^0-9]}
 
             # adding a new member to existing cluster (assuming all initial pods are available)
             if [ "${SET_ID}" -ge ${INITIAL_CLUSTER_SIZE} ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where by etcd pods will fail to come up after being deleted or the node they're attached to is drained. This is due to data being deleted during the preStop phase of the pod lifecycle and deletion should only occur on etcd nodes outside of the inital set created by helm.

**Which issue this PR fixes**
Fixes #6064

**Special notes for your reviewer**:
Also had to modify the way the `SET_ID` variable was set, in other projects such as [incubator/patroni] this caused issues as the hostname was more than 5 characters.