### PR TITLE
Updated `values.yaml` to include section on CORS issues related to usage with schema-registry-ui

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.4.4
+version: 0.4.5
 appVersion: 4.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -19,6 +19,10 @@ replicaCount: 1
 ## Configuration Options can be found here: https://docs.confluent.io/current/schema-registry/docs/config.html
 configurationOverrides:
   kafkastore.topic.replication.factor: 1
+  # If you are running the schema-registry-ui, you may run into CORS issues;
+  # uncomment the following two lines to fix. Source: https://github.com/Landoop/schema-registry-ui#prerequisites
+  # access.control.allow.methods: "GET,POST,PUT,OPTIONS"
+  # access.control.allow.origin: "*"
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -86,21 +90,14 @@ sasl:
     #       name: "zookeeper-secret"
     #       key: "zokeeper-client-password"
 
-# Scheme-Registry Settings
-configurationOverrides:
-  # Needed to run with 1 Kafka Broker
-  offsets.topic.replication.factor: 1
-  # If you are running the schema-registry-ui, you may run into CORS issues;
-  # unset the following two lines to fix. 
-  # Source: https://github.com/Landoop/schema-registry-ui#prerequisites
-  # access.control.allow.methods: "GET,POST,PUT,OPTIONS"
-  # access.control.allow.origin: "*"
-
 ## Kafka Settings
 kafka:
   ## This is enabled only to allow installations of this chart without arguments
   enabled: true
   imageTag: 4.0.1
+  configurationOverrides:
+    # Needed to run with 1 Kafka Broker
+    offsets.topic.replication.factor: 1
   replicas: 1
 
   ## Install only a single Zookeeper pod in the StatefulSet

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -86,14 +86,21 @@ sasl:
     #       name: "zookeeper-secret"
     #       key: "zokeeper-client-password"
 
+# Scheme-Registry Settings
+configurationOverrides:
+  # Needed to run with 1 Kafka Broker
+  offsets.topic.replication.factor: 1
+  # If you are running the schema-registry-ui, you may run into CORS issues;
+  # unset the following two lines to fix. 
+  # Source: https://github.com/Landoop/schema-registry-ui#prerequisites
+  # access.control.allow.methods: "GET,POST,PUT,OPTIONS"
+  # access.control.allow.origin: "*"
+
 ## Kafka Settings
 kafka:
   ## This is enabled only to allow installations of this chart without arguments
   enabled: true
   imageTag: 4.0.1
-  configurationOverrides:
-    # Needed to run with 1 Kafka Broker
-    offsets.topic.replication.factor: 1
   replicas: 1
 
   ## Install only a single Zookeeper pod in the StatefulSet


### PR DESCRIPTION
EDIT: Ignore this... I stupidly missed the `.Values.configurationOverrides` section which is in the correct place, mixing it up with the `.Values.kafka.configurationOverrides` section!

As such, have pivoted this pull request to include a section on CORS issues when attempting to use `schema-registry` with `schema-registry-ui`. This will be a common issue going forwards, given how these applications will be deployed in k8s. As such, I think it would be helpful to have the solution given in the Chart itself!

/************************************************************************************************/
/************************************************************************************************/
/************************************************************************************************/

Value "configurationOverrides" should be at 'root' of values.yaml as stated in README and referenced on line 106 of `deployment.yaml`

Without this fix, the reference in `deployment.yaml` [ `{{ range $configName, $configValue := .Values.configurationOverrides }}` ] will not work, because in the `values.yaml` file the `configurationOverrides` section is under `kafka`.  As such, if you try to set some value for `configurationOverrides`, it will not be picked up by the intended section in `deployment.yaml`!

The original docs have `configurationOverrides` as a section of its own - as a result I have moved `configurationOverrides` outside of the `kafka` section. Indeed, `configurationOverrides` has nothing to do with the Kafka settings, as they are specific to the `schema-registry` application.

Also, added a comment in the `values.yaml` file for a common CORS issues which is detailed as part of the `schema-registry-ui` documentation. This does not change the functionality of the chart itself, simply highlight a common gotcha which people wanting to run the `schema-registry-ui` with `schema-registry` on Kubernetes will inevitably run into.  

@benjigoldberg 