### PR TITLE
[stable/memcached]: Set pdbMinAvailable < replicaCount

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 2.2.1
+version: 2.2.2
 appVersion: 1.5.6
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -14,7 +14,9 @@ image: memcached:1.5.6-alpine
 replicaCount: 3
 
 ## Pod disruption budget minAvailable count
-pdbMinAvailable: 3
+## Ensure this value is lower than replicaCount in order to allow a worker
+## node to drain successfully
+pdbMinAvailable: 2
 
 ## Select AntiAffinity as either hard or soft, default is hard
 AntiAffinity: "hard"


### PR DESCRIPTION
When pdbMinAvailable == replicaCount, it will not be possible for Kubernetes
to drain any node which is hosting a memcached pod, as the PodDisruptionPolicy
will forbid Kubernetes from ejecting the pod and rescheduling it elsewhere.