### PR TITLE
[stable/keycloak] make sure user is added

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 3.0.2
+version: 3.0.3
 appVersion: 4.0.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/templates/configmap.yaml
+++ b/stable/keycloak/templates/configmap.yaml
@@ -15,6 +15,8 @@ data:
     set -eu
 
     /opt/jboss/keycloak/bin/jboss-cli.sh --file=/scripts/keycloak.cli
+    /opt/jboss/keycloak/bin/add-user.sh -u $KEYCLOAK_USER -p $KEYCLOAK_PASSWORD
+    /opt/jboss/keycloak/bin/add-user-keycloak.sh -r master -u $KEYCLOAK_USER -p $KEYCLOAK_PASSWORD
 
   {{- with .Values.keycloak.preStartScript }}
     echo 'Running custom pre-start script...'


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the user doesn't seem to reliably be added - see https://github.com/kubernetes/charts/issues/6373.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #6373

**Special notes for your reviewer**:

The env vars are available already because the configmap is mounted to the statefulset. These shell scripts are [provided](https://www.keycloak.org/docs/3.2/getting_started/topics/first-boot/initial-user.html) with [keycloak](https://github.com/keycloak/keycloak/blob/master/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/add-user-keycloak.sh). 

Using them results in extra logging that the user is added but it doesn't log the password as far as I can see.

The [script](https://github.com/keycloak/keycloak/blob/master/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/add-user-keycloak.sh) [calls](https://github.com/keycloak/keycloak/blob/master/distribution/feature-packs/server-feature-pack/src/main/resources/content/bin/add-user-keycloak.sh#L71) another piece of code that [does a check if the user is already present](https://github.com/keycloak/keycloak/blob/e1a0e581b91383f432325ec297523abd784ec214/wildfly/adduser/src/main/java/org/keycloak/wildfly/adduser/AddUser.java#L150) but it [just logs the message if the user is present already](https://github.com/keycloak/keycloak/blob/e1a0e581b91383f432325ec297523abd784ec214/wildfly/adduser/src/main/java/org/keycloak/wildfly/adduser/AddUser.java#L84). Using this I have seen this logging on pod startup:

```
09:28:29,879 INFO  [org.jboss.as] (MSC service thread 1-4) WFLYSRV0050: Keycloak 4.0.0.Final (WildFly Core 3.0.8.Final) stopped in 5ms
Added user 'keycloak' to file '/opt/jboss/keycloak/standalone/configuration/mgmt-users.properties'
Added user 'keycloak' to file '/opt/jboss/keycloak/domain/configuration/mgmt-users.properties'
Added 'keycloak' to '/opt/jboss/keycloak/standalone/configuration/keycloak-add-user.json', restart server to load user
User with username 'keycloak' already added to '/opt/jboss/keycloak/standalone/configuration/keycloak-add-user.json'
=========================================================================
```
The same 'already added' message that the script produces. And it goes on to start without error. So I think it is idempotent. I've not tested with multiple replicas and a shared db but the worst that could happen should be that we see that 'already added' message.