### PR TITLE
[stable/prometheus-blackbox-exporter] values.yaml: Added missing 'modu…

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.12.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -8,13 +8,14 @@ image:
 nodeSelector: {}
 
 config: {}
-  # http_2xx:
-  #   prober: http
-  #   timeout: 5s
-  #   http:
-  #     valid_http_versions: ["HTTP/1.1", "HTTP/2"]
-  #     no_follow_redirects: false
-  #     preferred_ip_protocol: "ip4" # defaults to "ip6"
+  # modules:
+  #   http_2xx:
+  #     prober: http
+  #     timeout: 5s
+  #     http:
+  #       valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+  #       no_follow_redirects: false
+  #       preferred_ip_protocol: "ip4" # defaults to "ip6"
 
 resources:
   # limits:


### PR DESCRIPTION
**What this PR does / why we need it**: Example configuration is missing the `modules` keyword.

@gianrubio 