### PR TITLE
fixes #7317 stable/fluentd-elasticsearch truncate config volume name

### DIFF
--- a/stable/fluentd-elasticsearch/Chart.yaml
+++ b/stable/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 1.0.2
+version: 1.0.3
 appVersion: 2.3.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
         - name: libsystemddir
           mountPath: /host/lib
           readOnly: true
-        - name: config-volume-{{ include "fluentd-elasticsearch.fullname" . }} | trunc 49 | trimSuffix "-"
+        - name: config-volume-{{ include "fluentd-elasticsearch.fullname" . | trunc 49 | trimSuffix "-" }}
           mountPath: /etc/fluent/config.d
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
         - name: libsystemddir
           mountPath: /host/lib
           readOnly: true
-        - name: config-volume-{{ template "fluentd-elasticsearch.fullname" . }}
+        - name: config-volume-{{ include "fluentd-elasticsearch.fullname" . }} | trunc 49 | trimSuffix "-"
           mountPath: /etc/fluent/config.d
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
@@ -122,7 +122,7 @@ spec:
       - name: libsystemddir
         hostPath:
           path: /usr/lib64
-      - name: config-volume-{{ template "fluentd-elasticsearch.fullname" . }}
+      - name: config-volume-{{ include "fluentd-elasticsearch.fullname" . | trunc 49 | trimSuffix "-" }}
         configMap:
           name: {{ template "fluentd-elasticsearch.fullname" . }}
 {{- if .Values.extraVolumes }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Truncates the config volume names to 63 characters for the DaemonSet ConfigMap Volumes, as the "config-volume-" string is prepended onto a 63-char truncated template value for the "fluentd-elasticsearch.fullname".

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #7317 
