### PR TITLE
Add new parameter to configure Drupal Installation Profile

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 1.0.2
+version: 1.1.0
 appVersion: 8.5.5
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the Drupal chart and th
 | `image.tag`                       | Drupal Image tag                      | `{VERSION}`                                               |
 | `image.pullPolicy`                | Drupal image pull policy              | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
 | `image.pullSecrets`               | Specify image pull secrets            | `nil` (does not add image pull secrets to deployed pods)  |
+| `drupalProfile`                   | Drupal installation profile           | `standard`                                                |
 | `drupalUsername`                  | User of the application               | `user`                                                    |
 | `drupalPassword`                  | Application password                  | _random 10 character long alphanumeric string_            |
 | `drupalEmail`                     | Admin email                           | `user@example.com`                                        |

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -60,15 +60,23 @@ spec:
         {{- else }}
           value: {{ default "" .Values.externalDatabase.password | quote }}
         {{- end }}
+        {{- if .Values.drupalProfile }}
+        - name: DRUPAL_PROFILE
+          value: {{ .Values.drupalProfile | quote }}
+        {{- end }}
+        {{- if .Values.drupalUsername }}
         - name: DRUPAL_USERNAME
-          value: {{ default "" .Values.drupalUsername | quote }}
+          value: {{ .Values.drupalUsername | quote }}
+        {{- end }}
         - name: DRUPAL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "drupal.fullname" . }}
               key: drupal-password
+        {{- if .Values.drupalEmail }}
         - name: DRUPAL_EMAIL
-          value: {{ default "" .Values.drupalEmail | quote }}
+          value: {{ .Values.drupalEmail | quote }}
+        {{- end }}
 {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 8 }}
 {{- end }}

--- a/stable/drupal/templates/secrets.yaml
+++ b/stable/drupal/templates/secrets.yaml
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.drupalPassword }}
-  drupal-password: {{ default "" .Values.drupalPassword | b64enc | quote }}
+  drupal-password: {{ .Values.drupalPassword | b64enc | quote }}
   {{ else }}
   drupal-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -17,6 +17,11 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+## Installation Profile
+## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
+##
+drupalProfile: standard
+
 ## User of the application
 ## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
 ##


### PR DESCRIPTION
**What this PR does / why we need it**:

There's a new environment variables supported on Drupal Docker Images which allows the user to configure the Installation Profile when initialising Drupal. This PR adds support for that new feature so it can be easily setup via parameters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/bitnami/bitnami-docker-drupal/issues/91