### PR TITLE
New helm chart for h2non/imaginary

### DIFF
--- a/incubator/imaginary/.helmignore
+++ b/incubator/imaginary/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+OWNERS

--- a/incubator/imaginary/Chart.yaml
+++ b/incubator/imaginary/Chart.yaml
@@ -11,5 +11,5 @@ home: https://github.com/h2non/imaginary
 sources:
 - https://github.com/h2non/imaginary
 maintainers:
-- name: Kirill Kuznetsov
+- name: dragonsmith
   email: agon.smith@gmail.com

--- a/incubator/imaginary/Chart.yaml
+++ b/incubator/imaginary/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: Fast HTTP microservice written in Go for high-level image processing backed by bimg and libvips.
+name: imaginary
+version: 0.1.1
+appVersion: 1.0.15
+keywords:
+- imaginary
+- image
+- processing
+sources:
+- https://github.com/h2non/imaginary
+maintainers:
+- name: Kirill Kuznetsov
+  email: agon.smith@gmail.com

--- a/incubator/imaginary/Chart.yaml
+++ b/incubator/imaginary/Chart.yaml
@@ -7,6 +7,7 @@ keywords:
 - imaginary
 - image
 - processing
+home: https://github.com/h2non/imaginary
 sources:
 - https://github.com/h2non/imaginary
 maintainers:

--- a/incubator/imaginary/OWNERS
+++ b/incubator/imaginary/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- dragonsmith
+reviewers:
+- dragonsmith

