### PR TITLE
[stable/traefik] Fix compress option identation when proxy protocol i…

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.38.0
+version: 1.38.1
 appVersion: 1.6.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -29,6 +29,7 @@ data:
     [entryPoints]
       [entryPoints.http]
       address = ":80"
+      compress = {{ .Values.gzip.enabled }}
       {{- if .Values.whiteListSourceRange }}
       {{ template "traefik.whiteListSourceRange" . }}
       {{- end }}
@@ -36,7 +37,6 @@ data:
         [entryPoints.http.proxyProtocol]
         {{ template "traefik.trustedips" . }}
       {{- end }}
-      compress = {{ .Values.gzip.enabled }}
         {{- if .Values.ssl.enforced }}
         [entryPoints.http.redirect]
           regex = "^http://(.*)"
@@ -48,11 +48,11 @@ data:
       {{ template "traefik.whiteListSourceRange" . }}
       {{- end }}
       address = ":443"
+      compress = {{ .Values.gzip.enabled }}
       {{- if .Values.proxyProtocol.enabled }}
         [entryPoints.https.proxyProtocol]
         {{ template "traefik.trustedips" . }}
       {{- end }}
-      compress = {{ .Values.gzip.enabled }}
         [entryPoints.https.tls]
           {{- if .Values.ssl.tlsMinVersion }}
           minVersion = "{{ .Values.ssl.tlsMinVersion }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

When using the ```proxyProtocol```, the ```compress``` option is generated as a child of ```proxyProtocol``` which is not the correct configuration, it should be under ```entryPoints.http```or ```entryPoints.https```.