### PR TITLE
stable/concourse: allow taking over the `concourse-work-dir` volume

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 2.1.2
+version: 2.2.0
 appVersion: 4.2.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -494,6 +494,13 @@ spec:
                 path: worker_key
               - key: worker-key-pub
                 path: worker_key.pub
+{{- define "concourse.are-there-additional-volumes.with-the-name.concourse-work-dir" }}
+  {{- range .Values.worker.additionalVolumes }}
+    {{- if .name | eq "concourse-work-dir" }}
+      {{- .name }}
+    {{- end }}
+  {{- end }}
+{{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
@@ -512,8 +519,10 @@ spec:
       {{- end }}
       {{- end }}
   {{- else }}
+      {{ if include "concourse.are-there-additional-volumes.with-the-name.concourse-work-dir" . | not }}
         - name: concourse-work-dir
           emptyDir: {}
+      {{- end }}
   {{- end }}
 {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
   updateStrategy:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -842,6 +842,15 @@ worker:
   #     hostPath:
   #       path: /dev/nvme0n1
   #       type: BlockDevice
+  #
+  # As a special exception, this allows taking over the `concourse-work-dir`
+  # volume (from the default emptyDir) if `persistence.enabled` is false:
+  #
+  # additionalVolumes:
+  #   - name: concourse-work-dir
+  #     hostPath:
+  #       path: /mnt/locally-mounted-fast-disk/concourse
+  #       type: DirectoryOrCreate
 
   ## Whether the workers should be forced to run on separate nodes.
   ## This is accomplished by setting their AntiAffinity with requiredDuringSchedulingIgnoredDuringExecution as opposed to preferred


### PR DESCRIPTION
This allows using a user-defined volume spec (set in `worker.additionalVolumes` with `name: concourse-work-dir`) instead of the default `emptyDir` when `persistence.enabled: false` is set.

It changes the behaviour in a backward-compatible way: previously using `name: concourse-work-dir` in any `worker.additionalVolumes` resulted in an error (two volumes defined with the same name), now instead of the error it will use that additionalVolume spec to back the `concourse-work-dir` volume mount (given that `persistence.enabled` is false) .