### PR TITLE
Add support for mounting secret in ZooKeeper chart

### DIFF
--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -74,6 +74,11 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/zookeeper
+            {{- if (.Values.secret) and (.Values.secret.enabled) }}
+            - name: secret
+              mountPath: {{ .Values.secret.mountPath }}
+              readOnly: true
+            {{- end }}
 
 {{- if .Values.exporters.jmx.enabled }}
         - name: jmx-exporter
@@ -147,6 +152,11 @@ spec:
     {{- end }}
       {{- if (or .Values.exporters.jmx.enabled (not .Values.persistence.enabled)) }}
       volumes:
+        {{- if (.Values.secret) and (.Values.secret.enabled) }}
+        - name: secret
+          secret:
+            secretName: {{ .Values.secret.secretName }}
+        {{- end }}
         {{- if .Values.exporters.jmx.enabled }}
         - name: config-jmx-exporter
           configMap:

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -120,6 +120,13 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
 
+secret:
+  ## Mounting secret (e.g. JAAS config or Kerberos keytab).
+  ##
+  enabled: false
+  mountPath: /opt/zookeeper/secret
+  secretName: zookeeper-secret
+
 ## Exporters query apps for metrics and make those metrics available for
 ## Prometheus to scrape.
 exporters:
@@ -276,6 +283,9 @@ env:
   ## The number of wall clock ms that corresponds to a Tick for the ensembles
   ## internal time.
   ZK_TICK_TIME: 2000
+
+  ## Example for passing JAAS config.
+  # SERVER_JVMFLAGS: -Djava.security.auth.login.config=/opt/zookeeper/secret/zookeeper_server_jaas.conf
 
 jobs:
   ## ref: http://zookeeper.apache.org/doc/r3.4.10/zookeeperProgrammers.html#ch_zkSessions


### PR DESCRIPTION
**What this PR does / why we need it:** Adds support for mounting a secret. For example, JAAS config file or Kerberos keytab.

**Special notes for your reviewer:** Also added an example on how to pass JAAS config to JVM.