### PR TITLE
nginx-ingress: Use lists as default in extraVolumes

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.24.0
+version: 0.24.1
 appVersion: 0.17.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -192,7 +192,7 @@ controller:
       http: ""
       https: ""
 
-  extraContainers: {}
+  extraContainers: []
   ## Additional containers to be added to the controller pod.
   ## See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
   #  - name: my-sidecar
@@ -216,12 +216,12 @@ controller:
   #    - name: copy-portal-skins
   #      mountPath: /srv/var/lib/lemonldap-ng/portal/skins
 
-  extraVolumeMounts: {}
+  extraVolumeMounts: []
   ## Additional volumeMounts to the controller main container.
   #  - name: copy-portal-skins
   #   mountPath: /var/lib/lemonldap-ng/portal/skins
 
-  extraVolumes: {}
+  extraVolumes: []
   ## Additional volumes to the controller pod.
   #  - name: copy-portal-skins
   #    emptyDir: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the error
```
warning: cannot overwrite table with non table for extraVolumeMounts (map[])
warning: cannot overwrite table with non table for extraVolumes (map[])
```
when setting a list for `extraVolumes` and `extraVolumeMounts`.