### PR TITLE
[stable/dokuwiki] Improve notes to access deployed services

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: dokuwiki
-version: 2.0.5
+version: 2.0.6
 appVersion: 0.20180422.201805030840
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/stable/dokuwiki/templates/NOTES.txt
+++ b/stable/dokuwiki/templates/NOTES.txt
@@ -18,7 +18,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "dokuwiki.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo "URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
@@ -26,12 +26,13 @@
 ** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "dokuwiki.fullname" . }} **
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "dokuwiki.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/
+  echo "URL: http://$SERVICE_IP/"
+
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "dokuwiki.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "URL: http://127.0.0.1:8080/"
+  kubectl port-forward svc/{{ template "dokuwiki.fullname" . }} 8080:80
+
 {{- end }}
 {{- end }}
 

--- a/stable/dokuwiki/templates/NOTES.txt
+++ b/stable/dokuwiki/templates/NOTES.txt
@@ -31,7 +31,7 @@
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
   echo "URL: http://127.0.0.1:8080/"
-  kubectl port-forward svc/{{ template "dokuwiki.fullname" . }} 8080:80
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dokuwiki.fullname" . }} 8080:80
 
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

As described on https://github.com/kubernetes/kubernetes/pull/59809, now `kubectl port-foward` resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward. 

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP' 