### PR TITLE
[stable/nginx-ingress] Add hostPort options for TCP/UDP ports.

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.22.1
+version: 0.22.2
 appVersion: 0.15.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -63,11 +63,11 @@ Parameter | Description | Default
 `controller.scope.namespace` | namespace to watch for ingress | `""` (use the release namespace)
 `controller.extraArgs` | Additional controller container arguments | `{}`
 `controller.kind` | install as Deployment or DaemonSet | `Deployment`
-`controller.daemonset.useHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for TCP/80 and TCP/443 | false
+`controller.daemonset.useHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for TCP/HTTP and TCP/HTTPS. Warning: make sure it does not conflict with ports used outside of Kubernetes | false
 `controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"80"`
 `controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"443"`
-`controller.daemonset.useTcpHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for all ports defined in `tcp` | false
-`controller.daemonset.useUdpHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for all ports defined in `udp` | false
+`controller.daemonset.useTcpHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for all ports defined in `tcp`. Warning: make sure it does not conflict with ports used outside of Kubernetes | false
+`controller.daemonset.useUdpHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for all ports defined in `udp`. Warning: make sure it does not conflict with ports used outside of Kubernetes | false
 `controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `controller.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -66,6 +66,8 @@ Parameter | Description | Default
 `controller.daemonset.useHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for TCP/80 and TCP/443 | false
 `controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"80"`
 `controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty, it sets the hostPort | `"443"`
+`controller.daemonset.useTcpHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for all ports defined in `tcp` | false
+`controller.daemonset.useUdpHostPort` | If `controller.kind` is `DaemonSet`, this will enable `hostPort` for all ports defined in `udp` | false
 `controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `controller.affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
 `controller.minReadySeconds` | how many seconds a pod needs to be ready before killing the next, during update | `0`

--- a/stable/nginx-ingress/templates/controller-daemonset.yaml
+++ b/stable/nginx-ingress/templates/controller-daemonset.yaml
@@ -124,11 +124,17 @@ spec:
             - name: "{{ $key }}-tcp"
               containerPort: {{ $key }}
               protocol: TCP
+              {{- if $.Values.controller.daemonset.useTcpHostPort }}
+              hostPort: {{ $key }}
+              {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.udp }}
             - name: "{{ $key }}-udp"
               containerPort: {{ $key }}
               protocol: UDP
+              {{- if $.Values.controller.daemonset.useUdpHostPort }}
+              hostPort: {{ $key }}
+              {{- end }}
           {{- end }}
           readinessProbe:
             httpGet:

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -22,13 +22,15 @@ controller:
   # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
   dnsPolicy: ClusterFirst
 
-  ## Use host ports 80 and 443
   daemonset:
+    ## Use host ports 80 and 443
     useHostPort: false
-
     hostPorts:
       http: 80
       https: 443
+    # Define port(s) defined for TCP and/or UDP as hostPort(s)
+    useTcpHostPort: false
+    useUdpHostPort: false
 
   ## Required only if defaultBackend.enabled = false
   ## Must be <namespace>/<service_name>


### PR DESCRIPTION
Allows to define a `hostPort` option for each UDP and/or TCP port if using `DaemonSet`.

The `hostPort` value will be the same as the `port` one.