### PR TITLE
stable/metallb: update to MetalLB 0.7.3.

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-version: 0.7.0
+version: 0.8.0
 
 name: metallb
-appVersion: 0.6.2
+appVersion: 0.7.3
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters
 keywords: ["load-balancer", "balancer", "lb", "bgp", "arp", "vrrp", "vip"]
 home: https://metallb.universe.tf

--- a/stable/metallb/templates/rbac.yaml
+++ b/stable/metallb/templates/rbac.yaml
@@ -38,24 +38,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "metallb.fullname" . }}-leader-election
-  labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
-rules:
-- apiGroups: [""]
-  resources: ["endpoints"]
-  resourceNames: ["metallb-speaker"]
-  verbs: ["get", "update"]
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["create"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
   name: {{ template "metallb.fullname" . }}-config-watcher
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -126,21 +108,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ template "metallb.fullname" . }}-config-watcher
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ template "metallb.fullname" . }}-leader-election
-  labels:
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "metallb.chart" . }}
-    app: {{ template "metallb.name" . }}
-subjects:
-- kind: ServiceAccount
-  name: {{ template "metallb.speakerServiceAccountName" . }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ template "metallb.fullname" . }}-leader-election
 {{- end -}}

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -53,7 +53,7 @@ serviceAccounts:
 controller:
   image:
     repository: metallb/controller
-    tag: v0.6.2
+    tag: v0.7.3
     pullPolicy: IfNotPresent
   resources: {}
     # limits:
@@ -68,7 +68,7 @@ controller:
 speaker:
   image:
     repository: metallb/speaker
-    tag: v0.6.2
+    tag: v0.7.3
     pullPolicy: IfNotPresent
   resources: {}
     # limits:


### PR DESCRIPTION
The new upstream version requires fewer cluster privileges,
so one Role and one RoleBinding are removed with the version
change.