### PR TITLE
[stable/concourse] Upgrade to Concourse 4

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,6 +1,6 @@
 name: concourse
-version: 1.16.0
-appVersion: 3.14.1
+version: 2.0.0
+appVersion: 4.1.0
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479
 keywords:

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -93,6 +93,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `concourse.mainTeam.githubTeams` | List of GitHub teams (in `ORG_NAME:TEAM_NAME` format) with access to the main team | `[]` |
 | `concourse.mainTeam.gitlabUsers` | List of GitLab users with access to the main team | `[]` |
 | `concourse.mainTeam.gitlabGroups` | List of GitLab groups with access to the main team | `[]` |
+| `concourse.mainTeam.ldapUsers` | List of LDAP users with access to the main team | `[]` |
+| `concourse.mainTeam.ldapGroups` | List of LDAP groups with access to the main team | `[]` |
 | `concourse.mainTeam.oauthUsers` | List of OAuth2 users with access to the main team | `[]` |
 | `concourse.mainTeam.oauthGroups` | List of OAuth2 groups with access to the main team | `[]` |
 | `concourse.workingDirectory` | The working directory for concourse | `/concourse-work-dir` |
@@ -199,6 +201,28 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.gitlabAuth.clientId` | GitLab Authentication: (Required if GitLab enabled) Client id | `nil` |
 | `secrets.gitlabAuth.clientSecret` | GitLab Authentication: (Required if GitLab enabled) Client secret | `nil` |
 | `secrets.gitlabAuth.host` | GitLab Authentication: Hostname of Gitlab Enterprise deployment (Include scheme, No trailing slash) | `nil` |
+| `secrets.ldapAuth.enabled` | LDAP Authentication: (Required) Enable LDAP authentication | `false` |
+| `secrets.ldapAuth.displayName` | LDAP Authentication: The auth provider name displayed to users on the login page | `nil` |
+| `secrets.ldapAuth.host` | LDAP Authentication: (Required if LDAP enabled) The host and optional port of the LDAP server. If port isn't supplied, it will be guessed based on the TLS configuration. 389 or 636. | `nil` |
+| `secrets.ldapAuth.bindDn` | LDAP Authentication: (Required if LDAP enabled) Bind DN for searching LDAP users and groups. Typically this is a read-only user. | `nil` |
+| `secrets.ldapAuth.bindPw` | LDAP Authentication: (Required if LDAP enabled) Bind Password for the user specified by `secrets.ldapBindDn` | `nil` |
+| `secrets.ldapAuth.insecureNoSsl` | LDAP Authentication: Required if LDAP host does not use TLS. | `nil` |
+| `secrets.ldapAuth.insecureSkipVerify` | LDAP Authentication: Skip certificate verification | `nil` |
+| `secrets.ldapAuth.startTls` | LDAP Authentication: Start on insecure port, then negotiate TLS | `nil` |
+| `secrets.ldapAuth.caCert` | LDAP Authentication: CA certificate | `nil` |
+| `secrets.ldapAuth.userSearchBaseDn` | LDAP Authentication: BaseDN to start the search from. For example `cn=users,dc=example,dc=com` | `nil` |
+| `secrets.ldapAuth.userSearchFilter` | LDAP Authentication: Optional filter to apply when searching the directory. For example `(objectClass=person)` | `nil` |
+| `secrets.ldapAuth.userSearchUsername` | LDAP Authentication: Attribute to match against the inputted username. This will be translated and combined with the other filter as '(<attr>=<username>)'. | `nil` |
+| `secrets.ldapAuth.userSearchScope` | LDAP Authentication: Can either be: `sub` - search the whole sub tree or `one` - only search one level. Defaults to 'sub' when not specified. | `nil` |
+| `secrets.ldapAuth.userSearchIdAttr` | LDAP Authentication: A mapping of attributes on the user entry to claims. Defaults to 'uid' when not specified. | `nil` |
+| `secrets.ldapAuth.userSearchEmailAttr` | LDAP Authentication: A mapping of attributes on the user entry to claims. Defaults to 'mail' when not specified. | `nil` |
+| `secrets.ldapAuth.userSearchNameAttr` | LDAP Authentication: A mapping of attributes on the user entry to claims. | `nil` |
+| `secrets.ldapAuth.groupSearchBaseDn` | LDAP Authentication: BaseDN to start the search from. For example `cn=groups,dc=example,dc=com` | `nil` |
+| `secrets.ldapAuth.groupSearchFilter` | LDAP Authentication: Optional filter to apply when searching the directory. For example `(objectClass=posixGroup)` | `nil` |
+| `secrets.ldapAuth.groupSearchScope` | LDAP Authentication: Can either be: `sub` - search the whole sub tree or `one` - only search one level. Defaults to 'sub' when not specified. | `nil` |
+| `secrets.ldapAuth.groupSearchUserAttr` | LDAP Authentication: Adds an additional requirement to the filter that an attribute in the group match the user's attribute value. The exact filter being added is: (<groupAttr>=<userAttr value>) | `nil` |
+| `secrets.ldapAuth.groupSearchGroupAttr` | LDAP Authentication: Adds an additional requirement to the filter that an attribute in the group match the user's attribute value. The exact filter being added is: (<groupAttr>=<userAttr value>) | `nil` |
+| `secrets.ldapAuth.groupSearchNameAttr` | LDAP Authentication: The attribute of the group that represents its name. | `nil` |
 | `secrets.oauthAuth.enabled` | OAuth2 Authentication: (Required) Enable OAuth2 authentication | `false` |
 | `secrets.oauthAuth.displayName` | OAuth2 Authentication: The auth provider name displayed to users on the login page | `nil` |
 | `secrets.oauthAuth.clientId` | OAuth2 Authentication: (Required if OAuth2 enabled) Client id | `nil` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -73,11 +73,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `concourse.externalURL` | URL used to reach any ATC from the outside world | `nil` |
 | `concourse.atcPort` | Concourse ATC listen port | `8080` |
 | `concourse.tsaPort` | Concourse TSA listen port | `2222` |
-| `concourse.allowSelfSignedCertificates` | Allow self signed certificates | `false` |
 | `concourse.authDuration` | Length of time for which tokens are valid | `24h` |
 | `concourse.resourceCheckingInterval` | Interval on which to check for new versions of resources | `1m` |
-| `concourse.oldResourceGracePeriod` | How long to cache the result of a get step after a newer version of the resource is found | `5m` |
-| `concourse.resourceCacheCleanupInterval` | The interval on which to check for and release old caches of resource versions | `30s` |
 | `concourse.baggageclaimDriver` | The filesystem driver used by baggageclaim | `naive` |
 | `concourse.containerPlacementStrategy` | The selection strategy for placing containers onto workers | `random` |
 | `concourse.dockerRegistry` | A URL pointing to the Docker registry to use to fetch Docker images | `nil` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -97,6 +97,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `concourse.mainTeam.ldapGroups` | List of LDAP groups with access to the main team | `[]` |
 | `concourse.mainTeam.oauthUsers` | List of OAuth2 users with access to the main team | `[]` |
 | `concourse.mainTeam.oauthGroups` | List of OAuth2 groups with access to the main team | `[]` |
+| `concourse.mainTeam.oidcUsers` | List of OIDC users with access to the main team | `[]` |
+| `concourse.mainTeam.oidcGroups` | List of OIDC groups with access to the main team | `[]` |
 | `concourse.workingDirectory` | The working directory for concourse | `/concourse-work-dir` |
 | `web.nameOverride` | Override the Concourse Web components name | `nil` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
@@ -234,6 +236,15 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.oauthAuth.groupsKey` | OAuth2 Authentication: The groups key indicates which claim to use to map external groups to Concourse teams. | `nil` |
 | `secrets.oauthAuth.caCert` | OAuth2 Authentication: CA Certificate | `nil` |
 | `secrets.oauthAuth.skipSslValidation` | OAuth2 Authentication: Skip SSL validation | `nil` |
+| `secrets.oidcAuth.enabled` | OIDC Authentication: (Required) Enable OIDC authentication | `false` |
+| `secrets.oidcAuth.displayName` | OIDC Authentication: The auth provider name displayed to users on the login page | `nil` |
+| `secrets.oidcAuth.issuer` | OIDC Authentication: (Required if OIDC enabled) An OIDC issuer URL that will be used to discover provider configuration using the .well-known/openid-configuration | `nil` |
+| `secrets.oidcAuth.clientId` | OIDC Authentication: (Required if OIDC enabled) Client id | `nil` |
+| `secrets.oidcAuth.clientSecret` | OIDC Authentication: (Required if OIDC enabled) Client secret | `nil` |
+| `secrets.oidcAuth.scope` | OIDC Authentication: Any additional scopes that need to be requested during authorization | `nil` |
+| `secrets.oidcAuth.groupsKey` | OIDC Authentication: The groups key indicates which claim to use to map external groups to Concourse teams. | `nil` |
+| `secrets.oidcAuth.caCert` | OIDC Authentication: CA Certificate | `nil` |
+| `secrets.oidcAuth.skipSslValidation` | OIDC Authentication: Skip SSL validation | `nil` |
 | `secrets.externalPostgres.enabled` | External Postgres: Use an externally provided postgres | `false` |
 | `secrets.externalPostgres.host` | External Postgres: (Required if external postgres enabled) The host to connect to. | `nil` |
 | `secrets.externalPostgres.port` | External Postgres: The port to connect to. | `5432` |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -201,7 +201,14 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.oauthAuth.groupsKey` | OAuth2 Authentication: The groups key indicates which claim to use to map external groups to Concourse teams. | `nil` |
 | `secrets.oauthAuth.caCert` | OAuth2 Authentication: CA Certificate | `nil` |
 | `secrets.oauthAuth.skipSslValidation` | OAuth2 Authentication: Skip SSL validation | `nil` |
-| `secrets.postgresqlUri` | PostgreSQL connection URI when `postgresql.enabled` is `false` | `nil` |
+| `secrets.externalPostgres.enabled` | External Postgres: Use an externally provided postgres | `false` |
+| `secrets.externalPostgres.host` | External Postgres: (Required if external postgres enabled) The host to connect to. | `nil` |
+| `secrets.externalPostgres.port` | External Postgres: The port to connect to. | `5432` |
+| `secrets.externalPostgres.user` | External Postgres: (Required if external postgres enabled) The user to sign in as. | `nil` |
+| `secrets.externalPostgres.password` | External Postgres: (Required if external postgres enabled) The user's password. | `nil` |
+| `secrets.externalPostgres.sslmode` | External Postgres: Whether or not to use SSL. [disable|require|verify-ca|verify-full]  | `nil` |
+| `secrets.externalPostgres.connectTimeout` | External Postgres: Dialing timeout. (0 means wait indefinitely) | `nil` |
+| `secrets.externalPostgres.database` | External Postgres: (Required if external postgres enabled) The name of the database to use.  | `nil` |
 | `secrets.vaultCaCert` | CA certificate   use to verify the vault server SSL cert. | `nil` |
 | `secrets.vaultClientToken` | Vault periodic client token | `nil` |
 | `secrets.vaultAppRoleId` | Vault AppRole RoleID | `nil` |
@@ -237,11 +244,17 @@ rm session-signing-key.pub
 printf "%s:%s" "concourse" "$(pbpaste)" > local-user-auth-local-users
 ```
 
