### PR TITLE
 [incubator/taiga] Release 0.2.0 (initial release)

### DIFF
--- a/incubator/taiga/.gitignore
+++ b/incubator/taiga/.gitignore
@@ -1,0 +1,3 @@
+**.swp
+charts
+requirements.lock

--- a/incubator/taiga/.helmignore
+++ b/incubator/taiga/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/taiga/Chart.yaml
+++ b/incubator/taiga/Chart.yaml
@@ -1,0 +1,18 @@
+name: taiga
+version: 0.2.0
+appVersion: "3.3.0-3-gd0ec0f9"
+description: Helm chart for the taiga project management platform
+keywords:
+- taiga
+- project management
+- scrum
+- kanban
+home: https://taiga.io
+icon: https://taiga.io/v-43b64963b3/images/logo-color.png
+sources:
+- https://github.com/mvitale1989/docker-taiga
+maintainers:
+- name: mvitale1989
+  email: mvitale1989@hotmail.com
+apiVersion: v1
+kubeVersion: ">=1.10.0"

--- a/incubator/taiga/README.md
+++ b/incubator/taiga/README.md
@@ -1,0 +1,194 @@
+# taiga
+
+[Taiga](https://taiga.io/) is a project management platform for agile developers & designers and project managers who want a beautiful tool that makes work truly enjoyable.
+
+This chart is a community effort, and is not endorsed by the taiga project developers.
+
+
+### TL;DR;
+
+Be sure to have a working [Helm](https://helm.sh) installation for your cluster first.
+
+```console
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm install --name taiga incubator/taiga
+```
+
+Wait for the taiga and database pods to come up, then execute:
+
+```console
+$ kubectl port-forward service/taiga 8080:80
+```
+
+You will now be able to access your taiga instance at `http://localhost:8080`.
+
+### Introduction
+
+This chart bootstrap a [taiga](https://taiga.io/) Deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. It provisions a basic taiga installation (taiga-events is not currently provisioned), which by default has no persistence, but can be configured to do so.
+
+Check out the [official taiga website](https://taiga.io/) for informations on how to use and configure your installation.
+
+
+## Prerequisites
+
+- Kubernetes 1.10+
+- Optionally, you can use your own pre-provisioned instance of PostgreSQL, for data storage. This chart provision a dedicated PostgreSQL database for you, by default.
+- Optionally, you can rely on a dynamic PV provisioner, for the persistence of both the taiga and PostgreSQL data.
+
+
+## Installing, uninstalling and configuring the Chart
+
+To install the chart with the release name `my-taiga`:
+
+```console
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm install --name my-taiga --set taiga.dbHost=my-taiga-postgresql incubator/taiga
+```
+
+Note that the `taiga.dbHost` parameter must be consistent with the release name, when provisioning PostgreSQL.
+
+To uninstall/delete the `my-taiga` release:
+
+```console
+$ helm delete my-taiga
+```
+
+Refer to the [Helm](https://www.helm.sh/) project documentation for more usage notes.
+
+
+## Configuration parameters
+
+The following table lists the configurable parameters of the taiga chart, and their default values. It also includes some useful options of the deployable PostgreSQL dependency, but any configuration valid for the `stable/postgresql` chart can be used.
+
+Parameter | Description | Default
+--- | --- | ---
+`image.repository` | Taiga image repository. | `mvitale1989/docker-taiga`
+`image.tag` | Taiga image tag. | `"20180818"`
+`image.initRepository` | Init image repository. | `alpine`
+`image.initTag` | Init image tag. | `3.7`
+`image.pullPolicy` | Pull policy for both taiga and init images. | `IfNotPresent`
+`service.type` | Service type for the taiga service. | `ClusterIP`
+`service.port` | Service port for the taiga service. | `80`
+`ingress.enabled` | Whether to enable the ingress resource for the taiga service, or not. | `false`
+`ingress.annotations` | Annotations for the ingress resource, if enabled. Useful e.g. for configuring automatic certificate provisioning. | `{}`
+`ingress.hosts` | List of hostnames which will expose this taiga service. | `[ "chart-example.local" ]`
+`ingress.tls` | TLS configuration for the ingress object | `[]`
+`resources` | Limits/requests for the taiga Pod object | `{}`
+`nodeSelector` | Node selector for the taiga Pod object | `{}`
+`tolerations` | Tolerations for the taiga Pod object | `[]`
+`affinity` | Affinity map for the taiga Pod object | `{}`
+`extraLabels` | Extra labels for all objects of a release | `{}`
+`taiga.apiserver` | The name on which the taiga backend server will be accessible to *all* clients. See F.A.Q. for more informations | `localhost:8080`
+`taiga.behindTlsProxy` | Whether taiga is behind a TLS termination; if using a TLS ingress, set this to true | `false`
+`taiga.dbHost` | PostgreSQL database host to use. **IMPORTANT**: set to `${release_name}-postgresql` if provisioning PostgreSQL | `taiga-postgresql`
+`taiga.dbName` | Name of PostgreSQL database to use | `taiga`
+`taiga.dbUser` | Username to use for PostgreSQL authentication | `taiga`
+`taiga.dbPassword` | Password to use for PostgreSQL authentication | `"changeme"`
+`taiga.emailEnabled` | Enable taiga email. If enabled, all other email parameters must also be set | `false`
+`taiga.emailFrom` | Value to use in the `From` header of the email. Not always honored | `""`, which defaults to `taiga@example.com`
+`taiga.emailUseTls` | Use TLS for SMTP communications | `""`, which defaults to `true`
+`taiga.emailSmtpHost` | SMTP host | `""`
+`taiga.emailSmtpPort` | SMTP port | `""`, which defaults to 587
+`taiga.emailSmtpUser` | SMTP username | `""`
+`taiga.emailSmtpPassword` | SMTP password  | `""`
+`taiga.secretKey` | taiga backend's secret key | `""`, which defaults to a 10 character random string
+`persistence.deployPostgres` | Deploy a PostgreSQL instance, along with taiga; configure with the `postgresql` parameter. **IMPORTANT**: see note on the `taiga.dbHost` parameter. | `true`
+`persistence.enabled` | Create a PVC for persistent storage of the taiga media directory. | `true`
+`persistence.size` | Size of the volume requested by the PVC. | `8Gi`
+`persistence.accessMode` | Access mode for the volume requested by the PVC. | `ReadWriteOnce`
+`persistence.annotations` | Annotations to use in the PVC of the taiga pod. | `{}`
+`persistence.storageClass` | Storage class of the PVC of the taiga pod. Use empty string for synamic provisioning. | `""`
+`persistence.existingClaim` | Name of the pre-provisioned PVC to use, for taiga persistence; setting this overrides the creation of the PVC. `persistence.enabled` must be true. | `""`
+`postgresql` | Configuration parameters for the provisioned PostgreSQL instance, if enabled. See the [PostgreSQL chart](https://github.com/helm/charts/tree/master/stable/postgresql) for details. | See parameters below
+`postgresql.postgresUser` | Username to create in the provisioned PostgreSQL instance. | `"taiga"`
+`postgresql.postgresPassword` | Password to configure for the provisioned PostgreSQL user. | `"changeme"`
+`postgresql.postgresDatabase` | Database to create in the provisioned PostgreSQL instance. | `"taiga"`
+`postgresql.persistence.enabled` | Create the PVC for the PostgreSQL instance. | `true`
+`postgresql.persistence.size` | Size of the PostgreSQL data volume requested by the PVC. | `2Gi`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`, or in alternative, persist them inside of a YAML file, which you can then reference during installs/upgrades by using the `-f ./values.yaml` flag.
+
+### Persistence
+
+By default, this chart deploys both a taiga API server and a PostgreSQL database instance, generating the following PVCs:
+* An `8Gi` volume dedicated to the taiga media directory
+* A `2Gi` volume for PostgreSQL storage
+
+You can tune the parameters associated with these volumes, or also choose to rely on already existing volumes instead, by using the `persistence` and `postgresql.persistence` parameters.
+
+By default, no storage class is set for these PVCs, so the default dynamic volume provisioner is expected to create the corresponding PV. But you can optionally declare a storageClass name to use, if you prefer.
+
+#### Using an External Database
+
+If needed, you can choose to use an existing PostgreSQL instance instead of provisioning one, by disabling the `persistence.deployPostgres` parameter, and setting the `taiga.db*` parameters with the correct address and credentials.
+
+
+## F.A.Q.
+
+1. **Why do i need to explicitly specify `taiga.apiserver` and `taiga.behindTlsProxy`?** The taiga frontend will need this information, to generate the URLs used for reaching the taiga backend API server (respectively for the host/port and scheme part of the URL). This chart provisions both frontend and backend under the same service, and thus behind the same host/port and scheme, but in the general case the frontend wouldn't know how to find the API server if you didn't specify it in those parameters, as they may be deployed separately.
+2. **Why do all web clients need to be able to reach what i specified in `taiga.apiserver`?** As mentioned in question 1, the frontend will use those parameters to generate the URLs pointing to the API server. This means that no matter what name you type in your browser to reach the frontend: the web client will attempt to reach the API server backend based on the `taiga.apiserver` and `taiga.behindTlsProxy` parameters. Note that despite this, you _can_ still connect to the frontend in any way you prefer (public name, `kubectl port-forward`, etc): just make sure it's also reachable through the name specified in the `taiga.apiserver` parameter.
+3. **Can i configure multiple instances of taiga behind the same name, but with different paths?** No, path multiplexing is currenty not supported.
+
+
+## Full example configuration
+
+The following configuration is an example that produces a taiga installation, satisfying the following requirements:
+- Taiga instance is publicly available, through an ingress controller (requires manual deployment and configuration of an ingress controller on the cluster, e.g. [ingress-nginx](https://github.com/kubernetes/ingress-nginx))
+- Automatic provisioning of [letsencrypt](https://letsencrypt.org/) TLS certificates (requires manual deployment and configuration of [cert-manager](https://github.com/jetstack/cert-manager) or equivalent)
+- Persistence for both taiga media files and PostgreSQL database (requires manual deployment of a dynamic volume provisioner, e.g. [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/ceph/rbd))
+- Keep the PVCs, when deleting the taiga release.
+
+```yaml
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/tls-acme: "true"
+  hosts:
+  - taiga.mycompany.com
+  tls:
+  - secretName: tls-taiga
+    hosts:
+    - taiga.mycompany.com
+
+taiga:
+  apiserver: taiga.mycompany.com
+  behindTlsProxy: true
+  dbHost: my-taiga-postgresql
+  dbName: taiga
+  dbUser: taiga
+  dbPassword: verySecureDatabasePassword
+  emailEnabled: true
+  emailFrom: taiga@mycompany.com
+  emailSmtpHost: smtp.gmail.com
+  emailSmtpUser: smtp-user@mycompany.com
+  emailSmtpPassword: verySecureSmtpPassword
+  secretKey: verySecureSecretKey
+
+persistence:
+  deployPostgres: true
+  enabled: true
+  size: 50Gi
+  annotations:
+    "helm.sh/resource-policy": keep
+
+postgresql:
+  postgresPassword: verySecureDatabasePassword
+  persistence:
+    enabled: true
+    size: 8Gi
+  annotations:
+    "helm.sh/resource-policy": keep
+  networkPolicy:
+    enabled: false
+```
+
+Save the above in the `values.yaml` file, and then deploy your taiga instance on the cluster by executing the following:
+
+```console
+### Note: release name is relevant, and must be consistent with the `taiga.dbHost` parameter when provisioning the PostgreSQL database.
+$ helm install -f values.yaml -n my-taiga incubator/taiga
+```
+
+After everything's been initialized, you will be able to access your taiga instance at `https://taiga.mycompany.com`.
+
+Be sure to configure a DNS record `taiga.mycompany.com`, pointing to your ingress controller.

--- a/incubator/taiga/requirements.yaml
+++ b/incubator/taiga/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: postgresql
+  version: ~0.15.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: persistence.deployPostgres

--- a/incubator/taiga/templates/NOTES.txt
+++ b/incubator/taiga/templates/NOTES.txt
@@ -1,0 +1,43 @@
+{{- define "taiga.scheme" -}} http{{ if .Values.ingress.tls }}s{{- end -}} {{- end -}}
+{{- define "taiga.apiserver_url" -}} {{ template "taiga.scheme" . }}://{{ .Values.taiga.apiserver }} {{- end -}}
+
+The Taiga service is now ready for you to use.
+
+IMPORTANT: ALL users, from both inside and outside of the cluster, must be able to reach the service through the URI `{{ template "taiga.apiserver_url" . }}`, where the frontend will expect the API server to be.
+Thus, given your provided `taiga.apiserver`:
+1. If your server is publicly reachable (e.g. using Ingress or NodePort/ExternalIP/LoadBalancer Service), create a corresponding public DNS record pointing to the IP where the service will be reachable.
+2. If you're using using the service in-cluster only, ensure that either `taiga.apiserver` is a cluster-localr name for the service, or create an internal DNS record pointing to it (e.g. by configuring CoreDNS).
+3. If you're testing from your local machine, you can simply alias the given `taiga.apiserver` to the IP you'll be using to test the service, in your local `/etc/hosts` file. E.g. if testing through `kubectl port-forward` or ssh tunnels, you may want to add a line like `127.0.0.1 my-taiga-hostname.mycompany.com`.
+
+In addition to the aforementioned API server URL, you can also access the service in the following ways:
+{{- if .Values.ingress.enabled }}
+- From outside of the cluster, at the names:
+{{- range .Values.ingress.hosts }}
+  * `{{ template "taiga.scheme" $ }}://{{ . }}`
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+- From outside of the cluster, by executing the following:
+    $ export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "taiga.fullname" . }})
+    $ export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    $ echo "Visit http://$NODE_IP:$NODE_PORT to use your application"
+{{- else if contains "LoadBalancer" .Values.service.type }}
+- From outside of the cluster, by executing the following:
+    $ export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "taiga.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    $ echo "Visit {{ template "taiga.scheme" . }}://$SERVICE_IP:{{ .Values.service.port }} to user your application"
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get svc -w {{ template "taiga.fullname" . }}'
+{{- else if contains "ClusterIP" .Values.service.type }}
+* From inside of the cluster, by executing the following:
+    $ export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "taiga.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+    $ echo "Visit http://localhost:8080 to use your application"
+    $ kubectl port-forward $POD_NAME 8080:80
+{{- end }}
+{{- if .Release.IsInstall }}
+
+
+The first-time credentials for using Taiga are:
+User name: admin
+Password: 123123
+
+Please change your password on your first login.
+{{- end }}

--- a/incubator/taiga/templates/_helpers.tpl
+++ b/incubator/taiga/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Expand the name of the chart. */}}
+{{- define "taiga.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create a default fully qualified app name. We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec). If release name contains chart name it will be used as a full name. */}}
+{{- define "taiga.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "taiga.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Define the docker image name */}}
+{{- define "taiga.image" -}}
+{{- if regexMatch "^@" .Values.image.tag -}}
+{{ .Values.image.repository }}{{ .Values.image.tag }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/* Labels to attach to every auth-proxy object. */}}
+{{- define "taiga.labels" -}}
+app: {{ template "taiga.name" . }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+chart: {{ include "taiga.chart" . }}
+{{ if .Values.extraLabels -}}
+{{ .Values.extraLabels | toYaml }}
+{{- end -}}
+{{- end -}}
+
+{{/* Environment variables for configuring the containers */}}
+{{- define "taiga.envfrom" -}}
+- secretRef:
+    name: {{ include "taiga.fullname" . }}
+    optional: false
+- configMapRef:
+    name: {{ include "taiga.fullname" . }}
+    optional: false
+{{- end -}}

--- a/incubator/taiga/templates/configmap.yaml
+++ b/incubator/taiga/templates/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "taiga.fullname" . }}
+  labels:
+{{ include "taiga.labels" . | indent 4 }}
+data:
+  TAIGA_HOSTNAME: {{ required "taiga.apiserver must be set" .Values.taiga.apiserver }}
+  TAIGA_SSL: "false"
+  TAIGA_SSL_BY_REVERSE_PROXY: {{ .Values.taiga.behindTlsProxy | ternary "True" "False" | quote }}
+  TAIGA_DB_HOST: {{ required "taiga.dbHost must be set" .Values.taiga.dbHost }}
+  TAIGA_DB_NAME: {{ required "taiga.dbName must be set" .Values.taiga.dbName }}
+  TAIGA_DB_USER: {{ required "taiga.dbUser must be set" .Values.taiga.dbUser }}
+  TAIGA_ENABLE_EMAIL: {{ .Values.taiga.emailEnabled | ternary "True" "False" | quote }}
+{{- if .Values.taiga.emailEnabled }}
+  TAIGA_EMAIL_FROM: {{ .Values.taiga.emailFrom | default "taiga@example.com" |  quote }}
+  TAIGA_EMAIL_USE_TLS: {{ .Values.taiga.emailUseTls | default true | ternary "True" "False" | quote }}
+  TAIGA_EMAIL_HOST: {{ required "taiga.emailSmtpHost must be set" .Values.taiga.emailSmtpHost | quote }}
+  TAIGA_EMAIL_PORT: {{ default 587 .Values.taiga.emailSmtpPort | quote }}
+  TAIGA_EMAIL_USER: {{ required "taiga.emailSmtpUser must be set" .Values.taiga.emailSmtpUser | quote }}
+{{- end }}

--- a/incubator/taiga/templates/deployment.yaml
+++ b/incubator/taiga/templates/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "taiga.fullname" . }}
+  labels:
+{{ include "taiga.labels" . | indent 4 }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+{{ include "taiga.labels" . | indent 6 }}
+  template:
+    metadata:
+      labels:
+{{ include "taiga.labels" . | indent 8 }}
+    spec:
+      initContainers:
+      - name: init-db
+        image: {{ include "taiga.image" . | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: TAIGA_SLEEP
+          value: "60"
+        - name: TAIGA_DB_CHECK_ONLY
+          value: "True"
+        envFrom:
+{{ include "taiga.envfrom" . | indent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}-front
+        image: {{ include "taiga.image" . | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+        env:
+        - name: TAIGA_COMPONENT
+          value: "front"
+        - name: TAIGA_SKIP_DB_CHECK
+          value: "True"
+        envFrom:
+{{ include "taiga.envfrom" . | indent 8 }}
+        volumeMounts:
+        - name: taiga-data
+          mountPath: /usr/src/taiga-back/media
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      - name: {{ .Chart.Name }}-back
+        image: {{ include "taiga.image" . | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /api/v1/projects
+            port: 80
+        readinessProbe:
+          httpGet:
+            path: /api/v1/projects
+            port: 80
+        env:
+        - name: TAIGA_COMPONENT
+          value: "back"
+        - name: TAIGA_SKIP_DB_CHECK
+          value: "True"
+        envFrom:
+{{ include "taiga.envfrom" . | indent 8 }}
+        volumeMounts:
+        - name: taiga-data
+          mountPath: /usr/src/taiga-back/media
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+      - name: taiga-data
+    {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default ( include "taiga.fullname" . ) }}
+    {{- else }}
+        emptyDir: {}
+    {{- end }}

--- a/incubator/taiga/templates/ingress.yaml
+++ b/incubator/taiga/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "taiga.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "taiga.name" . }}
+    chart: {{ template "taiga.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/incubator/taiga/templates/pvc.yaml
+++ b/incubator/taiga/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "taiga.fullname" . }}
+  labels:
+{{ include "taiga.labels" . | indent 4 }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+  - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end -}}

--- a/incubator/taiga/templates/secret.yaml
+++ b/incubator/taiga/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "taiga.fullname" . }}
+  labels:
+{{ include "taiga.labels" . | indent 4 }}
+data:
+  TAIGA_DB_PASSWORD: {{ .Values.taiga.dbPassword | required "taiga.dbPassword must be set" | b64enc }}
+  TAIGA_SECRET_KEY: {{ .Values.taiga.secretKey | default ( randAlphaNum 10 ) |  b64enc }}
+  {{ if .Values.taiga.emailEnabled }}TAIGA_EMAIL_PASS: {{ required "taiga.emailSmtpPassword must be set" .Values.taiga.emailSmtpPassword | b64enc }}{{ end }}

--- a/incubator/taiga/templates/service.yaml
+++ b/incubator/taiga/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "taiga.fullname" . }}
+  labels:
+{{ include "taiga.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+{{ include "taiga.labels" . | indent 4 }}

--- a/incubator/taiga/values.yaml
+++ b/incubator/taiga/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: mvitale1989/docker-taiga
-  tag: "20180818"
+  tag: "20181218-4.0.3"
   initRepository: alpine
   initTag: 3.7
   pullPolicy: IfNotPresent

--- a/incubator/taiga/values.yaml
+++ b/incubator/taiga/values.yaml
@@ -1,0 +1,132 @@
+### Default values for taiga.
+
+image:
+  repository: mvitale1989/docker-taiga
+  tag: "20180818"
+  initRepository: alpine
+  initTag: 3.7
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+  - chart-example.local
+  tls: []
+  # - secretName: chart-example-tls
+  #   hosts:
+  #   - chart-example.local
+
+resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraLabels: {}
+
+
+### Parameters for the taiga service
+###
+taiga:
+
+  ### The name on which the taiga backend API server will be accessible. In this chart, it's the same name you will use to
+  ### access the frontend.  Notes:
+  ### - Must be formatted exactly as you would type the hostname part of the URL in a browser, including the port number if needed.
+  ### - Must be reachable by ALL clients using the service. See F.A.Q. in the readme, for more informations.
+  ###
+  apiserver: localhost:8080
+
+  ### Whether taiga is behind a TLS termination; if using a TLS ingress, set this to true.
+  ###
+  behindTlsProxy: false
+
+  ### Database access parameters
+  ### If deploying postgres, the dbHost should be `${release_name}-postgresql`
+  ###
+  dbHost: taiga-postgresql
+  dbName: taiga
+  dbUser: taiga
+  dbPassword: "changeme"
+
+  ### If you enable email, also uncomment and configure the parameters below
+  ###
+  emailEnabled: false
+  # emailFrom: "taiga@mycompany.net"
+  # emailUseTls: true
+  # emailSmtpHost: "smtp.example.com"
+  # emailSmtpPort: 587
+  # emailSmtpUser: "user@example.com"
+  # emailSmtpPassword: ""
+
+  ### Configure taiga-back's secret key
+  ### If omitted, a random alphanumeric string of 10 characters will be generated
+  ###
+  # secretKey: "changeme"
+
+
+### Persistent volume and database configuration for the taiga service
+###
+persistence:
+
+  ### Whether or not you want this chart to provision the database for you
+  ### Database parameters must be specified under the `postgres` value
+  ###
+  deployPostgres: true
+
+  ### If you don't want persistence for the taiga media storage, disable this
+  ###
+  enabled: true
+  size: 8Gi
+  accessMode: ReadWriteOnce
+  # annotations:
+  #   "helm.sh/resource-policy": keep
+
+  ### StorageClass for the provisioned PVC.
+  ###
+  # storageClass: ""
+
+  ### If you prefer using a PVC defined outside of this chart instead, uncomment this
+  ### Requires `persistence.enabled: true`
+  ###
+  # existingClaim: ""
+
+
+### Any stable/postgres values can be defined here
+###
+postgresql:
+
+  ### Create a postgres user, password and database
+  ###
+  postgresUser: "taiga"
+  postgresPassword: "changeme"
+  postgresDatabase: "taiga"
+
+  persistence:
+    enabled: true
+    size: 2Gi
+    # annotations:
+    #   "helm.sh/resource-policy": keep
+
+    ### StorageClass for the provisioned PVC.
+    ###
+    # storageClass: ""
+
+    ### If you prefer using a PVC defined outside of this chart instead, uncomment this
+    ### Requires `postgresql.persistence.enabled: true`
+    ###
+    # existingClaim: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the [taiga](https://taiga.io/) project management application chart into the incubator directory.

**Special notes for your reviewer**:
When provisioning PostgreSQL (`persistence.deployPostgres: true`, which is the default), If using a release name other than `taiga`, the parameter `taiga.dbHost` must be tuned accordingly, as documented in the readme.

**Remarks**:
* This chart is based on [mvitale1989/docker-taiga](https://github.com/mvitale1989/docker-taiga), a fork of the [benhutchins/docker-taiga](https://github.com/benhutchins/docker-taiga) community-mantained image, on which some tunings have been done to adapt it to work well under Kubernetes. There is a [currently open PR](https://github.com/benhutchins/docker-taiga/pull/62) for merging these change back into it, and then switch to using the upstream image.
* The [taiga](https://github.com/taigaio/taiga-back) code itself is released under the AGPL-3.0 license, which grants permission to distribute the software.
* The taiga-events ancillary feature is currently not implemented, but there's no downside to it other than not having live updates in the web interface