### PR TITLE
[stable/suitecrm] Improve notes to access deployed services

### DIFF
--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,5 +1,5 @@
-name: suitecrm
-version: 2.0.4
+8name: suitecrm
+version: 2.0.5
 appVersion: 7.10.7
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,4 +1,4 @@
-8name: suitecrm
+name: suitecrm
 version: 2.0.5
 appVersion: 7.10.7
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.

--- a/stable/suitecrm/templates/NOTES.txt
+++ b/stable/suitecrm/templates/NOTES.txt
@@ -46,12 +46,13 @@ host. To configure SuiteCRM with the URL of your service:
 
 {{- if eq .Values.serviceType "ClusterIP" }}
 
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  echo "SuiteCRM URL: http://127.0.0.1:8080/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "fullname" . }} $POD_NAME 8080:80
+
 {{- else }}
 
-  echo URL : http://{{ include "host" . }}/
+  echo "SuiteCRM URL: http://{{ include "host" . }}/"
+
 {{- end }}
 
 2. Get your SuiteCRM login credentials by running:


### PR DESCRIPTION
**What this PR does / why we need it:**

As described on kubernetes/kubernetes#59809, now kubectl port-foward resolves service port to target port. Therefore, we can access the services deployed as 'ClusterIP' using a simple port-forward.

This PR improves the NOTES.txt so this new method is the one recommended to access the application when using 'ClusterIP'