### PR TITLE
[stable/sentry] Creating the admin user in optionally

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.3.0
+version: 0.3.1
 appVersion: 8.22
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -47,7 +47,8 @@ $ helm delete my-release
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 > **Warning**: Jobs are not deleted automatically. They need to be manually deleted
-```consule
+
+```console
 $ kubectl delete job/sentry-db-init job/sentry-user-create
 ```
 
@@ -82,6 +83,7 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `worker.schedulerName`               | Name of an alternate scheduler for worker   | `nil`                                                      |
 | `worker.affinity`                    | Affinity settings for worker pod assignment | `{}`                                                       |
 | `worker.tolerations`                 | Toleration labels for worker pod assignment | `[]`                                                       |
+| `user.create`                        | Create the default admin                    | `true`                                                     |
 | `user.email`                         | Username for default admin                  | `admin@sentry.local`                                       |
 | `email.from_address`                 | Email notifications are from                | `smtp`                                                     |
 | `email.host`                         | SMTP host for sending email                 | `smtp`                                                     |

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.user.create -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -77,3 +78,4 @@ spec:
           value: {{ .Values.email.use_tls | quote }}
         - name: SENTRY_SERVER_EMAIL
           value: {{ .Values.email.from_address | quote }}
+{{- end -}}

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -63,8 +63,11 @@ worker:
   affinity: {}
   # schedulerName:
 
-# Initial admin user to create
+# Admin user to create
 user:
+  # Indicated to create the admin user or not,
+  # Default is true as the initial installation.
+  create: true
   email: admin@sentry.local
 
 # BYO Email server


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The sentry chart installation failed caused by the `user-create` job that complaining the `admin user already exists` in the scenario of re-installing the chart with an existing database.

For compatible with the above similar scenarios(with the existing DB volume), we should provide a flag that enables to create the admin user in optionally.
