### PR TITLE
Update CouchDB to version 2.2.0

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 0.1.8
+version: 0.2.0
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: couchdb
 version: 0.1.8
-appVersion: 2.1.2
+appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
   reliability.

--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: couchdb
-version: 0.1.7
-appVersion: 2.1.1
+version: 0.1.8
+appVersion: 2.1.2
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for
   reliability.

--- a/incubator/couchdb/README.md
+++ b/incubator/couchdb/README.md
@@ -75,7 +75,7 @@ CouchDB chart and their default values:
 |           Parameter             |             Description                               |                Default                 |
 |---------------------------------|-------------------------------------------------------|----------------------------------------|
 | `clusterSize`                   | The initial number of nodes in the CouchDB cluster    | 3                                      |
-| `couchdbConfig`                 | Map allowing override elements of server .ini config  | {}                                     |
+| `couchdbConfig`                 | Map allowing override elements of server .ini config  | chttpd.bind_address=any                |
 | `allowAdminParty`               | If enabled, start cluster without admin account       | false (requires creating a Secret)     |
 | `createAdminSecret`             | If enabled, create an admin account and cookie secret | true                                   |
 | `erlangFlags`                   | Map of flags supplied to the underlying Erlang VM     | name: couchdb, setcookie: monster

--- a/incubator/couchdb/README.md
+++ b/incubator/couchdb/README.md
@@ -94,7 +94,7 @@ A variety of other parameters are also configurable. See the comments in the
 | `helperImage.tag`               | 0.1.0                                  |
 | `helperImage.pullPolicy`        | IfNotPresent                           |
 | `image.repository`              | couchdb                                |
-| `image.tag`                     | 2.1.1                                  |
+| `image.tag`                     | 2.2.0                                  |
 | `image.pullPolicy`              | IfNotPresent                           |
 | `ingress.enabled`               | false                                  |
 | `ingress.hosts`                 | chart-example.local                    |

--- a/incubator/couchdb/values.yaml
+++ b/incubator/couchdb/values.yaml
@@ -40,7 +40,7 @@ persistentVolume:
 ## The CouchDB image
 image:
   repository: couchdb
-  tag: 2.1.2
+  tag: 2.2.0
   pullPolicy: IfNotPresent
 
 ## Sidecar that connects the individual Pods into a cluster

--- a/incubator/couchdb/values.yaml
+++ b/incubator/couchdb/values.yaml
@@ -103,5 +103,5 @@ erlangFlags:
 ## by a ConfigMap object.
 ## ref: http://docs.couchdb.org/en/latest/config/index.html
 couchdbConfig:
-  # cluster:
-  #   q: 8 # Create 8 shards for each database
+  chttpd:
+    bind_address: any

--- a/incubator/couchdb/values.yaml
+++ b/incubator/couchdb/values.yaml
@@ -40,7 +40,7 @@ persistentVolume:
 ## The CouchDB image
 image:
   repository: couchdb
-  tag: 2.1.1
+  tag: 2.1.2
   pullPolicy: IfNotPresent
 
 ## Sidecar that connects the individual Pods into a cluster


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: updates the CouchDB chart to use the latest version of CouchDB by default.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**Special notes for your reviewer**: CouchDB 2.1.2 is a security release, addressing CVE-2018-8007: Authenticated privilege escalation. See http://blog.couchdb.org/2018/07/11/cve-2018-8007 for details

