### PR TITLE
add myself as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,3 +10,4 @@ approvers:
   - unguiculus
   - scottrigby
   - mattfarina
+  - davidkarlsen


### PR DESCRIPTION
I'd like to nominate myself as an approver as I've reviewed a number of charts lately, and I'm also the owner of the cerebro chart.

Most of my later reviews can be found here: https://github.com/helm/charts/pulls/assigned/davidkarlsen
and also some PRs: https://github.com/helm/charts/pulls/davidkarlsen

My k8s membership: https://groups.google.com/d/msg/kubernetes-membership/R5JR2xYT9c4/lgLMHGdEAAAJ - my sponsors are @unguiculus and @prydonius 