### PR TITLE
[stable/traefik] Add option for enabling Jaeger or Zipkin tracing

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.35.1
+version: 1.36.0
 appVersion: 1.6.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -162,6 +162,17 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `deployment.hostPort.httpsEnabled`     | Whether to enable hostPort binding to host for https.                                                                        | `false`                                           |
 | `deployment.hostPort.dashboardEnabled` | Whether to enable hostPort binding to host for dashboard.                                                                    | `false`                                           |
 | `sendAnonymousUsage`                   | Send anonymous usage statistics.                                                                                             | `false`                                           |
+| `tracing.enabled`                      | Whether to enable request tracing                                                                                            | `false`                                           |
+| `tracing.backend`                      | Tracing backend to use, either `jaeger` or `zipkin`                                                                       | None                                              |
+| `tracing.serviceName`                  | Service name to be used in tracing backend                                                                                   | `traefik`                                         |
+| `tracing.jaeger.localAgentHostPort`    | Location of the Jaeger agent where spans will be sent                                                                        | `127.0.0.1:6831`                                  |
+| `tracing.jaeger.samplingServerUrl`     | Address of the Jaeger agent HTTP sampling server                                                                             | `http://localhost:5778/sampling`                  |
+| `tracing.jaeger.samplingType`          | Type of Jaeger sampler to use, one of: `const`, `probabilistic`, `ratelimiting`                                              | `const`                                           |
+| `tracing.jaeger.samplingParam`         | Value passed to the Jaeger sampler                                                                                           | `1.0`                                             |
+| `tracing.zipkin.httpEndpoint`          | Zipkin HTTP endpoint                                                                                                         | `http://localhost:9411/api/v1/spans`              |
+| `tracing.zipkin.debug`                 | Enables Zipkin debugging                                                                                                     | `false`                                           |
+| `tracing.zipkin.sameSpan`              | Use Zipkin SameSpan RPC style traces                                                                                         | `false`                                           |
+| `tracing.zipkin.id128Bit`              | Use Zipkin 128 bit root span IDs                                                                                             | `true`                                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -162,3 +162,38 @@ data:
       pushinterval = {{ .Values.metrics.statsd.pushinterval | quote }}
       {{- end}}
     {{- end }}
+    {{- if .Values.tracing.enabled }}
+    [tracing]
+      backend = {{ .Values.tracing.backend | quote }}
+      serviceName = {{ .Values.tracing.serviceName | quote}}
+      {{ if eq .Values.tracing.backend "jaeger" }}
+      [tracing.jaeger]
+        {{ if .Values.tracing.jaeger.localAgentHostPort }}
+        localAgentHostPort = {{ .Values.tracing.jaeger.localAgentHostPort | quote }}
+        {{- end }}
+        {{ if .Values.tracing.jaeger.samplingServerUrl }}
+        samplingServerUrl = {{ .Values.tracing.jaeger.samplingServerUrl | quote }}
+        {{- end }}
+        {{ if .Values.tracing.jaeger.samplingType }}
+        samplingType = {{ .Values.tracing.jaeger.samplingType | quote }}
+        {{- end }}
+        {{ if ne (.Values.tracing.jaeger.samplingParam | quote) "" }}
+        samplingParam = {{ .Values.tracing.jaeger.samplingParam }}
+        {{- end }}
+      {{- end }}
+      {{ if eq .Values.tracing.backend "zipkin" }}
+      [tracing.zipkin]
+        {{ if .Values.tracing.zipkin.httpEndpoint }}
+        httpEndpoint = {{ .Values.tracing.zipkin.httpEndpoint | quote }}
+        {{- end }}
+        {{ if ne (.Values.tracing.zipkin.debug | quote) "" }}
+        debug = {{ .Values.tracing.zipkin.debug }}
+        {{- end }}
+        {{ if ne (.Values.tracing.zipkin.sameSpan | quote) "" }}
+        sameSpan = {{ .Values.tracing.zipkin.sameSpan }}
+        {{- end }}
+        {{ if ne (.Values.tracing.zipkin.id128bit | quote) "" }}
+        id128bit = {{ .Values.tracing.zipkin.id128bit }}
+        {{- end }}
+      {{- end }}
+    {{- end }}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -166,33 +166,33 @@ data:
     [tracing]
       backend = {{ .Values.tracing.backend | quote }}
       serviceName = {{ .Values.tracing.serviceName | quote}}
-      {{ if eq .Values.tracing.backend "jaeger" }}
+      {{- if eq .Values.tracing.backend "jaeger" }}
       [tracing.jaeger]
-        {{ if .Values.tracing.jaeger.localAgentHostPort }}
+        {{- if .Values.tracing.jaeger.localAgentHostPort }}
         localAgentHostPort = {{ .Values.tracing.jaeger.localAgentHostPort | quote }}
         {{- end }}
-        {{ if .Values.tracing.jaeger.samplingServerUrl }}
+        {{- if .Values.tracing.jaeger.samplingServerUrl }}
         samplingServerUrl = {{ .Values.tracing.jaeger.samplingServerUrl | quote }}
         {{- end }}
-        {{ if .Values.tracing.jaeger.samplingType }}
+        {{- if .Values.tracing.jaeger.samplingType }}
         samplingType = {{ .Values.tracing.jaeger.samplingType | quote }}
         {{- end }}
-        {{ if ne (.Values.tracing.jaeger.samplingParam | quote) "" }}
+        {{- if ne (.Values.tracing.jaeger.samplingParam | quote) "" }}
         samplingParam = {{ .Values.tracing.jaeger.samplingParam }}
         {{- end }}
       {{- end }}
-      {{ if eq .Values.tracing.backend "zipkin" }}
+      {{- if eq .Values.tracing.backend "zipkin" }}
       [tracing.zipkin]
-        {{ if .Values.tracing.zipkin.httpEndpoint }}
+        {{- if .Values.tracing.zipkin.httpEndpoint }}
         httpEndpoint = {{ .Values.tracing.zipkin.httpEndpoint | quote }}
         {{- end }}
-        {{ if ne (.Values.tracing.zipkin.debug | quote) "" }}
+        {{- if ne (.Values.tracing.zipkin.debug | quote) "" }}
         debug = {{ .Values.tracing.zipkin.debug }}
         {{- end }}
-        {{ if ne (.Values.tracing.zipkin.sameSpan | quote) "" }}
+        {{- if ne (.Values.tracing.zipkin.sameSpan | quote) "" }}
         sameSpan = {{ .Values.tracing.zipkin.sameSpan }}
         {{- end }}
-        {{ if ne (.Values.tracing.zipkin.id128bit | quote) "" }}
+        {{- if ne (.Values.tracing.zipkin.id128bit | quote) "" }}
         id128bit = {{ .Values.tracing.zipkin.id128bit }}
         {{- end }}
       {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -238,3 +238,17 @@ deployment:
     httpsEnabled: false
     dashboardEnabled: false
 sendAnonymousUsage: false
+tracing:
+  enabled: false
+  serviceName: traefik
+  # backend: choices are jaeger, zipkin
+  # jaeger:
+  #   localAgentHostPort: "127.0.0.1:6831"
+  #   samplingServerURL: http://localhost:5778/sampling
+  #   samplingType: const
+  #   samplingParam: 1.0
+  # zipkin:
+  #   httpEndpoint: http://localhost:9411/api/v1/spans
+  #   debug: false
+  #   sameSpan: false
+  #   id128bit: true


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds options to turn on the Opentracing implementations already included with traefik. See https://docs.traefik.io/configuration/tracing/ for more information on this feature.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5157