### PR TITLE
[stable/postgresql] Fix custom metrics volume

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.18.0
+version: 0.18.1
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -159,10 +159,11 @@ spec:
       {{- end }}
       {{- if and .Values.metrics.enabled .Values.metrics.customMetrics }}
       - name: custom-metrics
-        valueFrom:
-          configMapKeyRef:
-            name: {{ template "postgresql.fullname" . }}
-            key: custom-metrics.yaml
+        configMap:
+          name: {{ template "postgresql.fullname" . }}
+          items:
+            - key: custom-metrics.yaml
+              path: custom-metrics.yaml
       {{- end }}
       {{- if .Values.usePasswordFile }}
       - name: password-file


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Currently, custom metrics for "metrics" image of postgresql pod are broken. This is because the volume is specified incorrectly. Thus, the deployment ends up creating `emptyDir: {}` volume instead of `configMap` one.

This commit fixes it.

