### PR TITLE
[stable/keycloak] Fix incorrect default value for extraEnv

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 3.0.1
+version: 3.0.2
 appVersion: 4.0.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -44,10 +44,13 @@ keycloak:
   password: ""
 
   ## Allows the specification of additional environment variables for Keycloak
-  extraEnv: {}
-    # KEYCLOAK_LOGLEVEL: DEBUG
-    # WILDFLY_LOGLEVEL: DEBUG
-    # CACHE_OWNERS: 2
+  extraEnv: |
+    # - name: KEYCLOAK_LOGLEVEL
+    #   value: DEBUG
+    # - name: WILDFLY_LOGLEVEL
+    #   value: DEBUG
+    # - name: CACHE_OWNERS
+    #   value: "2"
 
   affinity: |
     podAntiAffinity:


### PR DESCRIPTION
The default value has to be an empty string instead of an empty map because
it is passed to the `tpl` function. Otherwise Helm gives you a warning when the chart is installed and `keycloak.extraEnv` is used.

```
2018/06/27 14:18:18 warning: cannot overwrite table with non table for extraEnv (map[])
```
