### PR TITLE
[stable/nginx-ingress] Make PodDisruptionBudget optional.

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.23.0
+version: 0.24.0
 appVersion: 0.15.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -125,6 +125,7 @@ Parameter | Description | Default
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
 `controller.updateStrategy` | allows setting of RollingUpdate strategy | `{}`
+`controller.podDisruptionBudget.enabled` | if `true`, enable the PodDisruptionBudget for the controller | `true`
 `defaultBackend.name` | name of the default backend component | `default-backend`
 `defaultBackend.image.repository` | default backend container image repository | `k8s.gcr.io/defaultbackend`
 `defaultBackend.image.tag` | default backend container image tag | `1.3`
@@ -144,6 +145,7 @@ Parameter | Description | Default
 `defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `defaultBackend.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `defaultBackend.service.type` | type of default backend service to create | `ClusterIP`
+`defaultBackend.podDisruptionBudget.enabled` | if `true`, enable the PodDisruptionBudget for the default backend | `true`
 `imagePullSecrets` | name of Secret resource containing private registry credentials | `nil`
 `rbac.create` | if `true`, create & use RBAC resources | `true`
 `serviceAccount.create` | if `true`, create a service account | ``

--- a/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controller.podDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -15,3 +16,4 @@ spec:
       release: {{ .Release.Name }}
       component: "{{ .Values.controller.name }}"
   minAvailable: {{ .Values.controller.minAvailable }}
+{{- end }}

--- a/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/stable/nginx-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.defaultBackend.enabled .Values.defaultBackend.podDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -15,3 +16,4 @@ spec:
       release: {{ .Release.Name }}
       component: "{{ .Values.defaultBackend.name }}"
   minAvailable: {{ .Values.defaultBackend.minAvailable }}
+{{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -276,6 +276,9 @@ controller:
 
   priorityClassName: ""
 
+  podDisruptionBudget:
+    enabled: true
+
 ## Rollback limit
 ##
 revisionHistoryLimit: 10
@@ -348,6 +351,9 @@ defaultBackend:
 
   priorityClassName: ""
 
+  podDisruptionBudget:
+    enabled: true
+
 ## Enable RBAC as per https://github.com/kubernetes/ingress/tree/master/examples/rbac/nginx and https://github.com/kubernetes/ingress/issues/266
 rbac:
   create: true
@@ -372,9 +378,3 @@ tcp: {}
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
-
-controllerPodDisruptionBudget:
-  create: true
-
-defaultBackendPodDisruptionBudget:
-  create: true

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -372,3 +372,9 @@ tcp: {}
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
+
+controllerPodDisruptionBudget:
+  create: true
+
+defaultBackendPodDisruptionBudget:
+  create: true


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Adds two options `controller.podDisruptionBudget.enabled` and `defaultBackend.podDisruptionBudget.enabled`. If false, the corresponding PodDisruptionBudget will not be created. The default value is `true` which is backwards compatible with the current behaviour.

Users should have the option to deploy the chart without PodDisruptionBudget as sometimes the permissions to create these resources are restricted.

**Special notes for your reviewer**:

@jackzampolin @mgoodness @chancez
