### PR TITLE
[stable/oauth2-proxy] Adds additional configuration options for oauth2 providers

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.5.0
+version: 0.6.0
 apiVersion: v1
 appVersion: 2.2
 home: http://www.videntity.com/

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -45,6 +45,7 @@ Parameter | Description | Default
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'` | `""`
 `config.configFile` | custom [oauth2_proxy.cfg](https://github.com/bitly/oauth2_proxy/blob/master/contrib/oauth2_proxy.cfg.example) contents for settings not overridable via environment nor command line | `""`
+`emailDomains` | list of domains to authenticate | \- "*"
 `extraArgs` | key:value list of extra arguments to give the binary | `{}`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.repository` | Image repository | `a5huynh/oauth2_proxy`
@@ -53,7 +54,8 @@ Parameter | Description | Default
 `ingress.enabled` | enable ingress | `false`
 `nodeSelector` | node labels for pod assignment | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
-`podLabels` | additional labesl to add to each pod | `{}`
+`podLabels` | additional labels to add to each pod | `{}`
+`providers` | provider-specific configuration options, detailed below | None
 `replicaCount` | desired number of pods | `1`
 `resources` | pod resource requests & limits | `{}`
 `priorityClassName` | priorityClassName | `nil` 
@@ -75,3 +77,21 @@ $ helm install stable/oauth2-proxy --name my-release -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Provider configurations
+#### Google
+> **Tip**: This is only needed if authentication needs to be limited to specific groups
+
+Parameter | Description
+---|---
+`providers.google.adminEmail` | e-mail of admin to impersonate
+`providers.google.groups` | list of groups to authenticate
+`providers.google.jsonCredentials` | contents of the JSON credentials file for the service account
+
+#### GitHub
+> **Tip**: This is only needed if authentication needs to be limited to specific orgs or teams
+
+Parameter | Description
+--- | ---
+`providers.github.orgs` | list of orgs to authenticate
+`providers.github.teams` | list of teams to authenticate

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -34,8 +34,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-        {{- range $domain := .Values.emailDomains }}
+        {{- if .Values.emailDomains }}
+          {{- range $domain := .Values.emailDomains }}
           - --email-domain={{ $domain }}
+          {{- end }}
         {{- end }}
         {{- if .Values.providers.google }}
           - --google-admin-email={{ .Values.providers.google.adminEmail }}
@@ -44,7 +46,7 @@ spec:
           {{- end }}
           - --google-service-account-json=/etc/credentials/google-credentials
         {{- end }}
-        {{ - if .Values.providers.github }}
+        {{- if .Values.providers.github }}
           {{- range $org := .Values.providers.github.orgs }}
           - --github-org={{ $org }}
           {{- end }}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-        {{- if .Values.emailDomains }}
+        {{- if (not (index .Values.extraArgs "email-domain")) and (.Values.emailDomains) }}
           {{- range $domain := .Values.emailDomains }}
           - --email-domain={{ $domain }}
           {{- end }}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -34,6 +34,24 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+        {{- range $domain := .Values.emailDomains }}
+          - --email-domain={{ $domain }}
+        {{- end }}
+        {{- if .Values.providers.google }}
+          - --google-admin-email={{ .Values.providers.google.adminEmail }}
+          {{- range $group := .Values.providers.google.groups }}
+          - --google-group={{ $group }}
+          {{- end }}
+          - --google-service-account-json=/etc/credentials/google-credentials
+        {{- end }}
+        {{ - if .Values.providers.github }}
+          {{- range $org := .Values.providers.github.orgs }}
+          - --github-org={{ $org }}
+          {{- end }}
+          {{- range $team := .Values.providers.github.teams }}
+          - --github-team={{ $team }}
+          {{- end }}
+        {{- end }}
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -78,11 +96,28 @@ spec:
         volumeMounts:
         - mountPath: /etc/oauth2_proxy
           name: {{ template "oauth2-proxy.fullname" . }}-configmap
+{{ end }}
+{{- if .Values.providers.google }}
+        volumeMounts:
+        - mountPath: /etc/credentials
+          name: {{ template "oauth2-proxy.fullname" . }}-google-credentials
+{{ end }}
+{{- if .Values.config.configFile }}
       volumes:
       - configMap:
           defaultMode: 420
           name: {{ template "oauth2-proxy.fullname" . }}
         name: {{ template "oauth2-proxy.fullname" . }}-configmap
+{{- end }}
+{{- if .Values.providers.google }}
+      volumes:
+      - secret:
+          defaultMode: 420
+          secretName: {{ template "oauth2-proxy.fullname" . }}
+          items:
+            - key: google-credentials
+              path: google-credentials
+        name: {{ template "oauth2-proxy.fullname" . }}-google-credentials
 {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -34,36 +34,36 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-        {{- if (not (index .Values.extraArgs "email-domain")) and (.Values.emailDomains) }}
-          {{- range $domain := .Values.emailDomains }}
+{{- if (not (index .Values.extraArgs "email-domain")) and (.Values.emailDomains) }}
+  {{- range $domain := .Values.emailDomains }}
           - --email-domain={{ $domain }}
-          {{- end }}
-        {{- end }}
-        {{- if .Values.providers.google }}
+  {{- end }}
+{{- end }}
+{{- if .Values.providers.google }}
           - --google-admin-email={{ .Values.providers.google.adminEmail }}
-          {{- range $group := .Values.providers.google.groups }}
+  {{- range $group := .Values.providers.google.groups }}
           - --google-group={{ $group }}
-          {{- end }}
+  {{- end }}
           - --google-service-account-json=/etc/credentials/google-credentials
-        {{- end }}
-        {{- if .Values.providers.github }}
-          {{- range $org := .Values.providers.github.orgs }}
+{{- end }}
+{{- if .Values.providers.github }}
+  {{- range $org := .Values.providers.github.orgs }}
           - --github-org={{ $org }}
-          {{- end }}
-          {{- range $team := .Values.providers.github.teams }}
+  {{- end }}
+  {{- range $team := .Values.providers.github.teams }}
           - --github-team={{ $team }}
-          {{- end }}
-        {{- end }}
-        {{- range $key, $value := .Values.extraArgs }}
-          {{- if $value }}
+  {{- end }}
+{{- end }}
+{{- range $key, $value := .Values.extraArgs }}
+  {{- if $value }}
           - --{{ $key }}={{ $value }}
-          {{- else }}
+  {{- else }}
           - --{{ $key }}
-          {{- end }}
-        {{- end }}
-        {{- if .Values.config.configFile }}
+  {{- end }}
+{{- end }}
+{{- if .Values.config.configFile }}
           - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
-        {{- end }}
+{{- end }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -12,3 +12,6 @@ data:
   cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
   client-secret: {{ .Values.config.clientSecret | b64enc | quote }}
   client-id: {{ .Values.config.clientID | b64enc | quote }}
+{{- if .Values.providers.google }}
+  google-credentials: {{ .Values.providers.google.jsonCredentials | b64enc | quote }}
+{{- end }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -44,12 +44,12 @@ providers:
   # Additional configuration for the GitHub provider
   # Only required if authentication is limited to certain orgs and teams
   github:
-    # The GitHub orgs to restrict access to
-    orgs:
-      - "xxx"
-    # The GitHub teams to restrict access to
-    teams:
-      - "xxx"
+    # # The GitHub orgs to restrict access to
+    # orgs:
+    #   - "xxx"
+    # # The GitHub teams to restrict access to
+    # teams:
+    #   - "xxx"
 
 image:
   repository: "a5huynh/oauth2_proxy"

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -1,3 +1,7 @@
+# E-mail domains to authenticate
+emailDomains:
+  - "*" # authenticate all domains
+
 # Oauth client configuration specifics
 config:
   # OAuth client ID
@@ -13,6 +17,40 @@ config:
   #   pass_access_token = true
   configFile: ""
 
+# Provider-specific configuration
+providers:
+  # Additional configuration for the Google provider
+  # Only required if authentication limited to certain Google Groups
+  google:
+    # # The admin e-mail address to impersonate
+    # adminEmail: "xxx@yyy.zzz"
+    # # A list of groups to allow
+    # groups:
+    #   - "xxx@yyy.zzz"
+    # # Service account credentials in JSON format
+    # jsonCredentials: |-
+    #   {
+    #     "type": "",
+    #     "project_id": "",
+    #     "private_key_id": "",
+    #     "private_key": "",
+    #     "client_email": "",
+    #     "client_id": "",
+    #     "auth_uri": "",
+    #     "token_uri": "",
+    #     "auth_provider_x509_cert_url": "",
+    #     "client_x509_cert_url": ""
+    #   }
+  # Additional configuration for the GitHub provider
+  # Only required if authentication is limited to certain orgs and teams
+  github:
+    # The GitHub orgs to restrict access to
+    orgs:
+      - "xxx"
+    # The GitHub teams to restrict access to
+    teams:
+      - "xxx"
+
 image:
   repository: "a5huynh/oauth2_proxy"
   tag: "2.2"
@@ -25,7 +63,6 @@ image:
   # - name: myRegistryKeySecretName
 
 extraArgs:
-  email-domain: "*"
   upstream: "file:///dev/null"
   http-address: "0.0.0.0:4180"
 

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -1,6 +1,6 @@
 # E-mail domains to authenticate
 emailDomains:
-  - "*" # authenticate all domains
+  - "*"  # authenticate all domains
 
 # Oauth client configuration specifics
 config:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds configuration for the `google` and `github` providers. This allows authentication to easily be restricted to certain groups, orgs and teams. The `google` provider configuration specifically adds the required credentials to the existing oauth2_proxy secret.

It also moves the e-mail domains configuration to its own field within `values.yaml`, which allows these to more easily be configured within a values file.

**Special notes for your reviewer**:
I've added some additional checks in to ensure that backwards compatibility is maintained.