### PR TITLE
Allow sidecars for NATS.

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,5 +1,5 @@
 name: nats
-version: 0.0.2
+version: 0.0.3
 appVersion: 1.1.0
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -114,7 +114,7 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `ingress.secrets[0].key`             | TLS Secret Key                                                                               | `nil`                             |
 | `networkPolicy.enabled`              | Enable NetworkPolicy                                                                         | `false`                           |
 | `networkPolicy.allowExternal`        | Allow external connections                                                                   | `true`                            |
-| `sidecars`                           | Attach additional containers to the pod.                                                     | `{}`                              |
+| `sidecars`                           | Attach additional containers to the pod.                                                     | `nil`                             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -137,7 +137,7 @@ $ helm install --name my-release -f values.yaml stable/nats
 
 ## Sidecars
 
-If you have a need for additional containers to run within the same pod as NATS (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter.
+If you have a need for additional containers to run within the same pod as NATS (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
 
 ```yaml
 sidecars:

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -114,8 +114,10 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `ingress.secrets[0].key`             | TLS Secret Key                                                                               | `nil`                             |
 | `networkPolicy.enabled`              | Enable NetworkPolicy                                                                         | `false`                           |
 | `networkPolicy.allowExternal`        | Allow external connections                                                                   | `true`                            |
+| `sidecars`                           | Attach additional containers to the pod.                                                     | `{}`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
 
 ```bash
 $ helm install --name my-release \
@@ -132,6 +134,20 @@ $ helm install --name my-release -f values.yaml stable/nats
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Sidecars
+
+If you have a need for additional containers to run within the same pod as NATS (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter.
+
+```yaml
+sidecars:
+- name: your-image-name
+  image: your-image
+  imagePullPolicy: Always
+  ports:
+  - name: portname
+   containerPort: 1234
+```
 
 ## Production settings and horizontal scaling
 

--- a/stable/nats/templates/statefulset.yaml
+++ b/stable/nats/templates/statefulset.yaml
@@ -113,6 +113,9 @@ spec:
           - name: config
             mountPath: /opt/bitnami/nats/gnatsd.conf
             subPath: gnatsd.conf
+        {{- if .Values.sidecars }}
+{{ toYaml .Values.sidecars | indent 6 }}
+        {{- end }}
       volumes:
       - name: config
         configMap:

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -239,3 +239,13 @@ ingress:
   # - name: nats.local-tls
   #   key:
   #   certificate:
+
+sidecars:
+## Add sidecars to the pod.
+## e.g.
+# - name: your-image-name
+  # image: your-image
+  # imagePullPolicy: Always
+  # ports:
+  # - name: portname
+  #   containerPort: 1234

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -243,3 +243,13 @@ ingress:
   # - name: nats.local-tls
   #   key:
   #   certificate:
+
+sidecars:
+## Add sidecars to the pod.
+## e.g.
+# - name: your-image-name
+  # image: your-image
+  # imagePullPolicy: Always
+  # ports:
+  # - name: portname
+  #   containerPort: 1234


### PR DESCRIPTION
**What this PR does / why we need it**:
NATS has a [prometheus exporter](https://github.com/nats-io/prometheus-nats-exporter) that requires a 1:1 mapping that matches the NATS server instances. This can be achieved by deploying that exporter (or any other) as a sidecar.
However, the current template does not allow for any sidecars to be deployed alongside NATS.
This change makes it possible.