### PR TITLE
[stable/percona] Add support for nodeSelector and tolerations labels

### DIFF
--- a/stable/percona/Chart.yaml
+++ b/stable/percona/Chart.yaml
@@ -1,5 +1,5 @@
 name: percona
-version: 0.3.2
+version: 0.3.3
 appVersion: 5.7.17
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL
@@ -14,6 +14,6 @@ sources:
 - https://github.com/kubernetes/charts
 - https://github.com/docker-library/percona
 maintainers:
-- name: Patrick Galbraith
+- name: CaptTofu
   email: patg@patg.net
 engine: gotpl

--- a/stable/percona/README.md
+++ b/stable/percona/README.md
@@ -1,4 +1,4 @@
-# Percona 
+# Percona
 
 [Percona Server](https://MySQL.org) for MySQL® is a free, fully compatible, enhanced, open source drop-in replacement for MySQL that provides superior performance, scalability and instrumentation. With over 3,000,000 downloads, Percona Server for MySQL's self-tuning algorithms and support for extremely high-performance hardware delivers excellent performance and reliability. 
 
@@ -59,6 +59,8 @@ The following table lists the configurable parameters of the Percona chart and t
 | `persistence.storageClass` | Type of persistent volume claim    | nil  (uses alpha storage class annotation)                 |
 | `persistence.accessMode`   | ReadWriteOnce or ReadOnly          | ReadWriteOnce                                              |
 | `resources`                | CPU/Memory resource requests/limits | Memory: `256Mi`, CPU: `100m`                              |
+| `nodeSelector`             | Node labels for pod assignment     | `{}`							|
+| `tolerations`              | Node labels for pod assignment     | `[]`							|
 
 Some of the parameters above map to the env variables defined in the [Percona Server DockerHub image](https://hub.docker.com/_/percona/).
 

--- a/stable/percona/templates/deployment.yaml
+++ b/stable/percona/templates/deployment.yaml
@@ -15,9 +15,9 @@ spec:
     spec:
       initContainers:
       - name: "remove-lost-found"
-        image: "busybox:1.25.0" 
+        image: "busybox:1.25.0"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-        command: 
+        command:
         - "rm"
         - "-fr"
         - "/var/lib/mysql/lost+found"
@@ -77,4 +77,12 @@ spec:
           claimName: {{ template "percona.fullname" . }}
       {{- else }}
         emptyDir: {}
+      {{- end -}}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end -}}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end -}}

--- a/stable/percona/values.yaml
+++ b/stable/percona/values.yaml
@@ -48,3 +48,14 @@ resources:
   requests:
     memory: 256Mi
     cpu: 100m
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations labels for pod assignment
+## Allow the scheduling on tainted nodes (requires Kubernetes >= 1.6)
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []


### PR DESCRIPTION
Hi @CaptTofu:

This PR adds support for the following scheduling labels:

- nodeSelector:
  https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
- tolerations:
  https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

These couple of labels will allow custom pods scheduling depending on
specified labels. By default, both labels will be empty.