### PR TITLE
[stable/sonarqube] support imagePullSecret for private repositories

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.7.4
+version: 0.8.0
 appVersion: 6.7.3
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -42,6 +42,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `image.repository`                          | image repository                          | `sonarqube`                                |
 | `image.tag`                                 | `sonarqube` image tag.                    | 6.5                                        |
 | `image.pullPolicy`                          | Image pull policy                         | `IfNotPresent`                             |
+| `image.pullSecret`                          | imagePullSecret to use for private repository      |                                   |
 | `ingress.enabled`                           | Flag for enabling ingress                 | false                                      |
 | `service.type`                              | Kubernetes service type                   | `LoadBalancer`                             |
 | `service.annotations`                       | Kubernetes service annotations            | None                                       |

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
       {{- end }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -5,6 +5,8 @@ replicaCount: 1
 image:
   repository: sonarqube
   tag: 6.7.3
+  # If using a private repository, the name of the imagePullSecret to use
+  # pullSecret: my-repo-secret
 service:
   name: sonarqube
   type: LoadBalancer


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the ability to set an imagePullSecret to use in case you want to override the `image.repository` and use a private one instead.
