### PR TITLE
[stable/joomla] Improve notes to access deployed services

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 2.0.7
+version: 2.0.8
 appVersion: 3.8.11
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/templates/NOTES.txt
+++ b/stable/joomla/templates/NOTES.txt
@@ -19,7 +19,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "joomla.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo "Joomla! URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
@@ -27,12 +27,13 @@
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "joomla.fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "joomla.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP/
+  echo "Joomla! URL: http://$SERVICE_IP/"
+
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "joomla.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Joomla! URL: http://127.0.0.1:8080/"
+  kubectl port-forward svc/{{ template "joomla.fullname" . }} 8080:80
+
 {{- end }}
 {{- end }}
 

--- a/stable/joomla/templates/NOTES.txt
+++ b/stable/joomla/templates/NOTES.txt
@@ -32,7 +32,7 @@
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
   echo "Joomla! URL: http://127.0.0.1:8080/"
-  kubectl port-forward svc/{{ template "joomla.fullname" . }} 8080:80
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "joomla.fullname" . }} 8080:80
 
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'