### PR TITLE
[stable/redis] move serviceAccountName out of if block

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.7.0
+version: 3.7.1
 appVersion: 4.0.10
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/metrics-deployment.yaml
+++ b/stable/redis/templates/metrics-deployment.yaml
@@ -30,10 +30,10 @@ spec:
         {{- end}}
       {{- end}}
       {{- if .Values.metrics.nodeSelector }}
-      serviceAccountName: "{{ template "redis.serviceAccountName" . }}"
       nodeSelector:
 {{ toYaml .Values.metrics.nodeSelector | indent 8 }}
       {{- end }}
+      serviceAccountName: "{{ template "redis.serviceAccountName" . }}"
       {{- if .Values.metrics.tolerations }}
       tolerations:
 {{ toYaml .Values.metrics.tolerations | indent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, `serviceAccountName` would only work if `nodeSelector` was set.