### PR TITLE
[stable/parse] Improve notes to access deployed services

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,5 +1,5 @@
 name: parse
-version: 2.0.3
+version: 2.0.4
 appVersion: 2.8.2
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/templates/NOTES.txt
+++ b/stable/parse/templates/NOTES.txt
@@ -21,10 +21,10 @@ Parse Server
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "parse.fullname" . }}'
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "parse.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}'):{{ .Values.server.port }}
+
 {{- else if contains "ClusterIP"  .Values.serviceType }}
 
-  export SERVER_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "parse.name" . }},release={{ .Release.Name }},component=server" -o jsonpath="{.items[0].metadata.name}")
-  kubectl port-forward $SERVER_POD_NAME {{ .Values.server.port }}:{{ .Values.server.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "parse.fullname" . }} {{ .Values.server.port }}:{{ .Values.server.port }}
   export SERVICE_IP=127.0.0.1:{{ .Values.server.port }}
 
 {{- end }}
@@ -66,12 +66,13 @@ service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export DASHBOARD_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "parse.name" . }},release={{ .Release.Name }},component=dashboard" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:4040/
-  kubectl port-forward $DASHBOARD_POD_NAME 4040:4040
+  echo "Parse Dashboard URL: http://127.0.0.1:4040/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "parse.fullname" . }} 4040:4040
+
 {{- else }}
 
-  echo http://{{ include "parse.host" . }}/
+  echo "Parse Dashboard URL: http://{{ include "parse.host" . }}/"
+
 {{- end }}
 
 2. Get your Parsh Dashboard login credentials by running:


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'