### PR TITLE
Allow user to specify a static IP for the Concourse loadbalancer

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.14.1
+version: 1.15.0
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -113,7 +113,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.nodeSelector` | Node selector for web nodes | `{}` |
 | `web.service.type` | Concourse Web service type | `ClusterIP` |
 | `web.service.annotations` | Concourse Web Service annotations | `nil` |
-| `web.service.loadBalancerIP` | Concourse Web Service Load Balancer IP | `nil` |
+| `web.service.loadBalancerIP` | The IP to use when web.service.type is LoadBalancer | `nil` |
 | `web.service.loadBalancerSourceRanges` | Concourse Web Service Load Balancer Source IP ranges | `nil` |
 | `web.service.atcNodePort` | Sets the nodePort for atc when using `NodePort` | `nil` |
 | `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -113,6 +113,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.nodeSelector` | Node selector for web nodes | `{}` |
 | `web.service.type` | Concourse Web service type | `ClusterIP` |
 | `web.service.annotations` | Concourse Web Service annotations | `nil` |
+| `web.service.loadBalancerIP` | Concourse Web Service Load Balancer IP | `nil` |
 | `web.service.loadBalancerSourceRanges` | Concourse Web Service Load Balancer Source IP ranges | `nil` |
 | `web.service.atcNodePort` | Sets the nodePort for atc when using `NodePort` | `nil` |
 | `web.service.tsaNodePort` | Sets the nodePort for tsa when using `NodePort` | `nil` |

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -23,6 +23,9 @@ spec:
     - {{ . }}
     {{- end }}
   {{ end }}
+  {{ if and (eq "LoadBalancer" .Values.web.service.type) .Values.web.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.web.service.loadBalancerIP }}
+  {{ end }}
   ports:
     - name: atc
       port: {{ .Values.concourse.atcPort }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -247,6 +247,9 @@ web:
     ##
     type: ClusterIP
 
+    ## When using web.service.type: LoadBalancer, sets the user-specified load balancer IP
+    # loadBalancerIP: 172.217.1.174
+
     ## Annotations to be added to the web service.
     ##
     # annotations:


### PR DESCRIPTION
Signed-off-by: Divya Dadlani <ddadlani@pivotal.io>

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Allows the user to specify a static load balancer IP for their Concourse deployment.

**Which issue this PR fixes**: fixes #3682

**Special notes for your reviewer**:
