### PR TITLE
[stable/magento] Improve notes to access deployed services

### DIFF
--- a/stable/magento/Chart.yaml
+++ b/stable/magento/Chart.yaml
@@ -1,5 +1,5 @@
 name: magento
-version: 2.0.4
+version: 2.0.5
 appVersion: 2.2.5
 description: A feature-rich flexible e-commerce solution. It includes transaction options, multi-store functionality, loyalty programs, product categorization and shopper filtering, promotion rules, and more.
 keywords:

--- a/stable/magento/templates/NOTES.txt
+++ b/stable/magento/templates/NOTES.txt
@@ -48,11 +48,13 @@ host. To configure Magento with the URL of your service:
 
   echo "Store URL: http://127.0.0.1:8080/"
   echo "Admin URL: http://127.0.0.1:8080/{{ .Values.magentoAdminUri }}"
-  kubectl port-forward svc/{{ template "magento.fullname" . }} 8080:80
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "magento.fullname" . }} 8080:80
+
 {{- else }}
 
   echo Store URL : http://{{ include "magento.host" . }}/
   echo Admin URL : http://{{ include "magento.host" . }}/{{ .Values.magentoAdminUri }}
+
 {{- end }}
 
 2. Get your Magento login credentials by running:

--- a/stable/magento/templates/NOTES.txt
+++ b/stable/magento/templates/NOTES.txt
@@ -46,9 +46,9 @@ host. To configure Magento with the URL of your service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "magento.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Store URL: http://127.0.0.1:8080/"
+  echo "Admin URL: http://127.0.0.1:8080/{{ .Values.magentoAdminUri }}"
+  kubectl port-forward svc/{{ template "magento.fullname" . }} 8080:80
 {{- else }}
 
   echo Store URL : http://{{ include "magento.host" . }}/


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'