### PR TITLE
[stable/mongodb-replicaset] Avoid unnecessary initialization

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.5.1
+version: 3.5.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -94,7 +94,12 @@ fi
 log "Peers: ${peers[*]}"
 
 log "Starting a MongoDB instance..."
-mongod --config /data/configdb/mongod.conf --dbpath=/data/db --replSet="$replica_set" --port=27017 "${auth_args[@]}" --bind_ip=0.0.0.0 >> /work-dir/log.txt 2>&1 &
+if [ -f /data/configdb/mongod.conf ]
+then
+    mongod --config /data/configdb/mongod.conf --dbpath=/data/db --replSet="$replica_set" --port=27017 "${auth_args[@]}" --bind_ip=0.0.0.0 >> /work-dir/log.txt 2>&1 &
+else
+    mongod --dbpath=/data/db --replSet="$replica_set" --port=27017 "${auth_args[@]}" --bind_ip=0.0.0.0 >> /work-dir/log.txt 2>&1 &
+fi
 
 log "Waiting for MongoDB to be ready..."
 until mongo "${ssl_args[@]}" --eval "db.adminCommand('ping')"; do

--- a/stable/mongodb-replicaset/templates/mongodb-mongodb-configmap.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-mongodb-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.configmap -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,3 +14,4 @@ metadata:
 data:
   mongod.conf: |
 {{ toYaml .Values.configmap | indent 4 }}
+{{- end -}}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -33,6 +33,7 @@ spec:
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
+        {{- if or .Values.configmap .Values.tls.enabled .Values.auth.enabled }}
         - name: copy-config
           image: busybox
           command:
@@ -43,7 +44,9 @@ spec:
               set -e
               set -x
 
+            {{- if .Values.configmap }}
               cp /configdb-readonly/mongod.conf /data/configdb/mongod.conf
+            {{- end }}
 
             {{- if .Values.tls.enabled }}
               cp /ca-readonly/tls.key /data/configdb/tls.key
@@ -57,8 +60,10 @@ spec:
           volumeMounts:
             - name: workdir
               mountPath: /work-dir
+          {{- if .Values.configmap }}
             - name: config
               mountPath: /configdb-readonly
+          {{- end }}
             - name: configdir
               mountPath: /data/configdb
           {{- if .Values.tls.enabled }}
@@ -69,6 +74,7 @@ spec:
             - name: keydir
               mountPath: /keydir-readonly
           {{- end }}
+        {{- end }}
         - name: install
           image: "{{ .Values.installImage.repository }}:{{ .Values.installImage.tag }}"
           args:
@@ -132,7 +138,9 @@ spec:
           command:
             - mongod
           args:
+          {{- if .Values.configmap }}
             - --config=/data/configdb/mongod.conf
+          {{- end }}
             - --dbpath=/data/db
             - --replSet={{ .Values.replicaSetName }}
             - --port=27017
@@ -198,9 +206,11 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
+        {{- if .Values.configmap }}
         - name: config
           configMap:
             name: {{ template "mongodb-replicaset.fullname" . }}-mongodb
+        {{- end }}
         - name: init
           configMap:
             defaultMode: 0755


### PR DESCRIPTION
**What this PR does / why we need it**:

In the `values` file you can override some values for mongodb configuration.
If there is no overridden configuration, no tls configuration and no authentication the first init container is redundant
