### PR TITLE
cert-manager: fast-forward to upstream ad30555d

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.4.0
-appVersion: v0.4.0
+version: v0.4.1
+appVersion: v0.4.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.4.0` |
+| `image.tag` | Image tag | `v0.4.1` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.4.0
+  tag: v0.4.1
   pullPolicy: IfNotPresent
 
 createCustomResource: true


### PR DESCRIPTION
Automated sync PR to update cert-manager helm chart to v0.4.1 (latest patch release, cut today)

* Bump image version for v0.4.1 (jetstack/cert-manager#815)
