### PR TITLE
[incubator/escalator] Initial support

### DIFF
--- a/incubator/escalator/.helmignore
+++ b/incubator/escalator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/incubator/escalator/Chart.yaml
+++ b/incubator/escalator/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: 0.0.0
+description: Escalator is a batch or job optimized horizontal autoscaler for Kubernetes
+name: escalator
+version: 0.1.0
+home: https://github.com/atlassian/escalator
+sources:
+- https://github.com/atlassian/escalator
+maintainers:
+- name: wendorf
+  email: github@danwendorf.com

--- a/incubator/escalator/OWNERS
+++ b/incubator/escalator/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- wendorf
+reviewers:
+- wendorf

--- a/incubator/escalator/README.md
+++ b/incubator/escalator/README.md
@@ -1,0 +1,64 @@
+# Escalator
+
+[Escalator](https://github.com/atlassian/escalator) is a batch or job optimized horizontal autoscaler for Kubernetes
+
+## Prerequisites
+
+- Kubernetes cluster v1.8+ 
+- Escalator currently only supports scaling AWS Auto Scaling Groups
+
+## Configuration
+
+See the [Escalator docs](https://github.com/atlassian/escalator/blob/master/docs/README.md) for detailed documentation
+about the configuration, operation, and behavior of Escalator.
+
+The following table lists the configurable parameters of the Concourse chart and their default values.
+
+| Parameter               | Description                           | Default                                                    |
+| ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
+| `affinity` | node/pod affinities | `{}`
+| `aws.roleArn` | AWS role arn to assume. Only usable when using the aws cloud provider. | None
+| `aws.region` | AWS region your autoscaling groups are in. | `us-east-1`
+| `cloudProvider` | Cloud provider to use. Currently, only aws is available | `aws`
+| `dryMode` | Log the actions that Escalator will perform without actually running them | `true`
+| `image.pullPolicy` | Image pull policy | `IfNotPresent`
+| `image.repository` | Image repository | `atlassian/escalator`
+| `image.tag` | Image tag | `v1.0.0`
+| `ingress.path` | Ingress path | `/`
+| `ingress.enabled` | Enables Ingress | `false`
+| `ingress.annotations` | Ingress annotations | `{}`
+| `ingress.hosts` | Ingress accepted hostnames | `[]`
+| `ingress.tls` | Ingress TLS configuration | `[]`
+| `kubeConfig.enabled` | Use a custom kubeConfig when querying the API. Only necessary if autoscaling a different cluster than the one in which Escalator is deployed. | `false`
+| `kubeConfig.secretKey` | Secret key with contents of custom kubeConfig | None
+| `kubeConfig.secretName` | Kubernetes Secret with a custom kubeConfig | None
+| `logFormat` | Format of logging output (json, ascii) | `ascii`
+| `logLevel` | Log level (4 for info, 5 for debug) | `4`
+| `nodeSelector` | node labels for pod assignment | `{}`
+| `nodeGroups` | Configuration for node groups to autoscale | `[]`
+| `podAnnotations` | annotations to add to each pod | `{}`
+| `rbac.create` | Specifies whether RBAC resources should be created. | `true`
+| `replicaCount` | desired number of pods | `1`
+| `resources` | pod resource requests & limits | `{}`
+| `scanInterval` | How often cluster is reevaluated for scale up or down | `60s`
+| `service.annotations` | Kubernetes service annotations | `{}`
+| `service.port` | port for the service | `80`
+| `service.type` | type of service | `ClusterIP`
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created. | `true`
+| `serviceAccount.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template. | Nothing
+| `tolerations` | List of node taints to tolerate | `[]`
+
+### Node Groups
+
+The `nodeGroups` parameter takes an array of node groups to scale with escalator, and must be provided for escalator
+to perform any autoscaling. See the [official docs](https://github.com/atlassian/escalator/blob/master/docs/configuration/nodegroup.md)
+for an up-to-date list of parameters and their descriptions. For even more detail, see the [advanced configuration](https://github.com/atlassian/escalator/blob/master/docs/configuration/advanced-configuration.md).
+
+### Dry Mode
+
+By default, Escalator will not perform any autoscaling. Set `dryMode: false` to enable autoscaling.
+
+## Metrics
+
+Metrics are available at the `/metrics`. See the [metrics docs](https://github.com/atlassian/escalator/blob/master/docs/metrics.md)
+for more information.

--- a/incubator/escalator/templates/NOTES.txt
+++ b/incubator/escalator/templates/NOTES.txt
@@ -1,0 +1,28 @@
+{{- if .Values.dryMode }}
+Escalator is running in **dry mode** and will not do any autoscaling. To enable autoscaling, set `dryMode: false`.
+{{- else -}}
+Escalator is **live** and will autoscale your cluster. To disable autoscaling for testing, set `dryMode: true`.
+{{- end }}
+
+View Escalator's metrics by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}metrics
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "escalator.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/metrics
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "escalator.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "escalator.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}/metrics
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "escalator.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080/metrics to view Escalator metrics"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}
+
+For more info on Escalator, visit:
+  https://github.com/atlassian/escalator

--- a/incubator/escalator/templates/_helpers.tpl
+++ b/incubator/escalator/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "escalator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "escalator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "escalator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "escalator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "escalator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/escalator/templates/clusterrole.yaml
+++ b/incubator/escalator/templates/clusterrole.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "escalator.fullname" . }}
+  labels:
+    app: {{ template "escalator.name" . }}
+    chart: {{ template "escalator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - update
+  - patch
+  - watch
+  - list
+  - get
+  - delete
+{{- end }}

--- a/incubator/escalator/templates/clusterrolebinding.yaml
+++ b/incubator/escalator/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "escalator.fullname" . }}
+  labels:
+    app: {{ template "escalator.name" . }}
+    chart: {{ template "escalator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "escalator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "escalator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/incubator/escalator/templates/configmap.yaml
+++ b/incubator/escalator/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "escalator.fullname" . }}
+  labels:
+    app: {{ template "escalator.name" . }}
+    chart: {{ template "escalator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  nodegroups_config.yaml: |
+  {{- with .Values.nodeGroups }}
+    node_groups:
+{{ toYaml . | indent 6 }}
+  {{- end }}

--- a/incubator/escalator/templates/deployment.yaml
+++ b/incubator/escalator/templates/deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "escalator.fullname" . }}
+  labels:
+    app: {{ template "escalator.name" . }}
+    chart: {{ template "escalator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "escalator.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+      labels:
+        app: {{ template "escalator.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "escalator.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+          command:
+            - "./main"
+            - "--nodegroups"
+            - "/opt/conf/nodegroups/nodegroups_config.yaml"
+            - "--loglevel={{ .Values.logLevel }}"
+            - "--logfmt={{ .Values.logFormat }}"
+            - "--scaninterval={{ .Values.scanInterval }}"
+            - "--cloud-provider={{ .Values.cloudProvider }}"
+            {{- if .Values.dryMode }}
+            - "--drymode"
+            {{- end }}
+            {{- if .Values.aws.roleArn }}
+            - "--aws-assume-role-arn={{ .Values.aws.roleArn }}"
+            {{- end }}
+            {{- if .Values.kubeConfig.enabled }}
+            - "--kubeconfig"
+            - "/opt/conf/kubeconfig/{{ $.Values.kubeConfig.secretKey }}"
+            {{- end }}
+          volumeMounts:
+            - name: nodegroups
+              mountPath: /opt/conf/nodegroups
+              readOnly: true
+            {{- if .Values.kubeConfig.enabled }}
+            - name: kubeconfig
+              mountPath: /opt/conf/kubeconfig
+            {{- end }}
+          env:
+          {{- if .Values.aws.region }}
+            - name: AWS_REGION
+              value: {{ .Values.aws.region }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: nodegroups
+          configMap:
+            name: {{ template "escalator.fullname" . }}
+            defaultMode: 0644
+            items:
+            - key: nodegroups_config.yaml
+              path: nodegroups_config.yaml
+        {{- if .Values.kubeConfig.enabled }}
+        - name: kubeconfig
+          secret:
+            secretName: {{ .Values.kubeConfig.secretName }}
+        {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/incubator/escalator/templates/ingress.yaml
+++ b/incubator/escalator/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "escalator.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "escalator.name" . }}
+    chart: {{ template "escalator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/incubator/escalator/templates/service.yaml
+++ b/incubator/escalator/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "escalator.fullname" . }}
+  labels:
+    app: {{ template "escalator.name" . }}
+    chart: {{ template "escalator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "escalator.name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/escalator/templates/serviceaccount.yaml
+++ b/incubator/escalator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "escalator.serviceAccountName" . }}
+  labels:
+    app: {{ template "escalator.name" . }}
+    chart: {{ template "escalator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/incubator/escalator/values.yaml
+++ b/incubator/escalator/values.yaml
@@ -1,0 +1,116 @@
+# Default values for escalator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: atlassian/escalator
+  tag: v1.0.0
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # Annotations to add to the service
+  annotations: {}
+
+# Annotations to add to every pod
+podAnnotations: {}
+
+## General Escalator configuration. Additional documentation:
+#  https://github.com/atlassian/escalator/blob/master/docs/configuration/command-line.md
+
+# Log level (4 for info, 5 for debug)
+logLevel: 4
+
+# Format of logging output (json, ascii)
+logFormat: ascii
+
+# How often cluster is reevaluated for scale up or down
+scanInterval: 60s
+
+# Log the actions that Escalator will perform without actually running them
+dryMode: true
+
+# Cloud provider to use. Currently, only aws is available
+cloudProvider: aws
+
+aws:
+  # AWS role arn to assume. Only usable when using the aws cloud provider.
+  # roleArn: arn:aws:iam::111111111111:role/escalator
+
+  # AWS region your autoscaling groups are in. Only necessary if providing an ARN.
+  region: us-east-1
+
+# Kubernetes configuration to use when querying the API. Only necessary if autoscaling a different cluster than the one
+# in which Escalator is deployed.
+kubeConfig:
+  # Use a custom kubeConfig
+  enabled: false
+#  # Kubernetes Secret with a custom kubeConfig
+#  secretName: my-kubeconfig
+#  # Secret key with contents of custom kubeConfig
+#  secretKey: config
+
+## Each node group to autoscale
+#  See https://github.com/atlassian/escalator/blob/master/docs/configuration/nodegroup.md
+#  for details for each key
+nodeGroups: []
+  # - name: "default"
+  #   label_key: "customer"
+  #   label_value: "shared"
+  #   cloud_provider_group_name: "shared-nodes"
+  #   min_nodes: 1
+  #   max_nodes: 30
+  #   dry_mode: false
+  #   taint_upper_capacity_threshold_percent: 40
+  #   taint_lower_capacity_threshold_percent: 10
+  #   slow_node_removal_rate: 2
+  #   fast_node_removal_rate: 5
+  #   scale_up_threshold_percent: 70
+  #   scale_up_cool_down_period: 2m
+  #   scale_up_cool_down_timeout: 10m
+  #   soft_delete_grace_period: 1m
+  #   hard_delete_grace_period: 10m


### PR DESCRIPTION
**What this PR does / why we need it**:

[Escalator](https://github.com/atlassian/escalator/blob/master/docs/configuration/nodegroup.md) is a batch or job optimized horizontal autoscaler for Kubernetes

- Attempts to support all the command-line flags for Escalator
- Supports providing custom IAM credentials via annotations
- Custom kubeConfig can be provided to autoscale a separate cluster

**Special notes for your reviewer**:

- ~~There is no official image, so the chart defaults to wendorf/escalator. https://github.com/atlassian/escalator/issues/114 has been filed to track getting an official image.~~ An official image is now available.
- The autoscaling group configuration is passed directly to escalator, and the chart documentation points users to Escalator's documentation, since the algorithm is nuanced. That felt like the right call, but I'm definitely open to being more explicit in the chart if that's preferred.
