### PR TITLE
mongodb: added nodeSelector for arbiter, primary and secondary components

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 4.0.1
+version: 4.0.2
 appVersion: 3.6.6
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -28,6 +28,10 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -28,6 +28,10 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -29,6 +29,10 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}


### PR DESCRIPTION
Adds an ability to stick to the particular nodes for for arbiter, primary and secondary components.
Odd, but without this the chart produces the following error https://github.com/bitnami/bitnami-docker-mongodb/issues/103