### PR TITLE
[stable/redmine] Improve notes to access deployed services

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 4.0.2
+version: 4.0.3
 appVersion: 3.4.6
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/templates/NOTES.txt
+++ b/stable/redmine/templates/NOTES.txt
@@ -4,7 +4,7 @@
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "redmine.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/
+  echo "Redmine URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- else if contains "LoadBalancer" .Values.serviceType }}
 
@@ -13,16 +13,17 @@
 
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "redmine.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
-  echo http://$SERVICE_IP/
+  echo "Redmine URL: http://$SERVICE_IP/"
 
 {{- else if .Values.ingress.enabled }}
-  http://{{ .Values.ingress.hostname }}/
+
+  echo "Redmine URL: http://{{ .Values.ingress.hostname }}/"
 
 {{- else if contains "ClusterIP" .Values.serviceType }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "redmine.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:3000/
-  kubectl port-forward $POD_NAME 3000:3000
+  echo "Redmine URL: http://127.0.0.1:3000/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "redmine.fullname" . }} 3000:3000
+
 {{- end }}
 
 2. Login with the following credentials


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'