### PR TITLE
[stable/grafana] Add delay for liveness as readiness Probe

### DIFF
--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -197,6 +197,10 @@ spec:
             httpGet:
               path: /api/health
               port: 3000
+            initialDelaySeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 10
+            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /api/health


### PR DESCRIPTION
**What this PR does / why we need it**:
It wait a longer times (livenessprobe) before restarting the container at startup.
Without this, liveness will fail and container will be restarted during DB migration. Next container start will fail because trying to make DB changes already applied.
