### PR TITLE
Separating master slave service configuration

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 2.2.1
+version: 3.0.0
 appVersion: 4.0.8-r0
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-master-service.yaml
+++ b/stable/redis-ha/templates/redis-master-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{ include "labels.standard" . | indent 4 }}
   annotations:
-{{ toYaml .Values.servers.annotations | indent 4 }}
+{{ toYaml .Values.servers.master.annotations | indent 4 }}
 spec:
   ports:
   - port: 6379
@@ -16,4 +16,4 @@ spec:
     release: "{{ .Release.Name }}"
     redis-node: "true"
     redis-role: "master"
-  type: "{{ .Values.servers.serviceType }}"
+  type: "{{ .Values.servers.master.serviceType }}"

--- a/stable/redis-ha/templates/redis-slave-service.yaml
+++ b/stable/redis-ha/templates/redis-slave-service.yaml
@@ -6,7 +6,7 @@ metadata:
     role: service
 {{ include "labels.standard" . | indent 4 }}
   annotations:
-{{ toYaml .Values.servers.annotations | indent 4 }}
+{{ toYaml .Values.servers.slave.annotations | indent 4 }}
 spec:
   ports:
   - port: 6379
@@ -17,4 +17,4 @@ spec:
     release: "{{ .Release.Name }}"
     redis-node: "true"
     redis-role: "slave"
-  type: "{{ .Values.servers.serviceType }}"
+  type: "{{ .Values.servers.slave.serviceType }}"

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -47,8 +47,12 @@ replicas:
   servers: 3
   sentinels: 3
 servers:
-  serviceType: ClusterIP  # [ClusterIP|LoadBalancer]
-  annotations: {}
+  master:
+    serviceType: ClusterIP  # [ClusterIP|LoadBalancer]
+    annotations: {}
+  slave:
+    serviceType: ClusterIP  # [ClusterIP|LoadBalancer]
+    annotations: {}
 
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
**What this PR does / why we need it**:
I am attempting to create DNS entries on loadbalancer services which are created for this chart, so that they can be accessed externally.  Currently to do this I provide an annotation on a load balancer service that looks as such:
```
  annotations:
    external-dns.alpha.kubernetes.io/hostname: redis.myzone.mydomain.com
spec:
  clusterIP: 10.233.63.168
  externalTrafficPolicy: Cluster
  ports:
  - nodePort: 31936
    port: 6379
    protocol: TCP
    targetPort: 6379
  selector:
    app: redis-ha
    redis-node: "true"
    redis-role: master
    release: test
  sessionAffinity: None
  type: LoadBalancer
```
Currently both the master and the slave share a couple of variables.
`serviceType`:  I may not need a LoadBalancer for the slave, and because of quota reasons it may be benifitial for these to be separated.
`annotations`:  I do not want the record to point to the slave LoadBalancer, or I do not want to share the record.

Ideally replicas might be separated into these distinct sections later.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#6914

**Special notes for your reviewer**:
Below is an example value override:
```
servers:
  master:
    serviceType: LoadBalancer
    annotations:
      external-dns.alpha.kubernetes.io/hostname: "redis.myZone.myDomain.com"
  resources:
    server:
      limits:
        cpu: 8
        memory: 100Gi
      requests:
        cpu: 2
        memory: 100Gi
    sentinel:
      limits:
        cpu: 2
        memory: 200Mi
      requests:
        cpu: 500m
        memory: 200Mi
  auth: false
  replicas:
    servers: 3
    sentinels: 3
```
Which will create the following services:
```
kubectl get svc
NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)          AGE
kubernetes                 ClusterIP      10.233.0.1     <none>           443/TCP          18d
test-redis-ha-master-svc   LoadBalancer   10.233.48.36   1.2.3.4   6379:31904/TCP   1m
test-redis-ha-sentinel     ClusterIP      10.233.39.15   <none>           26379/TCP        1m
test-redis-ha-slave-svc    ClusterIP      10.233.52.56   <none>           6379/TCP         1m
```
<Abstracted the external IP>

which creates an a-record in route53, external-dns provider.  The master is of type LoadBalancer, which opens up a node port corresponding with communication with the master-svc, while slave remains clusterIP

```
$ kubectl get pods
NAME                                     READY     STATUS    RESTARTS   AGE
test-redis-ha-sentinel-cd44967bb-6rplp   1/1       Running   2          4m
test-redis-ha-sentinel-cd44967bb-ksb68   1/1       Running   2          4m
test-redis-ha-sentinel-cd44967bb-st4gg   1/1       Running   0          4m
test-redis-ha-server-5bf47c6545-668m8    1/1       Running   0          4m
test-redis-ha-server-5bf47c6545-c88w2    1/1       Running   0          4m
test-redis-ha-server-5bf47c6545-gdgcx    1/1       Running   0          4m
```