### PR TITLE
stable/fluent-bit: Fix `http` backend configuration

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -42,13 +42,6 @@ backend:
     # TLS debugging levels = 1-5
     tls_debug: 1
 
-parsers:
-  ## List the respective parsers in key: value format per entry
-  ## Regex required fields are name and regex. JSON required field
-  ## is name.
-  regex: []
-  json: []
-
   ##
   ## Ref: http://fluentbit.io/documentation/current/output/http.html
   ##
@@ -59,6 +52,13 @@ parsers:
     ## Specify the data format to be used in the HTTP request body
     ## Can be either 'msgpack' or 'json'
     format: msgpack
+
+parsers:
+  ## List the respective parsers in key: value format per entry
+  ## Regex required fields are name and regex. JSON required field
+  ## is name.
+  regex: []
+  json: []
 
 env: []
 


### PR DESCRIPTION
Fixes: #6671
See: https://github.com/kubernetes/charts/issues/6671
See: 7da6e88d13b6d01559771dfca5da6185c23f6582
See: https://github.com/kubernetes/charts/commit/7da6e88d13b6d01559771dfca5da6185c23f6582
See: #5398
See: https://github.com/kubernetes/charts/pull/5398