### PR TITLE
[stable/osclass] Improve notes to access deployed services

### DIFF
--- a/stable/osclass/Chart.yaml
+++ b/stable/osclass/Chart.yaml
@@ -1,5 +1,5 @@
 name: osclass
-version: 2.0.3
+version: 2.0.4
 appVersion: 3.7.4
 description: Osclass is a php script that allows you to quickly create and manage
   your own free classifieds site.

--- a/stable/osclass/templates/NOTES.txt
+++ b/stable/osclass/templates/NOTES.txt
@@ -46,14 +46,15 @@ host. To configure Osclass with the URL of your service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "osclass.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo URL       : http://127.0.0.1:8080/
   echo Admin URL : http://127.0.0.1:8080/oc-admin/
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "osclass.fullname" . }} 8080:80
+
 {{- else }}
 
   echo URL       : http://{{ include "osclass.host" . }}/
   echo Admin URL : http://{{ include "osclass.host" . }}/oc-admin/
+
 {{- end }}
 
 2. Get your Osclass login credentials by running:


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'