### PR TITLE
[stable/mongodb] replicaset.useHostnames option

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 4.0.6
+version: 4.1.0
 appVersion: 4.0.1
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `port`                                  | MongoDB service port                                                                         | `27017`                                                  |
 | `replicaSet.enabled`                    | Switch to enable/disable replica set configuration                                           | `false`                                                  |
 | `replicaSet.name`                       | Name of the replica set                                                                      | `rs0`                                                    |
+| `replicaSet.useHostnames`               | Enable DNS hostnames in the replica set config                                               | `true` |
 | `replicaSet.key`                        | Key used for authentication in the replica set                                               | `nil`                                                    |
 | `replicaSet.replicas.secondary`         | Number of secondary nodes in the replica set                                                 | `1`                                                      |
 | `replicaSet.replicas.arbiter`           | Number of arbiter nodes in the replica set                                                   | `1`                                                      |

--- a/stable/mongodb/templates/secrets.yaml
+++ b/stable/mongodb/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{ if or .Values.usePassword .Values.mongodbPassword -}}
+{{ if and .Values.usePassword (not .Values.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -48,12 +48,20 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          - name: MONGODB_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: MONGODB_REPLICA_SET_MODE
             value: "arbiter"
           - name: MONGODB_PRIMARY_HOST
-            value: {{ template "mongodb.fullname" . }} 
+            value: {{ template "mongodb.fullname" . }}
           - name: MONGODB_REPLICA_SET_NAME
             value: {{ .Values.replicaSet.name | quote }}
+            {{- if .Values.replicaSet.useHostnames }}
+          - name: MONGODB_ADVERTISED_HOSTNAME
+            value: "$(MONGODB_POD_NAME).{{ template "mongodb.fullname" . }}-headless.{{ .Release.Namespace }}"
+            {{- end }}
             {{- if .Values.usePassword }}
           - name: MONGODB_PRIMARY_ROOT_PASSWORD
             valueFrom:

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -48,10 +48,18 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          - name: MONGODB_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: MONGODB_REPLICA_SET_MODE
             value: "primary"
           - name: MONGODB_REPLICA_SET_NAME
             value: {{ .Values.replicaSet.name | quote }}
+            {{- if .Values.replicaSet.useHostnames }}
+          - name: MONGODB_ADVERTISED_HOSTNAME
+            value: "$(MONGODB_POD_NAME).{{ template "mongodb.fullname" . }}-headless.{{ .Release.Namespace }}"
+            {{- end }}
           - name: MONGODB_USERNAME
             value: {{ .Values.mongodbUsername | quote }}
           - name: MONGODB_DATABASE

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -49,12 +49,20 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          - name: MONGODB_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: MONGODB_REPLICA_SET_MODE
             value: "secondary"
           - name: MONGODB_PRIMARY_HOST
-            value: {{ template "mongodb.fullname" . }} 
+            value: {{ template "mongodb.fullname" . }}
           - name: MONGODB_REPLICA_SET_NAME
             value: {{ .Values.replicaSet.name | quote }}
+            {{- if .Values.replicaSet.useHostnames }}
+          - name: MONGODB_ADVERTISED_HOSTNAME
+            value: "$(MONGODB_POD_NAME).{{ template "mongodb.fullname" . }}-headless.{{ .Release.Namespace }}"
+            {{- end }}
             {{- if .Values.usePassword }}
           - name: MONGODB_PRIMARY_ROOT_PASSWORD
             valueFrom:

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -66,9 +66,14 @@ service:
   # nodePort:
 
 
+## Setting up replication
+## ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
+#
 replicaSet:
   ## Whether to create a MongoDB replica set for high availability or not
   enabled: true
+  useHostnames: true
+
   ## Name of the replica set
   ##
   name: rs0

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -65,10 +65,14 @@ service:
   ##
   # nodePort:
 
-
+## Setting up replication
+## ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
+#
 replicaSet:
   ## Whether to create a MongoDB replica set for high availability or not
   enabled: false
+  useHostnames: true
+
   ## Name of the replica set
   ##
   name: rs0


### PR DESCRIPTION
Added option to use bitnami `MONGODB_ADVERTISED_HOSTNAME` environment variable, it's enabled by default.