### PR TITLE
[stable/traefik] set non-nil default values and comment out loadBalancerIP

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.38.1
+version: 1.38.2
 appVersion: 1.6.5
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
   loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}
   {{- if .Values.externalIP }}
-  externalIPs: 
+  externalIPs:
     - {{ .Values.externalIP }}
   {{- end }}
   {{- if .Values.loadBalancerSourceRanges }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -3,7 +3,7 @@ image: traefik
 imageTag: 1.6.5
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
-loadBalancerIP:
+# loadBalancerIP: ""
 # loadBalancerSourceRanges: []
 whiteListSourceRange: []
 externalTrafficPolicy: Cluster
@@ -45,7 +45,7 @@ tolerations: []
 proxyProtocol:
   enabled: false
   # trustedIPs is required when enabled
-  trustedIPs:
+  trustedIPs: []
   # - 10.0.0.0/8
 ssl:
   enabled: false
@@ -178,18 +178,18 @@ acme:
 dashboard:
   enabled: false
   domain: traefik.example.com
-  service:
+  service: {}
     # annotations:
     #   key: value
-  ingress:
+  ingress: {}
     # annotations:
     #   key: value
     # labels:
     #   key: value
-  auth:
+  auth: {}
     # basic:
     #   username: password
-  statistics:
+  statistics: {}
     ## Number of recent errors to show in the ‘Health’ tab
     # recentErrors:
 service:


### PR DESCRIPTION
**What this PR does / why we need it**:

*reopening from https://github.com/helm/charts/pull/6612, due to merging issues

- Setting non-nil default values to avoid warnings like the following:

        warning: destination for statistics is a table. Ignoring non-table value <nil>

- Commenting out `loadBalancerIP` by default as it gets reset on every deploy, which can trigger unnecessary upgrades is some scenarios.
- linting readme