### PR TITLE
common: fix empty templates exception

### DIFF
--- a/incubator/common/Chart.yaml
+++ b/incubator/common/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Common chartbuilding components and helpers
 name: common
-version: 0.0.4
-appVersion: 0.0.4
+version: 0.0.5
+appVersion: 0.0.5
 home: https://helm.sh
 maintainers:
 - name: technosophos

--- a/incubator/common/templates/_util.tpl
+++ b/incubator/common/templates/_util.tpl
@@ -9,7 +9,7 @@ This takes an array of three values:
 */ -}}
 {{- define "common.util.merge" -}}
 {{- $top := first . -}}
-{{- $overrides := fromYaml (include (index . 1) $top) -}}
-{{- $tpl := fromYaml (include (index . 2) $top) -}}
+{{- $overrides := fromYaml (include (index . 1) $top) | default (dict ) -}}
+{{- $tpl := fromYaml (include (index . 2) $top) | default (dict ) -}}
 {{- toYaml (merge $overrides $tpl) -}}
 {{- end -}}


### PR DESCRIPTION
(Copied from https://github.com/helm/helm/issues/4495)

In many of the docs of the common chart, the documentation suggest using the templates as follows, because everything is taken care of in the common package directly :

```
{{- template "common.persistentvolumeclaim" (list . "pypicloud.persistentvolumeclaim") -}}
{{- define "pypicloud.persistentvolumeclaim" -}}
{{- end -}}
```

However, doing this will make the chart impossible to render, raising the following error Error: rendering template failed: assignment to entry in nil map.

I have found that by overriding a known key is enough to overcome the error. I found the best to just override the metadata.name with the common template.

```
{{- template "common.persistentvolumeclaim" (list . "pypicloud.persistentvolumeclaim") -}}
{{- define "pypicloud.persistentvolumeclaim" -}}
metadata:
  name: {{template "common.fullname" .}}
{{- end -}}
```

If using helmsman, an error to render the template will throw an error like the following:

```
2018/08/20 00:27:07 INFO: namespace validation -- Tiller is desired to be deployed WITHOUT TLS in namespace [ kube-system ].                                                                 
2018/08/20 00:27:07 INFO: namespace validation -- Tiller is desired to be deployed WITHOUT TLS in namespace [ javier-domingo ].                                                              
2018/08/20 00:27:07 WARN: I could not create namespace [kube-system ]. It already exists. I am skipping this.                                                                                
2018/08/20 00:27:08 WARN: I could not create namespace [javier-domingo ]. It already exists. I am skipping this.                                                                             
2018/08/20 00:27:08 INFO: deploying Tiller in namespace [ kube-system ].                                                                                                                     
2018/08/20 00:27:09 INFO: deploying Tiller in namespace [ javier-domingo ].                                                                                                                  
2018/08/20 00:27:20 INFO: checking what I need to do for your charts ...                                                                                                                     
2018/08/20 00:27:20 INFO: mapping the current helm state ...                                                                                                                                 
2018/08/20 00:27:22 INFO: checking if any Helmsman managed releases are no longer tracked by your desired state ...                                                                          
2018/08/20 00:27:23 INFO: no untracked releases found.                                                                                                                                       
2018/08/20 00:27:23 INFO: sorting the commands in the plan based on priorities (order flags) ...                                                                                             
----------------------                                                                                                                                                                       
2018/08/20 00:27:23 INFO: Plan generated at: Sun Aug 19 2018 23:27:20
DECISION: release [ pypicloud-javier ] is desired to be enabled and is currently enabled.I will upgrade it in case you changed your values.yaml! -- priority: 0                              
2018/08/20 00:27:23 INFO: sorting the commands in the plan based on priorities (order flags) ...                                                                                             
2018/08/20 00:27:23 INFO: Executing the plan ...
2018/08/20 00:27:24 Command returned with exit code: . And error message: Error: UPGRADE FAILED: cannot re-use a name that is still in use                                                   
```

This PR fixes these situations by adding an empty dict as default value, so that common package README instruction can be followed.