### PR TITLE
[stable/minio] Securing access to Minio on Kubernetes with TLS

### DIFF
--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
           {{- end }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.ssl.enabled }}
+            - name: secret-volume
+              mountPath: /root/.minio/certs
+            {{- end }}
             - name: export
               mountPath: {{ .Values.mountPath }}
               {{- if and .Values.persistence.enabled .Values.persistence.subPath }}
@@ -88,6 +92,18 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       volumes:
+        {{- if .Values.ssl.enabled }}
+        - name: secret-volume
+          secret:
+            secretName: {{ .Values.ssl.secret }}
+            items:
+            - key: public.crt
+              path: public.crt
+            - key: private.key
+              path: private.key
+            - key: root.crt
+              path: CAs/root.crt
+        {{- end }}
         - name: export
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/stable/minio/templates/secrets.yaml
+++ b/stable/minio/templates/secrets.yaml
@@ -14,3 +14,26 @@ data:
 {{- if .Values.gcsgateway.enabled }}
   gcs_key.json: {{ .Values.gcsgateway.gcsKeyJson | b64enc }}
 {{- end }}
+{{- if .Values.ssl.enabled }}
+{{- if .Values.ssl.certificates }}
+{{- if .Values.ssl.certificates.private }}
+{{- if .Values.ssl.certificates.public }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.ssl.secret }}
+  labels:
+    app: {{ template "minio.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+data:
+  private.key: {{ .Values.ssl.certificates.private | b64enc }}
+  public.crt: {{ .Values.ssl.certificates.public | b64enc }}
+  root.crt: {{ .Values.ssl.certificates.root | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -34,10 +34,18 @@ spec:
           args:
             - server
             {{- range $i := until $nodeCount }}
+            {{- if $.Values.ssl.enabled }}
+            - https://{{ template "minio.fullname" $ }}-{{ $i }}.{{ template "minio.fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local{{ $.Values.mountPath }}
+            {{- else }}
             - http://{{ template "minio.fullname" $ }}-{{ $i }}.{{ template "minio.fullname" $ }}.{{ $.Release.Namespace }}.svc.cluster.local{{ $.Values.mountPath }}
             {{- end }}
             {{- end }}
+            {{- end }}
           volumeMounts:
+            {{- if .Values.ssl.enabled }}
+            - name: secret-volume
+              mountPath: /root/.minio/certs
+            {{- end }}
             - name: export
               mountPath: {{ .Values.mountPath }}
               {{- if and .Values.persistence.enabled .Values.persistence.subPath }}
@@ -72,6 +80,18 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
+        {{- if .Values.ssl.enabled }}
+        - name: secret-volume
+          secret:
+            secretName: {{ .Values.ssl.secret }}
+            items:
+            - key: public.crt
+              path: public.crt
+            - key: private.key
+              path: private.key
+            - key: root.crt
+              path: CAs/root.crt
+        {{- end }}
         - name: minio-user
           secret:
             secretName: {{ template "minio.fullname" . }}

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -207,3 +207,19 @@ minioConfig:
 networkPolicy:
   enabled: false
   allowExternal: true
+ssl:
+  enabled: false
+  secret: tls-ssl-minio
+  certificates:
+#    private: |-
+#      -----BEGIN RSA PRIVATE KEY-----
+#      .....
+#      -----END RSA PRIVATE KEY-----
+#    public: |-
+#      -----BEGIN CERTIFICATE-----
+#      .....
+#      -----END CERTIFICATE-----
+#    root: |-
+#      -----BEGIN CERTIFICATE-----
+#      .....
+#      -----END CERTIFICATE-----


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: This PR contains updates to chart that will give users an option to enable SSL for secure access to Minio. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: References have been taken from similar kind of implementation in this chart - https://github.com/kubernetes/charts/tree/master/stable/mysql
Updates as per the minio documentation from here - https://github.com/minio/minio/tree/master/docs/tls/kubernetes
