### PR TITLE
[stable/opencart] Improve notes to access deployed services

### DIFF
--- a/stable/opencart/Chart.yaml
+++ b/stable/opencart/Chart.yaml
@@ -1,5 +1,5 @@
 name: opencart
-version: 2.0.3
+version: 2.0.4
 appVersion: 3.0.2-0
 description: A free and open source e-commerce platform for online merchants. It provides
   a professional and reliable foundation for a successful online store.

--- a/stable/opencart/templates/NOTES.txt
+++ b/stable/opencart/templates/NOTES.txt
@@ -46,12 +46,15 @@ host. To configure OpenCart with the URL of your service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "opencart.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "URL: http://127.0.0.1:8080/"
+  echo "Administration URL: http://127.0.0.1:8080/admin"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "opencart.fullname" . }} 8080:80
+
 {{- else }}
-  echo URL               : http://{{ include "opencart.host" . }}/
-  echo Administration URL : http://{{ include "opencart.host" . }}/admin
+
+  echo "URL: http://{{ include "opencart.host" . }}/"
+  echo "Administration URL: http://{{ include "opencart.host" . }}/admin"
+
 {{- end }}
 
 2. Get your OpenCart login credentials by running:


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'