### PR TITLE
Use proper docker image for rabbitmq chart

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 2.0.0
+version: 2.0.1
 appVersion: 3.7.6
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.7.6-ol-7-r1
+  tag: 3.7.7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.7.6-ol-7
+  tag: 3.7.7
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb


### PR DESCRIPTION
The rabbitmq chart was using an outdated version of the apps and also a  wrong distro. This should fix the issue introduced in https://github.com/helm/charts/pull/6792