### PR TITLE
[stable/kibana] add extraEnv (directly instead of KV)

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.14.1
+version: 0.14.2
 appVersion: 6.4.0
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the kibana chart and th
 |-----------------------------------------------|--------------------------------------------|----------------------------------------|
 | `affinity`                                    | node/pod affinities                        | None                                   |
 | `env`                                         | Environment variables to configure Kibana  | `{}`                                   |
+| `extraEnv`                                    | `containers[].env` entries to configure Kibana, for example allows using ConfigMaps | `{}` |
 | `files`                                       | Kibana configuration files                 | None                                   |
 | `image.pullPolicy`                            | Image pull policy                          | `IfNotPresent`                         |
 | `image.repository`                            | Image repository                           | `docker.elastic.co/kibana/kibana-oss`  |
@@ -73,8 +74,7 @@ The following table lists the configurable parameters of the kibana chart and th
 | `dashboardImport.xpackauth.username`          | Optional Xpack username                    | `myuser`                               |
 | `dashboardImport.xpackauth.password`          | Optional Xpack password                    | `mypass`                               |
 | `dashboardImport.dashboards`                  | Dashboards                                 | `{}`                                   |
-| `plugins`                             | List of URLs pointing to zip files of Kibana plugins to install                                 | None:                                   |
-
+| `plugins`                                     | List of URLs pointing to zip files of Kibana plugins to install | None:             |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
+{{ toYaml .Values.extraEnv | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
           name: {{ template "kibana.name" . }}
@@ -83,6 +84,7 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
+{{ toYaml .Values.extraEnv | indent 8 }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
           name: {{ template "kibana.name" . }}
@@ -110,6 +112,7 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
+{{ toYaml .Values.extraEnv | indent 8 }}
 {{- if (not .Values.authProxyEnabled) }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -44,7 +44,9 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
-{{ toYaml .Values.extraEnv | indent 8 }}
+{{- with .Values.extraEnv }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
           name: {{ template "kibana.name" . }}
@@ -84,7 +86,9 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
-{{ toYaml .Values.extraEnv | indent 8 }}
+{{- with .Values.extraEnv }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
           name: {{ template "kibana.name" . }}
@@ -112,7 +116,9 @@ spec:
         - name: "{{ $key }}"
           value: "{{ $value }}"
         {{- end }}
-{{ toYaml .Values.extraEnv | indent 8 }}
+{{- with .Values.extraEnv }}
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- if (not .Values.authProxyEnabled) }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -16,6 +16,11 @@ env: {}
   # LOGGING_VERBOSE: "true"
   # SERVER_DEFAULTROUTE: "/app/kibana"
 
+extraEnv: []
+  # Extra environment directly mapped to containers.env
+  # - configMapRef:
+  #     name: "some-configmap"
+
 files:
   kibana.yml:
     ## Default Kibana configuration from kibana-docker.


### PR DESCRIPTION
**What this PR does / why we need it**:
It allows to fine-tune `containers[].env` instead of being restricted to Key-Value pairs:
- enables using `stable/kibana` as a subchart passing a `ConfigMap` from parent chart,
- enables storing passwords in a `Secret`,