### PR TITLE
[stable/datadog] Use Capabilities.APIVersions.Has instead of semver compare

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.4.1
+version: 1.4.2
 appVersion: 6.4.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/_helpers.tpl
+++ b/stable/datadog/templates/_helpers.tpl
@@ -59,9 +59,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the appropriate apiVersion for RBAC APIs.
 */}}
 {{- define "rbac.apiVersion" -}}
-{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion -}}
-"rbac.authorization.k8s.io/v1"
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1beta1" -}}
 "rbac.authorization.k8s.io/v1beta1"
+{{- else -}}
+"rbac.authorization.k8s.io/v1"
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Use Capabilities.APIVersions.Has to check for available rbac API.
Found at https://github.com/rook/rook/pull/1569.

Received the following error with Helm 2.7+:

```
[ERROR] templates/: render error in "datadog/templates/clusterrolebinding.yaml":
template: datadog/templates/_helpers.tpl:54:7: executing "rbac.apiVersion" at
<semverCompare ">=1.8...>: error calling semverCompare: Invalid Semantic Version
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: Did not create an issue.

**Special notes for your reviewer**: I'm not sure if this is backwards-compatible with older versions of Helm.