### PR TITLE
[stable/gcloud-sqlproxy] Allow for getting credentials via metadata

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: gcloud-sqlproxy
-version: 0.4.0
+version: 0.5.0
 appVersion: 1.11
 description: Google Cloud SQL Proxy
 keywords:

--- a/stable/gcloud-sqlproxy/templates/NOTES.txt
+++ b/stable/gcloud-sqlproxy/templates/NOTES.txt
@@ -1,11 +1,14 @@
 ** Please be patient while the chart is being deployed **
 
-{{- if not .Values.serviceAccountKey }}
-##############################################################################
-####   ERROR: You did not provide Google Cloud Service Account key.       ####
-##############################################################################
+{{ if not (or .Values.serviceAccountKey .Values.existingSecret) -}}
+################################################################################
+####   WARNING: You did not provide Google Cloud Service Account key.       ####
+################################################################################
 
-All pods do not go to the running state if the GCP Service Account key was not provided.
+gcloud-sqlproxy requires API access to Cloud SQL API. Without specifying a
+service account key, gcloud-sqlproxy will rely on default access via instance
+scopes or some other external method. Be sure you cluster provides this access.
+All pods do not go to the running state if valid credentials are not available.
 
 {{- end }}
 
@@ -20,7 +23,7 @@ settings were not provided.
 
 {{- end }}
 
-{{- if and .Values.serviceAccountKey (ne (index .Values.cloudsql.instances 0).instance "instance") }}
+{{- if ne (index .Values.cloudsql.instances 0).instance "instance" }}
 
 The SQL server instances can be accessed via ports:
 {{- range .Values.cloudsql.instances }}
@@ -29,7 +32,7 @@ The SQL server instances can be accessed via ports:
 on the following DNS name from within your cluster:
 - {{ template "gcloud-sqlproxy.fullname" . }}.{{ .Release.Namespace }}
 
-{{- else -}}
+{{- else }}
 
 This deployment will be incomplete until you provide GCP Service Account key
 and instances settings:

--- a/stable/gcloud-sqlproxy/templates/deployment.yaml
+++ b/stable/gcloud-sqlproxy/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.serviceAccountKey .Values.existingSecret) (ne (index .Values.cloudsql.instances 0).instance "instance") }}
+{{- if ne (index .Values.cloudsql.instances 0).instance "instance" }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -24,33 +24,37 @@ spec:
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-        command: ["/cloud_sql_proxy", "--dir=/cloudsql",
-                  "-instances={{- range .Values.cloudsql.instances -}}
-                                {{ .project }}:{{ .region }}:{{ .instance }}=tcp:0.0.0.0:{{ .port }},
-                              {{- end }}",
-                  "-credential_file=/secrets/cloudsql/{{- if .Values.existingSecret -}} {{ .Values.existingSecretKey }} {{- else -}} credentials.json {{- end -}}"]
+        command:
+        - /cloud_sql_proxy
+        - --dir=/cloudsql
+        - -instances={{- range .Values.cloudsql.instances -}}
+                        {{ .project }}:{{ .region }}:{{ .instance }}=tcp:0.0.0.0:{{ .port }},
+                     {{- end }}
+        {{ if or .Values.serviceAccountKey .Values.existingSecret -}}
+        - -credential_file=/secrets/cloudsql/{{- if .Values.existingSecret -}} {{ .Values.existingSecretKey }} {{- else -}} credentials.json {{- end }}
+        {{ end -}}
         ports:
         {{- range .Values.cloudsql.instances }}
         - name: {{ .instanceShortName | default (.instance | trunc 15) }}
           containerPort: {{ .port }}
         {{- end }}
         volumeMounts:
+        {{ if or .Values.serviceAccountKey .Values.existingSecret -}}
         - name: cloudsql-oauth-credentials
           mountPath: /secrets/cloudsql
+        {{ end -}}
         - name: cloudsql
           mountPath: /cloudsql
       volumes:
+      {{ if or .Values.serviceAccountKey .Values.existingSecret -}}
       - name: cloudsql-oauth-credentials
         secret:
-          {{ if (not .Values.existingSecret) -}}
-          secretName: {{ template "gcloud-sqlproxy.fullname" . }}
-          {{- else -}}
-          secretName: {{ .Values.existingSecret }}
-          {{- end }}
+          secretName: {{ default (include "gcloud-sqlproxy.fullname" .) .Values.existingSecret }}
+      {{ end -}}
       - name: cloudsql
         emptyDir: {}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}    
+{{ toYaml .Values.nodeSelector | indent 8 }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
       tolerations:


### PR DESCRIPTION
Because sqlproxy requires auth, the chart currently allows for either a) passing in the credentials or b) passing in the name of an existing secret that contains the credentials. This PR adds a third option: using the instance credentials (https://developers.google.com/identity/protocols/googlescopes). To do that, you now just _don't_ specify any credentials.

I'm pretty sure we shouldn't consider this "breaking" because existing deployments (where some form of credentials were specified) will continue to work the same. The only thing that has changed is the default behavior for new installations which will now use instance credentials instead of printing an error and skipping the `Deployment`.