### PR TITLE
[stable/kiam] add option to use hostNetwork for server

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kiam
-version: 1.1.0
+version: 1.2.0
 appVersion: 2.8
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/README.md
+++ b/stable/kiam/README.md
@@ -124,6 +124,7 @@ Parameter | Description | Default
 `server.tlsFiles.key` | Base64 encoded strings for the server's private key | `null`
 `server.tolerations` | Tolerations to be applied to server pods | `[]`
 `server.updateStrategy` | Strategy for server DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
+`server.useHostNetwork` | If true, use hostNetwork on server to bypass agent iptable rules | `false`
 `rbac.create` | If `true`, create & use RBAC resources | `true`
 `serviceAccounts.agent.create` | If true, create the agent service account | `true`
 `serviceAccounts.agent.name` | Name of the agent service account to use or create | `{{ kiam.agent.fullname }}`

--- a/stable/kiam/templates/server-daemonset.yaml
+++ b/stable/kiam/templates/server-daemonset.yaml
@@ -30,6 +30,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "kiam.serviceAccountName.server" . }}
+      hostNetwork: {{ .Values.server.useHostNetwork }}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}

--- a/stable/kiam/values.yaml
+++ b/stable/kiam/values.yaml
@@ -179,6 +179,9 @@ server:
   ## Session duration for STS tokens
   ##
   sessionDuration: 15m
+  ## Use hostNetwork for server
+  ## Set this to true when running the servers on the same nodes as the agents
+  useHostNetwork: false
 
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
**What this PR does / why we need it**:
Deploying this chart before this change without specifying `nodeSelectors` for agents & servers will deploy both on all servers.
Since the `agent` intercepts traffic for the EC2 metadata service from all pods on the same node it will also intercept the calls of the server to get the credentials that are used by the server to assume roles for other pods (assuming an instance role is used, which should probably be the most used use-case).
This may have gone unnoticed since the deployment may sometimes work if the server started faster than the agent and was able to reach the EC2 metadata service before the agent could apply the `iptables` rules, but restarting a server (delete the pod) will show that a new pod cannot start.

This has been discussed also in:
* https://github.com/uswitch/kiam/issues/69
* https://github.com/uswitch/kiam/issues/39


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
