### PR TITLE
added optional `web.logLevel` for setting $CONCOURSE_LOG_LEVEL

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.10.1
+version: 1.10.2
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -102,6 +102,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `concourse.genericOauth.authUrlParam` | Parameters (comma separated) to pass to the authentication server AuthURL | `nil` |
 | `concourse.genericOauth.scope` | Optional scope required to authorize user | `nil` |
 | `concourse.genericOauth.tokenUrl` | Generic OAuth provider TokenURL endpoint | `nil` |
+| `web.logLevel` | Override the Concourse Web logging level. E.g: debug, warn, error (concourse defaults to info) | `nil` |
 | `web.nameOverride` | Override the Concourse Web components name | `nil` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -331,6 +331,10 @@ spec:
             - name: CONCOURSE_INFLUXDB_INSECURE_SKIP_VERIFY
               value: {{ .Values.web.metrics.influxdb.insecureSkipVerify | quote}}
             {{- end }}
+            {{- if .Values.web.logLevel }}
+            - name: CONCOURSE_LOG_LEVEL
+              value: {{ .Values.web.logLevel | quote }}
+            {{- end }}
           ports:
             - name: atc
               containerPort: {{ .Values.concourse.atcPort }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -178,6 +178,11 @@ concourse:
 ## Configuration values for Concourse Web components.
 ##
 web:
+  ## Modify the log level (defaults to info)
+  ## options are: debug|info|error|fatal
+  ##
+  # logLevel: info
+
   ## Override the components name (defaults to web).
   ##
   # nameOverride:


### PR DESCRIPTION
This allows for the setting of  debug, warn, error, info etc..

NB: without this set concourse (web) defaults to `info`