### PR TITLE
[stable/kube-state-metrics] Possible to add custom pod/service labels

### DIFF
--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app: {{ template "kube-state-metrics.name" . }}
         release: "{{ .Release.Name }}"
+{{- if .Values.podLabels}}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
 {{- if .Values.podAnnotations }}
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/stable/kube-state-metrics/templates/service.yaml
+++ b/stable/kube-state-metrics/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
   {{- if .Values.prometheusScrape }}
   annotations:
     prometheus.io/scrape: '{{ .Values.prometheusScrape }}'

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -5,6 +5,8 @@ image:
   tag: v1.3.1
   pullPolicy: IfNotPresent
 service:
+  # labels:
+  #   key: value
   port: 8080
   # Default to clusterIP for backward compatibility
   type: ClusterIP
@@ -15,6 +17,10 @@ rbac:
   create: false
   # Ignored if rbac.create is true
   serviceAccountName: default
+
+# If you wish to provide additional labels to apply to the pod(s), specify
+# them here
+podLabels: {}
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
ping @rk295 @fiunchinho @unguiculus 

**What this PR does / why we need it**:
Make it possible to add custom labels for the `kube-state-metrics` pods and service.
This is needed for the `newrelic-infrastructure` chart to perform auto-discovery.

See https://github.com/kubernetes/charts/blob/master/stable/newrelic-infrastructure/README.md#chart-details

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

```
helm install ./kube-state-metrics \
  --name kube-state-metrics \
  --namespace kube-system \
  --set podLabels.k8s-app=kube-state-metrics \
  --set service.labels.k8s-app=kube-state-metrics \
```

```
❯ kubectl -n kube-system describe svc kube-state-metrics
Name:              kube-state-metrics
Labels:            app=kube-state-metrics
                   chart=kube-state-metrics-0.8.0
                   heritage=Tiller
                   **k8s-app=kube-state-metrics**
                   release=kube-state-metrics
```

```
❯ kubectl -n kube-system describe pod kube-state-metrics-877ff7c89-sqkfr
Name:           kube-state-metrics-877ff7c89-sqkfr
Labels:         app=kube-state-metrics
                **k8s-app=kube-state-metrics**
                pod-template-hash=433993745
                release=kube-state-metrics
```