### PR TITLE
[incubator/grav] Introducing Grav  - a modern open source flat-file CMS

### DIFF
--- a/incubator/grav/.helmignore
+++ b/incubator/grav/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/grav/Chart.yaml
+++ b/incubator/grav/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+appVersion: 1.4.8
+description: Grav is a modern open source flat-file CMS
+home: https://getgrav.org/
+icon: https://getgrav-grav.netdna-ssl.com/user/pages/media/grav-logo.svg
+name: grav
+version: 0.1.0

--- a/incubator/grav/README.md
+++ b/incubator/grav/README.md
@@ -1,0 +1,156 @@
+# Grav
+[Grav](https://getgrav.org/) is a modern open source flat-file CMS.
+
+## TL;DR;
+```bash
+helm install incubator/grav
+```
+
+## Introduction
+This chart deploys [Grav](https://getgrav.org/) on Kubernetes using thelm package manager.
+
+## Prerequisites
+- PV provisioner support
+
+## Installation
+To install the chart with the release name `my-release`
+```bash
+helm install --name my-release incubator/grav
+```
+This command will deploy Grav with the default configuration.
+
+## Uninstalling
+```bash
+helm delete my-release
+```
+This command removes all the Kubernetes resources associated with the chart and deletes the release.
+
+## Configuration
+The following table lists the configurable parameters and their default values.
+| Parameter                            | Description                                | Default value                                              |
+| ------------------------------------ | ------------------------------------------ | ---------------------------------------------------------- |
+| `image.repository`                   | Grav image name                            | `flojon/grav`                                              |
+| `image.tag`                          | Grav image tag                             | `1.4.8`                                                    |
+| `image.pullPolicy`                   | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `image.pullSecrets`                  | Specify image pull secrets                 | `nil`                                                      |
+| `replicaCount`                       | Number of Grav Pods to run                 | `1`                                                        |
+| `serviceType`                        | Kubernetes Service type                    | `ClusterIP`                                                |
+| `nodePorts.http`                     | Kubernetes http node port                  | `""`                                                       |
+| `nodePorts.https`                    | Kubernetes https node port                 | `""`                                                       |
+| `ingress.enabled`                    | Enable ingress controller resource         | `false`                                                    |
+| `ingress.hosts[0].name`              | Hostname to your Grav installation         | `grav.local`                                               |
+| `ingress.hosts[0].path`              | Path within the url structure              | `/`                                                        |
+| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress             | `false`                                                    |
+| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                  | `grav.local-tls-secret`                                    |
+| `ingress.hosts[0].annotations`       | Annotations for this host's ingress record | `[]`                                                       |
+| `ingress.secrets[0].name`            | TLS Secret Name                            | `nil`                                                      |
+| `ingress.secrets[0].certificate`     | TLS Secret Certificate                     | `nil`                                                      |
+| `ingress.secrets[0].key`             | TLS Secret Key                             | `nil`                                                      |
+| `persistence.enabled`                | Enable persistence using PVC               | `true`                                                     |
+| `persistence.existingClaim`          | Enable persistence using an existing PVC   | `nil`                                                      |
+| `persistence.storageClass`           | PVC Storage Class                          | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`             | PVC Access Mode                            | `ReadWriteOnce`                                            |
+| `persistence.size`                   | PVC Storage Request                        | `10Gi`                                                     |
+| `nodeSelector`                       | Node labels for pod assignment             | `{}`                                                       |
+| `tolerations`                        | List of node taints to tolerate            | `[]`                                                       |
+| `affinity`                           | Map of node/pod affinities                 | `{}`                                                       |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install --name my-release \
+  --set replicaCount=3,persistence.size=1Gi \
+    incubator/grav
+```
+The above command will set replica count to 3 and volume size to 1Gb.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```bash
+helm install --name my-release -f values.yaml incubator/grav
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Persistence
+
+The [flojon/grav](https://github.com/flojon/docker-grav) image stores the data and configurations at the `/var/www/html` path of the container.
+
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
+See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Ingress
+
+This chart provides support for ingress resources. If you have an
+ingress controller installed on your cluster, such as [nginx-ingress](https://kubeapps.com/charts/stable/nginx-ingress)
+or [traefik](https://kubeapps.com/charts/stable/traefik) you can utilize
+the ingress controller to serve your Grav application.
+
+To enable ingress integration, please set `ingress.enabled` to `true`
+
+### Hosts
+
+Most likely you will only want to have one hostname that maps to this
+Grav installation, however, it is possible to have more than one
+host.  To facilitate this, the `ingress.hosts` object is an array.
+
+For each item, please indicate a `name`, `tls`, `tlsSecret`, and any
+`annotations` that you may want the ingress controller to know about.
+
+Indicating TLS will cause Grav to generate HTTPS URLs, and
+Grav will be connected to at port 443.  The actual secret that
+`tlsSecret` references do not have to be generated by this chart.
+However, please note that if TLS is enabled, the ingress record will not
+work until this secret exists.
+
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md).
+Not all annotations are supported by all ingress controllers, but this
+document does a good job of indicating which annotation is supported by
+many popular ingress controllers.
+
+### TLS Secrets
+
+This chart will facilitate the creation of TLS secrets for use with the
+ingress controller, however, this is not required.  There are three
+common use cases:
+
+* helm generates/manages certificate secrets
+* user generates/manages certificates separately
+* an additional tool (like [kube-lego](https://kubeapps.com/charts/stable/kube-lego))
+manages the secrets for the application
+
+In the first two cases, one will need a certificate and a key.  We would
+expect them to look like this:
+
+* certificate files should look like (and there can be more than one
+certificate if there is a certificate chain)
+
+```
+-----BEGIN CERTIFICATE-----
+MIID6TCCAtGgAwIBAgIJAIaCwivkeB5EMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
+...
+jScrvkiBO65F46KioCL9h5tDvomdU1aqpI/CBzhvZn1c0ZTf87tGQR8NK7v7
+-----END CERTIFICATE-----
+```
+* keys should look like:
+```
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAvLYcyu8f3skuRyUgeeNpeDvYBCDcgq+LsWap6zbX5f8oLqp4
+...
+wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
+-----END RSA PRIVATE KEY-----
+````
+
+If you are going to use Helm to manage the certificates, please copy
+these values into the `certificate` and `key` values for a given
+`ingress.secrets` entry.
+
+If you are going are going to manage TLS secrets outside of Helm, please
+know that you can create a TLS secret by doing the following:
+
+```
+kubectl create secret tls Grav.local-tls --key /path/to/key.key --cert /path/to/cert.crt
+```
+
+Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls)
+for more information.

--- a/incubator/grav/templates/NOTES.txt
+++ b/incubator/grav/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grav.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "grav.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grav.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grav.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/incubator/grav/templates/NOTES.txt
+++ b/incubator/grav/templates/NOTES.txt
@@ -1,7 +1,7 @@
-1. Get the application URL by running these commands:
+Get the Grav URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+  {{ if .tls }}https{{ else }}http{{ end }}://{{ .name }}{{ $.Values.ingress.path }}
 {{- end }}
 {{- else if contains "NodePort" .Values.serviceType }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grav.fullname" . }})
@@ -14,6 +14,6 @@
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.serviceType }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grav.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
+  echo "Visit http://127.0.0.1:8080 to use your Grav installation"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}

