### PR TITLE
 Add `configVolumeName` chart variable

### DIFF
--- a/stable/fluentd-elasticsearch/Chart.yaml
+++ b/stable/fluentd-elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluentd-elasticsearch
 version: 1.0.1
-appVersion: 2.3.1
+appVersion: 2.3.2
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png

--- a/stable/fluentd-elasticsearch/README.md
+++ b/stable/fluentd-elasticsearch/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.buffer_queue_limit` | Elasticsearch buffer queue limit           | `8`                                                        |
 | `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
 | `extraVolume`                      | Extra volume                               |                                                            |
+| `configVolumeName`                 | Name for the `/etc/fluent/config.d` volume | `config-volume-{{ template "fluentd-elasticsearch.fullname" . }}` |
 | `image.repository`                 | Image                                      | `gcr.io/google-containers/fluentd-elasticsearch`           |
 | `image.tag`                        | Image tag                                  | `v2.3.1`                                                   |
 | `image.pullPolicy`                 | Image pull policy                          | `IfNotPresent`                                             |

--- a/stable/fluentd-elasticsearch/README.md
+++ b/stable/fluentd-elasticsearch/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | ---------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
 | `annotations`                      | Optional daemonset annotations             | `NULL`                                                     |
 | `configMaps`                       | Fluentd configmaps                         | `default conf files`                                       |
-| `elasticsearch.host`               | Elstaicsearch Host                         | `elasticsearch-client`                                     |
+| `elasticsearch.host`               | Elasticsearch Host                         | `elasticsearch-client`                                     |
 | `elasticsearch.port`               | Elasticsearch Port                         | `9200`                                                     |
 | `elasticsearch.buffer_chunk_limit` | Elasticsearch buffer chunk limit           | `2M`                                                       |
 | `elasticsearch.buffer_queue_limit` | Elasticsearch buffer queue limit           | `8`                                                        |
@@ -63,8 +63,8 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `resources.requests.memory`        | Memory request                             | `200Mi`                                                    |
 | `service`                          | Service definition                         | `{}`                                                       |
 | `serviceAccount.create`            | Specifies whether a service account should be created.| `true`                                          |
-| `serviceAccount.name`              | Name of the service account.               |                                                            |   
-| `livenessProbe.enabled`            | Whether to enable livenessProbe             | `true`                                                    |   
+| `serviceAccount.name`              | Name of the service account.               |                                                            |
+| `livenessProbe.enabled`            | Whether to enable livenessProbe            | `true`                                                     |
 | `tolerations`                      | Optional daemonset tolerations             | `NULL`                                                     |
 
 

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -68,15 +68,15 @@ spec:
           readOnly: true
         - name: config-volume-{{ template "fluentd-elasticsearch.fullname" . }}
           mountPath: /etc/fluent/config.d
-        ports:          
+        ports:
 {{- range $port := .Values.service.ports }}
           - name: {{ $port.name }}
             containerPort: {{ $port.port }}
-{{- end }}          
+{{- end }}
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
-{{- if .Values.livenessProbe.enabled }}       
+{{- if .Values.livenessProbe.enabled }}
         # Liveness probe is aimed to help in situarions where fluentd
         # silently hangs for no apparent reasons until manual restart.
         # The idea of this probe is that if fluentd is not queueing or
@@ -109,7 +109,7 @@ spec:
               then
                 exit 1;
               fi;
-{{- end }}              
+{{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -66,7 +66,11 @@ spec:
         - name: libsystemddir
           mountPath: /host/lib
           readOnly: true
+{{- if .Values.configVolumeName }}
+        - name: {{ .Values.configVolumeName }}
+{{- else }}
         - name: config-volume-{{ template "fluentd-elasticsearch.fullname" . }}
+{{- end }}
           mountPath: /etc/fluent/config.d
         ports:
 {{- range $port := .Values.service.ports }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

The default value for the config volume adds 35 characters on top of the release name. If the release name is 30 characters (or more) long, the deployment will fail because it doesn't support names longer than 63.

This commit introduces, in a backwards-compatible way, the `configVolumeName` variable, which if present will take precedence over the default autogenerated name.
