### PR TITLE
[stable/kiam] Adding step to annotate namespace

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kiam
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.8
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/templates/NOTES.txt
+++ b/stable/kiam/templates/NOTES.txt
@@ -2,7 +2,15 @@ To verify that kiam has started, run:
 
   kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "kiam.name" . }},release={{ .Release.Name }}"
 
-Add an `iam.amazonaws.com/role` annotation to your pods with the role you want them to assume.
+Step1 : Add an annotation to your namespace as below:
+~~~
+kind: Namespace
+metadata:
+  name: iam-example
+  annotations:
+    iam.amazonaws.com/permitted: “<Role ARN or a Regex matching role ARN(s)>”
+~~~
+Step 2 :  Add an `iam.amazonaws.com/role` annotation to your pods with the role you want them to assume.
 Use `curl` to verify the pod's role from within:
 
   curl http://169.254.169.254/latest/meta-data/iam/security-credentials/


### PR DESCRIPTION

**What this PR does / why we need it**: This PR updates note with the helm chart to require user to annotate their namespace without which kiam will not allow pods to assume role.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # Documentation fix

**Special notes for your reviewer**: Let me know if you want me to bump up the chart version. 
