### PR TITLE
few fixes for README and apittimeout variable for Azure

### DIFF
--- a/stable/ark/README.md
+++ b/stable/ark/README.md
@@ -36,7 +36,8 @@ See here for the official documentation https://heptio.github.io/ark/v0.8.1/conf
 
 Parameter | Description | Default | Required
 --- | --- | --- | ---
-`cloudprovider` | Cloud provider  | `nil` | yes
+`persistentVolumeProvider.name` | Cloud Volume provider  | `nil` | yes
+`backupStorageProvider.name` | Cloud Backup Storage provider  | `nil` | yes
 `bucket` | Object storage where to store backups  | `nil` | yes
 `region` | AWS region  | `nil` | only if using AWS
 `apitimeout` | Api Timeout  | `nil` | only if using Azure
@@ -66,7 +67,7 @@ Parameter | Description | Default
 `configuration.persistentVolumeProvider.name` | The name of the cloud provider the cluster is using for persistent volumes, if any | `{}`
 `configuration.persistentVolumeProvider.config.region` | The cloud provider region (AWS only) | ``
 `configuration.persistentVolumeProvider.config.apiTimeout` | The API timeout (Azure only) |
-`configuration.backupStorageProvider.nam` | The name of the cloud provider that will be used to actually store the backups (`aws`, `azure`, `gcp`) | ``
+`configuration.backupStorageProvider.name` | The name of the cloud provider that will be used to actually store the backups (`aws`, `azure`, `gcp`) | ``
 `configuration.backupStorageProvider.bucket` | The storage bucket where backups are to be uploaded | ``
 `configuration.backupStorageProvider.config.regio`n | The cloud provider region (AWS only) | ``
 `configuration.backupStorageProvider.config.s3ForcePathStyle` | Set to `true` for a local storage service like Minio | ``

--- a/stable/ark/values.yaml
+++ b/stable/ark/values.yaml
@@ -36,7 +36,7 @@ configuration:
   #  name:
   #  config:
   #    region:
-  #    apiTimeout:
+  #    apitimeout:
 
   backupStorageProvider:
     name:


### PR DESCRIPTION

**What this PR does / why we need it**:
it provide more accurate README for deploying ark charts showing 2 missing required variables. 
also fixes a variables typos in values.yml for same chart.