### PR TITLE
Fix Rancher 2.0 support for the Stolon chart

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,5 +1,5 @@
 name: stolon
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.11.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/templates/secret.yaml
+++ b/stable/stolon/templates/secret.yaml
@@ -9,5 +9,14 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  pg_su_password:  {{ required "A valid .Values.superuserPassword entry is required!" .Values.superuserPassword | b64enc | quote }}
-  pg_repl_password:  {{ required "A valid .Values.replicationPassword entry is required!" .Values.replicationPassword | b64enc | quote }}
+{{ if .Values.superuserPassword }}
+  pg_su_password:  {{ .Values.superuserPassword | b64enc | quote }}
+{{ else }}
+  pg_su_password: {{ randAlphaNum 40 | b64enc | quote }}
+{{ end }}
+
+{{ if .Values.replicationPassword }}
+  pg_repl_password:  {{ .Values.replicationPassword | b64enc | quote }}
+{{ else }}
+  pg_repl_password: {{ randAlphaNum 40 | b64enc | quote }}
+{{ end }}

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -35,12 +35,12 @@ serviceAccount:
 superuserUsername: "stolon"
 
 ## password for the superuser (REQUIRED)
-#superuserPassword:
+# superuserPassword:
 
 replicationUsername: "repluser"
 
 ## password for the replication user (REQUIRED)
-#replicationPassword:
+# replicationPassword:
 
 ## backend could be one of the following: consul, etcdv2, etcdv3 or kubernetes
 store:

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -35,12 +35,12 @@ serviceAccount:
 superuserUsername: "stolon"
 
 ## password for the superuser (REQUIRED)
-superuserPassword:
+#superuserPassword:
 
 replicationUsername: "repluser"
 
 ## password for the replication user (REQUIRED)
-replicationPassword:
+#replicationPassword:
 
 ## backend could be one of the following: consul, etcdv2, etcdv3 or kubernetes
 store:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes functionality with Rancher and basically just mirrors what lwolf/stolon-chart which this chart is based upon has already done. It comments out `replicationPassword` and ``superuserPassword` to fix compatibility with Rancher's answers. Rancher does not seem to like it when a value is empty and for some reason refuses to replace it with the answers it's given in their UI.

Accommodating this it also generates a 40 character long alpha numeric if the passwords are not set, as lwolf does.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
There has been no issue submitted about this on this repository but this commit fixes Rancher compatibility with Rancher's answers functionality that fills in values. lwolf recently fixed this in his repository and I thought I'd apply it here as well.