### PR TITLE
Add google-cloud-tasks-pull-to-push chart to incubator

### DIFF
--- a/incubator/google-cloud-tasks-pull-to-push/Chart.yaml
+++ b/incubator/google-cloud-tasks-pull-to-push/Chart.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+name: google-cloud-tasks-pull-to-push
+description: Google Cloud Tasks Push queue for arbitrary URLs.
+version: 0.1.0
+appVersion: 0.1.0
+home: https://github.com/tclift/google-cloud-tasks-pull-to-push
+sources:
+- https://github.com/tclift/google-cloud-tasks-pull-to-push
+maintainers:
+- name: tclift
+  email: tom@clift.id.au

--- a/incubator/google-cloud-tasks-pull-to-push/README.md
+++ b/incubator/google-cloud-tasks-pull-to-push/README.md
@@ -1,0 +1,17 @@
+# google-cloud-tasks-pull-to-push
+
+Google Cloud Tasks Push queue emulation for arbitrary destination URLs (if you need it, you know).
+
+See [github:tclift/google-cloud-tasks-pull-to-push](https://github.com/tclift/google-cloud-tasks-pull-to-push).
+
+
+## GCP Authentication
+
+It is best to use a service account with a JSON credentials file rather than the Application Default Credentials, as the
+ADC belong to the cluster, and giving the cluster's service account permissions to Cloud Tasks is likely both
+undesirable and (at time of writing) requires creation of a new node pool to modify.
+
+Create a secret with key `credentials.json`, and put the secret name in `credentialsSecret` in `values.yaml`.
+
+    kubectl create secret generic google-cloud-tasks-pull-to-push-credentials \
+      --from-file=credentials.json=./my-credentials.json

--- a/incubator/google-cloud-tasks-pull-to-push/templates/NOTES.txt
+++ b/incubator/google-cloud-tasks-pull-to-push/templates/NOTES.txt
@@ -1,0 +1,2 @@
+Add your GCP project id to google-cloud-tasks-pull-to-push.project in values.yaml.
+See README.md for additional configuration.

--- a/incubator/google-cloud-tasks-pull-to-push/templates/_helpers.tpl
+++ b/incubator/google-cloud-tasks-pull-to-push/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/google-cloud-tasks-pull-to-push/templates/deployment.yaml
+++ b/incubator/google-cloud-tasks-pull-to-push/templates/deployment.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "chart.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "chart.name" . }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: {{ template "chart.fullname" . }}
+      labels:
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        app: {{ template "chart.name" . }}
+    spec:
+      {{- if .Values.restartPolicy }}
+      restartPolicy: {{ .Values.restartPolicy }}
+      {{- end}}
+      containers:
+      - name: google-cloud-tasks-pull-to-push
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        {{- if .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- end}}
+        args:
+        - --project={{ .Values.project }}
+        {{- if .Values.location }}
+        - --location={{ .Values.location}}
+        {{- end}}
+        {{- if .Values.queue }}
+        - --queue={{ .Values.queue }}
+        {{- end}}
+        {{- if .Values.rate }}
+        - --rate={{ .Values.rate }}
+        {{- end}}
+        {{- if .Values.leaseDuration }}
+        - --lease-duration={{ .Values.leaseDuration }}
+        {{- end}}
+        {{- if .Values.pull }}
+        {{- if .Values.pull.minBackoff }}
+        - --pull-min-backoff={{ .Values.pull.minBackoff }}
+        {{- end}}
+        {{- if .Values.pull.maxBackoff }}
+        - --pull-max-backoff={{ .Values.pull.maxBackoff }}
+        {{- end}}
+        {{- if .Values.pull.maxDoublings }}
+        - --pull-max-doublings={{ .Values.pull.maxDoublings }}
+        {{- end}}
+        {{- end}}
+        {{- if .Values.push }}
+        {{- if .Values.push.minBackoff }}
+        - --push-min-backoff={{ .Values.push.minBackoff }}
+        {{- end}}
+        {{- if .Values.push.maxBackoff }}
+        - --push-max-backoff={{ .Values.push.maxBackoff }}
+        {{- end}}
+        {{- if .Values.push.maxDoublings }}
+        - --push-max-doublings={{ .Values.push.maxDoublings }}
+        {{- end}}
+        {{- end}}
+        env:
+        {{- if .Values.credentialsSecret }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /app/auth/credentials.json
+        {{- end}}
+        {{- if .Values.resources }}
+        resources:
+    {{ toYaml .Values.resources | trim | indent 6 }}
+        {{- end}}
+        {{- if .Values.credentialsSecret }}
+        volumeMounts:
+        - name: gcp-credentials
+          mountPath: /app/auth
+          readOnly: true
+        {{- end}}
+      {{- if .Values.credentialsSecret }}
+      volumes:
+      - name: gcp-credentials
+        secret:
+          secretName: {{ .Values.credentialsSecret }}
+      {{- end}}

--- a/incubator/google-cloud-tasks-pull-to-push/values.yaml
+++ b/incubator/google-cloud-tasks-pull-to-push/values.yaml
@@ -1,0 +1,32 @@
+---
+credentialsSecret: google-cloud-tasks-pull-to-push-credentials
+project: my-project
+#location: us-central1
+#queue: pull-to-push
+#rate: 1s
+#leaseDuration: 1m
+#pull:
+#  minBackoff: 2s
+#  maxBackoff: 30s
+#  maxDoublings: 4
+#push:
+#  minBackoff: 5s
+#  maxBackoff: 1h
+#  maxDoublings: 5
+
+image:
+  repository: tclift/google-cloud-tasks-pull-to-push
+  tag: 0.1.0
+#  pullPolicy: IfNotPresent
+
+# max memory will depend on your task payload sizes
+#resources:
+#  requests:
+#    cpu: '0.002'
+#    memory: '30Mi'
+#  limits:
+#    cpu: '0.05'
+#    memory: '100Mi'
+
+#nameOverride: google-cloud-tasks-pull-to-push
+#restartPolicy: Always


### PR DESCRIPTION
**What this PR does / why we need it**: New incubator chart for the `google-cloud-tasks-pull-to-push` tool. This tool is for a GCP-specific purpose: to work around the inability of Google Cloud Tasks push queues to target arbitrary URLs (they can currently only target App Engine hosted URLs).

**Special notes for your reviewer**: At the moment I don't know of any other users of this tool / chart. Is this suitable for adding to the chart repo? The guidelines don't mention 'notability' 😄. Being in the repo would at least simplify deployment for me.
