### PR TITLE
[stable/docker-registry] Allow custom S3 endpoint

### DIFF
--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -47,6 +47,7 @@ their default values.
 | `resources.limits.memory`   | Container requested memory                                                                 | `nil`           |
 | `priorityClassName      `   | priorityClassName                                                                          | `""`            |
 | `storage`                   | Storage system to use                                                                      | `filesystem`    |
+| `storageRedirectDisable`    | Forward all storage traffic via the registry                                               | `false`         |
 | `tlsSecretName`             | Name of secret for TLS certs                                                               | `nil`           |
 | `secrets.htpasswd`          | Htpasswd authentication                                                                    | `nil`           |
 | `secrets.s3.accessKey`      | Access Key for S3 configuration                                                            | `nil`           |
@@ -56,6 +57,7 @@ their default values.
 | `haSharedSecret`            | Shared secret for Registry                                                                 | `nil`           |
 | `configData`                | Configuration hash for docker                                                              | `nil`           |
 | `s3.region`                 | S3 region                                                                                  | `nil`           |
+| `s3.regionendpoint`         | S3 region endpoint (Minio, ...)                                                            | `nil`           |
 | `s3.bucket`                 | S3 bucket name                                                                             | `nil`           |
 | `s3.encrypt`                | Store images in encrypted format                                                           | `nil`           |
 | `s3.secure`                 | Use HTTPS                                                                                  | `nil`           |

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
             - name: REGISTRY_HTTP_TLS_KEY
               value: /etc/ssl/docker/tls.key
 {{- end }}
+{{- if .Values.storageRedirectDisable }}
+            - name: REGISTRY_STORAGE_REDIRECT_DISABLE
+              value: true
+{{- end }}
 {{- if eq .Values.storage "filesystem" }}
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
@@ -96,6 +100,10 @@ spec:
             {{- end }}
             - name: REGISTRY_STORAGE_S3_REGION
               value: {{ required ".Values.s3.region is required" .Values.s3.region }}
+          {{- if .Values.s3.regionendpoint }}
+            - name: REGISTRY_STORAGE_S3_REGIONENDPOINT
+              value: {{ .Values.s3.regionendpoint }}
+          {{- end }}
             - name: REGISTRY_STORAGE_S3_BUCKET
               value: {{ required ".Values.s3.bucket is required" .Values.s3.bucket }}
           {{- if .Values.s3.encrypt }}

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -58,6 +58,7 @@ persistence:
 
 # set the type of filesystem to use: filesystem, s3
 storage: filesystem
+storageRedirectDisable: false
 
 # Set this to name of secret for tls certs
 # tlsSecretName: registry.docker.example.com
@@ -76,6 +77,7 @@ secrets:
 # Options for s3 storage type:
 # s3:
 #  region: us-east-1
+#  regionendpoint: http://<my-s3-address>:<my-s3-port>
 #  bucket: my-bucket
 #  encrypt: false
 #  secure: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Using the default S3 configuration suffices only if you are using Amazon's service.
Given the rise of private S3-compatible solutions, it might be desirable to run the docker-registry from an in-cluster S3 storage engine.
The possibility to disable redirects allows all traffic between the storage provider and the registry to be completely transparent to the user and invisible outside the cluster.

Fixes #5866