### PR TITLE
[eventrouter] fix CrashLoopBackOff

### DIFF
--- a/stable/eventrouter/Chart.yaml
+++ b/stable/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.2
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/stable/eventrouter/templates/configmap.yaml
+++ b/stable/eventrouter/templates/configmap.yaml
@@ -9,5 +9,5 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "sink": {{ .Values.sink }}
+      "sink": "{{ .Values.sink }}"
     }


### PR DESCRIPTION
Because the current configmap is created without quotes the event router pod cannot start.
```
$ k get pods -n kube-system 
kube-system-eventrouter-9bcbc8495-mjtmg                            0/1       CrashLoopBackOff    2          40s
```

```
$ k logs -f -n kube-system kube-system-eventrouter-9bcbc8495-mjtmg
panic: While parsing config: invalid character 'g' looking for beginning of value

goroutine 1 [running]:
main.loadConfig(0x116ae00, 0xc42031f8f0)
	/go/src/github.com/heptiolabs/eventrouter/main.go:77 +0x415
main.main()
	/go/src/github.com/heptiolabs/eventrouter/main.go:108 +0x43
```