### PR TITLE
[stable/sonatype-nexus] Enable use of hostAliases

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.5.1
+version: 1.5.2
 appVersion: 3.12.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.5.2
+version: 1.6.0
 appVersion: 3.12.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.readinessProbe.periodSeconds`        | Seconds between polls               | 30                                      |
 | `nexus.readinessProbe.failureThreshold`     | Number of attempts before failure   | 6                                       |
 | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
-| `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | {}                                      |
+| `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | []                                      |
 | `nexusProxy.port`                           | Port for exposing Nexus             | `8080`                                  |
 | `nexusProxy.imageName`                      | Proxy image                         | `quay.io/travelaudience/docker-nexus-proxy` |
 | `nexusProxy.imageTag`                       | Proxy image version                 | `2.1.0`                                 |

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.readinessProbe.periodSeconds`        | Seconds between polls               | 30                                      |
 | `nexus.readinessProbe.failureThreshold`     | Number of attempts before failure   | 6                                       |
 | `nexus.readinessProbe.path`                 | Path for ReadinessProbe             | /                                       |
+| `nexus.hostAliases`                         | Aliases for IPs in /etc/hosts       | {}                                      |
 | `nexusProxy.port`                           | Port for exposing Nexus             | `8080`                                  |
 | `nexusProxy.imageName`                      | Proxy image                         | `quay.io/travelaudience/docker-nexus-proxy` |
 | `nexusProxy.imageTag`                       | Proxy image version                 | `2.1.0`                                 |

--- a/stable/sonatype-nexus/templates/deployment.yaml
+++ b/stable/sonatype-nexus/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nexus.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.nexus.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.nexus.hostAliases | indent 8 }}
+      {{- end }}
       containers:
         - name: nexus
           image: {{ .Values.nexus.imageName }}:{{ .Values.nexus.imageTag }}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -37,6 +37,12 @@ nexus:
     periodSeconds: 30
     failureThreshold: 6
     path: /
+  # hostAliases allows the modification of the hosts file inside a container
+  hostAliases:
+  # - ip: "192.168.1.10"
+  #   hostnames:
+  #   - "example.com"
+  #   - "www.example.com"
 
 nexusProxy:
   imageName: quay.io/travelaudience/docker-nexus-proxy

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -38,7 +38,7 @@ nexus:
     failureThreshold: 6
     path: /
   # hostAliases allows the modification of the hosts file inside a container
-  hostAliases:
+  hostAliases: []
   # - ip: "192.168.1.10"
   #   hostnames:
   #   - "example.com"


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable use of [hostAliases](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#hostalias-v1-core)