-You'll also need to create/copy secret values for optional features. See [templates/secrets.yaml](templates/secrets.yaml) for possible values. In the example below, we are not using the [PostgreSQL](#postgresql) chart dependency, and so we must set a `postgresql-uri` secret.
+You'll also need to create/copy secret values for optional features. See [templates/secrets.yaml](templates/secrets.yaml)
+for possible values. In the example below, we are not using the [PostgreSQL](#postgresql) chart dependency, and so we
+must set `secrets.externalPostgres.enabled` to true, and create the `external-postgres-*` secrets.
 
 ```console
-# copy a posgres URI to clipboard and paste it to file
-printf "%s" "$(pbpaste)" > postgresql-uri
+# Enable external postgres and copy a postgres host, port, user, password, and database to clipboard and paste them to files
+printf "%s" "$(pbpaste)" > external-postgres-host
+printf "%s" "$(pbpaste)" > external-postgres-port
+printf "%s" "$(pbpaste)" > external-postgres-user
+printf "%s" "$(pbpaste)" > external-postgres-password
+printf "%s" "$(pbpaste)" > external-postgres-database
 # copy Github client id and secrets to clipboard and paste to files
 printf "%s" "$(pbpaste)" > github-auth-client-id
 printf "%s" "$(pbpaste)" > github-auth-client-secret
@@ -331,11 +344,11 @@ web:
 
 By default, this chart will use a PostgreSQL database deployed as a chart dependency, with default values for username, password, and database name. These can be modified by setting the `postgresql.*` values.
 
-You can also bring your own PostgreSQL. To do so, set `postgresql.enabled` to false. You'll then need to specify the full uri to the database, including the username and password, e.g. `postgres://concourse:changeme@my-postgres.com:5432/concourse?sslmode=require`. You can do this one of two ways:
+You can also bring your own PostgreSQL. To do so, set `postgresql.enabled` to false and `secrets.externalPostgres.enabled` to true. You'll then need to specify the connection parameters. You can do this one of two ways:
 
-1. Set `secrets.postgresqlUri` in your values
+1. Set `secrets.externalPostgres.*` in your values
 
-2. Set `postgresql-uri` in your release's secrets as described in [Secrets](#secrets).
+2. Set `external-postgres-*` values in your release's secrets as described in [Secrets](#secrets).
 
 The only way to completely avoid putting secrets in Helm is to bring your own PostgreSQL, and use option 2 above.
 

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -107,7 +107,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |
 | `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
-| `web.env` | Configure additional environment variables for the web containers | `[]` |
+| `web.extraEnv` | Configure additional environment variables for the web containers | `[]` |
 | `web.annotations`| Concourse Web deployment annotations | `nil` |
 | `web.tolerations` | Tolerations for the web nodes | `[]` |
 | `web.nodeSelector` | Node selector for web nodes | `{}` |
@@ -137,7 +137,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.replicas` | Number of Concourse Worker replicas | `2` |
 | `worker.minAvailable` | Minimum number of workers available after an eviction | `1` |
 | `worker.resources` | Concourse Worker resource requests and limits | `{requests: {cpu: "100m", memory: "512Mi"}}` |
-| `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
+| `worker.extraEnv` | Configure additional environment variables for the worker container(s) | `[]` |
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
 | `worker.additionalVolumeMounts` | VolumeMounts to be added to the worker pods | `nil` |
 | `worker.additionalVolumes` | Volumes to be added to the worker pods | `nil` |
@@ -218,7 +218,7 @@ $ helm install --name my-release -f values.yaml stable/concourse
 
 ### Secrets
 
-For your convenience, this chart provides some default values for secrets, but it is recommended that you generate and manage these secrets outside the Helm chart. To do this, set `secrets.create` to `false`, create files for each secret value, and turn it all into a k8s secret. Be careful with introducing trailing newline characters; following the steps below ensures none will end up in your secrets. First, perform the following to create the manditory secret values:
+For your convenience, this chart provides some default values for secrets, but it is recommended that you generate and manage these secrets outside the Helm chart. To do this, set `secrets.create` to `false`, create files for each secret value, and turn it all into a k8s secret. Be careful with introducing trailing newline characters; following the steps below ensures none will end up in your secrets. First, perform the following to create the mandatory secret values:
 
 ```console
 mkdir concourse-secrets

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -83,25 +83,15 @@ The following table lists the configurable parameters of the Concourse chart and
 | `concourse.dockerRegistry` | A URL pointing to the Docker registry to use to fetch Docker images | `nil` |
 | `concourse.insecureDockerRegistry` | Docker registry(ies) (comma separated) to allow connecting to even if not secure | `nil` |
 | `concourse.encryption.enabled` | Enable encryption of pipeline configuration | `false` |
-| `concourse.basicAuth.enabled` | Enable basic auth for the "main" Concourse team| `true` |
-| `concourse.githubAuth.enabled` | Enable Github auth for the "main" Concourse team| `false` |
-| `concourse.githubAuth.organization` | GitHub organizations (comma separated) whose members will have access | `nil` |
-| `concourse.githubAuth.team` | GitHub teams (comma separated) whose members will have access | `nil` |
-| `concourse.githubAuth.user` | GitHub users (comma separated) to permit access | `nil` |
-| `concourse.githubAuth.authUrl` | Override default endpoint AuthURL for Github Enterprise | `nil` |
-| `concourse.githubAuth.tokenUrl` | Override default endpoint TokenURL for Github Enterprise | `nil` |
-| `concourse.githubAuth.apiUrl` | Override default API endpoint URL for Github Enterprise | `nil` |
-| `concourse.gitlabAuth.enabled` | Enable Gitlab auth for the "main" Concourse team| `false` |
-| `concourse.gitlabAuth.group` | GitLab groups (comma separated) whose members will have access | `nil` |
-| `concourse.gitlabAuth.authUrl` | Endpoint AuthURL for GitLab server | `nil` |
-| `concourse.gitlabAuth.tokenUrl` | Endpoint TokenURL for GitLab server | `nil` |
-| `concourse.gitlabAuth.apiUrl` | API endpoint URL for GitLab server | `nil` |
-| `concourse.genericOauth.enabled` | Enable generic OAuth for the "main" Concourse team| `false` |
-| `concourse.genericOauth.displayName` | Name for this auth method on the web UI | `nil` |
-| `concourse.genericOauth.authUrl` | Generic OAuth provider AuthURL endpoint | `nil` |
-| `concourse.genericOauth.authUrlParam` | Parameters (comma separated) to pass to the authentication server AuthURL | `nil` |
-| `concourse.genericOauth.scope` | Optional scope required to authorize user | `nil` |
-| `concourse.genericOauth.tokenUrl` | Generic OAuth provider TokenURL endpoint | `nil` |
+| `concourse.mainTeam.localUsers` | List of local concourse users with access to the main team | `["concourse"]` |
+| `concourse.mainTeam.allowAllUsers` | Allow all logged in users to access the main team. ALL OF THEM. If, for example, you've configured GitHub, any user with a GitHub account will have access to your main team. | `false` |
+| `concourse.mainTeam.githubUsers` | List of GitHub users with access to the main team | `[]` |
+| `concourse.mainTeam.githubOrgs` | List of GitHub orgs with access to the main team | `[]` |
+| `concourse.mainTeam.githubTeams` | List of GitHub teams (in `ORG_NAME:TEAM_NAME` format) with access to the main team | `[]` |
+| `concourse.mainTeam.gitlabUsers` | List of GitLab users with access to the main team | `[]` |
+| `concourse.mainTeam.gitlabGroups` | List of GitLab groups with access to the main team | `[]` |
+| `concourse.mainTeam.oauthUsers` | List of OAuth2 users with access to the main team | `[]` |
+| `concourse.mainTeam.oauthGroups` | List of OAuth2 groups with access to the main team | `[]` |
 | `concourse.workingDirectory` | The working directory for concourse | `/concourse-work-dir` |
 | `web.nameOverride` | Override the Concourse Web components name | `nil` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
@@ -189,14 +179,28 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.awsSsmAccessKey` | AWS Access Key ID for SSM access | `nil` |
 | `secrets.awsSsmSecretKey` | AWS Secret Access Key ID for SSM access | `nil` |
 | `secrets.awsSsmSessionToken` | AWS Session Token for SSM access | `nil` |
-| `secrets.basicAuthUsername` | Concourse Basic Authentication Username | `concourse` |
-| `secrets.basicAuthPassword` | Concourse Basic Authentication Password | `concourse` |
-| `secrets.githubAuthClientId` | Application client ID for GitHub OAuth | `nil` |
-| `secrets.githubAuthClientSecret` | Application client secret for GitHub OAuth | `nil` |
-| `secrets.gitlabAuthClientId` | Application client ID for GitLab OAuth | `nil` |
-| `secrets.gitlabAuthClientSecret` | Application client secret for GitLab OAuth | `nil` |
-| `secrets.genericOauthClientId` | Application client ID for Generic OAuth | `nil` |
-| `secrets.genericOauthClientSecret` | Application client secret for Generic OAuth | `nil` |
+| `secrets.localUserAuth.enabled` | Local User Authentication: (Required) Enable Local User authentication | `true` |
+| `secrets.localUserAuth.localUsers` | List of `username:password` combinations for all your local users. The password can be bcrypted - if so, it must have a minimum cost of 10. | `["concourse:<bcrypt hash of 'concourse'>]`
+| `secrets.githubAuth.enabled` | GitHub Authentication: (Required) Enable GitHub authentication | `false` |
+| `secrets.githubAuth.clientId` | GitHub Authentication: (Required if GitHub enabled) Client id | `nil` |
+| `secrets.githubAuth.clientSecret` | GitHub Authentication: (Required if GitHub enabled) Client secret | `nil` |
+| `secrets.githubAuth.host` | GitHub Authentication: Hostname of GitHub Enterprise deployment (No scheme, No trailing slash) | `nil` |
+| `secrets.githubAuth.caCert` | GitHub Authentication: CA certificate of GitHub Enterprise deployment | `nil` |
+| `secrets.gitlabAuth.enabled` | GitLab Authentication: (Required) Enable GitLab authentication | `false` |
+| `secrets.gitlabAuth.clientId` | GitLab Authentication: (Required if GitLab enabled) Client id | `nil` |
+| `secrets.gitlabAuth.clientSecret` | GitLab Authentication: (Required if GitLab enabled) Client secret | `nil` |
+| `secrets.gitlabAuth.host` | GitLab Authentication: Hostname of Gitlab Enterprise deployment (Include scheme, No trailing slash) | `nil` |
+| `secrets.oauthAuth.enabled` | OAuth2 Authentication: (Required) Enable OAuth2 authentication | `false` |
+| `secrets.oauthAuth.displayName` | OAuth2 Authentication: The auth provider name displayed to users on the login page | `nil` |
+| `secrets.oauthAuth.clientId` | OAuth2 Authentication: (Required if OAuth2 enabled) Client id | `nil` |
+| `secrets.oauthAuth.clientSecret` | OAuth2 Authentication: (Required if OAuth2 enabled) Client secret | `nil` |
+| `secrets.oauthAuth.authUrl` | OAuth2 Authentication: (Required if OAuth2 enabled) Authorization URL | `nil` |
+| `secrets.oauthAuth.tokenUrl` | OAuth2 Authentication: (Required if OAuth2 enabled) Token URL | `nil` |
+| `secrets.oauthAuth.userinfoUrl` | OAuth2 Authentication: Userinfo URL | `nil` |
+| `secrets.oauthAuth.scope` | OAuth2 Authentication: Any additional scopes that need to be requested during authorization | `nil` |
+| `secrets.oauthAuth.groupsKey` | OAuth2 Authentication: The groups key indicates which claim to use to map external groups to Concourse teams. | `nil` |
+| `secrets.oauthAuth.caCert` | OAuth2 Authentication: CA Certificate | `nil` |
+| `secrets.oauthAuth.skipSslValidation` | OAuth2 Authentication: Skip SSL validation | `nil` |
 | `secrets.postgresqlUri` | PostgreSQL connection URI when `postgresql.enabled` is `false` | `nil` |
 | `secrets.vaultCaCert` | CA certificate   use to verify the vault server SSL cert. | `nil` |
 | `secrets.vaultClientToken` | Vault periodic client token | `nil` |
@@ -229,8 +233,8 @@ ssh-keygen -t rsa -f worker-key  -N ''
 mv worker-key.pub worker-key-pub
 ssh-keygen -t rsa -f session-signing-key  -N ''
 rm session-signing-key.pub
-printf "%s" "concourse" > basic-auth-username
-printf "%s" "$(openssl rand -base64 24)" > basic-auth-password
+# copy bcrypted password to clipboard
+printf "%s:%s" "concourse" "$(pbpaste)" > local-user-auth-local-users
 ```
 
 You'll also need to create/copy secret values for optional features. See [templates/secrets.yaml](templates/secrets.yaml) for possible values. In the example below, we are not using the [PostgreSQL](#postgresql) chart dependency, and so we must set a `postgresql-uri` secret.

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -85,6 +85,9 @@ The following table lists the configurable parameters of the Concourse chart and
 | `concourse.encryption.enabled` | Enable encryption of pipeline configuration | `false` |
 | `concourse.mainTeam.localUsers` | List of local concourse users with access to the main team | `["concourse"]` |
 | `concourse.mainTeam.allowAllUsers` | Allow all logged in users to access the main team. ALL OF THEM. If, for example, you've configured GitHub, any user with a GitHub account will have access to your main team. | `false` |
+| `concourse.mainTeam.cfUsers` | List of CloudFoundry users with access to the main team | `[]` |
+| `concourse.mainTeam.cfOrgs` | List of CloudFoundry orgs with access to the main team | `[]` |
+| `concourse.mainTeam.cfSpaces` | List of whitelisted CloudFoundry spaces (in `ORG_NAME:SPACE_NAME` format) with access to the main team | `[]` |
 | `concourse.mainTeam.githubUsers` | List of GitHub users with access to the main team | `[]` |
 | `concourse.mainTeam.githubOrgs` | List of GitHub orgs with access to the main team | `[]` |
 | `concourse.mainTeam.githubTeams` | List of GitHub teams (in `ORG_NAME:TEAM_NAME` format) with access to the main team | `[]` |
@@ -181,6 +184,12 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.awsSsmSessionToken` | AWS Session Token for SSM access | `nil` |
 | `secrets.localUserAuth.enabled` | Local User Authentication: (Required) Enable Local User authentication | `true` |
 | `secrets.localUserAuth.localUsers` | List of `username:password` combinations for all your local users. The password can be bcrypted - if so, it must have a minimum cost of 10. | `["concourse:<bcrypt hash of 'concourse'>]`
+| `secrets.cfAuth.enabled` | CloudFoundry Authentication: (Required) Enable CloudFoundry authentication | `false` |
+| `secrets.cfAuth.clientId` | CloudFoundry Authentication: (Required if CloudFoundry enabled) Client id | `nil` |
+| `secrets.cfAuth.clientSecret` | CloudFoundry Authentication: (Required if CloudFoundry enabled) Client secret | `nil` |
+| `secrets.cfAuth.apiUrl` | CloudFoundry Authentication: (Required if CloudFoundry enabled) The base API URL of your CF deployment. It will use this information to discover information about the authentication provider. | `nil` |
+| `secrets.cfAuth.caCert` | CloudFoundry Authentication: CA Certificate | `nil` |
+| `secrets.cfAuth.skipSslValidation` | CloudFoundry Authentication: Skip SSL validation | `nil` |
 | `secrets.githubAuth.enabled` | GitHub Authentication: (Required) Enable GitHub authentication | `false` |
 | `secrets.githubAuth.clientId` | GitHub Authentication: (Required if GitHub enabled) Client id | `nil` |
 | `secrets.githubAuth.clientSecret` | GitHub Authentication: (Required if GitHub enabled) Client secret | `nil` |

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -33,12 +33,12 @@
     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.concourse.atcPort }}
     {{- end }}
   {{- end }}
-{{- if .Values.concourse.basicAuth.enabled }}
+{{- if and .Values.secrets.localUserAuth.enabled (gt (len .Values.concourse.mainTeam.localUsers) 0) }}
 
 * Login with the following credentials
   {{ if .Values.secrets.create }}
-  Username: {{ .Values.secrets.basicAuthUsername }}
-  Password: {{ .Values.secrets.basicAuthPassword }}
+  Username: {{ index .Values.concourse.mainTeam.localUsers 0 }}
+  Password: if unchanged from chart default, password is 'concourse'
   {{ else }}
   Username: see basic-auth-username in secret {{ template "concourse.concourse.fullname" . }}
   Password: see basic-auth-password in secret {{ template "concourse.concourse.fullname" . }}

--- a/stable/concourse/templates/_helpers.tpl
+++ b/stable/concourse/templates/_helpers.tpl
@@ -36,9 +36,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "concourse.secret.required" -}}
 {{- if .is }}
-{{- required (printf "secrets.%s is required because secrets.create is true and %s is true" .key .is) (index .root.Values.secrets .key ) | b64enc | quote }}
+{{- required (printf "secrets.%s is required because secrets.create is true and %s is true" .key .is) (index .root .key ) | b64enc | quote }}
 {{- else -}}
-{{- required (printf "secrets.%s is required because secrets.create is true and %s isn't true" .key .isnt) (index .root.Values.secrets .key ) | b64enc | quote }}
+{{- required (printf "secrets.%s is required because secrets.create is true and %s isn't true" .key .isnt) (index .root .key ) | b64enc | quote }}
 {{- end -}}
 {{- end -}}
 

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -49,6 +49,29 @@ data:
   gitlab-auth-client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "secrets.gitlabAuth.enabled" "root" .Values.secrets.gitlabAuth }}
   gitlab-auth-host: {{ default "" .Values.secrets.gitlabAuth.host | b64enc | quote }}
   {{- end }}
+  {{- if .Values.secrets.ldapAuth.enabled }}
+  ldap-auth-display-name: {{ default "" .Values.secrets.ldapAuth.displayName | b64enc | quote }}
+  ldap-auth-host: {{ template "concourse.secret.required" dict "key" "host" "is" "secrets.ldapAuth.enabled" "root" .Values.secrets.ldapAuth }}
+  ldap-auth-bind-dn: {{ template "concourse.secret.required" dict "key" "bindDn" "is" "secrets.ldapAuth.enabled" "root" .Values.secrets.ldapAuth }}
+  ldap-auth-bind-pw: {{ template "concourse.secret.required" dict "key" "bindPw" "is" "secrets.ldapAuth.enabled" "root" .Values.secrets.ldapAuth }}
+  ldap-auth-insecure-no-ssl: {{ default "" .Values.secrets.ldapAuth.insecureNoSsl | b64enc | quote }}
+  ldap-auth-insecure-skip-verify: {{ default "" .Values.secrets.ldapAuth.insecureSkipVerify | b64enc | quote }}
+  ldap-auth-start-tls: {{ default "" .Values.secrets.ldapAuth.startTls | b64enc | quote }}
+  ldap-auth-ca-cert: {{ default "" .Values.secrets.ldapAuth.caCert | b64enc | quote }}
+  ldap-auth-user-search-base-dn: {{ default "" .Values.secrets.ldapAuth.userSearchBaseDn | b64enc | quote }}
+  ldap-auth-user-search-filter: {{ default "" .Values.secrets.ldapAuth.userSearchFilter | b64enc | quote }}
+  ldap-auth-user-search-username: {{ default "" .Values.secrets.ldapAuth.userSearchUsername | b64enc | quote }}
+  ldap-auth-user-search-scope: {{ default "" .Values.secrets.ldapAuth.userSearchScope | b64enc | quote }}
+  ldap-auth-user-search-id-attr: {{ default "" .Values.secrets.ldapAuth.userSearchIdAttr | b64enc | quote }}
+  ldap-auth-user-search-email-attr: {{ default "" .Values.secrets.ldapAuth.userSearchEmailAttr | b64enc | quote }}
+  ldap-auth-user-search-name-attr: {{ default "" .Values.secrets.ldapAuth.userSearchNameAttr | b64enc | quote }}
+  ldap-auth-group-search-base-dn: {{ default "" .Values.secrets.ldapAuth.groupSearchBaseDn | b64enc | quote }}
+  ldap-auth-group-search-filter: {{ default "" .Values.secrets.ldapAuth.groupSearchFilter | b64enc | quote }}
+  ldap-auth-group-search-scope: {{ default "" .Values.secrets.ldapAuth.groupSearchScope | b64enc | quote }}
+  ldap-auth-group-search-user-attr: {{ default "" .Values.secrets.ldapAuth.groupSearchUserAttr | b64enc | quote }}
+  ldap-auth-group-search-group-attr: {{ default "" .Values.secrets.ldapAuth.groupSearchGroupAttr | b64enc | quote }}
+  ldap-auth-group-search-name-attr: {{ default "" .Values.secrets.ldapAuth.groupSearchNameAttr | b64enc | quote }}
+  {{- end }}
   {{- if .Values.secrets.oauthAuth.enabled }}
   oauth-auth-client-id: {{ template "concourse.secret.required" dict "key" "clientId" "is" "secrets.oauthAuth.enabled" "root" .Values.secrets.oauthAuth }}
   oauth-auth-client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "secrets.oauthAuth.enabled" "root" .Values.secrets.oauthAuth }}

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -84,6 +84,16 @@ data:
   oauth-auth-ca-cert: {{ default "" .Values.secrets.oauthAuth.caCert | b64enc | quote }}
   oauth-auth-skip-ssl-validation: {{ default "" .Values.secrets.oauthAuth.skipSslValidation | b64enc | quote }}
   {{- end }}
