### PR TITLE
[stable/chaoskube] Support K8S older then 1.9

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chaoskube
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.9.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare "^1.9-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if .Capabilities.APIVersions.Has "apps/v1" }}
 apiVersion: apps/v1
 {{- else }}
 apiVersion: apps/v1beta1

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare "^1.9-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: apps/v1
+{{- else }}
+apiVersion: apps/v1beta1
+{{- end }}
 kind: Deployment
 metadata:
   name: {{ include "chaoskube.fullname" . }}

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -1,7 +1,7 @@
-{{- if .Capabilities.APIVersions.Has "apps/v1" }}
-apiVersion: apps/v1
-{{- else }}
+{{- if .Capabilities.APIVersions.Has "apps/v1beta1" }}
 apiVersion: apps/v1beta1
+{{- else }}
+apiVersion: apps/v1
 {{- end }}
 kind: Deployment
 metadata:


### PR DESCRIPTION
Add support for API versions for older k8s in the deployment file.