### PR TITLE
[stable/mysql] Add podAnnotations

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.9.2
+version: 0.9.3
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -94,6 +94,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `imagePullSecrets`                           | Name of Secret resource containing private registry credentials                              | `nil`                                                |
 | `initializationFiles`                        | List of SQL files which are run after the container started                                  | `nil`                                                |
 | `timezone`                                   | Container and mysqld timezone (TZ env)                                                       | `nil` (UTC depending on image)                       |
+| `podAnnotations`                             | Map of annotations to add to the pods                                                        | `{}`                                                 |
 
 Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).
 

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -12,6 +12,10 @@ spec:
     metadata:
       labels:
         app: {{ template "mysql.fullname" . }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -154,3 +154,6 @@ ssl:
 ## Default: nil (mysql will use image's default timezone, normally UTC)
 ## Example: 'Australia/Sydney'
 # timezone:
+
+# To be added to the database server pod(s)
+podAnnotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

Various things check use the annotations on a pod to decide things about the pod (eg the cluster autoscaler looks for `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"` to make decisions about removing a pod). This allows annotations on the mysql pod(s).