### PR TITLE
Use IP address instead of hostname

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.0.0
+version: 1.0.1
 appVersion: 4.1.1
 keywords:
   - confluent

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
           - name: SCHEMA_REGISTRY_HOST_NAME
             valueFrom:
               fieldRef:
-                fieldPath: metadata.name
+                fieldPath: status.podIP
           - name: SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
             value: {{ template "schema-registry.kafkaStore.bootstrapServers" . }}
           - name: SCHEMA_REGISTRY_KAFKASTORE_GROUP_ID


### PR DESCRIPTION
**What this PR does / why we need it**:
Use IP address instead of the hostname for SCHEMA_REGISTRY_HOST_NAME.  Since internal DNS for pods can be disabled,  the slave might not be able to communicate to master.

By using IP address,  we do not have to rely on DNS resolution for pods.

