### PR TITLE
Add resources configuration

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.9.1
 description: A Helm chart for ark
 name: ark
-version: 1.2.0
+version: 1.2.1
 home: https://heptio.com/products/#heptio-ark
 sources:
 - https://github.com/heptio/ark

--- a/stable/ark/README.md
+++ b/stable/ark/README.md
@@ -61,6 +61,7 @@ Parameter | Description | Default
 `rbac.server.serviceAccount.name` | Service account to be used for the server. If not set and `rbac.server.serviceAccount.create` is `true` a name is generated using the fullname template | ``
 `rbac.hook.serviceAccount.create` | Whether a new service account name that the hook will use should be created | `true`
 `rbac.hook.serviceAccount.name` | Service account to be used for the server. If not set and `rbac.hook.serviceAccount.create` is `true` a name is generated using the fullname template | ``
+`resources` | Resource requests and limits | `{}`
 `tolerations` | List of node taints to tolerate | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `configuration.persistentVolumeProvider.name` | The name of the cloud provider the cluster is using for persistent volumes, if any | `{}`

--- a/stable/ark/templates/deployment.yaml
+++ b/stable/ark/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
             - secretRef:
                 name: {{ template "ark.secretName" . }}
           {{- end }}
+          {{- with .Values.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           volumeMounts:
             - name: plugins
               mountPath: /plugins

--- a/stable/ark/values.yaml
+++ b/stable/ark/values.yaml
@@ -17,6 +17,8 @@ podAnnotations: {}
 rbac:
   create: true
 
+resources: {}
+
 serviceAccount:
   hook:
     create: true


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Adds the option to configure compute resources in the ark container.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/helm/charts/issues/7342

**Special notes for your reviewer**: @domcar @unguiculus Hi, I hope you find this PR useful and constructive. I think having the option to configure compute resources is a necessity for community charts. I understand that ark can be bursty in its resource utilization, so I thought it best to not include commented out defaults and leave that option completely open to chart consumers. 
