### PR TITLE
[stable/dokuwiki] set default value of `serviceExternalTrafficPolicy` to `Cluster`

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: dokuwiki
-version: 2.0.4
+version: 2.0.5
 appVersion: 0.20180422.201805030840
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/stable/dokuwiki/README.md
+++ b/stable/dokuwiki/README.md
@@ -56,7 +56,7 @@ The following table lists the configurable parameters of the DokuWiki chart and 
 | `dokuwikiEmail`                      | User email                                                 | `user@example.com`                            |
 | `dokuwikiWikiName`                   | Wiki name                                                  | `My Wiki`                                     |
 | `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                       | `nil`                                         |
-| `service.externalTrafficPolicy`      | Enable client source IP preservation                       | `Local`                                       |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                       | `Cluster`                                       |
 | `service.nodePorts.http`             | Kubernetes http node port                                  | `""`                                          |
 | `service.nodePorts.https`            | Kubernetes https node port                                 | `""`                                          |
 | `ingress.enabled`                    | Enable ingress controller resource                         | `false`                                       |

--- a/stable/dokuwiki/values.yaml
+++ b/stable/dokuwiki/values.yaml
@@ -64,7 +64,7 @@ service:
   ## Enable client source IP preservation
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
 
 ## Configure the ingress resource that allows you to access the
 ## Dokuwiki installation. Set up the URL


### PR DESCRIPTION
When set to `Local`, we discovered that on OKE, Oracle's LoadBalancer tries route
to nodes where the Pod isn't running and as a result it doesn't work. Change the
default value to `Cluster` seems to be the sane default value we should use.

/assign @prydonius @tompizmor