### PR TITLE
make config map name unique

### DIFF
--- a/incubator/elasticsearch-curator/Chart.yaml
+++ b/incubator/elasticsearch-curator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "5.4.1"
 description: A Helm chart for Elasticsearch Curator
 name: elasticsearch-curator
-version: 0.2.2
+version: 0.2.3
 home: https://github.com/elastic/curator
 keywords:
 - curator

--- a/incubator/elasticsearch-curator/templates/configmap.yaml
+++ b/incubator/elasticsearch-curator/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: curator-config
+  name: {{ template "elasticsearch-curator.fullname" . }}-config
   labels:
     app: {{ template "elasticsearch-curator.name" . }}
     chart: {{ template "elasticsearch-curator.chart" . }}

--- a/incubator/elasticsearch-curator/templates/cronjob.yaml
+++ b/incubator/elasticsearch-curator/templates/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           volumes:
             - name: config-volume
               configMap:
-                name: curator-config
+                name: {{ template "elasticsearch-curator.fullname" . }}-config
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 12 }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently you cannot deploy more than one instance of curator at a time as the cm resource name is hardcoded. This now uses the fullname, which has the release name in it.

**Special notes for your reviewer**:
none.
