### PR TITLE
[incubator/patroni] Add kubernetes DCS

### DIFF
--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,6 +1,6 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
-version: 0.9.0
+version: 0.10.0
 appVersion: 1.4-p7
 home: https://github.com/zalando/patroni
 sources:

--- a/incubator/patroni/Chart.yaml
+++ b/incubator/patroni/Chart.yaml
@@ -1,7 +1,7 @@
 name: patroni
 description: 'Highly available elephant herd: HA PostgreSQL cluster.'
 version: 0.10.0
-appVersion: 1.4-p7
+appVersion: 1.4-p11
 home: https://github.com/zalando/patroni
 sources:
 - https://github.com/zalando/patroni

--- a/incubator/patroni/README.md
+++ b/incubator/patroni/README.md
@@ -3,7 +3,7 @@
 This directory contains a Kubernetes chart to deploy a five node [Patroni](https://github.com/zalando/patroni/) cluster using a [Spilo](https://github.com/zalando/spilo) and a StatefulSet.
 
 ## Prerequisites Details
-* Kubernetes 1.5+
+* Kubernetes 1.9+
 * PV support on the underlying infrastructure
 
 ## StatefulSet Details

--- a/incubator/patroni/requirements.lock
+++ b/incubator/patroni/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.3.9
+  version: 0.4.1
 - name: zookeeper
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 1.0.0
+  version: 1.1.0
 digest: sha256:2cba87a0a23df25d78a0908f4ce9ae27acb0530a5aac430f19a2dbc0778aa4b2
 generated: 2018-05-14T14:49:09.901956221+02:00

--- a/incubator/patroni/requirements.yaml
+++ b/incubator/patroni/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: etcd
-  version: 0.3.9
+  version: 0.4.1
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: etcd.deployChart
 - name: zookeeper
-  version: 1.0.0
+  version: 1.1.0
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: zookeeper.deployChart

--- a/incubator/patroni/templates/role-patroni.yaml
+++ b/incubator/patroni/templates/role-patroni.yaml
@@ -43,7 +43,7 @@ rules:
   - update
   - watch
 {{- else }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "patroni.fullname" . }}

--- a/incubator/patroni/templates/role-patroni.yaml
+++ b/incubator/patroni/templates/role-patroni.yaml
@@ -1,4 +1,48 @@
 {{- if .Values.rbac.create }}
+{{- if .Values.kubernetesDCS }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "patroni.fullname" . }}
+  labels:
+    app: {{ template "patroni.name" . }}
+    chart: {{ template "patroni.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - patch
+  - update
+  - create
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
@@ -12,4 +56,5 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints", "pods"]
     verbs: ["patch"]
+{{- end }}
 {{- end }}

--- a/incubator/patroni/templates/rolebinding-patroni.yaml
+++ b/incubator/patroni/templates/rolebinding-patroni.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "patroni.fullname" . }}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "patroni.fullname" . }}
@@ -10,6 +10,8 @@ metadata:
 spec:
   serviceName: {{ template "patroni.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: {{ template "patroni.name" . }}

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -58,6 +58,13 @@ spec:
         - name: ZOOKEEPER_HOSTS
           value: {{ .Values.zookeeper.hosts | quote }}
         {{- end }}
+        {{- else if .Values.kubernetesDCS.enable }}
+        - name: PATRONI_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: PATRONI_KUBERNETES_LABELS
+          value: '{app: {{ template "patroni.name" . }},release: {{ .Release.Name }} }'
         {{- end }}
         - name: SCOPE
           value: {{ template "patroni.fullname" . }}
@@ -102,6 +109,10 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         ports:
         - containerPort: 8008
         - containerPort: 5432

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -164,7 +164,6 @@ spec:
         {{- end }}
         labels:
           app: {{ template "patroni.name" . }}
-          chart: {{ template "patroni.chart" . }}
           release: {{ .Release.Name }}
           heritage: {{ .Release.Service }}
       spec:

--- a/incubator/patroni/templates/statefulset-patroni.yaml
+++ b/incubator/patroni/templates/statefulset-patroni.yaml
@@ -61,12 +61,16 @@ spec:
           value: {{ .Values.zookeeper.hosts | quote }}
         {{- end }}
         {{- else if .Values.kubernetesDCS.enable }}
+        - name: DCS_ENABLE_KUBERNETES_API
+          value: {{ .Values.kubernetesDCS.enable | quote }}
         - name: PATRONI_KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: PATRONI_KUBERNETES_LABELS
-          value: '{app: {{ template "patroni.name" . }},release: {{ .Release.Name }} }'
+        - name: KUBERNETES_LABELS
+          value: '{"app": "{{ template "patroni.name" . }}", "release": "{{ .Release.Name }}"}'
+        - name: KUBERNETES_SCOPE_LABEL
+          value: release
         {{- end }}
         - name: SCOPE
           value: {{ template "patroni.fullname" . }}

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -17,9 +17,11 @@ credentials:
 
 # Distribution Configuration stores
 # Please note that only one of the following stores should be enabled.
-etcd:
+kubernetesDCS:
   enable: true
-  deployChart: true
+etcd:
+  enable: false
+  deployChart: false
   # If not deploying etcd chart, fill-in value for etcd service
   # <service>.<namespace>.svc.cluster.local
   host:

--- a/incubator/patroni/values.yaml
+++ b/incubator/patroni/values.yaml
@@ -4,7 +4,7 @@ image:
   # Image was built from
   # https://github.com/zalando/spilo/tree/master/postgres-appliance
   repository: registry.opensource.zalan.do/acid/spilo-10
-  tag: 1.4-p7
+  tag: 1.4-p11
   pullPolicy: IfNotPresent
 
 # Credentials used by Patroni


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add kubernetes DCS, much simple way when run in kubernetes than use zookeeper or etcd
* Use kubernetes DCS as default and avoid to deploy other service
* Remove chart label in volumeClaimTemplates metadata since it is inmutable and this value change on every chart version so is preventing updates
* Add UpdateStrategy to StatefulSet
