### PR TITLE
Elasticsearch tolerations

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.1.4
+version: 1.2.0
 appVersion: 6.1.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.1.3
+version: 1.1.4
 appVersion: 6.1.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.heapSize`                    | Client node heap size                                               | `512m`                               |
 | `client.podAnnotations`              | Client Deployment annotations                                       | `{}`                                 |
 | `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
+| `client.tolerations`                 | Client tolerations                                                  | `{}`                                 |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                 |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                          |
 | `master.exposeHttp`                  | Expose http port 9200 on master Pods for monitoring, etc            | `false`                              |
@@ -85,6 +86,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.resources`                   | Master node resources requests & limits                             | `{} - cpu limit must be an integer`  |
 | `master.podAnnotations`              | Master Deployment annotations                                       | `{}`                                 |
 | `master.nodeSelector`                | Node labels for master pod assignment                               | `{}`                                 |
+| `master.tolerations`                 | Master tolerations                                                  | `{}`                                 |
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
@@ -103,6 +105,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |
 | `data.podAnnotations`                | Data StatefulSet annotations                                        | `{}`                                 |
 | `data.nodeSelector`                  | Node labels for data pod assignment                                 | `{}`                                 |
+| `data.tolerations`                   | Data tolerations                                                    | `{}`                                 |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
 

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -49,6 +49,9 @@ spec:
 {{- if .Values.client.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.client.nodeSelector | indent 8 }}
+{{- if .Values.client.tolerations }}
+      tolerations:
+{{ toYaml .Values.client.tolerations | indent 8 }}
 {{- end }}
       initContainers:
       # see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -49,6 +49,7 @@ spec:
 {{- if .Values.client.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.client.nodeSelector | indent 8 }}
+{{- end }}
 {{- if .Values.client.tolerations }}
       tolerations:
 {{ toYaml .Values.client.tolerations | indent 8 }}

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
 {{- if .Values.data.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.data.nodeSelector | indent 8 }}
+{{- if .Values.data.tolerations }}
+      tolerations:
+{{ toYaml .Values.data.tolerations | indent 8 }}
 {{- end }}
       initContainers:
       # see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -50,6 +50,7 @@ spec:
 {{- if .Values.data.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.data.nodeSelector | indent 8 }}
+{{- end }}
 {{- if .Values.data.tolerations }}
       tolerations:
 {{ toYaml .Values.data.tolerations | indent 8 }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -50,6 +50,7 @@ spec:
 {{- if .Values.master.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.master.nodeSelector | indent 8 }}
+{{- end }}
 {{- if .Values.master.tolerations }}
       tolerations:
 {{ toYaml .Values.master.tolerations | indent 8 }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
 {{- if .Values.master.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.master.nodeSelector | indent 8 }}
+{{- if .Values.master.tolerations }}
+      tolerations:
+{{ toYaml .Values.master.tolerations | indent 8 }}
 {{- end }}
       initContainers:
       # see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -33,6 +33,7 @@ client:
   heapSize: "512m"
   antiAffinity: "soft"
   nodeSelector: {}
+  tolerations: {}
   resources:
     limits:
       cpu: "1"
@@ -58,6 +59,7 @@ master:
     # storageClass: "ssd"
   antiAffinity: "soft"
   nodeSelector: {}
+  tolerations: {}
   resources:
     limits:
       cpu: "1"
@@ -84,6 +86,7 @@ data:
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"
   nodeSelector: {}
+  tolerations: {}
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
**What this PR does / why we need it**: Adds ability to configure tolerations within the client deployment and master/data stateful sets.