### PR TITLE
Mediawiki fix probes & improve notes

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 3.0.1
+version: 3.0.2
 appVersion: 1.31.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation
   that uses PHP to process and display data stored in a database.

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the MediaWiki chart and
 |              Parameter               |               Description                                   |                         Default                         |
 |--------------------------------------|-------------------------------------------------------------|---------------------------------------------------------|
 | `image.registry`                     | MediaWiki image registry                                    | `docker.io`                                             |
-| `image.repository`                   | MwdiaWiki Image name                                        | `bitnami/mediawiki`                                     |
+| `image.repository`                   | MediaWiki Image name                                        | `bitnami/mediawiki`                                     |
 | `image.tag`                          | MediaWiki Image tag                                         | `{VERSION}`                                             |
 | `image.pullPolicy`                   | Image pull policy                                           | `Always`                                                |
 | `image.pullSecrets`                  | Specify image pull secrets                                  | `nil`                                                   |
@@ -67,10 +67,10 @@ The following table lists the configurable parameters of the MediaWiki chart and
 | `externalDatabase.password`          | Password for the above username                             | `nil`                                                   |
 | `externalDatabase.database`          | Name of the existing database                               | `bitnami_mediawiki`                                     |
 | `mariadb.enabled`                    | Use or not the mariadb chart                                | `true`                                                  |
-| `mariadb.rootUser.password`        | MariaDB admin password                                      | `nil`                                                   |
-| `mariadb.db.name`            | Database name to create                                     | `bitnami_mediawiki`                                     |
-| `mariadb.db.user`                | Database user to create                                     | `bn_mediawiki`                                          |
-| `mariadb.db.password`            | Password for the database                                   | _random 10 character long alphanumeric string_          |
+| `mariadb.rootUser.password`          | MariaDB admin password                                      | `nil`                                                   |
+| `mariadb.db.name`                    | Database name to create                                     | `bitnami_mediawiki`                                     |
+| `mariadb.db.user`                    | Database user to create                                     | `bn_mediawiki`                                          |
+| `mariadb.db.password`                | Password for the database                                   | _random 10 character long alphanumeric string_          |
 | `service.type`                       | Kubernetes Service type                                     | `LoadBalancer`                                          |
 | `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                        | `nil`                                                   |
 | `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Local`                                                 |

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 4.2.5
-digest: sha256:d70084dc9ad9691db5908f774781eae34b6bfafc91900ca1735df0f4616b6917
-generated: 2018-06-26T13:00:34.148503336+02:00
+digest: sha256:5cb42bb2a3015c1a452f31ac1b35a9f5626bc742eebff8f8487a6b760d51e3e9
+generated: 2018-06-26T13:16:49.199227824+02:00

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.2.3
-digest: sha256:5cb42bb2a3015c1a452f31ac1b35a9f5626bc742eebff8f8487a6b760d51e3e9
-generated: 2018-06-13T22:19:33.7137449Z
+  version: 4.2.5
+digest: sha256:d70084dc9ad9691db5908f774781eae34b6bfafc91900ca1735df0f4616b6917
+generated: 2018-06-26T13:00:34.148503336+02:00

--- a/stable/mediawiki/templates/NOTES.txt
+++ b/stable/mediawiki/templates/NOTES.txt
@@ -1,5 +1,18 @@
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
+** Please be patient while the chart is being deployed **
+
+{{- if .Values.ingress.enabled }}
+
+1. Get the Mediawiki URL indicated on the Ingress Rule and associate it to your cluster external IP:
+
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ template "mediawiki.fullname" . }} -o jsonpath='{.spec.rules[0].host}')
+   echo "Mediawiki URL: http://$HOSTNAME/"
+   echo "$CLUSTER_IP  $HOSTNAME" | sudo tee -a /etc/hosts
+
+{{- else }}
+
 1. Get the MediaWiki URL by running:
 
 {{- if contains "NodePort" .Values.service.type }}
@@ -20,6 +33,7 @@
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mediawiki.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8080/
   kubectl port-forward $POD_NAME 8080:80
+{{- end }}
 {{- end }}
 
 2. Get your MediaWiki login credentials by running:

--- a/stable/mediawiki/templates/apache-pvc.yaml
+++ b/stable/mediawiki/templates/apache-pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "mediawiki.fullname" . }}-apache
   labels:
-    app: {{ template "mediawiki.fullname" . }}
+    app: {{ template "mediawiki.name" . }}
     chart: {{ template "mediawiki.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -37,9 +37,9 @@ spec:
         - name: MARIADB_PORT_NUMBER
         {{- if .Values.mariadb.enabled }}
           value: "3306"
-        {{ else }}
+        {{- else }}
           value: {{ .Values.externalDatabase.port | quote }}
-        {{ end }}
+        {{- end }}
         - name: MEDIAWIKI_DATABASE_NAME
         {{- if .Values.mariadb.enabled }}
           value: {{ .Values.mariadb.db.name | quote }}
@@ -122,9 +122,9 @@ spec:
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-        {{- end }}
         volumeMounts:
         - name: mediawiki-data
           mountPath: /bitnami/mediawiki

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "mediawiki.fullname" . }}
   labels:
-    app: {{ template "mediawiki.fullname" . }}
+    app: {{ template "mediawiki.name" . }}
     chart: {{ template "mediawiki.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "mediawiki.fullname" . }}
+        app: {{ template "mediawiki.name" . }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/mediawiki/templates/externaldb-secrets.yaml
+++ b/stable/mediawiki/templates/externaldb-secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
   labels:
-    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+    app: {{ template "mediawiki.name" . }}
     chart: {{ template "mediawiki.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/mediawiki/templates/ingress.yaml
+++ b/stable/mediawiki/templates/ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
+  name: {{ template "mediawiki.fullname" $ }}
   labels:
     app: {{ template "mediawiki.fullname" $ }}
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
@@ -24,7 +24,7 @@ spec:
         - path: {{ default "/" .path }}
           backend:
             serviceName: {{ template "mediawiki.fullname" $ }}
-            servicePort: 80
+            servicePort: http
 {{- if .tls }}
   tls:
   - hosts:

--- a/stable/mediawiki/templates/ingress.yaml
+++ b/stable/mediawiki/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "mediawiki.fullname" $ }}
   labels:
     app: {{ template "mediawiki.fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "mediawiki.chart" $ }}
     release: {{ $.Release.Name | quote }}
     heritage: {{ $.Release.Service | quote }}
   annotations:

--- a/stable/mediawiki/templates/ingress.yaml
+++ b/stable/mediawiki/templates/ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ template "mediawiki.fullname" $ }}
   labels:
-    app: {{ template "mediawiki.fullname" $ }}
+    app: {{ template "mediawiki.name" $ }}
     chart: {{ template "mediawiki.chart" $ }}
     release: {{ $.Release.Name | quote }}
     heritage: {{ $.Release.Service | quote }}

--- a/stable/mediawiki/templates/mediawiki-pvc.yaml
+++ b/stable/mediawiki/templates/mediawiki-pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "mediawiki.fullname" . }}-mediawiki
   labels:
-    app: {{ template "mediawiki.fullname" . }}
+    app: {{ template "mediawiki.name" . }}
     chart: {{ template "mediawiki.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/mediawiki/templates/secrets.yaml
+++ b/stable/mediawiki/templates/secrets.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ template "mediawiki.fullname" . }}
   labels:
-    app: {{ template "mediawiki.fullname" . }}
+    app: {{ template "mediawiki.name" . }}
     chart: {{ template "mediawiki.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/mediawiki/templates/svc.yaml
+++ b/stable/mediawiki/templates/svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "mediawiki.fullname" . }}
   labels:
-    app: {{ template "mediawiki.fullname" . }}
+    app: {{ template "mediawiki.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -29,4 +29,4 @@ spec:
     nodePort: {{ .Values.service.nodePorts.https }}
     {{- end }}
   selector:
-    app: {{ template "mediawiki.fullname" . }}
+    app: {{ template "mediawiki.name" . }}

--- a/stable/mediawiki/templates/tls-secrets.yaml
+++ b/stable/mediawiki/templates/tls-secrets.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: {{ .name }}
   labels:
-    app: {{ template "mediawiki.fullname" . }}
+    app: {{ template "mediawiki.name" . }}
     chart: {{ template "mediawiki.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -226,12 +226,14 @@ resources:
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 livenessProbe:
+  enbaled: true
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
 readinessProbe:
+  enabled: true
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -226,7 +226,7 @@ resources:
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 livenessProbe:
-  enbaled: true
+  enabled: true
   initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR provides several improvements to Mediawiki Helm Chart:

- Fix Readiness/Liveness probes.
- Improves NOTES
- Update MariaDB dependency