### PR TITLE
[incubator/jaeger] Fixes HotRod example in Chart

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.7.0
+version: 0.7.1
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -130,7 +130,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "jaeger.hotrod.tracing.host" -}}
-{{- $host := printf "%s-agent" (include "jaeger.agent.name" .) -}}
+{{- $host := printf "%s" (include "jaeger.agent.name" .) -}}
 {{- default $host .Values.hotrod.tracing.host -}}
 {{- end -}}
 

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -24,8 +24,6 @@ data:
   es.username: {{ .Values.storage.elasticsearch.user }}
   es.nodes-wan-only: {{ .Values.storage.elasticsearch.nodesWanOnly | quote }}
   hotrod.agent-host-port: "{{ template "jaeger.hotrod.tracing.host" . }}:{{ .Values.hotrod.tracing.port }}"
-  hotrod.agent-host: {{ template "jaeger.hotrod.tracing.host" . }}
-  hotrod.agent-port: {{ .Values.hotrod.tracing.port | quote }}
   span-storage.type: {{ .Values.storage.type | quote }}
   query.health-check-http-port: {{ .Values.query.healthCheckPort | quote }}
   query.port: {{ .Values.query.service.targetPort | quote }}

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -24,6 +24,8 @@ data:
   es.username: {{ .Values.storage.elasticsearch.user }}
   es.nodes-wan-only: {{ .Values.storage.elasticsearch.nodesWanOnly | quote }}
   hotrod.agent-host-port: "{{ template "jaeger.hotrod.tracing.host" . }}:{{ .Values.hotrod.tracing.port }}"
+  hotrod.agent-host: {{ template "jaeger.hotrod.tracing.host" . }}
+  hotrod.agent-port: {{ .Values.hotrod.tracing.port | quote }}
   span-storage.type: {{ .Values.storage.type | quote }}
   query.health-check-http-port: {{ .Values.query.healthCheckPort | quote }}
   query.port: {{ .Values.query.service.targetPort | quote }}

--- a/incubator/jaeger/templates/hotrod-deploy.yaml
+++ b/incubator/jaeger/templates/hotrod-deploy.yaml
@@ -22,14 +22,12 @@ spec:
     spec:
       containers:
         - name: {{ template "jaeger.fullname" . }}-hotrod
-          image: {{ .Values.hotrod.image.repository }}:{{ .Values.hotrod.image.tag }}
+          image: {{ .Values.hotrod.image.repository }}:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
-          env:
-            - name: JAEGER_AGENT_HOST_PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ template "jaeger.fullname" . }}
-                  key: hotrod.agent-host-port
+          command:
+            - "/go/bin/hotrod-linux"
+            - "all"
+            - "--jaeger-agent.host-port={{ template "jaeger.hotrod.tracing.host" . }}:{{ .Values.hotrod.tracing.port }}"
           ports:
             - containerPort: {{ .Values.hotrod.service.internalPort }}
           livenessProbe:

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -6,7 +6,7 @@ provisionDataStore:
   cassandra: true
   elasticsearch: false
 
-tag: 1.4.1
+tag: 1.6.0
 
 storage:
   # allowed values (cassandra, elasticsearch)
@@ -230,7 +230,6 @@ hotrod:
   replicaCount: 1
   image:
     repository: jaegertracing/example-hotrod
-    tag: latest
     pullPolicy: Always
   service:
     annotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the optional HotRod example that comes with the Jaeger chart. It appears that HotRod has been broken for some time now.

**Which issue this PR fixes**: fixes Issue https://github.com/helm/charts/issues/6421

**Special notes for your reviewer**:
- Bumped Jaeger to use latest version 1.6.0. This is required to get all the versions of each component to be in sync including hotrod.
- Through extensive testing, the HotRod env variables just don't work. Reverting to using the command line parameters to set the agent address.
- Bug with `define "jaeger.hotrod.tracing.host"` is placing `-agent-agent` for the name of the agent in the HotRod component.

**Testing Done**:
Tested on Kubernetes 1.11.1. 
Using Jaeger version 1.6.0.
Works as excepted.