### PR TITLE
Add support for custom annotations for service resource for stable/luigi chart

### DIFF
--- a/stable/luigi/Chart.yaml
+++ b/stable/luigi/Chart.yaml
@@ -18,5 +18,5 @@ keywords:
 - spark
 - kubernetes job manager
 name: luigi
-version: 2.7.4
+version: 2.7.5
 appVersion: 2.7.2

--- a/stable/luigi/templates/service.yaml
+++ b/stable/luigi/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/luigi/values.yaml
+++ b/stable/luigi/values.yaml
@@ -11,6 +11,7 @@ service:
   name: luigi
   type: LoadBalancer
   externalPort: 80
+  annotations: {}
 
   # Luigi config: these values should mattch the luigi documentation
   # https://luigi.readthedocs.io/en/stable/configuration.html


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Allows for users to pass custom annotations to the service resource. This allows for ALB ingress and other use cases (external-dns etc).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:
