### PR TITLE
Update README to change k8s member step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: lint
           command: |
-            git remote add k8s https://github.com/kubernetes/charts
+            git remote add k8s https://github.com/helm/charts
             git fetch k8s master
             chart_test.sh --config test/.testenv --no-install
   sync:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,13 @@
 Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
 make sure you are aware of our technical requirements and best practices:
 
-* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
+* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
 * https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices
 
 For a quick overview across what we will look at reviewing your PR, please read
 our review guidelines:
 
-* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md
+* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md
 
 Following our best practices right from the start will accelerate the review process and
 help get your PR merged quicker.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 <!--
-Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
+Thank you for contributing to helm/charts. Before you submit this PR we'd like to
 make sure you are aware of our technical requirements and best practices:
 
 * https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
-* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices
+* https://github.com/helm/helm/tree/master/docs/chart_best_practices
 
 For a quick overview across what we will look at reviewing your PR, please read
 our review guidelines:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ This repository is used by Chart developers for maintaining the official charts 
 * All Chart dependencies should also be submitted independently
 * Must pass the linter (`helm lint`)
 * Must successfully launch with default values (`helm install .`)
-    * All pods go to the running state (or NOTES.txt provides further instructions if a required value is missing e.g. [minecraft](https://github.com/kubernetes/charts/blob/master/stable/minecraft/templates/NOTES.txt#L3))
+    * All pods go to the running state (or NOTES.txt provides further instructions if a required value is missing e.g. [minecraft](https://github.com/helm/charts/blob/master/stable/minecraft/templates/NOTES.txt#L3))
     * All services have at least one endpoint
 * Must include source GitHub repositories for images used in the Chart
 * Images should not have any major security vulnerabilities
@@ -73,7 +73,7 @@ Once the Chart has been merged, the release job will automatically run in the CI
 
 Whether you are a user or contributor, official support channels include:
 
-- GitHub issues: https://github.com/kubernetes/charts/issues
+- GitHub issues: https://github.com/helm/charts/issues
 - Slack: Helm Users - #Helm-users room in the [Kubernetes Slack](http://slack.kubernetes.io/)
 - Slack: Helm Developers - #Helm-dev room in the [Kubernetes Slack](http://slack.kubernetes.io/)
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Individual charts can be maintained by one or more members of the Kubernetes com
 
 1. Be listed on the chart, in the `Chart.yaml` file, as a maintainer. If you need sponsors and have contributed to the chart, please reach out to the existing maintainers, or if you are having trouble connecting with them, please reach out to one of the [OWNERS](OWNERS) of the charts repository.
 1. Be invited (and accept your invite) as a read-only collaborator on [this repo](https://github.com/helm/charts). This is required for @k8s-ci-robot [PR comment interaction](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md).
-1. An OWNERS file needs to be added to a chart. That OWNERS file should list the maintainers GitHub Login names for both the reviewers and approvers sections. For an example see the [Drupal chart](stable/drupal/OWNERS). The `OWNERS` file should also be appended to the `.helmignore` file.
+1. An OWNERS file needs to be added to a chart. That OWNERS file should list the maintainers' GitHub login names for both the reviewers and approvers sections. For an example see the [Drupal chart](stable/drupal/OWNERS). The `OWNERS` file should also be appended to the `.helmignore` file.
 
 Once these two steps are done a chart approver can merge pull requests following the directions in the [REVIEW_GUIDELINES.md](REVIEW_GUIDELINES.md) file.
 

--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ To provide that support the API versions of objects should be those that work fo
 
 ## Status of the Project
 
-This project is still under active development, so you might run into [issues](https://github.com/kubernetes/charts/issues). If you do, please don't be shy about letting us know, or better yet, contribute a fix or feature.
+This project is still under active development, so you might run into [issues](https://github.com/helm/charts/issues). If you do, please don't be shy about letting us know, or better yet, contribute a fix or feature.

--- a/README.md
+++ b/README.md
@@ -60,17 +60,17 @@ Note: We use the same [workflow](https://github.com/kubernetes/community/blob/ma
 
 ## Owning and Maintaining A Chart
 
-Individual charts can be maintained by one or more members of the Kubernetes community. When someone maintains a chart they have the access to merge changes to that chart. To have merge access to a chart someone first needs to be listed on the chart, in the `Chart.yaml` file, as a maintainer. If that is the case there are two steps that need to happen:
+Individual charts can be maintained by one or more members of the Kubernetes community. When someone maintains a chart they have the access to merge changes to that chart. To have merge access to a chart someone needs to:
 
-1. Become a [member of the Kubernetes community](https://github.com/kubernetes/community/blob/master/community-membership.md). If you need sponsors and have contributed to charts please reach out to one of the [OWNERS](OWNERS) of the charts repository.
-2. An OWNERS file needs to be added to a chart. That OWNERS file should list the maintainers GitHub Login names for both the reviewers and approvers sections. For an example see the [Drupal chart](stable/drupal/OWNERS). The `OWNERS` file should also be appended to the `.helmignore` file.
+1. Be listed on the chart, in the `Chart.yaml` file, as a maintainer. If you need sponsors and have contributed to the chart, please reach out to the existing maintainers, or if you are having trouble connecting with them, please reach out to one of the [OWNERS](OWNERS) of the charts repository.
+1. Be invited (and accept your invite) as a read-only collaborator on [this repo](https://github.com/helm/charts). This is required for @k8s-ci-robot [PR comment interaction](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md).
+1. An OWNERS file needs to be added to a chart. That OWNERS file should list the maintainers GitHub Login names for both the reviewers and approvers sections. For an example see the [Drupal chart](stable/drupal/OWNERS). The `OWNERS` file should also be appended to the `.helmignore` file.
 
 Once these two steps are done a chart approver can merge pull requests following the directions in the [REVIEW_GUIDELINES.md](REVIEW_GUIDELINES.md) file.
 
 ## Review Process
 
 For information related to the review procedure used by the Chart repository maintainers, see [Merge approval and release process](CONTRIBUTING.md#merge-approval-and-release-process).
-
 
 ### Stale Pull Requests and Issues
 

--- a/REVIEW_GUIDELINES.md
+++ b/REVIEW_GUIDELINES.md
@@ -1,10 +1,10 @@
 # Chart Review Guidelines
 
-Anyone is welcome to review pull requests. Besides our [technical requirements](https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements) and [best practices](https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices), here's an overview of process and review guidelines.
+Anyone is welcome to review pull requests. Besides our [technical requirements](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements) and [best practices](https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices), here's an overview of process and review guidelines.
 
 ## Process
 
-The process to get a pull request merged is fairly simple. First, all required tests need to pass and the contributor needs to have a signed CLA. See [Charts Testing](https://github.com/kubernetes/charts/blob/master/test/README.md) for details on our CI system and how you can provide custom values for testing. If there is a problem with some part of the test, such as a timeout issue, please contact one of the charts repository maintainers by commenting `cc @kubernetes/charts-maintainers`.
+The process to get a pull request merged is fairly simple. First, all required tests need to pass and the contributor needs to have a signed CLA. See [Charts Testing](https://github.com/helm/charts/blob/master/test/README.md) for details on our CI system and how you can provide custom values for testing. If there is a problem with some part of the test, such as a timeout issue, please contact one of the charts repository maintainers by commenting `cc @kubernetes/charts-maintainers`.
 
 The charts repository uses the OWNERS files to provide merge access. If a chart has an OWNERS file, an approver listed in that file can approve the pull request. If the chart does not have an OWNERS file, an approver in the OWNERS file at the root of the repository can approve the pull request.
 

--- a/test/README.md
+++ b/test/README.md
@@ -25,8 +25,8 @@ Pull requests testing is run via the [Kubernetes Test Infrastructure](https://gi
 
 The configuration of the Pull Request trigger is [in the config.json](https://github.com/kubernetes/test-infra/blob/827797c54b48295045698465b437f463ca9276c2/jobs/config.json#L10285).
 
-This snippet tells Test Infra to run the [test/e2e.sh](https://github.com/kubernetes/charts/blob/master/test/e2e.sh)
-when testing is triggered on a pull request. The e2e.sh script will use the [Charts test image](https://github.com/kubernetes/charts/blob/master/test/Dockerfile)
+This snippet tells Test Infra to run the [test/e2e.sh](https://github.com/helm/charts/blob/master/test/e2e.sh)
+when testing is triggered on a pull request. The e2e.sh script will use the [Charts test image](https://github.com/helm/charts/blob/master/test/Dockerfile)
 to run the [chart_test.sh](https://github.com/kubernetes-helm/chart-testing/blob/master/chart_test.sh) script. This script
 is the main logic for validation of a pull request. It intends to only test charts that have changed in this PR.
 
@@ -52,11 +52,11 @@ This check is there to ensure that PRs are spot checked for any nefarious code. 
 ## Repo Syncing
 
 The syncing of charts to the stable and incubator repos happens from a Jenkins instance that is polling for changes
-to the master branch. On each change it will use the [test/repo-sync.sh](https://github.com/kubernetes/charts/blob/master/test/repo-sync.sh)
+to the master branch. On each change it will use the [test/repo-sync.sh](https://github.com/helm/charts/blob/master/test/repo-sync.sh)
 to update the public repositories. The procedure is as follows:
 
-1. [Setup Helm](https://github.com/kubernetes/charts/blob/master/test/repo-sync.sh#L16)
-1. [Authenticate to Google Cloud so that we can upload to the Cloud Storage bucket that hosts the charts](https://github.com/kubernetes/charts/blob/master/test/repo-sync.sh#L27)
+1. [Setup Helm](https://github.com/helm/charts/blob/master/test/repo-sync.sh#L16)
+1. [Authenticate to Google Cloud so that we can upload to the Cloud Storage bucket that hosts the charts](https://github.com/helm/charts/blob/master/test/repo-sync.sh#L27)
 1. For the stable and incubator folders:
    - Download the existing index.yaml from the repository
    - Run `helm dep build` on all the charts in the current repository

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -33,7 +33,7 @@ fi
 readonly PULL_INFO
 
 main() {
-    git remote add k8s https://github.com/kubernetes/charts
+    git remote add k8s https://github.com/helm/charts
     git fetch k8s master
 
     local config_container_id


### PR DESCRIPTION
After the repo moved to helm/helm, this PR updates steps for _Owning and Maintaining A Chart_ in the README.

Also changes repo URL from kubernetes/helm to helm/helm everywhere above chart directories. I'm thinking we may want the changes in chart directories to be separate PRs. I can automate that in a bit if we agree.