### PR TITLE
[stable/odoo] set default value of `serviceExternalTrafficPolicy` to `Cluster`

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,5 +1,5 @@
 name: odoo
-version: 2.0.4
+version: 2.0.5
 appVersion: 11.0.20180715
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/README.md
+++ b/stable/odoo/README.md
@@ -62,7 +62,7 @@ The following table lists the configurable parameters of the Odoo chart and thei
 | `smtpProtocol`                        | SMTP protocol [`ssl`, `tls`]                                | `nil`                                          |
 | `service.type`                        | Kubernetes Service type                                     | `LoadBalancer`                                 |
 | `service.loadBalancer`                | Kubernetes LoadBalancerIP to request                        | `nil`                                          |
-| `service.externalTrafficPolicy`       | Enable client source IP preservation                        | `Local`                                        |
+| `service.externalTrafficPolicy`       | Enable client source IP preservation                        | `Cluster`                                        |
 | `service.nodePort`                    | Kubernetes http node port                                   | `""`                                           |
 | `ingress.enabled`                     | Enable ingress controller resource                          | `false`                                        |
 | `ingress.hosts[0].name`               | Hostname to your Odoo installation                          | `odoo.local`                                   |

--- a/stable/odoo/values.yaml
+++ b/stable/odoo/values.yaml
@@ -89,7 +89,7 @@ service:
   ## Enable client source IP preservation
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
 
 ## Configure the ingress resource that allows you to access the
 ## Odoo installation. Set up the URL


### PR DESCRIPTION
When set to `Local`, we discovered that on OKE, Oracle's LoadBalancer tries route
to nodes where the Pod isn't running and as a result it doesn't work. Change the
default value to `Cluster` seems to be the sane default value we should use.

/assign @prydonius @tompizmor