### PR TITLE
Updated readme to reflect default value. Bumped chart version

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.4.0
+version: 1.4.1
 appVersion: 6.3.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -97,7 +97,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
 | `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                              |
-| `data.replicas`                      | Data node replicas (statefulset)                                    | `3`                                  |
+| `data.replicas`                      | Data node replicas (statefulset)                                    | `2`                                  |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
 | `data.priorityClassName`             | Data priorityClass                                                  | `nil`                                |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |


### PR DESCRIPTION
**What this PR does / why we need it**:
The documentation in README is not the same as the actual value in the values.yaml
The documentation claims there are 3 data replicas, but the values.yaml defines 2 by default.

