### PR TITLE
[stable/verdaccio]: Avoid hard-coding gid in securityContext

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.3.1
+version: 0.3.3
 appVersion: 3.2
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/templates/deployment.yaml
+++ b/stable/verdaccio/templates/deployment.yaml
@@ -56,9 +56,6 @@ spec:
             - mountPath: /verdaccio/conf
               name: config
               readOnly: true
-      # Allow non-root user to access PersistentVolume
-      securityContext:
-        fsGroup: 1000
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, deploying verdaccio on OpenShift fails because when containers are deploying on OpenShift clusters, the gid 1000 does not exist. Containers on OpenShift are created with randomized IDs.

This PR avoids forcing volume with a specific gid which may not exist.