### PR TITLE
[stable/dex]: Add support to configure nodePort

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.2.1
+version: 0.3.0
 appVersion: 2.10.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.2.0
+version: 0.2.1
 appVersion: 2.10.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/templates/service.yaml
+++ b/stable/dex/templates/service.yaml
@@ -19,6 +19,9 @@ spec:
   - name: {{ .name }} 
     port: {{ .containerPort }}
     targetPort: {{ .containerPort}}
+{{- if and (eq "NodePort" $.Values.service.type) (hasKey . "nodePort") }}
+    nodePort: {{ .nodePort }}
+{{- end}}
 {{- end}}
 {{- if hasKey .Values.service "externalIPs" }}
   externalIPs:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -25,6 +25,7 @@ ports:
   - name: http
     containerPort: 8080
     protocol: TCP
+#   nodePort: 32080
   - name: grpc
     containerPort: 5000
     protocol: TCP


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for configuring the `nodePort` that will be used when the Dex service type is set to `NodePort`.