### PR TITLE
Update signalfx-agent chart for 3.6.1 release

### DIFF
--- a/stable/signalfx-agent/Chart.yaml
+++ b/stable/signalfx-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: The SignalFx Kubernetes agent
 name: signalfx-agent
-appVersion: 3.2.2
-version: 0.2.1
+appVersion: 3.6.1
+version: 0.3.0
 keywords:
 - monitoring
 - alerting

--- a/stable/signalfx-agent/templates/clusterrole.yaml
+++ b/stable/signalfx-agent/templates/clusterrole.yaml
@@ -22,6 +22,7 @@ rules:
   - replicationcontrollers
   - replicationcontrollers/status
   - services
+  - resourcequotas
   # Only need to be able to view secrets if using k8s annotation
   # agent.signalfx.com/configWithSecret.*.  You can also whitelist specific
   # secrets for finer-grain permission sets.

--- a/stable/signalfx-agent/templates/configmap.yaml
+++ b/stable/signalfx-agent/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
     globalDimensions:
       kubernetes_cluster: {{ .Values.clusterName }}
 
-    sendMachineID: true
+    sendMachineID: false
 
     observers:
     - type: k8s-api
@@ -45,8 +45,9 @@ data:
     - type: collectd/protocols
     - type: collectd/signalfx-metadata
       procFSPath: /hostfs/proc
+    - type: host-metadata
       etcPath: /hostfs/etc
-      persistencePath: /run
+      procFSPath: /hostfs/proc
     - type: collectd/uptime
     - type: collectd/vmem
 
@@ -67,6 +68,7 @@ data:
     {{ if .Values.gatherClusterMetrics -}}
     # Collects k8s cluster-level metrics
     - type: kubernetes-cluster
+      useNodeName: true
     {{- end }}
 
     {{ if .Values.gatherDockerMetrics -}}

--- a/stable/signalfx-agent/values.yaml
+++ b/stable/signalfx-agent/values.yaml
@@ -1,6 +1,6 @@
 # Version of the signalfx-agent to deploy.  This will be the default for the
 # docker image tag if not overridden with imageTag
-agentVersion: 3.2.2
+agentVersion: 3.6.1
 
 # The access token for SignalFx.  REQUIRED
 signalFxAccessToken: ""
@@ -64,7 +64,7 @@ clusterName:
 
 # How frequently to send metrics by default in the agent.  This can be
 # overridden by individual monitors.
-metricIntervalSeconds: 15
+metricIntervalSeconds: 10
 
 # The log level of the agent.  Valid values are 'debug', 'info', 'warn', and
 # 'error'.  Info is a good default and won't be too spamy.  Note that 'debug'


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Updates the SignalFx agent chart to use the latest release by default.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
