### PR TITLE
Added support for more Datadog environment variables

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.0.0
+version: 1.0.1
 appVersion: 6.3.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -100,6 +100,22 @@ spec:
           - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
             value: {{.Values.datadog.logsConfigContainerCollectAll | quote}}
           {{- end }}
+          {{- if .Values.datadog.processAgent }}
+          - name: DD_PROCESS_AGENT_ENABLED
+            value: {{.Values.datadog.processAgent | quote}}
+          {{- end }}
+          {{- if .Values.datadog.hostname }}
+          - name: DD_HOSTNAME
+            value: {{.Values.datadog.hostname | quote}}
+          {{- end }}
+          {{- if .Values.datadog.acInclude }}
+          - name: DD_AC_INCLUDE
+            value: {{.Values.datadog.acInclude | quote}}
+          {{- end }}
+          {{- if .Values.datadog.acExclude }}
+          - name: DD_AC_EXCLUDE
+            value: {{.Values.datadog.acExclude | quote}}
+          {{- end }}
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for more Datadog specific environment variables to be set at install time:

- DD_PROCESS_AGENT_ENABLED (`datadog.processAgentEnabled`)
- DD_DOGSTATSD_NON_LOCAL_TRAFFIC (`datadog.dogstatsdNonLocalTraffic`)
- DD_HOSTNAME (`datadog.hostname`)
- DD_AC_INCLUDE (`datadog.acInclude`)
- DD_AC_EXCLUDE (`datadog.acExclude`)

