### PR TITLE
Added optional imagePullSecret at install time

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.0.0
+version: 1.0.1
 appVersion: 6.3.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -172,6 +172,10 @@ spec:
       affinity:
 {{ toYaml .Values.daemonset.affinity | indent 8 }}
       {{- end }}
+      {{ if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "datadog.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       {{- if .Values.daemonset.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to provide an image pull secret at install time via the config param `image.pullSecret`. This allows for using customized, private Datadog agent images.

Example:
`helm install --set image.pullSecret=my-pull-secret,image.repository=acme/my-private-dd-agent-image stable/datadog`
