### PR TITLE
Support configuring a path for Traefik Dashboard

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.34.0
+version: 1.35.0
 appVersion: 1.6.2
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -129,6 +129,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `acme.persistence.size`         | Minimum size of the volume requested                                 | `1Gi`                                     |
 | `dashboard.enabled`             | Whether to enable the Traefik dashboard                              | `false`                                   |
 | `dashboard.domain`              | Domain for the Traefik dashboard                                     | `traefik.example.com`                     |
+| `dashboard.path`                | Path for the Traefik dashboard                                       | `/`                                       |
 | `dashboard.service.annotations` | Annotations for the Traefik dashboard Service definition, specified as a map | None                |
 | `dashboard.ingress.annotations` | Annotations for the Traefik dashboard Ingress definition, specified as a map | None                |
 | `dashboard.ingress.labels`      | Labels for the Traefik dashboard Ingress definition, specified as a map      | None                              |

--- a/stable/traefik/templates/dashboard-ingress.yaml
+++ b/stable/traefik/templates/dashboard-ingress.yaml
@@ -24,7 +24,8 @@ spec:
   - host: {{ .Values.dashboard.domain }}
     http:
       paths:
-      - backend:
+      - path: {{ .Values.dashboard.path }}
+        backend:
           serviceName: {{ template "traefik.fullname" . }}-dashboard
           servicePort: 80
 {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -163,6 +163,7 @@ acme:
 dashboard:
   enabled: false
   domain: traefik.example.com
+  path: /
   service:
     # annotations:
     #   key: value


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support to specify a custom path for the Traefik dashboard

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3919

**Special notes for your reviewer**:

@krancour @emilevauge @dtomcej @ldez