### PR TITLE
stable/external-dns: fix log verbosity options

### DIFF
--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -63,7 +63,7 @@ podAnnotations: {}
 
 podLabels: {}
 
-# Verbosity of the logs (options: panic, debug, info, warn, error, fatal)
+# Verbosity of the logs (options: debug, info, warning, error, fatal, panic)
 logLevel: info
 
 extraArgs: {}


### PR DESCRIPTION
error when choosing "warn" 

`level=fatal msg="flag parsing error: enum value must be one of panic,fatal,error,warning,info,debug, got 'warn'"`