### PR TITLE
[stable/jasperreports] Improve notes to access deployed services

### DIFF
--- a/stable/jasperreports/Chart.yaml
+++ b/stable/jasperreports/Chart.yaml
@@ -1,5 +1,5 @@
 name: jasperreports
-version: 2.0.3
+version: 2.0.4
 appVersion: 7.1.0
 description: The JasperReports server can be used as a stand-alone or embedded reporting
   and BI server that offers web-based reporting, analytic tools and visualization,

--- a/stable/jasperreports/templates/NOTES.txt
+++ b/stable/jasperreports/templates/NOTES.txt
@@ -7,7 +7,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jasperreports.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo "URL: http://$NODE_IP:$NODE_PORT/"
+  echo "JasperReports URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
@@ -15,12 +15,12 @@
 ** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jasperreports.fullname" . }} **
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jasperreports.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo "URL: http://$SERVICE_IP/jasperserver/"
+  echo "JasperReports URL: http://$SERVICE_IP/jasperserver/"
 
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-  echo "URL: http://127.0.0.1:8080/jasperserver/"
-  kubectl port-forward svc/{{ template "jasperreports.fullname" . }} 8080:8080
+  echo "JasperReports URL: http://127.0.0.1:8080/jasperserver/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "jasperreports.fullname" . }} 8080:8080
 
 {{- end }}
 

--- a/stable/jasperreports/templates/NOTES.txt
+++ b/stable/jasperreports/templates/NOTES.txt
@@ -7,7 +7,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jasperreports.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo "URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
@@ -15,12 +15,13 @@
 ** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jasperreports.fullname" . }} **
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jasperreports.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/jasperserver/
+  echo "URL: http://$SERVICE_IP/jasperserver/"
+
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "jasperreports.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/jasperserver/
-  kubectl port-forward $POD_NAME 8080:8080
+  echo "URL: http://127.0.0.1:8080/jasperserver/"
+  kubectl port-forward svc/{{ template "jasperreports.fullname" . }} 8080:8080
+
 {{- end }}
 
 2. Login with the following credentials


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'