### PR TITLE
[ stable/mariadb ] - Allow using custom initialization scripts

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 4.2.7
+version: 4.3.0
 appVersion: 10.1.34
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave) | `1`                                                               |
 | `slave.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
 | `metrics.enabled`                         | Start a side-car prometheus exporter                | `false`                                                           |
-| `metrics.image.registry`                           | Exporter image registry                                 | `docker.io` | 
+| `metrics.image.registry`                           | Exporter image registry                                 | `docker.io` |
 `metrics.image.repository`                           | Exporter image name                                 | `prom/mysqld-exporter`                                            |
 | `metrics.image.tag`                        | Exporter image tag                                  | `v0.10.0`                                                         |
 | `metrics.image.pullPolicy`                 | Exporter image pull policy                          | `IfNotPresent`                                                    |
@@ -129,6 +129,12 @@ $ helm install --name my-release -f values.yaml stable/mariadb
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Initialize a fresh instance
+
+The [Bitnami MariaDB](https://github.com/bitnami/bitnami-docker-mariadb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+
+The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
 
 ## Persistence
 

--- a/stable/mariadb/files/docker-entrypoint-initdb.d/README.md
+++ b/stable/mariadb/files/docker-entrypoint-initdb.d/README.md
@@ -1,0 +1,3 @@
+You can copy here your custom .sh, .sql or .sql.gz file so they are executed during the first boot of the image.
+
+More info in the [bitnami-docker-mariadb](https://github.com/bitnami/bitnami-docker-mariadb#initializing-a-new-instance) repository.

--- a/stable/mariadb/templates/initialization-configmap.yaml
+++ b/stable/mariadb/templates/initialization-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "master.fullname" . }}-init-scripts
+  labels:
+    app: {{ template "mariadb.name" . }}
+    component: "master"
+    chart: {{ template "mariadb.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*").AsConfig | indent 2 }}

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -110,6 +110,8 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /bitnami/mariadb
+        - name: custom-init-scripts
+          mountPath: /docker-entrypoint-initdb.d
 {{- if .Values.master.config }}
         - name: config
           mountPath: /opt/bitnami/mariadb/conf/my.cnf
@@ -150,6 +152,9 @@ spec:
           configMap:
             name: {{ template "master.fullname" . }}
       {{- end }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "master.fullname" . }}-init-scripts
 {{- if .Values.master.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -4,7 +4,7 @@
 image:
   registry: docker.io
   repository: bitnami/mariadb
-  tag: 10.2.14
+  tag: 10.1.34-debian-9
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR adds a new feature to the chart. Now it is possible to execute your custom `.sh`, `.sql` and `.sql.gz` the first time the database image is initialized.

More info about the usage is documented in the README.
