### PR TITLE
Migrate to DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,24 +2,81 @@
 
 The Kubernetes Charts project accepts contributions via GitHub pull requests. This document outlines the process to help get your contribution accepted.
 
-### Contributor License Agreements
+## Sign Your Work
 
-We'd love to accept your patches! Before we can take them, we have to jump a couple of legal hurdles.
+The sign-off is a simple line at the end of the explanation for a commit. All 
+commits needs to be signed. Your signature certifies that you wrote the patch or
+otherwise have the right to contribute the material. The rules are pretty simple,
+if you can certify the below (from [developercertificate.org](http://developercertificate.org/)):
 
-The Cloud Native Computing Foundation (CNCF) CLA [must be signed](https://github.com/kubernetes/community/blob/master/CLA.md) by all contributors.
-Please fill out either the individual or corporate Contributor License
-Agreement (CLA).
+```
+Developer Certificate of Origin
+Version 1.1
 
-Once you are CLA'ed, we'll be able to accept your pull requests. For any issues that you face during this process,
-please add a comment [here](https://github.com/kubernetes/kubernetes/issues/27796) explaining the issue and we will help get it sorted out.
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
 
-***NOTE***: Only original source code from you and other people that have signed the CLA can be accepted into the main repository.
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@example.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.
+
+Note: If your git config information is set properly then viewing the
+ `git log` information for your commit will look something like this:
+
+```
+Author: Joe Smith <joe.smith@example.com>
+Date:   Thu Feb 2 11:41:15 2018 -0800
+
+    Update README
+
+    Signed-off-by: Joe Smith <joe.smith@example.com>
+```
+
+Notice the `Author` and `Signed-off-by` lines match. If they don't
+your PR will be rejected by the automated DCO check.
 
 ### Reporting a Bug in Helm
 
 This repository is used by Chart developers for maintaining the official charts for Kubernetes Helm. If your issue is in the Helm tool itself, please use the issue tracker in the [helm/helm](https://github.com/helm/helm) repository.
 
-### How to Contribute a Chart
+## How to Contribute a Chart
 
 1. If you haven't already done so, sign a Contributor License Agreement (see details above).
 1. Fork this repository, develop and test your Chart.
@@ -29,7 +86,7 @@ This repository is used by Chart developers for maintaining the official charts 
 
 ***NOTE***: In order to make testing and merging of PRs easier, please submit changes to multiple charts in separate PRs.
 
-#### Technical requirements
+### Technical requirements
 
 * All Chart dependencies should also be submitted independently
 * Must pass the linter (`helm lint`)
@@ -53,7 +110,7 @@ This repository is used by Chart developers for maintaining the official charts 
   (especially for [labels](https://github.com/helm/helm/blob/master/docs/chart_best_practices/labels.md)
   and [values](https://github.com/helm/helm/blob/master/docs/chart_best_practices/values.md))
 
-#### Documentation requirements
+### Documentation requirements
 
 * Must include an in-depth `README.md`, including:
     * Short description of the Chart
@@ -63,13 +120,13 @@ This repository is used by Chart developers for maintaining the official charts 
     * Any relevant post-installation information for the Chart
     * Instructions on how to access the application or service provided by the Chart
 
-#### Merge approval and release process
+### Merge approval and release process
 
 A Kubernetes Charts maintainer will review the Chart submission, and start a validation job in the CI to verify the technical requirements of the Chart. A maintainer may add "LGTM" (Looks Good To Me) or an equivalent comment to indicate that a PR is acceptable. Any change requires at least one LGTM. No pull requests can be merged until at least one maintainer signs off with an LGTM.
 
 Once the Chart has been merged, the release job will automatically run in the CI to package and release the Chart in the [`gs://kubernetes-charts` Google Storage bucket](https://console.cloud.google.com/storage/browser/kubernetes-charts/).
 
-### Support Channels
+## Support Channels
 
 Whether you are a user or contributor, official support channels include:
 

--- a/brigade.js
+++ b/brigade.js
@@ -1,0 +1,118 @@
+const { events, Job } = require("brigadier");
+
+// The push event only contains the new commits being pushed. Instead we are
+// looking at the pull_request changes, which might be overkill, but provides
+// the ability to query all the commits on the PR.
+events.on("pull_request", async function(e, project) {
+
+    // The payload is a string we need to parse into JSON to access
+    const ghData = JSON.parse(e.payload);
+
+    // Notify GH that 
+    var ghn = new Notification("dco-labeler", e, project);
+    ghn.text = "Checking for DCO";
+    await ghn.run();
+
+    // Get the commits to iterate over
+    var cj = new Job(`github-pr-commits`, "mattfarina/github-pr-commits:0.1.0");
+    cj.env = {
+        GITHUB_REPO: project.repo.name,
+        GITHUB_TOKEN: project.secrets.ghToken,
+        GITHUB_PR_NUMBER: ghData.number.toString(),
+    }
+    res = await cj.run();
+    var tempJson = JSON.stringify(res.toString());
+    tempJson = tempJson.replace(/\\n/g, "\\n")
+                .replace(/\\'/g, "\\'")
+                .replace(/\\"/g, '\\"')
+                .replace(/\\&/g, "\\&")
+                .replace(/\\r/g, "\\r")
+                .replace(/\\t/g, "\\t")
+                .replace(/\\b/g, "\\b")
+                .replace(/\\f/g, "\\f");
+    const commits = JSON.parse(tempJson);
+    const re = /^Signed-off-by: (.*) <(.*)>$/im
+
+    var count = 0, missed = 0;
+
+    for (const {commit, parents} of commits) {
+        // Skipping old commits that might be merged in but are not part of this PR.
+        const isMerge = parents && parents.length > 1;
+        if (isMerge) {
+          continue;
+        }
+      
+        var signedOff = re.exec(commit.message);
+
+        if (signedOff === null){
+            missed++;
+        }
+        count++
+    }
+
+    // A notification that some were missed
+    if (missed > 0) {
+        // This is paired with org wide probot DCO checking that will list
+        // the commits missing a DCO signoff. We are interested in the label and
+        // if this bot is seeing an issue for debugging.
+        ghn.text = missed + " out of " + count + " commits are missing signoff";
+        ghn.state = "failure";
+
+        // Remove the label if already present
+        var j = new Job(`github-label-remover`, "mattfarina/github-label-remover:0.1.0");
+        j.env = {
+            GITHUB_REPO: project.repo.name,
+            GITHUB_ISSUE_LABEL: "Contribution%20Allowed",
+            GITHUB_TOKEN: project.secrets.ghToken,
+            GITHUB_ISSUE_NUMBER: ghData.number.toString(),
+        }
+        j.run();
+    } else {
+        ghn.text = "All commits have signoff";
+        ghn.state = "success";
+
+        // Add the label so the bot knows it can merge
+        var j = new Job(`github-label-adder`, "mattfarina/github-label-adder:0.1.0");
+        j.env = {
+            GITHUB_REPO: project.repo.name,
+            GITHUB_ISSUE_LABEL: "Contribution Allowed",
+            GITHUB_TOKEN: project.secrets.ghToken,
+            GITHUB_ISSUE_NUMBER: ghData.number.toString(),
+        }
+        j.run();
+    }
+    ghn.run();
+})
+
+class Notification {
+    constructor(name, e, p) {
+        this.proj = p;
+        this.e = e;
+        this.payload = e.payload;
+        this.text = "";
+
+        this.context = name;
+
+        // count allows us to send the notification multiple times, with a distinct pod name
+        // each time.
+        this.count = 0;
+
+        // One of: "success", "failure", "neutral", "cancelled", or "timed_out".
+        this.state = "pending";
+    }
+
+    // Send a new notification, and return a Promise<result>.
+    run() {
+        this.count++
+        var j = new Job(`${ this.context }-${ this.count }`, "technosophos/github-notify:1.0.0");
+        j.env = {
+            GH_REPO: this.proj.repo.name,
+            GH_STATE: this.state,
+            GH_TOKEN: this.proj.secrets.ghToken,
+            GH_COMMIT: this.e.revision.commit,
+            GH_DESCRIPTION: this.text,
+            GH_CONTEXT: this.context,
+        }
+        return j.run();
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE UNTIL HELM MOVES TO DCO**

Helm is moving from a CLA to a DCO. This PR adds support for brigade to manage labels for the prow/tide merge automation along with updating the contribution guidelines.

/cc @michelleN 

/hold

Adding a hold so it is not merged until we make the change and setup a brigade webhook