### PR TITLE
[stable/spotify-docker-gc] Support tolerations and node selectors

### DIFF
--- a/stable/spotify-docker-gc/Chart.yaml
+++ b/stable/spotify-docker-gc/Chart.yaml
@@ -1,6 +1,6 @@
 name: spotify-docker-gc
 home: https://github.com/spotify/docker-gc
-version: 0.1.3
+version: 0.1.4
 appVersion: latest
 description: A simple Docker container and image garbage collection script.
 sources:

--- a/stable/spotify-docker-gc/Chart.yaml
+++ b/stable/spotify-docker-gc/Chart.yaml
@@ -1,6 +1,6 @@
 name: spotify-docker-gc
 home: https://github.com/spotify/docker-gc
-version: 0.1.4
+version: 0.2.0
 appVersion: latest
 description: A simple Docker container and image garbage collection script.
 sources:

--- a/stable/spotify-docker-gc/README.md
+++ b/stable/spotify-docker-gc/README.md
@@ -21,16 +21,18 @@ The following table lists the configurable parameters of the Spotify Docker GC c
 
 See the [spotify/docker-gc GitHub repository][] for more settings which may be added to this chart as needed.
 
-| Parameter                         | Description                              | Default                                 |
-| --------------------------------- | ---------------------------------------- | --------------------------------------- |
-| `cron.schedule`                   | cron schedule                            | `0 0 * * *` (daily at 12:00AM UTC)      |
-| `cron.log`                        | cron log name                            | `/var/logs/cron.log`                    |
-| `env.gracePeriodSeconds`          | grace period in seconds before gc occurs | `0`                                     |
-| `env.dockerAPIVersion`            | Docker API Version for docker-gc client  | Not set                                 |
-| `exclude.images`                  | images to be excluded                    | Not set                                 |
-| `exclude.containers`              | containers to be excluded                | Not set                                 |
-| `serviceAccount`                  | service account to attach to deamonset   | Not set                                 |
-| `imagePullSecrets`                | Specify image pull secrets               | Not set                                 |
+| Parameter                         | Description                                | Default                                 |
+| --------------------------------- | ------------------------------------------ | --------------------------------------- |
+| `cron.schedule`                   | cron schedule                              | `0 0 * * *` (daily at 12:00AM UTC)      |
+| `cron.log`                        | cron log name                              | `/var/logs/cron.log`                    |
+| `env.gracePeriodSeconds`          | grace period in seconds before gc occurs   | `0`                                     |
+| `env.dockerAPIVersion`            | Docker API Version for docker-gc client    | Not set                                 |
+| `exclude.images`                  | images to be excluded                      | Not set                                 |
+| `exclude.containers`              | containers to be excluded                  | Not set                                 |
+| `serviceAccount`                  | service account to attach to deamonset     | Not set                                 |
+| `imagePullSecrets`                | Specify image pull secrets                 | Not set                                 |
+| `tolerations`                     | Daemonset tolerations                      | Not set                                 |
+| `nodeSelector`                    | Node labels for daemonset pod assignment   | Not set                                 |
 
 ## Design/Evolution
 

--- a/stable/spotify-docker-gc/README.md
+++ b/stable/spotify-docker-gc/README.md
@@ -21,18 +21,18 @@ The following table lists the configurable parameters of the Spotify Docker GC c
 
 See the [spotify/docker-gc GitHub repository][] for more settings which may be added to this chart as needed.
 
-| Parameter                         | Description                                | Default                                 |
-| --------------------------------- | ------------------------------------------ | --------------------------------------- |
-| `cron.schedule`                   | cron schedule                              | `0 0 * * *` (daily at 12:00AM UTC)      |
-| `cron.log`                        | cron log name                              | `/var/logs/cron.log`                    |
-| `env.gracePeriodSeconds`          | grace period in seconds before gc occurs   | `0`                                     |
-| `env.dockerAPIVersion`            | Docker API Version for docker-gc client    | Not set                                 |
-| `exclude.images`                  | images to be excluded                      | Not set                                 |
-| `exclude.containers`              | containers to be excluded                  | Not set                                 |
-| `serviceAccount`                  | service account to attach to deamonset     | Not set                                 |
-| `imagePullSecrets`                | Specify image pull secrets                 | Not set                                 |
-| `tolerations`                     | Daemonset tolerations                      | Not set                                 |
-| `nodeSelector`                    | Node labels for daemonset pod assignment   | Not set                                 |
+| Parameter                         | Description                              | Default                                 |
+| --------------------------------- | ---------------------------------------- | --------------------------------------- |
+| `cron.schedule`                   | cron schedule                            | `0 0 * * *` (daily at 12:00AM UTC)      |
+| `cron.log`                        | cron log name                            | `/var/logs/cron.log`                    |
+| `env.gracePeriodSeconds`          | grace period in seconds before gc occurs | `0`                                     |
+| `env.dockerAPIVersion`            | Docker API Version for docker-gc client  | Not set                                 |
+| `exclude.images`                  | images to be excluded                    | Not set                                 |
+| `exclude.containers`              | containers to be excluded                | Not set                                 |
+| `serviceAccount`                  | service account to attach to deamonset   | Not set                                 |
+| `imagePullSecrets`                | Specify image pull secrets               | Not set                                 |
+| `tolerations`                     | Daemonset tolerations                    | Not set                                 |
+| `nodeSelector`                    | Node labels for daemonset pod assignment | Not set                                 |
 
 ## Design/Evolution
 

--- a/stable/spotify-docker-gc/templates/daemonset.yaml
+++ b/stable/spotify-docker-gc/templates/daemonset.yaml
@@ -45,3 +45,11 @@ spec:
       - name: docker-socket
         hostPath:
           path: /var/run/docker.sock
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}

--- a/stable/spotify-docker-gc/values.yaml
+++ b/stable/spotify-docker-gc/values.yaml
@@ -31,3 +31,17 @@ env:
 #
 # imagePullSecrets:
 #   - name: myRegistryKeySecretName
+
+## Node tolerations for spotify-docker-gc scheduling to nodes with taints
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+##
+tolerations: []
+# - key: "key"
+#  operator: "Equal|Exists"
+#  value: "value"
+#  effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+## Node labels for spotify-docker-gc pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}


### PR DESCRIPTION
We run tainted masters and still want to be able to schedule GC daemon set there. Other charts support these types of vars so I'd like to extend this chart as well. Toleration like
```
tolerations:
- effect: "NoSchedule"
  operator: "Exists"
```
allows to bypass master taint.

Node selector also useful. Use case: we have a set of nodes used for jenkins job scheduling which rotate tons of workload during the day. Thus I want a custom GC schedule for them (more frequent). With node selectors, I can solve this by creating another helm installation with a custom schedule, limited to my worker type nodes only.

Based on https://github.com/kubernetes/charts/blob/master/stable/fluent-bit/templates/daemonset.yaml#L62-L69