### PR TITLE
[stable/drone] Add support for envSecrets to be an auto-generated secret

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 1.5.0-dev.kody.9
+version: 1.5.0
 appVersion: 0.8.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 1.4.0
+version: 1.5.0-dev.kody.9
 appVersion: 0.8.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the drone charts and th
 | `ingress.tls`               | Ingress TLS configuration                                                                     | `[]`                        |
 | `server.host`               | Drone **server** scheme and hostname                                                          | `(internal hostname)`       |
 | `server.env`                | Drone **server** environment variables                                                        | `(default values)`          |
-| `server.envSecrets`         | Drone **server** secret environment variables                                                 | `(default values)`          |
+| `server.envSecrets`         | Drone **server** secret environment variables                                                 | `{}`                        |
 | `server.annotations`        | Drone **server** annotations                                                                  | `{}`                        |
 | `server.resources`          | Drone **server** pod resource requests & limits                                               | `{}`                        |
 | `server.schedulerName`      | Drone **server** alternate scheduler name                                                     | `nil`                       |

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -45,13 +45,13 @@ spec:
               secretKeyRef:
                 name: {{ template "drone.fullname" . }}
                 key: secret
-          {{- range $secret, $keys := .Values.server.envSecrets }}
-          {{- range $keys }}
-          - name: {{ . }}
+          {{- range $secretName, $secrets := .Values.server.envSecrets }}
+          {{- range $key, $value := $secrets }}
+          - name: {{ $key }}
             valueFrom:
               secretKeyRef:
-                name: {{ $secret }}
-                key: {{ . | quote }}
+                name: {{ $secretName }}
+                key: {{ $key }}
           {{- end }}
           {{- end }}
           - name: DRONE_HOST

--- a/stable/drone/templates/server-secrets.yaml
+++ b/stable/drone/templates/server-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.server.envSecrets }}
+{{- range $secretName, $secrets := .Values.server.envSecrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app: {{ template "drone.name" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+data:
+  {{- range $key, $value := $secrets }}
+  {{ $key }}: {{ $value | toString | b64enc }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/stable/drone/values.yaml
+++ b/stable/drone/values.yaml
@@ -89,13 +89,13 @@ server:
 
   ## Secret environment variables are configured in `server.envSecrets`.
   ## Each item in `server.envSecrets` references a Kubernetes Secret.
-  ## These Secrets should be created before they are referenced.
+  ## These Secrets will be created and mapped.
   ##
   # envSecrets:
   #   # The name of a Kubernetes Secret
   #   drone-server-secrets:
-  #     # A list of Secret keys to include as environment variables
-  #     - DRONE_GITHUB_SECRET
+  #     # A map of Secret keys to include as environment variables
+  #     DRONE_GITHUB_SECRET: "secret_value"
 
   ## Additional server annotations.
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for the `envSecrets` to be imported as an actual Kubernetes secret. Currently, the chart is expecting the secret to already exist somehow prior to use.

@christian-roggia 