### PR TITLE
[incubator/cassandra] improve pvc support

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.5.2
+version: 0.6.0
 appVersion: 3.11.2
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "cassandra.name" . }}
+      release: {{ .Release.Name }}
   serviceName: {{ template "cassandra.fullname" . }}
   replicas: {{ .Values.config.cluster_size }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -138,11 +138,18 @@ spec:
         requests:
           storage: {{ .Values.persistence.size | quote }}
     {{- if .Values.persistence.storageClass }}
-    {{- if (eq "-" .Values.persistence.storageClass) }}
+      {{- if (eq "-" .Values.persistence.storageClass) }}
       storageClassName: ""
-    {{- else }}
+      {{- else }}
       storageClassName: "{{ .Values.persistence.storageClass }}"
+      {{- end }}
     {{- end }}
+    {{- with .Values.persistence.selector }}
+      selector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- if .Values.persistence.volumeName }}
+    volumeName: {{ tpl .Values.persistence.volumeName . }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -113,6 +113,12 @@ spec:
       - name: data
         emptyDir: {}
 {{- else }}
+  {{- if .Values.persistence.existingClaim }}
+      volumes:
+      - name: "data"
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim }}
+  {{- else }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -134,4 +140,5 @@ spec:
       storageClassName: "{{ .Values.persistence.storageClass }}"
     {{- end }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -26,6 +26,14 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 10Gi
+  ## A label query over volumes to consider for binding.
+  ## ref: https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#labelselector-v1-meta
+  # selector:
+  #   matchLabels:
+  #     label: value
+  ## VolumeName is the binding reference to the PersistentVolume backing this claim.
+  ## Could be templates
+  # volumeName: "{{ .Release.Name }}-data-0"
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
**What this PR does / why we need it**:
* added pod-selector for support k8s 1.8+ (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector) #7285
* add support for existing pvc (works only for 1 replica)
* improved compliance with the pvc specification (pvc template):
  * added selectors support
  * added volume name support (could be templated)
