### PR TITLE
[datadog] add env var for dd agent host and port when apm is enabled

### DIFF
--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -73,6 +73,12 @@ spec:
           {{- if .Values.datadog.apmEnabled }}
           - name: DD_APM_ENABLED
             value: {{ .Values.datadog.apmEnabled | quote }}
+          - name: DD_AGENT_SERVICE_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: DD_AGENT_PORT
+            value: 8126
           {{- end }}
           - name: KUBERNETES_LEADER_CANDIDATE # agent5
             value: {{ .Values.datadog.leaderElection | quote}}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -57,6 +57,12 @@ spec:
           {{- if .Values.datadog.apmEnabled }}
           - name: DD_APM_ENABLED
             value: {{ .Values.datadog.apmEnabled | quote }}
+          - name: DD_AGENT_SERVICE_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+          - name: DD_AGENT_PORT
+            value: 8126
           {{- end }}
           - name: SD_BACKEND
             value: docker

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -119,7 +119,7 @@ datadog:
 
   ## Un-comment this to enable APM and tracing, on ports 7777 and 8126
   ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
-  ## Additionally this exposes env variables `DD_AGENT_SERVICE_HOST` and `DD_APM_ENABLED`
+  ## Additionally this exposes env variables `DD_AGENT_SERVICE_HOST` and `DD_AGENT_PORT`
   ## ref: https://docs.datadoghq.com/tracing/setup/kubernetes/
   ##
   # apmEnabled: true

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -119,6 +119,8 @@ datadog:
 
   ## Un-comment this to enable APM and tracing, on ports 7777 and 8126
   ## ref: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
+  ## Additionally this exposes env variables `DD_AGENT_SERVICE_HOST` and `DD_APM_ENABLED`
+  ## ref: https://docs.datadoghq.com/tracing/setup/kubernetes/
   ##
   # apmEnabled: true
 


### PR DESCRIPTION
This PR adds 2 environment variables when APM is enabled, datadog agent host and port.  These changes reflect the datadog documentation for [Tracing Kubernetes Applications](https://docs.datadoghq.com/tracing/setup/kubernetes/).

@xvello @irabinovitch @hkaj 

fixes #5671