### PR TITLE
[stable/kibana] Prevent "env: Not a table" warnings

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.10.0
+version: 0.10.1
 appVersion: 6.3.1
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -6,7 +6,7 @@ image:
 commandline:
   args:
 
-env:
+env: {}
   # All Kibana configuration options are adjustable via env vars.
   # To adjust a config option to an env var uppercase + replace `.` with `_`
   # Ref: https://www.elastic.co/guide/en/kibana/current/settings.html


### PR DESCRIPTION
Set the default value of `env` to `{}` to avoid errors like the following, when using Kibana as a subchart.

```
2018/08/07 10:39:27 warning: skipped value for env: Not a table.
2018/08/07 10:39:27 warning: skipped value for env: Not a table.
2018/08/07 10:39:27 warning: skipped value for env: Not a table.
2018/08/07 10:39:27 warning: skipped value for env: Not a table.
```