### PR TITLE
Metabase add ingress labels

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.4.1
-appVersion: v0.27.2
+version: 0.4.2
+appVersion: v0.29.3
 maintainers:
 - name: pmint93
   email: phamminhthanh69@gmail.com

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | service.annotations    | Service annotations                                        | {}                |
 | ingress.enabled        | Enable ingress controller resource                         | false             |
 | ingress.hosts          | Ingress resource hostnames                                 | null              |
+| ingress.labels         | Ingress labels configuration                               | null              |
 | ingress.annotations    | Ingress annotations configuration                          | null              |
 | ingress.tls            | Ingress TLS configuration                                  | null              |
 | resources              | Server resource requests and limits                        | {}                |

--- a/stable/metabase/templates/ingress.yaml
+++ b/stable/metabase/templates/ingress.yaml
@@ -10,9 +10,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- range $key, $value := .Values.ingress.labels }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/stable/metabase/templates/ingress.yaml
+++ b/stable/metabase/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.ingress.labels }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 image:
   repository: metabase/metabase
-  tag: v0.27.2
+  tag: v0.29.3
   pullPolicy: IfNotPresent
 
 # Config Jetty web server
@@ -60,6 +60,10 @@ ingress:
   # Used to create Ingress record (should used with service.type: ClusterIP).
   hosts:
     # - metabase.domain.com
+  labels:
+    # Used to add custom labels to the Ingress
+    # Useful if for example you have multiple Ingress controllers and want your Ingress controllers to bind to specific Ingresses
+    # traffic: internal
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
@pmint93 

**What this PR does / why we need it**:
This adds support for custom labels to attach to the ingress object. We in particular use this feature as we have multiple ingress controllers to handle services that are internal or public and use Ingress labels to determine which controller binds a particular Ingress object. We've tested this in our own k8s cluster and it works as expected.

**Special notes for your reviewer**:
Also updated the base version of Metabase to v0.29.3. Let me know if you want to split that out to a separate PR.