### PR TITLE
[incubator/couchdb] Allow overriding of full name in couchdb chart

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 0.1.6
+version: 0.1.7
 appVersion: 2.1.1
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/templates/_helpers.tpl
+++ b/incubator/couchdb/templates/_helpers.tpl
@@ -24,8 +24,12 @@ In the event that we create both a headless service and a traditional one,
 ensure that the latter gets a unique name.
 */}}
 {{- define "couchdb.svcname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-svc-%s" .Values.fullnameOverride .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-svc-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/incubator/couchdb/templates/_helpers.tpl
+++ b/incubator/couchdb/templates/_helpers.tpl
@@ -11,8 +11,12 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "couchdb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-%s" .Values.fullnameOverride .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to provide a custom name in the values instead of the helm release name for the CouchDB chart.

**Special notes for your reviewer**:
This is my first contribution to kubernetes (or any OSS project) so if something is missing or not up to standard, please let me know and I'll fix to the best of my abilities