### PR TITLE
Make mariadb's service supports NodePort mode

### DIFF
--- a/stable/mariadb/templates/master-svc.yaml
+++ b/stable/mariadb/templates/master-svc.yaml
@@ -13,11 +13,16 @@ metadata:
 {{ toYaml .Values.metrics.annotations | indent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.master.service.type }}
   ports:
   - name: mysql
-    port: {{ .Values.service.port }}
+    port: {{ .Values.master.service.port }}
+{{- if eq .Values.master.service.type "ClusterIP" }}
     targetPort: mysql
+{{- end }}
+{{- if eq .Values.master.service.type "NodePort" }}
+    nodePort: {{ .Values.master.service.nodePort }}
+{{- end }}
 {{- if .Values.metrics.enabled }}
   - name: metrics
     port: 9104

--- a/stable/mariadb/templates/slave-svc.yaml
+++ b/stable/mariadb/templates/slave-svc.yaml
@@ -14,11 +14,16 @@ metadata:
 {{ toYaml .Values.metrics.annotations | indent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.slave.service.type }}
   ports:
   - name: mysql
-    port: {{ .Values.service.port }}
+    port: {{ .Values.slave.service.port }}
+{{- if eq .Values.slave.service.type "ClusterIP" }}
     targetPort: mysql
+{{- end }}
+{{- if eq .Values.slave.service.type "NodePort" }}
+    nodePort: {{ .Values.slave.service.nodePort }}
+{{- end }}
 {{- if .Values.metrics.enabled }}
   - name: metrics
     port: 9104


### PR DESCRIPTION
In my case, the MariaDB which is deployed on kubernetes is going to be used by apps out of kubernetes, so I did such things to achieve that goal:

- Move `service` to each of master and slave's configure content (master and slaves use different external ports)
- Add new service type: NodePort
