### PR TITLE
[stable/drupal] Improve notes to access deployed services

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 1.1.2
+version: 1.1.3
 appVersion: 8.5.6
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/templates/NOTES.txt
+++ b/stable/drupal/templates/NOTES.txt
@@ -17,12 +17,11 @@
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "drupal.fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "drupal.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/
+  echo "URL: http://$SERVICE_IP/"
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "drupal.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "URL: http://127.0.0.1:8080/"
+  kubectl port-forward svc/{{ template "drupal.fullname" . }} 8080:80
 {{- end }}
 
 {{- if contains "NodePort" .Values.serviceType }}
@@ -31,7 +30,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "drupal.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo "URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- end }}
 

--- a/stable/drupal/templates/NOTES.txt
+++ b/stable/drupal/templates/NOTES.txt
@@ -17,11 +17,13 @@
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "drupal.fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "drupal.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo "URL: http://$SERVICE_IP/"
+  echo "Drupal URL: http://$SERVICE_IP/"
+
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-  echo "URL: http://127.0.0.1:8080/"
-  kubectl port-forward svc/{{ template "drupal.fullname" . }} 8080:80
+  echo "Drupal URL: http://127.0.0.1:8080/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "drupal.fullname" . }} 8080:80
+
 {{- end }}
 
 {{- if contains "NodePort" .Values.serviceType }}
@@ -30,7 +32,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "drupal.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo "URL: http://$NODE_IP:$NODE_PORT/"
+  echo "Drupal URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'