### PR TITLE
Allow the ability to provide a Sampling Strat File in the form of a ConfigMap

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.7.0
+version: 0.7.2
 keywords:
   - jaeger
   - opentracing
@@ -14,7 +14,7 @@ sources:
   - https://hub.docker.com/u/jaegertracing/
 maintainers:
   - name: dvonthenen
-    email: david.vonthenen@dell.com
+    email: vonthenend@vmware.com
   - name: mikelorant
     email: michael.lorant@fairfaxmedia.com.au
   - name: pavelnikolov

--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.7.2
+version: 0.7.1
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -165,7 +165,8 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.image`                        | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
 | `collector.pullPolicy`                   | Collector image pullPolicy          |  IfNotPresent                          |
 | `collector.tolerations`                  | Node Tolerations                    | `[]`                                   |
-| `collector.samplingStrategiesFile`       | ConfigMap containing sampling file  |  nil                                   |
+| `collector.samplingStrategiesConfigmap`  | ConfigMap containing sampling file  |  nil                                   |
+| `collector.samplingStrategiesFilename`   | Sampling filename within configmap  |  sampling.json                         |
 | `collector.service.annotations`          | Annotations for Collector SVC       |  nil                                   |
 | `collector.service.httpPort`             | Client port for HTTP thrift         |  14268                                 |
 | `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`   |

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -165,6 +165,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.image`                        | Image for jaeger collector          |  jaegertracing/jaeger-collector        |
 | `collector.pullPolicy`                   | Collector image pullPolicy          |  IfNotPresent                          |
 | `collector.tolerations`                  | Node Tolerations                    | `[]`                                   |
+| `collector.samplingStrategiesFile`       | ConfigMap containing sampling file  |  nil                                   |
 | `collector.service.annotations`          | Annotations for Collector SVC       |  nil                                   |
 | `collector.service.httpPort`             | Client port for HTTP thrift         |  14268                                 |
 | `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`   |

--- a/incubator/jaeger/templates/_helpers.tpl
+++ b/incubator/jaeger/templates/_helpers.tpl
@@ -129,6 +129,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "jaeger.collector.sampling-filename" -}}
+{{- default "sampling.json" .Values.collector.samplingStrategiesFilename -}}
+{{- end -}}
+
 {{- define "jaeger.hotrod.tracing.host" -}}
 {{- $host := printf "%s-agent" (include "jaeger.agent.name" .) -}}
 {{- default $host .Values.hotrod.tracing.host -}}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -98,9 +98,9 @@ spec:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: collector.zipkin.http-port
-          {{- if .Values.collector.samplingStrategiesFile }}
+          {{- if .Values.collector.samplingStrategiesConfigmap }}
           - name: SAMPLING_STRATEGIES_FILE
-            value: /etc/sampling
+            value: /etc/sampling/{{ template "jaeger.collector.sampling-filename" . }}
           {{- end }}
         ports:
         - containerPort: {{ .Values.collector.service.tchannelPort }}
@@ -125,7 +125,7 @@ spec:
           initialDelaySeconds: 10
         resources:
 {{ toYaml .Values.collector.resources | indent 10 }}
-        {{- if .Values.collector.samplingStrategiesFile }}
+        {{- if .Values.collector.samplingStrategiesConfigmap }}
         volumeMounts:
             - name: sampling-volume
               mountPath: /etc/sampling
@@ -137,6 +137,6 @@ spec:
       volumes:
         - name: sampling-volume
           configMap:
-            name: {{ .Values.collector.samplingStrategiesFile }}
+            name: {{ .Values.collector.samplingStrategiesConfigmap }}
       {{- end }}
 {{- end -}}

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -133,7 +133,7 @@ spec:
         {{- end }}
       dnsPolicy: {{ .Values.collector.dnsPolicy }}
       restartPolicy: Always
-      {{- if .Values.collector.samplingStrategiesFile }}
+      {{- if .Values.collector.samplingStrategiesConfigmap }}
       volumes:
         - name: sampling-volume
           configMap:

--- a/incubator/jaeger/templates/collector-deploy.yaml
+++ b/incubator/jaeger/templates/collector-deploy.yaml
@@ -98,6 +98,10 @@ spec:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: collector.zipkin.http-port
+          {{- if .Values.collector.samplingStrategiesFile }}
+          - name: SAMPLING_STRATEGIES_FILE
+            value: /etc/sampling
+          {{- end }}
         ports:
         - containerPort: {{ .Values.collector.service.tchannelPort }}
           name: tchannel
@@ -121,6 +125,18 @@ spec:
           initialDelaySeconds: 10
         resources:
 {{ toYaml .Values.collector.resources | indent 10 }}
+        {{- if .Values.collector.samplingStrategiesFile }}
+        volumeMounts:
+            - name: sampling-volume
+              mountPath: /etc/sampling
+              readOnly: true
+        {{- end }}
       dnsPolicy: {{ .Values.collector.dnsPolicy }}
       restartPolicy: Always
+      {{- if .Values.collector.samplingStrategiesFile }}
+      volumes:
+        - name: sampling-volume
+          configMap:
+            name: {{ .Values.collector.samplingStrategiesFile }}
+      {{- end }}
 {{- end -}}

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -151,6 +151,9 @@ collector:
   ## Allow the scheduling on tainted nodes (requires Kubernetes >= 1.6)
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
+  # Collector sampling# sets a named configmap with a sampling file to be mounted
+  # and used by the Collector
+  samplingStrategiesFile: null
 
 query:
   enabled: true

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -153,7 +153,8 @@ collector:
   tolerations: []
   # Collector sampling# sets a named configmap with a sampling file to be mounted
   # and used by the Collector
-  samplingStrategiesFile: null
+  samplingStrategiesFilename: null
+  samplingStrategiesConfigmap: null
 
 query:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements new functionality which enables setting --sampling.strategies-file pointed to by a ConfigMap which contains the JSON for the sampling configuration.

A ConfigMap with the sampling strategy JSON can be created using the following command:
```bash
kubectl create configmap jaeger-sampling --from-file=sampling.json
```

The deploy the chart enabling the following helm option:
`--set collector.samplingStrategiesFile=jaeger-sampling`

**Which issue this PR fixes**: fixes https://github.com/helm/charts/issues/6631

**Special notes for your reviewer**:
Need someone to verify the functionality. I have attached a zip file containing the helm chart tgz. Unpack the zip file and deploy the tgz file using helm.
[jaeger.zip](https://github.com/helm/charts/files/2246091/jaeger.zip)


