### PR TITLE
possibility to keep persistence resource

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.9.3
+version: 0.9.4
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.9.4
+version: 0.10.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `persistence.accessMode`                     | ReadWriteOnce or ReadOnly                                                                    | ReadWriteOnce                                        |
 | `persistence.existingClaim`                  | Name of existing persistent volume                                                           | `nil`                                                |
 | `persistence.subPath`                        | Subdirectory of the volume to mount                                                          | `nil`                                                |
+| `persistence.resourcePolicy`                 | Policy for persistence resources                             				      | delete						     |
 | `nodeSelector`                               | Node labels for pod assignment                                                               | {}                                                   |
 | `metrics.enabled`                            | Start a side-car prometheus exporter                                                         | `false`                                              |
 | `metrics.image`                              | Exporter image                                                                               | `prom/mysqld-exporter`                               |

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `persistence.accessMode`                     | ReadWriteOnce or ReadOnly                                                                    | ReadWriteOnce                                        |
 | `persistence.existingClaim`                  | Name of existing persistent volume                                                           | `nil`                                                |
 | `persistence.subPath`                        | Subdirectory of the volume to mount                                                          | `nil`                                                |
-| `persistence.resourcePolicy`                 | Policy for persistence resources                             				      | delete						     |
+| `persistence.annotations`                    | Persistent Volume annotations                             				      | {}						     |
 | `nodeSelector`                               | Node labels for pod assignment                                                               | {}                                                   |
 | `metrics.enabled`                            | Start a side-car prometheus exporter                                                         | `false`                                              |
 | `metrics.image`                              | Exporter image                                                                               | `prom/mysqld-exporter`                               |

--- a/stable/mysql/templates/pvc.yaml
+++ b/stable/mysql/templates/pvc.yaml
@@ -3,8 +3,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "mysql.fullname" . }}
+{{- with .Values.persistence.annotations  }}
   annotations:
-    "helm.sh/resource-policy": {{ .Values.persistence.resourcePolicy }}
+{{ toYaml . | indent 4 }}
+{{- end }}
   labels:
     app: {{ template "mysql.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/mysql/templates/pvc.yaml
+++ b/stable/mysql/templates/pvc.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "mysql.fullname" . }}
+  annotations:
+    "helm.sh/resource-policy": {{ .Values.persistence.resourcePolicy }}
   labels:
     app: {{ template "mysql.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -80,7 +80,7 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 8Gi
-  resourcePolicy: delete
+  annotations: {}
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -80,6 +80,7 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 8Gi
+  resourcePolicy: delete
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables set resource policy for `pvc` to `keep` (default `delete`).

On `helm delete` command resources not annotated as `keep` are deleted, in this case: pvc, pv and consequently your cloud volume, which could lead to trouble if you haven't planned to delete your data. Therefore this PR is created.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The issue of `"helm.sh/resource-policy": keep` was encouraged by @technosophos on https://github.com/helm/helm/issues/1875#issuecomment-279872793

Alternatively or in addition, change the `pv.persistentVolumeReclaimPolicy` to `Retain` is desired, currently not possible to change on chart level since `pv` is provisioned.
