### PR TITLE
stable/fluent-bit: Add labels to all objects

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.7.0
+version: 0.8.0
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "fluent-bit.fullname" . }}-config
   labels:
     app: {{ template "fluent-bit.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 data:
   fluent-bit.conf: |-
     [SERVICE]

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: fluent-bit
   labels:
     app: {{ template "fluent-bit.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -11,6 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ template "fluent-bit.fullname" . }}
+        release: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}

--- a/stable/fluent-bit/templates/secret.yaml
+++ b/stable/fluent-bit/templates/secret.yaml
@@ -4,6 +4,9 @@ metadata:
   name: "{{ template "fluent-bit.fullname" . }}-es-tls-secret"
   labels:
     app: {{ template "fluent-bit.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 type: Opaque
 data:
   es-tls-ca.crt: {{ .Values.backend.es.tls_ca | b64enc | quote }}

--- a/stable/fluent-bit/templates/service.yaml
+++ b/stable/fluent-bit/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ template "fluent-bit.fullname" . }}-metrics
   labels:
     app: {{ template "fluent-bit.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   type: {{ .Values.metrics.service.type}}
   sessionAffinity: None
@@ -14,4 +17,5 @@ spec:
     name: metrics
   selector:
     app: {{ template "fluent-bit.fullname" . }}
+    release: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
Also: restrict the `Service` `selector` somewhat to include the release
name.

Fixes: #6672
See: https://github.com/kubernetes/charts/issues/6672