### PR TITLE
[stable/weave-scope] Add `read-only` mode (#6977)

### DIFF
--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,6 +1,6 @@
 name: weave-scope
-version: 0.9.2
-appVersion: 1.6.5
+version: 0.9.3
+appVersion: 1.9.1
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:
   - containers

--- a/stable/weave-scope/Chart.yaml
+++ b/stable/weave-scope/Chart.yaml
@@ -1,5 +1,5 @@
 name: weave-scope
-version: 0.9.3
+version: 0.10.0
 appVersion: 1.9.1
 description: A Helm chart for the Weave Scope cluster visualizer.
 keywords:

--- a/stable/weave-scope/README.md
+++ b/stable/weave-scope/README.md
@@ -6,12 +6,6 @@ This chart contains two subcharts (*weave-scope-frontend* and *weave-scope-agent
 
 Either subchart can be deployed on its own (set the "enabled" value to "false" for the chart you want to suppress) or the two can be deployed together (the default).
 
-## Compatibility notes
-
-* This chart is designed and tested with Weave Scope 1.6.2 and 1.6.5 and Kubernetes 1.7.
-* Weave Scope 1.6.2 was originally released by WeaveWorks for Kubernetes 1.6 but seems to work fine on 1.7.
-* On Kubernetes 1.6 Weave Scope versions as old as 1.3.0 will probably work.
-
 ## Prerequisites
 
 * The service account, cluster role, cluster role binding and service specified in the rendered version of this chart must not already exist.
@@ -54,6 +48,7 @@ The **agent** section controls how the Weave Scope node agent pods are installed
 | Parameter | Description | Default |
 |----------:|:------------|:--------|
 | **enabled** | controls whether the agent is deployed | true |
+| **disableFrontendControls** | disable controls for frontend, like delete, reset, run shell, etc | false |
 | **dockerBridge** | the name of the Docker bridge interface | "docker0" |
 | **scopeFrontendAddr** | the host:port of a Scope frontend to send data to -- this is only needed in cases where the frontend is deployed separately from the agent (e.g. an install outside the cluster or a pre-existing install inside it) | |
 | **probeToken** | the token used to connect to Weave Cloud -- this is not needed for connecting to non-cloud Scope frontends | |
@@ -61,11 +56,13 @@ The **agent** section controls how the Weave Scope node agent pods are installed
 | **rbac.create** | whether RBAC resources should be created (required) -- this **must** be set to false if RBAC is not enabled in the cluster; it *may* be set to false in an RBAC-enabled cluster to allow for external management of RBAC | true |
 | **serviceAccount.create** | whether a new service account name that the agent will use should be created. | true |
 | **serviceAccount.name** | service account to be used.  If not set and serviceAccount.create is `true` a name is generated using the fullname template. |  |
+| **serviceAccount.readonly** | whether delete and update permissions for cluster role should be granted | false |
 | **resources.*** | controls requests/limits for the agent (these values are all optional) | |
 | **resources.requests.cpu** | CPU request in MHz (m) | |
 | **resources.requests.memory** | memory request in MiB (Mi)| |
 | **resources.limits.cpu** | CPU limit in MHz (m) | |
 | **resources.limits.memory** | memory limit in MiB (Mi) | |
+
 
 ## Other notes
 

--- a/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
@@ -1,6 +1,6 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-agent
-version: 0.9.3
+version: 0.10.0
 appVersion: 1.9.1
 keywords:
   - containers

--- a/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/Chart.yaml
@@ -1,7 +1,7 @@
 description: A Helm chart for the Weave Scope cluster visualizer node agent.
 name: weave-scope-agent
-version: 0.9.2
-appVersion: 1.6.5
+version: 0.9.3
+appVersion: 1.9.1
 keywords:
   - containers
   - dashboard

--- a/stable/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/_helpers.tpl
@@ -12,7 +12,7 @@ cloud.weave.works/launcher-info: |-
   {
     "server-version": "master-4fe8efe",
     "original-request": {
-      "url": "/k8s/v1.7/scope.yaml"
+      "url": "/k8s/v1.10/scope.yaml"
     },
     "email-address": "support@weave.works",
     "source-app": "weave-scope",

--- a/stable/weave-scope/charts/weave-scope-agent/templates/clusterrole.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/clusterrole.yaml
@@ -28,6 +28,8 @@ rules:
       - services
       - nodes
       - namespaces
+      - persistentvolumes
+      - persistentvolumeclaims
     verbs:
       - get
       - list
@@ -67,5 +69,13 @@ rules:
 {{ if not .Values.serviceAccount.readonly }}
       - update
 {{ end }}
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}
 {{- end -}}

--- a/stable/weave-scope/charts/weave-scope-agent/templates/clusterrole.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/clusterrole.yaml
@@ -11,14 +11,61 @@ metadata:
     {{- include "weave-scope.annotations" . | indent 4 }}
 rules:
   - apiGroups:
-      - '*'
+      - ''
     resources:
-      - '*'
+      - pods
     verbs:
-      - '*'
-  - nonResourceURLs:
-      - '*'
+      - get
+      - list
+      - watch
+{{ if not .Values.serviceAccount.readonly }}
+      - delete
+{{ end }}
+  - apiGroups:
+      - ''
+    resources:
+      - pods/log
+      - services
+      - nodes
+      - namespaces
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments/scale
+    verbs:
+      - get
+{{ if not .Values.serviceAccount.readonly }}
+      - update
+{{ end }}
 {{- end }}
 {{- end -}}

--- a/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
             - '--probe.docker=true'
             - '--probe.kubernetes=true'
             {{ if .Values.disableFrontendControls }}
-            - "-probe.no-controls"
+            - "--probe.no-controls"
             {{ end }}
             {{- if .Values.global.probeToken }}
             - '--probe-token={{ .Values.global.probeToken }}'

--- a/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
+++ b/stable/weave-scope/charts/weave-scope-agent/templates/daemonset.yaml
@@ -34,6 +34,9 @@ spec:
             - '--probe.docker.bridge={{ .Values.dockerBridge }}'
             - '--probe.docker=true'
             - '--probe.kubernetes=true'
+            {{ if .Values.disableFrontendControls }}
+            - "-probe.no-controls"
+            {{ end }}
             {{- if .Values.global.probeToken }}
             - '--probe-token={{ .Values.global.probeToken }}'
             {{- else if .Values.global.scopeFrontendAddr }}

--- a/stable/weave-scope/charts/weave-scope-frontend/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 description: A Helm chart for the Weave Scope cluster visualizer frontend.
 name: weave-scope-frontend
-version: 0.9.2
-appVersion: 1.6.5
+version: 0.9.3
+appVersion: 1.9.1
 keywords:
   - containers
   - dashboard

--- a/stable/weave-scope/charts/weave-scope-frontend/Chart.yaml
+++ b/stable/weave-scope/charts/weave-scope-frontend/Chart.yaml
@@ -1,6 +1,6 @@
 description: A Helm chart for the Weave Scope cluster visualizer frontend.
 name: weave-scope-frontend
-version: 0.9.3
+version: 0.10.0
 appVersion: 1.9.1
 keywords:
   - containers

--- a/stable/weave-scope/charts/weave-scope-frontend/templates/_helpers.tpl
+++ b/stable/weave-scope/charts/weave-scope-frontend/templates/_helpers.tpl
@@ -12,7 +12,7 @@ cloud.weave.works/launcher-info: |-
   {
     "server-version": "master-4fe8efe",
     "original-request": {
-      "url": "/k8s/v1.7/scope.yaml"
+      "url": "/k8s/v1.10/scope.yaml"
     },
     "email-address": "support@weave.works",
     "source-app": "weave-scope",

--- a/stable/weave-scope/templates/_helpers.tpl
+++ b/stable/weave-scope/templates/_helpers.tpl
@@ -12,7 +12,7 @@ cloud.weave.works/launcher-info: |-
   {
     "server-version": "master-4fe8efe",
     "original-request": {
-      "url": "/k8s/v1.7/scope.yaml"
+      "url": "/k8s/v1.10/scope.yaml"
     },
     "email-address": "support@weave.works",
     "source-app": "weave-scope",

--- a/stable/weave-scope/values.yaml
+++ b/stable/weave-scope/values.yaml
@@ -4,7 +4,7 @@ global:
   # global.image: the image that will be used for this release
   image:
     repository: weaveworks/scope
-    tag: "1.6.5"
+    tag: "1.9.1"
     # global.image.pullPolicy: must be Always, IfNotPresent, or Never
     pullPolicy: "IfNotPresent"
   # global.service.*: the configuration of the service used to access the frontend
@@ -40,6 +40,8 @@ weave-scope-frontend:
 # weave-scope-agent.* controls how the Weave Scope node agent pods are installed
 weave-scope-agent:
   enabled: true
+  # disable controls for frontend, like delete, reset, run shell, etc
+  disableFrontendControls: false
   # weave-scope-agent.dockerBridge: (required if agent.enabled == true) the name of the Docker bridge interface
   dockerBridge: "docker0"
   # weave-scope-agent.scopeFrontendAddr: the host:port of a Scope frontend to send data to
@@ -57,6 +59,8 @@ weave-scope-agent:
   serviceAccount:
     # Specifies whether a ServiceAccount should be created
     create: true
+    # Whether delete and update permissions for cluster role should be granted
+    # readonly: false
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     # name: "weave-scope"


### PR DESCRIPTION
* add option to disable controls (e.g. start/stop containers, terminals, logs etc)
* use more granular permissions for cluster role
* use newer weave scope release
* bump chart version
* remove compatibility note for EOL kubernetes versions and older weave scope versions

**What this PR does / why we need it**: implements features requested in #6977

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #6977

 **Special notes for your reviewer:** @omkensey please review