### PR TITLE
[stable/ghost] Add option for external database port number

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 4.0.12
+version: 4.0.13
 appVersion: 1.25.3
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `ghostBlogTitle`              | Ghost Blog name                                               | `User's Blog`                                            |
 | `allowEmptyPassword`          | Allow DB blank passwords                                      | `yes`                                                    |
 | `externalDatabase.host`       | Host of the external database                                 | `nil`                                                    |
+| `externalDatabase.port`       | Port of the external database                                 | `3306`                                                    |
 | `externalDatabase.user`       | Existing username in the external db                          | `bn_ghost`                                               |
 | `externalDatabase.password`   | Password for the above username                               | `nil`                                                    |
 | `externalDatabase.database`   | Name of the existing database                                 | `bitnami_ghost`                                          |

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -62,7 +62,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `ghostBlogTitle`              | Ghost Blog name                                               | `User's Blog`                                            |
 | `allowEmptyPassword`          | Allow DB blank passwords                                      | `yes`                                                    |
 | `externalDatabase.host`       | Host of the external database                                 | `nil`                                                    |
-| `externalDatabase.port`       | Port of the external database                                 | `3306`                                                    |
+| `externalDatabase.port`       | Port of the external database                                 | `nil`                                                    |
 | `externalDatabase.user`       | Existing username in the external db                          | `bn_ghost`                                               |
 | `externalDatabase.password`   | Password for the above username                               | `nil`                                                    |
 | `externalDatabase.database`   | Name of the existing database                                 | `bitnami_ghost`                                          |

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -49,7 +49,11 @@ spec:
           value: {{ .Values.externalDatabase.host | quote }}
         {{- end }}
         - name: MARIADB_PORT_NUMBER
+        {{- if .Values.mariadb.enabled }}
           value: "3306"
+        {{- else }}
+          value: {{ .Values.externalDatabase.port | default "3306" | quote }}
+        {{- end }}
         - name: GHOST_DATABASE_NAME
         {{- if .Values.mariadb.enabled }}
           value: {{ .Values.mariadb.db.name | quote }}

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -48,11 +48,9 @@ spec:
         {{- else }}
           value: {{ .Values.externalDatabase.host | quote }}
         {{- end }}
+        {{- if and (not .Values.mariadb.enabled) .Values.externalDatabase.port }}
         - name: MARIADB_PORT_NUMBER
-        {{- if .Values.mariadb.enabled }}
-          value: "3306"
-        {{- else }}
-          value: {{ .Values.externalDatabase.port | default "3306" | quote }}
+          value: {{ .Values.externalDatabase.port | quote }}
         {{- end }}
         - name: GHOST_DATABASE_NAME
         {{- if .Values.mariadb.enabled }}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -82,6 +82,9 @@ externalDatabase:
   ## Database host
   # host:
 
+  ## Database port
+  # port:
+
   ## Database user
   # user: bn_ghost
 


### PR DESCRIPTION
Add option to stable/ghost for setting the port number of external database. Default is 3306. If MariaDB chart is enabled then port is also set to 3306._