### PR TITLE
[incubator/zookeeper]: incorrect terminationGracePeriodSeconds element

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 1.1.1
+version: 1.1.2
 appVersion: 3.4.10
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   serviceName: {{ template "zookeeper.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
-  terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   selector:
     matchLabels:
       app: {{ template "zookeeper.name" . }}
@@ -39,6 +38,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}


### PR DESCRIPTION
**terminationGracePeriodSeconds on StatefulSet is in incorrect place and current chart is broken**:

Currently for zookeper
```
helm install .
```
fails with following :

```
Error: error validating "": error validating data: found invalid field terminationGracePeriodSeconds for v1beta1.StatefulSetSpec
```
I suppose this is due to `terminationGracePeriodSeconds` mentioned incorrectly. This PR fixes it.

@lachie83 @kow3ns please have a look and merge to fix. Thanks
