### PR TITLE
[stable/phabricator] Improve notes to access deployed services

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,5 +1,5 @@
 name: phabricator
-version: 2.1.4
+version: 2.1.5
 appVersion: 2018.30.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/templates/NOTES.txt
+++ b/stable/phabricator/templates/NOTES.txt
@@ -35,12 +35,13 @@ host. To configure Phabricator with the URL of your service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "phabricator.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Phabricator URL: http://127.0.0.1:8080/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "phabricator.fullname" . }} 8080:80
+
 {{- else }}
 
-  echo URL : http://{{ include "phabricator.host" . }}/
+  echo "Phabricator URL: http://{{ include "phabricator.host" . }}/"
+
 {{- end }}
 
 2. Get your Phabricator login credentials by running:


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'