### PR TITLE
incubator/elastic-stack:  change default chart behavior to override hardcoded service addresses

### DIFF
--- a/incubator/elastic-stack/Chart.yaml
+++ b/incubator/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 0.9.0
+version: 0.9.1
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/incubator/elastic-stack/values.yaml
+++ b/incubator/elastic-stack/values.yaml
@@ -11,6 +11,8 @@ kibana:
 
 logstash:
   enabled: true
+  elasticsearch:
+    host: elasticsearch-discovery
 
 fluentd:
   enabled: false

--- a/incubator/elastic-stack/values.yaml
+++ b/incubator/elastic-stack/values.yaml
@@ -2,9 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+elasticsearch:
+  fullnameOverride: elasticsearch
+
 kibana:
   env:
-    ELASTICSEARCH_URL: http://http.default.svc.cluster.local:9200
+    ELASTICSEARCH_URL: http://elasticsearch-discovery:9200
 
 logstash:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR adds the ability to install this chart with different release names and namespaces by default

this variable removes release name from elasticsearch fullname ("elasticsearch" which is used by default in logstash chart, instead of {{ .Release.Name }}-{{ .Chart.Name }}):

``
elasticsearch.fullnameOverride: elasticsearch
``

this variable defines elasticsearch url without release name and without default namespace ("elasticsearch-discovery" instead of {{ "elasticsearch.fullname" . }}-discovery.{{ .Release.Namespace }}.svc.{{ .Values.cluster.kubernetesDomain }})

``
ELASTICSEARCH_URL: http://elasticsearch-discovery:9200
``

**Which issue this PR fixes**
fixes #7114