### PR TITLE
[stable/rabbit-ha] Added liveness probe period 

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,6 +1,6 @@
 name: rabbitmq-ha
 apiVersion: v1
-appVersion: 3.7.4
+appVersion: 3.7.5
 version: 1.6.3
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -98,6 +98,7 @@ spec:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             exec:
               command:

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -260,7 +260,7 @@ livenessProbe:
   initialDelaySeconds: 120
   timeoutSeconds: 5
   failureThreshold: 6
-  periodSeconds: 5
+  periodSeconds: 10
 
 readinessProbe:
   initialDelaySeconds: 10

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -260,6 +260,7 @@ livenessProbe:
   initialDelaySeconds: 120
   timeoutSeconds: 5
   failureThreshold: 6
+  periodSeconds: 5
 
 readinessProbe:
   initialDelaySeconds: 10


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Enable liveness probe period for rabbit-ha nodes. The current liveness probe looks like it is cpu intensive, the idling pods consume ~500 millicores because of the liveness probe.

This allows for users to decide how frequently to run liveness probe and cutting down cpu usage drastically.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3855 

**Special notes for your reviewer**:
