### PR TITLE
stable/concourse: use the correct work dir in the container preamble

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.16.0
+version: 1.16.1
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -39,7 +39,7 @@ spec:
             - -c
             - |-
               cp /dev/null /tmp/.liveness_probe
-              rm -rf /concourse-work-dir/*
+              rm -rf ${CONCOURSE_WORK_DIR:-/concourse-work-dir}/*
               while ! concourse retire-worker --name=${HOSTNAME} | grep -q worker-not-found; do
                 touch /tmp/.pre_start_cleanup
                 sleep 5

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -111,7 +111,7 @@ spec:
               mountPath: /concourse-keys
               readOnly: true
             - name: concourse-work-dir
-              mountPath: /concourse-work-dir
+              mountPath: {{ .Values.concourse.workingDirectory | default "/concourse-work-dir" | quote }}
 {{- if .Values.worker.additionalVolumeMounts }}
 {{ toYaml .Values.worker.additionalVolumeMounts | indent 12 }}
 {{- end }}


### PR DESCRIPTION
There's a short preamble (written in shell) in the container that cleans up before the container starts. It had the work dir hard-coded, while its value has been configurable since a few chart versions.

Now it uses the same configured value.