### PR TITLE
[stable/concourse] add support for custom envvars for the web containers

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.11.0
+version: 1.12.0
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |
 | `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
+| `web.env` | Configure additional environment variables for the web containers | `[]` |
 | `web.annotations`| Concourse Web deployment annotations | `nil` |
 | `web.tolerations` | Tolerations for the web nodes | `[]` |
 | `web.nodeSelector` | Node selector for web nodes | `{}` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -335,6 +335,9 @@ spec:
             - name: CONCOURSE_INFLUXDB_INSECURE_SKIP_VERIFY
               value: {{ .Values.web.metrics.influxdb.insecureSkipVerify | quote}}
             {{- end }}
+{{- if .Values.web.env }}
+{{ toYaml .Values.web.env | indent 12 }}
+{{- end }}
           ports:
             - name: atc
               containerPort: {{ .Values.concourse.atcPort }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -194,6 +194,14 @@ web:
       cpu: "100m"
       memory: "128Mi"
 
+  ## Configure additional environment variables for the
+  ## web containers.
+  # env:
+  #   - name: CONCOURSE_LOG_LEVEL
+  #     value: "debug"
+  #   - name: CONCOURSE_TSA_LOG_LEVEL
+  #     value: "debug"
+
   ## Additional affinities to add to the web pods.
   ##
   # additionalAffinities:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for providing custom environment variables to the "web" containers. This can be useful for eg. increasing the log level of Concourse for debugging purposes.