### PR TITLE
[stable/verdaccio] feat(verdaccio): configurable securityContext

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.3.2
+version: 0.4.0
 appVersion: 3.2
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/templates/deployment.yaml
+++ b/stable/verdaccio/templates/deployment.yaml
@@ -56,9 +56,12 @@ spec:
             - mountPath: /verdaccio/conf
               name: config
               readOnly: true
+      {{- if .Values.securityContext.enabled }}
       # Allow non-root user to access PersistentVolume
       securityContext:
-        fsGroup: 1000
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/stable/verdaccio/values.yaml
+++ b/stable/verdaccio/values.yaml
@@ -133,3 +133,8 @@ persistence:
 #  - mountPath: /var/nothing
 #    name: nothing
 #    readOnly: true
+
+securityContext:
+  enabled: true
+  runAsUser: 100
+  fsGroup: 101


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Some environments and configurations (e.g. openshift) impose policies to forbid running containers as root and startup processes under a random uid. This PR adds a configurable feature flag to enable the `securityContext` in the deployment file, and also decide which values should be used for `runAsUser` and `fsGroup`.

It also corrects the default value of `fsGroup` from `1000` to `101`, which is the actual value used in the verdaccio 3.x Dockerfile.

**Which issue this PR fixes**:
Replaces https://github.com/helm/charts/pull/6814

**Special notes for your reviewer**:
This PR goes hand in hand with the support for random uids implemented in Verdaccio 4.x  
https://github.com/verdaccio/verdaccio/pull/864