### PR TITLE
[rabbitmq-ha] Namespace for alerts to match one provided in values

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.4
-version: 1.6.3
+version: 1.6.4
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -78,7 +78,7 @@ and their default values.
 | `persistentVolume.size`            | Persistent volume size                                          | `8Gi`                                                    |
 | `persistentVolume.storageClass`    | Persistent volume storage class                                 | `-`                                                      |
 | `podAntiAffinity`                  | Pod antiaffinity, `hard` or `soft`                              | `hard`                                                   |
-| `prometheus.exporter.enabled`      | Configures Prometheus Exporter to expose and scrape stats       | `true`                                                   |
+| `prometheus.exporter.enabled`      | Configures Prometheus Exporter to expose and scrape stats       | `false`                                                   |
 | `prometheus.exporter.env`          | Environment variables to set for Exporter container             | `{}`                                                   |
 | `prometheus.exporter.image.repository`   | Prometheus Exporter repository                              | `kbudde/rabbitmq-exporter`                                                   |
 | `prometheus.exporter.image.tag`   | Image Tag                          | `latest`                  |

--- a/stable/rabbitmq-ha/templates/alerts.yaml
+++ b/stable/rabbitmq-ha/templates/alerts.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-rabbitmq-alerts
-  namespace: monitoring
+  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
   labels:
     app: "rabbitmq"
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Currently alerts.yaml are fixed to `monitoring` namespace, I have fixed it now so it fetches the value from values.yaml.

Also fixing the readme to reflect correct default.

Fixes https://github.com/helm/charts/issues/6072

@etiennetremel please review, or reassign to appropriate committer. 

Thanks :) 