### PR TITLE
[stable/ark] update Ark to 0.9.1

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.9.0
+appVersion: 0.9.1
 description: A Helm chart for ark
 name: ark
-version: 1.1.0
+version: 1.2.0
 home: https://heptio.com/products/#heptio-ark
 sources:
 - https://github.com/heptio/ark

--- a/stable/ark/README.md
+++ b/stable/ark/README.md
@@ -50,10 +50,10 @@ Parameter | Description | Default | Required
 Parameter | Description | Default
 --- | --- | ---
 `image.repository` | Image repository | `gcr.io/heptio-images/ark`
-`image.tag` | Image tag | `v0.8.2`
+`image.tag` | Image tag | `v0.9.1`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
-`kubectl.image.repository` | Image repository | `gcr.io/heptio-images/ark`
-`kubectl.image.tag` | Image tag | `v0.8.2`
+`kubectl.image.repository` | Image repository | `claranet/gcloud-kubectl-docker`
+`kubectl.image.tag` | Image tag | `1.0.0`
 `kubectl.image.pullPolicy` | Image pull policy | `IfNotPresent`
 `podAnnotations` | Annotations for the Ark server pod | `{}`
 `rbac.create` | If true, create and use RBAC resources | `true`

--- a/stable/ark/values.yaml
+++ b/stable/ark/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: gcr.io/heptio-images/ark
-  tag: v0.8.2
+  tag: v0.9.1
   pullPolicy: IfNotPresent
 
 # A docker image with kubectl installed


### PR DESCRIPTION
https://github.com/helm/charts/pull/6777 did update the resources for 0.9.0 but did not change the image version. I updated the chart to use 0.9.1 to include some more fixes. 

@unguiculus  @domcar