### PR TITLE
[incubator/haproxy-ingress] Add default-ssl-certificate flag configuration

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: haproxy-ingress
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.5.3
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -49,6 +49,8 @@ Parameter | Description | Default
 `controller.image.repository` | controller container image repository | `quay.io/jcmoraisjr/haproxy-ingress`
 `controller.image.tag` | controller container image tag | `v0.5-beta.3`
 `controller.image.pullPolicy` | controller container image pullPolicy | `IfNotPresent`
+`controller.defaultSslCertificate.secret.namespace` | namespace of default certificate for controller | `{{ .Release.Namespace }}`
+`controller.defaultSslCertificate.secret.name` | name of the secret for default certificate of controller | `""`
 `controller.config` | haproxy ConfigMap entries | none
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -27,6 +27,9 @@ spec:
           imagePullPolicy: "{{ .Values.controller.image.pullPolicy }}"
           args:
             - --default-backend-service={{ .Release.Namespace }}/{{ .Values.defaultBackend.service.name }}
+          {{- if .Values.controller.defaultSslCertificate.secret.name }}
+            - --default-ssl-certificate={{ .Values.controller.defaultSslCertificate.secret.namespace | default .Release.Namespace }}/{{ .Values.controller.defaultSslCertificate.secret.name }}
+          {{- end}}
             - --configmap={{ .Release.Namespace }}/{{ template "haproxy-ingress.fullname" . }}
             - --sort-backends
           ports:

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -31,6 +31,13 @@ controller:
     tag: "v0.5-beta.3"
     pullPolicy: IfNotPresent
 
+  defaultSslCertificate:
+    secret:
+      # If not set, release namespace is used
+      namespace:
+      # Required
+      name:
+
   # ConfigMap to configure haproxy ingress
   config: {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Adds a default-ssl-certificate flag configuration

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes none

**Special notes for your reviewer**:
none