### PR TITLE
incubator/kafka support for additional clouds

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.8.4
+version: 0.8.5
 appVersion: 4.1.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -52,11 +52,14 @@ associated resources to become healthy.
   {{  $fullName := include "kafka.fullname" . }}
   {{- $replicas := .Values.replicas | int }}
   {{- $servicePort := .Values.external.servicePort }}
-  {{- $externalFqdn := printf "%s.%s" .Release.Name .Values.external.domain }}
   {{- $root := . }}
   {{- range $i, $e := until $replicas }}
     {{- $externalListenerPort := add $root.Values.external.firstListenerPort $i }}
-{{ printf "%s:%d" $externalFqdn $externalListenerPort | indent 2 }}
+    {{- if $root.Values.external.distinct }}
+{{ printf "%s-%d.%s:%d" $root.Release.Name $i $root.Values.external.domain  $externalListenerPort | indent 2 }}
+    {{- else }}
+{{ printf "%s.%s:%d" $root.Release.Name $root.Values.external.domain $externalListenerPort | indent 2 }}
+    {{- end }}
   {{- end }}
 {{- end }}
 

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -2,17 +2,27 @@
   {{- $fullName := include "kafka.fullname" . }}
   {{- $replicas := .Values.replicas | int }}
   {{- $servicePort := .Values.external.servicePort }}
+  {{- $dnsPrefix := printf "%s" .Release.Name }}
   {{- $root := . }}
   {{- range $i, $e := until $replicas }}
     {{- $externalListenerPort := add $root.Values.external.firstListenerPort $i }}
     {{- $responsiblePod := printf "%s-%d" (printf "%s" $fullName) $i }}
+    {{- $distinctPrefix := printf "%s-%d" $dnsPrefix $i }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    ## ref: https://github.com/kubernetes/kops/blob/master/dns-controller/pkg/watchers/annotations.go#L21
-    dns.alpha.kubernetes.io/internal: "{{ $root.Release.Name }}.{{ $root.Values.external.domain }}"
+    {{- if $root.Values.external.distinct }}
+    dns.alpha.kubernetes.io/internal: "{{ $distinctPrefix }}.{{ $root.Values.external.domain }}"
+    external-dns.alpha.kubernetes.io/hostname: "{{ $distinctPrefix }}.{{ $root.Values.external.domain }}"
+    {{- else }}
+    dns.alpha.kubernetes.io/internal: "{{ $dnsPrefix }}.{{ $root.Values.external.domain }}"
+    external-dns.alpha.kubernetes.io/hostname: "{{ $dnsPrefix }}.{{ $root.Values.external.domain }}"
+    {{- end }}
+    {{- if $root.Values.external.annotations }}
+{{ toYaml $root.Values.external.annotations | indent 4 }}
+    {{- end }}
   name: {{ $root.Release.Name }}-{{ $i }}-external
   labels:
     app: {{ include "kafka.name" $root }}
@@ -21,12 +31,18 @@ metadata:
     heritage: {{ $root.Release.Service }}
     pod: {{ $responsiblePod | quote }}
 spec:
-  type: NodePort
+  type: {{ $root.Values.external.type }}
   ports:
     - name: external-broker
+      {{- if eq $root.Values.external.type "LoadBalancer" }}
+      port: {{ $externalListenerPort }}
+      {{- else }}
       port: {{ $servicePort }}
+      {{- end }}
       targetPort: {{ $externalListenerPort }}
+      {{- if eq $root.Values.external.type "NodePort" }}
       nodePort: {{ $externalListenerPort }}
+      {{- end }}
       protocol: TCP
   selector:
     app: {{ include "kafka.name" $root }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -113,6 +113,12 @@ tolerations: []
 ## External access.
 ##
 external:
+  type: NodePort
+  # annotations:
+  #  service.beta.kubernetes.io/openstack-internal-load-balancer: "true"
+
+  # create an A record for each statefulset pod
+  distinct: false
   enabled: false
   servicePort: 19092
   firstListenerPort: 31090


### PR DESCRIPTION
**What this PR does / why we need it**:
external-service-brokers currently only supports kops deployments in aws

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes https://github.com/helm/charts/issues/6739

**Special notes for your reviewer**:
I have added the ability to make the annotation for external-dns distinct for each statefulset service.  This seems required as I am using LoadBalancer, which will create 3 load balancers in for example openstack.  If these shared the same DNS A record external DNS happens to not append and update it only to the last one, which is coupled to a single port in openstack.  Even if it did append load balancers it would happen to round robin between them.  A separate lookup for each loadbalancer allows me to reference the openstack loadbalancer which is coupled to the service port.