### PR TITLE
[stable/concourse] optionally pass additional cli arguments to workers

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.13.0
+version: 1.14.0
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -136,6 +136,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.minAvailable` | Minimum number of workers available after an eviction | `1` |
 | `worker.resources` | Concourse Worker resource requests and limits | `{requests: {cpu: "100m", memory: "512Mi"}}` |
 | `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
+| `worker.additionalArguments` | Configure additional command-line arguments to pass to the workers | `nil` |
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `{}` |
 | `worker.tolerations` | Tolerations for the worker nodes | `[]` |

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
                 sleep 5
               done
               rm -f /tmp/.pre_start_cleanup
-              concourse worker --name=${HOSTNAME} | tee -a /tmp/.liveness_probe
+              concourse worker --name=${HOSTNAME} {{ .Values.worker.additionalArguments }} | tee -a /tmp/.liveness_probe
           livenessProbe:
             exec:
               command:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -380,6 +380,10 @@ worker:
   #   - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
   #     value: "true"
 
+  ## Will be passed verbatim; no shell-escaping.
+  ##
+  # additionalArguments : "--certs-dir /etc/ssl/certs/"
+
   ## Annotations to be added to the worker pods.
   ##
   # annotations:


### PR DESCRIPTION
### What this PR does / why we need it:
- Allow configuring command-line arguments that will be passed to the Concourse workers
- Arguments are given as a single string and will be passed verbatim (no escaping)
### Possible use-case:
Some users are running in a corporate environment with private certificate authorities. Using the `--certs-dir` option trust relationships can be established to those CA and, thus, having to disable tls-validation can be avoided (which not all resources might even support).