### PR TITLE
[stable/gocd] Add support for SSH keys on server and agent (New PR Cr…

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.3.0
+
+* [750de42c](https://github.com/kubernetes/charts/commit/750de42c):  Add support for SSH keys on server and agent
+
 ### 1.2.0
 
 * [514a1856](https://github.com/kubernetes/charts/commit/514a1856):  Bump up GoCD app version to 18.7.0

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.2.1
+version: 1.3.0
 appVersion: 18.7.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -89,6 +89,8 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | `server.healthCheck.initialDelaySeconds`   | Initial delays in seconds to start the health checks. **Note**:GoCD server start up time.                     | `90`                |
 | `server.healthCheck.periodSeconds`         | GoCD server health check interval period.                                                                      | `15`                |
 | `server.healthCheck.failureThreshold`      | Number of unsuccessful attempts made to the GoCD server health check endpoint before restarting.              | `10`                |
+| `server.security.ssh.enabled`              | Enable the use of SSH keys for GoCD server                                                                    | `false`             |
+| `server.security.ssh.secretName`           | The name of the secret holding the SSH keys                                                                   | `gocd-server-ssh`   |
 
 #### Preconfiguring the GoCD Server
 
@@ -130,6 +132,21 @@ The cases when the attempt to preconfigure the GoCD server fails:
 1. The service account token mounted as a secret for the GoCD server pod does not have sufficient permissions. The API call to configure the plugin settings will fail.
 2. If the GoCD server is started with an existing configuration with security configured, then the API calls in the preconfigure script will fail. 
 
+#### SSH keys
+For accessing repositories over SSH in GoCD server, you need to add SSH keys to the GoCD server.
+Generate a new keypair, fetch the host key for the [host] you want to connect to and create the secret.
+The secret is structured to hold the entire contents of the .ssh folder on the GoCD server.
+
+ ```bash
+$ ssh-keygen -t rsa -b 4096 -C "user@example.com" -f gocd-server-ssh -P ''
+$ ssh-keyscan [host] > gocd_known_hosts
+$ kubectl create secret generic gocd-server-ssh \
+    --from-file=id_rsa=gocd-server-ssh \
+    --from-file=id_rsa.pub=gocd-server-ssh.pub \
+    --from-file=known_hosts=gocd_known_hosts
+```
+ The last step is to copy the key over to the host, so GoCD server can connect.
+
 ### GoCD Agent
 
 | Parameter                                 | Description                                                                                                                                                                      | Default                      |
@@ -151,6 +168,8 @@ The cases when the attempt to preconfigure the GoCD server fails:
 | `agent.healthCheck.initialDelaySeconds`   | GoCD agent start up time.                                                                                                                                                        | `60`                         |
 | `agent.healthCheck.periodSeconds`         | GoCD agent health check interval period.                                                                                                                                          | `60`                         |
 | `agent.healthCheck.failureThreshold`      | GoCD agent health check failure threshold. Number of unsuccessful attempts made to the GoCD server health check endpoint before restarting.                                       | `60`                         |
+| `agent.security.ssh.enabled`              | Enable the use of SSH keys for GoCD agent                                                                                                                                        | `false`                      |
+| `agent.security.ssh.secretName`           | The name of the secret holding the SSH keys                                                                                                                                      | `gocd-agent-ssh`             |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -162,6 +181,20 @@ $ helm install --namespace gocd --name gocd-app -f values.yaml stable/gocd
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+#### SSH keys
+For accessing repositories over SSH in GoCD agent, you need to add SSH keys to the GoCD agent.
+Generate a new keypair, fetch the host key for the [host] you want to connect to and create the secret.
+The secret is structured to hold the entire contents of the .ssh folder on the GoCD agent.
+
+ ```bash
+$ ssh-keygen -t rsa -b 4096 -C "user@example.com" -f gocd-agent-ssh -P ''
+$ ssh-keyscan [host] > gocd_known_hosts
+$ kubectl create secret generic gocd-agent-ssh \
+    --from-file=id_rsa=gocd-agent-ssh \
+    --from-file=id_rsa.pub=gocd-agent-ssh.pub \
+    --from-file=known_hosts=gocd_known_hosts
+```
+ The last step is to copy the key over to the host, so GoCD agent can connect.
 
 ## Persistence
 
@@ -223,28 +256,6 @@ $ helm install --name gocd-app --set server.persistence.existingClaim=PVC_NAME s
 
 1. That packages being cached here is shared between all the agents.
 2. That all the agents sharing this directory are privy to all the secrets in `/home/go`
-
-## SSH keys
-For accessing repositories over SSH, you need to add SSH keys to the server and the agent.
-Generate a new keypair, fetch the host key for the [host] you want to connect to and create the secret.
-The secret is structured to hold the entire contents of the .ssh folder on the GoCD server and agent.
- ```bash
-$ ssh-keygen -t rsa -b 4096 -C "user@example.com" -f gocd-ssh -P ''
-$ ssh-keyscan [host] > gocd_known_hosts
-$ kubectl create secret generic gocd-ssh \
-    --from-file=id_rsa=gocd-ssh \
-    --from-file=id_rsa.pub=gocd-ssh.pub \
-    --from-file=known_hosts=gocd_known_hosts
-```
- The last step is to copy the key over to the host, so GoCD can connect.
-
-### SSH key configuration parameters
- | Parameter                                     | Description                                         | Default              |
-| --------------------------------------------- | --------------------------------------------------- | -------------------- |
-| `server.security.ssh.enabled`                 | Enable the use of SSH keys for GoCD server          | `false`              |
-| `server.security.ssh.secretName`              | The name of the secret holding the SSH keys         | `gocd-ssh`           |
-| `agent.security.ssh.enabled`                  | Enable the use of SSH keys for GoCD agent           | `false`              |
-| `agent.security.ssh.secretName`               | The name of the secret holding the SSH keys         | `gocd-ssh`           |
 
 ## RBAC and Service Accounts
 

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -217,6 +217,13 @@ $ helm install --name gocd-app --set server.persistence.existingClaim=PVC_NAME s
 | `agent.persistence.subpath.homego`            | The /home/go path on Persistence Volume              | `homego`             |
 | `agent.persistence.subpath.dockerEntryPoint`  | The /docker-entrypoint.d path on Persistence Volume  | `scripts`            |
 
+##### Note:
+
+`/home/go` directory shared between multiple agents implies:
+
+1. That packages being cached here is shared between all the agents.
+2. That all the agents sharing this directory are privy to all the secrets in `/home/go`
+
 ## SSH keys
 For accessing repositories over SSH, you need to add SSH keys to the server and the agent.
 Generate a new keypair, fetch the host key for the [host] you want to connect to and create the secret.
@@ -225,8 +232,8 @@ The secret is structured to hold the entire contents of the .ssh folder on the G
 $ ssh-keygen -t rsa -b 4096 -C "user@example.com" -f gocd-ssh -P ''
 $ ssh-keyscan [host] > gocd_known_hosts
 $ kubectl create secret generic gocd-ssh \
-    --from-file=id-rsa=gocd-ssh \
-    --from-file=id-rsa.pub=gocd-ssh.pub \
+    --from-file=id_rsa=gocd-ssh \
+    --from-file=id_rsa.pub=gocd-ssh.pub \
     --from-file=known_hosts=gocd_known_hosts
 ```
  The last step is to copy the key over to the host, so GoCD can connect.
@@ -234,15 +241,10 @@ $ kubectl create secret generic gocd-ssh \
 ### SSH key configuration parameters
  | Parameter                                     | Description                                         | Default              |
 | --------------------------------------------- | --------------------------------------------------- | -------------------- |
-| `security.ssh.enabled`                        | Enable the use of SSH keys for GoCD agent/server    | `false`              |
-| `security.ssh.secretName`                     | The name of the secret holding the SSH keys         | `gocd-ssh`           |
-
-##### Note:
-
-`/home/go` directory shared between multiple agents implies:
-
-1. That packages being cached here is shared between all the agents.
-2. That all the agents sharing this directory are privy to all the secrets in `/home/go`
+| `server.security.ssh.enabled`                 | Enable the use of SSH keys for GoCD server          | `false`              |
+| `server.security.ssh.secretName`              | The name of the secret holding the SSH keys         | `gocd-ssh`           |
+| `agent.security.ssh.enabled`                  | Enable the use of SSH keys for GoCD agent           | `false`              |
+| `agent.security.ssh.secretName`               | The name of the secret holding the SSH keys         | `gocd-ssh`           |
 
 ## RBAC and Service Accounts
 

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -217,6 +217,26 @@ $ helm install --name gocd-app --set server.persistence.existingClaim=PVC_NAME s
 | `agent.persistence.subpath.homego`            | The /home/go path on Persistence Volume              | `homego`             |
 | `agent.persistence.subpath.dockerEntryPoint`  | The /docker-entrypoint.d path on Persistence Volume  | `scripts`            |
 
+## SSH keys
+For accessing repositories over SSH, you need to add SSH keys to the server and the agent.
+Generate a new keypair, fetch the host key for the [host] you want to connect to and create the secret.
+The secret is structured to hold the entire contents of the .ssh folder on the GoCD server and agent.
+ ```bash
+$ ssh-keygen -t rsa -b 4096 -C "user@example.com" -f gocd-ssh -P ''
+$ ssh-keyscan [host] > gocd_known_hosts
+$ kubectl create secret generic gocd-ssh \
+    --from-file=id-rsa=gocd-ssh \
+    --from-file=id-rsa.pub=gocd-ssh.pub \
+    --from-file=known_hosts=gocd_known_hosts
+```
+ The last step is to copy the key over to the host, so GoCD can connect.
+
+### SSH key configuration parameters
+ | Parameter                                     | Description                                         | Default              |
+| --------------------------------------------- | --------------------------------------------------- | -------------------- |
+| `security.ssh.enabled`                        | Enable the use of SSH keys for GoCD agent/server    | `false`              |
+| `security.ssh.secretName`                     | The name of the secret holding the SSH keys         | `gocd-ssh`           |
+
 ##### Note:
 
 `/home/go` directory shared between multiple agents implies:

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         release: {{ .Release.Name | quote }}
         component: agent
     spec:
-      {{- if or .Values.agent.persistence.enabled .Values.security.ssh.enabled }}
+      {{- if or .Values.agent.persistence.enabled .Values.agent.security.ssh.enabled }}
       volumes:
       {{- end }}
       {{- if .Values.agent.persistence.enabled }}
@@ -30,10 +30,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.agent.persistence.existingClaim | default (printf "%s-%s" (include "gocd.fullname" .) "agent")  }}
       {{- end }}
-      {{- if .Values.security.ssh.enabled }}
+      {{- if .Values.agent.security.ssh.enabled }}
         - name: ssh-secrets
           secret:
-            secretName: {{ .Values.security.ssh.secretName }}
+            secretName: {{ .Values.agent.security.ssh.secretName }}
       {{- end }}
       containers:
         - name: {{ template "gocd.name" . }}-agent
@@ -95,7 +95,7 @@ spec:
               port: 8152
             initialDelaySeconds: {{ .Values.agent.healthCheck.initialDelaySeconds }}
           {{- end }}
-          {{- if or .Values.agent.persistence.enabled .Values.security.ssh.enabled }}
+          {{- if or .Values.agent.persistence.enabled .Values.agent.security.ssh.enabled }}
           volumeMounts:
           {{- end }}
           {{- if .Values.agent.persistence.enabled }}
@@ -106,7 +106,7 @@ spec:
               mountPath: /docker-entrypoint.d
               subPath: {{ .Values.agent.persistence.subpath.dockerEntryPoint }}
           {{- end }}
-          {{- if .Values.security.ssh.enabled }}
+          {{- if .Values.agent.security.ssh.enabled }}
             - name: ssh-secrets
               readOnly: true
               mountPath: /home/go/.ssh

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -22,11 +22,18 @@ spec:
         release: {{ .Release.Name | quote }}
         component: agent
     spec:
-      {{- if .Values.agent.persistence.enabled }}
+      {{- if or .Values.agent.persistence.enabled .Values.security.ssh.enabled }}
       volumes:
+      {{- end }}
+      {{- if .Values.agent.persistence.enabled }}
         - name: goagent-vol
           persistentVolumeClaim:
             claimName: {{ .Values.agent.persistence.existingClaim | default (printf "%s-%s" (include "gocd.fullname" .) "agent")  }}
+      {{- end }}
+      {{- if .Values.security.ssh.enabled }}
+        - name: ssh-secrets
+          secret:
+            secretName: {{ .Values.security.ssh.secretName }}
       {{- end }}
       containers:
         - name: {{ template "gocd.name" . }}-agent
@@ -88,14 +95,21 @@ spec:
               port: 8152
             initialDelaySeconds: {{ .Values.agent.healthCheck.initialDelaySeconds }}
           {{- end }}
-          {{- if .Values.agent.persistence.enabled }}
+          {{- if or .Values.agent.persistence.enabled .Values.security.ssh.enabled }}
           volumeMounts:
+          {{- end }}
+          {{- if .Values.agent.persistence.enabled }}
             - name: goagent-vol
               mountPath: /home/go
               subPath: {{ .Values.agent.persistence.subpath.homego }}
             - name: goagent-vol
               mountPath: /docker-entrypoint.d
               subPath: {{ .Values.agent.persistence.subpath.dockerEntryPoint }}
+          {{- end }}
+          {{- if .Values.security.ssh.enabled }}
+            - name: ssh-secrets
+              readOnly: true
+              mountPath: /home/go/.ssh
           {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         component: server
     spec:
       serviceAccountName: {{ template "gocd.serviceAccountName" . }}
-      {{- if or .Values.server.persistence.enabled .Values.security.ssh.enabled }}
+      {{- if or .Values.server.persistence.enabled .Values.server.security.ssh.enabled }}
       volumes:
       {{- end }}
       {{- if .Values.server.persistence.enabled }}
@@ -37,10 +37,10 @@ spec:
           configMap:
             name: {{ template "gocd.fullname" . }}
       {{- end }}
-      {{- if .Values.security.ssh.enabled }}
+      {{- if .Values.server.security.ssh.enabled }}
         - name: ssh-secrets
           secret:
-            secretName: {{ .Values.security.ssh.secretName }}
+            secretName: {{ .Values.server.security.ssh.secretName }}
       {{- end }}
       containers:
         - name: {{ template "gocd.name" . }}-server
@@ -75,7 +75,7 @@ spec:
             initialDelaySeconds: {{ .Values.server.healthCheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.healthCheck.periodSeconds }}
             failureThreshold: {{ .Values.server.healthCheck.failureThreshold }}
-          {{- if or .Values.server.persistence.enabled .Values.security.ssh.enabled }}
+          {{- if or .Values.server.persistence.enabled .Values.server.security.ssh.enabled }}
           volumeMounts:
           {{- end }}
           {{- if .Values.server.persistence.enabled }}
@@ -92,7 +92,7 @@ spec:
               mountPath: /preconfigure_server.sh
               subPath: preconfigure_server.sh
           {{- end }}
-          {{- if .Values.security.ssh.enabled }}
+          {{- if .Values.server.security.ssh.enabled }}
             - name: ssh-secrets
               readOnly: true
               mountPath: /home/go/.ssh

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -26,14 +26,21 @@ spec:
         component: server
     spec:
       serviceAccountName: {{ template "gocd.serviceAccountName" . }}
-      {{- if .Values.server.persistence.enabled }}
+      {{- if or .Values.server.persistence.enabled .Values.security.ssh.enabled }}
       volumes:
+      {{- end }}
+      {{- if .Values.server.persistence.enabled }}
         - name: goserver-vol
           persistentVolumeClaim:
             claimName: {{ .Values.server.persistence.existingClaim | default (printf "%s-%s" (include "gocd.fullname" .) "server") }}
         - name: config-vol
           configMap:
             name: {{ template "gocd.fullname" . }}
+      {{- end }}
+      {{- if .Values.security.ssh.enabled }}
+        - name: ssh-secrets
+          secret:
+            secretName: {{ .Values.security.ssh.secretName }}
       {{- end }}
       containers:
         - name: {{ template "gocd.name" . }}-server
@@ -68,8 +75,10 @@ spec:
             initialDelaySeconds: {{ .Values.server.healthCheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.healthCheck.periodSeconds }}
             failureThreshold: {{ .Values.server.healthCheck.failureThreshold }}
-          {{- if .Values.server.persistence.enabled }}
+          {{- if or .Values.server.persistence.enabled .Values.security.ssh.enabled }}
           volumeMounts:
+          {{- end }}
+          {{- if .Values.server.persistence.enabled }}
             - name: goserver-vol
               mountPath: /godata
               subPath: {{ .Values.server.persistence.subpath.godata }}
@@ -82,6 +91,11 @@ spec:
             - name: config-vol
               mountPath: /preconfigure_server.sh
               subPath: preconfigure_server.sh
+          {{- end }}
+          {{- if .Values.security.ssh.enabled }}
+            - name: ssh-secrets
+              readOnly: true
+              mountPath: /home/go/.ssh
           {{- end }}
           {{- if .Values.server.shouldPreconfigure }}
           lifecycle:

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -129,6 +129,13 @@ server:
       # custom entrypoint scripts that should be run before starting the GoCD server inside the container.
       dockerEntryPoint: scripts
 
+  security:
+    ssh:
+      # server.security.ssh.enabled is the toggle to enable/disable mounting of ssh secret on GoCD server pods
+      enabled: false
+      # server.security.ssh.secretName specifies the name of the k8s secret object that contains the ssh key and known hosts
+      secretName: gocd-ssh
+
 agent:
   # agent.replicaCount is the GoCD Agent replicas Count. Specify the number of GoCD agents to run
   replicaCount: 0
@@ -188,6 +195,13 @@ agent:
     # agent.healthCheck.failureThreshold is the health check failure threshold of GoCD agent
     failureThreshold: 60
 
+  security:
+    ssh:
+      # agent.security.ssh.enabled is the toggle to enable/disable mounting of ssh secret on GoCD agent pods
+      enabled: false
+      # agent.security.ssh.secretName specifies the name of the k8s secret object that contains the ssh key and known hosts
+      secretName: gocd-ssh
+
   ## Configure GoCD agent resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -202,10 +216,3 @@ agent:
   ## Additional GoCD agent pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   nodeSelector: {}
-
-security:
-  ssh:
-    # security.ssh.enabled is the toggle to enable/disable mounting of ssh secret on GoCD server and agent pods
-    enabled: false
-    # security.ssh.secretName specifies the name of the k8s secret object that contains the ssh key and known hosts
-    secretName: gocd-ssh

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -134,7 +134,7 @@ server:
       # server.security.ssh.enabled is the toggle to enable/disable mounting of ssh secret on GoCD server pods
       enabled: false
       # server.security.ssh.secretName specifies the name of the k8s secret object that contains the ssh key and known hosts
-      secretName: gocd-ssh
+      secretName: gocd-server-ssh
 
 agent:
   # agent.replicaCount is the GoCD Agent replicas Count. Specify the number of GoCD agents to run
@@ -200,7 +200,7 @@ agent:
       # agent.security.ssh.enabled is the toggle to enable/disable mounting of ssh secret on GoCD agent pods
       enabled: false
       # agent.security.ssh.secretName specifies the name of the k8s secret object that contains the ssh key and known hosts
-      secretName: gocd-ssh
+      secretName: gocd-agent-ssh
 
   ## Configure GoCD agent resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -202,3 +202,10 @@ agent:
   ## Additional GoCD agent pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   nodeSelector: {}
+
+security:
+  ssh:
+    # security.ssh.enabled is the toggle to enable/disable mounting of ssh secret on GoCD server and agent pods
+    enabled: false
+    # security.ssh.secretName specifies the name of the k8s secret object that contains the ssh key and known hosts
+    secretName: gocd-ssh


### PR DESCRIPTION

This PR contains changes done in PR #4270 originally raised by @or1can inorder to add support for setting SSH keys on the gocd server and agent. Creating a new PR as PR #4270 ran into some commit issues and it would be super useful for many to get these changes merged at the earliest.