### PR TITLE
[stable/falco] Typo fix reference to daemonset

### DIFF
--- a/stable/falco/values.yaml
+++ b/stable/falco/values.yaml
@@ -35,7 +35,7 @@ daemonset: {}
   # Allow the DaemonSet to perform a rolling update on helm update
   # ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   # If you do want to specify resources, uncomment the following lines, adjust
-  # them as necessary, and remove the curly braces after 'resources:'.
+  # them as necessary, and remove the curly braces after 'daemonset:'.
   # updateStrategy: RollingUpdate
 
 ebpf:


### PR DESCRIPTION
This is a copy/paste typo. Should be `daemonset` instead of `resources`. `resources` is used a few lines above.
