### PR TITLE
[stable/jenkins] fix bump appVersion to reflect new jenkins lts release version 2.121.2

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.6
-appVersion: 2.121.1
+version: 0.16.7
+appVersion: 2.121.2
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
   projects as well as arbitrary scripts.


### PR DESCRIPTION
**What this PR does / why we need it**:
Jenkins LTS made a new release 2.121.2. This PR reflects this change and bumps the appVersion.
