### PR TITLE
[stable/nginx-ingress] Enhanced requests

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.28.2
+version: 0.28.3
 appVersion: 0.19.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -138,10 +138,10 @@ controller:
   resources: {}
   #  limits:
   #    cpu: 100m
-  #    memory: 64Mi
+  #    memory: 150Mi
   #  requests:
   #    cpu: 100m
-  #    memory: 64Mi
+  #    memory: 150Mi
 
   autoscaling:
     enabled: false


### PR DESCRIPTION


To avoid nginx-ingress POD OOMKilling when simply uncommenting controller requests, I propose to increase theses values since POD usage is around 70 MB when geoip is enable. Which is the case by default.

Furthermore, we enabling HPA with 50% as targetMemoryUtilizationPercentage, I think 150Mi is a reasonable value to avoid scaling to reaching MaxReplicas.

