### PR TITLE
[incubator/xray] Typo fix: postgressql->postgresql

### DIFF
--- a/incubator/xray/Chart.yaml
+++ b/incubator/xray/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: xray
-version: 0.3.0
+version: 0.3.1
 appVersion: 2.1.0
 home: https://www.jfrog.com/xray/
 description: Universal component scan for security and license inventory and impact analysis

--- a/incubator/xray/README.md
+++ b/incubator/xray/README.md
@@ -182,7 +182,7 @@ The following table lists the configurable parameters of the artifactory chart a
 | `common.stdOutEnabled`                         | Xray enable standard output                  | `true`               |
 | `common.masterKey`  | Xray Master Key Can be generated with `openssl rand -hex 32` | `FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
 | `global.mongoUrl`                              | Xray external MongoDB URL                    | ` `                  |
-| `global.postgresqlUrl`                         | Xray external PostgresSQL URL                | ` `                  |
+| `global.postgresqlUrl`                         | Xray external PostgreSQL URL                | ` `                  |
 | `analysis.name`                                | Xray Analysis name                           | `xray-analysis`      |
 | `analysis.image`                               | Xray Analysis container image                | `docker.bintray.io/jfrog/xray-analysis` |
 | `analysis.internalPort`                        | Xray Analysis internal port                  | `7000`               |

--- a/incubator/xray/values.yaml
+++ b/incubator/xray/values.yaml
@@ -11,7 +11,7 @@ imagePullSecrets:
 
 # PostgreSQL
 ## Configuration values for the postgresql dependency
-## ref: https://github.com/kubernetes/charts/blob/master/stable/postgressql/README.md
+## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
 ##
 postgresql:
   enabled: true


### PR DESCRIPTION
Fix typo "postgressql" in README and values.