+  {{- if .Values.secrets.oidcAuth.enabled }}
+  oidc-auth-display-name: {{ default "" .Values.secrets.oidcAuth.displayName | b64enc | quote }}
+  oidc-auth-issuer: {{ template "concourse.secret.required" dict "key" "issuer" "is" "secrets.oidcAuth.enabled" "root" .Values.secrets.oidcAuth }}
+  oidc-auth-client-id: {{ template "concourse.secret.required" dict "key" "clientId" "is" "secrets.oidcAuth.enabled" "root" .Values.secrets.oidcAuth }}
+  oidc-auth-client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "secrets.oidcAuth.enabled" "root" .Values.secrets.oidcAuth }}
+  oidc-auth-scope: {{ default "" .Values.secrets.oidcAuth.scope | b64enc | quote }}
+  oidc-auth-groups-key: {{ default "" .Values.secrets.oidcAuth.groupsKey | b64enc | quote }}
+  oidc-auth-ca-cert: {{ default "" .Values.secrets.oidcAuth.caCert | b64enc | quote }}
+  oidc-auth-skip-ssl-validation: {{ default "" .Values.secrets.oidcAuth.skipSslValidation | b64enc | quote }}
+  {{- end }}
   {{- if .Values.credentialManager.vault.enabled }}
   vault-ca-cert: {{ default "" .Values.secrets.vaultCaCert | b64enc | quote }}
   vault-client-token: {{ default "" .Values.secrets.vaultClientToken | b64enc | quote }}

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -16,27 +16,37 @@ data:
   worker-key: {{ .Values.secrets.workerKey | b64enc | quote }}
   worker-key-pub: {{ .Values.secrets.workerKeyPub | b64enc | quote }}
   {{- if not .Values.postgresql.enabled }}
-  postgresql-uri: {{ template "concourse.secret.required" dict "key" "postgresqlUri" "isnt" "postgresql.enabled" "root" . }}
+  postgresql-uri: {{ template "concourse.secret.required" dict "key" "postgresqlUri" "isnt" "postgresql.enabled" "root" .Values.secrets }}
   {{- end }}
   {{- if .Values.concourse.encryption.enabled }}
-  encryption-key: {{ template "concourse.secret.required" dict "key" "encryptionKey" "is" "concourse.encryption.enabled" "root" . }}
+  encryption-key: {{ template "concourse.secret.required" dict "key" "encryptionKey" "is" "concourse.encryption.enabled" "root" .Values.secrets }}
   old-encryption-key: {{ default "" .Values.secrets.oldEncryptionKey | b64enc | quote }}
   {{- end }}
-  {{- if .Values.concourse.basicAuth.enabled }}
-  basic-auth-username: {{ template "concourse.secret.required" dict "key" "basicAuthUsername" "is" "concourse.basicAuth.enabled" "root" . }}
-  basic-auth-password: {{ template "concourse.secret.required" dict "key" "basicAuthPassword" "is" "concourse.basicAuth.enabled" "root" . }}
+  {{- if .Values.secrets.localUserAuth.enabled }}
+  local-user-auth-local-users: {{ join "," .Values.secrets.localUserAuth.localUsers | b64enc | quote }}
   {{- end }}
-  {{- if .Values.concourse.githubAuth.enabled }}
-  github-auth-client-id: {{ template "concourse.secret.required" dict "key" "githubAuthClientId" "is" "concourse.githubAuth.enabled" "root" . }}
-  github-auth-client-secret: {{ template "concourse.secret.required" dict "key" "githubAuthClientSecret" "is" "concourse.githubAuth.enabled" "root" . }}
+  {{- if .Values.secrets.githubAuth.enabled }}
+  github-auth-client-id: {{ template "concourse.secret.required" dict "key" "clientId" "is" "secrets.githubAuth.enabled" "root" .Values.secrets.githubAuth }}
+  github-auth-client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "secrets.githubAuth.enabled" "root" .Values.secrets.githubAuth }}
+  github-auth-host: {{ default "" .Values.secrets.githubAuth.host | b64enc | quote }}
+  github-auth-ca-cert: {{ default "" .Values.secrets.githubAuth.caCert | b64enc | quote }}
   {{- end }}
-  {{- if .Values.concourse.gitlabAuth.enabled }}
-  gitlab-auth-client-id: {{ template "concourse.secret.required" dict "key" "gitlabAuthClientId" "is" "concourse.gitlabAuth.enabled" "root" . }}
-  gitlab-auth-client-secret: {{ template "concourse.secret.required" dict "key" "gitlabAuthClientSecret" "is" "concourse.gitlabAuth.enabled" "root" . }}
+  {{- if .Values.secrets.gitlabAuth.enabled }}
+  gitlab-auth-client-id: {{ template "concourse.secret.required" dict "key" "clientId" "is" "secrets.gitlabAuth.enabled" "root" .Values.secrets.gitlabAuth }}
+  gitlab-auth-client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "secrets.gitlabAuth.enabled" "root" .Values.secrets.gitlabAuth }}
+  gitlab-auth-host: {{ default "" .Values.secrets.gitlabAuth.host | b64enc | quote }}
   {{- end }}
-  {{- if .Values.concourse.genericOauth.enabled }}
-  generic-oauth-client-id: {{ template "concourse.secret.required" dict "key" "genericOauthClientId" "is" "concourse.genericOauth.enabled" "root" . }}
-  generic-oauth-client-secret: {{ template "concourse.secret.required" dict "key" "genericOauthClientSecret" "is" "concourse.genericOauth.enabled" "root" . }}
+  {{- if .Values.secrets.oauthAuth.enabled }}
+  oauth-auth-client-id: {{ template "concourse.secret.required" dict "key" "clientId" "is" "secrets.oauthAuth.enabled" "root" .Values.secrets.oauthAuth }}
+  oauth-auth-client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "secrets.oauthAuth.enabled" "root" .Values.secrets.oauthAuth }}
+  oauth-auth-auth-url: {{ template "concourse.secret.required" dict "key" "authUrl" "is" "secrets.oauthAuth.enabled" "root" .Values.secrets.oauthAuth }}
+  oauth-auth-token-url: {{ template "concourse.secret.required" dict "key" "tokenUrl" "is" "secrets.oauthAuth.enabled" "root" .Values.secrets.oauthAuth }}
+  oauth-auth-display-name: {{ default "" .Values.secrets.oauthAuth.displayName | b64enc | quote }}
+  oauth-auth-userinfo-url: {{ default "" .Values.secrets.oauthAuth.userinfoUrl | b64enc | quote }}
+  oauth-auth-scope: {{ default "" .Values.secrets.oauthAuth.scope | b64enc | quote }}
+  oauth-auth-groups-key: {{ default "" .Values.secrets.oauthAuth.groupsKey | b64enc | quote }}
+  oauth-auth-ca-cert: {{ default "" .Values.secrets.oauthAuth.caCert | b64enc | quote }}
+  oauth-auth-skip-ssl-validation: {{ default "" .Values.secrets.oauthAuth.skipSslValidation | b64enc | quote }}
   {{- end }}
   {{- if .Values.credentialManager.vault.enabled }}
   vault-ca-cert: {{ default "" .Values.secrets.vaultCaCert | b64enc | quote }}

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -15,8 +15,14 @@ data:
   session-signing-key: {{ .Values.secrets.sessionSigningKey | b64enc | quote }}
   worker-key: {{ .Values.secrets.workerKey | b64enc | quote }}
   worker-key-pub: {{ .Values.secrets.workerKeyPub | b64enc | quote }}
-  {{- if not .Values.postgresql.enabled }}
-  postgresql-uri: {{ template "concourse.secret.required" dict "key" "postgresqlUri" "isnt" "postgresql.enabled" "root" .Values.secrets }}
+  {{- if .Values.secrets.externalPostgres.enabled }}
+  postgres-host: {{ template "concourse.secret.required" dict "key" "host" "is" "secrets.externalPostgres.enabled" "root" .Values.secrets.externalPostgres }}
+  postgres-port: {{ default "" .Values.secrets.externalPostgres.port | b64enc | quote }}
+  postgres-user: {{ template "concourse.secret.required" dict "key" "user" "is" "secrets.externalPostgres.enabled" "root" .Values.secrets.externalPostgres }}
+  postgres-password: {{ template "concourse.secret.required" dict "key" "password" "is" "secrets.externalPostgres.enabled" "root" .Values.secrets.externalPostgres }}
+  postgres-sslmode: {{ default "" .Values.secrets.externalPostgres.sslmode | b64enc | quote }}
+  postgres-connect-timeout: {{ default "" .Values.secrets.externalPostgres.connectTimeout | b64enc | quote }}
+  postgres-database: {{ template "concourse.secret.required" dict "key" "database" "is" "secrets.externalPostgres.enabled" "root" .Values.secrets.externalPostgres }}
   {{- end }}
   {{- if .Values.concourse.encryption.enabled }}
   encryption-key: {{ template "concourse.secret.required" dict "key" "encryptionKey" "is" "concourse.encryption.enabled" "root" .Values.secrets }}

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -31,6 +31,13 @@ data:
   {{- if .Values.secrets.localUserAuth.enabled }}
   local-user-auth-local-users: {{ join "," .Values.secrets.localUserAuth.localUsers | b64enc | quote }}
   {{- end }}
