### PR TITLE
openvpn: nodeSelector option in Deployment template.

### DIFF
--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -54,6 +54,10 @@ spec:
             {{- end }}
             name: certs
             readOnly: false
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
       volumes:
       - name: openvpn
         configMap:

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -3,6 +3,8 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
+nodeSelector: {}
+
 updateStrategy: {}
   # type: RollingUpdate
   # rollingUpdate:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR adds the `nodeSelector` option to the openvpn Deployment template from `stable/openvpn` Chart. It is needed to pin a working OpenVPN instance to a designated node in some use cases.

**Special notes for your reviewer**:

none, just a tiny improvement.

Thank you!
