### PR TITLE
support nodePort service type in rabbitmq-ha chart

### DIFF
--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -15,7 +15,9 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
 spec:
+{{- if ne .Values.service.type "NodePort" }}
   clusterIP: "{{ .Values.service.clusterIP }}"
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}
@@ -31,14 +33,23 @@ spec:
     - name: http
       protocol: TCP
       port: {{ .Values.rabbitmqManagerPort }}
+     {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.rabbitmqManagerNodePort }}
+     {{- end }}
       targetPort: http
     - name: amqp
       protocol: TCP
       port: {{ .Values.rabbitmqNodePort }}
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.rabbitmqNodeNodePort }}
+      {{- end }}
       targetPort: amqp
     - name: epmd
       protocol: TCP
       port: {{ .Values.rabbitmqEpmdPort }}
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.rabbitmqEpmdNodePort }}
+      {{- end }}
       targetPort: epmd
     {{- if .Values.rabbitmqSTOMPPlugin.enabled }}
     - name: stomp-tcp

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -23,12 +23,24 @@ rabbitmqMemoryHighWatermark: 256MB
 ## Ref: https://www.rabbitmq.com/clustering.html
 ##
 rabbitmqEpmdPort: 4369
+## Customize nodePort number when service type is NodePort
+## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+##
+# rabbitmqEpmdNodePort: 31369
 
 ## Node port
 rabbitmqNodePort: 5672
+## Customize nodePort number when service type is NodePort
+## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+##
+# rabbitmqNodeNodePort: 30672
 
 ## Manager port
 rabbitmqManagerPort: 15672
+## Customize nodePort number when service type is NodePort
+## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+##
+# rabbitmqManagerNodePort: 31672
 
 ## Set to true to precompile parts of RabbitMQ with HiPE, a just-in-time
 ## compiler for Erlang. This will increase server throughput at the cost of


### PR DESCRIPTION
**What this PR does / why we need it**:
Add NodePort service type in rabbitmq-ha。By setting parameters, you can customize the exposed node port number. Also, K8s will randomly select the exposed node port number if you have not set it.

**Special notes for your reviewer**:
Thanks for taking the time to review this pr, let me know if there is any need for improvement. Thank you.