### PR TITLE
added ability to use loadBalancerSourceRanges in weave-scope

### DIFF
--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,5 +1,5 @@
 name: weave-scope
-version: 0.9.2
+version: 0.9.3
 appVersion: 1.6.5
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:

--- a/stable/weave-scope/charts/weave-scope-frontend/templates/service.yaml
+++ b/stable/weave-scope/charts/weave-scope-frontend/templates/service.yaml
@@ -19,4 +19,10 @@ spec:
     release: {{ .Release.Name }}
     component: frontend
   type: {{ .Values.global.service.type }}
+  {{- if .Values.global.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+  {{- range .Values.global.service.loadBalancerSourceRanges }}
+  - {{ . }}
+  {{- end }}
+  {{- end -}}
 {{- end -}}

--- a/stable/weave-scope/values.yaml
+++ b/stable/weave-scope/values.yaml
@@ -19,6 +19,9 @@ global:
     # global.service.type: (required if frontend.enabled == true) the type of the frontend service -- must be ClusterIP, NodePort or LoadBalancer
     # global.service.type is a global to keep it with the other values for configuring the frontend service
     type: "ClusterIP"
+    # global.service.loadBalancerSourceRanges: lets you limit the load balancer to a specific network range/s
+    # global.service.loadBalancerSourceRanges: [198.40.126.0/21,215.140.110.2/32]
+
 
 # weave-scope-frontend.* controls how the Scope frontend is installed
 weave-scope-frontend:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Adds load balancer source ranges functionality to weave-scope helm chart.
This is needed to allow limiting the loadbalancer to be exposed on specific network ranges.
@omkensey 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

 None
**Special notes for your reviewer**:
