### PR TITLE
[stable/owncloud] Improve notes to access deployed services

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 2.0.4
+version: 2.0.5
 appVersion: 10.0.9
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/templates/NOTES.txt
+++ b/stable/owncloud/templates/NOTES.txt
@@ -46,12 +46,13 @@ host. To configure ownCloud with the URL of your service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "owncloud.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "ownCloud URL: echo http://127.0.0.1:8080/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "owncloud.fullname" . }} 8080:80
+
 {{- else }}
 
-  echo http://{{ include "owncloud.host" . }}{{ if .Values.owncloudPort }}:{{ .Values.owncloudPort  }}{{ end }}/
+  echo "ownCloud URL: http://{{ include "owncloud.host" . }}{{ if .Values.owncloudPort }}:{{ .Values.owncloudPort  }}{{ end }}/"
+
 {{- end }}
 
 2. Get your ownCloud login credentials by running:


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'