### PR TITLE
Comment out persistence.storageClass to accomodate K8s default storag…

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 1.6.0
+version: 1.6.1
 appVersion: RELEASE.2018-07-10T01-42-11Z
 keywords:
 - storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -97,7 +97,7 @@ The following table lists the configurable parameters of the Minio chart and the
 | `persistence.enabled`      | Use persistent volume to store data | `true`                                                  |
 | `persistence.size`         | Size of persistent volume claim     | `10Gi`                                                  |
 | `persistence.existingClaim`| Use an existing PVC to persist data | `nil`                                                   |
-| `persistence.storageClass` | Storage class name of PVC           | `""`                                                    |
+| `persistence.storageClass` | Storage class name of PVC           | `nil`                                                   |
 | `persistence.accessMode`   | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                                         |
 | `persistence.subPath`      | Mount a sub directory of the persistent volume if set | `""`                                  |
 | `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                            |

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -97,7 +97,7 @@ The following table lists the configurable parameters of the Minio chart and the
 | `persistence.enabled`      | Use persistent volume to store data | `true`                                                  |
 | `persistence.size`         | Size of persistent volume claim     | `10Gi`                                                  |
 | `persistence.existingClaim`| Use an existing PVC to persist data | `nil`                                                   |
-| `persistence.storageClass` | Type of persistent volume claim     | `generic`                                               |
+| `persistence.storageClass` | Storage class name of PVC           | `""`                                                    |
 | `persistence.accessMode`   | ReadWriteOnce or ReadOnly           | `ReadWriteOnce`                                         |
 | `persistence.subPath`      | Mount a sub directory of the persistent volume if set | `""`                                  |
 | `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                            |

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -53,7 +53,7 @@ persistence:
   ##
   ## Storage class of PV to bind. By default it looks for standard storage class.
   ## If the PV uses a different storage class, specify that here.
-  storageClass: standard
+  # storageClass: standard
   accessMode: ReadWriteOnce
   size: 10Gi
 


### PR DESCRIPTION
Comment out persistence.storageClass to accomodate K8s default storage class.

K8s will by default use the storage class with annotation 'storageclass.kubernetes.io/is-default-class:  true'.   Setting the value persistence.storageClass to 'standard' hardcodes the storage class name to 'standard'.   By not defining value persistence.storageClass, K8s will use the default storage class, whatever it's name may be.