### PR TITLE
[concourse] Add service which targets prometheus port when prometheus metrics are enabled

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.10.1
+version: 1.11.0
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -20,6 +20,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "concourse.prometheus.fullname" -}}
+{{- $name := default "web" .Values.web.nameOverride -}}
+{{- printf "%s-%s-prometheus" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "concourse.worker.fullname" -}}
 {{- $name := default "worker" .Values.worker.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/stable/concourse/templates/web-prometheus-svc.yaml
+++ b/stable/concourse/templates/web-prometheus-svc.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  type: ClusterIP
+  clusterIP: "None"
   ports:
     - name: prometheus
       port: {{ .Values.web.metrics.prometheus.port }}

--- a/stable/concourse/templates/web-prometheus-svc.yaml
+++ b/stable/concourse/templates/web-prometheus-svc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.web.metrics.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "concourse.prometheus.fullname" . }}
+  labels:
+    app: {{ template "concourse.prometheus.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: ClusterIP
+  ports:
+    - name: prometheus
+      port: {{ .Values.web.metrics.prometheus.port }}
+      targetPort: prometheus
+  selector:
+    app: {{ template "concourse.web.fullname" . }}
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add a service that targets the prometheus metrics endpoint on the concourse webserver
- Use a service instead of prometheus.io labels as recommended for prometheus-operator (https://github.com/coreos/kube-prometheus/pull/16#issuecomment-305933103)


**Special notes for your reviewer**:
