### PR TITLE
resources for initcontainer if available

### DIFF
--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -38,6 +38,8 @@ spec:
         - name: copy-rabbitmq-config
           image: busybox
           command: ['sh', '-c', 'cp /configmap/* /etc/rabbitmq; rm -f /var/lib/rabbitmq/.erlang.cookie']
+          resources:
+{{ toYaml .Values.initContainer.resources | indent 12 }}
           volumeMounts:
             - name: configmap
               mountPath: /configmap

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -174,13 +174,20 @@ updateStrategy: OnDelete
 ##   rabbitmqMemoryHighWatermark = 0.4 * resources.limits.memory
 ##
 resources: {}
-# limits:
-#  cpu: 100m
-#  memory: 1Gi
-# requests:
-#  cpu: 100m
-#  memory: 1Gi
-
+  # limits:
+  #   cpu: 1
+  #   memory: 1Gi
+  # requests:
+  #   cpu: 1
+  #   memory: 1Gi
+initContainer: {}
+  # resources:
+  #   limits:
+  #     cpu: 1
+  #     memory: 1Gi
+  #   requests:
+  #     cpu: 1
+  #     memory: 1Gi
 
 ## Data Persistency
 persistentVolume:

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -175,19 +175,19 @@ updateStrategy: OnDelete
 ##
 resources: {}
   # limits:
-  #   cpu: 1
+  #   cpu: 100mm
   #   memory: 1Gi
   # requests:
-  #   cpu: 1
+  #   cpu: 100mm
   #   memory: 1Gi
 initContainer: {}
   # resources:
   #   limits:
-  #     cpu: 1
-  #     memory: 1Gi
+  #     cpu: 100mm
+  #     memory: 128Mi
   #   requests:
-  #     cpu: 1
-  #     memory: 1Gi
+  #     cpu: 100mm
+  #     memory: 128Mi
 
 ## Data Persistency
 persistentVolume:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Its introduces the option to set resources for the initContainer used. This enables to use this chart in resource quota restricted namespaces.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
