### PR TITLE
[stable/postgresql] Allow priorityClass for pod priority and use with preemption

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.19.0
+version: 0.20.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -12,10 +12,6 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- with .Values.strategy }}
-  strategy:
-{{ toYaml . | indent 4 }}
-{{- end }}
   selector:
     matchLabels:
       app: {{ template "postgresql.name" . }}
@@ -155,6 +151,9 @@ spec:
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
+      {{- if .Values.priorityClass }}
+      priorityClassName: {{ .Values.priorityClass }}
+      {{- end }}
       volumes:
       - name: data
       {{- if .Values.persistence.enabled }}

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -156,6 +156,6 @@ probes:
 deploymentAnnotations: {}
 podAnnotations: {}
 
-## Deployment pods replace strategy
-## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-# strategy: {}
+## Priority Class
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption
+# priorityClass:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds priorityClassName to the deployment, allowing prioritized scheduling.
https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/

Cleanup to remove unused strategy.  Strategy must always be Recreate and chart ignores any user-provided strategy property. https://github.com/helm/charts/pull/6343

**Which issue this PR fixes**: fixes #6955 


@databus23 