### PR TITLE
[Incubator/Cassandra] Fixes selector missing and update to 3.11.3

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.5.3
+version: 0.5.4
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 name: cassandra
 version: 0.5.3
-appVersion: 3
+appVersion: 3.11.2
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing
   high availability with no single point of failure.

--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,6 +1,6 @@
 name: cassandra
 version: 0.5.3
-appVersion: 3.11.2
+appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing
   high availability with no single point of failure.

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -81,7 +81,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | Parameter                  | Description                                     | Default                                                    |
 | -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
 | `image.repo`                         | `cassandra` image repository                    | `cassandra`                                                |
-| `image.tag`                          | `cassandra` image tag                           | `3`                                                        |
+| `image.tag`                          | `cassandra` image tag                           | `3.11.3`                                                        |
 | `image.pullPolicy`                   | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
 | `image.pullSecrets`                  | Image pull secrets                              | `nil`                                                      |
 | `config.cluster_name`                | The name of the cluster.                        | `cassandra`                                                |

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -13,6 +13,10 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}
+  selector:
+    matchLabels:
+      app: {{ template "cassandra.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/cassandra/
 image:
   repo: "cassandra"
-  tag: "3.11.2"
+  tag: "3.11.3"
   pullPolicy: IfNotPresent
   ## Specify ImagePullSecrets for Pods
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod


### PR DESCRIPTION

**What this PR does / why we need it**:
Fixes error that `spec.selector` was missing from cassandra's statefulset.yml


