### PR TITLE
[stable/grafana] Fix NOTES.txt error 

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.12.0
+version: 1.12.1
 appVersion: 5.1.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/NOTES.txt
+++ b/stable/grafana/templates/NOTES.txt
@@ -22,7 +22,7 @@
      export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grafana.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
      http://$SERVICE_IP:{{ .Values.service.port -}}
 {{ else if contains "ClusterIP"  .Values.service.type }}
-     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grafana.fullname" . }},component={{ .Values.name }}" -o jsonpath="{.items[0].metadata.name}")
+     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grafana.name" . }}" -o jsonpath="{.items[0].metadata.name}")
      kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `export POD_NAME` command in `NOTES.txt` for `stable/grafana` chart. This command currently fails as there is no `component` label assigned to the pods and incorrect use of the `fullname` attribute (this includes the release name) to target the `app` label.

**Special notes for your reviewer**:

FYI @zanhsieh and @rtluckie 🙂