### PR TITLE
Add ingress resources to Kong chart

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.14.0

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.3.1
+version: 0.4.0
 appVersion: 0.14.0

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -60,12 +60,22 @@ and their default values.
 | admin.nodePort                    | Node port when service type is `NodePort`                              |                       |
 | admin.type                        | k8s service type, Options: NodePort, ClusterIP, LoadBalancer           | `NodePort`            |
 | admin.loadBalancerIP              | Will reuse an existing ingress static IP for the admin service         | `null`                |
+| admin.ingress.enabled             | Enable ingress resource creation (works with proxy.type=ClusterIP)     | `false`               | 
+| admin.ingress.tls                 | Name of secret resource, containing TLS secret                         |                       |
+| admin.ingress.hosts               | List of ingress hosts.                                                 | `[]`                  |
+| admin.ingress.path                | Ingress path.                                                          | `/`                   |
+| admin.ingress.annotations         | Ingress annotations. See documentation for your ingress controller for details | `{}`          |
 | proxy.useTLS                      | Secure Proxy traffic                                                   | `true`                |
 | proxy.servicePort                 | TCP port on which the Kong Proxy Service is exposed                    | `8443`                |
 | proxy.containerPort               | TCP port on which the Kong app listens for Proxy traffic               | `8443`                |
 | proxy.nodePort                    | Node port when service type is `NodePort`                              |                       |
 | proxy.type                        | k8s service type. Options: NodePort, ClusterIP, LoadBalancer           | `NodePort`            |
 | proxy.loadBalancerIP              | To reuse an existing ingress static IP for the admin service           |                       |
+| proxy.ingress.enabled             | Enable ingress resource creation (works with proxy.type=ClusterIP)     | `false`               | 
+| proxy.ingress.tls                 | Name of secret resource, containing TLS secret                         |                       |
+| proxy.ingress.hosts               | List of ingress hosts.                                                 | `[]`                  |
+| proxy.ingress.path                | Ingress path.                                                          | `/`                   |
+| proxy.ingress.annotations         | Ingress annotations. See documentation for your ingress controller for details | `{}`          |
 | env                               | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)               |
 | runMigrations                     | Run Kong migrations job                                                | `true`                |
 | readinessProbe                    | Kong readiness probe                                                   |                       |

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -11,6 +11,21 @@ To connect from outside the K8s cluster:
      HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
      PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-admin -o jsonpath='{.spec.ports[0].nodePort}')
 
+   {{- else if .Values.admin.ingress.enabled  }}
+
+use one of the addresses listed below
+
+     {{- $path := .Values.admin.ingress.path -}}
+     {{- if .Values.admin.ingress.tls }}
+       {{- range .Values.admin.ingress.hosts }}
+         https://{{ . }}{{ $path }}
+       {{- end }}
+     {{- else }}
+       {{- range .Values.admin.ingress.hosts }}
+         http://{{ . }}{{ $path }}
+       {{- end }}
+     {{- end }}
+
    {{- else if contains "ClusterIP" .Values.admin.type }}
      HOST=127.0.0.1
 
@@ -33,6 +48,21 @@ To connect from outside the K8s cluster:
    {{- else if contains "NodePort" .Values.proxy.type }}
      HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
      PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+
+   {{- else if .Values.proxy.ingress.enabled  }}
+
+use one of the addresses listed below
+
+     {{- $path := .Values.proxy.ingress.path -}}
+     {{- if .Values.proxy.ingress.tls }}
+       {{- range .Values.proxy.ingress.hosts }}
+         https://{{ . }}{{ $path }}
+       {{- end }}
+     {{- else }}
+       {{- range .Values.proxy.ingress.hosts }}
+         http://{{ . }}{{ $path }}
+       {{- end }}
+     {{- end }}
 
    {{- else if contains "ClusterIP" .Values.proxy.type }}
      HOST=127.0.0.1

--- a/stable/kong/templates/ingress-admin.yaml
+++ b/stable/kong/templates/ingress-admin.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.admin.ingress.enabled -}}
+{{- $serviceName := include "kong.fullname" . -}}
+{{- $servicePort := .Values.admin.servicePort -}}
+{{- $path := .Values.admin.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "kong.fullname" . }}-admin
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- range $key, $value := .Values.admin.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.admin.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}-admin
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.admin.ingress.tls }}
+  tls:
+{{ toYaml .Values.admin.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/stable/kong/templates/ingress-proxy.yaml
+++ b/stable/kong/templates/ingress-proxy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.proxy.ingress.enabled -}}
+{{- $serviceName := include "kong.fullname" . -}}
+{{- $servicePort := .Values.proxy.servicePort -}}
+{{- $path := .Values.proxy.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "kong.fullname" . }}-proxy
+  labels:
+    app: {{ template "kong.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- range $key, $value := .Values.proxy.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.proxy.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $path }}
+            backend:
+              serviceName: {{ $serviceName }}-proxy
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.proxy.ingress.tls }}
+  tls:
+{{ toYaml .Values.proxy.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -22,6 +22,19 @@ admin:
   type: NodePort
   # Set a nodePort which is available
   # nodePort: 32444
+  # Kong admin ingress settings.
+  ingress:
+    # Enable/disable exposure using ingress.
+    enabled: false
+    # TLS secret name.
+    # tls: kong-admin.example.com-tls
+    # Array of ingress hosts.
+    hosts: []
+    # Map of ingress annotations.
+    annotations: {}
+    # Ingress path.
+    path: /
+
 proxy:
   # If you want to specify annotations for the proxy service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
@@ -35,6 +48,18 @@ proxy:
   type: NodePort
   # Set a nodePort which is available
   # nodePort: 32443
+  # Kong proxy ingress settings.
+  ingress:
+    # Enable/disable exposure using ingress.
+    enabled: false
+    # TLS secret name.
+    # tls: kong-proxy.example.com-tls
+    # Array of ingress hosts.
+    hosts: []
+    # Map of ingress annotations.
+    annotations: {}
+    # Ingress path.
+    path: /
 
 # Set runMigrations to run Kong migrations
 runMigrations: true


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Add Ingress resource to Kong chrt. Not each K8S cluster is being run on cloud provider, some are being deployed to bare-metal or cloud providers without native LB. So Service resource is not enough for chart, ingress should be added also. This changes come from our company needs, I suppose someone may be interested too.