### PR TITLE
fix maintainerId to match githubId

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 0.9.0
+version: 0.9.1
 appVersion: 1.0.6
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:
@@ -13,5 +13,5 @@ sources:
 maintainers:
 - name: Acaleph
   email: hello@acale.ph
-- name: Shashidhara TD
+- name: shashidharatd
   email: shashidhara.huawei@gmail.com


### PR DESCRIPTION
See failing test in https://github.com/helm/charts/pull/7039 .
The id of the maintainer does not match the githubid and thus tests fail: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/helm_charts/7039/pull-charts-e2e/12136/