### PR TITLE
[WIP] Dockerfile to upgrade spark 1.5 -> 2.3

### DIFF
--- a/stable/spark/Dockerfile
+++ b/stable/spark/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:8-alpine
+MAINTAINER Krishna Kalyan "krishnakalyan3@gmail.com"
+
+# Default Args
+ARG APACHE_MIRROR_SERVER=http://www-us.apache.org
+ARG SPARK_VERSION=2.3.1
+ARG HADOOP_VERSION=2.7
+
+RUN apk update && \
+    apk add bash curl git python3 wget vim openssl ca-certificates && \
+    rm -rf /var/cache/apk/*
+
+RUN mkdir -p /opt \
+    && wget -q -O - ${APACHE_MIRROR_SERVER}/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz | tar -xzf - -C /opt \
+    && mv /opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark
+
+ENV SPARK_HOME /opt/spark
+ENV PATH=$PATH:${SPARK_HOME}/sbin:${SPARK_HOME}/bin
+
+WORKDIR $SPARK_HOME

--- a/stable/spark/Dockerfile
+++ b/stable/spark/Dockerfile
@@ -1,5 +1,4 @@
 FROM openjdk:8-alpine
-MAINTAINER Krishna Kalyan "krishnakalyan3@gmail.com"
 
 # Default Args
 ARG APACHE_MIRROR_SERVER=http://www-us.apache.org


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the hem chart builds with spark 1.5. This Dockerfile upgrades the spark version to 2.3.

**Which issue this PR fixes** :
fixes #5799

**Special notes for your reviewer**:
@foxish

**ToDo** :
- [x] Create Dockerfile with spark 2.3.1
- [ ] Create Dockerfile with zepplin 0.8.0