### PR TITLE
[stable/mariadb] affinity and tolerations support for master and slave

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 4.3.3
+version: 4.4.0
 appVersion: 10.1.35
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -62,7 +62,9 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `replication.enabled`                     | MariaDB replication enabled                         | `true`                                                             |
 | `replication.user`                        | MariaDB replication user                            | `replicator`                                                       |
 | `replication.password`                    | MariaDB replication user password                   | _random 10 character alphanumeric string_                         |
+| `master.affinity`                         | Master affinity (in addition to master.antiAffinity when set)  | `{}`                                                   |
 | `master.antiAffinity`                     | Master pod anti-affinity policy                     | `soft`                                                            |
+| `master.tolerations`                      | List of node taints to tolerate (master)            | `[]`                                                              |
 | `master.persistence.enabled`              | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
 | `master.persistence.annotations`          | Persistent Volume Claim annotations                 | `{}`                                                              |
 | `master.persistence.storageClass`         | Persistent Volume Storage Class                     | ``                                                                |
@@ -83,7 +85,9 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)| `1`                                                               |
 | `master.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (master) | `3`                                                               |
 | `slave.replicas`                          | Desired number of slave replicas                    | `1`                                                               |
+| `slave.affinity`                          | Slave affinity (in addition to slave.antiAffinity when set) | `{}`                                                      |
 | `slave.antiAffinity`                      | Slave pod anti-affinity policy                      | `soft`                                                            |
+| `slave.tolerations`                       | List of node taints to tolerate for (slave)         | `[]`                                                              |
 | `slave.persistence.enabled`               | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
 | `slave.persistence.annotations`           | Persistent Volume Claim annotations                 | `{}`                                                              |
 | `slave.persistence.storageClass`          | Persistent Volume Storage Class                     | ``                                                                |

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -26,6 +26,9 @@ spec:
         fsGroup: 1001
       {{- if eq .Values.master.antiAffinity "hard" }}
       affinity:
+      {{- with .Values.master.affinity  }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
@@ -35,6 +38,9 @@ spec:
                   release: "{{ .Release.Name }}"
       {{- else if eq .Values.master.antiAffinity "soft" }}
       affinity:
+      {{- with .Values.master.affinity  }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -44,6 +50,15 @@ spec:
                 matchLabels:
                   app: "{{ template "mariadb.name" . }}"
                   release: "{{ .Release.Name }}"
+      {{- else}}
+      {{- with .Values.master.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.master.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -27,6 +27,9 @@ spec:
         fsGroup: 1001
       {{- if eq .Values.slave.antiAffinity "hard" }}
       affinity:
+      {{- with .Values.slave.affinity  }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
@@ -36,6 +39,9 @@ spec:
                   release: "{{ .Release.Name }}"
       {{- else if eq .Values.slave.antiAffinity "soft" }}
       affinity:
+      {{- with .Values.slave.affinity  }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -45,6 +51,15 @@ spec:
                 matchLabels:
                   app: "{{ template "mariadb.name" . }}"
                   release: "{{ .Release.Name }}"
+      {{- else}}
+      {{- with .Values.slave.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.slave.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -75,7 +75,21 @@ replication:
   forcePassword: true
 
 master:
+  ## Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Kept for backwards compatibility. You can now disable it by removing it.
+  ## if you wish to set it through master.affinity.podAntiAffinity instead.
+  ##
   antiAffinity: soft
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
@@ -158,7 +172,22 @@ master:
 
 slave:
   replicas: 2
+
+  ## Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Kept for backwards compatibility. You can now disable it by removing it.
+  ## if you wish to set it through slave.affinity.podAntiAffinity instead.
+  ##
   antiAffinity: soft
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
   persistence:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -75,7 +75,21 @@ replication:
   forcePassword: false
 
 master:
+  ## Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Kept for backwards compatibility. You can now disable it by removing it.
+  ## if you wish to set it through master.affinity.podAntiAffinity instead.
+  ##
   antiAffinity: soft
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
@@ -158,7 +172,22 @@ master:
 
 slave:
   replicas: 1
+
+  ## Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Kept for backwards compatibility. You can now disable it by removing it.
+  ## if you wish to set it through slave.affinity.podAntiAffinity instead.
+  ##
   antiAffinity: soft
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
   persistence:
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
     ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
Adds tolerations and affinity support to master and slave.

Relates to #6517.

**Tolerations :**
Added tolerations support like in a lot of other charts, both for master and slave.

**Affinity :**
Users should now be able to chose between :
- defining their own `affinity` section by setting `--master.antiAffinity=""` and populating `master.affinity` with a yaml object in their `values.yaml`, like most other charts.
- Using predefined `(master|slave).antiAffinity` `soft` or `hard` values.
- Combining the 2 above approaches, by setting both `(master|slave).affinity` and `(master|slave).antiAffinity`.

I paid attention to **not breaking backwards compatibility**. It should still be possible to set `podAntiAffinity` exactly the same. Values for `(master|slave).antiAffinity` can still be `"soft"`, `"hard"`, or `""` or anything else, and it should behave like it used to :
- **default** `--set master.antiAffinity=soft` ==> `preferredDuringSchedulingIgnoredDuringExecution` `podAntiAffinity`
- `--set master.antiAffinity=hard` ==> `requiredDuringSchedulingIgnoredDuringExecution` `podAntiAffinity`
- `--set master.antiAffinity=""` ==> no `podAntiAffinity` section in the yaml file.
- `--set master.antiAffinity=literallyAnything` ==> no `podAntiAffinity` section in the yaml file.

I successfully tested this in the following use case, to prevent from running master on a GKE preemptible node.
```
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: cloud.google.com/gke-preemptible
            operator: DoesNotExist
```