### PR TITLE
[stable/redis] fix cluster-less mode

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.7.5
+version: 3.7.6
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-svc.yaml
+++ b/stable/redis/templates/redis-master-svc.yaml
@@ -24,6 +24,4 @@ spec:
   selector:
     app: {{ template "redis.name" . }}
     release: "{{ .Release.Name }}"
-    {{- if .Values.cluster.enabled }}
     role: master
-    {{- end }}


### PR DESCRIPTION
## what
bring back role selector to redis-master-svc

## why
If `cluster.enabled` has value 'false' and `metrics.enabled` has value `true` then redis-master service selects both pods (master one and metrics one)