--- a/incubator/grav/templates/NOTES.txt
+++ b/incubator/grav/templates/NOTES.txt
@@ -3,16 +3,16 @@
 {{- range .Values.ingress.hosts }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.serviceType }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "grav.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.serviceType }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "grav.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "grav.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+{{- else if contains "ClusterIP" .Values.serviceType }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "grav.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80

--- a/incubator/grav/templates/_helpers.tpl
+++ b/incubator/grav/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "grav.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "grav.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "grav.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/grav/templates/deployment.yaml
+++ b/incubator/grav/templates/deployment.yaml
@@ -19,6 +19,12 @@ spec:
         app: {{ template "grav.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/incubator/grav/templates/deployment.yaml
+++ b/incubator/grav/templates/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "grav.fullname" . }}
+  labels:
+    app: {{ template "grav.name" . }}
+    chart: {{ template "grav.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "grav.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "grav.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+          - mountPath: /var/www/html
+            name: grav-data
+      volumes:
+      - name: grav-data
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "grav.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{ end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/incubator/grav/templates/ingress.yaml
+++ b/incubator/grav/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "grav.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "grav.name" . }}
+    chart: {{ template "grav.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/incubator/grav/templates/ingress.yaml
+++ b/incubator/grav/templates/ingress.yaml
@@ -1,38 +1,36 @@
-{{- if .Values.ingress.enabled -}}
-{{- $fullName := include "grav.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
-    app: {{ template "grav.name" . }}
-    chart: {{ template "grav.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-{{- with .Values.ingress.annotations }}
+    app: {{ template "grav.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- if .tls }}
+    ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-  {{- end }}
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "grav.fullname" $ }}
+            servicePort: 80
+{{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
 {{- end }}

--- a/incubator/grav/templates/ingress.yaml
+++ b/incubator/grav/templates/ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
+  name: {{ template "grav.fullname" $ }}
   labels:
     app: {{ template "grav.fullname" $ }}
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"

--- a/incubator/grav/templates/pvc.yaml
+++ b/incubator/grav/templates/pvc.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "grav.fullname" . }}
+  labels:
+    app: {{ template "grav.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/incubator/grav/templates/service.yaml
+++ b/incubator/grav/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "grav.fullname" . }}
+  labels:
+    app: {{ template "grav.name" . }}
+    chart: {{ template "grav.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "grav.name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/grav/templates/service.yaml
+++ b/incubator/grav/templates/service.yaml
@@ -3,17 +3,27 @@ kind: Service
 metadata:
   name: {{ template "grav.fullname" . }}
   labels:
-    app: {{ template "grav.name" . }}
-    chart: {{ template "grav.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app: {{ template "grav.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.serviceType }}
+  {{- if (or (eq .Values.serviceType "LoadBalancer") (eq .Values.serviceType "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.serviceExternalTrafficPolicy | quote }}
+  {{- end }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: 80
       targetPort: http
-      protocol: TCP
-      name: http
+      {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.nodePorts.http)))}}
+      nodePort: {{ .Values.nodePorts.http }}
+      {{- end }}
+    - name: https
+      port: 443
+      targetPort: https
+      {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.nodePorts.https)))}}
+      nodePort: {{ .Values.nodePorts.https }}
+      {{- end }}
   selector:
-    app: {{ template "grav.name" . }}
-    release: {{ .Release.Name }}
+    app: {{ template "grav.fullname" . }}

--- a/incubator/grav/templates/service.yaml
+++ b/incubator/grav/templates/service.yaml
@@ -26,4 +26,5 @@ spec:
       nodePort: {{ .Values.nodePorts.https }}
       {{- end }}
   selector:
-    app: {{ template "grav.fullname" . }}
+    app: {{ template "grav.name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/grav/values.yaml
+++ b/incubator/grav/values.yaml
@@ -9,22 +9,64 @@ image:
   tag: 1.4.8
   pullPolicy: IfNotPresent
 
-service:
-  type: ClusterIP
-  port: 80
+serviceType: ClusterIP
+## serviceType: NodePort
+## nodePorts:
+##   http: <to set explicitly, choose port between 30000-32767>
+##   https: <to set explicitly, choose port between 30000-32767>
+nodePorts:
+  http: ""
+  https: ""
+## Enable client source IP preservation
+## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+##
+serviceExternalTrafficPolicy: Local
 
+## Configure the ingress resource that allows you to access the
+## Grav installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
 ingress:
+  ## Set to true to enable ingress record generation
   enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  path: /
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
   hosts:
-    - grav.local
-  tls: []
-  #  - secretName: grav-tls
-  #    hosts:
-  #      - grav.local
+  - name: grav.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    ## A side effect of this will be that the backend Grav service will be connected at port 443
+    tls: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: grav.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## If you're using kube-lego, you will want to add:
+    ## kubernetes.io/tls-acme: true
+    ##
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+    #  kubernetes.io/tls-acme: true
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: grav.local-tls
+  #   key:
+  #   certificate:
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/incubator/grav/values.yaml
+++ b/incubator/grav/values.yaml
@@ -1,0 +1,65 @@
+# Default values for grav.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: flojon/grav
+  tag: 1.4.8
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - grav.local
+  tls: []
+  #  - secretName: grav-tls
+  #    hosts:
+  #      - grav.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+## Enable persistence using Persistent Volume Claims
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  enabled: true
+  ## grav data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  ##
+  ## If you want to reuse an existing claim, you can pass the name of the PVC using
+  ## the existingClaim variable
+  # existingClaim: your-claim
+  accessMode: ReadWriteOnce
+  size: 10Gi


### PR DESCRIPTION
This adds a chart for [Grav](https://getgrav.org/) - a modern open source flat-file CMS built on PHP.
The chart includes support for PVC and ingress. It's heavily inspired by the Wordpress chart, especially the config for ingress, service and persistence.
Since there is no official docker image for Grav I'm currently using my own docker image flojon/grav.
This chart has been tested using minikube with traefik ingress controller.