### PR TITLE
[stable/mediawiki] set default value of `serviceExternalTrafficPolicy` to `Cluster`

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 3.0.4
+version: 3.0.5
 appVersion: 1.31.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation
   that uses PHP to process and display data stored in a database.

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the MediaWiki chart and
 | `mariadb.db.password`                | Password for the database                                   | _random 10 character long alphanumeric string_          |
 | `service.type`                       | Kubernetes Service type                                     | `LoadBalancer`                                          |
 | `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                        | `nil`                                                   |
-| `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Local`                                                 |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Cluster`                                                 |
 | `service.nodePorts.http`             | Kubernetes http node port                                   | `""`                                                    |
 | `service.nodePorts.https`            | Kubernetes https node port                                  | `""`                                                    |
 | `ingress.enabled`                    | Enable ingress controller resource                          | `false`                                                 |

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -139,7 +139,7 @@ service:
   ## Enable client source IP preservation
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
 
 ## Configure the ingress resource that allows you to access the
 ## Mediawiki installation. Set up the URL


### PR DESCRIPTION
When set to `Local`, we discovered that on OKE, Oracle's LoadBalancer tries route
to nodes where the Pod isn't running and as a result it doesn't work. Change the
default value to `Cluster` seems to be the sane default value we should use.

/assign @prydonius @tompizmor