### PR TITLE
[stable/etcd-operator] Improve resources' names and flags passed to containers

### DIFF
--- a/stable/etcd-operator/Chart.yaml
+++ b/stable/etcd-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: CoreOS etcd-operator Helm chart for Kubernetes
 name: etcd-operator
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.9.2
 home: https://github.com/coreos/etcd-operator
 icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png

--- a/stable/etcd-operator/templates/_helpers.tpl
+++ b/stable/etcd-operator/templates/_helpers.tpl
@@ -9,10 +9,19 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name equals chart name it will be used as a full name.
 */}}
 {{- define "etcd-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.etcdOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- if eq $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "etcd-backup-operator.name" -}}
@@ -22,10 +31,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name equals chart name it will be used as a full name.
 */}}
 {{- define "etcd-backup-operator.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.backupOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $chartName := default .Chart.Name .Values.nameOverride -}}
+{{- if eq $chartName .Release.Name -}}
+{{- .Values.backupOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $chartName .Values.backupOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "etcd-restore-operator.name" -}}
@@ -35,10 +53,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name equals chart name it will be used as a full name.
 */}}
 {{- define "etcd-restore-operator.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.restoreOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $chartName := default .Chart.Name .Values.nameOverride -}}
+{{- if eq $chartName .Release.Name -}}
+{{- .Values.restoreOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $chartName .Values.restoreOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/backup-operator-deployment.yaml
@@ -29,8 +29,8 @@ spec:
         imagePullPolicy: {{ .Values.backupOperator.image.pullPolicy }}
         command:
         - etcd-backup-operator
-{{- range $key, $value := .Values.backupOperator.commandArgs }}
-        - "--{{ $key }}={{ $value }}"
+{{- range $value := .Values.backupOperator.commandArgs }}
+        - "{{ $value }}"
 {{- end }}
         env:
         - name: MY_POD_NAMESPACE

--- a/stable/etcd-operator/templates/operator-deployment.yaml
+++ b/stable/etcd-operator/templates/operator-deployment.yaml
@@ -29,8 +29,8 @@ spec:
         imagePullPolicy: {{ .Values.etcdOperator.image.pullPolicy }}
         command:
         - etcd-operator
-{{- range $key, $value := .Values.etcdOperator.commandArgs }}
-        - "--{{ $key }}={{ $value }}"
+{{- range $value := .Values.etcdOperator.commandArgs }}
+        - "{{ $value }}"
 {{- end }}
         env:
         - name: MY_POD_NAMESPACE

--- a/stable/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/stable/etcd-operator/templates/restore-operator-deployment.yaml
@@ -31,8 +31,8 @@ spec:
         - containerPort: {{ .Values.restoreOperator.port }}
         command:
         - etcd-restore-operator
-{{- range $key, $value := .Values.restoreOperator.commandArgs }}
-        - "--{{ $key }}={{ $value }}"
+{{- range $value := .Values.restoreOperator.commandArgs }}
+        - "{{ $value }}"
 {{- end }}
         env:
         - name: MY_POD_NAMESPACE

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -51,9 +51,9 @@ etcdOperator:
   ## Node labels for etcd-operator pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
-  ## additional command arguments go here; will be translated to `--key=value` form
-  ## e.g., analytics: true
+  ## additional command arguments go here
   commandArgs: {}
+    # -cluster-wide
   ## Configurable health checks against the /readyz endpoint that etcd-operator exposes
   readinessProbe:
     enabled: false
@@ -88,9 +88,9 @@ backupOperator:
   ## Node labels for etcd pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
-  ## additional command arguments go here; will be translated to `--key=value` form
-  ## e.g., analytics: true
-  commandArgs: {}
+  ## additional command arguments go here
+  commandArgs:
+    # -cluster-wide
 
 # restore spec
 restoreOperator:
@@ -113,9 +113,9 @@ restoreOperator:
   ## Node labels for etcd pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
-  ## additional command arguments go here; will be translated to `--key=value` form
-  ## e.g., analytics: true
+  ## additional command arguments go here
   commandArgs: {}
+    # -cluster-wide
 
 ## etcd-cluster specific values
 etcdCluster:


### PR DESCRIPTION
**What this PR does / why we need it**:

| .Release.Name | .Chart.Name | etcd-operator.fullname |  etcd-backup-operator.fullname | etcd-release-operator.fullname |
|---------------|---------------|--------------------------|-----------------------------------------------|------------------------------------------------|
| etcd-operator | etcd-operator | etcd-operator | etcd-backup-operator | etcd-restore-operator |
| my-release | etcd-operator | my-release-etcd-operator | my-release-etcd-operator-etcd-backup-operator | my-release-etcd-operator-etcd-restore-operator |

So now it doesn't have to be all that long as they were in case of same release name and chart name:
etcd-operator-etcd-operator-etcd-backup-operator (release name + chart name + component name).

Now you also can pass plain arguments to containers.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes none

**Special notes for your reviewer**:
**_BREAKING CHANGES_**