### PR TITLE
Adding the possibility to use registy on Docker image

### DIFF
--- a/stable/kubewatch/Chart.yaml
+++ b/stable/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 0.4.0
+version: 0.4.1
 apiVersion: v1
 appVersion: v0.0.4
 home: https://github.com/bitnami-labs/kubewatch

--- a/stable/kubewatch/README.md
+++ b/stable/kubewatch/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the kubewatch chart and
 |               Parameter                  |        Description                   |              Default              |
 | ---------------------------------------- | ------------------------------------ | --------------------------------- |
 | `affinity`                               | node/pod affinities                  | None                              |
+| `image.registry`                         | Image registry                       | `docker.io`                       |
 | `image.repository`                       | Image repository                     | `bitnami/kubewatch`               |
 | `image.tag`                              | Image tag                            | `{VERSION}`                       |
 | `image.pullPolicy`                       | Image pull policy                    | `Always`                          |

--- a/stable/kubewatch/templates/deployment.yaml
+++ b/stable/kubewatch/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: {{ template "kubewatch.name" . }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: {{ template "kubewatch.name" . }}-config-map

--- a/stable/kubewatch/values.yaml
+++ b/stable/kubewatch/values.yaml
@@ -31,6 +31,7 @@ resourcesToWatch:
   persistentvolume: false
 
 image:
+  registry: "docker.io"
   repository: "bitnami/kubewatch"
   tag: "0.0.4"
   pullPolicy: "Always"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the possibility of using a different registry (default docker.io) to retrieve the image from. This is very useful for people using its own private registries.  
