### PR TITLE
[Stable/Telegraf] Remove System Inputs from Single Instance Configuration

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,5 +1,5 @@
 name: telegraf
-version: 0.3.3
+version: 0.3.4
 appVersion: 1.5
 deprecated: true
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/stable/telegraf/values.yaml
+++ b/stable/telegraf/values.yaml
@@ -238,10 +238,10 @@ single:
 ##        topic: "telegraf"
 ##        data_format: "influx"
     inputs:
-      cpu:
-        percpu: false
-        totalcpu: true
-      system:
+##      cpu:
+##        percpu: false
+##        totalcpu: true
+##      system:
 ##      aerospike:
 ##        servers:
 ##          - "localhost:3000"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue with the telegraf single instance configuration by removing some system input plugins. The `system` and `cpu` plugins were getting added in the values, but these are inappropriate for the single instance configuration, as it is meant only to collect stats off remote services. These are not listed under the default configured plugins for the single instance, and it lacks the `system` plugin produces errors due to `/var/run/utmp` not being mounted. The DS pod does collect these metrics appropriately, and there is no function for them on the single instance anyway. Given the configuration format, there is no easy way to remove these otherwise. 
