### PR TITLE
[stable/concourse] Expose prometheus port in web service

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.12.0
+version: 1.13.0
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -36,5 +36,10 @@ spec:
       {{ if and (eq "NodePort" .Values.web.service.type) .Values.web.service.tsaNodePort }}
       nodePort: {{ .Values.web.service.tsaNodePort}}
       {{ end }}
+    {{- if .Values.web.metrics.prometheus.enabled }}
+    - name: prometheus
+      port: {{ .Values.web.metrics.prometheus.port }}
+      targetPort: prometheus
+    {{- end }}
   selector:
     app: {{ template "concourse.web.fullname" . }}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR exposes the prometheus port (if enabled) on the concourse web service. This enables users of the prometheus operator to create **ServiceMonitor** definitions to monitor concourse deployments.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
