### PR TITLE
[stable/dokuwiki] Delete duplicated word and some small typos

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: dokuwiki
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.20180422.201805030840
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/stable/dokuwiki/README.md
+++ b/stable/dokuwiki/README.md
@@ -1,6 +1,6 @@
 # DokuWiki
 
-[DokuWiki](https://www.dokuwiki.org) DokuWiki is a standards-compliant, simple to use wiki optimized for creating documentation. It is targeted at developer teams, workgroups, and small companies. All data is stored in plain text files, so no database is required.
+[DokuWiki](https://www.dokuwiki.org) is a standards-compliant, simple to use wiki optimized for creating documentation. It is targeted at developer teams, workgroups, and small companies. All data is stored in plain text files, so no database is required.
 
 ## TL;DR;
 
@@ -46,8 +46,8 @@ The following table lists the configurable parameters of the DokuWiki chart and 
 |              Parameter               |               Description                                  |                   Default                     |
 |--------------------------------------|------------------------------------------------------------|-----------------------------------------------|
 | `image.registry`                     | DokuWiki image registry                                    | `docker.io`                                   |
-| `image.repository`                   | DokuWiki Image name                                        | `bitnami/dokuwiki`                            |
-| `image.tag`                          | DokuWiki Image tag                                         | `{VERSION}`                                   |
+| `image.repository`                   | DokuWiki image name                                        | `bitnami/dokuwiki`                            |
+| `image.tag`                          | DokuWiki image tag                                         | `{VERSION}`                                   |
 | `image.pullPolicy`                   | Image pull policy                                          | `Always`                                      |
 | `image.pullSecrets`                  | Specify image pull secrets                                 | `nil`                                         |
 | `dokuwikiUsername`                   | User of the application                                    | `user`                                        |


### PR DESCRIPTION
Line 3: [DokuWiki](https://www.dokuwiki.org) DokuWiki is a ...
The word DokuWiki is duplicated.