### PR TITLE
[stable/falco] Add Falco NATS output integration

### DIFF
--- a/stable/falco/CHANGELOG.md
+++ b/stable/falco/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+
+This file documents all notable changes to Sysdig Falco Helm Chart. The release
+numbering uses [semantic versioning](http://semver.org).
+
+## v0.2.0
+
+### Major Changes
+
+* Add NATS Output integration
+
+### Minor Changes
+
+* Fix value mismatch between code and documentation
+
+## v0.1.1
+
+### Minor Changes
+
+* Fix several typos
+
+## v0.1.0
+
+### Major Changes
+
+* Initial release of Sysdig Falco Helm Chart

--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 0.1.1
+version: 0.2.0
 appVersion: 0.10.0
 description: Sysdig Falco
 keywords:

--- a/stable/falco/README.md
+++ b/stable/falco/README.md
@@ -60,7 +60,7 @@ The following table lists the configurable parameters of the Falco chart and the
 | `falco.logStderr`                               | Send Falco debugging information logs to stderr                     | `true`                                                                                 |
 | `falco.logSyslog`                               | Send Falco debugging information logs to syslog                     | `true`                                                                                 |
 | `falco.logLevel`                                | The minimum level of Falco debugging information to include in logs | `info`                                                                                 |
-| `falco.priority`                                | The minimum rule priority level to load and run                      | `debug`                                                                                |
+| `falco.priority`                                | The minimum rule priority level to load and run                     | `debug`                                                                                |
 | `falco.bufferedOutputs`                         | Use buffered outputs to channels                                    | `false`                                                                                |
 | `falco.outputs.rate`                            | Number of tokens gained per second                                  | `1`                                                                                    |
 | `falco.outputs.maxBurst`                        | Maximum number of tokens outstanding                                | `1000`                                                                                 |
@@ -76,6 +76,8 @@ The following table lists the configurable parameters of the Falco chart and the
 | `integrations.gcscc.enabled`                    | Enable Google Cloud Security Command Center integration             | `false`                                                                                |
 | `integrations.gcscc.webhookUrl`                 | The URL where sysdig-gcscc-connector webhook is listening           | `http://sysdig-gcscc-connector.default.svc.cluster.local:8080/events`                  |
 | `integrations.gcscc.webhookAuthenticationToken` | Token used for authentication and webhook                           | `b27511f86e911f20b9e0f9c8104b4ec4`                                                     |
+| `integrations.natsOutput.enabled`               | Enable NATS Output integration                                      | `false`                                                                                |
+| `integrations.natsOutput.natsUrl`               | The NATS' URL where Falco is going to publish security alerts       | `nats://nats.nats-io.svc.cluster.local:4222`                                           |
 | `tolerations`                                   | The tolerations for scheduling                                      | `node-role.kubernetes.io/master:NoSchedule`                                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/falco/templates/configmap.yaml
+++ b/stable/falco/templates/configmap.yaml
@@ -56,7 +56,7 @@ data:
     priority: {{ .Values.falco.priority }}
 
     # Whether or not output to any of the output channels below is
-    # buffered. Defaults to true
+    # buffered. Defaults to false
     buffered_outputs: {{ .Values.falco.bufferedOutputs }}
 
     # A throttling mechanism implemented as a token bucket limits the

--- a/stable/falco/templates/configmap.yaml
+++ b/stable/falco/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
       {{- end }}
 
     # Whether to output events in json or text
-    {{- if .Values.integrations.gcscc.enabled }}
+    {{- if (or .Values.integrations.gcscc.enabled .Values.integrations.natsOutput.enabled) }}
     json_output: true
     {{- else }}
     json_output: {{ .Values.falco.jsonOutput }}
@@ -36,7 +36,12 @@ data:
     # When using json output, whether or not to include the "output" property
     # itself (e.g. "File below a known binary directory opened for writing
     # (user=root ....") in the json output.
+
+    {{- if .Values.integrations.natsOutput.enabled }}
+    json_include_output_property: true
+    {{- else }}
     json_include_output_property: {{ .Values.falco.jsonIncludeOutputProperty }}
+    {{- end }}
 
     # Send information logs to stderr and/or syslog Note these are *not* security
     # notification logs! These are just Falco lifecycle (and possibly error) logs.
@@ -88,10 +93,17 @@ data:
     # Also, the file will be closed and reopened if falco is signaled with
     # SIGUSR1.
 
+    {{- if .Values.integrations.natsOutput.enabled }}
+    file_output:
+      enabled: true
+      keep_alive: true
+      filename: /var/run/falco/nats
+    {{- else }}
     file_output:
       enabled: {{ .Values.falco.fileOutput.enabled }}
       keep_alive: {{ .Values.falco.fileOutput.keepAlive }}
       filename: {{ .Values.falco.fileOutput.filename }}
+    {{- end }}
 
     stdout_output:
       enabled: {{ .Values.falco.stdoutOutput.enabled }}

--- a/stable/falco/templates/daemonset.yaml
+++ b/stable/falco/templates/daemonset.yaml
@@ -50,6 +50,28 @@ spec:
             - mountPath: /etc/falco/rules.d
               name: rules-volume
             {{- end }}
+            {{- if .Values.integrations.natsOutput.enabled }}
+            - mountPath: /var/run/falco/
+              name: shared-pipe
+              readOnly: false
+            {{- end }}
+      {{- if .Values.integrations.natsOutput.enabled }}
+        - name: {{ .Chart.Name }}-nats
+          image: sysdig/falco-nats:latest
+          imagePullPolicy: Always
+          args: [ "/bin/falco-nats", "-s", {{ .Values.integrations.natsOutput.natsUrl | quote }}]
+          volumeMounts:
+            - mountPath: /var/run/falco/
+              name: shared-pipe
+      initContainers:
+          - name: init-pipe
+            image: busybox
+            command: ['mkfifo','/var/run/falco/nats']
+            volumeMounts:
+            - mountPath: /var/run/falco/
+              name: shared-pipe
+              readOnly: false
+      {{- end }}
       volumes:
         - name: dshm
           emptyDir:
@@ -86,6 +108,10 @@ spec:
         - name: rules-volume
           configMap:
             name: {{ template "falco.fullname" . }}-rules
+        {{- end }}
+        {{- if .Values.integrations.natsOutput.enabled }}
+        - name: shared-pipe
+          emptyDir: {}
         {{- end }}
 
   updateStrategy:

--- a/stable/falco/values.yaml
+++ b/stable/falco/values.yaml
@@ -141,6 +141,7 @@ customRules: {}
   # rules-traefik.yaml: |-
   #   [ rule body ]
 
+integrations:
   # If Google Cloud Security Command Center integration is enabled, falco will
   # be configured to use this integration as program_output and sets the following values:
   # * json_output: true
@@ -148,11 +149,21 @@ customRules: {}
   #     enabled: true
   #     keep_alive: false
   #     program: "\"curl -d @- -X POST --header 'Content-Type: application/json' --header 'Authorization: authentication_token' url \""
-integrations:
   gcscc:
     enabled: false
     webhookUrl: http://sysdig-gcscc-connector.default.svc.cluster.local:8080/events
     webhookAuthenticationToken: b27511f86e911f20b9e0f9c8104b4ec4
+  # If Nats Output integration is enabled, falco will be configured to use this
+  # integration as file_output and sets the following values:
+  # * json_output: true
+  # * json_include_output_property: true
+  # * file_output:
+  #     enabled: true
+  #     keep_alive: true
+  #     filename: /var/run/falco/nats
+  natsOutput:
+    enabled: false
+    natsUrl: "nats://nats.nats-io.svc.cluster.local:4222"
 
 # Allow falco to run on Kubernetes 1.6 masters.
 tolerations:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR add a NATS output to Sysdig Falco Helm Chart. It configures a sidecar container which receives alerts from Falco and sends to a NATS server.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
