### PR TITLE
Logstash: When persistence.enabled=false, don't create a PVC

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.8.1
+version: 0.8.2
 appVersion: 6.3.2
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/templates/statefulset.yaml
+++ b/incubator/logstash/templates/statefulset.yaml
@@ -130,7 +130,10 @@ spec:
         - name: pipeline
           configMap:
             name: {{ template "logstash.fullname" . }}-pipeline
-
+{{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -147,3 +150,4 @@ spec:
         storageClassName: "{{ .Values.persistence.storageClass }}"
         {{- end }}
       {{- end }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

If you set `persistence.enabled=false`, a PVC is still created when using this chart.

Patch changes to use an `emptyDir` volume instead, as with similar charts that provide a `persistence.enabled` setting (elasticstack, kafka, etc.)