### PR TITLE
[stable/prometheus-redis-exporter] add option to supply extra arguments

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.16.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 0.2.0
+version: 0.3.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters and their default values.
 | `image.repository`     | prometheus-redis-exporter image repository          | `oliver006/redis_exporter`|
 | `image.tag`            | prometheus-redis-exporter image tag                 | `v0.16.0`                 |
 | `image.pullPolicy`     | image pull policy                                   | `IfNotPresent`            |
+| `extraArgs`            | extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter#flags)| {}
 | `resources`            | cpu/memory resource requests/limits                 | {}                        |
 | `service.type`         | desired service type                                | `ClusterIP`               |
 | `service.port`         | service external port                               | `9121`                    |

--- a/stable/prometheus-redis-exporter/templates/deployment.yaml
+++ b/stable/prometheus-redis-exporter/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
           ports:
             - name: exporter-port
               containerPort: 9121

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -15,6 +15,7 @@ image:
   repository: oliver006/redis_exporter
   tag: v0.16.0
   pullPolicy: IfNotPresent
+extraArgs: {}
 service:
   type: ClusterIP
   port: 9121


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds option to pass extra arguments to binary. This is particularly useful for monitoring specific keys with `--check-keys`.
