### PR TITLE
[stable/mysql] Support extra{Volumes,VolumeMounts,InitContainers}

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.9.0
+version: 0.9.1
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.8.5
+version: 0.9.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -50,8 +50,8 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `imageTag`                                   | `mysql` image tag.                                                                           | `5.7.14`                                             |
 | `imagePullPolicy`                            | Image pull policy                                                                            | `IfNotPresent`                                       |
 | `existingSecret`                             | Use Existing secret for Password details                                                     | `nil`                                                |
-| `extraVolumes`                               | Additional volumes                                                                           |                                                      |
-| `extraVolumeMounts`                          | Additional volumeMounts                                                                      |                                                      |
+| `extraVolumes`                               | Additional volumes as a string to be passed to the `tpl` function                            |                                                      |
+| `extraVolumeMounts`                          | Additional volumeMounts as a string to be passed to the `tpl` function                       |                                                      |
 | `extraInitContainers`                        | Additional init containers as a string to be passed to the `tpl` function                    |                                                      |
 | `mysqlRootPassword`                          | Password for the `root` user. Ignored if existing secret is provided                         | Random 10 characters                                 |
 | `mysqlUser`                                  | Username of new user to create.                                                              | `nil`                                                |

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -44,53 +44,56 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the MySQL chart and their default values.
 
