### PR TITLE
[Incubator/kafka] Add single un-routed nodePort option for external access

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.8.0
+version: 0.9.0
 appVersion: 4.1.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.external.enabled }}
   {{- $fullName := include "kafka.fullname" . }}
-  {{- $replicas := .Values.replicas | int }}
+  {{- $replicas := and (eq .Values.external.type "MultiPort") (.Values.replicas | int) | default 1 }}
   {{- $servicePort := .Values.external.servicePort }}
   {{- $root := . }}
   {{- range $i, $e := until $replicas }}
@@ -10,10 +10,16 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if $root.Values.external.domain }}
   annotations:
     ## ref: https://github.com/kubernetes/kops/blob/master/dns-controller/pkg/watchers/annotations.go#L21
-    dns.alpha.kubernetes.io/internal: "{{ $root.Release.Name }}.{{ $root.Values.external.domain }}"
-  name: {{ $root.Release.Name }}-{{ $i }}-external
+    dns.alpha.kubernetes.io/internal: "{{ include "kafka.fullname" $root }}.{{ $root.Values.external.domain }}"
+  {{- end }}
+  {{- if eq $root.Values.external.type "MultiPort" }}
+  name: {{ include "kafka.fullname" $root }}-{{ $i }}-external
+  {{- else if eq $root.Values.external.type "SinglePort" }}
+  name: {{ include "kafka.fullname" $root }}-external
+  {{- end }}
   labels:
     app: {{ include "kafka.name" $root }}
     chart: {{ $root.Chart.Name }}-{{ $root.Chart.Version }}
@@ -22,6 +28,9 @@ metadata:
     pod: {{ $responsiblePod | quote }}
 spec:
   type: NodePort
+  {{- if eq $root.Values.external.type "SinglePort" }}
+  externalTrafficPolicy: Local
+  {{- end }}
   ports:
     - name: external-broker
       port: {{ $servicePort }}
@@ -31,6 +40,33 @@ spec:
   selector:
     app: {{ include "kafka.name" $root }}
     release: {{ $root.Release.Name }}
