### PR TITLE
Use wildcard for ingress backend. Ensures /v1/health etc work correctly

### DIFF
--- a/incubator/goldfish/Chart.yaml
+++ b/incubator/goldfish/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Goldfish - Vault UI
 name: goldfish
-version: 0.2.6
+version: 0.2.7
 icon: https://github.com/Caiyeon/goldfish/blob/master/frontend/client/assets/logo@2x.png?raw=true
 home: https://vault-ui.io
 appVersion: 0.9.0

--- a/incubator/goldfish/templates/ingress.yaml
+++ b/incubator/goldfish/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}


### PR DESCRIPTION
@tuannvm @mlaccetti Without this, I found hitting /v1/health would return `404 - default backend` when using an Ingress
