### PR TITLE
[stable/minio] changed storageClass back to default

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 1.6.0
+version: 1.6.1
 appVersion: RELEASE.2018-07-10T01-42-11Z
 keywords:
 - storage

--- a/stable/minio/templates/pvc.yaml
+++ b/stable/minio/templates/pvc.yaml
@@ -21,7 +21,11 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
 {{- if .Values.persistence.storageClass }}
-  storageClassName: {{ .Values.persistence.storageClass | quote }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -51,9 +51,7 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  ## Storage class of PV to bind. By default it looks for standard storage class.
-  ## If the PV uses a different storage class, specify that here.
-  storageClass: standard
+# storageClass: "-"
   accessMode: ReadWriteOnce
   size: 10Gi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the default storage class to `""` so it respects `storageclass.kubernetes.io/is-default-class` like every other helm chart in this repo. This was recently set to `"standard"` in #6152 which ended up breaking my deployment (and probably that of others too).

**Which issue this PR fixes:** I guess i could have reported this as a issue/bug first, but didn't find that necessary.

**Special notes for your reviewer**:
This PR reverts a portion of #6152