### PR TITLE
kafka namespace documentation fix

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.8.0
+version: 0.8.1
 appVersion: 4.1.1
 keywords:
 - kafka

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -47,7 +47,7 @@ exists with:
 ```
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
 $ kubectl create ns kafka
-$ helm install --name my-kafka --set global.namespace=kafka incubator/kafka
+$ helm install --name my-kafka --namespace=kafka incubator/kafka
 ```
 
 This chart includes a ZooKeeper chart as a dependency to the Kafka

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -47,7 +47,7 @@ exists with:
 ```
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
 $ kubectl create ns kafka
-$ helm install --name my-kafka --namespace=kafka incubator/kafka
+$ helm install --name my-kafka --namespace kafka incubator/kafka
 ```
 
 This chart includes a ZooKeeper chart as a dependency to the Kafka


### PR DESCRIPTION
**What this PR does / why we need it**:
The current documentation for creating a kafka cluster in a different namespace doesn't work. This pull request updates the documentation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #6153 

**Special notes for your reviewer**:
Really small doc change. I verified it works on my machine.