### PR TITLE
Fix localhost issue

### DIFF
--- a/stable/magic-namespace/Chart.yaml
+++ b/stable/magic-namespace/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: magic-namespace
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.8.1
 home: https://github.com/kubernetes/charts/tree/master/stable/magic-namespace
 description: Elegantly enables a Tiller per namespace in RBAC-enabled clusters

--- a/stable/magic-namespace/templates/tiller-deployment.yaml
+++ b/stable/magic-namespace/templates/tiller-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             value: {{ quote .Values.tiller.maxHistory }}
           {{- if .Values.tiller.onlyListenOnLocalhost }}
           command: ["/tiller"]
-          args: ["--listen=localhost:44134"]
+          args: ["--listen=127.0.0.1:44134"]
           {{- else }}
           ports:
           - containerPort: 44134


### PR DESCRIPTION
Work around lack of proper nsswitch.conf on existing tiller images. versions 2.8.1 - 2.10.0 are known bad.

See https://github.com/helm/helm/issues/4511 for some details