### PR TITLE
[stable/jenkins] fix bump appVersion to reflect new jenkins lts release version 2.121.3

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.20
-appVersion: 2.121.2
+version: 0.16.21
+appVersion: 2.121.3
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
   projects as well as arbitrary scripts.


### PR DESCRIPTION
**What this PR does / why we need it**:

Jenkins LTS version 2.121.3 was released (see https://jenkins.io/changelog-stable). This PR reflects this change and bumps the appVersion.