### PR TITLE
[stable/metallb]: Add support for nodeSelector/affinity/tolerations

### DIFF
--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -87,23 +87,13 @@ By default, this chart does not install a configuration for MetalLB, and simply
 warns you that you must follow [the configuration instructions on MetalLB's
 website][metallb-config] to create an appropriate ConfigMap.
 
-For simple setups that only use MetalLB's [ARP mode][metallb-arpndp-concepts],
-you can specify a single IP range using the `arpAddresses` parameter to have the
-chart install a working configuration for you:
-
-```console
-$ helm install --name metallb \
-  --set arpAddresses=192.168.16.240/30 \
-  stable/metallb
-```
-
-If you have a more complex configuration and want Helm to manage it for you, you
-can provide it in the `config` parameter. The configuration format is
-[documented on MetalLB's website][metallb-config].
+If you have a configuration and want Helm to manage it for you, you can provide
+it in the `configInline` parameter. The configuration format is [documented on
+MetalLB's website][metallb-config].
 
 ```console
 $ cat values.yaml
-config:
+configInline:
   peers:
   - peer-address: 10.0.0.1
     peer-asn: 64512

--- a/stable/metallb/templates/controller.yaml
+++ b/stable/metallb/templates/controller.yaml
@@ -52,3 +52,15 @@ spec:
             drop:
             - all
           readOnlyRootFilesystem: true
+    {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.controller.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/metallb/templates/speaker.yaml
+++ b/stable/metallb/templates/speaker.yaml
@@ -56,3 +56,15 @@ spec:
             - all
             add:
             - net_raw
+    {{- with .Values.speaker.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.speaker.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.speaker.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -59,6 +59,9 @@ controller:
     # limits:
       # cpu: 100m
       # memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 # speaker contains configuration specific to the MetalLB speaker
 # daemonset.
@@ -71,3 +74,6 @@ speaker:
     # limits:
       # cpu: 100m
       # memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
Adds support for nodeSelector/affinity/tolerations for both the speaker
and controller pods.

Additionally, a second commit includes some minor README fixes.