### PR TITLE
[stable/joomla] set default value of `serviceExternalTrafficPolicy` to `Cluster`

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 2.0.6
+version: 2.0.7
 appVersion: 3.8.11
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -75,7 +75,7 @@ The following table lists the configurable parameters of the Joomla! chart and t
 | `mariadb.root.password`              | MariaDB admin password                                      | `nil`                                          |
 | `service.type`                       | Kubernetes Service type                                     | `LoadBalancer`                                 |
 | `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                        | `nil`                                          |
-| `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Local`                                        |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Cluster`                                        |
 | `service.nodePorts.http`             | Kubernetes http node port                                   | `""`                                           |
 | `service.nodePorts.https`            | Kubernetes https node port                                  | `""`                                           |
 | `ingress.enabled`                    | Enable ingress controller resource                          | `false`                                        |

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -131,7 +131,7 @@ service:
   ## Enable client source IP preservation
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
 
 ## Configure the ingress resource that allows you to access the
 ## Joomla! installation. Set up the URL


### PR DESCRIPTION
When set to `Local`, we discovered that on OKE, Oracle's LoadBalancer tries route
to nodes where the Pod isn't running and as a result it doesn't work. Change the
default value to `Cluster` seems to be the sane default value we should use.

/assign @prydonius @tompizmor