### PR TITLE
[stable/wordpress] set default value of `serviceExternalTrafficPolicy` to `Cluster`

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 2.1.5
+version: 2.1.6
 appVersion: 4.9.8
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -45,59 +45,60 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the WordPress chart and their default values.
 
-| Parameter                            | Description                                | Default                                                    |
-| ------------------------------------ | ------------------------------------------ | ---------------------------------------------------------- |
-| `image.registry`                     | WordPress image registry                   | `docker.io`                                                |
-| `image.repository`                   | WordPress image name                       | `bitnami/wordpress`                                        |
-| `image.tag`                          | WordPress image tag                        | `{VERSION}`                                                |
-| `image.pullPolicy`                   | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
-| `image.pullSecrets`                  | Specify image pull secrets                 | `nil`                                                      |
-| `wordpressUsername`                  | User of the application                    | `user`                                                     |
-| `wordpressPassword`                  | Application password                       | _random 10 character long alphanumeric string_             |
-| `wordpressEmail`                     | Admin email                                | `user@example.com`                                         |
-| `wordpressFirstName`                 | First name                                 | `FirstName`                                                |
-| `wordpressLastName`                  | Last name                                  | `LastName`                                                 |
-| `wordpressBlogName`                  | Blog name                                  | `User's Blog!`                                             |
-| `wordpressTablePrefix`               | Table prefix                               | `wp_`                                                      |
-| `allowEmptyPassword`                 | Allow DB blank passwords                   | `yes`                                                      |
-| `smtpHost`                           | SMTP host                                  | `nil`                                                      |
-| `smtpPort`                           | SMTP port                                  | `nil`                                                      |
-| `smtpUser`                           | SMTP user                                  | `nil`                                                      |
-| `smtpPassword`                       | SMTP password                              | `nil`                                                      |
-| `smtpUsername`                       | User name for SMTP emails                  | `nil`                                                      |
-| `smtpProtocol`                       | SMTP protocol [`tls`, `ssl`]               | `nil`                                                      |
-| `replicaCount`                       | Number of WordPress Pods to run            | `1`                                                        |
-| `mariadb.enabled`                    | Deploy MariaDB container(s)                | `true`                                                     |
-| `mariadb.rootUser.password`        | MariaDB admin password                     | `nil`                                                      |
-| `mariadb.db.name`            | Database name to create                    | `bitnami_wordpress`                                        |
-| `mariadb.db.user`                | Database user to create                    | `bn_wordpress`                                             |
-| `mariadb.db.password`            | Password for the database                  | _random 10 character long alphanumeric string_             |
-| `externalDatabase.host`              | Host of the external database              | `localhost`                                                |
-| `externalDatabase.user`              | Existing username in the external db       | `bn_wordpress`                                             |
-| `externalDatabase.password`          | Password for the above username            | `nil`                                                      |
-| `externalDatabase.database`          | Name of the existing database              | `bitnami_wordpress`                                        |
-| `externalDatabase.port`              | Database port number                       | `3306`                                                     |
-| `serviceType`                        | Kubernetes Service type                    | `LoadBalancer`                                             |
-| `nodePorts.http`                     | Kubernetes http node port                  | `""`                                                       |
-| `nodePorts.https`                    | Kubernetes https node port                 | `""`                                                       |
-| `healthcheckHttps`                   | Use https for liveliness and readiness     | `false`                                                    |
-| `ingress.enabled`                    | Enable ingress controller resource         | `false`                                                    |
-| `ingress.hosts[0].name`              | Hostname to your WordPress installation    | `wordpress.local`                                          |
-| `ingress.hosts[0].path`              | Path within the url structure              | `/`                                                        |
-| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress             | `false`                                                    |
-| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                  | `wordpress.local-tls-secret`                               |
-| `ingress.hosts[0].annotations`       | Annotations for this host's ingress record | `[]`                                                       |
-| `ingress.secrets[0].name`            | TLS Secret Name                            | `nil`                                                      |
-| `ingress.secrets[0].certificate`     | TLS Secret Certificate                     | `nil`                                                      |
-| `ingress.secrets[0].key`             | TLS Secret Key                             | `nil`                                                      |
-| `persistence.enabled`                | Enable persistence using PVC               | `true`                                                     |
-| `persistence.existingClaim`          | Enable persistence using an existing PVC   | `nil`                                                      |
-| `persistence.storageClass`           | PVC Storage Class                          | `nil` (uses alpha storage class annotation)                |
-| `persistence.accessMode`             | PVC Access Mode                            | `ReadWriteOnce`                                            |
-| `persistence.size`                   | PVC Storage Request                        | `10Gi`                                                     |
-| `nodeSelector`                       | Node labels for pod assignment             | `{}`                                                       |
-| `tolerations`                        | List of node taints to tolerate            | `[]`                                                       |
-| `affinity`                           | Map of node/pod affinities                 | `{}`                                                       |
+|            Parameter             |                Description                 |                         Default                         |
+|----------------------------------|--------------------------------------------|---------------------------------------------------------|
+| `image.registry`                 | WordPress image registry                   | `docker.io`                                             |
+| `image.repository`               | WordPress image name                       | `bitnami/wordpress`                                     |
+| `image.tag`                      | WordPress image tag                        | `{VERSION}`                                             |
+| `image.pullPolicy`               | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullSecrets`              | Specify image pull secrets                 | `nil`                                                   |
+| `wordpressUsername`              | User of the application                    | `user`                                                  |
+| `wordpressPassword`              | Application password                       | _random 10 character long alphanumeric string_          |
+| `wordpressEmail`                 | Admin email                                | `user@example.com`                                      |
+| `wordpressFirstName`             | First name                                 | `FirstName`                                             |
+| `wordpressLastName`              | Last name                                  | `LastName`                                              |
+| `wordpressBlogName`              | Blog name                                  | `User's Blog!`                                          |
+| `wordpressTablePrefix`           | Table prefix                               | `wp_`                                                   |
+| `allowEmptyPassword`             | Allow DB blank passwords                   | `yes`                                                   |
+| `smtpHost`                       | SMTP host                                  | `nil`                                                   |
+| `smtpPort`                       | SMTP port                                  | `nil`                                                   |
+| `smtpUser`                       | SMTP user                                  | `nil`                                                   |
+| `smtpPassword`                   | SMTP password                              | `nil`                                                   |
+| `smtpUsername`                   | User name for SMTP emails                  | `nil`                                                   |
+| `smtpProtocol`                   | SMTP protocol [`tls`, `ssl`]               | `nil`                                                   |
+| `replicaCount`                   | Number of WordPress Pods to run            | `1`                                                     |
+| `mariadb.enabled`                | Deploy MariaDB container(s)                | `true`                                                  |
+| `mariadb.rootUser.password`      | MariaDB admin password                     | `nil`                                                   |
+| `mariadb.db.name`                | Database name to create                    | `bitnami_wordpress`                                     |
+| `mariadb.db.user`                | Database user to create                    | `bn_wordpress`                                          |
+| `mariadb.db.password`            | Password for the database                  | _random 10 character long alphanumeric string_          |
+| `externalDatabase.host`          | Host of the external database              | `localhost`                                             |
+| `externalDatabase.user`          | Existing username in the external db       | `bn_wordpress`                                          |
+| `externalDatabase.password`      | Password for the above username            | `nil`                                                   |
+| `externalDatabase.database`      | Name of the existing database              | `bitnami_wordpress`                                     |
+| `externalDatabase.port`          | Database port number                       | `3306`                                                  |
+| `serviceType`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
+| `serviceExternalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
+| `nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
+| `nodePorts.https`                | Kubernetes https node port                 | `""`                                                    |
+| `healthcheckHttps`               | Use https for liveliness and readiness     | `false`                                                 |
+| `ingress.enabled`                | Enable ingress controller resource         | `false`                                                 |
+| `ingress.hosts[0].name`          | Hostname to your WordPress installation    | `wordpress.local`                                       |
+| `ingress.hosts[0].path`          | Path within the url structure              | `/`                                                     |
+| `ingress.hosts[0].tls`           | Utilize TLS backend in ingress             | `false`                                                 |
+| `ingress.hosts[0].tlsSecret`     | TLS Secret (certificates)                  | `wordpress.local-tls-secret`                            |
+| `ingress.hosts[0].annotations`   | Annotations for this host's ingress record | `[]`                                                    |
+| `ingress.secrets[0].name`        | TLS Secret Name                            | `nil`                                                   |
+| `ingress.secrets[0].certificate` | TLS Secret Certificate                     | `nil`                                                   |
+| `ingress.secrets[0].key`         | TLS Secret Key                             | `nil`                                                   |
+| `persistence.enabled`            | Enable persistence using PVC               | `true`                                                  |
+| `persistence.existingClaim`      | Enable persistence using an existing PVC   | `nil`                                                   |
+| `persistence.storageClass`       | PVC Storage Class                          | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`         | PVC Access Mode                            | `ReadWriteOnce`                                         |
+| `persistence.size`               | PVC Storage Request                        | `10Gi`                                                  |
+| `nodeSelector`                   | Node labels for pod assignment             | `{}`                                                    |
+| `tolerations`                    | List of node taints to tolerate            | `[]`                                                    |
+| `affinity`                       | Map of node/pod affinities                 | `{}`                                                    |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -144,7 +144,7 @@ nodePorts:
 ## Enable client source IP preservation
 ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
 ##
-serviceExternalTrafficPolicy: Local
+serviceExternalTrafficPolicy: Cluster
 
 ## Allow health checks to be pointed at the https port
 healthcheckHttps: false


### PR DESCRIPTION
When set to `Local`, we discovered that on OKE, Oracle's LoadBalancer tries route
to nodes where the Pod isn't running and as a result it doesn't work. Change the
default value to `Cluster` seems to be the sane default value we should use.