### PR TITLE
[stable/prestashop] Improve notes to access deployed services

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 2.0.7
+version: 2.0.8
 appVersion: 1.7.4-2
 description: A popular open source ecommerce solution. Professional tools are easily
   accessible to increase online sales including instant guest checkout, abandoned

--- a/stable/prestashop/templates/NOTES.txt
+++ b/stable/prestashop/templates/NOTES.txt
@@ -46,13 +46,15 @@ host. To configure PrestaShop with the URL of your service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prestashop.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "Store URL: http://127.0.0.1:8080/"
+  echo "Amin URL: http://127.0.0.1:8080/administration"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "prestashop.fullname" . }} 8080:80
+
 {{- else }}
 
-  echo Store URL : http://{{ include "prestashop.host" . }}/
-  echo Admin URL : http://{{ include "prestashop.host" . }}/administration
+  echo "Store URL: http://{{ include "prestashop.host" . }}/"
+  echo "Admin URL: http://{{ include "prestashop.host" . }}/administration"
+
 {{- end }}
 
 2. Get your PrestaShop login credentials by running:


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'