### PR TITLE
[stable/prometheus-adapter] allow using external TLS secret

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.1.0
+version: v0.1.1
 appVersion: v0.2.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -34,31 +34,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Prometheus Adapter chart and their default values.
 
-| Parameter                       | Description                                                                     | Default                                     |
-| ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
-| `affinity`                      | Node affinity                                                                   | `{}`                                        |
-| `image.repository`              | Image repository                                                                | `directxman12/k8s-prometheus-adapter-amd64` |
-| `image.tag`                     | Image tag                                                                       | `v0.2.1`                                    |
-| `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
-| `logLevel`                      | Log level                                                                       | `4`                                         |
-| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `30s`                                       |
-| `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
-| `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
-| `prometheus.port`               | Port of where we can find the Prometheus service                                | `9090`                                      |
-| `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
-| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
-| `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
-| `rules.custom`                  | A list of custom configmap rules                                                | `{}`                                        |
-| `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
-| `service.port`                  | Service port to expose                                                          | `443`                                       |
-| `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |
-| `serviceAccount.create`         | If true, create & use Serviceaccount                                            | `true`                                      |
-| `serviceAccount.name`           | If not set and create is true, a name is generated using the fullname template  | ``                                          |
-| `tls.enable`                    | If true, use the provided certificates. If false, generate self-signed certs    | `false`                                     |
-| `tls.ca`                        | Public CA file that signed the APIService (ignored if tls.enable=false)         | ``                                          |
-| `tls.key`                       | Private key of the APIService (ignored if tls.enable=false)                     | ``                                          |
-| `tls.certificate`               | Public key of the APIService (ignored if tls.enable=false)                      | ``                                          |
-| `tolerations`                   | List of node taints to tolerate                                                 | `[]`                                        |
+| Parameter                       | Description                                                                          | Default                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------|
+| `affinity`                      | Node affinity                                                                        | `{}`                                        |
+| `image.repository`              | Image repository                                                                     | `directxman12/k8s-prometheus-adapter-amd64` |
+| `image.tag`                     | Image tag                                                                            | `v0.2.1`                                    |
+| `image.pullPolicy`              | Image pull policy                                                                    | `IfNotPresent`                              |
+| `logLevel`                      | Log level                                                                            | `4`                                         |
+| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus        | `30s`                                       |
+| `nodeSelector`                  | Node labels for pod assignment                                                       | `{}`                                        |
+| `prometheus.url`                | Url of where we can find the Prometheus service                                      | `http://prometheus.default.svc`             |
+| `prometheus.port`               | Port of where we can find the Prometheus service                                     | `9090`                                      |
+| `rbac.create`                   | If true, create & use RBAC resources                                                 | `true`                                      |
+| `resources`                     | CPU/Memory resource requests/limits                                                  | `{}`                                        |
+| `rules.default`                 | If `true`, enable a set of default rules in the configmap                            | `true`                                      |
+| `rules.custom`                  | A list of custom configmap rules                                                     | `{}`                                        |
+| `service.annotations`           | Annotations to add to the service                                                    | `{}`                                        |
+| `service.port`                  | Service port to expose                                                               | `443`                                       |
+| `service.type`                  | Type of service to create                                                            | `ClusterIP`                                 |
+| `serviceAccount.create`         | If true, create & use Serviceaccount                                                 | `true`                                      |
+| `serviceAccount.name`           | If not set and create is true, a name is generated using the fullname template       | ``                                          |
+| `tls.enable`                    | If true, use the provided certificates. If false, generate self-signed certs         | `false`                                     |
+| `tls.secretName`                | If set use preconfigured Secret instead of creating one                              | `""`                                        |
+| `tls.ca`                        | Public CA file that signed the APIService (ignored if tls.enable=false)              | ``                                          |
+| `tls.key`                       | Private key of the APIService (ignored if tls.enable=false or tls.secretName is set) | ``                                          |
+| `tls.certificate`               | Public key of the APIService (ignored if tls.enable=false or tls.secretName is set)  | ``                                          |
+| `tolerations`                   | List of node taints to tolerate                                                      | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-adapter/templates/_helpers.tpl
+++ b/stable/prometheus-adapter/templates/_helpers.tpl
@@ -41,3 +41,11 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "k8s-prometheus-adapter.tls.secretName" -}}
+{{- if .Values.tls.secretName -}}
+    {{ .Values.tls.secretName }}
+{{- else -}}
+    {{ include "k8s-prometheus-adapter.fullname" . }}
+{{- end -}}
+{{- end -}}

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -94,5 +94,5 @@ spec:
 {{- if .Values.tls.enable }}
       - name: volume-serving-cert
         secret:
-          secretName: {{ template "k8s-prometheus-adapter.fullname" . }}
+          secretName: {{ template "k8s-prometheus-adapter.tls.secretName" . }}
 {{- end }}

--- a/stable/prometheus-adapter/templates/secret.yaml
+++ b/stable/prometheus-adapter/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tls.enable -}}
+{{- if and .Values.tls.enable (not .Values.tls.secretName) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -56,6 +56,8 @@ service:
 
 tls:
   enable: false
+  # Use external tls secret name instead of managing one
+  secretName: ""
   ca: |-
     # Public CA file that signed the APIService
   key: |-


### PR DESCRIPTION
**What this PR does / why we need it**:
This change allows using externally create secret for `prometheus-adapter` TLS
