### PR TITLE
[stable/rabbitmq] Add log file location

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 2.1.2
+version: 2.1.3
 appVersion: 3.7.7
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 2.1.3
+version: 2.2.1
 appVersion: 3.7.7
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `rabbitmq.diskFreeLimit`    | Disk free limit                                         | `"6GiB"`                                                 |
 | `rabbitmq.plugins`         | configuration file for plugins to enable                 | `[rabbitmq_management,rabbitmq_peer_discovery_k8s].`  |
 | `rabbitmq.configuration`    | rabbitmq.conf content                                   | see values.yaml                                                 |
+| `rabbitmq.logFileLocation`  | Log File Location                                       | `nil`                                                    |
 | `serviceType`               | Kubernetes Service type                                 | `ClusterIP`                                              |
 | `persistence.enabled`       | Use a PVC to persist data                               | `false`                                                   |
 | `persistence.storageClass`  | Storage class of backing PVC                            | `nil` (uses alpha storage class annotation)              |

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -114,6 +114,10 @@ spec:
           - name: NAMI_DEBUG
             value: 1
         {{- end }}
+        {{- if .Values.rabbitmq.logFileLocation}}
+          - name: RABBITMQ_LOGS
+            value: "{{ .Values.rabbitmq.logFileLocation }}"
+        {{- end}}
           - name: MY_POD_IP
             valueFrom:
               fieldRef:

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -65,6 +65,11 @@ rabbitmq:
   ##
   diskFreeLimit: '"6GiB"'
 
+  ## RabbitMQ Log File Location
+  ## ref: https://www.rabbitmq.com/logging.html#log-file-location
+  ##
+  # logFileLocation: "-"
+
   ## Plugins to enable
   plugins: |-
       [rabbitmq_management,rabbitmq_peer_discovery_k8s].

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -64,6 +64,11 @@ rabbitmq:
   ##
   diskFreeLimit: '"6GiB"'
 
+  ## RabbitMQ Log File Location
+  ## ref: https://www.rabbitmq.com/logging.html#log-file-location
+  ##
+  # logFileLocation: "-"
+
   ## Plugins to enable
   plugins: |-
       [rabbitmq_management, rabbitmq_peer_discovery_k8s].


### PR DESCRIPTION
**What this PR does / why we need it**:

Default configuration send logs to:

```
  ##  ##
  ##  ##      RabbitMQ 3.7.7. Copyright (C) 2007-2018 Pivotal Software, Inc.
  ##########  Licensed under the MPL.  See http://www.rabbitmq.com/
  ######  ##
  ##########  Logs: /opt/bitnami/rabbitmq/var/log/rabbitmq/rabbit@10.0.1.8.log
                    /opt/bitnami/rabbitmq/var/log/rabbitmq/rabbit@10.0.1.8_upgrade.log
```

Log file location (`logFileLocation: "-"`) can help sends logs to stdout:

```
  ##  ##
  ##  ##      RabbitMQ 3.7.7. Copyright (C) 2007-2018 Pivotal Software, Inc.
  ##########  Licensed under the MPL.  See http://www.rabbitmq.com/
  ######  ##
  ##########  Logs: <stdout>
```

**Special notes for your reviewer**:

Log file location (`logFileLocation`) disabled by default.
