### PR TITLE
[stable/dex]: Add support for Ingress

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.1.0
+version: 0.1.1
 appVersion: 2.10.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.1.1
+version: 0.2.0
 appVersion: 2.10.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/ingress.yaml
+++ b/stable/dex/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dex.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "dex.name" . }}
+    chart: {{ template "dex.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: https
+  {{- end }}
+{{- end }}

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -18,6 +18,19 @@ service:
   port: 5556
   # externalIPs:
 
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 resources:
   # Normal resource usage of dex server
   # limits:


### PR DESCRIPTION
This adds support for ingress to the Dex chart. Usage with nginx-ingress and
cert-manager as follows:

    selfSigned:
      create: false

    ingress:
      enabled: true
      path: /
      hosts:
        - dex.example.com
      annotations:
        kubernetes.io/tls-acme: "true"
        nginx.ingress.kubernetes.io/secure-backends: "true"

      tls:
        - secretName: dex.example.com-tls
          hosts:
            - dex.example.com

    secret:
      tlsName: dex.example.com-tls

    config:
      issuer: https://dex.example.com

      staticClients:
        - id: kubernetes
          name: 'Kubernetes'
          secret: 490b4de6-1cc3-487a-878e-003df5ef1f34
          redirectURIs:
            - urn:ietf:wg:oauth:2.0:oob

      # python -c 'import bcrypt; print(bcrypt.hashpw("password", bcrypt.gensalt()))'
      staticPasswords:
        - userID: "58545898-472b-4e1a-a275-955afdc66544"
          username: "user"
          email: "user@example.com"
          hash: "$2b$12$oFyCPL9/G.DXT6b9Ksy97uu34BKwCr.p33wEsxemqnSqEcxUkqqYS"