### PR TITLE
Add `server.extraVolumeMounts` optional value

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 1.4.0
+version: 1.4.1
 appVersion: 0.8.5
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/README.md
+++ b/stable/drone/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the drone charts and th
 | `server.nodeSelector`       | Drone **server** node labels for pod assignment                                               | `{}`                        |
 | `server.extraContainers`    | Additional sidecar containers                                                                 | `""`                        |
 | `server.extraVolumes`       | Additional volumes for use in extraContainers                                                 | `""`                        |
+| `server.extraVolumeMounts`  | Additional volumes to mount in server pods                                                    | `[]`                        |
 | `agent.env`                 | Drone **agent** environment variables                                                         | `(default values)`          |
 | `agent.replicas`            | Drone **agent** replicas                                                                      | `1`                         |
 | `agent.annotations`         | Drone **agent** annotations                                                                   | `{}`                        |

--- a/stable/drone/templates/deployment-server.yaml
+++ b/stable/drone/templates/deployment-server.yaml
@@ -80,6 +80,9 @@ spec:
         volumeMounts:
           - name: data
             mountPath: /var/lib/drone
+{{- with .Values.server.extraVolumeMounts }}
+{{ tpl . $ | indent 10 }}
+{{- end }}
 {{- with .Values.server.extraContainers }}
 {{ tpl . $ | indent 6 }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Some features in the Drone Enterprise expansion pack require that files are present in a container with things like shared registry credentials and global secrets. This patch makes it possible to mount extra secrets / configmaps in the server pods.

**Special notes for your reviewer**:
