### PR TITLE
Use initContainer to get around read-only configMap volume

### DIFF
--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -27,6 +27,17 @@ spec:
         app: {{ template "openldap.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.customLdifFiles }}
+      initContainers:
+        - name: copy-custom
+          image: busybox
+          command: ["sh", "-c", "cp /custom/* /custom-ldif/"]
+          volumeMounts:
+            - name: customldif-pre
+              mountPath: /custom
+            - name: customldif
+              mountPath: /custom-ldif
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -80,9 +91,11 @@ spec:
     {{- end }}
       volumes:
         {{- if .Values.customLdifFiles }}
-        - name: customldif
+        - name: customldif-pre
           configMap:
             name: {{ template "openldap.fullname" . }}-customldif
+        - name: customldif
+          emptyDir: {}
         {{- end }}
         - name: data
         {{- if .Values.persistence.enabled }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
