### PR TITLE
[rabbitmq] Set securityContext with correct user

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 2.0.3
+version: 2.1.0
 appVersion: 3.7.7
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -65,6 +65,9 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `persistence.storageClass`  | Storage class of backing PVC                            | `nil` (uses alpha storage class annotation)              |
 | `persistence.accessMode`    | Use volume as ReadOnly or ReadWrite                     | `ReadWriteOnce`                                          |
 | `persistence.size`          | Size of data volume                                     | `8Gi`                                                    |
+| `securityContext.enabled`   | Enable security context                                 | `true`                                                   |
+| `securityContext.fsGroup`   | Group ID for the container                              | `1001`                                                   |
+| `securityContext.runAsUser` | User ID for the container                               | `1001`                                                   |
 | `resources`                  | resource needs and limits to apply to the pod           | {}                                                       |
 | `nodeSelector`              | Node labels for pod assignment                          | {}                                                       |
 | `affinity`                  | Affinity settings for pod assignment                    | {}                                                       |

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -134,6 +134,11 @@ spec:
               secretKeyRef:
                 name: {{ template "rabbitmq.fullname" . }}
                 key: rabbitmq-password
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -85,6 +85,14 @@ rabbitmq:
 ## Kubernetes service type
 serviceType: ClusterIP
 
+## Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
 persistence:
   ## this enables PVC templates that will create one per pod
   enabled: false


### PR DESCRIPTION
tl;dr Latest version of rabbitmq helm chart crashes because of permission issues.

Allows kubernetes to chown a potential PersistentVolume to this user.
The most recent version of rabbitmq bitnami docker images uses the user 1001: https://github.com/bitnami/bitnami-docker-rabbitmq/blob/3.7.7-debian-9-r21/3.7/debian-9/Dockerfile\#L33

Previously, with 2.0.1 and a new persistentvolume, the boot script was not able to chown echo `/opt/bitnami/rabbitmq/var/lib/rabbitmq/.erlang.cookie` because of permission issue (PersistentVolume is owned by root by default in Kubernetes/Docker).

ping @bitnami-bot (is there anybody behind you, dear bot?)