### PR TITLE
[stable/kibana] Added option to specify nodeport

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.8.0
+version: 0.8.1
 appVersion: 6.3.1
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.8.1
+version: 0.9.0
 appVersion: 6.3.1
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -59,6 +59,7 @@ Parameter | Description | Default
 `service.internalPort` | internal port for the service | `4180`
 `service.externalIPs` | external IP addresses | None:
 `service.loadBalancerIP` | Load Balancer IP address (to use with service.type LoadBalancer) | None:
+`service.nodePort` | NodePort value if service.type is NodePort | None:
 `service.type` | type of service | `ClusterIP`
 `service.annotations` | Kubernetes service annotations | None:
 `service.labels` | Kubernetes service labels | None:

--- a/stable/kibana/templates/service.yaml
+++ b/stable/kibana/templates/service.yaml
@@ -20,6 +20,9 @@ spec:
     - port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{ .Values.service.nodePort }}
+{{ end }}      
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -30,6 +30,7 @@ service:
   ## Default: nil
   ##
   # loadBalancerIP: 10.2.2.2
+  # nodePort: 30000
   annotations:
     # Annotation example: setup ssl with aws cert when service.type is LoadBalancer
     # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:EXAMPLE_CERT


### PR DESCRIPTION
**What this PR does / why we need it**: It adds the option to specify what nodePort will be used when the service type is NodePort.
