### PR TITLE
chaoskube: bump chart version to v0.9.0

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chaoskube
-version: 0.8.1
+version: 0.9.0
 appVersion: 0.9.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube


### PR DESCRIPTION
This bumps the chart version because the last PR changed the semantics in values.yaml a little
* In https://github.com/helm/charts/pull/6579 the format of `resources` was aligned with the rest of the charts but it has been different before: users that are upgrading need to change their `values.yaml`, hence the bump.