### PR TITLE
Added namespace name  in kubectl exec command

### DIFF
--- a/stable/janusgraph/templates/NOTES.txt
+++ b/stable/janusgraph/templates/NOTES.txt
@@ -2,7 +2,7 @@ Connect to JanusGraph using gremlin-server with the following configuration:
 
   To connect to your JanusGraph deployment using gremlin.sh from within your Kubernetes cluster:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "janusgraph.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl exec -it $POD_NAME -- /janusgraph-0.2.0-hadoop2/bin/gremlin.sh
+  kubectl exec -it $POD_NAME --namespace {{ .Release.Namespace }} -- /janusgraph-0.2.0-hadoop2/bin/gremlin.sh
 
 
 


### PR DESCRIPTION
In order to connect to correct pod, need to mention  namespace name, so that it will connect to pod, else will error out as "pods not found"

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
