### PR TITLE
[stable/rabbitmq-ha] align to using same headless config as prometheus

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.4
-version: 1.6.2
+version: 1.6.3
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -120,7 +120,7 @@ and their default values.
 | `serviceAccount.create`            | Create service account                                          | `true`                                                   |
 | `serviceAccount.name`              | Service account name to use                                     | _name of the release_                                    |
 | `service.annotations`              | Annotations to add to the service                               | `{}`                                                     |
-| `service.clusterIP`                | IP address to assign to the service                             | `""`                                                     |
+| `service.clusterIP`                | IP address to assign to the service                             | `None`                                                     |
 | `service.externalIPs`              | Service external IP addresses                                   | `[]`                                                     |
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)            | `""`                                                     |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`                                                     |

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -148,7 +148,7 @@ terminationGracePeriodSeconds: 10
 
 service:
   annotations: {}
-  clusterIP: ""
+  clusterIP: None
 
   ## List of IP addresses at which the service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently seeing `Service is invalid`, `spec.clusterIP: Invalid value: "": field is immutable` errors on upgrade with the default config, as per https://github.com/kubernetes/charts/issues/6442. This is the same message that a previous version of stable/prometheus had (https://github.com/kubernetes/charts/issues/5128) and that was [resolved by switching clusterIP "" to None in that chart's default config](https://github.com/kubernetes/charts/pull/5529)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Closes https://github.com/kubernetes/charts/issues/6442