### PR TITLE
Add support for S3 region endpoints

### DIFF
--- a/stable/docker-registry/README.md
+++ b/stable/docker-registry/README.md
@@ -59,6 +59,7 @@ their default values.
 | `s3.bucket`                 | S3 bucket name                                                                             | `nil`           |
 | `s3.encrypt`                | Store images in encrypted format                                                           | `nil`           |
 | `s3.secure`                 | Use HTTPS                                                                                  | `nil`           |
+| `s3.endpoint`               | Optional region endpoint to use for accessing S3                                           | `nil`           |
 | `swift.authurl`             | Swift authurl                                                                              | `nil`           |
 | `swift.container`           | Swift container                                                                            | `nil`           |
 

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -106,6 +106,10 @@ spec:
             - name: REGISTRY_STORAGE_S3_SECURE
               value: {{ .Values.s3.secure | quote }}
           {{- end }}
+          {{- if .Values.s3.endpoint }}
+            - name: REGISTRY_STORAGE_S3_REGIONENDPOINT
+              value: {{ .Values.s3.endpoint | quote }}
+          {{- end }}
 {{- else if eq .Values.storage "swift" }}
             - name: REGISTRY_STORAGE_SWIFT_AUTHURL
               value: {{ required ".Values.swift.authurl is required" .Values.swift.authurl }}

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -79,6 +79,7 @@ secrets:
 #  bucket: my-bucket
 #  encrypt: false
 #  secure: true
+#  endpoint: https://s3.us-east-2.amazonaws.com
 
 # Options for swift storage type:
 # swift:


### PR DESCRIPTION
This PR adds support for using a S3 region endpoint to the docker-registry chart. This enables the docker registry to be used with any service that supports a S3 interface.