### PR TITLE
add configurable path for liveness / readinessProbe

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.5.0
+version: 1.5.1
 appVersion: 3.12.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -75,9 +75,11 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.livenessProbe.initialDelaySeconds`   | LivenessProbe initial delay         | 30                                      |
 | `nexus.livenessProbe.periodSeconds`         | Seconds between polls               | 30                                      |
 | `nexus.livenessProbe.failureThreshold`      | Number of attempts before failure   | 6                                       |
+| `nexus.livenessProbe.path`                  | Path for LivenessProbe              | /                                       |
 | `nexus.readinessProbe.initialDelaySeconds`  | ReadinessProbe initial delay        | 30                                      |
 | `nexus.readinessProbe.periodSeconds`        | Seconds between polls               | 30                                      |
 | `nexus.readinessProbe.failureThreshold`     | Number of attempts before failure   | 6                                       |
+| `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
 | `nexusProxy.port`                           | Port for exposing Nexus             | `8080`                                  |
 | `nexusProxy.imageName`                      | Proxy image                         | `quay.io/travelaudience/docker-nexus-proxy` |
 | `nexusProxy.imageTag`                       | Proxy image version                 | `2.1.0`                                 |

--- a/stable/sonatype-nexus/templates/deployment.yaml
+++ b/stable/sonatype-nexus/templates/deployment.yaml
@@ -35,14 +35,14 @@ spec:
               name: nexus-http
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.nexus.livenessProbe.path }}
               port: {{ .Values.nexus.nexusPort }}
             initialDelaySeconds: {{ .Values.nexus.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.nexus.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.nexus.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.nexus.readinessProbe.path }}
               port: {{ .Values.nexus.nexusPort }}
             initialDelaySeconds: {{ .Values.nexus.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.nexus.readinessProbe.periodSeconds }}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -31,10 +31,12 @@ nexus:
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 6
+    path: /
   readinessProbe:
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 6
+    path: /
 
 nexusProxy:
   imageName: quay.io/travelaudience/docker-nexus-proxy


### PR DESCRIPTION
The path for livenessProbe/readiness probe is configurable now. I run an installation of nexus2.x with this chart. The nexus-2.x images are listening on path /nexus.
@rjkernick