### PR TITLE
Neo4j remove privileged security context, upgrade to 3.4.x series

### DIFF
--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,6 +1,6 @@
 name: neo4j
 home: https://www.neo4j.com
-version: 0.7.4
+version: 0.8.0
 appVersion: 3.4.5
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png

--- a/stable/neo4j/Chart.yaml
+++ b/stable/neo4j/Chart.yaml
@@ -1,7 +1,7 @@
 name: neo4j
 home: https://www.neo4j.com
-version: 0.7.3
-appVersion: 3.3.4
+version: 0.7.4
+appVersion: 3.4.5
 description: Neo4j is the world's leading graph database
 icon: http://info.neo4j.com/rs/773-GON-065/images/neo4j_logo.png
 sources:

--- a/stable/neo4j/templates/core-statefulset.yaml
+++ b/stable/neo4j/templates/core-statefulset.yaml
@@ -73,8 +73,6 @@ spec:
           name: browser
         - containerPort: 7687
           name: bolt
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: datadir
           mountPath: "{{ .Values.core.persistentVolume.mountPath }}"

--- a/stable/neo4j/templates/readreplicas-deployment.yaml
+++ b/stable/neo4j/templates/readreplicas-deployment.yaml
@@ -66,8 +66,6 @@ spec:
         volumeMounts:
         - name: plugins
           mountPath: /plugins
-        securityContext:
-          privileged: true
 {{- if .Values.core.sidecarContainers }}
 {{ toYaml .Values.core.sidecarContainers | indent 6 }}
 {{- end }}

--- a/stable/neo4j/values.yaml
+++ b/stable/neo4j/values.yaml
@@ -7,7 +7,7 @@ name: "neo4j"
 
 # Specs for the Neo4j docker image
 image: "neo4j"
-imageTag: "3.3.4-enterprise"
+imageTag: "3.4.5-enterprise"
 imagePullPolicy: "IfNotPresent"
 # imagePullSecret: registry-secret
 acceptLicenseAgreement: "no"


### PR DESCRIPTION
**What this PR does / why we need it**

* Removes privileged: true from securityContext for both core and read replica pods.  Why we need it is twofold:  the neo4j docker container explicitly drops permissions and runs as user neo4j inside of the container whenever possible, and it's a good idea to run with least privileges as a matter of good practice.  Question about this arose in a support case for us with this helm chart, so verifying that these permissions were not needed, it seemed appropriate to remove them from defaults.

* Updates to latest Neo4j 3.4 series release (3.4.5).   Neo4j version 3.4 is backwards compatible with the rest, and introduces a number of new features documented on the neo4j site that users requested in kubernetes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:
