### PR TITLE
[stable/mongodb-replicaset]: use mongodb as port name to allow DNS seedlists

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.5.3
+version: 3.5.4
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service.yaml
@@ -20,7 +20,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: peer
+    - name: mongodb
       port: {{ .Values.port }}
 {{- if .Values.metrics.enabled }}
     - name: metrics

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -144,7 +144,7 @@ spec:
 {{ toYaml .Values.extraVars | indent 12 }}
         {{- end }}
           ports:
-            - name: peer
+            - name: mongodb
               containerPort: 27017
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
By changing the service's port name to `mongodb`, Kubernetes automatically creates SRV DNS records under `_mongodb._tcp.my-mongo-service.namespace.svc.cluster.local` that point to the running instances (including the port for each instance). This is exactly what MongoDB clients support in the [DNS Seedlist Connection Format](https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format). The benefit is that for replica sets you can use a connection URI like `mongodb+srv://my-mongo-service.namespace.svc.cluster.local/?replicaSet=my-rs` that has a single host name. Otherwise you have to construct a URI with all hostnames of the replica set which is a bit tedious.

**Special notes for your reviewer**:
This only looks like a cosmetic change but the name `mongodb` is expected by MongoDB clients, see https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format. `peer` was arbitrary I assume so it shouldn't affect anything. I also tested it and it works fine.

ping @foxish @unguiculus