### PR TITLE
[stable/grafana] Add support for overriding securityContext

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.12.0
+version: 1.13.0
 appVersion: 5.1.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -34,6 +34,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `replicas`                 | Number of nodes | `1` |
 | `deploymentStrategy`       | Deployment strategy | `RollingUpdate` |
+| `securityContext`          | Deployment securityContext | `{"runAsUser": 472, "fsGroup": 472}` |
 | `image.repository`         | Image repository | `grafana/grafana` |
 | `image.tag`                | Image tag. (`Must be >= 5.0.0`) Possible values listed [here](https://hub.docker.com/r/grafana/grafana/tags/).| `5.0.4`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -33,9 +33,10 @@ spec:
 {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
+{{- if .Values.securityContext }}
       securityContext:
-        runAsUser: 472
-        fsGroup: 472
+{{ toYaml .Values.securityContext | indent 8 }}
+{{- end }}
 {{- if .Values.dashboards }}
       initContainers:
         - name: download-dashboards

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -21,6 +21,10 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+securityContext:
+  runAsUser: 472
+  fsGroup: 472
+
 downloadDashboardsImage:
   repository: appropriate/curl
   tag: latest


### PR DESCRIPTION
grafana < 5.1 are using 104 as user ID, in order to support upgrading
from older version, overridding the grafana image tag with older
version, or adding more securityContext, this change allows setting
`securityContext` in more flexible way.
