### PR TITLE
[stable/presto] Ability to add connectors through configMap and secret

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.196
 description: Distributed SQL query engine for running interactive analytic queries
 name: presto
-version: 0.1
+version: 0.1.1
 home: https://prestodb.io
 icon: https://prestodb.io/static/presto.png
 sources:

--- a/stable/presto/README.md
+++ b/stable/presto/README.md
@@ -31,3 +31,37 @@ $ helm install --name my-release -f values.yaml stable/presto
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+### Connectors
+
+Presto can query across multiple data sources, and it currently supports [20 different connectors](https://prestodb.io/docs/current/connector). You can upload custom connectors as a [configMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) or as file [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/). 
+
+In the default setup, two connectors are added through [configmap-connectors.yaml](templates/configmap-connectors.yaml) as a demo. 
+These connectors provides a set of schemas to support the [TPC Benchmark™](http://www.tpc.org/information/benchmarks.asp). These connectors can be used to test the capabilities and query syntax of Presto without configuring access to an external data source. When you query a schema, the connector generates the data on the fly using a deterministic algorithm.
+
+**configMap**
+
+You can create a configMap with connector `properties` files, and launch your cluster with it.
+
+```bash
+kubectl create configmap my-presto-connectors \
+	--from-file=/presto/connectors/directory/
+
+helm install stable/presto --name my-presto-cluster \
+	--set server.connectors.volumeMount.type=configMap,server.connectors.volumeMount.name=my-presto-connectors
+```
+
+**secret**
+
+Alternatively, kubernetes secret is an excellent way to upload connectors to your presto cluster securely.
+
+You can package your connector files into a secret, and launch your cluster with it.
+
+```bash
+kubectl create secret generic my-presto-connectors \
+	--from-file=/presto/connectors/directory/
+
+helm install stable/presto --name my-presto-cluster \
+	--set server.connectors.volumeMount.type=secret,server.connectors.volumeMount.name=my-presto-connectors
+
+```

--- a/stable/presto/templates/_helpers.tpl
+++ b/stable/presto/templates/_helpers.tpl
@@ -32,6 +32,24 @@ If release name contains chart name it will be used as a full name.
 {{ template "presto.fullname" . }}-worker
 {{- end -}}
 
+{{- define "presto.connectors" -}}
+{{ template "presto.fullname" . }}-connectors
+{{- end -}}
+
+{{- define "presto.connectors.volumeMount.nameKeyVal" -}}
+{{- if (eq "configMap" .Values.server.connectors.volumeMount.type) -}}
+{{- if (eq "" .Values.server.connectors.volumeMount.name) -}}
+name: {{ template "presto.connectors" . }}
+{{- else -}}
+name: {{ .Values.server.connectors.volumeMount.name }}
+{{- end -}}
+{{- else -}}
+{{- if (eq "secret" .Values.server.connectors.volumeMount.type) -}}
+secretName: {{ .Values.server.connectors.volumeMount.name }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/stable/presto/templates/configmap-connectors.yaml
+++ b/stable/presto/templates/configmap-connectors.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "presto.connectors" . }}
+  labels:
+    app: {{ template "presto.name" . }}
+    chart: {{ template "presto.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  tpch.properties: |
+    connector.name=tpch
+
+  tpcds.properties: |
+    connector.name=tpcds
+
+---

--- a/stable/presto/templates/deployment-coordinator.yaml
+++ b/stable/presto/templates/deployment-coordinator.yaml
@@ -25,6 +25,9 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "presto.coordinator" . }}
+        - name: catalog-volume
+          {{ .Values.server.connectors.volumeMount.type }}:
+            {{ template "presto.connectors.volumeMount.nameKeyVal" . }}
       containers:
         - name: {{ .Chart.Name }}-coordinator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -35,6 +38,8 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume
+            - mountPath: {{ .Values.server.connectors.catalogDir }}
+              name: catalog-volume
           ports:
             - name: http-coord
               containerPort: {{ .Values.server.config.http.port }}

--- a/stable/presto/templates/deployment-worker.yaml
+++ b/stable/presto/templates/deployment-worker.yaml
@@ -27,6 +27,9 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "presto.worker" . }}
+        - name: catalog-volume
+          {{ .Values.server.connectors.volumeMount.type }}:
+            {{ template "presto.connectors.volumeMount.nameKeyVal" . }}
       containers:
         - name: {{ .Chart.Name }}-worker
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -37,6 +40,8 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.path }}
               name: config-volume
+            - mountPath: {{ .Values.server.connectors.catalogDir }}
+              name: catalog-volume
           livenessProbe:
             exec:
               command:

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -3,6 +3,11 @@ server:
   node:
     environment: production
     dataDir: /presto/etc/data
+  connectors:
+    catalogDir: /presto/etc/catalog
+    volumeMount:
+      type: configMap           # supports `configMap` and `secret`
+      name: ""                  # name of the secret or configMap
   log:
     presto:
       level: INFO


### PR DESCRIPTION
I have added support to add connectors to Presto. Below are the instuctions to add custom connector files.

### Connectors

Presto can query across multiple data sources, and it currently supports [20 different connectors](https://prestodb.io/docs/current/connector). You can upload custom connectors as a [configMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) or as file [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/). 

In the default setup, two connectors are added through [configmap-connectors.yaml](templates/configmap-connectors.yaml) as a demo. 
These connectors provides a set of schemas to support the [TPC Benchmark™](http://www.tpc.org/information/benchmarks.asp). These connectors can be used to test the capabilities and query syntax of Presto without configuring access to an external data source. When you query a schema, the connector generates the data on the fly using a deterministic algorithm.

**configMap**

You can create a configMap with connector `properties` files, and launch your cluster with it.

```bash
kubectl create configmap my-presto-connectors \
	--from-file=/presto/connectors/directory/

helm install stable/presto --name my-presto-cluster \
	--set server.connectors.volumeMount.type=configMap,server.connectors.volumeMount.name=my-presto-connectors
```

**secret**

Alternatively, kubernetes secret is an excellent way to upload connectors to your presto cluster securely.

You can package your connector files into a secret, and launch your cluster with it.

```bash
kubectl create secret generic my-presto-connectors \
	--from-file=/presto/connectors/directory/

helm install stable/presto --name my-presto-cluster \
	--set server.connectors.volumeMount.type=secret,server.connectors.volumeMount.name=my-presto-connectors

```