### PR TITLE
Fix typo in readme formatting

### DIFF
--- a/incubator/fluentd-elasticsearch/README.md
+++ b/incubator/fluentd-elasticsearch/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
 | `extraVolume`                      | Extra volume                               |                                                            |
 | `image.repository`                 | Image                                      | `gcr.io/google-containers/fluentd-elasticsearch`           |
-| `image.tag`                        | Image tag                                  | `v2.0.4                                                    |
+| `image.tag`                        | Image tag                                  | `v2.0.4`                                                   |
 | `image.pullPolicy`                 | Image pull policy                          | `Always` if `image.tag` is `imagePullPolicy`               |
 | `rbac.create`                      | RBAC                                       | `true`                                                     |
 | `resources.limits.cpu`             | CPU limit                                  | `100m`                                                     |


### PR DESCRIPTION
The backtick that was formatting the tag was missing the closing backtick. Now the tag looks nicer when rendering the markdown.

