### PR TITLE
[stable/sysdig] Fix readinessProbe

### DIFF
--- a/stable/sysdig/CHANGELOG.md
+++ b/stable/sysdig/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.0.2
+
+### Minor Changes
+
+* Fix readinessProbe in daemonset's pod spec
+
 ## v1.0.1
 
 ### Minor Changes

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,5 +1,5 @@
 name: sysdig
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.81.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/templates/daemonset.yaml
+++ b/stable/sysdig/templates/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
           readinessProbe:
             exec:
               command: [ "test", "-e", "/opt/draios/logs/draios.log" ]
-              initialDelaySeconds: 10
+            initialDelaySeconds: 10
           volumeMounts:
             - mountPath: /host/var/run/docker.sock
               name: docker-sock


### PR DESCRIPTION


**What this PR does / why we need it**: `initialDelaysSeconds` was improperty indented beneath `exec`, instead of directly beneath `readinessProbe`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: n/a

**Special notes for your reviewer**: n/a
