### PR TITLE
Schema registry update kafka zk

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.4.4
+version: 0.4.6
 appVersion: 4.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.4.6
+version: 0.5.0
 appVersion: 4.1.1
 keywords:
   - confluent

--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 0.5.0
+version: 1.0.0
 appVersion: 4.1.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -83,7 +83,6 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `kafka.enabled` | If `true`, install Kafka/Zookeeper alongside the `SchemaRegistry`. This is intended for testing and argument-less helm installs of this chart only and should not be used in Production. | `true` |
 | `kafka.replicas` | The number of Kafka Pods to install as part of the `StatefulSet` if `kafka.Enabled` is `true`| `1` |
 | `kafka.configurationOverrides` | Any Kafka Configuration overrides to provide to the underlying kafka chart | `{offsets.topic.replica.factor: 1}` |
-| `kafka.persistence.enabled` | Whether or not to use a persistent volume for kafka | `false` |
 | `kafka.zookeeper.servers` | The number of Zookeeper Pods to install as part of the `StatefulSet` if `kafka.Enabled` is `true`| `1` |
 | `ingress.enabled` | Enable Ingress? | `false` |
 | `ingress.hostname` | set hostname for ingress | `""` |

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -82,7 +82,10 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `kafkaStore.overrideBootstrapServers` | Defaults to Kafka Servers in the same release, it can be overridden in case there was a separate release for Kafka Deploy | `{{- printf "PLAINTEXT://%s-kafka-headless:9092" .Release.Name }}`
 | `kafka.enabled` | If `true`, install Kafka/Zookeeper alongside the `SchemaRegistry`. This is intended for testing and argument-less helm installs of this chart only and should not be used in Production. | `true` |
 | `kafka.replicas` | The number of Kafka Pods to install as part of the `StatefulSet` if `kafka.Enabled` is `true`| `1` |
+| `kafka.configurationOverrides` | Any Kafka Configuration overrides to provide to the underlying kafka chart | `{offsets.topic.replica.factor: 1}` |
+| `kafka.persistence.enabled` | Whether or not to use a persistent volume for kafka | `false` |
 | `kafka.zookeeper.servers` | The number of Zookeeper Pods to install as part of the `StatefulSet` if `kafka.Enabled` is `true`| `1` |
-| `ingress.enabled` | Enable Ingress? | `false`
-| `ingress.hostname` | set hostname for ingress | `""`
-| `ingress.annotations` | set annotations for ingress | `{}`
+| `ingress.enabled` | Enable Ingress? | `false` |
+| `ingress.hostname` | set hostname for ingress | `""` |
+| `ingress.annotations` | set annotations for ingress | `{}` |
+| `ingress.labels` | Additional labels for the ingress | `{}` |

--- a/incubator/schema-registry/requirements.lock
+++ b/incubator/schema-registry/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kafka
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.7.0
-digest: sha256:c399015621a2e560cd0ae1ca3200582728a6b5ad345b38b958b825c678565535
-generated: 2018-05-02T08:52:15.399751782-05:00
+  version: 0.8.5
+digest: sha256:adabb725b053f1a598fecb6c086dc638e74b3631f08d8b65ecabecad638f2775
+generated: 2018-08-02T09:16:11.217500469-05:00

--- a/incubator/schema-registry/requirements.yaml
+++ b/incubator/schema-registry/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: kafka
-  version: 0.7.0
+  version: 0.8.5
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: kafka.enabled

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -7,7 +7,7 @@
 ## schema-registry repository
 image: "confluentinc/cp-schema-registry"
 ## The container tag to use
-imageTag: 4.0.1
+imageTag: 4.1.1
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 imagePullPolicy: "IfNotPresent"
@@ -96,10 +96,6 @@ kafka:
     offsets.topic.replication.factor: 1
   ## Run only a single kafka broker by default
   replicas: 1
-  ## Do not enable kafka persistence by default. This setting is only acceptable in test
-  ## environments.
-  persistence:
-    enabled: false
 
   ## Kafka Zookeeper chart settings
   zookeeper:

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -90,18 +90,29 @@ sasl:
 kafka:
   ## This is enabled only to allow installations of this chart without arguments
   enabled: true
-  imageTag: 4.0.1
+  ## Override kafka settings for default installations
   configurationOverrides:
     # Needed to run with 1 Kafka Broker
     offsets.topic.replication.factor: 1
+  ## Run only a single kafka broker by default
   replicas: 1
+  ## Do not enable kafka persistence by default. This setting is only acceptable in test
+  ## environments.
+  persistence:
+    enabled: false
 
-  ## Install only a single Zookeeper pod in the StatefulSet
+  ## Kafka Zookeeper chart settings
   zookeeper:
-    servers: 1
+    # Install only a single Zookeeper pod in the StatefulSet
+    replicaCount: 1
 
+## Provides schema registry ingress settings
 ingress:
+  ## If true provide ingress to the schema registry
   enabled: false
+  ## Annotations for the ingress, if any
   annotations: {}
+  ## Hostname of the ingress
   hostname: ""
+  ## Any additional labels to add to the ingress
   labels: {}


### PR DESCRIPTION
Updating Schema Registry Kafka dependency to 0.8.5 to keep up with the latest. This required a few minor changes to the subchart configuration:
* default persistence off
* change the zookeeper `servers` variable to the new `replicaCount` variable

Also added some missing documentation to README and the values file.