+    {{- if eq $root.Values.external.type "MultiPort" }}
     pod: {{ $responsiblePod | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.external.type "SinglePort") .Values.external.singlePort.bootstrapService.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka.fullname" . }}-external-bootstrap
+  labels:
+    app: {{ include "kafka.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.external.singlePort.bootstrapService.type }}
+  ports:
+    - name: external-broker-bootstrap
+      port: {{ .Values.external.servicePort }}
+      targetPort: external-0
+      {{- if and (eq .Values.external.singlePort.bootstrapService.type "NodePort") .Values.external.singlePort.bootstrapService.nodePort }}
+      nodePort: {{ .Values.external.singlePort.bootstrapService.nodePort }}
+      {{- end }}
+      protocol: TCP
+  selector:
+    app: {{ include "kafka.name" . | quote }}
+    release: {{ .Release.Name | quote }}
   {{- end }}
 {{- end }}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -31,12 +31,12 @@ spec:
 {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{- end }}
-    {{- if .Values.external.enabled }}
+    {{- if and .Values.external.enabled (eq .Values.external.type "MultiPort") }}
       ## ref: https://github.com/Yolean/kubernetes-kafka/blob/master/kafka/50kafka.yml
       initContainers:
       - name: init-ext
-        image: "{{ .Values.external.init.image }}:{{ .Values.external.init.imageTag }}"
-        imagePullPolicy: "{{ .Values.external.init.imagePullPolicy }}"
+        image: "{{ .Values.external.multiPort.init.image }}:{{ .Values.external.multiPort.init.imageTag }}"
+        imagePullPolicy: "{{ .Values.external.multiPort.init.imagePullPolicy }}"
         command:
           - sh
           - -euxc
@@ -71,8 +71,8 @@ spec:
         - sh
         - -exc
         - |
-          trap "exit 0" TERM; \
-          while :; do \
+          trap "exit 0" TERM
+          while :; do
           java \
           -XX:+UnlockExperimentalVMOptions \
           -XX:+UseCGroupMemoryLimitForHeap \
@@ -81,8 +81,8 @@ spec:
           -jar \
           jmx_prometheus_httpserver.jar \
           {{ .Values.prometheus.jmx.port | quote }} \
-          /etc/jmx-kafka/jmx-kafka-prometheus.yml & \
-          wait $! || sleep 3; \
+          /etc/jmx-kafka/jmx-kafka-prometheus.yml &
+          wait $! || sleep 3
           done
         ports:
         - containerPort: {{ .Values.prometheus.jmx.port }}
@@ -130,9 +130,9 @@ spec:
         - containerPort: 9092
           name: kafka
         {{- if .Values.external.enabled }}
-          {{- $replicas := .Values.replicas | int }}
+          {{- $numPorts := and (eq .Values.external.type "MultiPort") (.Values.replicas | int) | default 1 }}
           {{- $root := . }}
-          {{- range $i, $e := until $replicas }}
+          {{- range $i, $e := until $numPorts }}
         - containerPort: {{ add $root.Values.external.firstListenerPort $i }}
           name: external-{{ $i }}
           {{- end }}
@@ -155,6 +155,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        {{- if .Values.external.enabled }}
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        {{- end }}
         - name: KAFKA_HEAP_OPTS
           value: {{ .Values.kafkaHeapOptions }}
         {{- if not (hasKey .Values.configurationOverrides "zookeeper.connect") }}
@@ -181,9 +187,16 @@ spec:
         - sh
         - -exc
         - |
-          unset KAFKA_PORT && \
-          export KAFKA_BROKER_ID=${HOSTNAME##*-} && \
-          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_IP}:9092{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }} && \
+          {{- if .Values.external.enabled }}
+            {{- if eq .Values.external.type "MultiPort" }}
+          export EXTERNAL_PORT=$(( {{ .Values.external.firstListenerPort }} + ${HOSTNAME##*-}))
+            {{- else }}
+          export EXTERNAL_PORT={{ .Values.external.firstListenerPort }}
+            {{- end }}
+          {{- end }}
+          unset KAFKA_PORT
+          export KAFKA_BROKER_ID=${HOSTNAME##*-}
+          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_IP}:9092{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }}
           exec /etc/confluent/docker/run
         volumeMounts:
         - name: datadir

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -111,19 +111,39 @@ tolerations: []
 #   effect: "NoSchedule"
 
 ## External access.
-##
+  ## Note that 2 configurationOverrides are required for external access via NodePorts
+  ## 1) Set EXTERNAL traffic to use (e.g.) PLAITEXT protocol:
+  # "listener.security.protocol.map": PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+  ## 2) Advertise the EXTERNAL reachable address:port for each broker, one of:
+  ## 2a) with direct host IP
+  # "advertised.listeners": EXTERNAL://${HOST_IP}:${EXTERNAL_PORT}
+  ## 2b) with DNS and kubeproxy forwarding (requires type: MultiPort)
+  # "advertised.listeners": EXTERNAL://kafka.cluster.local:${EXTERNAL_PORT}
+  ## ref:
+  ## - http://kafka.apache.org/documentation/#security_configbroker
+  ## - https://cwiki.apache.org/confluence/display/KAFKA/KIP-103%3A+Separation+of+Internal+and+External+traffic
+  ####
 external:
   enabled: false
+  type: SinglePort ## MultiPort | SinglePort
   servicePort: 19092
   firstListenerPort: 31090
-  domain: cluster.local
-  init:
-    image: "lwolf/kubectl_deployer"
-    imageTag: "0.4"
-    imagePullPolicy: "IfNotPresent"
+#  domain: cluster.local
+  singlePort:
+    bootstrapService:
+      enabled: false
+      type: NodePort
+      nodePort: 31992
+  multiPort:
+    init:
+      image: "lwolf/kubectl_deployer"
+      imageTag: "0.4"
+      imagePullPolicy: "IfNotPresent"
 
 ## Configuration Overrides. Specify any Kafka settings you would like set on the StatefulSet
 ## here in map format, as defined in the official docs.
+## Note that "advertised.listeners" as set here is appeneded to "PLAINTEXT://${POD_IP}:9092,"
+## which is used for cluster internal traffic
 ## ref: https://kafka.apache.org/documentation/#brokerconfigs
 ##
 configurationOverrides:
@@ -132,17 +152,8 @@ configurationOverrides:
   # "auto.create.topics.enable": true
   # "controlled.shutdown.enable": true
   # "controlled.shutdown.max.retries": 100
-
-  ## Options required for external access via NodePort
-  ## ref:
-  ## - http://kafka.apache.org/documentation/#security_configbroker
-  ## - https://cwiki.apache.org/confluence/display/KAFKA/KIP-103%3A+Separation+of+Internal+and+External+traffic
-  ##
-  ## Setting "advertised.listeners" here appends to "PLAINTEXT://${POD_IP}:9092,"
-  # "advertised.listeners": |-
-  #   EXTERNAL://kafka.cluster.local:$((31090 + ${KAFKA_BROKER_ID}))
-  # "listener.security.protocol.map": |-
-  #   PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+  # "listener.security.protocol.map": PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+  # "advertised.listeners": EXTERNAL://${HOST_IP}:${EXTERNAL_PORT}
 
 ## A collection of additional ports to expose on brokers (formatted as normal containerPort yaml)
 # Useful when the image exposes metrics (like prometheus, etc.) through a javaagent instead of a sidecar


### PR DESCRIPTION
Straw-man for 2nd external access option - opinions and comments very welcome. 

I've merged in the external access implementation I've been running for a while to give 2 options in the chart - MultiPort or SinglePort.

I think we need to consider:
- Should we have 2 options in the chart?  KISS - just choose one?
- If two, which should be the default?

Very open to feedback