### PR TITLE
[stable/sentry] Add missing values for the db-init and user-create jobs

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.3.4
+version: 1.3.5
 appVersion: 9.0
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -89,6 +89,20 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `worker.schedulerName`               | Name of an alternate scheduler for worker   | `nil`                                                      |
 | `worker.affinity`                    | Affinity settings for worker pod assignment | `{}`                                                       |
 | `worker.tolerations`                 | Toleration labels for worker pod assignment | `[]`                                                       |
+| `jobs.dbInit.podAnnotations`         | db-init job annotations                     | `{}`                                                       |
+| `jobs.dbInit.resources.limits`       | db-init job resource limits                 | `{cpu: "1", memory: 2Gi}`                                  |
+| `jobs.dbInit.resources.requests`     | db-init job resource requests               | `{cpu: 100m, memory: 200Mi}`                               |
+| `jobs.dbInit.nodeSelector`           | Node labels for db-init job assignment      | `{}`                                                       |
+| `jobs.dbInit.schedulerName`          | Name of an alternate scheduler for db-init  | `nil`                                                      |
+| `jobs.dbInit.affinity`               | Affinity settings for db-init job assignment | `{}`                                                      |
+| `jobs.dbInit.tolerations`            | Toleration labels for db-init job assignment | `[]`                                                      |
+| `jobs.userCreate.podAnnotations`     | user-create job annotations                 | `{}`                                                       |
+| `jobs.userCreate.resources.limits`   | user-create job resource limits             | `{cpu: 200m, memory: 200Mi}`                               |
+| `jobs.userCreate.resources.requests` | user-create job resource requests           | `{cpu: 100m, memory: 100Mi}`                               |
+| `jobs.userCreate.nodeSelector`       | Node labels for user-create job assignment  | `{}`                                                       |
+| `jobs.userCreate.schedulerName`      | Name of an alternate scheduler for user-create | `nil`                                                   |
+| `jobs.userCreate.affinity`           | Affinity settings for user-create job assignment | `{}`                                                  |
+| `jobs.userCreate.tolerations`        | Toleration labels for user-create job assignment | `[]`                                                  |
 | `user.create`                        | Create the default admin                    | `true`                                                     |
 | `user.email`                         | Username for default admin                  | `admin@sentry.local`                                       |
 | `email.from_address`                 | Email notifications are from                | `smtp`                                                     |

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -17,6 +17,10 @@ metadata:
 spec:
   template:
     metadata:
+      {{- if .Values.jobs.dbInit.podAnnotations }}
+      annotations:
+{{ toYaml .Values.jobs.dbInit.podAnnotations | indent 8 }}
+      {{- end }}
       name: "{{ .Release.Name }}-db-init"
       labels:
         app: {{ template "fullname" . }}
@@ -26,6 +30,21 @@ spec:
         {{- end }}
     spec:
       restartPolicy: Never
+      {{- if .Values.jobs.dbInit.affinity }}
+      affinity:
+{{ toYaml .Values.jobs.dbInit.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.jobs.dbInit.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.jobs.dbInit.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.jobs.dbInit.tolerations }}
+      tolerations:
+{{ toYaml .Values.jobs.dbInit.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.jobs.dbInit.schedulerName }}
+      schedulerName: "{{ .Values.jobs.dbInit.schedulerName }}"
+      {{- end }}
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
@@ -95,6 +114,8 @@ spec:
         - mountPath: /etc/sentry
           name: config
           readOnly: true
+        resources:
+{{ toYaml .Values.jobs.dbInit.resources | indent 12 }}
       volumes:
       - name: config
         configMap:

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -17,6 +17,10 @@ metadata:
 spec:
   template:
     metadata:
+      {{- if .Values.jobs.userCreate.podAnnotations }}
+      annotations:
+{{ toYaml .Values.jobs.userCreate.podAnnotations | indent 8 }}
+      {{- end }}
       name: "{{ .Release.Name }}-user-create"
       labels:
         app: {{ template "fullname" . }}
@@ -26,6 +30,21 @@ spec:
         {{- end }}
     spec:
       restartPolicy: Never
+      {{- if .Values.jobs.userCreate.affinity }}
+      affinity:
+{{ toYaml .Values.jobs.userCreate.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.jobs.userCreate.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.jobs.userCreate.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.jobs.userCreate.tolerations }}
+      tolerations:
+{{ toYaml .Values.jobs.userCreate.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.jobs.userCreate.schedulerName }}
+      schedulerName: "{{ .Values.jobs.userCreate.schedulerName }}"
+      {{- end }}
       {{- if .Values.image.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
@@ -100,6 +119,8 @@ spec:
         - mountPath: /etc/sentry
           name: config
           readOnly: true
+        resources:
+{{ toYaml .Values.jobs.userCreate.resources | indent 12 }}
       volumes:
       - name: config
         configMap:

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -69,6 +69,33 @@ worker:
   # Optional extra labels for pod, i.e. redis-client: "true"
   # podLabels: []
 
+# Job resources
+jobs:
+  dbInit:
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 200Mi
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    # schedulerName
+  userCreate:
+    resources:
+      limits:
+        cpu: 200m
+        memory: 200Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    # schedulerName
+
 # Admin user to create
 user:
   # Indicated to create the admin user or not,


### PR DESCRIPTION

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Adds missing resource configuration - and ability to set selectors, tolerations, affinity, and scheduler name - for the db-init and user-create jobs.
This should make it more possible to deploy sentry on clusters with resource quotas, tainted nodes, and/or other cluster restrictions.

**Which issue this PR fixes**: fixes #6321