### PR TITLE
[CI] Use latest chart-testing image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             shellcheck -x test/repo-sync.sh
   lint-charts:
     docker:
-      - image: gcr.io/kubernetes-charts-ci/test-image:v2.0.2
+      - image: gcr.io/kubernetes-charts-ci/test-image:v2.0.3
     steps:
       - checkout
       - run:

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/kubernetes-charts-ci/chart-testing:v1.0.2
+FROM gcr.io/kubernetes-charts-ci/chart-testing:v1.0.3
 
 ENV PATH /google-cloud-sdk/bin:$PATH
-ARG CLOUD_SDK_VERSION=202.0.0
+ARG CLOUD_SDK_VERSION=212.0.0
 RUN curl -LO "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz" && \
     tar xzf "google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz" && \
     rm "google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz" && \

--- a/test/build.sh
+++ b/test/build.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly IMAGE_TAG=v2.0.2
+readonly IMAGE_TAG=v2.0.3
 readonly IMAGE_REPOSITORY="gcr.io/kubernetes-charts-ci/test-image"
 readonly SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly IMAGE_TAG=v2.0.2
+readonly IMAGE_TAG=v2.0.3
 readonly IMAGE_REPOSITORY="gcr.io/kubernetes-charts-ci/test-image"
 readonly REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 


### PR DESCRIPTION
Updates CI to use the chart-testing:v1.0.3.

I already pushed the new image (`gcr.io/kubernetes-charts-ci/test-image:v2.0.3`).