### PR TITLE
[stable/external-dns] Add support for zone Id filters

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -1,10 +1,11 @@
 apiVersion: v1
-description: Configure external DNS servers (AWS Route53, Google CloudDNS and others)
+description:
+  Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 0.7.3
+version: 0.7.4
 appVersion: 0.5.5
 home: https://github.com/kubernetes-incubator/external-dns
 sources:
-- https://github.com/kubernetes-incubator/external-dns
+  - https://github.com/kubernetes-incubator/external-dns
 engine: gotpl

--- a/stable/external-dns/README.md
+++ b/stable/external-dns/README.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the external-dns chart 
 | `affinity`                         | List of affinities (requires Kubernetes >=1.6)                                                                             | `{}`                                               |
 | `txtOwnerId`                       | When using the TXT registry, a name that identifies this instance of ExternalDNS (optional)                                | `"default"`                                        |
 | `txtPrefix`                        | When using the TXT registry, a prefix for ownership records that avoids collision with CNAME entries (optional)            | `""`                                               |
+| `zoneIdFilters`                    | Limit possible target zones by zone id (optional)                                                                          | `[]`                                               |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           {{- range .Values.domainFilters }}
             - --domain-filter={{ . }}
           {{- end }}
+          {{- range .Values.zoneIdFilters }}
+            - --zone-id-filter={{ . }}
+          {{- end }}
             - --policy={{ .Values.policy }}
             - --provider={{ .Values.provider }}
             - --registry={{ .Values.registry }}

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -37,6 +37,8 @@ google:
 
 ## Limit possible target zones by domain suffixes (optional)
 domainFilters: []
+## Limit possible target zones by zone id (optional)
+zoneIdFilters: []
 # Filter sources managed by external-dns via annotation using label selector semantics (default: all sources)
 annotationFilter: ""
 


### PR DESCRIPTION
## what

[external-dns 0.5.0](https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.5.0) added a new argument that allows filtering by zone Id. This PR adds support for the argument as a first class setting

The use of `extraArgs` is limiting when you want to pass the `zoneIdFilter` multiple times

external-dns PR: https://github.com/kubernetes-incubator/external-dns/pull/422

