### PR TITLE
Ngnix ingress namespace override

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.22.0
+version: 0.23.0
 appVersion: 0.15.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/NOTES.txt
+++ b/stable/nginx-ingress/templates/NOTES.txt
@@ -6,24 +6,24 @@ Get the application URL by running these commands:
 {{- if (not (empty .Values.controller.service.nodePorts.http)) }}
   export HTTP_NODE_PORT={{ .Values.controller.service.nodePorts.http }}
 {{- else }}
-  export HTTP_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
+  export HTTP_NODE_PORT=$(kubectl --namespace {{ template "nginx-ingress.namespace" . }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
 {{- end }}
 {{- if (not (empty .Values.controller.service.nodePorts.https)) }}
   export HTTPS_NODE_PORT={{ .Values.controller.service.nodePorts.https }}
 {{- else }}
-  export HTTPS_NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
+  export HTTPS_NODE_PORT=$(kubectl --namespace {{ template "nginx-ingress.namespace" . }} get services -o jsonpath="{.spec.ports[1].nodePort}" {{ template "nginx-ingress.controller.fullname" . }})
 {{- end }}
-  export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
+  export NODE_IP=$(kubectl --namespace {{ template "nginx-ingress.namespace" . }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}")
 
   echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
   echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."
 {{- else if contains "LoadBalancer" .Values.controller.service.type }}
 It may take a few minutes for the LoadBalancer IP to be available.
-You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "nginx-ingress.controller.fullname" . }}'
+You can watch the status by running 'kubectl --namespace {{ template "nginx-ingress.namespace" . }} get services -o wide -w {{ template "nginx-ingress.controller.fullname" . }}'
 {{- else if contains "ClusterIP"  .Values.controller.service.type }}
 Get the application URL by running these commands:
-  export POD_NAME=$(kubectl --namespace {{ .Release.Namespace }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+  export POD_NAME=$(kubectl --namespace {{ template "nginx-ingress.namespace" . }} get pods -o jsonpath="{.items[0].metadata.name}" -l "app={{ template "nginx-ingress.name" . }},component={{ .Values.controller.name }},release={{ .Release.Name }}")
+  kubectl --namespace {{ template "nginx-ingress.namespace" . }} port-forward $POD_NAME 8080:80
   echo "Visit http://127.0.0.1:8080 to access your application."
 {{- end }}
 

--- a/stable/nginx-ingress/templates/_helpers.tpl
+++ b/stable/nginx-ingress/templates/_helpers.tpl
@@ -7,6 +7,13 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Determine the namespace to deploy resources into.
+*/}}
+{{- define "nginx-ingress.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/nginx-ingress/templates/_helpers.tpl
+++ b/stable/nginx-ingress/templates/_helpers.tpl
@@ -49,7 +49,7 @@ Users can provide an override for an explicit service they want bound via `.Valu
 
 */}}
 {{- define "nginx-ingress.controller.publishServicePath" -}}
-{{- $defServiceName := printf "%s/%s" .Release.Namespace (include "nginx-ingress.controller.fullname" .) -}}
+{{- $defServiceName := printf "%s/%s" (include "nginx-ingress.namespace" .) (include "nginx-ingress.controller.fullname" .) -}}
 {{- $servicePath := default $defServiceName .Values.controller.publishService.pathOverride }}
 {{- print $servicePath | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/stable/nginx-ingress/templates/clusterrolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "nginx-ingress.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "nginx-ingress.namespace" . }}
 {{- end -}}

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -8,10 +8,11 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 data:
   enable-vts-status: "{{ .Values.controller.stats.enabled }}"
 {{- if .Values.controller.headers }}
-  proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
+  proxy-set-headers: {{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
 {{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   updateStrategy:
@@ -28,6 +29,7 @@ spec:
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8}}
         {{- end }}
+      namespace: {{ template "nginx-ingress.namespace" . }}
     spec:
       dnsPolicy: {{ .Values.controller.dnsPolicy }}
       {{- if .Values.imagePullSecrets }}
@@ -44,7 +46,7 @@ spec:
           {{- end }}
           args:
             - /nginx-ingress-controller
-            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
           {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
@@ -55,18 +57,18 @@ spec:
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
           {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
-            - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --configmap={{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
-            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --nginx-configmap={{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- end }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+            - --tcp-services-configmap={{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+            - --udp-services-configmap={{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
-            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+            - --watch-namespace={{ default (include "nginx-ingress.namespace" .) .Values.controller.scope.namespace }}
           {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
             {{- if $value }}

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -28,6 +29,7 @@ spec:
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
+      namespace: {{ template "nginx-ingress.namespace" . }}
     spec:
       dnsPolicy: {{ .Values.controller.dnsPolicy }}
       {{- if .Values.imagePullSecrets }}
@@ -44,7 +46,7 @@ spec:
           {{- end }}
           args:
             - /nginx-ingress-controller
-            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
+            - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
           {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
@@ -55,18 +57,18 @@ spec:
             - --ingress-class={{ .Values.controller.ingressClass }}
           {{- end }}
           {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
-            - --configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --configmap={{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- else }}
-            - --nginx-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
+            - --nginx-configmap={{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- end }}
           {{- if .Values.tcp }}
-            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-tcp
+            - --tcp-services-configmap={{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.fullname" . }}-tcp
           {{- end }}
           {{- if .Values.udp }}
-            - --udp-services-configmap={{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-udp
+            - --udp-services-configmap={{ template "nginx-ingress.namespace" . }}/{{ template "nginx-ingress.fullname" . }}-udp
           {{- end }}
           {{- if .Values.controller.scope.enabled }}
-            - --watch-namespace={{ default .Release.Namespace .Values.controller.scope.namespace }}
+            - --watch-namespace={{ default (include "nginx-ingress.namespace" .) .Values.controller.scope.namespace }}
           {{- end }}
           {{- range $key, $value := .Values.controller.extraArgs }}
             {{- if $value }}

--- a/stable/nginx-ingress/templates/controller-hpa.yaml
+++ b/stable/nginx-ingress/templates/controller-hpa.yaml
@@ -10,6 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta1

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -13,6 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-metrics
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   clusterIP: "{{ .Values.controller.metrics.service.clusterIP }}"
 {{- if .Values.controller.metrics.service.externalIPs }}

--- a/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -8,6 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   selector:
     matchLabels:

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -15,6 +15,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   clusterIP: "{{ .Values.controller.service.clusterIP }}"
 {{- if .Values.controller.service.externalIPs }}

--- a/stable/nginx-ingress/templates/controller-stats-service.yaml
+++ b/stable/nginx-ingress/templates/controller-stats-service.yaml
@@ -13,6 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-stats
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   clusterIP: "{{ .Values.controller.stats.service.clusterIP }}"
 {{- if .Values.controller.stats.service.externalIPs }}

--- a/stable/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/stable/nginx-ingress/templates/default-backend-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   replicas: {{ .Values.defaultBackend.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
@@ -25,6 +26,7 @@ spec:
         {{- if .Values.defaultBackend.podLabels }}
 {{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
         {{- end }}
+      namespace: {{ template "nginx-ingress.namespace" . }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -8,6 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   selector:
     matchLabels:

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -13,6 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 spec:
   clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
 {{- if .Values.defaultBackend.service.externalIPs }}

--- a/stable/nginx-ingress/templates/headers-configmap.yaml
+++ b/stable/nginx-ingress/templates/headers-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-custom-headers
+  namespace: {{ template "nginx-ingress.namespace" . }}
 data:
 {{ toYaml .Values.controller.headers | indent 2 }}
 {{- end }}

--- a/stable/nginx-ingress/templates/role.yaml
+++ b/stable/nginx-ingress/templates/role.yaml
@@ -8,6 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 rules:
   - apiGroups:
       - ""

--- a/stable/nginx-ingress/templates/rolebinding.yaml
+++ b/stable/nginx-ingress/templates/rolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -15,5 +16,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "nginx-ingress.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "nginx-ingress.namespace" . }}
 {{- end -}}

--- a/stable/nginx-ingress/templates/serviceaccount.yaml
+++ b/stable/nginx-ingress/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.serviceAccountName" . }}
+  namespace: {{ template "nginx-ingress.namespace" . }}
 {{- end -}}

--- a/stable/nginx-ingress/templates/tcp-configmap.yaml
+++ b/stable/nginx-ingress/templates/tcp-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-tcp
+  namespace: {{ template "nginx-ingress.namespace" . }}
 data:
 {{ toYaml .Values.tcp | indent 2 }}
 {{- end }}

--- a/stable/nginx-ingress/templates/udp-configmap.yaml
+++ b/stable/nginx-ingress/templates/udp-configmap.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-udp
+  namespace: {{ template "nginx-ingress.namespace" . }}
 data:
 {{ toYaml .Values.udp | indent 2 }}
 {{- end }}


### PR DESCRIPTION
This PR enables overriding the namespace that resources are deployed into by setting a value.

This is useful when this chart is used as a subchart and we want to deploy the nginx ingress controller and associated resources into a different namespace from the top level chart. In this case it's not possible to use the `--namespace` command line option to control the namespace of the subchart.

I have deliberately not added documentation of this option or added it to the default values, as it feels analogous to `.Values.nameOverride`, which also appears in `_helpers.tpl`, but not in the documentation / default values.

As suggested in PR template, tagging the chart maintainers: @jackzampolin @mgoodness @chancez 