### PR TITLE
[stable/prestashop] adds `externalTrafficPolicy` configurable chart parameter

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 2.0.6
+version: 2.0.7
 appVersion: 1.7.4-2
 description: A popular open source ecommerce solution. Professional tools are easily
   accessible to increase online sales including instant guest checkout, abandoned

--- a/stable/prestashop/README.md
+++ b/stable/prestashop/README.md
@@ -45,45 +45,46 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the PrestaShop chart and their default values.
 
-|               Parameter               |                                        Description                                           |                         Default                          |
-|---------------------------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| `image.registry`                      | PrestaShop image registry                                                                    | `docker.io`                                              |
-| `image.repository`                    | PrestaShop image name                                                                        | `bitnami/prestashop`                                     |
-| `image.tag`                           | PrestaShop image tag                                                                         | `{VERSION}`                                              |
-| `image.pullPolicy`                    | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
-| `image.pullSecrets`                   | Specify image pull secrets                                                                   | `nil`                                                    |
-| `prestashopHost`                      | PrestaShop host to create application URLs                                                   | `nil`                                                    |
-| `prestashopLoadBalancerIP`            | `loadBalancerIP` for the PrestaShop Service                                                  | `nil`                                                    |
-| `prestashopUsername`                  | User of the application                                                                      | `user@example.com`                                       |
-| `prestashopPassword`                  | Application password                                                                         | _random 10 character long alphanumeric string_           |
-| `prestashopEmail`                     | Admin email                                                                                  | `user@example.com`                                       |
-| `prestashopFirstName`                 | First Name                                                                                   | `Bitnami`                                                |
-| `prestashopLastName`                  | Last Name                                                                                    | `Name`                                                   |
-| `smtpHost`                            | SMTP host                                                                                    | `nil`                                                    |
-| `smtpPort`                            | SMTP port                                                                                    | `nil`                                                    |
-| `smtpUser`                            | SMTP user                                                                                    | `nil`                                                    |
-| `smtpPassword`                        | SMTP password                                                                                | `nil`                                                    |
-| `smtpProtocol`                        | SMTP protocol [`ssl`, `tls`]                                                                 | `nil`                                                    |
-| `allowEmptyPassword`                  | Allow DB blank passwords                                                                     | `yes`                                                    |
-| `externalDatabase.host`               | Host of the external database                                                                | `nil`                                                    |
-| `externalDatabase.port`               | SMTP protocol [`ssl`, `none`]                                                                | `3306`                                                   |
-| `externalDatabase.user`               | Existing username in the external db                                                         | `bn_prestashop`                                          |
-| `externalDatabase.password`           | Password for the above username                                                              | `nil`                                                    |
-| `externalDatabase.database`           | Name of the existing database                                                                | `bitnami_prestashop`                                     |
-| `mariadb.enabled`                     | Whether to use the MariaDB chart                                                             | `true`                                                   |
-| `mariadb.db.name`             | Database name to create                                                                      | `bitnami_prestashop`                                     |
-| `mariadb.db.user`                 | Database user to create                                                                      | `bn_prestashop`                                          |
-| `mariadb.db.password`             | Password for the database                                                                    | `nil`                                                    |
-| `mariadb.rootUser.password`         | MariaDB admin password                                                                       | `nil`                                                    |
-| `serviceType`                         | Kubernetes Service type                                                                      | `LoadBalancer`                                           |
-| `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                                   |
-| `persistence.apache.storageClass`     | PVC Storage Class for Apache volume                                                          | `nil` (uses alpha storage class annotation)              |
-| `persistence.apache.accessMode`       | PVC Access Mode for Apache volume                                                            | `ReadWriteOnce`                                          |
-| `persistence.apache.size`             | PVC Storage Request for Apache volume                                                        | `1Gi`                                                    |
-| `persistence.prestashop.storageClass` | PVC Storage Class for PrestaShop volume                                                      | `nil` (uses alpha storage class annotation)              |
-| `persistence.prestashop.accessMode`   | PVC Access Mode for PrestaShop volume                                                        | `ReadWriteOnce`                                          |
-| `persistence.prestashop.size`         | PVC Storage Request for PrestaShop volume                                                    | `8Gi`                                                    |
-| `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                             |
+|               Parameter               |                                         Description                                          |                         Default                         |
+|---------------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `image.registry`                      | PrestaShop image registry                                                                    | `docker.io`                                             |
+| `image.repository`                    | PrestaShop image name                                                                        | `bitnami/prestashop`                                    |
+| `image.tag`                           | PrestaShop image tag                                                                         | `{VERSION}`                                             |
+| `image.pullPolicy`                    | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullSecrets`                   | Specify image pull secrets                                                                   | `nil`                                                   |
+| `prestashopHost`                      | PrestaShop host to create application URLs                                                   | `nil`                                                   |
+| `prestashopLoadBalancerIP`            | `loadBalancerIP` for the PrestaShop Service                                                  | `nil`                                                   |
+| `prestashopUsername`                  | User of the application                                                                      | `user@example.com`                                      |
+| `prestashopPassword`                  | Application password                                                                         | _random 10 character long alphanumeric string_          |
+| `prestashopEmail`                     | Admin email                                                                                  | `user@example.com`                                      |
+| `prestashopFirstName`                 | First Name                                                                                   | `Bitnami`                                               |
+| `prestashopLastName`                  | Last Name                                                                                    | `Name`                                                  |
+| `smtpHost`                            | SMTP host                                                                                    | `nil`                                                   |
+| `smtpPort`                            | SMTP port                                                                                    | `nil`                                                   |
+| `smtpUser`                            | SMTP user                                                                                    | `nil`                                                   |
+| `smtpPassword`                        | SMTP password                                                                                | `nil`                                                   |
+| `smtpProtocol`                        | SMTP protocol [`ssl`, `tls`]                                                                 | `nil`                                                   |
+| `allowEmptyPassword`                  | Allow DB blank passwords                                                                     | `yes`                                                   |
+| `externalDatabase.host`               | Host of the external database                                                                | `nil`                                                   |
+| `externalDatabase.port`               | SMTP protocol [`ssl`, `none`]                                                                | `3306`                                                  |
+| `externalDatabase.user`               | Existing username in the external db                                                         | `bn_prestashop`                                         |
+| `externalDatabase.password`           | Password for the above username                                                              | `nil`                                                   |
+| `externalDatabase.database`           | Name of the existing database                                                                | `bitnami_prestashop`                                    |
+| `mariadb.enabled`                     | Whether to use the MariaDB chart                                                             | `true`                                                  |
+| `mariadb.db.name`                     | Database name to create                                                                      | `bitnami_prestashop`                                    |
+| `mariadb.db.user`                     | Database user to create                                                                      | `bn_prestashop`                                         |
+| `mariadb.db.password`                 | Password for the database                                                                    | `nil`                                                   |
+| `mariadb.rootUser.password`           | MariaDB admin password                                                                       | `nil`                                                   |
+| `serviceType`                         | Kubernetes Service type                                                                      | `LoadBalancer`                                          |
+| `externalTrafficPolicy`               | Set to `Local` to preserve the client source IP                                              | `Cluster`                                               |
+| `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                                  |
+| `persistence.apache.storageClass`     | PVC Storage Class for Apache volume                                                          | `nil` (uses alpha storage class annotation)             |
+| `persistence.apache.accessMode`       | PVC Access Mode for Apache volume                                                            | `ReadWriteOnce`                                         |
+| `persistence.apache.size`             | PVC Storage Request for Apache volume                                                        | `1Gi`                                                   |
+| `persistence.prestashop.storageClass` | PVC Storage Class for PrestaShop volume                                                      | `nil` (uses alpha storage class annotation)             |
+| `persistence.prestashop.accessMode`   | PVC Access Mode for PrestaShop volume                                                        | `ReadWriteOnce`                                         |
+| `persistence.prestashop.size`         | PVC Storage Request for PrestaShop volume                                                    | `8Gi`                                                   |
+| `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                            |
 | `livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                     | 600                                                     |
 | `livenessProbe.periodSeconds`         | How often to perform the probe                                                               | 3                                                       |
 | `livenessProbe.timeoutSeconds`        | When the probe times out                                                                     | 5                                                       |

--- a/stable/prestashop/templates/svc.yaml
+++ b/stable/prestashop/templates/svc.yaml
@@ -9,9 +9,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.serviceType }}
-  {{- if eq .Values.serviceType "LoadBalancer" }}
-  loadBalancerIP: {{ default "" .Values.prestashopLoadBalancerIP }}
-  externalTrafficPolicy: Local
+  {{- if (and (eq .Values.serviceType "LoadBalancer") (not (empty .Values.prestashopLoadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.prestashopLoadBalancerIP }}
+  {{- end }}
+  {{- if (or (eq .Values.serviceType "LoadBalancer") (eq .Values.serviceType "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.externalTrafficPolicy | quote }}
   {{- end }}
   ports:
   - name: http

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -134,6 +134,10 @@ mariadb:
 ##
 serviceType: LoadBalancer
 
+## Set external traffic policy to: "Local" to preserve source IP on providers supporting it
+## ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport
+externalTrafficPolicy: Cluster
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
This PR exposes the `externalTrafficPolicy` service parameter allowing users to configure it as required

/assign @prydonius @tompizmor

<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: