### PR TITLE
Changed Master.Jobs inline configuration to Master.JobsConfigMap

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.3
+version: 0.17.0
 appVersion: 2.107
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 name: jenkins
 home: https://jenkins.io/
 version: 0.17.0
-appVersion: 2.107
+appVersion: 2.121.1
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
   projects as well as arbitrary scripts.

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -67,7 +67,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
 | `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
-| `Master.JobsConfigMap`            | ConfigMap that contains Jenkins XML job configs              | Not set                                                                      |
+| `Master.JobsConfigMap`            | ConfigMap that contains Jenkins job XML configs              | Not set                                                                      |
 | `Master.InstallPlugins`           | List of Jenkins plugins to install   | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |
 | `Master.ScriptApproval`           | List of groovy functions to approve  | Not set                                                                      |
 | `Master.NodeSelector`             | Node labels for pod assignment       | `{}`                                                                         |

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -67,7 +67,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
 | `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
-| `Master.Jobs`                     | Jenkins XML job configs              | Not set                                                                      |
+| `Master.JobsConfigMap`            | ConfigMap that contains Jenkins XML job configs              | Not set                                                                      |
 | `Master.InstallPlugins`           | List of Jenkins plugins to install   | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |
 | `Master.ScriptApproval`           | List of groovy functions to approve  | Not set                                                                      |
 | `Master.NodeSelector`             | Node labels for pod assignment       | `{}`                                                                         |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -187,7 +187,7 @@ data:
 {{- if .Values.Master.SecretsFilesSecret }}
     cp -n /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets;
 {{- end }}
-{{- if .Values.Master.Jobs }}
+{{- if .Values.Master.JobsConfigMap }}
     for job in $(ls /var/jenkins_jobs); do
       mkdir -p /var/jenkins_home/jobs/$job
       cp -n /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -73,7 +73,7 @@ spec:
               name: jenkins-secrets
               readOnly: true
             {{- end }}
-            {{- if .Values.Master.Jobs }}
+            {{- if .Values.Master.JobsConfigMap }}
             -
               mountPath: /var/jenkins_jobs
               name: jenkins-jobs
@@ -165,7 +165,7 @@ spec:
               name: jenkins-secrets
               readOnly: true
             {{- end }}
-            {{- if .Values.Master.Jobs }}
+            {{- if .Values.Master.JobsConfigMap }}
             -
               mountPath: /var/jenkins_jobs
               name: jenkins-jobs
@@ -198,10 +198,10 @@ spec:
         secret:
           secretName: {{ .Values.Master.SecretsFilesSecret }}
       {{- end }}
-      {{- if .Values.Master.Jobs }}
+      {{- if .Values.Master.JobsConfigMap }}
       - name: jenkins-jobs
         configMap:
-          name: {{ template "jenkins.fullname" . }}-jobs
+          name: {{ .Values.Master.JobsConfigMap }}
       {{- end }}
       {{- if .Values.Master.InstallPlugins }}
       - name: plugin-dir

--- a/stable/jenkins/templates/jobs.yaml
+++ b/stable/jenkins/templates/jobs.yaml
@@ -1,8 +1,0 @@
-{{- if .Values.Master.Jobs }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ template "jenkins.fullname" . }}-jobs
-data:
-{{ .Values.Master.Jobs | indent 2 }}
-{{- end -}}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -97,14 +97,21 @@ Master:
   # useful to manage encryption keys used for credentials.xml for instance (such as
   # master.key and hudson.util.Secret)
   # SecretsFilesSecret: jenkins-secrets
-  # Jobs are configured via a ConfigMap. Job name servers as a key and pointing to the configuration XML:
-  # data:
-  #   job-1-name: |
-  #     <xml>
-  #      ....
-  #   job-X-name: |
-  #     <xml>
-  # JobsConfigMap: <<ConfigMap name>>
+  #
+  # Jenkins jobs are configured with a ConfigMap where job name serves as a key pointing to the configuration XML.
+  # The following example ConfigMap defines jobs 'job-1', ..., 'job-X' with their respective XML configurations 'xml-1', ..., 'xml-X':
+  #  apiVersion: v1
+  #  kind: ConfigMap
+  #  metadata:
+  #    name: jenkins-jobs
+  #  data:
+  #    job-1: |
+  #      <xml-1>
+  #       ...
+  #    job-X: |
+  #      <xml-X>
+  #  The name of the ConfigMap can then be used to configure this chart: 'JobsConfigMap: jenkins-jobs'
+  JobsConfigMap:
   CustomConfigMap: false
   # Node labels and tolerations for pod assignment
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -97,10 +97,14 @@ Master:
   # useful to manage encryption keys used for credentials.xml for instance (such as
   # master.key and hudson.util.Secret)
   # SecretsFilesSecret: jenkins-secrets
-  # Jenkins XML job configs to provision
-  # Jobs: |-
-  #   test: |-
-  #     <<xml here>>
+  # Jobs are configured via a ConfigMap. Job name servers as a key and pointing to the configuration XML:
+  # data:
+  #   job-1-name: |
+  #     <xml>
+  #      ....
+  #   job-X-name: |
+  #     <xml>
+  # JobsConfigMap: <<ConfigMap name>>
   CustomConfigMap: false
   # Node labels and tolerations for pod assignment
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -98,19 +98,21 @@ Master:
   # master.key and hudson.util.Secret)
   # SecretsFilesSecret: jenkins-secrets
   #
-  # Jenkins jobs are configured with a ConfigMap where job name serves as a key pointing to the configuration XML.
-  # The following example ConfigMap defines jobs 'job-1', ..., 'job-X' with their respective XML configurations 'xml-1', ..., 'xml-X':
-  #  apiVersion: v1
-  #  kind: ConfigMap
-  #  metadata:
-  #    name: jenkins-jobs
-  #  data:
-  #    job-1: |
-  #      <xml-1>
-  #       ...
-  #    job-X: |
-  #      <xml-X>
-  #  The name of the ConfigMap can then be used to configure this chart: 'JobsConfigMap: jenkins-jobs'
+  # Jobs are configured with a ConfigMap.
+  # JobsConfigMap: my-jenkins-jobs-configmap
+  # Job name serves as a key pointing to the configuration XML. Example ConfigMap definition:
+  # ---
+  # apiVersion: v1
+  # kind: ConfigMap
+  # metadata:
+  #   name: my-jenkins-jobs-configmap
+  # data:
+  #   job-1-name: |
+  #     <xml>
+  #      ....
+  #   job-X-name: |
+  #     <xml>
+  # ---
   JobsConfigMap:
   CustomConfigMap: false
   # Node labels and tolerations for pod assignment


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Jenkins Master.Jobs should use ConfigMap instead of the current inline configuration.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #6336

**Special notes for your reviewer**:
Shall I change the version to 0.16.4?
