### PR TITLE
fixing url output for elasticsearch client

### DIFF
--- a/incubator/elasticsearch/templates/NOTES.txt
+++ b/incubator/elasticsearch/templates/NOTES.txt
@@ -4,7 +4,7 @@ Elasticsearch can be accessed:
 
   * Within your cluster, at the following DNS name at port 9200:
 
-    {{ template "elasticsearch.client.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{ template "elasticsearch.client.fullname" . }}.{{ .Release.Namespace }}.svc.{{ template "cluster.kubernetesDomain" }}
 
   * From outside the cluster, run these commands in the same shell:
     {{- if contains "NodePort" .Values.client.serviceType }}

--- a/incubator/elasticsearch/templates/NOTES.txt
+++ b/incubator/elasticsearch/templates/NOTES.txt
@@ -4,7 +4,7 @@ Elasticsearch can be accessed:
 
   * Within your cluster, at the following DNS name at port 9200:
 
-    {{ template "elasticsearch.client.fullname" . }}.{{ .Release.Namespace }}.svc.{{ template "cluster.kubernetesDomain" }}
+    {{ template "elasticsearch.client.fullname" . }}.{{ .Release.Namespace }}.svc.{{ template "cluster.kubernetesDomain" . }}
 
   * From outside the cluster, run these commands in the same shell:
     {{- if contains "NodePort" .Values.client.serviceType }}


### PR DESCRIPTION
domain was hardcoded to `cluster.local` instead of using value from chart

**What this PR does / why we need it**: Fixes elasticsearch client url output after `helm install`.
