### PR TITLE
[stable/prometheus-adapter] Enhancements

### DIFF
--- a/stable/prometheus-adapter/.helmignore
+++ b/stable/prometheus-adapter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.0.1
+version: v0.1.0
 appVersion: v0.2.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -1,16 +1,6 @@
 # Prometheus Adapter
 
-* Installs [Prometheus-adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter).
-
-## TL;DR;
-
-```console
-$ helm install stable/prometheus-adapter
-```
-
-## Introduction
-
-This charts install the [Prometheus Adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter) on your kubernetes clutser using the [Helm](https://helm.sh) package manager.
+Installs the [Prometheus Adapter](https://github.com/DirectXMan12/k8s-prometheus-adapter) for the Custom Metrics API. Custom metrics are used in Kubernetes by [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to scale workloads based upon your own metric pulled from an external metrics provider like Prometheus. This chart complements the [metrics-server](https://github.com/helm/charts/tree/master/stable/metrics-server) chart that provides resource only metrics.
 
 ## Prerequisites
 
@@ -24,7 +14,11 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release stable/prometheus-adapter
 ```
 
-This command deploys the prometheus operator with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+This command deploys the prometheus adapter with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Using the Chart
+
+To use the chart, ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. Additionally, the chart comes with a set of default rules out of the box but they may pull in too many metrics or not map them correctly for your needs. Therefore, it is recommended to populate `rules.custom` with a list of rules (see the [config document](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/docs/config.md) for the proper format). Finally, to configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 
 ## Uninstalling the Chart
 
@@ -42,24 +36,29 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 
 | Parameter                       | Description                                                                     | Default                                     |
 | ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
+| `affinity`                      | Node affinity                                                                   | `{}`                                        |
 | `image.repository`              | Image repository                                                                | `directxman12/k8s-prometheus-adapter-amd64` |
-| `image.tag`                     | Image tag                                                                       | `latest`                                    |
+| `image.tag`                     | Image tag                                                                       | `v0.2.1`                                    |
 | `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
-| `resources.limits.cpu`          | CPU limit                                                                       | `100m`                                      |
-| `resources.limits.memory`       | Memory limit                                                                    | `128Mi`                                     |
-| `resources.requests.cpu`        | CPU request                                                                     | `100m`                                      |
-| `resources.requests.memory`     | Memory request                                                                  | `128Mi`                                     |
+| `logLevel`                      | Log level                                                                       | `4`                                         |
+| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `30s`                                       |
+| `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
+| `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
+| `prometheus.port`               | Port of where we can find the Prometheus service                                | `9090`                                      |
 | `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
-| `serviceaccount.create`         | If true, create & use Serviceaccount                                            | `true`                                      |
-| `serviceaccount.name`           | If not set and create is true, a name is generated using the fullname template  | ``                                          |
-| `tls.enable`                    | If true, setup & use secret for TLS                                             | `false`                                     |
+| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
+| `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
+| `rules.custom`                  | A list of custom configmap rules                                                | `{}`                                        |
+| `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
+| `service.port`                  | Service port to expose                                                          | `443`                                       |
+| `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |
+| `serviceAccount.create`         | If true, create & use Serviceaccount                                            | `true`                                      |
+| `serviceAccount.name`           | If not set and create is true, a name is generated using the fullname template  | ``                                          |
+| `tls.enable`                    | If true, use the provided certificates. If false, generate self-signed certs    | `false`                                     |
 | `tls.ca`                        | Public CA file that signed the APIService (ignored if tls.enable=false)         | ``                                          |
 | `tls.key`                       | Private key of the APIService (ignored if tls.enable=false)                     | ``                                          |
 | `tls.certificate`               | Public key of the APIService (ignored if tls.enable=false)                      | ``                                          |
-| `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
-| `prometheus.port`               | Port of where we can find the Prometheus service                                | `9090`                                      |
-| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `30s`                                       |
-| `logLevel`                      | Log level                                                                       | `10`                                        |
+| `tolerations`                   | List of node taints to tolerate                                                 | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-adapter/templates/NOTES.txt
+++ b/stable/prometheus-adapter/templates/NOTES.txt
@@ -1,0 +1,5 @@
+{{ template "k8s-prometheus-adapter.fullname" .  }} has been deployed.
+In a few minutes you should be able to list metrics using the following command:
+
+  kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1
+

--- a/stable/prometheus-adapter/templates/_helpers.tpl
+++ b/stable/prometheus-adapter/templates/_helpers.tpl
@@ -9,11 +9,19 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "k8s-prometheus-adapter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- $fullname := printf "%s-%s" $name .Release.Name -}}
-{{- default $fullname .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -22,6 +22,12 @@ spec:
         heritage: {{ .Release.Service }}
       name: {{ template "k8s-prometheus-adapter.name" . }}
     spec:
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["all"]
+        runAsNonRoot: true
+        runAsUser: 10001
       serviceAccountName: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
@@ -43,6 +49,19 @@ spec:
         - --config=/etc/adapter/config.yaml
         ports:
         - containerPort: 6443
+          name: https
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -56,6 +75,18 @@ spec:
           name: volume-serving-cert
           readOnly: true
 {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
       - name: config
         configMap:

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-service.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
   label:
     app: {{ template "k8s-prometheus-adapter.name" . }}
     chart: {{ template "k8s-prometheus-adapter.chart" . }}
@@ -9,8 +11,11 @@ metadata:
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
 spec:
   ports:
-  - port: 443
-    targetPort: 6443
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: https
   selector:
     app: {{ template "k8s-prometheus-adapter.name" . }}
     release: {{ .Release.Name }}
+  type: {{ .Values.service.type }}
+

--- a/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -10,6 +10,7 @@ metadata:
 data:
   config.yaml: |
     rules:
+{{- if .Values.rules.default }}
     - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
       seriesFilters: []
       resources:
@@ -76,3 +77,8 @@ data:
         matches: ^(.*)_seconds_total$
         as: ""
       metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
+{{- end -}}
+{{- if .Values.rules.custom }}
+{{ toYaml .Values.rules.custom | indent 4 }}
+{{- end -}}
+

--- a/stable/prometheus-adapter/templates/secret.yaml
+++ b/stable/prometheus-adapter/templates/secret.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ template "k8s-prometheus-adapter.fullname" . }}
-type: Opaque
+type: kubernetes.io/tls
 data:
   tls.crt: {{ b64enc .Values.tls.certificate }}
   tls.key: {{ b64enc .Values.tls.key }}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -41,13 +41,13 @@ resources:
 rules:
   default: true
   custom: {}
-  #- seriesQuery: '{__name__=~"^some_metric_count$"}'
-  #  resources:
-  #    template: <<.Resource>>
-  #  name:
-  #    matches: ""
-  #    as: "my_custom_metric"
-  #  metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+# - seriesQuery: '{__name__=~"^some_metric_count$"}'
+#   resources:
+#     template: <<.Resource>>
+#   name:
+#     matches: ""
+#     as: "my_custom_metric"
+#   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
 
 service:
   annotations: {}
@@ -64,4 +64,3 @@ tls:
     # Public key of the APIService
 
 tolerations: []
-

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -1,8 +1,21 @@
 # Default values for k8s-prometheus-adapter..
+affinity: {}
+
 image:
   repository: directxman12/k8s-prometheus-adapter-amd64
   tag: v0.2.1
   pullPolicy: IfNotPresent
+
+logLevel: 4
+
+metricsRelistInterval: 30s
+
+nodeSelector: {}
+
+# Url to access prometheus
+prometheus:
+  url: http://prometheus.default.svc
+  port: 9090
 
 replicas: 1
 
@@ -25,6 +38,22 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+rules:
+  default: true
+  custom: {}
+  #- seriesQuery: '{__name__=~"^some_metric_count$"}'
+  #  resources:
+  #    template: <<.Resource>>
+  #  name:
+  #    matches: ""
+  #    as: "my_custom_metric"
+  #  metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+
+service:
+  annotations: {}
+  port: 443
+  type: ClusterIP
+
 tls:
   enable: false
   ca: |-
@@ -34,10 +63,5 @@ tls:
   certificate: |-
     # Public key of the APIService
 
-# Url to access prometheus
-prometheus:
-  url: http://prometheus.default.svc
-  port: 9090
+tolerations: []
 
-metricsRelistInterval: 30s
-logLevel: 10


### PR DESCRIPTION
**What this PR does / why we need it**:
Ports my changes from closed [PR](https://github.com/helm/charts/pull/7159) to stable/prometheus-adapter.

- Add readiness and liveness probes
- Adds ability to disable default rules and add custom rules
- Adds affinity, nodeSelector, tolerations
- Adds a NOTES.txt and .helmignore per standard
- Adds securityContext to reduce pod permissions
- Adds ability to customize service values
- Fixes fullnameOverride
- Reduces logLevel as it was way too verbose.
- Minor cleanup to sort values in README and in values.yaml and fix typos

**Which issue this PR fixes** : N/A

**Special notes for your reviewer**:

@mattiasgees