--- a/incubator/imaginary/README.md
+++ b/incubator/imaginary/README.md
@@ -1,0 +1,101 @@
+# Imaginary
+
+[Imaginary](https://github.com/h2non/imaginary/blob/master/README.md#imaginary-----) is a fast HTTP microservice written in Go for high-level image processing backed by bimg and libvips.
+
+## TL;DR
+
+To install Imaginary to your kubernetes cluster simply run:
+
+```shell
+helm install --name imaginary --namespace imaginary-prod incubator/imaginary
+```
+
+## Introduction
+
+As the [official repo states](https://github.com/h2non/imaginary/blob/master/README.md#imaginary-----):
+
+**[Fast](#benchmarks) HTTP [microservice](http://microservices.io/patterns/microservices.html)** written in Go **for high-level image processing** backed by [bimg](https://github.com/h2non/bimg) and [libvips](https://github.com/jcupitt/libvips). `imaginary` can be used as private or public HTTP service for massive image processing with first-class support for [Docker](#docker) & [Heroku](#heroku).
+It's almost dependency-free and only uses [`net/http`](http://golang.org/pkg/net/http/) native package without additional abstractions for better [performance](#performance).
+
+Supports multiple [image operations](#supported-image-operations) exposed as a simple [HTTP API](#http-api),
+with additional optional features such as **API token authorization**, **HTTP traffic throttle** strategy and **CORS support** for web clients.
+
+`imaginary` **can read** images **from HTTP POST payloads**, **server local path** or **remote HTTP servers**, supporting **JPEG**, **PNG**, **WEBP**, and optionally **TIFF**, **PDF**, **GIF** and **SVG** formats if `libvips@8.3+` is compiled with proper library bindings.
+
+`imaginary` is able to output images as JPEG, PNG and WEBP formats, including transparent conversion across them.
+
+`imaginary` also optionally **supports image placeholder fallback mechanism** in case of image processing error or server error of any nature, therefore an image will be always returned by the server in terms of HTTP response body and content MIME type, even in case of error, matching the expected image size and format transparently.
+
+It uses internally `libvips`, a powerful and efficient library written in C for image processing
+which requires a [low memory footprint](http://www.vips.ecs.soton.ac.uk/index.php?title=Speed_and_Memory_Use)
+and it's typically 4x faster than using the quickest ImageMagick and GraphicsMagick
+settings or Go native `image` package, and in some cases it's even 8x faster processing JPEG images.
+
+See [official README](https://github.com/h2non/imaginary/blob/master/README.md#contents) for more.
+
+## Prerequisites
+
+* Kubernetes 1.4+ with Beta APIs enabled
+
+## Installing chart
+
+```shell
+helm install --name imaginary --namespace imaginary-prod incubator/imaginary
+```
+
+The command deploys Imaginary on the Kubernetes cluster in the default configuration. The [configuration section](#configuration) lists various ways to override default configuration during deployment.
+
+> **Tip:** To list all releases use `helm list`
+
+## Uninstalling the Chart
+
+```shell
+helm delete imaginary
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+Specify each parameter using the `--set key=value[,key=value]` argument to helm install or provide your own file via `-f values.yaml`. For example,
+
+```shell
+helm install \
+  --name imaginary \
+  --namespace imaginary-prod \
+  --set image.tag=1.0.15 \
+  incubator/imaginary
+```
+
+The above command installs a specified version of Imaginary.
+
+## Supporterd Chart values
+
+These are the values used to configure Imaginary itself:
+
+|Value|Description|Default|
+|-----|-----------|-------|
+|**config.pathPrefix**|Url path prefix to listen to|`/`|
+|**config.cors**|Enable CORS support||
+|**config.gzip**|Enable gzip compression (deprecated)||
+|**config.disableEndpoints**|Comma separated endpoints to disable. E.g: form,crop,rotate,health||
+|**config.key**|Define API key for authorization||
+|**config.mount**|Mount server local directory||
+|**config.httpCacheTTL**|The TTL in seconds. Adds caching headers to locally served files.||
+|**config.httpReadTimeout**|HTTP read timeout in seconds|`30`|
+|**config.httpWriteTimeout**|HTTP write timeout in seconds|`30`|
+|**config.enableURLSource**|Restrict remote image source processing to certain origins (separated by commas)||
+|**config.enablePlaceholder**|Enable image response placeholder to be used in case of error|
+|**config.enableAuthForwarding**|Forwards X-Forward-Authorization or Authorization header to the image source server. -enable-url-source flag must be defined. Tip: secure your server from public access to prevent attack vectors||
+|**config.enableURLSignature**|Enable URL signature (URL-safe Base64-encoded HMAC digest)|`false`|
+|**config.urlSignatureKey**|The URL signature key (32 characters minimum)||
+|**config.allowedOrigins**|Restrict remote image source processing to certain origins (separated by commas)||
+|**config.maxAllowedSize**|Restrict maximum size of http image source (in bytes)||
+|**config.authorization**|Defines a constant Authorization header value passed to all the image source servers. -enable-url-source flag must be defined. This overwrites authorization headers forwarding behavior via X-Forward-Authorization||
+|**config.placeholder**|Image path to image custom placeholder to be used in case of error. Recommended minimum image size is: 1200x1200||
+|**config.concurrency**|Throttle concurrency limit per second||
+|**config.burst**|Throttle burst max cache size|`100`|
+|**config.mrelease**|OS memory release interval in seconds|`30`|
+|**config.cpus**|Number of used cpu cores.||
+
+See `values.yaml` for some more Kubernetes-specific configuration options.

--- a/incubator/imaginary/templates/NOTES.txt
+++ b/incubator/imaginary/templates/NOTES.txt
@@ -1,0 +1,29 @@
+Imaginary is now running in your cluster.
+
+It can be accessed:
+
+{{- if contains "NodePort" .Values.serviceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "imaginary.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status by running 'kubectl get svc -w {{ template "imaginary.fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "imaginary.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo $SERVICE_IP
+{{- else if contains "ClusterIP"  .Values.serviceType }}
+
+  "{{ template "imaginary.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+  from within the cluster
+{{- end }}
+
+{{ if .Values.ingress.enabled -}}
+There is also an Ingress resource enabled for this installation.
+It can be accessed outside via the URL:
+  {{ $scheme := "http" -}}
+  {{ if .Values.ingress.tls -}}
+    {{- $scheme := "https" }}
+  {{- end }}
+  "{{ $scheme }}://{{ .Values.ingress.host }}{{ .Values.config.pathPrefix | default "/" }}"
+{{- end }}

--- a/incubator/imaginary/templates/_helpers.tpl
+++ b/incubator/imaginary/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "imaginary.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "imaginary.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/imaginary/templates/deployment.yaml
+++ b/incubator/imaginary/templates/deployment.yaml
@@ -1,0 +1,153 @@
+apiVersion: {{ .Values.apiVersion }}
+kind: Deployment
+metadata:
+  name: {{ template "imaginary.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "imaginary.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "imaginary.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "imaginary.fullname" . }}
+        release: {{ .Release.Name | quote }}
+    spec:
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      containers:
+      - name: "imaginary"
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: PORT
+          value: "{{ .Values.httpPort }}"
+        args:
+        {{- with .Values.config }}
+        {{- if .pathPrefix }}
+        - "-path-prefix={{ .pathPrefix }}"
+        {{- end }}
+        {{- if .cors }}
+        - "-cors"
+        {{- end }}
+        {{- if .gzip }}
+        - "-gzip"
+        {{- end }}
+        {{- if .disableEndpoints }}
+        - "-disable-endpoints={{ .disableEndpoints }}"
+        {{- end }}
+        {{- if .key }}
+        - "-key={{ .key }}"
+        {{- end }}
+        {{- if .mount }}
+        - "-mount={{ .mount }}"
+        {{- end }}
+        {{- if .httpCacheTTL }}
+        - "-http-cache-ttl={{ int .httpCacheTTL }}"
+        {{- end }}
+        {{- if .httpReadTimeout }}
+        - "-http-read-timeout={{ int .httpReadTimeout }}"
+        {{- end }}
+        {{- if .httpWriteTimeout }}
+        - "-http-write-timeout={{ int .httpWriteTimeout }}"
+        {{- end }}
+        {{- if .enableURLSource }}
+        - "-enable-url-source"
+        {{- end }}
+        {{- if .enablePlaceholder }}
+        - "-enable-placeholder"
+        {{- end }}
+        {{- if .enableAuthForwarding }}
+        - "-enable-auth-forwarding"
+        {{- end }}
+        {{- if .enableURLSignature}}
+        - "-enable-url-signature"
+        {{- end }}
+        {{- if .urlSignatureKey}}
+        - "-url-signature-key={{ .urlSignatureKey }}"
+        {{- end }}
+        {{- if .allowedOrigins }}
+        - "-allowed-origins={{ .allowedOrigins }}"
+        {{- end }}
+        {{- if .maxAllowedSize }}
+        - "-max-allowed-size={{ int .maxAllowedSize }}"
+        {{- end }}
+        {{- if .authorization }}
+        - "-authorization={{ .authorization }}"
+        {{- end }}
+        {{- if .placeholder }}
+        - "-placeholder={{ .placeholder }}"
+        {{- end }}
+        {{- if .concurrency }}
+        - "-concurrency={{ int .concurrency }}"
+        {{- end }}
+        {{- if .burst }}
+        - "-burst={{ int .burst }}"
+        {{- end }}
+        {{- if .mrelease }}
+        - "-mrelease={{ int .mrelease }}"
+        {{- end }}
+        {{- if .cpus }}
+        - "-cpus={{ int .cpus }}"
+        {{- end }}
+        {{- end }}
+        {{- if and (not .Values.ingress.tls) (and .Values.tls.certificate .Values.config.privateKey) }}
+        - "-certfile=/etc/tls.crt"
+        - "-keyfile=/etc/tls.key"
+        volumeMounts:
+        - mountPath: /etc/tls.key
+          name: certificates
+          subPath: tls.key
+        - mountPath: /etc/tls.crt
+          name: certificates
+          subPath: tls.crt
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - containerPort: {{ .Values.httpPort }}
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            {{- if .Values.config.pathPrefix }}
+            path: {{ .Values.config.pathPrefix }}/health
+            {{- else }}
+            path: /health
+            {{- end }}
+            port: {{ .Values.httpPort }}
+            scheme: HTTP
+          {{- with .Values.readinessProbe }}
+          initialDelaySeconds: {{ .initialDelaySeconds | default 10 }}
+          timeoutSeconds: {{ .timeoutSeconds | default 5}}
+          successThreshold: {{ .successThreshold | default 1 }}
+          failureThreshold: {{ .failureThreshold | default 5 }}
+          {{- end }}
+        livenessProbe:
+          httpGet:
+            {{- if .Values.config.pathPrefix }}
+            path: {{ .Values.config.pathPrefix }}/health
+            {{- else }}
+            path: /health
+            {{- end }}
+            port: {{ .Values.httpPort }}
+            scheme: HTTP
+          {{- with .Values.livenessProbe }}
+          initialDelaySeconds: {{ .initialDelaySeconds | default 50 }}
+          timeoutSeconds: {{ .timeoutSeconds | default 5}}
+          successThreshold: {{ .successThreshold | default 1 }}
+          failureThreshold: {{ .failureThreshold | default 5 }}
+          {{- end }}
+      {{- if and (not .Values.ingress.tls) (and .Values.tls.certificate .Values.config.privateKey) }}
+      volumes:
+      - name: certificates
+        secret:
+          secretName: {{ template "imaginary.fullname" . }}-tls
+      {{- end }}

--- a/incubator/imaginary/templates/ingress.yaml
+++ b/incubator/imaginary/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "imaginary.fullname" . }}
+  labels:
+    app: {{ template "imaginary.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- if and .Values.ingress.tls .Values.ingress.acme }}
+    kubernetes.io/tls-acme: "true"
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ template "imaginary.fullname" . }}-tls
+{{- end }}
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: {{ .Values.config.pathPrefix | default "/" }}
+        backend:
+          serviceName: {{ template "imaginary.fullname" . }}
+          servicePort: {{ .Values.httpPort }}
+{{- end -}}

--- a/incubator/imaginary/templates/secrets.yaml
+++ b/incubator/imaginary/templates/secrets.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.tls.privateKey .Values.tls.certificate }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "imaginary.fullname" . }}-tls
+  labels:
+    app: {{ template "imaginary.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: kubernetes.io/tls
+data:
+  tls.key: {{ .Values.tls.privateKey }}
+  tls.crt: {{ .Values.tls.certificate }}
+{{- end }}

--- a/incubator/imaginary/templates/service.yaml
+++ b/incubator/imaginary/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "imaginary.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ .Release.Name | quote }}
+spec:
+  selector:
+    app: {{ template "imaginary.fullname" . }}
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  type: {{ default "ClusterIP" .Values.serviceType }}

--- a/incubator/imaginary/values.yaml
+++ b/incubator/imaginary/values.yaml
@@ -1,0 +1,144 @@
+---
+# How many instances of Imaginary you desire to spin up.
+replicaCount: 1
+
+# A node selector label.
+nodeSelector: {}
+
+# Docker image repository, tag and a policy for Kubernetes to pull it.
+image:
+  repo: h2non/imaginary
+  tag: 1.0.15
+  pullPolicy: IfNotPresent
+
+# Kubernetes API version to use for Imaginary Deployment
+apiVersion: apps/v1
+
+# Set kubernetes specific resource limits
+resources: {}
+  # limits:
+  #   cpu: 700m
+  #   memory: 700Mi
+  # requests:
+  #   cpu: 700m
+  #   memory: 700Mi
+
+# Which port should Imaginary and its Kubernetes service listen
+httpPort: 80
+
+# Kubernetes service type
+serviceType: "ClusterIP"
+
+# Timeuouts and counters options for Liveness & Readiness probes for Imaginary
+# Kubernets Deployment
+readinessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 5
+livenessProbe:
+  initialDelaySeconds: 50
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 5
+
+
+# Imaginary application configuration:
+config: {}
+  ## Url path prefix to listen to [default: "/"]
+  # pathPrefix: "/nya"
+
+  ## Enable CORS support
+  # cors: true
+
+  ## Enable gzip compression (deprecated)
+  # gzip: true
+
+  ## Comma separated endpoints to disable. E.g: form,crop,rotate,health
+  # disableEndpoints: "form,crop,rotate,health"
+
+  ## Define API key for authorization
+  # key: "ChangeMePlease"
+
+  ## Mount server local directory
+  # mount: "/mount/dir"
+
+  ## The TTL in seconds. Adds caching headers to locally served files.
+  # httpCacheTTL: 300
+
+  ## HTTP read timeout in seconds [default: 30]
+  # httpReadTimeout: "23"
+
+  ## HTTP write timeout in seconds [default: 30]
+  # httpWriteTimeout: "42"
+
+  ## Restrict remote image source processing to certain origins (separated by commas)
+  # enableURLSource: true
+
+  ## Enable image response placeholder to be used in case of error
+  # enablePlaceholder: true
+
+  ## Forwards X-Forward-Authorization or Authorization header to the image
+  ## source server. -enable-url-source flag must be defined.
+  ## Tip: secure your server from public access to prevent attack vectors
+  # enableAuthForwarding: true
+
+  ## Enable URL signature (URL-safe Base64-encoded HMAC digest) [default: false]
+  # enableURLSignature: true
+
+  ## The URL signature key (32 characters minimum)
+  # urlSignatureKey: EXAMPLEaeth7aiphopoo7laezohtai9M
+
+  ## Restrict remote image source processing to certain origins (separated by commas)
+  # allowedOrigins: "http://localhost,http://example.com"
+
+  ## Restrict maximum size of http image source (in bytes)
+  # maxAllowedSize: 31337
+
+  ## Defines a constant Authorization header value passed to all the image
+  ## source servers. -enable-url-source flag must be defined. This overwrites
+  ## authorization headers forwarding behavior via X-Forward-Authorization
+  # authorization: "Basic AwDJdL2DbwrD=="
+
+  ## Image path to image custom placeholder to be used in case of error.
+  ## Recommended minimum image size is: 1200x1200
+  # placeholder: "/neko.jpg"
+
+  ## Throttle concurrency limit per second
+  # concurrency: "13"
+
+  ## Throttle burst max cache size [default: 100]
+  # burst: "23"
+
+  ## OS memory release interval in seconds [default: 30]
+  # mrelease: "42"
+
+  ## Number of used cpu cores.
+  # cpus: "32"
+
+# Values to configure Ingress Kubernetes resource for Imaginary
+ingress:
+  # Enable or disable Ingress resource creation
+  enabled: false
+
+  # Enable or disable Let's Encrypt certificate
+  acme: false
+
+  # Enable or disable HTTPS for this Ingress resource at all
+  tls: false
+
+  # Add some custom Ingress resource annotations for Ingress Controller fine-tuning
+  annotations: {}
+
+  # Host to publish Imaginary application on
+  host: example.com
+
+# Base64 encoded SSL certificate & key for Ingress. Fill it if you want to
+# enable HTTPS and have your own certifiacte. Otherwise you may use SSL
+# certificates from Let's Encrypt
+tls: {}
+  ## Base64 encoded private key file for TLS certificate.
+  # privateKey: ""
+
+  ## Base64 encoded TLS certificate file
+  # certificate: ""


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

It brings a new Helm chart for [h2non/imaginary](https://github.com/h2non/imaginary/)

**Comments for a reviewer:**

The linting failure is because of the icon absence. I do not know how to address that as I have not found any official logo or an icon for "imaginary" app.
