### PR TITLE
Expose prometheus on service

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.11.0
+version: 1.11.1
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -36,5 +36,10 @@ spec:
       {{ if and (eq "NodePort" .Values.web.service.type) .Values.web.service.tsaNodePort }}
       nodePort: {{ .Values.web.service.tsaNodePort}}
       {{ end }}
+    {{- if .Values.web.metrics.prometheus.enabled }}
+    - name: prometheus
+      port: {{ .Values.web.metrics.prometheus.port }}
+      targetPort: prometheus
+    {{- end }}
   selector:
     app: {{ template "concourse.web.fullname" . }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes the prometheus port on the service. I think it makes sense to collect the metrics from the service rather than the pod.
