### PR TITLE
[stable/redmine] add configurable replicas, pod disruption budget, and resources

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 4.0.3
+version: 4.1.0
 appVersion: 3.4.6
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -88,9 +88,9 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `persistence.accessMode`          | PVC Access Mode                          | `ReadWriteOnce`                                         |
 | `persistence.size`                | PVC Storage Request                      | `8Gi`                                                   |
 | `podDisruptionBudget.enabled`     | Pod Disruption Budget toggle             | `false`                                                 |
-| `podDisruptionBudget.minAvailable`| Minimum availble pods                   | `nil`                                                     |
-| `podDisruptionBudget.maxUnavailable`| Maximum unavailble pods               | `nil`                                                     |
-| `replicas`                        | The number of pod replicas               | `1`                                                     |
+| `podDisruptionBudget.minAvailable`| Minimum available pods                   | `nil`                                                     |
+| `podDisruptionBudget.maxUnavailable`| Maximum unavailable pods               | `nil`                                                     |
+| `replicas`                        | The number of pod replicas (See [Replicas](#replicas)) | `1`                                                     |
 | `resources`                       | Resources allocation (Requests and Limits) | `{}` |
 
 The above parameters map to the env variables defined in [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine). For more information please refer to the [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine) image documentation.
@@ -112,6 +112,13 @@ $ helm install --name my-release -f values.yaml stable/redmine
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Replicas
+
+Redmine writes uploaded files to a persistent volume. By default that volume
+cannot be shared between pods (RWO). In such a configuration the `replicas` option
+must be set to `1`. If the persistent volume supports more than one writer
+(RWX), ie NFS, `replicas` can be greater than `1`.
 
 ## Persistence
 

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -88,10 +88,10 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `persistence.accessMode`          | PVC Access Mode                          | `ReadWriteOnce`                                         |
 | `persistence.size`                | PVC Storage Request                      | `8Gi`                                                   |
 | `podDisruptionBudget.enabled`     | Pod Disruption Budget toggle             | `false`                                                 |
-| `podDisruptionBudget.minAvailable`| Minimum avaialble pods                   | `1`                                                     |
-| `podDisruptionBudget.maxUnavailable`| Minimum unavaialble pods               | `1`                                                     |
+| `podDisruptionBudget.minAvailable`| Minimum availble pods                   | `nil`                                                     |
+| `podDisruptionBudget.maxUnavailable`| Maximum unavailble pods               | `nil`                                                     |
 | `replicas`                        | The number of pod replicas               | `1`                                                     |
-| `resources`                       | Resources allocation (Requests and Limits) | `{requests: {cpu: 1, memory: 1G}, limits: {cpu: 2, memory: 1G}}`|
+| `resources`                       | Resources allocation (Requests and Limits) | `{}` |
 
 The above parameters map to the env variables defined in [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine). For more information please refer to the [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine) image documentation.
 

--- a/stable/redmine/README.md
+++ b/stable/redmine/README.md
@@ -87,6 +87,11 @@ The following table lists the configurable parameters of the Redmine chart and t
 | `persistence.storageClass`        | PVC Storage Class                        | `nil` (uses alpha storage class annotation)             |
 | `persistence.accessMode`          | PVC Access Mode                          | `ReadWriteOnce`                                         |
 | `persistence.size`                | PVC Storage Request                      | `8Gi`                                                   |
+| `podDisruptionBudget.enabled`     | Pod Disruption Budget toggle             | `false`                                                 |
+| `podDisruptionBudget.minAvailable`| Minimum avaialble pods                   | `1`                                                     |
+| `podDisruptionBudget.maxUnavailable`| Minimum unavaialble pods               | `1`                                                     |
+| `replicas`                        | The number of pod replicas               | `1`                                                     |
+| `resources`                       | Resources allocation (Requests and Limits) | `{requests: {cpu: 1, memory: 1G}, limits: {cpu: 2, memory: 1G}}`|
 
 The above parameters map to the env variables defined in [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine). For more information please refer to the [bitnami/redmine](http://github.com/bitnami/bitnami-docker-redmine) image documentation.
 

--- a/stable/redmine/templates/deployment.yaml
+++ b/stable/redmine/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: {{ default 1 .Values.replicas }}
+  replicas: {{ .Values.replicas }}
   template:
     metadata:
       labels:

--- a/stable/redmine/templates/deployment.yaml
+++ b/stable/redmine/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: 1
+  replicas: {{ default 1 .Values.replicas }}
   template:
     metadata:
       labels:
@@ -26,6 +26,8 @@ spec:
       - name: {{ template "redmine.fullname" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         env:
         {{- if .Values.extraVars }}
 {{ toYaml .Values.extraVars | indent 8 }}

--- a/stable/redmine/templates/pdb.yaml
+++ b/stable/redmine/templates/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "redmine.fullname" . }}
+  labels:
+    app: {{ template "redmine.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "redmine.name" . }}
+      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+      release: "{{ .Release.Name }}"
+      heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/stable/redmine/templates/pdb.yaml
+++ b/stable/redmine/templates/pdb.yaml
@@ -20,5 +20,4 @@ spec:
       app: {{ template "redmine.name" . }}
       chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
-      heritage: "{{ .Release.Service }}"
 {{- end }}

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -190,6 +190,7 @@ podDisruptionBudget:
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 replicas: 1
 
+## Redmine pods resource requests and limits
 ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container
 resources: {}
   # requests:

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -187,6 +187,7 @@ podDisruptionBudget:
   # maxUnavailable: 1
 
 ## Define the number of pods the deployment will create
+## Do not change unless your persistent volume allows more than one writer, ie NFS
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 replicas: 1
 

--- a/stable/redmine/values.yaml
+++ b/stable/redmine/values.yaml
@@ -178,3 +178,23 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 8Gi
+
+## Define a disruption budget
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: 1
+  # maxUnavailable: 1
+
+## Define the number of pods the deployment will create
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+replicas: 1
+
+## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container
+resources: {}
+  # requests:
+  #   cpu: "1"
+  #   memory: "1G"
+  # limits:
+  #   cpu: "2"
+  #   memory: "1G"


### PR DESCRIPTION
@prydonius @tompizmor @sameersbn @carrodher @juan131

**What this PR does / why we need it**:
Provide users with the ability to configure their deployment resource, replicas, and PDB. 
