### PR TITLE
[stable/neo4j]: add labels to StatefulSet

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,6 +1,6 @@
 name: neo4j
 home: https://www.neo4j.com
-version: 0.7.2
+version: 0.7.3
 appVersion: 3.3.4
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -2,6 +2,12 @@ apiVersion: "apps/v1beta2"
 kind: StatefulSet
 metadata:
   name: "{{ template "neo4j.core.fullname" . }}"
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "neo4j.name" . }}
+    component: core
 spec:
   serviceName: {{ template "neo4j.fullname" . }}
   replicas: {{ .Values.core.numberOfServers }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Now core's StatefulSet doesn't have any label and can't be selected.

**Special notes for your reviewer**:
I added labels to core's StatefulSet same way as in replica's Reployment.