### PR TITLE
Make liveness and readiness settings configurable for the metrics con…

### DIFF
--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -133,14 +133,14 @@ spec:
           httpGet:
             path: /metrics
             port: metrics
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
             path: /metrics
             port: metrics
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
+          initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
       {{- end }}        

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -100,6 +100,12 @@ metrics:
   annotations: {}
     # prometheus.io/scrape: "true"
     # prometheus.io/port: "9104"
+  livenessProbe:
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+  readinessProbe:
+    initialDelaySeconds: 5
+    timeoutSeconds: 1
 
 ## Configure the service
 ## ref: http://kubernetes.io/docs/user-guide/services/


### PR DESCRIPTION
Need to make liveness / readiness settings configurable for the metrics container.
Background: Low timeout values may mark the metrics container unavailable, which in turn means new connections to mysql cannot be made.