### PR TITLE
[stable/fluent-bit] parsers.conf is never used

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.8.0
+version: 0.9.0
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/daemonset.yaml
+++ b/stable/fluent-bit/templates/daemonset.yaml
@@ -45,6 +45,9 @@ spec:
         - name: config
           mountPath: /fluent-bit/etc/fluent-bit.conf
           subPath: fluent-bit.conf
+        - name: config
+          mountPath: /fluent-bit/etc/parsers.conf
+          subPath: parsers.conf
 {{- if .Values.backend.es.tls_ca }}
         - name: es-tls-secret
           mountPath: /secure/es-tls-ca.crt


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if you define custom regex rules on values.yml, they are completely ignored because file "parsers.conf" is never passed inside the fluent-bit container.

**Special notes for your reviewer**:
helm upgrade is enough to fix the bug on a current install. 
helm lint is OK.