+  {{- if .Values.secrets.cfAuth.enabled }}
+  cf-auth-client-id: {{ template "concourse.secret.required" dict "key" "clientId" "is" "secrets.cfAuth.enabled" "root" .Values.secrets.cfAuth }}
+  cf-auth-client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "secrets.cfAuth.enabled" "root" .Values.secrets.cfAuth }}
+  cf-auth-api-url: {{ template "concourse.secret.required" dict "key" "apiUrl" "is" "secrets.cfAuth.enabled" "root" .Values.secrets.cfAuth }}
+  cf-auth-ca-cert: {{ default "" .Values.secrets.cfAuth.caCert | b64enc | quote }}
+  cf-auth-skip-ssl-validation: {{ default "" .Values.secrets.cfAuth.skipSslValidation | b64enc | quote }}
+  {{- end }}
   {{- if .Values.secrets.githubAuth.enabled }}
   github-auth-client-id: {{ template "concourse.secret.required" dict "key" "clientId" "is" "secrets.githubAuth.enabled" "root" .Values.secrets.githubAuth }}
   github-auth-client-secret: {{ template "concourse.secret.required" dict "key" "clientSecret" "is" "secrets.githubAuth.enabled" "root" .Values.secrets.githubAuth }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -30,15 +30,6 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           args:
             - "web"
-            {{- if eq (default "" .Values.credentialManager.vault.authBackend) "approle" }}
-            - "--vault-auth-param"
-            - "role_id=$(CONCOURSE_VAULT_APPROLE_ID)"
-            - "--vault-auth-param"
-            - "secret_id=$(CONCOURSE_VAULT_APPROLE_SECRET_ID)"
-            {{- end }}
-            {{- if .Values.credentialManager.kubernetes.enabled }}
-            - "--kubernetes-in-cluster"
-            {{- end }}
             {{- if .Values.credentialManager.ssm.enabled }}
             - "--aws-ssm-region"
             - "$(CONCOURSE_AWS_SSM_REGION)"
@@ -46,16 +37,6 @@ spec:
             {{- if .Values.credentialManager.awsSecretsManager.enabled }}
             - "--aws-secretsmanager-region"
             - "$(CONCOURSE_AWS_SECRETSMANAGER_REGION)"
-            {{- end }}
-            {{- if .Values.web.metrics.datadog.enabled }}
-            - "--datadog-agent-host"
-            - "$(CONCOURSE_DATADOG_AGENT_HOST)"
-            - "--datadog-agent-port"
-            - "$(CONCOURSE_DATADOG_AGENT_PORT)"
-            {{- if .Values.web.metrics.datadog.prefix }}
-            - "--datadog-prefix"
-            - {{ .Values.web.metrics.datadog.prefix }}
-            {{- end }}
             {{- end }}
           env:
             - name: CONCOURSE_TSA_HOST_KEY
@@ -430,6 +411,8 @@ spec:
             {{- if .Values.credentialManager.kubernetes.enabled }}
             - name: CONCOURSE_KUBERNETES_NAMESPACE_PREFIX
               value: {{ template "concourse.namespacePrefix" . }}
+            - name: CONCOURSE_KUBERNETES_IN_CLUSTER
+              value: ""
             {{- end }}
             {{- if .Values.credentialManager.vault.enabled }}
             - name: CONCOURSE_VAULT_URL
@@ -464,6 +447,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-approle-secret-id
+            - name: CONCOURSE_VAULT_AUTH_PARAM
+              value: "role_id=$(CONCOURSE_VAULT_APPROLE_ID),secret_id=$(CONCOURSE_VAULT_APPROLE_SECRET_ID)"
             {{- end }}
             {{- end }}
             {{- if .Values.credentialManager.ssm.enabled }}
@@ -545,6 +530,10 @@ spec:
             {{- end }}
             - name: CONCOURSE_DATADOG_AGENT_PORT
               value: {{ .Values.web.metrics.datadog.agentPort | quote }}
+            {{- if .Values.web.metrics.datadog.prefix }}
+            - name: CONCOURSE_DATADOG_PREFIX
+              value: {{ .Values.web.metrics.datadog.prefix }}
+            {{- end }}
             {{- end }}
             {{- if .Values.web.metrics.influxdb.enabled }}
             - name: CONCOURSE_INFLUXDB_URL

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -122,16 +122,10 @@ spec:
               value: "http://$(POD_IP):$(CONCOURSE_BIND_PORT)"
             - name: CONCOURSE_TSA_BIND_PORT
               value: {{ .Values.concourse.tsaPort | quote }}
-            - name: CONCOURSE_ALLOW_SELF_SIGNED_CERTIFICATES
-              value: {{ .Values.concourse.allowSelfSignedCertificates | quote }}
             - name: CONCOURSE_AUTH_DURATION
               value: {{ .Values.concourse.authDuration | quote }}
             - name: CONCOURSE_RESOURCE_CHECKING_INTERVAL
               value: {{ .Values.concourse.resourceCheckingInterval | quote }}
-            - name: CONCOURSE_OLD_RESOURCE_GRACE_PERIOD
-              value: {{ .Values.concourse.oldResourceGracePeriod | quote }}
-            - name: CONCOURSE_RESOURCE_CACHE_CLEANUP_INTERVAL
-              value: {{ .Values.concourse.resourceCacheCleanupInterval | quote }}
             - name: CONCOURSE_CONTAINER_PLACEMENT_STRATEGY
               value: {{ .Values.concourse.containerPlacementStrategy | quote }}
             {{- if .Values.secrets.localUserAuth.enabled }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -64,26 +64,56 @@ spec:
               value: "/concourse-keys/session_signing_key"
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
               value: "/concourse-keys/worker_key.pub"
-            {{- if .Values.postgresql.enabled }}
-            - name: POSTGRES_HOST
+            {{- if .Values.secrets.externalPostgres.enabled }}
+            - name: CONCOURSE_POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: postgres-host
+            - name: CONCOURSE_POSTGRES_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: postgres-port
+            - name: CONCOURSE_POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: postgres-user
+            - name: CONCOURSE_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: postgres-password
+            - name: CONCOURSE_POSTGRES_SSLMODE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: postgres-sslmode
+            - name: CONCOURSE_POSTGRES_CONNECT_TIMEOUT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: postgres-connect-timeout
+            - name: CONCOURSE_POSTGRES_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: postgres-database
+            {{- else if .Values.postgresql.enabled }}
+            - name: CONCOURSE_POSTGRES_HOST
               value: {{ template "concourse.postgresql.fullname" . }}
-            - name: POSTGRES_USER
+            - name: CONCOURSE_POSTGRES_USER
               value: {{ .Values.postgresql.postgresUser }}
-            - name: POSTGRES_PASSWORD
+            - name: CONCOURSE_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.postgresql.fullname" . }}
                   key: postgres-password
-            - name: POSTGRES_DATABASE
+            - name: CONCOURSE_POSTGRES_DATABASE
               value: {{ .Values.postgresql.postgresDatabase | quote }}
-            - name: CONCOURSE_POSTGRES_DATA_SOURCE
-              value: postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST)/$(POSTGRES_DATABASE)?sslmode=disable
-            {{- else }}
-            - name: CONCOURSE_POSTGRES_DATA_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
-                  key: postgresql-uri
+            - name: CONCOURSE_POSTGRES_SSLMODE
+              value: "disable"
             {{- end }}
             {{- if .Values.concourse.encryption.enabled }}
             - name: CONCOURSE_ENCRYPTION_KEY

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -335,8 +335,8 @@ spec:
             - name: CONCOURSE_INFLUXDB_INSECURE_SKIP_VERIFY
               value: {{ .Values.web.metrics.influxdb.insecureSkipVerify | quote}}
             {{- end }}
-{{- if .Values.web.env }}
-{{ toYaml .Values.web.env | indent 12 }}
+{{- if .Values.web.extraEnv }}
+{{ toYaml .Values.web.extraEnv | indent 12 }}
 {{- end }}
           ports:
             - name: atc

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -160,6 +160,33 @@ spec:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: local-user-auth-local-users
             {{- end }}
+            {{- if .Values.secrets.cfAuth.enabled }}
+            - name: CONCOURSE_CF_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: cf-auth-client-id
+            - name: CONCOURSE_CF_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: cf-auth-client-secret
+            - name: CONCOURSE_CF_API_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: cf-auth-api-url
+            - name: CONCOURSE_CF_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: cf-auth-ca-cert
+            - name: CONCOURSE_CF_SKIP_SSL_VALIDATION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: cf-auth-skip-ssl-validation
+            {{- end }}
             {{- if .Values.secrets.githubAuth.enabled }}
             - name: CONCOURSE_GITHUB_CLIENT_ID
               valueFrom:
@@ -392,6 +419,12 @@ spec:
             - name: CONCOURSE_MAIN_TEAM_ALLOW_ALL_USERS
               value: ""
             {{- end }}
+            - name: CONCOURSE_MAIN_TEAM_CF_USER
+              value: {{ join "," .cfUsers }}
+            - name: CONCOURSE_MAIN_TEAM_CF_ORG
+              value: {{ join "," .cfOrgs }}
+            - name: CONCOURSE_MAIN_TEAM_CF_SPACE
+              value: {{ join "," .cfSpaces }}
             - name: CONCOURSE_MAIN_TEAM_GITHUB_USER
               value: {{ join "," .githubUsers }}
             - name: CONCOURSE_MAIN_TEAM_GITHUB_ORG

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -226,6 +226,113 @@ spec:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: gitlab-auth-host
             {{- end }}
+            {{- if .Values.secrets.ldapAuth.enabled }}
+            - name: CONCOURSE_LDAP_DISPLAY_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-display-name
+            - name: CONCOURSE_LDAP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-host
+            - name: CONCOURSE_LDAP_BIND_DN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-bind-dn
+            - name: CONCOURSE_LDAP_BIND_PW
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-bind-pw
+            - name: CONCOURSE_LDAP_INSECURE_NO_SSL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-insecure-no-ssl
+            - name: CONCOURSE_LDAP_INSECURE_SKIP_VERIFY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-insecure-skip-verify
+            - name: CONCOURSE_LDAP_START_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-start-tls
+            - name: CONCOURSE_LDAP_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-ca-cert
+            - name: CONCOURSE_LDAP_USER_SEARCH_BASE_DN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-user-search-base-dn
+            - name: CONCOURSE_LDAP_USER_SEARCH_FILTER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-user-search-filter
+            - name: CONCOURSE_LDAP_USER_SEARCH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-user-search-username
+            - name: CONCOURSE_LDAP_USER_SEARCH_SCOPE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-user-search-scope
+            - name: CONCOURSE_LDAP_USER_SEARCH_ID_ATTR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-user-search-id-attr
+            - name: CONCOURSE_LDAP_USER_SEARCH_EMAIL_ATTR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-user-search-email-attr
+            - name: CONCOURSE_LDAP_USER_SEARCH_NAME_ATTR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-user-search-name-attr
+            - name: CONCOURSE_LDAP_GROUP_SEARCH_BASE_DN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-group-search-base-dn
+            - name: CONCOURSE_LDAP_GROUP_SEARCH_FILTER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-group-search-filter
+            - name: CONCOURSE_LDAP_GROUP_SEARCH_SCOPE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-group-search-scope
+            - name: CONCOURSE_LDAP_GROUP_SEARCH_USER_ATTR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-group-search-user-attr
+            - name: CONCOURSE_LDAP_GROUP_SEARCH_GROUP_ATTR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-group-search-group-attr
+            - name: CONCOURSE_LDAP_GROUP_SEARCH_NAME_ATTR
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: ldap-auth-group-search-name-attr
+            {{- end }}
             {{- if .Values.secrets.oauthAuth.enabled }}
             - name: CONCOURSE_OAUTH_CLIENT_ID
               valueFrom:
@@ -435,6 +542,10 @@ spec:
               value: {{ join "," .gitlabUsers }}
             - name: CONCOURSE_MAIN_TEAM_GITLAB_GROUP
               value: {{ join "," .gitlabGroups }}
+            - name: CONCOURSE_MAIN_TEAM_LDAP_USER
+              value: {{ join "," .ldapUsers }}
+            - name: CONCOURSE_MAIN_TEAM_LDAP_GROUP
+              value: {{ join "," .ldapGroups }}
             - name: CONCOURSE_MAIN_TEAM_OAUTH_USER
               value: {{ join "," .oauthUsers }}
             - name: CONCOURSE_MAIN_TEAM_OAUTH_GROUP

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -123,83 +123,103 @@ spec:
               value: {{ .Values.concourse.resourceCacheCleanupInterval | quote }}
             - name: CONCOURSE_CONTAINER_PLACEMENT_STRATEGY
               value: {{ .Values.concourse.containerPlacementStrategy | quote }}
-            {{- if .Values.concourse.basicAuth.enabled }}
-            - name: CONCOURSE_BASIC_AUTH_USERNAME
+            {{- if .Values.secrets.localUserAuth.enabled }}
+            - name: CONCOURSE_ADD_LOCAL_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
-                  key: basic-auth-username
-            - name: CONCOURSE_BASIC_AUTH_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "concourse.concourse.fullname" . }}
-                  key: basic-auth-password
+                  key: local-user-auth-local-users
             {{- end }}
