### PR TITLE
[stable/datadog]: update labels to match recommended standards

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 0.18.0
+version: 0.18.1
 appVersion: 6.3.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/autoconf-configmap.yaml
+++ b/stable/datadog/templates/autoconf-configmap.yaml
@@ -3,8 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.autoconf.fullname" . }}
   labels:
-    app: {{ template "datadog.autoconf.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "datadog.autoconf.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/stable/datadog/templates/autoconf-configmap.yaml
+++ b/stable/datadog/templates/autoconf-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.autoconf.fullname" . }}
   labels:
-    app: {{ template "datadog.autoconf.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/autoconf-configmap.yaml
+++ b/stable/datadog/templates/autoconf-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "datadog.autoconf.fullname" . }}
   labels:
     app: {{ template "datadog.autoconf.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:

--- a/stable/datadog/templates/autoconf-configmap.yaml
+++ b/stable/datadog/templates/autoconf-configmap.yaml
@@ -3,10 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.autoconf.fullname" . }}
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "datadog.autoconf.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
     checksum/autoconf-config: {{ toYaml .Values.datadog.autoconf | sha256sum }}
 data:

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -3,10 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.checksd.fullname" . }}
   labels:
-    app: "{{ template "datadog.checksd.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "datadog.checksd.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
     checksum/checksd-config: {{ toYaml .Values.datadog.checksd | sha256sum }}
 data:

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.checksd.fullname" . }}
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.checksd.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "datadog.checksd.fullname" . }}
   labels:
     app: {{ template "datadog.checksd.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -3,8 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.checksd.fullname" . }}
   labels:
-    app: {{ template "datadog.checksd.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "datadog.checksd.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.checksd.fullname" . }}
   labels:
-    app: {{ template "datadog.checksd.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/clusterrole.yaml
+++ b/stable/datadog/templates/clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "datadog.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/stable/datadog/templates/clusterrole.yaml
+++ b/stable/datadog/templates/clusterrole.yaml
@@ -3,10 +3,10 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:
-    app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    app: {{ template "datadog.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
   name: {{ template "datadog.fullname" . }}
 rules:
 - nonResourceURLs:

--- a/stable/datadog/templates/clusterrole.yaml
+++ b/stable/datadog/templates/clusterrole.yaml
@@ -3,10 +3,10 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "datadog.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
   name: {{ template "datadog.fullname" . }}
 rules:
 - nonResourceURLs:

--- a/stable/datadog/templates/clusterrole.yaml
+++ b/stable/datadog/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: {{ template "datadog.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
   name: {{ template "datadog.fullname" . }}

--- a/stable/datadog/templates/clusterrole.yaml
+++ b/stable/datadog/templates/clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/stable/datadog/templates/clusterrolebinding.yaml
+++ b/stable/datadog/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "datadog.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/clusterrolebinding.yaml
+++ b/stable/datadog/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: {{ template "datadog.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}

--- a/stable/datadog/templates/clusterrolebinding.yaml
+++ b/stable/datadog/templates/clusterrolebinding.yaml
@@ -3,10 +3,10 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "datadog.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   name: {{ template "datadog.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/datadog/templates/clusterrolebinding.yaml
+++ b/stable/datadog/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/clusterrolebinding.yaml
+++ b/stable/datadog/templates/clusterrolebinding.yaml
@@ -3,10 +3,10 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "datadog.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
   name: {{ template "datadog.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -3,8 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.confd.fullname" . }}
   labels:
-    app: {{ template "datadog.confd.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "datadog.confd.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.confd.fullname" . }}
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.confd.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.confd.fullname" . }}
   labels:
-    app: {{ template "datadog.confd.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -3,10 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "datadog.confd.fullname" . }}
   labels:
-    app: "{{ template "datadog.confd.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "datadog.confd.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
     checksum/confd-config: {{ toYaml .Values.datadog.confd | sha256sum }}
 data:

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "datadog.confd.fullname" . }}
   labels:
     app: {{ template "datadog.confd.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -5,10 +5,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "datadog.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   template:
     metadata:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: {{ template "datadog.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
     app: {{ template "datadog.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -5,7 +5,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   template:
     metadata:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: {{ template "datadog.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
     app: {{ template "datadog.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "datadog.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   template:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -5,7 +5,10 @@ kind: Deployment
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.deployment.replicas }}
   template:

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "datadog.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
   api-key: {{ default "MISSING" .Values.datadog.apiKey | b64enc | quote }}

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -5,8 +5,8 @@ kind: Secret
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: {{ template "datadog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: {{ template "datadog.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/secrets.yaml
+++ b/stable/datadog/templates/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
     app: {{ template "datadog.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 type: Opaque

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -4,10 +4,10 @@ kind: Service
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "datadog.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   type: {{ .Values.serviceType }}
   selector:

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: {{ template "datadog.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
     app: {{ template "datadog.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -4,9 +4,10 @@ kind: Service
 metadata:
   name: {{ template "datadog.fullname" . }}
   labels:
-    app: {{ template "datadog.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.serviceType }}
   selector:

--- a/stable/datadog/templates/serviceaccount.yaml
+++ b/stable/datadog/templates/serviceaccount.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: "{{ template "datadog.fullname" . }}"
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    heritage: "{{ .Release.Service }}"
-    release: "{{ .Release.Name }}"
+    app: {{ template "datadog.fullname" . | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
   name: {{ template "datadog.fullname" . }}
 {{- end -}}

--- a/stable/datadog/templates/serviceaccount.yaml
+++ b/stable/datadog/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "datadog.fullname" . | quote }}
+    app: "{{ template "datadog.autoconf.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/stable/datadog/templates/serviceaccount.yaml
+++ b/stable/datadog/templates/serviceaccount.yaml
@@ -4,9 +4,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "datadog.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    app: "{{ template "datadog.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
   name: {{ template "datadog.fullname" . }}
 {{- end -}}

--- a/stable/datadog/templates/serviceaccount.yaml
+++ b/stable/datadog/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: "{{ template "datadog.autoconf.fullname" . }}"
+    app: "{{ template "datadog.fullname" . }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/stable/datadog/templates/serviceaccount.yaml
+++ b/stable/datadog/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: {{ template "datadog.fullname" . | quote }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
   name: {{ template "datadog.fullname" . }}


### PR DESCRIPTION
@hkaj @irabinovitch @xvello
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Follow [recommended](https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/labels.md) label standards. I'm doing some CD and my work's been based on the release and chart labels. I canna deploy my datadog updates without these labels. 

