### PR TITLE
Make mariadb's service supports NodePort mode

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 4.3.2
+version: 4.3.3
 appVersion: 10.1.35
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/master-svc.yaml
+++ b/stable/mariadb/templates/master-svc.yaml
@@ -18,6 +18,13 @@ spec:
   - name: mysql
     port: {{ .Values.service.port }}
     targetPort: mysql
+{{- if eq .Values.service.type "NodePort" }}
+{{- if .Values.service.nodePort }}
+{{- if .Values.service.nodePort.master }}
+    nodePort: {{ .Values.service.nodePort.master }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- if .Values.metrics.enabled }}
   - name: metrics
     port: 9104

--- a/stable/mariadb/templates/slave-svc.yaml
+++ b/stable/mariadb/templates/slave-svc.yaml
@@ -19,6 +19,13 @@ spec:
   - name: mysql
     port: {{ .Values.service.port }}
     targetPort: mysql
+{{- if (eq .Values.service.type "NodePort") }}
+{{- if .Values.service.nodePort }}
+{{- if .Values.service.nodePort.slave }}
+    nodePort: {{ .Values.service.nodePort.slave }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- if .Values.metrics.enabled }}
   - name: metrics
     port: 9104

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -18,9 +18,15 @@ image:
   #   - myRegistrKeySecretName
 
 service:
-  ## Kubernetes service type
+  ## Kubernetes service type, ClusterIP and NodePort are supported at present
   type: ClusterIP
   port: 3306
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  #   master: 30001
+  #   slave: 30002
 
 rootUser:
   ## MariaDB admin password

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -18,9 +18,15 @@ image:
   #   - myRegistrKeySecretName
 
 service:
-  ## Kubernetes service type
+  ## Kubernetes service type, ClusterIP and NodePort are supported at present
   type: ClusterIP
   port: 3306
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  #   master: 30001
+  #   slave: 30002
 
 rootUser:
   ## MariaDB admin password


### PR DESCRIPTION
In my case, the MariaDB which is deployed on kubernetes is going to be used by apps outside kubernetes, so I did such things to achieve the goal:

- Move `service` to each of master and slave's config content
- Add new service type: `NodePort`
- Update `NOTES.txt`
- Update `values.yaml` and `values-production.yaml`