### PR TITLE
Allow pulling image from private registry

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.0.2
+version: 1.0.3
 appVersion: 6.3.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `image.repository`          | The image repository to pull from  | `datadog/agent`                           |
 | `image.tag`                 | The image tag to pull              | `6.3.2`                                   |
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
+| `image.pullSecrets`         | Image pull secrets                 |  `nil`                                    |
 | `rbac.create`               | If true, create & use RBAC resources | `true`                                  |
 | `rbac.serviceAccount`       | existing ServiceAccount to use (ignored if rbac.create=true) | `default`       |
 | `datadog.env`               | Additional Datadog environment variables | `nil`                               |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -29,6 +29,10 @@ spec:
       {{- if .Values.daemonset.useHostPID }}
       hostPID: {{ .Values.daemonset.useHostPID }}
       {{- end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         checksum/confd-config: {{ toYaml .Values.datadog.confd | sha256sum }}
         checksum/checksd-config: {{ toYaml .Values.datadog.checksd | sha256sum }}
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -5,6 +5,10 @@ image:
   # repository: datadog/dogstatsd         # Standalone DogStatsD6
   tag: 6.3.2  # Use 6.3.2-jmx to enable jmx fetch collection
   pullPolicy: IfNotPresent
+  ## It is possible to specify docker registry credentials
+  ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  # pullSecrets:
+  #    - regsecret
 
 # NB! Normally you need to keep Datadog DaemonSet enabled!
 # The exceptional case could be a situation when you need to run

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -8,7 +8,7 @@ image:
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   # pullSecrets:
-  #    - regsecret
+  #    - name: regsecret
 
 # NB! Normally you need to keep Datadog DaemonSet enabled!
 # The exceptional case could be a situation when you need to run


### PR DESCRIPTION
**What this PR does / why we need it**:

What it does: Allow pulling the data dog image from private registry.
Why need it: Variety of reasons such as customization of the image and bug fixes such as https://github.com/helm/charts/issues/6481 and other.

**Which issue this PR fixes** *
fixes #6485
**Special notes for your reviewer**:
