### PR TITLE
Schema Registry: Support TLS for Ingress

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.4.4
+version: 0.4.5
 appVersion: 4.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -86,3 +86,6 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `ingress.enabled` | Enable Ingress? | `false` |
 | `ingress.hostname` | set hostname for ingress | `""` |
 | `ingress.annotations` | set annotations for ingress | `{}` |
+| `ingress.tls.enabled` | Enable TLS for the Ingress | `false` |
+| `ingress.tls.secretName` | Name of the Kubernetes `Secret` object to obtain the TLS certificate from | `schema-registry-tls` |
+

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -83,6 +83,6 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `kafka.enabled` | If `true`, install Kafka/Zookeeper alongside the `SchemaRegistry`. This is intended for testing and argument-less helm installs of this chart only and should not be used in Production. | `true` |
 | `kafka.replicas` | The number of Kafka Pods to install as part of the `StatefulSet` if `kafka.Enabled` is `true`| `1` |
 | `kafka.zookeeper.servers` | The number of Zookeeper Pods to install as part of the `StatefulSet` if `kafka.Enabled` is `true`| `1` |
-| `ingress.enabled` | Enable Ingress? | `false`
-| `ingress.hostname` | set hostname for ingress | `""`
-| `ingress.annotations` | set annotations for ingress | `{}`
+| `ingress.enabled` | Enable Ingress? | `false` |
+| `ingress.hostname` | set hostname for ingress | `""` |
+| `ingress.annotations` | set annotations for ingress | `{}` |

--- a/incubator/schema-registry/templates/NOTES.txt
+++ b/incubator/schema-registry/templates/NOTES.txt
@@ -1,7 +1,11 @@
 Confluent Schema-Registry is now installed on your Kubernetes cluster. For more information on
 Schema-Registry, please navigate to https://github.com/confluentinc/schema-registry
 
+{{ if .Values.ingress.enabled }}
+1. Visit http{{ if .Values.ingress.tls.enabled }}s{{ end }}://{{ .Values.ingress.hostname }}/ to use your application
+{{ else }}
 1. Get the application URL by running these commands:
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "schema-registry.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.servicePort }}
+{{ end }}

--- a/incubator/schema-registry/templates/ingress.yaml
+++ b/incubator/schema-registry/templates/ingress.yaml
@@ -24,4 +24,10 @@ spec:
             backend:
               serviceName: {{ template "schema-registry.fullname" . }}
               servicePort: {{ .Values.servicePort }}
+{{- if .Values.ingress.tls.enabled }}
+  tls:
+    - secretName: {{ .Values.ingress.tls.secretName }}
+      hosts:
+        - {{ .Values.ingress.hostname }}
+{{- end -}}
 {{ end -}}

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -105,3 +105,6 @@ ingress:
   annotations: {}
   hostname: ""
   labels: {}
+  tls:
+    enabled: false
+    secretName: schema-registry-tls


### PR DESCRIPTION
Adding support for TLS on the Ingress config for Schema Registry chart.

Examples:

Ingress with no TLS:

```bash
$ helm template incubator/schema-registry -x templates/ingress.yaml --set kafka.enabled=false --set ingress.hostname=example.com --set ingress.enabled=true
---
# Source: schema-registry/templates/ingress.yaml

apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: RELEASE-NAME-schema-registry
  labels:
    app: RELEASE-NAME-schema-registry
    chart: "schema-registry-0.4.4"
    release: RELEASE-NAME
    heritage: Tiller
spec:
  rules:
    - host: example.com
      http:
        paths:
          - path: /
            backend:
              serviceName: RELEASE-NAME-schema-registry
              servicePort: 8081
```

Ingress *with* TLS:

```bash
$ helm template incubator/schema-registry -x templates/ingress.yaml --set kafka.enabled=false --set ingress.hostname=example.com --set ingress.enabled=true --set ingress.tls.
enabled=true --set ingress.tls.secretName=banana
---
# Source: schema-registry/templates/ingress.yaml

apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: RELEASE-NAME-schema-registry
  labels:
    app: RELEASE-NAME-schema-registry
    chart: "schema-registry-0.4.4"
    release: RELEASE-NAME
    heritage: Tiller
spec:
  rules:
    - host: example.com
      http:
        paths:
          - path: /
            backend:
              serviceName: RELEASE-NAME-schema-registry
              servicePort: 8081
  tls:
    - secretName: banana
      hosts:
        - example.com
```

Lint:

```bash
$ helm lint incubator/schema-registry
==> Linting incubator/schema-registry
Lint OK

1 chart(s) linted, no failures
```

Also updated the `NOTES.txt` to display the Ingress URL when enabled, instead of the port forward stuff:

No TLS:

```bash
$ helm install incubator/schema-registry --name aaron-test --set kafka.enabled=false --set ingress.enabled=true --set ingress.hostname=example.com --namespace aaron-test
NAME:   aaron-test
LAST DEPLOYED: Wed Aug  1 09:23:49 2018
NAMESPACE: aaron-test
STATUS: DEPLOYED

RESOURCES:
==> v1/Service
NAME                        TYPE       CLUSTER-IP    EXTERNAL-IP  PORT(S)   AGE
aaron-test-schema-registry  ClusterIP  10.100.45.56  <none>       8081/TCP  1s

==> v1beta1/Deployment
NAME                        DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
aaron-test-schema-registry  1        1        1           0          1s

==> v1beta1/Ingress
NAME                        HOSTS        ADDRESS  PORTS  AGE
aaron-test-schema-registry  example.com  80       1s

==> v1/Pod(related)
NAME                                         READY  STATUS             RESTARTS  AGE
aaron-test-schema-registry-5c649db779-z4wdm  0/1    ContainerCreating  0         1s


NOTES:
Confluent Schema-Registry is now installed on your Kubernetes cluster. For more information on
Schema-Registry, please navigate to https://github.com/confluentinc/schema-registry


1. Visit http://example.com/ to use your application
```

TLS:

```bash
$ helm upgrade aaron-test incubator/schema-registry --set kafka.enabled=false --set ingress.enabled=true --set ingress.hostname=example.com --namespace aaron-test --set ingre
ss.tls.enabled=true --set ingress.tls.secretName=banana
Release "aaron-test" has been upgraded. Happy Helming!
LAST DEPLOYED: Wed Aug  1 09:24:37 2018
NAMESPACE: aaron-test
STATUS: DEPLOYED

RESOURCES:
==> v1/Pod(related)
NAME                                         READY  STATUS  RESTARTS  AGE
aaron-test-schema-registry-5c649db779-z4wdm  0/1    Error   2         48s

==> v1/Service
NAME                        TYPE       CLUSTER-IP    EXTERNAL-IP  PORT(S)   AGE
aaron-test-schema-registry  ClusterIP  10.100.45.56  <none>       8081/TCP  48s

==> v1beta1/Deployment
NAME                        DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
aaron-test-schema-registry  1        1        1           0          48s

==> v1beta1/Ingress
NAME                        HOSTS        ADDRESS           PORTS    AGE
aaron-test-schema-registry  example.com  aa96b5a4094a7...  80, 443  48s


NOTES:
Confluent Schema-Registry is now installed on your Kubernetes cluster. For more information on
Schema-Registry, please navigate to https://github.com/confluentinc/schema-registry


1. Visit https://example.com/ to use your application
```