-| Parameter                                    | Description                               | Default                                              |
-| -------------------------------------------- | ----------------------------------------- | ---------------------------------------------------- |
-| `image`                                      | `mysql` image repository.                 | `mysql`                                              |
-| `imageTag`                                   | `mysql` image tag.                        | `5.7.14`                                             |
-| `imagePullPolicy`                            | Image pull policy                         | `IfNotPresent`                                       |
-| `existingSecret`                             | Use Existing secret for Password details  | `nil`                                                |
-| `mysqlRootPassword`                          | Password for the `root` user. Ignored if existing secret is provided      | Random 10 characters |
-| `mysqlUser`                                  | Username of new user to create.           | `nil`                                                |
-| `mysqlPassword`                              | Password for the new user. Ignored if existing secret is provided         | Random 10 characters |
-| `mysqlDatabase`                              | Name for new database to create.          | `nil`                                                |
-| `livenessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated  | 30                                                   |
-| `livenessProbe.periodSeconds`                | How often to perform the probe            | 10                                                   |
-| `livenessProbe.timeoutSeconds`               | When the probe times out                  | 5                                                    |
-| `livenessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed. | 1 |
-| `livenessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3 |
-| `readinessProbe.initialDelaySeconds`         | Delay before readiness probe is initiated | 5                                                    |
-| `readinessProbe.periodSeconds`               | How often to perform the probe            | 10                                                   |
-| `readinessProbe.timeoutSeconds`              | When the probe times out                  | 1                                                    |
-| `readinessProbe.successThreshold`            | Minimum consecutive successes for the probe to be considered successful after having failed. | 1 |
-| `readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3 |
-| `persistence.enabled`                        | Create a volume to store data             | true                                                 |
-| `persistence.size`                           | Size of persistent volume claim           | 8Gi RW                                               |
-| `persistence.storageClass`                   | Type of persistent volume claim           | nil  (uses alpha storage class annotation)           |
-| `persistence.accessMode`                     | ReadWriteOnce or ReadOnly                 | ReadWriteOnce                                        |
-| `persistence.existingClaim`                  | Name of existing persistent volume        | `nil`                                                |
-| `persistence.subPath`                        | Subdirectory of the volume to mount       | `nil`                                                |
-| `nodeSelector`                               | Node labels for pod assignment            | {}                                                   |
-| `metrics.enabled`                            | Start a side-car prometheus exporter      | `false`                                              |
-| `metrics.image`                              | Exporter image                            | `prom/mysqld-exporter`                               |
-| `metrics.imageTag`                           | Exporter image                            | `v0.10.0`                                            |
-| `metrics.imagePullPolicy`                    | Exporter image pull policy                | `IfNotPresent`                                       |
-| `metrics.resources`                          | Exporter resource requests/limit          | `nil`                                                |
-| `metrics.livenessProbe.initialDelaySeconds`  | Delay before metrics liveness probe is initiated  | 15                                           |
-| `metrics.livenessProbe.timeoutSeconds`       | When the probe times out            | 5                                                          |
-| `metrics.readinessProbe.initialDelaySeconds` | Delay before metrics readiness probe is initiated | 5                                            |
-| `metrics.readinessProbe.timeoutSeconds`      | When the probe times out                  | 1                                                    |
-| `resources`                                  | CPU/Memory resource requests/limits       | Memory: `256Mi`, CPU: `100m`                         |
-| `configurationFiles`                         | List of mysql configuration files         | `nil`                                                |
-| `ssl.enabled`                                | Setup and use SSL for MySQL connections   | `false`                                              |
-| `ssl.secret`                                 | Name of the secret containing the SSL certificates                             | mysql-ssl-certs |
-| `ssl.certificates[0].name`                   | Name of the secret containing the SSL certificates                                       | `nil` |
-| `ssl.certificates[0].ca`                     | CA certificate                            | `nil`                                                |
-| `ssl.certificates[0].cert`                   | Server certificate (public key)           | `nil`                                                |
-| `ssl.certificates[0].key`                    | Server key (private key)                  | `nil`                                                |
-| `imagePullSecrets`                           | Name of Secret resource containing private registry credentials | `nil`                          |
-| `initializationFiles`                        | List of SQL files which are run after the container started        | `nil`                       |
-| `timezone`                           | Container and mysqld timezone (TZ env)    | `nil` (UTC depending on image)                       |
+| Parameter                                    | Description                                                                                  | Default                                              |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `image`                                      | `mysql` image repository.                                                                    | `mysql`                                              |
+| `imageTag`                                   | `mysql` image tag.                                                                           | `5.7.14`                                             |
+| `imagePullPolicy`                            | Image pull policy                                                                            | `IfNotPresent`                                       |
+| `existingSecret`                             | Use Existing secret for Password details                                                     | `nil`                                                |
+| `extraVolumes`                               | Additional volumes                                                                           |                                                      |
+| `extraVolumeMounts`                          | Additional volumeMounts                                                                      |                                                      |
+| `extraInitContainers`                        | Additional init containers as a string to be passed to the `tpl` function                    |                                                      |
+| `mysqlRootPassword`                          | Password for the `root` user. Ignored if existing secret is provided                         | Random 10 characters                                 |
+| `mysqlUser`                                  | Username of new user to create.                                                              | `nil`                                                |
+| `mysqlPassword`                              | Password for the new user. Ignored if existing secret is provided                            | Random 10 characters                                 |
+| `mysqlDatabase`                              | Name for new database to create.                                                             | `nil`                                                |
+| `livenessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated                                                     | 30                                                   |
+| `livenessProbe.periodSeconds`                | How often to perform the probe                                                               | 10                                                   |
+| `livenessProbe.timeoutSeconds`               | When the probe times out                                                                     | 5                                                    |
+| `livenessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                    |
+| `livenessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                                                    |
+| `readinessProbe.initialDelaySeconds`         | Delay before readiness probe is initiated                                                    | 5                                                    |
+| `readinessProbe.periodSeconds`               | How often to perform the probe                                                               | 10                                                   |
+| `readinessProbe.timeoutSeconds`              | When the probe times out                                                                     | 1                                                    |
+| `readinessProbe.successThreshold`            | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                    |
+| `readinessProbe.failureThreshold`            | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 3                                                    |
+| `persistence.enabled`                        | Create a volume to store data                                                                | true                                                 |
+| `persistence.size`                           | Size of persistent volume claim                                                              | 8Gi RW                                               |
+| `persistence.storageClass`                   | Type of persistent volume claim                                                              | nil  (uses alpha storage class annotation)           |
+| `persistence.accessMode`                     | ReadWriteOnce or ReadOnly                                                                    | ReadWriteOnce                                        |
+| `persistence.existingClaim`                  | Name of existing persistent volume                                                           | `nil`                                                |
+| `persistence.subPath`                        | Subdirectory of the volume to mount                                                          | `nil`                                                |
+| `nodeSelector`                               | Node labels for pod assignment                                                               | {}                                                   |
+| `metrics.enabled`                            | Start a side-car prometheus exporter                                                         | `false`                                              |
+| `metrics.image`                              | Exporter image                                                                               | `prom/mysqld-exporter`                               |
+| `metrics.imageTag`                           | Exporter image                                                                               | `v0.10.0`                                            |
+| `metrics.imagePullPolicy`                    | Exporter image pull policy                                                                   | `IfNotPresent`                                       |
+| `metrics.resources`                          | Exporter resource requests/limit                                                             | `nil`                                                |
+| `metrics.livenessProbe.initialDelaySeconds`  | Delay before metrics liveness probe is initiated                                             | 15                                                   |
+| `metrics.livenessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                                    |
+| `metrics.readinessProbe.initialDelaySeconds` | Delay before metrics readiness probe is initiated                                            | 5                                                    |
+| `metrics.readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | 1                                                    |
+| `resources`                                  | CPU/Memory resource requests/limits                                                          | Memory: `256Mi`, CPU: `100m`                         |
+| `configurationFiles`                         | List of mysql configuration files                                                            | `nil`                                                |
+| `ssl.enabled`                                | Setup and use SSL for MySQL connections                                                      | `false`                                              |
+| `ssl.secret`                                 | Name of the secret containing the SSL certificates                                           | mysql-ssl-certs                                      |
+| `ssl.certificates[0].name`                   | Name of the secret containing the SSL certificates                                           | `nil`                                                |
+| `ssl.certificates[0].ca`                     | CA certificate                                                                               | `nil`                                                |
+| `ssl.certificates[0].cert`                   | Server certificate (public key)                                                              | `nil`                                                |
+| `ssl.certificates[0].key`                    | Server key (private key)                                                                     | `nil`                                                |
+| `imagePullSecrets`                           | Name of Secret resource containing private registry credentials                              | `nil`                                                |
+| `initializationFiles`                        | List of SQL files which are run after the container started                                  | `nil`                                                |
+| `timezone`                                   | Container and mysqld timezone (TZ env)                                                       | `nil` (UTC depending on image)                       |
 
 Some of the parameters above map to the env variables defined in the [MySQL DockerHub image](https://hub.docker.com/_/mysql/).
 
@@ -138,9 +141,9 @@ configurationFiles:
 
 ## MySQL initialization files
 
-The [MySQL](https://hub.docker.com/_/mysql/) image accepts *.sh, *.sql and *.sql.gz files at the path `/docker-entrypoint-initdb.d`. 
+The [MySQL](https://hub.docker.com/_/mysql/) image accepts *.sh, *.sql and *.sql.gz files at the path `/docker-entrypoint-initdb.d`.
 These files are being run exactly once for container initialization and ignored on following container restarts.
-If you want to use initialization scripts, you can create initialization files by passing the file contents on the `initializationFiles` attribute. 
+If you want to use initialization scripts, you can create initialization files by passing the file contents on the `initializationFiles` attribute.
 
 
 ```yaml

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
           mountPath: /ssl
         {{- end }}
         {{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{ tpl .Values.extraVolumeMounts . | indent 8 }}
         {{- end }}
       {{- if .Values.metrics.enabled }}
       - name: metrics
@@ -178,5 +178,5 @@ spec:
         emptyDir: {}
       {{- end -}}
       {{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | indent 6 }}
+{{ tpl .Values.extraVolumes . | indent 6 }}
       {{- end }}

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -28,10 +28,13 @@ spec:
           {{- if .Values.persistence.subPath }}
           subPath: {{ .Values.persistence.subPath }}
           {{- end }}
+      {{- if .Values.extraInitContainers }}
+{{ tpl .Values.extraInitContainers . | indent 6 }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- end }}          
+      {{- end }}
       containers:
       - name: {{ template "mysql.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -115,6 +118,9 @@ spec:
         - name: certificates
           mountPath: /ssl
         {{- end }}
+        {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+        {{- end }}
       {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
@@ -147,7 +153,7 @@ spec:
           timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
-      {{- end }}        
+      {{- end }}
       volumes:
       {{- if .Values.configurationFiles }}
       - name: configurations
@@ -171,3 +177,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end -}}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -29,11 +29,11 @@ imageTag: "5.7.14"
 ##
 imagePullPolicy: IfNotPresent
 
-extraVolumes: []
+extraVolumes: |
   # - name: extras
   #   emptyDir: {}
 
-extraVolumeMounts: []
+extraVolumeMounts: |
   # - name: extras
   #   mountPath: /usr/share/extras
   #   readOnly: true

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -29,6 +29,20 @@ imageTag: "5.7.14"
 ##
 imagePullPolicy: IfNotPresent
 
+extraVolumes: []
+  # - name: extras
+  #   emptyDir: {}
+
+extraVolumeMounts: []
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
+extraInitContainers: |
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']
+
 # Optionally specify an array of imagePullSecrets.
 # Secrets must be manually created in the namespace.
 # ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding support for `extraVolumes`, `extraVolumeMounts`, and `extraInitContainers` is notably useful for preseeding the database with binary data. We use it mount AWS credentials in an init container and grab a tarball from S3, expanding it to `/var/lib/mysql`.