### PR TITLE
[incubator/elasticsearch] consistently check .Values.appVersion for older Elasticsearch versions

### DIFF
--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -109,12 +109,12 @@ spec:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
-{{- if hasPrefix "2." .Values.image.tag }}
+{{- if hasPrefix "2." .Values.appVersion }}
         - mountPath: /usr/share/elasticsearch/config/logging.yml
           name: config
           subPath: logging.yml
 {{- end }}
-{{- if hasPrefix "5." .Values.image.tag }}
+{{- if hasPrefix "5." .Values.appVersion }}
         - mountPath: /usr/share/elasticsearch/config/log4j2.properties
           name: config
           subPath: log4j2.properties

--- a/incubator/elasticsearch/templates/configmap.yaml
+++ b/incubator/elasticsearch/templates/configmap.yaml
@@ -76,7 +76,7 @@ data:
 {{- if .Values.cluster.config }}
 {{ toYaml .Values.cluster.config | indent 4 }}
 {{- end }}
-{{- if hasPrefix "2." .Values.image.tag }}
+{{- if hasPrefix "2." .Values.appVersion }}
   logging.yml: |-
     # you can override this using by setting a system property, for example -Des.logger.level=DEBUG
     es.logger.level: INFO
@@ -92,7 +92,7 @@ data:
         layout:
           type: consolePattern
           conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
-{{- else if hasPrefix "5." .Values.image.tag }}
+{{- else if hasPrefix "5." .Values.appVersion }}
   log4j2.properties: |-
     status = error
     appender.console.type = Console
@@ -103,7 +103,7 @@ data:
     rootLogger.appenderRef.console.ref = console
     logger.searchguard.name = com.floragunn
     logger.searchguard.level = info
-{{- else if hasPrefix "6." .Values.image.tag }}
+{{- else if hasPrefix "6." .Values.appVersion }}
   log4j2.properties: |-
     status = error
     appender.console.type = Console

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -116,12 +116,12 @@ spec:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
-{{- if hasPrefix "2." .Values.image.tag }}
+{{- if hasPrefix "2." .Values.appVersion }}
         - mountPath: /usr/share/elasticsearch/config/logging.yml
           name: config
           subPath: logging.yml
 {{- end }}
-{{- if hasPrefix "5." .Values.image.tag }}
+{{- if hasPrefix "5." .Values.appVersion }}
         - mountPath: /usr/share/elasticsearch/config/log4j2.properties
           name: config
           subPath: log4j2.properties

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -120,12 +120,12 @@ spec:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
-{{- if hasPrefix "2." .Values.image.tag }}
+{{- if hasPrefix "2." .Values.appVersion }}
         - mountPath: /usr/share/elasticsearch/config/logging.yml
           name: config
           subPath: logging.yml
 {{- end }}
-{{- if hasPrefix "5." .Values.image.tag }}
+{{- if hasPrefix "5." .Values.appVersion }}
         - mountPath: /usr/share/elasticsearch/config/log4j2.properties
           name: config
           subPath: log4j2.properties


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the checks for older Elasticsearch versions use either `.Values.appVersion` or `.Values.image.tag`. Imho this can lead to unexpected behavior.

This PR consistently uses `.Values.appVersion` over `.Values.image.tag` across all templates. This enables users to use non-semantic image tags without breaking the chart. It is also a bit more resilient, should Elastic ever decide move away from semantic versioning for the official docker images.

**Special notes for your reviewer**:

@simonswine @icereval @rendhalver 