### PR TITLE
cert-manager: fast-forward to upstream 90742f35

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.3.3
-appVersion: v0.3.1
+version: v0.3.4
+appVersion: v0.3.2
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.3.1` |
+| `image.tag` | Image tag | `v0.3.2` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.3.1
+  tag: v0.3.2
   pullPolicy: IfNotPresent
 
 createCustomResource: true


### PR DESCRIPTION
This PR updates the Helm chart for the latest release of cert-manager, containing a critical bugfix.

* Bump Helm chart for v0.3.2 (jetstack/cert-manager#702)
