### PR TITLE
Match dashboard provider path to mount point

### DIFF
--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -148,7 +148,8 @@ dashboardProviders: {}
 #      disableDeletion: false
 #      editable: true
 #      options:
-#        path: /var/lib/grafana/default/dashboards
+#        path: /var/lib/grafana/dashboards/default
+               
 
 ## Configure grafana dashboard to import
 ## NOTE: To use dashboards you must also enable/configure dashboardProviders


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the comments match the implementation.
When `dashboardProviders` are defined their path should match the mount point.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
