### PR TITLE
stable/metrics-server: add parameter image.custom_command_args

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.2.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 0.0.3
+version: 0.1.0
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -2,6 +2,13 @@
 
 Metrics Server is a cluster-wide aggregator of resource usage data.
 
+## Requirements
+* Kubernetes >1.8
+
+## References
+* https://kubernetes.io/docs/tasks/debug-application-cluster/core-metrics-pipeline/#metrics-server
+* https://github.com/kubernetes/community/blob/master/contributors/design-proposals/instrumentation/resource-metrics-api.md#endpoints
+
 ## Configuration
 
 Parameter | Description | Default
@@ -13,3 +20,4 @@ Parameter | Description | Default
 `image.repository` | Image repository | `gcr.io/google_containers/metrics-server-amd64`
 `image.tag` | Image tag | `v0.2.1`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
+`image.custom_command_args` | Additionally command args | You can pass different values like ```kubeletPort``` to change the port. Example: ```?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250&insecure=true```. To use that you need to enable kubelet_authentication_token_webhook. Solve the issue when you get that error: the server could not find the requested resource (get services http:heapster:)

--- a/stable/metrics-server/templates/NOTES.txt
+++ b/stable/metrics-server/templates/NOTES.txt
@@ -1,9 +1,12 @@
-The metric server has been deployed. 
+The metrics server has been deployed.
 {{ if .Values.apiService.create }}
 In a few minutes you should be able to list metrics using the following
 command:
 
   kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes"
+
+  NOTE: If use have existing hpa resources you may need to re-create them.
+
 {{ else }}
 NOTE: You have disabled the API service creation for this release. The metrics
 API will not work with this release unless you configure the metrics API

--- a/stable/metrics-server/templates/_helpers.tpl
+++ b/stable/metrics-server/templates/_helpers.tpl
@@ -31,6 +31,14 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/* Helm requires labels */}}
+{{- define "metrics-server.labels" -}}
+app: {{ template "metrics-server.fullname" . }}
+chart: {{ template "metrics-server.name" . }}-{{ .Chart.Version }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- end -}}
+
 {{/*
 Create a service name that defaults to app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/stable/metrics-server/templates/metrics-server-deployment.yaml
+++ b/stable/metrics-server/templates/metrics-server-deployment.yaml
@@ -2,27 +2,32 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: {{ template "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "metrics-server.name" . }}
-    chart: {{ template "metrics-server.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "metrics-server.labels" . | indent 4 }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "metrics-server.name" . }}
+      app: {{ template "metrics-server.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "metrics-server.name" . }}
+        app: {{ template "metrics-server.fullname" . }}
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "metrics-server.serviceAccountName" . }}
       containers:
-        - name: metrics-server
+        - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /metrics-server
+            {{- if .Values.image.custom_command_args }}
+            - --source=kubernetes.summary_api:''{{ .Values.image.custom_command_args }}
+            {{- else }}
             - --source=kubernetes.summary_api:''
+            {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -1,3 +1,7 @@
+# Default values for metrics-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
  * add label part to _helpers.tpl
  * add dynamic resources part
  * update README
  * change metrics-server.name to metrics-server.fullname in some parts of the deployment
  * bump version

We need to use additional arguments after the command like:  ```?useServiceAccount=true&kubeletHttps=true&kubeletPort=10250&insecure=true"```.
Without the kubeletPort given it tries to connect to port 10255 (form. heapster) what is not available anymore. I think this is fixed in a higher k8s version.
We are running Kubernetes v1.9.5 right now.

Just a side note: kubelet_authentication_token_webhook must be true but that is set as default in the kubespray by commit c192a01b20608379510f030320ee4754eae444b7 if you use kubespray of course.
