### PR TITLE
[stable/owncloud] template owncloud.fullname in ingress.yaml

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 2.0.1
+version: 2.0.2
 appVersion: 10.0.8
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/templates/ingress.yaml
+++ b/stable/owncloud/templates/ingress.yaml
@@ -2,9 +2,9 @@
 apiVersion: {{ required "A valid .Values.networkPolicyApiVersion entry required!" .Values.networkPolicyApiVersion }}
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "owncloud.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "owncloud.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -19,7 +19,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ template "fullname" . }}
+          serviceName: {{ template "owncloud.fullname" . }}
           servicePort: {{ .Values.ingress.servicePort }}
 {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
**What this PR does / why we need it**: 

ingress.yaml wasn't rendering if enabled. (template to be used was owncloud.fullname, not fullname).

```
Error: render error in "owncloud/templates/ingress.yaml": template: owncloud/templates/ingress.yaml:5:20: executing "owncloud/templates/ingress.yaml" at <{{template "fullname...>: template "fullname" not defined
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

no issue.

**Special notes for your reviewer**:

-
