### PR TITLE
[stable/ghost] Improve notes to access deployed services

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 4.0.11
+version: 4.0.12
 appVersion: 1.25.3
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world

--- a/stable/ghost/templates/NOTES.txt
+++ b/stable/ghost/templates/NOTES.txt
@@ -29,10 +29,9 @@ host. To configure Ghost with the URL of your service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "ghost.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo Blog URL  : http://127.0.0.1:{{ default "80" .Values.ghostPort }}{{ .Values.ghostPath }}
   echo Admin URL : http://127.0.0.1:{{ default "80" .Values.ghostPort }}{{ .Values.ghostPath }}ghost
-  kubectl port-forward $POD_NAME {{ default "80" .Values.ghostPort }}:2368
+  kubectl port-forward svc/{{ template "ghost.fullname" . }} {{ default "80" .Values.ghostPort }}:2368
 
 {{- else if eq .Values.serviceType "NodePort" }}
   export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/stable/ghost/templates/NOTES.txt
+++ b/stable/ghost/templates/NOTES.txt
@@ -31,7 +31,7 @@ host. To configure Ghost with the URL of your service:
 
   echo Blog URL  : http://127.0.0.1:{{ default "80" .Values.ghostPort }}{{ .Values.ghostPath }}
   echo Admin URL : http://127.0.0.1:{{ default "80" .Values.ghostPort }}{{ .Values.ghostPath }}ghost
-  kubectl port-forward svc/{{ template "ghost.fullname" . }} {{ default "80" .Values.ghostPort }}:2368
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "ghost.fullname" . }} {{ default "80" .Values.ghostPort }}:2368
 
 {{- else if eq .Values.serviceType "NodePort" }}
   export APP_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'