### PR TITLE
[stable/verdaccio] Route all traffic to the service

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.3.0
+version: 0.3.1
 appVersion: 3.2
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/templates/ingress.yaml
+++ b/stable/verdaccio/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/stable/verdaccio/templates/ingress.yaml
+++ b/stable/verdaccio/templates/ingress.yaml
@@ -20,6 +20,10 @@ spec:
     - host: {{ $host }}
       http:
         paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
           - path: /*
             backend:
               serviceName: {{ $serviceName }}


### PR DESCRIPTION
Will now route all traffic to the service and not just the root path.

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
To properly serve the UI and other sub-path routes, we will need to modify the ingress controller to route all traffic, not just the root path.

**Special notes for your reviewer**:
We use Google's Identity-Aware Proxy on all our fallback routes, so this is needed to circumvent it.
