### PR TITLE
[incubator/elasticsearch] Custom elasticsearch container args

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.4.0
+version: 1.4.1
 appVersion: 6.3.1
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `cluster.kubernetesDomain`           | Kubernetes cluster domain name                                      | `cluster.local`                      |
 | `cluster.xpackEnable`                | Writes the X-Pack configuration options to the configuration file   | `false`                              |
 | `cluster.config`                     | Additional cluster config appended                                  | `{}`                                 |
+| `cluster.args`                       | Cluster custom elasticsearch containers args                        | `nil`                                |
 | `cluster.env`                        | Cluster environment variables                                       | `{}`                                 |
 | `client.name`                        | Client component name                                               | `client`                             |
 | `client.replicas`                    | Client node replicas (deployment)                                   | `2`                                  |

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -89,6 +89,9 @@ spec:
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
+{{- if .Values.cluster.args }}
+        args: {{ .Values.cluster.args }}
+{{- end }}
         resources:
 {{ toYaml .Values.client.resources | indent 12 }}
         readinessProbe:

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -97,6 +97,9 @@ spec:
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
+{{- if .Values.cluster.args }}
+        args: {{ .Values.cluster.args }}
+{{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         ports:

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -101,6 +101,9 @@ spec:
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
+{{- if .Values.cluster.args }}
+        args: {{ .Values.cluster.args }}
+{{- end }}
         resources:
 {{ toYaml .Values.master.resources | indent 12 }}
         readinessProbe:

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -15,6 +15,7 @@ cluster:
   # enabled in the environment variables outlined in the README
   xpackEnable: false
   config:
+  args:
   env:
     # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes
     # To prevent data loss, it is vital to configure the discovery.zen.minimum_master_nodes setting so that each master-eligible


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Problem: to install plugin  `bin/elasticsearch-plugin install` must be executed on each node, also to add access credentials `bin/elasticsearch-keystore add` must be executed also on each node. For example to add s3 snapshot plugin:
https://www.elastic.co/guide/en/elasticsearch/plugins/6.3/repository-s3.html
`bin/elasticsearch-plugin install --batch -v repository-s3` 
https://www.elastic.co/guide/en/elasticsearch/plugins/6.3/repository-s3-client.html
`echo 'secret_key' | ./bin/elasticsearch-keystore add --force --stdin s3.client.default.secret_key`
`echo 'access_key' | ./bin/elasticsearch-keystore add --force --stdin s3.client.default.access_key`
Elasticsearch reads keystore and loads plugins on start.
Official image doesn't have any mechanism to install plugins or to populate keystore 

Solutions: Add custom args to install plugins and populate keystore  as workaround https://github.com/elastic/elasticsearch-docker/pull/162#issuecomment-395107255


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
