### PR TITLE
[stable/newrelic-infrastructure] version 1.0.0 has been released

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.4.2
-appVersion: 0.0.19
+version: 0.4.3
+appVersion: 1.0.0
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:
   - https://github.com/kubernetes/kubernetes/tree/master/examples/newrelic-infrastructure

--- a/stable/newrelic-infrastructure/README.md
+++ b/stable/newrelic-infrastructure/README.md
@@ -1,27 +1,33 @@
-# newrelic-infra
+# newrelic-infrastructure
 
 ## Chart Details
 
 This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 
-Note: 
-This chart requires kube-state-metrics with the label `k8s-app: kube-state-metrics`
-
 ## Configuration
 
-| Parameter          | Description                                                  | Default                    |
-| ------------------ | ------------------------------------------------------------ | -------------------------- |
-| `cluster`          | The cluster name for the Kubernetes cluster.                 | ``                         |
-| `config`           | A `newrelic.yml` file if you wish to provide.                | ` `                        |
-| `image.name`       | The container to pull.                                       | `newrelic/infrastructure`  |
-| `image.pullPolicy` | The pull policy.                                             | `IfNotPresent`             |
-| `image.tag`        | The version of the container to pull.                        | `1.0.0-beta1.0`            |
-| `licenseKey`       | The license key for your New Relic Account.                  | ``                         |
-| `resources`        | Any resources you wish to assign to the pod.                 | See Resources below        |
-| `verboseLog`       | Should the agent log verbosely. (Boolean)                    | `false`                    |
-| `nodeSelector`     | Node label to use for scheduling                             | `nil`                      |
-| `tolerations`      | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`                      |
-| `updateStrategy`   | Strategy for DaemonSet updates (requires Kubernetes >= 1.6)  | `RollingUpdate`            |
+| Parameter             | Description                                                  | Default                    |
+| ------------------    | ------------------------------------------------------------ | -------------------------- |
+| `cluster`             | The cluster name for the Kubernetes cluster.                 |                          |
+| `licenseKey`          | The [license key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key)  for your New Relic Account. | |
+| `config`              | A `newrelic.yml` file if you wish to provide.                |                         |
+| `kubeStateMetricsUrl` | If provided, the discovery process for kube-state-metrics endpoint won't be triggered. Example: http://172.17.0.3:8080 | |
+| `image.name`          | The container to pull.                                       | `newrelic/infrastructure`  |
+| `image.pullPolicy`    | The pull policy.                                             | `IfNotPresent`             |
+| `image.tag`           | The version of the container to pull.                        | `1.0.0`            |
+| `resources`           | Any resources you wish to assign to the pod.                 | See Resources below        |
+| `verboseLog`          | Should the agent log verbosely. (Boolean)                    | `false`                    |
+| `nodeSelector`        | Node label to use for scheduling                             | `nil`                      |
+| `tolerations`         | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`                      |
+| `updateStrategy`      | Strategy for DaemonSet updates (requires Kubernetes >= 1.6)  | `RollingUpdate`            |
+
+## Example
+
+```sh
+helm install stable/newrelic-infrastructure \
+--set licenseKey=<enter_new_relic_license_key> \
+--set cluster=my-k8s-cluster
+```
 
 ## Resources
 

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -39,13 +39,22 @@ spec:
                   key: license
             - name: "CLUSTER_NAME"
               value: "{{ .Values.cluster }}"
+           {{- if .Values.kubeStateMetricsUrl }}
+            - name: "KUBE_STATE_METRICS_URL"
+              value: "{{ .Values.kubeStateMetricsUrl }}"
+           {{- end }}
             - name: "NRIA_DISPLAY_NAME"
               valueFrom:
                 fieldRef:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
+            - name: "NRK8S_NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  apiVersion: "v1"
+                  fieldPath: "spec.nodeName"
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
-              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME"
+              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL"
             {{- if .Values.verboseLog }}
             - name: NRIA_VERBOSE
               value: "1"
@@ -62,11 +71,11 @@ spec:
             {{- end }}
             - name: dev
               mountPath: /dev
-            - name: run
+            - name: host-docker-socket
               mountPath: /var/run/docker.sock
             - name: log
               mountPath: /var/log
-            - name: host-root
+            - name: host-volume
               mountPath: /host
               readOnly: true
           {{- if .Values.resources }}
@@ -77,13 +86,13 @@ spec:
         - name: dev
           hostPath:
             path: /dev
-        - name: run
+        - name: host-docker-socket
           hostPath:
               path: /var/run/docker.sock
         - name: log
           hostPath:
               path: /var/log
-        - name: host-root
+        - name: host-volume
           hostPath:
               path: /
         {{- if .Values.config }}

--- a/stable/newrelic-infrastructure/templates/rbac.yaml
+++ b/stable/newrelic-infrastructure/templates/rbac.yaml
@@ -8,6 +8,7 @@ rules:
 - apiGroups: [""]
   resources:
     - "nodes"
+    - "nodes/metrics"
     - "nodes/stats"
     - "nodes/proxy"
     - "pods"

--- a/stable/newrelic-infrastructure/values.yaml
+++ b/stable/newrelic-infrastructure/values.yaml
@@ -5,6 +5,10 @@
 # https://docs.newrelic.com/docs/kubernetes-monitoring-integration
 # cluster: ""
 
+# kubeStateMetricsUrl - if provided, the discovery process for kube-state-metrics endpoint won't be triggered
+# Only HTTP is accepted. This is an example value: http://172.17.0.3:8080
+# kubeStateMetricsUrl:
+
 verboseLog: false
 
 # This can be set, the default is shown below
@@ -12,7 +16,7 @@ verboseLog: false
 
 image:
   repository: newrelic/infrastructure-k8s
-  tag: 1.0.0-beta1.0
+  tag: 1.0.0
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Previous `newrelic-infrastructure` chart is using an old docker image from NewRelic (`1.0.0-beta1.0`)
This PR updates the `newrelic-infrastructure` chart to use the v1.0.0 _release_ docker image published by New Relic on the 24th of July 2018. This means we're no longer in Beta.

https://download.newrelic.com/infrastructure_agent/integrations/kubernetes/newrelic-infrastructure-k8s-latest.yaml

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: **fixes #6793**

**Special notes for your reviewer**:

Without `the nodes/metrics` k8s API permission, I was getting the following error from the newrelic pod even with v1.0.0-beta1.0:
`Non-recoverable error group: error querying Kubelet. error requesting cadvisor metrics endpoint. error calling prometheus exposed metrics endpoint. Got status code: 403`


It works beautifully now:

```
❯ kubectl logs newrelic-infrastructure-cx2kf
time="2018-07-09T23:17:26Z" level=info msg="Using Display Name: ip-10-0-4-115.ec2.internal"
time="2018-07-09T23:17:26Z" level=info msg="New Relic Infrastructure Agent version 1.0.912 Creating Service (372.016µs)"
time="2018-07-09T23:17:26Z" level=info msg="Agent service manager started successfully. (402.889µs)" service=newrelic-infra
time="2018-07-09T23:17:26Z" level=info msg="New Relic Infrastructure Agent version 1.0.912 Initializing (555.85µs)"
time="2018-07-09T23:17:27Z" level=info msg="New Relic Infrastructure Agent version 1.0.912 Running (597.134914ms)"
```