### PR TITLE
[mongodb-replicaset] Add support for init standalone maintenance scripts

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.5.7
+version: 3.6.0
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `auth.existingAdminSecret`          | If set, and existing secret with this name is used for the admin user     | ``                                                  |
 | `serviceAnnotations`                | Annotations to be added to the service                                    | `{}`                                                |
 | `configmap`                         | Content of the MongoDB config file                                        | ``                                                  |
+| `initMongodStandalone`              | If set, initContainer executes script in standalone mode                  | ``                                                  |
 | `nodeSelector`                      | Node labels for pod assignment                                            | `{}`                                                |
 | `affinity`                          | Node/pod affinities                                                       | `{}`                                                |
 | `tolerations`                       | List of node taints to tolerate                                           | `[]`                                                |
@@ -355,3 +356,22 @@ connecting to: mongodb://127.0.0.1:27017
 ### Scaling
 
 Scaling should be managed by `helm upgrade`, which is the recommended way.
+
+### Indexes and Maintenance
+
+You can run Mongo in standalone mode and execute Javascript code on each replica at initContainer time using `initMongodStandalone`.
+This allows you to create indexes on replicasets following [best practices](https://docs.mongodb.com/manual/tutorial/build-indexes-on-replica-sets/).
+
+#### Example: Creating Indexes
+
+```js
+initMongodStandalone: |+
+  db = db.getSiblingDB("mydb")
+  db.my_users.createIndex({email: 1})
+```
+
+Tail the logs to debug running indexes or to follow their progress
+
+```sh
+kubectl exec -it $RELEASE-mongodb-replicaset-0 -c bootstrap -- tail -f /work-dir/log.txt
+```

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -45,6 +45,20 @@ shutdown_mongo() {
     mongo admin "${admin_creds[@]}" "${ssl_args[@]}" --eval "db.shutdownServer({$args})"
 }
 
+init_mongod_standalone() {
+    log "Starting a MongoDB instance as standalone..."
+    mongod --config /data/configdb/mongod.conf --dbpath=/data/db "${auth_args[@]}" --bind_ip=0.0.0.0 >> /work-dir/log.txt 2>&1 &
+    log "Waiting for MongoDB to be ready..."
+    until mongo "${ssl_args[@]}" --eval "db.adminCommand('ping')"; do
+        log "Retrying..."
+        sleep 2
+    done
+    log "Initialized."
+    log "Running init js script on standalone mongod..."
+    mongo admin "${admin_creds[@]}" "${ssl_args[@]}" /init/initMongodStandalone.js
+    shutdown_mongo
+}
+
 my_hostname=$(hostname)
 log "Bootstrapping MongoDB replica set member: $my_hostname"
 
@@ -97,10 +111,16 @@ EOL
     rm mongo.key mongo.crt
 fi
 
+if [ -f /init/initMongodStandalone.js ]
+then
+    init_mongod_standalone
+else
+    log "Skipping init mongod standalone script"
+fi
 
 log "Peers: ${peers[*]}"
 
-log "Starting a MongoDB instance..."
+log "Starting a MongoDB instance as replica..."
 mongod --config /data/configdb/mongod.conf --dbpath=/data/db --replSet="$replica_set" --port=27017 "${auth_args[@]}" --bind_ip=0.0.0.0 >> /work-dir/log.txt 2>&1 &
 
 log "Waiting for MongoDB to be ready..."
@@ -175,4 +195,3 @@ if mongo "${ssl_args[@]}" --eval "rs.status()" | grep "no replset config has bee
 fi
 
 shutdown_mongo
-log "Good bye."

--- a/stable/mongodb-replicaset/templates/mongodb-init-configmap.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-init-configmap.yaml
@@ -13,3 +13,8 @@ metadata:
 data:
   on-start.sh: |
 {{ .Files.Get "init/on-start.sh" | indent 4 }}
+{{- if .Values.initMongodStandalone }}
+  initMongodStandalone.js: |
+{{ .Values.initMongodStandalone | indent 4 }}
+{{- end }}
+

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -107,6 +107,14 @@ tls:
 # Entries for the MongoDB config file
 configmap:
 
+# Javascript code to execute on each replica at initContainer time
+# This is the recommended way to create indexes on replicasets.
+# Below is an example that creates indexes in foreground on each replica in standalone mode.
+# ref: https://docs.mongodb.com/manual/tutorial/build-indexes-on-replica-sets/
+# initMongodStandalone: |+
+#   db = db.getSiblingDB("mydb")
+#   db.my_users.createIndex({email: 1})
+
 # Readiness probe
 readinessProbe:
   initialDelaySeconds: 5


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce a way to run maintenance scripts in Mongodb replicasets. This is especially useful for creating new indexes in a rolling fashion with no downtime and fastest performance according to the best practices. More info added in README.md.

**Special notes for your reviewer**:
@foxish @unguiculus