-            {{- if .Values.concourse.githubAuth.enabled }}
-            - name: CONCOURSE_GITHUB_AUTH_CLIENT_ID
+            {{- if .Values.secrets.githubAuth.enabled }}
+            - name: CONCOURSE_GITHUB_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: github-auth-client-id
-            - name: CONCOURSE_GITHUB_AUTH_CLIENT_SECRET
+            - name: CONCOURSE_GITHUB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: github-auth-client-secret
-            - name: CONCOURSE_GITHUB_AUTH_ORGANIZATION
-              value: {{ .Values.concourse.githubAuth.organization | quote }}
-            - name: CONCOURSE_GITHUB_AUTH_TEAM
-              value: {{ .Values.concourse.githubAuth.team | quote }}
-            - name: CONCOURSE_GITHUB_AUTH_USER
-              value: {{ .Values.concourse.githubAuth.user | quote }}
-            - name: CONCOURSE_GITHUB_AUTH_AUTH_URL
-              value: {{ .Values.concourse.githubAuth.authUrl | quote }}
-            - name: CONCOURSE_GITHUB_AUTH_TOKEN_URL
-              value: {{ .Values.concourse.githubAuth.tokenUrl | quote }}
-            - name: CONCOURSE_GITHUB_AUTH_API_URL
-              value: {{ .Values.concourse.githubAuth.apiUrl | quote }}
+            - name: CONCOURSE_GITHUB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: github-auth-host
+            - name: CONCOURSE_GITHUB_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: github-auth-ca-cert
             {{- end }}
-            {{- if .Values.concourse.gitlabAuth.enabled }}
-            - name: CONCOURSE_GITLAB_AUTH_CLIENT_ID
+            {{- if .Values.secrets.gitlabAuth.enabled }}
+            - name: CONCOURSE_GITLAB_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: gitlab-auth-client-id
-            - name: CONCOURSE_GITLAB_AUTH_CLIENT_SECRET
+            - name: CONCOURSE_GITLAB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: gitlab-auth-client-secret
-            - name: CONCOURSE_GITLAB_AUTH_GROUP
-              value: {{ .Values.concourse.gitlabAuth.group | quote }}
-            - name: CONCOURSE_GITLAB_AUTH_AUTH_URL
-              value: {{ .Values.concourse.gitlabAuth.authUrl | quote }}
-            - name: CONCOURSE_GITLAB_AUTH_TOKEN_URL
-              value: {{ .Values.concourse.gitlabAuth.tokenUrl | quote }}
-            - name: CONCOURSE_GITLAB_AUTH_API_URL
-              value: {{ .Values.concourse.gitlabAuth.apiUrl | quote }}
+            - name: CONCOURSE_GITLAB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: gitlab-auth-host
             {{- end }}
-            {{- if .Values.concourse.genericOauth.enabled }}
-            - name: CONCOURSE_GENERIC_OAUTH_CLIENT_ID
+            {{- if .Values.secrets.oauthAuth.enabled }}
+            - name: CONCOURSE_OAUTH_CLIENT_ID
+              valueFrom:
+                  secretKeyRef:
+                    name: {{ template "concourse.concourse.fullname" . }}
+                    key: oauth-auth-client-id
+            - name: CONCOURSE_OAUTH_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
-                  key: generic-oauth-client-id
-            - name: CONCOURSE_GENERIC_OAUTH_CLIENT_SECRET
+                  key: oauth-auth-client-secret
+            - name: CONCOURSE_OAUTH_AUTH_URL
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
-                  key: generic-oauth-client-secret
-            - name: CONCOURSE_GENERIC_OAUTH_DISPLAY_NAME
-              value: {{ .Values.concourse.genericOauth.displayName | quote }}
-            - name: CONCOURSE_GENERIC_OAUTH_AUTH_URL
-              value: {{ .Values.concourse.genericOauth.authUrl | quote }}
-            - name: CONCOURSE_GENERIC_OAUTH_AUTH_URL_PARAM
-              value: {{ .Values.concourse.genericOauth.authUrlParam | quote }}
-            - name: CONCOURSE_GENERIC_OAUTH_SCOPE
-              value: {{ .Values.concourse.genericOauth.scope | quote }}
-            - name: CONCOURSE_GENERIC_OAUTH_TOKEN_URL
-              value: {{ .Values.concourse.genericOauth.tokenUrl | quote }}
+                  key: oauth-auth-auth-url
+            - name: CONCOURSE_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oauth-auth-token-url
+            - name: CONCOURSE_OAUTH_DISPLAY_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oauth-auth-display-name
+            - name: CONCOURSE_OAUTH_USERINFO_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oauth-auth-userinfo-url
+            - name: CONCOURSE_OAUTH_SCOPE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oauth-auth-scope
+            - name: CONCOURSE_OAUTH_GROUPS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oauth-auth-groups-key
+            - name: CONCOURSE_OAUTH_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oauth-auth-ca-cert
+            - name: CONCOURSE_OAUTH_SKIP_SSL_VALIDATION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oauth-auth-skip-ssl-validation
             {{- end }}
             {{- if .Values.credentialManager.kubernetes.enabled }}
             - name: CONCOURSE_KUBERNETES_NAMESPACE_PREFIX
@@ -334,6 +354,28 @@ spec:
                   key: influxdb-password
             - name: CONCOURSE_INFLUXDB_INSECURE_SKIP_VERIFY
               value: {{ .Values.web.metrics.influxdb.insecureSkipVerify | quote}}
