### PR TITLE
Makes WordPress replicas configurable from values

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 2.0.0
+version: 2.0.1
 appVersion: 4.9.6
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -66,6 +66,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `smtpPassword`                       | SMTP password                              | `nil`                                                      |
 | `smtpUsername`                       | User name for SMTP emails                  | `nil`                                                      |
 | `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]               | `nil`                                                      |
+| `replicaCount`                       | Number of WordPress Pods to run            | `1`                                                        |
 | `mariadb.enabled`                    | Deploy MariaDB container(s)                | `true`                                                     |
 | `mariadb.rootUser.password`        | MariaDB admin password                     | `nil`                                                      |
 | `mariadb.db.name`            | Database name to create                    | `bitnami_wordpress`                                        |
@@ -123,11 +124,11 @@ The following repo contains the recommended production settings for wordpress ca
 To horizontally scale this chart, first download the [values-production.yaml](values-production.yaml) file to your local folder, then:
 
 ```console
-$ 
+$
 $ helm install --name my-release -f ./values-production.yaml stable/wordpress
-$ kubectl scale deployment my-wp-deployment --replicas=3 
 ```
-To use the /admin portal and to ensure you can scale wordpress you need to provide a ReadWriteMany PVC, if you dont have a provisioner for this type of storage, we recommend that you install the nfs provisioner and map it to a RWO volume.
+
+Note that values-production.yaml includes a replicaCount of 3, so there will be 3 WordPress pods. As a result, to use the /admin portal and to ensure you can scale wordpress you need to provide a ReadWriteMany PVC, if you don't have a provisioner for this type of storage, we recommend that you install the nfs provisioner and map it to a RWO volume.
 
 ```console
 $ helm install stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -124,11 +124,10 @@ The following repo contains the recommended production settings for wordpress ca
 To horizontally scale this chart, first download the [values-production.yaml](values-production.yaml) file to your local folder, then:
 
 ```console
-$
 $ helm install --name my-release -f ./values-production.yaml stable/wordpress
 ```
 
-Note that values-production.yaml includes a replicaCount of 3, so there will be 3 WordPress pods. As a result, to use the /admin portal and to ensure you can scale wordpress you need to provide a ReadWriteMany PVC, if you don't have a provisioner for this type of storage, we recommend that you install the nfs provisioner and map it to a RWO volume.
+Note that [values-production.yaml](values-production.yaml) includes a replicaCount of 3, so there will be 3 WordPress pods. As a result, to use the /admin portal and to ensure you can scale wordpress you need to provide a ReadWriteMany PVC, if you don't have a provisioner for this type of storage, we recommend that you install the nfs provisioner and map it to a RWO volume.
 
 ```console
 $ helm install stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -63,6 +63,8 @@ allowEmptyPassword: "yes"
 # smtpUsername:
 # smtpProtocol:
 
+replicaCount: 3
+
 externalDatabase:
 ## All of these values are only used when mariadb.enabled is set to false
   ## Database host
@@ -223,7 +225,7 @@ persistence:
   ## the existingClaim variable
   # existingClaim: your-claim
   ##
-  ## To use the /admin portal and to ensure you can scale wordpress you need to provide a 
+  ## To use the /admin portal and to ensure you can scale wordpress you need to provide a
   ## ReadWriteMany PVC, if you dont have a provisioner for this type of storage
   ## We recommend that you install the nfs provisioner and map it to a RWO volume
   ## helm install stable/nfs-server-provisioner --set persistence.enabled=true,persistence.size=10Gi

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -67,6 +67,8 @@ allowEmptyPassword: "yes"
 # smtpUsername:
 # smtpProtocol:
 
+replicaCount: 1
+
 externalDatabase:
 ## All of these values are only used when mariadb.enabled is set to false
   ## Database host


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates WordPress chart to be more idiomatic (i.e. less imperative config for the production scaling config). Also, makes updates using the `values-production.yaml` behave as expected (since right now, a `helm update` would scale the deployment back down to 1.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` 
None in particular. 

**Special notes for your reviewer**:
None