### PR TITLE
[stable/eventrouter] fix ConfigMap value

### DIFF
--- a/stable/eventrouter/Chart.yaml
+++ b/stable/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventruter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.2
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/stable/eventrouter/templates/configmap.yaml
+++ b/stable/eventrouter/templates/configmap.yaml
@@ -9,5 +9,5 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "sink": {{ .Values.sink }}
+      "sink": "{{ .Values.sink }}"
     }


### PR DESCRIPTION
ConfigMap value was missing `"` around the sink value.