### PR TITLE
[stable/kube-state-metrics] Use recommended repo

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.8.0
+version: 0.8.1
 appVersion: 1.3.1
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -13,7 +13,7 @@ $ helm install stable/kube-state-metrics
 ## Configuration
 
 | Parameter                             | Description                                             | Default                                     |
-|---------------------------------------|---------------------------------------------------------|---------------------------------------|
+|---------------------------------------|---------------------------------------------------------|---------------------------------------------|
 | `image.repository`                    | The image repository to pull from                       | quay.io/coreos/kube-state-metrics           |
 | `image.tag`                           | The image tag to pull from                              | `<latest version>`                          |
 | `image.pullPolicy`                    | Image pull policy                                       | IfNotPresent                                |
@@ -22,7 +22,7 @@ $ helm install stable/kube-state-metrics
 | `rbac.create`                         | If true, create & use RBAC resources                    | False                                       |
 | `rbac.serviceAccountName`             | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
 | `nodeSelector`                        | Node labels for pod assignment                          | {}                                          |
-| `tolerations`                         | Tolerations for pod assignment	                        | []                                          |
+| `tolerations`                         | Tolerations for pod assignment	                      | []                                          |
 | `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
 | `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |
 | `collectors.cronjobs`                 | Enable the cronjobs collector.                          | true                                        |

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -13,7 +13,7 @@ $ helm install stable/kube-state-metrics
 ## Configuration
 
 | Parameter                             | Description                                             | Default                                     |
-|---------------------------------------|---------------------------------------------------------|---------------------------------------------|
+|---------------------------------------|---------------------------------------------------------|---------------------------------------|
 | `image.repository`                    | The image repository to pull from                       | quay.io/coreos/kube-state-metrics           |
 | `image.tag`                           | The image tag to pull from                              | `<latest version>`                          |
 | `image.pullPolicy`                    | Image pull policy                                       | IfNotPresent                                |
@@ -22,7 +22,7 @@ $ helm install stable/kube-state-metrics
 | `rbac.create`                         | If true, create & use RBAC resources                    | False                                       |
 | `rbac.serviceAccountName`             | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
 | `nodeSelector`                        | Node labels for pod assignment                          | {}                                          |
-| `tolerations`                         | Tolerations for pod assignment	                  | []                                          |
+| `tolerations`                         | Tolerations for pod assignment	                        | []                                          |
 | `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
 | `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |
 | `collectors.cronjobs`                 | Enable the cronjobs collector.                          | true                                        |

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -14,7 +14,7 @@ $ helm install stable/kube-state-metrics
 
 | Parameter                             | Description                                             | Default                                     |
 |---------------------------------------|---------------------------------------------------------|---------------------------------------------|
-| `image.repository`                    | The image repository to pull from                       | k8s.gcr.io/kube-state-metrics               |
+| `image.repository`                    | The image repository to pull from                       | quay.io/coreos/kube-state-metrics           |
 | `image.tag`                           | The image tag to pull from                              | `<latest version>`                          |
 | `image.pullPolicy`                    | Image pull policy                                       | IfNotPresent                                |
 | `service.port`                        | The port of the container                               | 8080                                        |
@@ -22,7 +22,7 @@ $ helm install stable/kube-state-metrics
 | `rbac.create`                         | If true, create & use RBAC resources                    | False                                       |
 | `rbac.serviceAccountName`             | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
 | `nodeSelector`                        | Node labels for pod assignment                          | {}                                          |
-| `tolerations`                         | Tolerations for pod assignment	                      | []                                          |
+| `tolerations`                         | Tolerations for pod assignment	                  | []                                          |
 | `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
 | `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |
 | `collectors.cronjobs`                 | Enable the cronjobs collector.                          | true                                        |

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -1,7 +1,7 @@
 # Default values for kube-state-metrics.
 prometheusScrape: true
 image:
-  repository: k8s.gcr.io/kube-state-metrics
+  repository: quay.io/coreos/kube-state-metrics
   tag: v1.3.1
   pullPolicy: IfNotPresent
 service:


### PR DESCRIPTION
https://github.com/kubernetes/kube-state-metrics#container-image defines the quay.io repo as the preferred repo