### PR TITLE
stable/mongodb: unable to use existingSecret

### DIFF
--- a/stable/mongodb/templates/secrets.yaml
+++ b/stable/mongodb/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{ if or .Values.usePassword .Values.mongodbPassword -}}
+{{ if and (not .Values.existingSecret) (or .Values.usePassword .Values.mongodbPassword) -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

`existingSecret` means that a secret resource already exists and that this secret should be used.
Right now this is impossible. 

---

The secret is created unless `usePassword` is `false`. But as soon `usePassword` is set to `false` `existingSecret` will not be used anymore. (e.g. `statefulset-primary-rs.yaml:48`)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Does not create mongodb secret if `existingSecret` set.

**Special notes for your reviewer**:

n/a