+            {{- end }}
+            {{- with .Values.concourse.mainTeam }}
+            - name: CONCOURSE_MAIN_TEAM_LOCAL_USER
+              value: {{ join "," .localUsers }}
+            {{- if .allowAllUsers }}
+            - name: CONCOURSE_MAIN_TEAM_ALLOW_ALL_USERS
+              value: ""
+            {{- end }}
+            - name: CONCOURSE_MAIN_TEAM_GITHUB_USER
+              value: {{ join "," .githubUsers }}
+            - name: CONCOURSE_MAIN_TEAM_GITHUB_ORG
+              value: {{ join "," .githubOrgs }}
+            - name: CONCOURSE_MAIN_TEAM_GITHUB_TEAM
+              value: {{ join "," .githubTeams }}
+            - name: CONCOURSE_MAIN_TEAM_GITLAB_USER
+              value: {{ join "," .gitlabUsers }}
+            - name: CONCOURSE_MAIN_TEAM_GITLAB_GROUP
+              value: {{ join "," .gitlabGroups }}
+            - name: CONCOURSE_MAIN_TEAM_OAUTH_USER
+              value: {{ join "," .oauthUsers }}
+            - name: CONCOURSE_MAIN_TEAM_OAUTH_GROUP
+              value: {{ join "," .oauthGroups }}
             {{- end }}
 {{- if .Values.web.extraEnv }}
 {{ toYaml .Values.web.extraEnv | indent 12 }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -385,6 +385,48 @@ spec:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: oauth-auth-skip-ssl-validation
             {{- end }}
+            {{- if .Values.secrets.oidcAuth.enabled }}
+            - name: CONCOURSE_OIDC_DISPLAY_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oidc-auth-display-name
+            - name: CONCOURSE_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oidc-auth-issuer
+            - name: CONCOURSE_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oidc-auth-client-id
+            - name: CONCOURSE_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oidc-auth-client-secret
+            - name: CONCOURSE_OIDC_SCOPE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oidc-auth-scope
+            - name: CONCOURSE_OIDC_GROUPS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oidc-auth-groups-key
+            - name: CONCOURSE_OIDC_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oidc-auth-ca-cert
+            - name: CONCOURSE_OIDC_SKIP_SSL_VALIDATION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: oidc-auth-skip-ssl-validation
+            {{- end }}
             {{- if .Values.credentialManager.kubernetes.enabled }}
             - name: CONCOURSE_KUBERNETES_NAMESPACE_PREFIX
               value: {{ template "concourse.namespacePrefix" . }}
@@ -550,6 +592,10 @@ spec:
               value: {{ join "," .oauthUsers }}
             - name: CONCOURSE_MAIN_TEAM_OAUTH_GROUP
               value: {{ join "," .oauthGroups }}
+            - name: CONCOURSE_MAIN_TEAM_OIDC_USER
+              value: {{ join "," .oidcUsers }}
+            - name: CONCOURSE_MAIN_TEAM_OIDC_GROUP
+              value: {{ join "," .oidcGroups }}
             {{- end }}
 {{- if .Values.web.extraEnv }}
 {{ toYaml .Values.web.extraEnv | indent 12 }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -30,13 +30,13 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           args:
             - "web"
-            {{- if .Values.credentialManager.ssm.enabled }}
+            {{- if and .Values.credentialManager.ssm.enabled .Values.credentialManager.ssm.region }}
             - "--aws-ssm-region"
-            - "$(CONCOURSE_AWS_SSM_REGION)"
+            - {{ .Values.credentialManager.ssm.region | quote }}
             {{- end }}
-            {{- if .Values.credentialManager.awsSecretsManager.enabled }}
+            {{- if and .Values.credentialManager.awsSecretsManager.enabled .Values.credentialManager.awsSecretsManager.region }}
             - "--aws-secretsmanager-region"
-            - "$(CONCOURSE_AWS_SECRETSMANAGER_REGION)"
+            - {{ .Values.credentialManager.awsSecretsManager.region | quote }}
             {{- end }}
           env:
             - name: CONCOURSE_TSA_HOST_KEY
@@ -469,10 +469,6 @@ spec:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: aws-ssm-session-token
             {{- end }}
-            {{- if .Values.credentialManager.ssm.region }}
-            - name: CONCOURSE_AWS_SSM_REGION
-              value: {{ .Values.credentialManager.ssm.region | quote }}
-            {{- end }}
             {{- if .Values.credentialManager.ssm.pipelineSecretTemplate }}
             - name: CONCOURSE_AWS_SSM_PIPELINE_SECRET_TEMPLATE
               value: {{ .Values.credentialManager.ssm.pipelineSecretTemplate | quote }}
@@ -499,10 +495,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: aws-secretsmanager-session-token
-            {{- end }}
-            {{- if .Values.credentialManager.awsSecretsManager.region }}
-            - name: CONCOURSE_AWS_SECRETSMANAGER_REGION
-              value: {{ .Values.credentialManager.awsSecretsManager.region | quote }}
             {{- end }}
             {{- if .Values.credentialManager.awsSecretsManager.pipelineSecretTemplate }}
             - name: CONCOURSE_AWS_SECRETSMANAGER_PIPELINE_SECRET_TEMPLATE

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -93,8 +93,8 @@ spec:
               value: {{ .Values.concourse.baggageclaimDriver | quote }}
             - name: LIVENESS_PROBE_FATAL_ERRORS
               value: {{ .Values.worker.fatalErrors | quote }}
-{{- if .Values.worker.env }}
-{{ toYaml .Values.worker.env | indent 12 }}
+{{- if .Values.worker.extraEnv }}
+{{ toYaml .Values.worker.extraEnv | indent 12 }}
 {{- end }}
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -78,13 +78,7 @@ spec:
                     done
           env:
             - name: CONCOURSE_TSA_HOST
-          {{- if semverCompare "^3.10.x" .Values.imageTag }}
               value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.tsaPort}}"
-          {{- else }}
-              value: {{ template "concourse.web.fullname" . }}
-            - name: CONCOURSE_TSA_PORT
-              value: {{ .Values.concourse.tsaPort | quote }}
-          {{- end }}
             - name: CONCOURSE_GARDEN_DOCKER_REGISTRY
               value: {{ .Values.concourse.dockerRegistry | quote }}
             - name: CONCOURSE_GARDEN_INSECURE_DOCKER_REGISTRY

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -96,88 +96,36 @@ concourse:
   encryption:
     enabled: false
 
-  ## Enable basic auth for the "main" Concourse team.
-  ## See https://concourse-ci.org/teams.html#basic-auth
+  ## Configuration for the main team
+  ## See https://concourse-ci.org/main-team.html
   ##
-  basicAuth:
-    enabled: true
+  mainTeam:
+    ## List of local concourse users with access to the main team
+    localUsers: ["concourse"]
 
-  ## Enable GitHub auth for the "main" Concourse team.
-  ## See https://concourse-ci.org/teams.html#github-auth
-  ##
-  githubAuth:
-    enabled: false
+    ## Allow all logged in users to access the main team. ALL OF THEM. If, for example, you've configured GitHub, any user with a GitHub account will have access to your main team.
+    allowAllUsers: false
 
-    ## GitHub organizations (comma separated) whose members will have access.
-    ##
-    # organization:
+    ## List of GitHub users with access to the main team
+    githubUsers: []
 
-    ## GitHub teams (comma separated) whose members will have access.
-    ##
-    # team:
+    ## List of GitHub orgs with access to the main team
+    githubOrgs: []
 
-    ## GitHub users (comma separated) to permit access.
-    ##
-    # user:
+    ## List of GitHub teams (in `ORG_NAME:TEAM_NAME` format) with access to the main team
+    githubTeams: []
 
-    ## Override default endpoint AuthURL for Github Enterprise.
-    ##
-    # authUrl:
+    ## List of GitLab users with access to the main team
+    gitlabUsers: []
 
-    ## Override default endpoint TokenURL for Github Enterprise.
-    ##
-    # tokenUrl:
+    ## List of GitLab groups with access to the main team
+    gitlabGroups: []
 
-    ## Override default API endpoint URL for Github Enterprise.
-    ##
-    # apiUrl:
+    ## List of OAuth2 users with access to the main team
+    oauthUsers: []
 
-  ## Enable Gitlab auth for the "main" Concourse team.
-  ##
-  gitlabAuth:
-    enabled: false
-
-    ## GitLab Group (comma separated) whose members will have access.
-    ##
-    # group:
-
-    ## Endpoint AuthURL for Gitlab server.
-    ##
-    # authUrl:
-
-    ## Endpoint TokenURL for Gitlab server.
-    ##
-    # tokenUrl:
-
-    ## API endpoint URL for Gitlab server.
-    ##
-    # apiUrl:
-
-  ## Enable generic OAuth for the "main" Concourse team.
-  ## See https://concourse-ci.org/teams.html#generic-oauth
-  ##
-  genericOauth:
-    enabled: false
-
-    ## Name for this auth method on the web UI.
-    ##
-    # displayName:
-
-    ## Generic OAuth provider AuthURL endpoint.
-    ##
-    # authUrl:
-
-    ## Parameters (comma separated) to pass to the authentication server AuthURL.
-    ##
-    # authUrlParam:
-
-    ## Optional scope required to authorize user.
-    ##
-    # scope:
-
-    ## Generic OAuth provider TokenURL endpoint.
-    ##
-    # tokenUrl:
+    ## List of OAuth2 groups with access to the main team
+    oauthGroups: []
 
 ## Configuration values for Concourse Web components.
 ##
@@ -768,25 +716,86 @@ secrets:
   # awsSecretsmanagerSecretKey:
   # awsSecretsmanagerSessionToken:
 
-  ## Secrets for Concourse basic auth
-  ##
-  basicAuthUsername: concourse
-  basicAuthPassword: concourse
+  ## Secrets for Local User auth.
+  ## See https://concourse-ci.org/install.html#local-auth-config
+  localUserAuth:
+    ## Enable the Local User auth provider
+    enabled: true
 
-  ## Secrets for GitHub OAuth.
-  ##
-  # githubAuthClientId:
-  # githubAuthClientSecret:
+    ## List of username:password combinations for all your local users. The password can be bcrypted - if so, it must have a minimum cost of 10.
+    ## Default password for "concourse" user is "concourse"
+    localUsers:
+      - "concourse:$2a$12$HKPJ1pXLZjJWG0qLJegI9ezG4W.U5bC0blWV37u0vLePc/2uYRykm"
 
-  ## Secrets for GitLab OAuth.
+  ## Secrets for GitHub auth.
+  ## See https://concourse-ci.org/install.html#github-auth-config
   ##
-  # gitlabAuthClientId:
-  # gitlabAuthClientSecret:
+  githubAuth:
+    ## Enable the GitHub auth provider
+    enabled: false
 
-  ## Secrets for generic OAuth.
-  ##
-  # genericOauthClientId:
-  # genericOauthClientSecret:
+    ## (Required if GitHub enabled) Client id
+    # clientId:
+
+    ## (Required if GitHub enabled) Client secret
+    # clientSecret:
+
+    ## Hostname of GitHub Enterprise deployment (No scheme, No trailing slash)
+    # host:
+
+    ## CA certificate of GitHub Enterprise deployment
+    # caCert:
+
+  ## Secrets for GitLab auth.
+  ## See: https://concourse-ci.org/install.html#gitlab-auth-config
+  gitlabAuth:
+    ## Enable the GitLab auth provider
+    enabled: false
+
+    ## (Required if GitLab enabled) Client id
+    # clientId:
+
+    ## (Required if GitLab enabled) Client secret
+    # clientSecret:
+
+    ## Hostname of Gitlab Enterprise deployment (Include scheme, No trailing slash)
+    # host:
+
+  ## Secrets for OAuth2.
+  ## See https://concourse-ci.org/install.html#generic-oauth-config
+  oauthAuth:
+    ## Enable the Oauth2 auth provider
+    enabled: false
+
+    ## The auth provider name displayed to users on the login page
+    # displayName:
+
+    ## (Required if OAuth2 enabled) Client id
+    # clientId:
+
+    ## (Required if OAuth2 enabled) Client secret
+    # clientSecret:
+
+    ## (Required if OAuth2 enabled) Authorization URL
+    # authUrl:
+
+    ## (Required if OAuth2 enabled) Token URL
+    # tokenUrl:
+
+    ## Userinfo URL
+    # userinfoUrl:
+
+    ## Any additional scopes that need to be requested during authorization
+    # scope:
+
+    ## The groups key indicates which claim to use to map external groups to Concourse teams.
+    # groupsKey:
+
+    ## CA Certificate
+    # caCert:
+
+    ## Skip SSL validation
+    # skipSslValidation:
 
   ## If bringing your own PostgreSQL, set this to the full uri to use
   ## e.g. postgres://concourse:changeme@my-postgres.com:5432/concourse?sslmode=disable

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -130,6 +130,12 @@ concourse:
     ## List of GitLab groups with access to the main team
     gitlabGroups: []
 
+    ## List of LDAP users with access to the main team
+    ldapUsers: []
+
+    ## List of LDAP groups with access to the main team
+    ldapGroups: []
+
     ## List of OAuth2 users with access to the main team
     oauthUsers: []
 
@@ -790,6 +796,73 @@ secrets:
 
     ## Hostname of Gitlab Enterprise deployment (Include scheme, No trailing slash)
     # host:
+
+  ldapAuth:
+    ## Enable the LDAP auth provider
+    enabled: false
+
+    ## The auth provider name displayed to users on the login page
+    # displayName:
+
+    ## (Required if LDAP enabled) The host and optional port of the LDAP server. If port isn't supplied, it will be guessed based on the TLS configuration. 389 or 636.
+    # host:
+
+    ## (Required if LDAP enabled) Bind DN for searching LDAP users and groups. Typically this is a read-only user.
+    # bindDn:
+
+    ## (Required if LDAP enabled) Bind Password for the user specified by `secrets.ldapBindDn`
+    # bindPw:
+
+    ## Required if LDAP host does not use TLS.
+    # insecureNoSsl:
+
+    ## Skip certificate verification
+    # insecureSkipVerify:
+
+    ## Start on insecure port, then negotiate TLS
+    # startTls:
+
+    ## CA certificate
+    # caCert:
+
+    ## BaseDN to start the search from. For example `cn=users,dc=example,dc=com`
+    # userSearchBaseDn:
+
+    ## Optional filter to apply when searching the directory. For example `(objectClass=person)`
+    # userSearchFilter:
+
+    ## Attribute to match against the inputted username. This will be translated and combined with the other filter as '(<attr>=<username>)'.
+    # userSearchUsername:
+
+    ## Can either be: `sub` - search the whole sub tree or `one` - only search one level. Defaults to 'sub' when not specified.
+    # userSearchScope:
+
+    ## A mapping of attributes on the user entry to claims. Defaults to 'uid' when not specified.
+    # userSearchIdAttr:
+
+    ## A mapping of attributes on the user entry to claims. Defaults to 'mail' when not specified.
+    # userSearchEmailAttr:
+
+    ## A mapping of attributes on the user entry to claims.
+    # userSearchNameAttr:
+
+    ## BaseDN to start the search from. For example `cn=groups,dc=example,dc=com`
+    # groupSearchBaseDn:
+
+    ## Optional filter to apply when searching the directory. For example `(objectClass=posixGroup)`
+    # groupSearchFilter:
+
+    ## Can either be: `sub` - search the whole sub tree or `one` - only search one level. Defaults to 'sub' when not specified.
+    # groupSearchScope:
+
+    ## Adds an additional requirement to the filter that an attribute in the group match the user's attribute value. The exact filter being added is: (<groupAttr>=<userAttr value>)
+    # groupSearchUserAttr:
+
+    ## Adds an additional requirement to the filter that an attribute in the group match the user's attribute value. The exact filter being added is: (<groupAttr>=<userAttr value>)
+    # groupSearchGroupAttr:
+
+    ## The attribute of the group that represents its name.
+    # groupSearchNameAttr:
 
   ## Secrets for OAuth2.
   ## See https://concourse-ci.org/install.html#generic-oauth-config

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -35,10 +35,6 @@ concourse:
   ##
   tsaPort: 2222
 
-  ## Allow self signed certificates.
-  ##
-  allowSelfSignedCertificates: false
-
   ## Length of time for which tokens are valid. Afterwards, users will have to log back in.
   ## Use Go duration format (48h = 48 hours).
   ##
@@ -48,16 +44,6 @@ concourse:
   ## Use Go duration format (1m = 1 minute).
   ##
   resourceCheckingInterval: 1m
-
-  ## How long to cache the result of a get step after a newer version of the resource is found.
-  ## Use Go duration format (1m = 1 minute).
-  ##
-  oldResourceGracePeriod: 5m
-
-  ## The interval on which to check for and release old caches of resource versions.
-  ## Use Go duration format (1m = 1 minute),
-  ##
-  resourceCacheCleanupInterval: 30s
 
   ## URL used to reach any ATC from the outside world.
   ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -446,7 +446,7 @@ persistence:
 postgresql:
 
   ## Use the PostgreSQL chart dependency.
-  ## Set to false if bringing your own PostgreSQL, and set secret value postgresql-uri.
+  ## Set to false if bringing your own PostgreSQL, and set secret values for "postgres-*".
   ##
   enabled: true
 
@@ -797,10 +797,33 @@ secrets:
     ## Skip SSL validation
     # skipSslValidation:
 
-  ## If bringing your own PostgreSQL, set this to the full uri to use
-  ## e.g. postgres://concourse:changeme@my-postgres.com:5432/concourse?sslmode=disable
-  ##
-  # postgresqlUri:
+  ## Configurations for bringing your own PostgreSQL
+  externalPostgres:
+    enabled: false
+
+    ## Use an externally provided postgres (takes precedence over `postgres.enabled` if both are true)
+    # enabled:
+
+    ## The host to connect to.
+    # host:
+
+    ## The port to connect to.
+    port: "5432"
+
+    ## The user to sign in as.
+    # user:
+
+    ## The user's password.
+    # password:
+
+    ## Whether or not to use SSL. [disable|require|verify-ca|verify-full]
+    # sslmode:
+
+    ## Dialing timeout. (0 means wait indefinitely)
+    # connectTimeout:
+
+    ## The name of the database to use.
+    # database:
 
   ## Secrets for using Hashcorp Vault as a credential manager.
   ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -142,6 +142,12 @@ concourse:
     ## List of OAuth2 groups with access to the main team
     oauthGroups: []
 
+    ## List of OIDC users with access to the main team
+    oidcUsers: []
+
+    ## List of OIDC groups with access to the main team
+    oidcGroups: []
+
 ## Configuration values for Concourse Web components.
 ##
 web:
@@ -887,6 +893,36 @@ secrets:
 
     ## Userinfo URL
     # userinfoUrl:
+
+    ## Any additional scopes that need to be requested during authorization
+    # scope:
+
+    ## The groups key indicates which claim to use to map external groups to Concourse teams.
+    # groupsKey:
+
+    ## CA Certificate
+    # caCert:
+
+    ## Skip SSL validation
+    # skipSslValidation:
+
+  ## Secrets for OIDC.
+  ## See https://concourse-ci.org/install.html#generic-oidc-config
+  oidcAuth:
+    ## Enable the OIDC auth provider
+    enabled: false
+
+    ## The auth provider name displayed to users on the login page
+    # displayName:
+
+    ## (Required if OIDC enabled) An OIDC issuer URL that will be used to discover provider configuration using the .well-known/openid-configuration
+    # issuer:
+
+    ## (Required if OIDC enabled) Client id
+    # clientId:
+
+    ## (Required if OIDC enabled) Client secret
+    # clientSecret:
 
     ## Any additional scopes that need to be requested during authorization
     # scope:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -13,7 +13,7 @@ image: concourse/concourse
 ## Concourse image version.
 ## ref: https://hub.docker.com/r/concourse/concourse/tags/
 ##
-imageTag: "3.14.1"
+imageTag: "4.1.0"
 
 ## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
 ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -106,6 +106,15 @@ concourse:
     ## Allow all logged in users to access the main team. ALL OF THEM. If, for example, you've configured GitHub, any user with a GitHub account will have access to your main team.
     allowAllUsers: false
 
+    ## List of CloudFoundry users with access to the main team
+    cfUsers: []
+
+    ## List of CloudFoundry orgs with access to the main team
+    cfOrgs: []
+
+    ## List of whitelisted CloudFoundry spaces (in `ORG_NAME:SPACE_NAME` format) with access to the main team
+    cfSpaces: []
+
     ## List of GitHub users with access to the main team
     githubUsers: []
 
@@ -726,6 +735,27 @@ secrets:
     ## Default password for "concourse" user is "concourse"
     localUsers:
       - "concourse:$2a$12$HKPJ1pXLZjJWG0qLJegI9ezG4W.U5bC0blWV37u0vLePc/2uYRykm"
+
+  ## Secrets for CloudFoundry auth.
+  ## See https://concourse-ci.org/install.html#cf-auth-config
+  cfAuth:
+    ## Enable the GitHub auth provider
+    enabled: false
+
+    ## (Required if CloudFoundry enabled) Client id
+    # clientId:
+
+    ## (Required if CloudFoundry enabled) Client secret
+    # clientSecret:
+
+    ## (Required if CloudFoundry enabled) The base API URL of your CF deployment. It will use this information to discover information about the authentication provider.
+    # apiUrl:
+
+    ## CA Certificate
+    # caCert:
+
+    ## Skip SSL validation
+    # skipSslValidation:
 
   ## Secrets for GitHub auth.
   ## See https://concourse-ci.org/install.html#github-auth-config


### PR DESCRIPTION
**What this PR does / why we need it**:

Supports the recently-released Concourse 4, and drops support for versions earlier than 4.0.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #6873

**Special notes for your reviewer**:

This is a big PR, potentially too big. I've split up the pieces of work into individual commits, so can easily remove pieces if needed. I've tried to capture all the desires in #6873, including removing old parameters not supported in 4.0. I have left one deprecated parameter, `CONCOURSE_POSTGRES_DATA_SOURCE`, because it's a little painful to change all of the documentation and usage to use the new split-up parameters, and this was already becoming a big PR. If that's something we would like, though, I can certainly do the work and update this PR.