### PR TITLE
[nginx-ingress] add support for defining a prometheus service monitor

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.24.0
+version: 0.25.0
 appVersion: 0.17.1
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/service-monitor.yaml
+++ b/stable/nginx-ingress/templates/service-monitor.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.prometheus.operator.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.prometheus.operator.serviceMonitor.selector }}
+{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+{{- end }}
+  name: {{ template "nginx-ingress.fullname" . }}
+  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+spec:
+  jobLabel: {{ template "nginx-ingress.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      interval: 15s
+{{- end -}}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -372,3 +372,17 @@ tcp: {}
 ##
 udp: {}
 #  53: "kube-system/kube-dns:53"
+
+prometheus:
+  operator:
+    enabled: false
+
+    serviceMonitor:
+      # Namespace Prometheus is installed in
+      namespace: kube-system
+
+      ## Defaults to whats used if you follow CoreOS [Prometheus Install Instructions](https://github.com/coreos/prometheus-operator/tree/master/helm#tldr)
+      ## [Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus/templates/prometheus.yaml#L65)
+      ## [Kube Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/kube-prometheus/values.yaml#L298)
+      selector:
+        prometheus: kube-prometheus


### PR DESCRIPTION
Users of nginx-ingress may wish to monitor it using prometheus.

The prometheus operator gives us new CRDs for specifying targets.
This PR adds support to conditionally enable prometheus monitoring
for nginx-ingress using prometheus operator.

@jackzampolin @mgoodness @chancez let me know what you think.

Signed-off-by: Ian Duffy <ian.duffy@shipyardtech.com>
