### PR TITLE
[stable/influxdb] Support adding annotations to pod

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 0.10.0
+version: 0.11.0
 appVersion: 1.4
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         app: {{ template "influxdb.fullname" . }}
+      {{- if .Values.pod.annotations }}
+      annotations:
+{{ toYaml .Values.pod.annotations | indent 8 }}
+      {{- end }}
     spec:
       containers:
       - name: {{ template "influxdb.fullname" . }}

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -5,6 +5,10 @@ image:
   tag: "1.4-alpine"
   pullPolicy: IfNotPresent
 
+pod:
+  ## Add annotations to pod
+  annotations: {}
+
 ## Specify a service type
 ## NodePort is default
 ## ref: http://kubernetes.io/docs/user-guide/services/


### PR DESCRIPTION
**What this PR does / why we need it**:

Helm chart doesn't support adding annotations to the influxdb pod. This PR adds support for this in chart configuration.