### PR TITLE
[stable/stolon] Add option to force-disable stolon auto-cluster-creation

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,5 +1,5 @@
 name: stolon
-version: 0.3.0
+version: 0.4.0
 appVersion: 0.11.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -48,6 +48,7 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `store.kubeResourceKind`                | Kubernetes resource kind (only for kubernetes) | `configmap`                                                  |
 | `pgParameters`                          | [`postgresql.conf`][pgconf] options used during cluster creation | `{}`                                       |
 | `ports`                                 | Ports to expose on pods                        | `{"stolon":{"containerPort": 5432},"metrics":{"containerPort": 8080}}`|
+| `job.autoCreateCluster                  | Set to `false` to force-disable auto-cluster-creation which may clear pre-existing postgres db data | `true`  |
 | `keeper.replicaCount`                   | Number of keeper nodes                         | `2`                                                          |
 | `keeper.resources`                      | Keeper resource requests/limit                 | `{}`                                                         |
 | `keeper.priorityClassName`              | Keeper priorityClassName                       | `nil`                                                        |

--- a/stable/stolon/templates/create-cluster-job.yaml
+++ b/stable/stolon/templates/create-cluster-job.yaml
@@ -1,4 +1,4 @@
-{{ if .Release.IsInstall }}
+{{ if and .Release.IsInstall .Values.job.autoCreateCluster }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -56,6 +56,9 @@ ports:
   metrics:
     containerPort: 8080
 
+job:
+  autoCreateCluster: true
+
 keeper:
   replicaCount: 2
   annotations: {}


### PR DESCRIPTION
* In some cases, when upgrading an existing stolon installation with
  existing postgres data, the cluster-creation job may trigger
  resulting in the resetting of the postgres db within the
  stolon-keepers.  This happens most notably when upgrading this
  stolon chart in conjunction with the consul/etcd chart, when the
  consul/etcd chart renames PVCs resulting in empty stolon state,
  which in turn triggers auto-cluster-creation which clears all
  postgresdb data.  Adding an optional safety mechanism to prevent
  this from happening.
