### PR TITLE
[stable/traefik] Update Image to 1.6.6

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: traefik
-version: 1.41.1
-appVersion: 1.6.5
+version: 1.42.0
+appVersion: 1.6.6
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
 - traefik

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 ## Default values for Traefik
 image: traefik
-imageTag: 1.6.5
+imageTag: 1.6.6
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
 # loadBalancerIP: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the Traefik image to 1.6.6

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

This image update fixes [cve-2018-15598](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15598)