### PR TITLE
[stable/redis] Add service account to metrics deployment

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.6.4
+version: 3.6.5
 appVersion: 4.0.10
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/metrics-deployment.yaml
+++ b/stable/redis/templates/metrics-deployment.yaml
@@ -30,6 +30,7 @@ spec:
         {{- end}}
       {{- end}}
       {{- if .Values.metrics.nodeSelector }}
+      serviceAccountName: "{{ template "redis.serviceAccountName" . }}"
       nodeSelector:
 {{ toYaml .Values.metrics.nodeSelector | indent 8 }}
       {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
For clusters with RBAC, every deployment should have a service account.

