### PR TITLE
[stable/metrics-server] Update RBAC to handle disabled kubelet read-only port

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.2.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 1.0.0
+version: 1.0.1
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/templates/cluster-role.yaml
+++ b/stable/metrics-server/templates/cluster-role.yaml
@@ -19,4 +19,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/stats
+    verbs:
+    - get
+    - create
 {{- end -}}


### PR DESCRIPTION
A disabled kubelet read-only port is the default behaviour in K8S 1.11+

Along with #6620, fixes https://github.com/kubernetes-incubator/metrics-server/issues/77
