### PR TITLE
[stable/neo4j] Add License agreement in replica pod too

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,6 +1,6 @@
 name: neo4j
 home: https://www.neo4j.com
-version: 0.7.2
+version: 0.7.3
 appVersion: 3.3.4
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -22,6 +22,8 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         env:
+          - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+            value: "{{ .Values.acceptLicenseAgreement }}"
           - name: NEO4J_dbms_mode
             value: READ_REPLICA
           - name: NEO4J_dbms_security_auth__enabled


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing issue in #6577, 
When Neo4j has been set up with Replica pods in helm, it crushed since it does not contain a license agreement inside of it. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixing issue in #6577

**Special notes for your reviewer**:
To perform regression test, 
1. Type below cmd then you will get a timeout,  
`helm install stable/neo4j --debug --wait --name neo-helm  --set authEnabled=true --set acceptLicenseAgreement=yes --set readReplica.numberOfServers=1`

When you check `kubectl get po -w `, you will see that Replica pod had crushed already. 
```
NAME                                      READY     STATUS             RESTARTS   AGE
neo-helm-neo4j-core-0                     1/1       Running            0          3h
neo-helm-neo4j-core-1                     1/1       Terminating        0          3h
neo-helm-neo4j-replica-7b548b5f68-5jfcn   0/1       CrashLoopBackOff   5          3h
source-ip-app-8687dbf9f-p6wz6             1/1       Running            0          13d
```

2. Get this PR changes, and type as below. 
`helm install ./charts/stable/neo4j --debug --wait --name neo-helm  --set authEnabled=true --set acceptLicenseAgreement=yes --set readReplica.numberOfServers=1 # or type upgrade instead of install`
Do again, `kubectl get po - w` then Replica pod is running at this moment. 
```NAME                                      READY     STATUS    RESTARTS   AGE
neo-helm-neo4j-core-0                     1/1       Running   0          3h
neo-helm-neo4j-core-1                     1/1       Running   0          3h
neo-helm-neo4j-core-2                     1/1       Running   0          3h
neo-helm-neo4j-replica-6f97b6b8d8-mj9gb   1/1       Running   0          3h```