### PR TITLE
[stable/artifactory] Remove default backend from Ingress

### DIFF
--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.3.0
+version: 7.3.1
 appVersion: 6.1.0
 description: Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.

--- a/stable/artifactory/templates/ingress.yaml
+++ b/stable/artifactory/templates/ingress.yaml
@@ -15,9 +15,6 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  backend:
-    serviceName: {{ $serviceName }}
-    servicePort: {{ $servicePort }}
 {{- if .Values.ingress.hosts }}
   rules:
   {{- range $host := .Values.ingress.hosts }}


### PR DESCRIPTION
**What this PR does / why we need it**: Remove default backend that can interfere with other configurations

**Which issue this PR fixes**: None

**Special notes for your reviewer**: Since `values.yaml` already specifies a dummy value in hosts the `if .Values.ingress.hosts` should always evaluate to true and thus be unnecessary. If the reason is that we want to allow to unset the hosts, we could also move the default backend into an else case.