### PR TITLE
[stable/minio] Allow multiple default buckets

### DIFF
--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -105,10 +105,9 @@ The following table lists the configurable parameters of the Minio chart and the
 | `nodeSelector`             | Node labels for pod assignment      | `{}`                                                    |
 | `affinity`                 | Affinity settings for pod assignment | `{}`                                                   |
 | `tolerations`              | Toleration labels for pod assignment | `[]`                                                   |
-| `defaultBucket.enabled`    | If set to true, a bucket will be created after minio install | `false`                        |
-| `defaultBucket.name`       | Bucket name                         | `bucket`                                                |
-| `defaultBucket.policy`     | Bucket policy                       | `none`                                                  |
-| `defaultBucket.purge`      | Purge the bucket if already exists  | `false`                                                 |
+| `defaultBuckets[n].name`   | Bucket name                         | `bucket`                                                |
+| `defaultBuckets[n].policy` | Bucket policy                       | `none`                                                  |
+| `defaultBuckets[n].purge`  | Purge the bucket if already exists  | `false`                                                 |
 | `azuregateway.enabled`     | Use minio as an [azure gateway](https://docs.minio.io/docs/minio-gateway-for-azure)| `false`  |
 | `gcsgateway.enabled`       | Use minio as a [Google Cloud Storage gateway](https://docs.minio.io/docs/minio-gateway-for-gcs)| `false` |
 | `gcsgateway.gcsKeyJson`    | credential json file of service account key | `""` |

--- a/stable/minio/templates/_helper_create_bucket.txt
+++ b/stable/minio/templates/_helper_create_bucket.txt
@@ -72,4 +72,6 @@ createBucket() {
 # Try connecting to Minio instance
 connectToMinio
 # Create the bucket
-createBucket {{ .Values.defaultBucket.name }} {{ .Values.defaultBucket.policy }} {{ .Values.defaultBucket.purge }}
+{{- range $bucket := .Values.defaultBuckets }}
+createBucket {{ $bucket.name }} {{ $bucket.policy }} {{ $bucket.purge }}
+{{- end }}

--- a/stable/minio/templates/configmap.yaml
+++ b/stable/minio/templates/configmap.yaml
@@ -8,8 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+{{- if .Values.defaultBuckets }}
   initialize: |-
 {{ include (print $.Template.BasePath "/_helper_create_bucket.txt") . | indent 4 }}
+{{- end }}
   config.json: |-
     {
       "version": "26",

--- a/stable/minio/templates/post-install-create-buckets-job.yaml
+++ b/stable/minio/templates/post-install-create-buckets-job.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.defaultBucket.enabled }}
+{{- if .Values.defaultBuckets }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "minio.fullname" . }}-make-bucket-job
+  name: {{ template "minio.fullname" . }}-make-buckets-job
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -105,16 +105,18 @@ resources:
     memory: 256Mi
     cpu: 250m
 
-## Create a bucket after minio install
+## Create these bucket after minio install
 ##
-defaultBucket:
-  enabled: false
+defaultBuckets:
   ## If enabled, must be a string with length > 0
-  name: bucket
+  #- name: bucket1
   ## Can be one of none|download|upload|public
-  policy: none
+  #  policy: none
   ## Purge if bucket exists already
-  purge: false
+  #  purge: false
+  #- name: bucket2
+  #  policy: none
+  #  purge: false
 
 ## Use minio as an azure blob gateway, you should disable data persistence so no volume claim are created.
 ## https://docs.minio.io/docs/minio-gateway-for-azure


### PR DESCRIPTION

**What this PR does / why we need it**:
This allows to create multiple default buckets instead of the single one that we had before.

**Note for the maintainer**
Semver bump due to config file changes?

@gtaylor
