### PR TITLE
[stable/wordpress] fix required string value being parsed as bool

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 2.1.8
+version: 2.1.9
 appVersion: 4.9.8
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -28,7 +28,11 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD
-          value: {{ .Values.allowEmptyPassword | quote }}
+        {{- if .Values.allowEmptyPassword }}
+          value: "yes"
+        {{- else }}
+          value: "no"
+        {{- end }}
         - name: MARIADB_HOST
         {{- if .Values.mariadb.enabled }}
           value: {{ template "mariadb.fullname" . }}

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -53,9 +53,9 @@ wordpressBlogName: User's Blog!
 ##
 wordpressTablePrefix: wp_
 
-## Set to `yes` to allow the container to be started with blank passwords
+## Set to `false` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-allowEmptyPassword: "yes"
+allowEmptyPassword: true
 
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -55,7 +55,7 @@ wordpressTablePrefix: wp_
 
 ## Set to `yes` to allow the container to be started with blank passwords
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
-allowEmptyPassword: yes
+allowEmptyPassword: "yes"
 
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration


### PR DESCRIPTION
Reverts #7101 which breaks ensuring the allowEmptyPassword is always a
string of value "yes" or "no".