### PR TITLE
[stable/mongodb] Add new parameter to enable/disable IPv6 on MongoDB

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 4.1.2
+version: 4.2.0
 appVersion: 4.0.1
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `mongodbUsername`                       | MongoDB custom user                                                                          | `nil`                                                    |
 | `mongodbPassword`                       | MongoDB custom user password                                                                 | `random alhpanumeric string (10)`                        |
 | `mongodbDatabase`                       | Database to create                                                                           | `nil`                                                    |
+| `mongodbEnableIPv6`                     | Switch to enable/disable IPv6 on MongoDB                                                     | `true`                                                   |
 | `mongodbExtraFlags`                     | MongoDB additional command line flags                                                        | []                                                       |
 | `service.annotations`                   | Kubernetes service annotations                                                               | `{}`                                                     |
 | `service.type`                          | Kubernetes Service type                                                                      | `ClusterIP`                                              |
@@ -75,9 +76,10 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `nodeSelector`                          | Node labels for pod assignment                                                               | {}                                                       |
 | `affinity`                              | Affinity for pod assignment                                                                  | {}                                                       |
 | `tolerations`                           | Toleration labels for pod assignment                                                         | {}                                                       |
-| `securityContext.enabled`            | Enable security context                                                                      | `true`                            |
-| `securityContext.fsGroup`            | Group ID for the container                                                                   | `1001`                            |
-| `securityContext.runAsUser`          | User ID for the container                                                                    | `1001`              | `persistence.enabled`                   | Use a PVC to persist data                                                                    | `true`                                                   |
+| `securityContext.enabled`               | Enable security context                                                                      | `true`                                                   |
+| `securityContext.fsGroup`               | Group ID for the container                                                                   | `1001`                                                   |
+| `securityContext.runAsUser`             | User ID for the container                                                                    | `1001`                                                   |
+| `persistence.enabled`                   | Use a PVC to persist data                                                                    | `true`                                                   |
 | `persistence.storageClass`              | Storage class of backing PVC                                                                 | `nil` (uses alpha storage class annotation)              |
 | `persistence.accessMode`                | Use volume as ReadOnly or ReadWrite                                                          | `ReadWriteOnce`                                          |
 | `persistence.size`                      | Size of data volume                                                                          | `8Gi`                                                    |

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -74,6 +74,12 @@ spec:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
                 key: mongodb-replica-set-key
             {{- end }}
+          - name: MONGODB_ENABLE_IPV6
+          {{- if .Values.mongodbEnableIPv6 }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
           - name: MONGODB_EXTRA_FLAGS
             value: {{ default "" .Values.mongodbExtraFlags | join " " }}
           {{- if .Values.livenessProbe.enabled }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -83,6 +83,12 @@ spec:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
                 key: mongodb-replica-set-key
             {{- end }}
+          - name: MONGODB_ENABLE_IPV6
+          {{- if .Values.mongodbEnableIPv6 }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
           - name: MONGODB_EXTRA_FLAGS
             value: {{ default "" .Values.mongodbExtraFlags | join " " }}
           {{- if .Values.livenessProbe.enabled }}

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -75,6 +75,12 @@ spec:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
                 key: mongodb-replica-set-key
             {{- end }}
+          - name: MONGODB_ENABLE_IPV6
+          {{- if .Values.mongodbEnableIPv6 }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
           - name: MONGODB_EXTRA_FLAGS
             value: {{ default "" .Values.mongodbExtraFlags | join " " }}
           {{- if .Values.livenessProbe.enabled }}

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -39,6 +39,11 @@ usePassword: true
 # mongodbPassword: password
 # mongodbDatabase: database
 
+## Whether enable/disable IPv6 on MongoDB
+## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
+##
+mongodbEnableIPv6: true
+
 ## MongoDB additional command line flags
 ##
 ## Can be used to specify command line flags, for example:

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -39,6 +39,12 @@ usePassword: true
 # mongodbPassword: password
 # mongodbDatabase: database
 
+
+## Whether enable/disable IPv6 on MongoDB
+## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
+##
+mongodbEnableIPv6: true
+
 ## MongoDB additional command line flags
 ##
 ## Can be used to specify command line flags, for example:


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds a new parameter that allows the user to enable/disable IPv6 on MongoDB configuration.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/bitnami/bitnami-docker-mongodb/issues/108