### PR TITLE
update clusterrolebinding.yaml missing field

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.8.0
+version: 3.8.1
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/sysdig/templates/clusterrolebinding.yaml
+++ b/stable/sysdig/templates/clusterrolebinding.yaml
@@ -15,4 +15,5 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: {{ template "sysdig.fullname" .}}
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
added apiGroup: rbac.authorization.k8s.io to the roleRef to appease some client side validation

**What this PR does / why we need it**:
This fixes an issue with rancher 2.0 client side validation on the parsed manifest
`"error validating data: field apiGroup: is required`
