### PR TITLE
[stable/verdaccio] Upgrade Verdaccio to 3.2

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.3.0
+version: 0.4.0
 appVersion: 3.2
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/README.md
+++ b/stable/verdaccio/README.md
@@ -53,9 +53,9 @@ and their default values.
 | Parameter                          | Description                                                     | Default                                                  |
 | ---------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------- |
 | `customConfigMap`                  | Use a custom ConfigMap                                          | `false`                                                  |
-| `image.pullPolicy`                 | Image pull policy                                               | `Always` if `image` tag is `latest`, else `IfNotPresent` |
+| `image.pullPolicy`                 | Image pull policy                                               | `IfNotPresent`                                           |
 | `image.repository`                 | Verdaccio container image repository                            | `verdaccio/verdaccio`                                    |
-| `image.tag`                        | Verdaccio container image tag                                   | `3.2`                                                  |
+| `image.tag`                        | Verdaccio container image tag                                   | `3.2`                                                    |
 | `nodeSelector`                     | Node labels for pod assignment                                  | `{}`                                                     |
 | `persistence.accessMode`           | PVC Access Mode for Verdaccio volume                            | `ReadWriteOnce`                                          |
 | `persistence.enabled`              | Enable persistence using PVC                                    | `true`                                                   |


### PR DESCRIPTION
- upgrade Verdaccio to 3.2, [release note](https://github.com/verdaccio/verdaccio/blob/master/CHANGELOG.md)
- simplify duplication of port mapping