### PR TITLE
[stable/percona-xtradb-cluster] Add tolerations labels

### DIFF
--- a/stable/percona-xtradb-cluster/Chart.yaml
+++ b/stable/percona-xtradb-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 name: percona-xtradb-cluster
-version: 0.2.0
+version: 0.3.0
 appVersion: 5.7.19
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL with Galera Replication (xtradb)

--- a/stable/percona-xtradb-cluster/README.md
+++ b/stable/percona-xtradb-cluster/README.md
@@ -66,6 +66,7 @@ The following table lists the configurable parameters of the Percona chart and t
 | `persistence.size`         | Size of persistent volume claim    | 8Gi RW                                                     |
 | `persistence.storageClass` | Type of persistent volume claim    | nil  (uses alpha storage class annotation)                 |
 | `persistence.accessMode`   | ReadWriteOnce or ReadOnly          | ReadWriteOnce                                              |
+| `tolerations`              | Node labels for pod assignment     | `[]`							|
 | `nodeSelector`             | Node labels for pod assignment     | `{}`							|
 | `podAnnotations`           | Pod annotations                    | `{}`                                                       |
 | `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                              |

--- a/stable/percona-xtradb-cluster/files/entrypoint.sh
+++ b/stable/percona-xtradb-cluster/files/entrypoint.sh
@@ -21,7 +21,7 @@ if [[ -z "${cluster_join}" ]]; then
     echo "I am the Primary Node"
     init_mysql
     write_password_file
-    exec mysqld --user=mysql --wsrep_cluster_name=$CLUSTER_NAME --wsrep_node_name=$hostname \
+    exec mysqld --user=mysql --wsrep_cluster_name=$SHORT_CLUSTER_NAME --wsrep_node_name=$hostname \
     --wsrep_cluster_address=gcomm:// --wsrep_sst_method=xtrabackup-v2 \
     --wsrep_sst_auth="xtrabackup:$XTRABACKUP_PASSWORD" \
     --wsrep_node_address="$ipaddr" $CMDARG
@@ -31,7 +31,7 @@ else
     touch /var/log/mysqld.log
     chown mysql:mysql /var/log/mysqld.log
     write_password_file
-    exec mysqld --user=mysql --wsrep_cluster_name=$CLUSTER_NAME --wsrep_node_name=$hostname \
+    exec mysqld --user=mysql --wsrep_cluster_name=$SHORT_CLUSTER_NAME --wsrep_node_name=$hostname \
     --wsrep_cluster_address="gcomm://$cluster_join" --wsrep_sst_method=xtrabackup-v2 \
     --wsrep_sst_auth="xtrabackup:$XTRABACKUP_PASSWORD" \
     --wsrep_node_address="$ipaddr" $CMDARG

--- a/stable/percona-xtradb-cluster/templates/_helpers.tpl
+++ b/stable/percona-xtradb-cluster/templates/_helpers.tpl
@@ -15,3 +15,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default "pxc" .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{/*
+Create a short cluster name in order to fulfill Percona's `wsrep_cluster_name` variable max size.
+https://www.percona.com/doc/percona-xtradb-cluster/LATEST/wsrep-system-index.html#wsrep_cluster_name
+*/}}
+{{- define "percona-xtradb-cluster.shortname" -}}
+{{- $name := default "pxc" .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 32 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/percona-xtradb-cluster/templates/statefulset.yaml
+++ b/stable/percona-xtradb-cluster/templates/statefulset.yaml
@@ -75,6 +75,8 @@ spec:
           value: {{ .Values.allowRootFrom | quote }}
         - name: CLUSTER_NAME
           value: {{ template "percona-xtradb-cluster.fullname" . }}
+        - name: SHORT_CLUSTER_NAME
+          value: {{ template "percona-xtradb-cluster.shortname" . }}
         - name: K8S_SERVICE_NAME
           value: {{ template "percona-xtradb-cluster.fullname" . }}-repl
         - name: DEBUG
@@ -156,6 +158,10 @@ spec:
       {{- if not .Values.persistence.enabled }}
       - name: mysql-data
         emptyDir: {}
+      {{- end -}}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end -}}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/stable/percona-xtradb-cluster/values.yaml
+++ b/stable/percona-xtradb-cluster/values.yaml
@@ -59,6 +59,12 @@ nodeSelector: {}
 ##
 podAnnotations: {}
 
+## Tolerations labels for pod assignment
+## Allow the scheduling on tainted nodes (requires Kubernetes >= 1.6)
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
Hi @paulczar,

I'm propossing this change to support taints and tolerations labels on new Percona XtraDB Cluster charts. More reference at: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
Thanks
