### PR TITLE
Cerebro service annotations, image update and configuration overrides

### DIFF
--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -6,7 +6,7 @@ sources:
  - https://github.com/yannart/docker-cerebro
  - https://github.com/lmenezes/cerebro
 name: cerebro
-version: 0.1.1
+version: 0.2.0
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -6,7 +6,7 @@ sources:
  - https://github.com/lmenezes/cerebro-docker
  - https://github.com/lmenezes/cerebro
 name: cerebro
-version: 0.2.1
+version: 0.3.0
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "0.8.1"
 description: A Helm chart for Cerebro - a web admin tool that replaces Kopf.
 home: https://github.com/lmenezes/cerebro
 sources:
- - https://github.com/yannart/docker-cerebro
+ - https://github.com/lmenezes/cerebro-docker
  - https://github.com/lmenezes/cerebro
 name: cerebro
-version: 0.2.0
+version: 0.2.1
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/cerebro/Chart.yaml
+++ b/stable/cerebro/Chart.yaml
@@ -6,7 +6,7 @@ sources:
  - https://github.com/lmenezes/cerebro-docker
  - https://github.com/lmenezes/cerebro
 name: cerebro
-version: 0.3.0
+version: 0.2.0
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -54,6 +54,9 @@ The following table lists the configurable parameters of the cerebro chart and t
 | `nodeSelector`                      | Settings for nodeselector          | `{}`                                      |
 | `tolerations`                       | Settings for toleration            | `{}`                                      |
 | `affinity`                          | Settings for affinity              | `{}`                                      |
+| `config.basePath`                   | Application base path              | `/`                                       |
+| `config.restHistorySize`            | Rest request history size per user | `50`                                      |
+| `config.hosts`                      | A list of known hosts              | `[]`                                      |
 
 
 

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters of the cerebro chart and t
 | `image.pullPolicy`                  | Image pull policy                  | `IfNotPresent`                            |
 | `service.type`                      | Type of Service                    | `ClusterIP`                               |
 | `service.port`                      | Port for kubernetes service        | `80`                                      |
+| `service.annotations`               | Annotations to add to the service  | `{}`                                      |
 | `resources.requests.cpu`            | CPU resource requests              |                                           |
 | `resources.limits.cpu`              | CPU resource limits                |                                           |
 | `resources.requests.memory`         | Memory resource requests           |                                           |

--- a/stable/cerebro/README.md
+++ b/stable/cerebro/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters of the cerebro chart and t
 |             Parameter               |            Description             |                    Default                |
 |-------------------------------------|------------------------------------|-------------------------------------------|
 | `replicaCount`                      | Number of replicas                 | `1`                                       |
-| `image.repository`                  | The image to run                   | `yannart/cerebro`                         |
+| `image.repository`                  | The image to run                   | `lmenezes/cerebro`                        |
 | `image.tag`                         | The image tag to pull              | `0.8.1`                                   |
 | `image.pullPolicy`                  | Image pull policy                  | `IfNotPresent`                            |
 | `service.type`                      | Type of Service                    | `ClusterIP`                               |

--- a/stable/cerebro/templates/configmap.yaml
+++ b/stable/cerebro/templates/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cerebro.fullname" . }}
+  labels:
+    app: {{ template "cerebro.name" . }}
+    chart: {{ template "cerebro.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  application.conf: |-
+    secret = {{ randAlphaNum 64 | quote }}
+
+    basePath = {{ .Values.config.basePath | quote }}
+
+    pidfile.path = /dev/null
+
+    rest.history.size = {{ .Values.config.restHistorySize }}
+
+    data.path = "/var/db/cerebro/cerebro.db"
+
+    es = {
+      gzip = true
+    }
+
+    auth = {
+    }
+
+    hosts = [
+      {{- range $index, $element := .Values.config.hosts }}
+      {{ if $index }},{{ end }}
+      {
+        host = {{ $element.host | quote }}
+        name = {{ $element.name | quote }}
+      }
+      {{- end }}
+    ]

--- a/stable/cerebro/templates/deployment.yaml
+++ b/stable/cerebro/templates/deployment.yaml
@@ -18,15 +18,30 @@ spec:
       labels:
         app: {{ template "cerebro.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+        - name: chown-db
+          image: docker.io/busybox:musl
+          command: ["chown", "1000:1000", "/var/db/cerebro"]
+          volumeMounts:
+            - name: db
+              mountPath: /var/db/cerebro
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["-Dconfig.file=/etc/cerebro/application.conf"]
           ports:
             - name: http
               containerPort: 9000
               protocol: TCP
+          volumeMounts:
+            - name: db
+              mountPath: /var/db/cerebro
+            - name: config
+              mountPath: /etc/cerebro
           livenessProbe:
             httpGet:
               path: /
@@ -37,6 +52,12 @@ spec:
               port: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: db
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: {{ template "cerebro.fullname" . }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/cerebro/templates/service.yaml
+++ b/stable/cerebro/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "cerebro.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -8,6 +8,7 @@ image:
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
 
 ingress:
   enabled: false

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: yannart/cerebro
+  repository: lmenezes/cerebro
   tag: 0.8.1
   pullPolicy: IfNotPresent
 

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -2,6 +2,8 @@ replicaCount: 1
 
 image:
   repository: lmenezes/cerebro
+  # Note: when updating the version, ensure `config` and the ConfigMap are kept
+  # in sync with the default configuration of the upstream image
   tag: 0.8.1
   pullPolicy: IfNotPresent
 
@@ -30,3 +32,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+config:
+  basePath: '/'
+  restHistorySize: 50
+  hosts: []
+  #  - host: 
+  #    name: 

--- a/stable/cerebro/values.yaml
+++ b/stable/cerebro/values.yaml
@@ -37,5 +37,5 @@ config:
   basePath: '/'
   restHistorySize: 50
   hosts: []
-  #  - host: 
-  #    name: 
+  #  - host:
+  #    name:


### PR DESCRIPTION
This PR updates the `stable/cerebro` chart to

- Allow to set annotations on the *Service*
- Update the default Docker image to use the official upstream one
- Allow to set various application configuration values through *values.yaml*
- Use out-of-container storage (`emptyDir`) for the application database

Note to reviewers:
- Unlike the original Docker image, the official one doesn't run as root, hence the `initContainer`
- Version bumped according to SEMVER with every commit for consistency, so `0.1.1` -> `0.2.0` -> `0.2.1` -> `0.3.0`