### PR TITLE
`annotations` needs to be pluralized in readme and values

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.1.3
+version: 0.1.4
 appVersion: v0.28.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/stable/prometheus-rabbitmq-exporter/README.md
+++ b/stable/prometheus-rabbitmq-exporter/README.md
@@ -51,13 +51,13 @@ The following table lists the configurable parameters and their default values.
 | `service.externalPort`   | public service port                                                    | `9419`                    |
 | `resources`              | cpu/memory resource requests/limits                                    | {}                        |
 | `loglevel`               | exporter log level                                                     | {}                        |
-| `rabbitmq.url`           | rabbitm management url                                                  | `http://myrabbit:15672`   |
+| `rabbitmq.url`           | rabbitm management url                                                 | `http://myrabbit:15672`   |
 | `rabbitmq.user`          | rabbitm user login                                                     | `guest`                   |
 | `rabbitmq.password`      | rabbitm password login                                                 | `guest`                   |
 | `rabbitmq.capabilities`  | comma-separated list of capabilities supported by the RabbitMQ server  | `bert,no_sort`            |
 | `rabbitmq.include_queues`| regex queue filter. just matching names are exported                   | `.*`                      |
 | `rabbitmq.skip_queues`   | regex, matching queue names are not exported                           | `.*`                      |
-| `annotation`             | pod annotations for easier discovery                                   | {}                        |
+| `annotations`            | pod annotations for easier discovery                                   | {}                        |
 
 For more information please refer to the [rabbitmq_exporter](https://github.com/kbudde/rabbitmq_exporter) documentation.
 

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -37,7 +37,7 @@ rabbitmq:
   include_queues: ".*"
   skip_queues: "^$"
 
-annotation: {}
+annotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/path: "/metrics"
 #  prometheus.io/port: 9419


### PR DESCRIPTION
Fixed pluralization typo in  README and values.yml that would trip up users like myself.