### PR TITLE
incubator/cassandra v0.4.2 - Templating for liveness/readiness probes

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.4.2
+version: 0.5.0
 appVersion: 3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.4.1
+version: 0.4.2
 appVersion: 3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -107,12 +107,12 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `updateStrategy.type`                | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated        | `90`                                                       |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                  | `30`                                                       |
-| `livenessProbe.timeoutSeconds`       | When the probe times out                        | `1`                                                        |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                        | `5`                                                        |
 | `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
 | `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
 | `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated       | `90`                                                       |
 | `readinessProbe.periodSeconds`       | How often to perform the probe                  | `30`                                                       |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                        | `1`                                                        |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                        | `5`                                                        |
 | `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
 | `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
 

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -80,31 +80,41 @@ The following table lists the configurable parameters of the Cassandra chart and
 
 | Parameter                  | Description                                     | Default                                                    |
 | -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
-| `image.repo`               | `cassandra` image repository                    | `cassandra`                                                |
-| `image.tag`                | `cassandra` image tag                           | `3`                                                        |
-| `image.pullPolicy`         | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `image.pullSecrets`        | Image pull secrets                              | `nil`                                                      |
-| `config.cluster_name`      | The name of the cluster.                        | `cassandra`                                                |
-| `config.cluster_size`      | The number of nodes in the cluster.             | `3`                                                        |
-| `config.seed_size`         | The number of seed nodes used to bootstrap new clients joining the cluster.                | `2`                                                        |
-| `config.num_tokens`        | Initdb Arguments                                | `256`                                                      |
-| `config.dc_name`           | Initdb Arguments                                | `DC1`                                                      |
-| `config.rack_name`         | Initdb Arguments                                | `RAC1`                                                     |
-| `config.endpoint_snitch`   | Initdb Arguments                                | `SimpleSnitch`                                             |
-| `config.max_heap_size`     | Initdb Arguments                                | `2048M`                                                    |
-| `config.heap_new_size`     | Initdb Arguments                                | `512M`                                                     |
-| `config.ports.cql`         | Initdb Arguments                                | `9042`                                                     |
-| `config.ports.thrift`      | Initdb Arguments                                | `9160`                                                     |
-| `config.ports.agent`       | The port of the JVM Agent (if any)              | `nil`                                                      |
-| `config.start_rpc`         | Initdb Arguments                                | `false`                                                    |
-| `persistence.enabled`      | Use a PVC to persist data                       | `true`                                                     |
-| `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
-| `persistence.accessMode`   | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
-| `persistence.size`         | Size of data volume                             | `10Gi`                                                     |
-| `resources`                | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
-| `service.type`             | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
-| `podManagementPolicy`      | podManagementPolicy of the StatefulSet          | `OrderedReady`                                             |
-| `updateStrategy.type`      | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
+| `image.repo`                         | `cassandra` image repository                    | `cassandra`                                                |
+| `image.tag`                          | `cassandra` image tag                           | `3`                                                        |
+| `image.pullPolicy`                   | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `image.pullSecrets`                  | Image pull secrets                              | `nil`                                                      |
+| `config.cluster_name`                | The name of the cluster.                        | `cassandra`                                                |
+| `config.cluster_size`                | The number of nodes in the cluster.             | `3`                                                        |
+| `config.seed_size`                   | The number of seed nodes used to bootstrap new clients joining the cluster.                            | `2` |
+| `config.num_tokens`                  | Initdb Arguments                                | `256`                                                      |
+| `config.dc_name`                     | Initdb Arguments                                | `DC1`                                                      |
+| `config.rack_name`                   | Initdb Arguments                                | `RAC1`                                                     |
+| `config.endpoint_snitch`             | Initdb Arguments                                | `SimpleSnitch`                                             |
+| `config.max_heap_size`               | Initdb Arguments                                | `2048M`                                                    |
+| `config.heap_new_size`               | Initdb Arguments                                | `512M`                                                     |
+| `config.ports.cql`                   | Initdb Arguments                                | `9042`                                                     |
+| `config.ports.thrift`                | Initdb Arguments                                | `9160`                                                     |
+| `config.ports.agent`                 | The port of the JVM Agent (if any)              | `nil`                                                      |
+| `config.start_rpc`                   | Initdb Arguments                                | `false`                                                    |
+| `persistence.enabled`                | Use a PVC to persist data                       | `true`                                                     |
+| `persistence.storageClass`           | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`             | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
+| `persistence.size`                   | Size of data volume                             | `10Gi`                                                     |
+| `resources`                          | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
+| `service.type`                       | k8s service type exposing ports, e.g. `NodePort`| `ClusterIP`                                                |
+| `podManagementPolicy`                | podManagementPolicy of the StatefulSet          | `OrderedReady`                                             |
+| `updateStrategy.type`                | UpdateStrategy of the StatefulSet               | `OnDelete`                                                 |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated        | `90`                                                       |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                  | `30`                                                       |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                        | `1`                                                        |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated       | `90`                                                       |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                  | `30`                                                       |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                        | `1`                                                        |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
 
 ## Scale cassandra
 When you want to change the cluster size of your cassandra, you can use the helm upgrade command.

--- a/incubator/cassandra/templates/cassandra-statefulset.yaml
+++ b/incubator/cassandra/templates/cassandra-statefulset.yaml
@@ -103,27 +103,16 @@ spec:
         livenessProbe:
           exec:
             command: [ "/bin/sh", "-c", "nodetool status" ]
-          {{- if not .Values.livenessProbe }}
-          initialDelaySeconds: 90
-          periodSeconds: 30
-          {{- else }}
-          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 90 }}
-          periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 30 }}
-          {{- if .Values.livenessProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.livenessProbe.successThreshold }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
-          {{- end }}
-          {{- if .Values.livenessProbe.failureThreshold }}
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          {{- end }}
-          {{- end }}
         readinessProbe:
           exec:
             command: [ "/bin/sh", "-c", "nodetool status | grep -E \"^UN\\s+${POD_IP}\"" ]
-          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 90 }}
-          periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 30 }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}

--- a/incubator/cassandra/templates/cassandra-statefulset.yaml
+++ b/incubator/cassandra/templates/cassandra-statefulset.yaml
@@ -103,13 +103,30 @@ spec:
         livenessProbe:
           exec:
             command: [ "/bin/sh", "-c", "nodetool status" ]
+          {{- if not .Values.livenessProbe }}
           initialDelaySeconds: 90
           periodSeconds: 30
+          {{- else }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 90 }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 30 }}
+          {{- if .Values.livenessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.livenessProbe.successThreshold }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- end }}
         readinessProbe:
           exec:
             command: [ "/bin/sh", "-c", "nodetool status | grep -E \"^UN\\s+${POD_IP}\"" ]
-          initialDelaySeconds: 90
-          periodSeconds: 30
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 90 }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 30 }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         ports:
         - name: intra
           containerPort: 7000

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -62,8 +62,14 @@ config:
     # If a JVM Agent is in place
     # agent: 61621
 
-## Readiness probe values.
+## Liveness and Readiness probe values.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
 readinessProbe:
   initialDelaySeconds: 90
   periodSeconds: 30

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -62,6 +62,15 @@ config:
     # If a JVM Agent is in place
     # agent: 61621
 
+## Readiness probe values.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+readinessProbe:
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
 ## Configure node selector. Edit code below for adding selector to pods
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 # selector:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds customizable liveness and readiness probe parameters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
N/A

**Special notes for your reviewer**:
None