### PR TITLE
[stable/phpmyadmin] Improve notes to access deployed services

### DIFF
--- a/stable/phpmyadmin/Chart.yaml
+++ b/stable/phpmyadmin/Chart.yaml
@@ -1,5 +1,5 @@
 name: phpmyadmin
-version: 0.1.9
+version: 0.1.10
 appVersion: 4.8.2
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/stable/phpmyadmin/templates/NOTES.txt
+++ b/stable/phpmyadmin/templates/NOTES.txt
@@ -12,8 +12,7 @@
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "phpmyadmin.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  
-  echo http://$NODE_IP:$NODE_PORT
+  echo "phpMyAdmin URL: http://$NODE_IP:$NODE_PORT"
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
   
@@ -21,13 +20,12 @@
          You can watch the status of by running 'kubectl get svc -w {{ template "phpmyadmin.fullname" . }}'
   
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "phpmyadmin.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo "phpMyAdmin URL: http://$SERVICE_IP:{{ .Values.service.port }}"
 
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "phpmyadmin.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  
-  kubectl port-forward $POD_NAME 8080:80
+  echo "phpMyAdmin URL: http://127.0.0.1:8080"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "phpmyadmin.fullname" . }} 8080:80
 
 {{- end }}
 


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'