### PR TITLE
Add support for tablespaces

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.19.0
+version: 0.20.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -92,6 +92,7 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `probes.readiness.failureThreshold` | Readiness probe failure threshold      | `5`                                                        |
 | `podAnnotations`           | Annotations for the postgresql pod              | {}                                                         |
 | `deploymentAnnotations`    | Annotations for the postgresql deployment       | {}                                                         |
+| `tablespaces`              | Tablespaces to be created                       | `[]`                                                       |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 
@@ -154,3 +155,9 @@ With NetworkPolicy enabled, traffic will be limited to just port 5432.
 For more precise policy, set `networkPolicy.allowExternal=false`. This will
 only allow pods with the generated client label to connect to PostgreSQL.
 This label will be displayed in the output of a successful install.
+
+## Tablespaces
+The chart supports tablespaces by using `subPath` on data volume as tablespace data directory. For every tablespace, the chart does the following:
+
+1. change the ownership (`chown`) of the tablespace data directory to `postgres:postgres`
+2. run a sql query to create the tablespace in the database

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -48,3 +48,14 @@ Generate chart secret name
 {{- define "postgresql.secretName" -}}
 {{ default (include "postgresql.fullname" .) .Values.existingSecret }}
 {{- end -}}
+
+{{/*
+Return volumeMounts for tablespaces
+*/}}
+{{- define "postgresql.tablespaces.volumeMounts" -}}
+{{- range .Values.tablespaces }}
+        - name: data
+          mountPath: {{ .mountPath }}
+          subPath: {{ .subPath }}
+{{- end }}
+{{- end -}}

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -50,6 +50,21 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if gt (len .Values.tablespaces) 0 }}
+      initContainers:
+      - name: init-tablespaces
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        command:
+          - /bin/sh
+          - -ec
+          - |
+            {{- range .Values.tablespaces }}
+            chown -R postgres:postgres {{ .mountPath }}
+            {{- end }}
+        volumeMounts:
+        {{- template "postgresql.tablespaces.volumeMounts" . }}
+      {{- end }}
       containers:
       - name: {{ template "postgresql.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -70,7 +85,7 @@ spec:
         - name: PGUSER
           value: {{ default "postgres" .Values.postgresUser | quote }}
         - name: POSTGRES_DB
-          value: {{ default "" .Values.postgresDatabase | quote }}
+          value: {{ default "postgres" .Values.postgresDatabase | quote }}
         - name: POSTGRES_INITDB_ARGS
           value: {{ default "" .Values.postgresInitdbArgs | quote }}
         - name: PGDATA
@@ -114,6 +129,7 @@ spec:
         - name: data
           mountPath: {{ .Values.persistence.mountPath }}
           subPath: {{ .Values.persistence.subPath }}
+        {{- template "postgresql.tablespaces.volumeMounts" . }}
         {{- if .Values.usePasswordFile }}
         - name: password-file
           mountPath: /conf

--- a/stable/postgresql/templates/job.yaml
+++ b/stable/postgresql/templates/job.yaml
@@ -1,0 +1,69 @@
+{{ if gt (len .Values.tablespaces) 0 }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "postgresql.fullname" . }}-create-tablespaces
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: wait-for-db
+        image: jwilder/dockerize
+        command: ['dockerize', '-timeout', '120s', '-wait', 'tcp://{{ template "postgresql.fullname" . }}.{{ .Release.Namespace }}:5432']
+      containers:
+      - name: create-tablespaces
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        command:
+        - /bin/sh
+        - -ec
+        - |
+          {{- if .Values.usePasswordFile }}
+          export PGPASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
+          {{- else }}
+          export PGPASSWORD=$POSTGRES_PASSWORD
+          {{- end }}
+          host={{- template "postgresql.fullname" . -}}.{{- .Release.Namespace -}}
+          {{- range .Values.tablespaces }}
+          psql -h $host -U $POSTGRES_USER -d $POSTGRES_DB -c "CREATE TABLESPACE {{ .name }} OWNER $POSTGRES_USER LOCATION '{{ .mountPath }}';"
+          {{- end }}
+        env:
+        - name: POSTGRES_USER
+          value: {{ default "postgres" .Values.postgresUser | quote }}
+        - name: POSTGRES_DB
+          value: {{ default "postgres" .Values.postgresDatabase | quote }}
+        {{- if .Values.usePasswordFile }}
+        - name: POSTGRES_PASSWORD_FILE
+          value: /conf/postgres-password
+        {{- else }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "postgresql.secretName" . }}
+              key: postgres-password
+        {{- end }}
+        volumeMounts:
+        {{- if .Values.usePasswordFile }}
+        - name: password-file
+          mountPath: /conf
+          readOnly: true
+        {{- end }}
+      volumes:
+      {{- if .Values.usePasswordFile }}
+      - name: password-file
+        secret:
+          secretName: {{ template "postgresql.secretName" . }}
+          items:
+            - key: postgres-password
+              path: postgres-password
+      {{- end }}
+{{ end }}

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -60,6 +60,13 @@ usePasswordFile: false
 #   host all all localhost trust
 #   host mydatabase mysuser 192.168.0.0/24 md5
 
+## Tablespaces
+## https://www.postgresql.org/docs/10/static/manage-ag-tablespaces.html
+tablespaces: []
+  # - name: tablespace_name
+  #   mountPath: /opt/data/tablspace_data
+  #   subPath: tablespace_subpath
+
 ## Persist data to a persistent volume
 persistence:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:

`postgresql` chart currently doesn't support tablespaces. This PR automates the creation of tablespaces using `subPath` on data volume as tablespace data directory.

Given a list of tablespaces via chart values, the chart does the following for each tablespace:

1. change the ownership (`chown`) of the tablespace data directory to `postgres:postgres`
2. run a sql query to create the tablespace in the database