### PR TITLE
[stable/graphite]: allow customizing of statsd configurations.

### DIFF
--- a/stable/graphite/Chart.yaml
+++ b/stable/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.1.3"
 description: Graphite metrics server
 name: graphite

--- a/stable/graphite/README.md
+++ b/stable/graphite/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the Graphite chart and 
 | `affinity`                     | Affinity                                     | `{}`                                   |
 | `configMaps`                   | Graphite Config files                        | see values.yaml                        |
 | `statsdConfigMaps`             | StatsD Config files                          | see values.yaml                        |
+| `statsd.interface`             | StatsD server interface, `TCP` or `UDP`      | `UDP`                                  |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/stable/graphite/README.md
+++ b/stable/graphite/README.md
@@ -58,7 +58,8 @@ The following table lists the configurable parameters of the Graphite chart and 
 | `nodeSelector`                 | NodeSelector                                 | `{}`                                   |
 | `tolerations`                  | Tolerations                                  | `[]`                                   |
 | `affinity`                     | Affinity                                     | `{}`                                   |
-| `configMaps`                   | All Config files                             | see values.yaml                        |
+| `configMaps`                   | Graphite Config files                        | see values.yaml                        |
+| `statsdConfigMaps`             | StatsD Config files                          | see values.yaml                        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/stable/graphite/templates/deployment.yaml
+++ b/stable/graphite/templates/deployment.yaml
@@ -58,12 +58,21 @@ spec:
         volumeMounts:
           - name: {{ template "graphite.fullname" . }}-configmap
             mountPath: /opt/graphite/conf/
+          - name: {{ template "graphite.fullname" . }}-statsd-configmap
+            subPath: config_tcp.js
+            mountPath: /opt/statsd/config_tcp.js
+          - name: {{ template "graphite.fullname" . }}-statsd-configmap
+            subPath: config_udp.js
+            mountPath: /opt/statsd/config_udp.js
           - name: {{ template "graphite.fullname" . }}-pvc
             mountPath: /opt/graphite/storage/
       volumes:
         - name: {{ template "graphite.fullname" . }}-configmap
           configMap:
             name: {{ template "graphite.fullname" . }}-configmap
+        - name: {{ template "graphite.fullname" . }}-statsd-configmap
+          configMap:
+            name: {{ template "graphite.fullname" . }}-statsd-configmap
         - name: {{ template "graphite.fullname" . }}-pvc
 {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/stable/graphite/templates/deployment.yaml
+++ b/stable/graphite/templates/deployment.yaml
@@ -53,7 +53,8 @@ spec:
             httpGet:
               path: /
               port: graphite-gui
-          resources:
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
           - name: {{ template "graphite.fullname" . }}-configmap
             mountPath: /opt/graphite/conf/
@@ -69,10 +70,6 @@ spec:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "graphite.fullname" . }}-pvc{{- end }}
 {{- else }}
           emptyDir: {}
-{{- end }}
-{{- if .Values.resources }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
 {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/graphite/templates/deployment.yaml
+++ b/stable/graphite/templates/deployment.yaml
@@ -42,9 +42,13 @@ spec:
         - name: aggregate-pickl
           containerPort: 2024
         - name: statsd
+          protocol: {{ .Values.statsd.interface }}
           containerPort: 8125
         - name: statsd-admin
           containerPort: 8126
+        env:
+        - name: "STATSD_INTERFACE"
+          value: {{ .Values.statsd.interface | lower }}
         livenessProbe:
           httpGet:
             path: /

--- a/stable/graphite/templates/deployment.yaml
+++ b/stable/graphite/templates/deployment.yaml
@@ -45,14 +45,14 @@ spec:
           containerPort: 8125
         - name: statsd-admin
           containerPort: 8126
-          livenessProbe:
-            httpGet:
-              path: /
-              port: graphite-gui
-          readinessProbe:
-            httpGet:
-              path: /
-              port: graphite-gui
+        livenessProbe:
+          httpGet:
+            path: /
+            port: graphite-gui
+        readinessProbe:
+          httpGet:
+            path: /
+            port: graphite-gui
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/graphite/templates/service.yaml
+++ b/stable/graphite/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
       protocol: TCP
     - name: statsd
       port: 8125
-      protocol: TCP
+      protocol: {{ .Values.statsd.interface }}
     - name: statsd-admin
       port: 8126
       protocol: TCP

--- a/stable/graphite/templates/statsd-configmap.yaml
+++ b/stable/graphite/templates/statsd-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "graphite.fullname" . }}-statsd-configmap
+  labels:
+    app: {{ template "graphite.name" . }}
+    chart: {{ template "graphite.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $value := .Values.statsdConfigMaps }}
+  {{ $key }}: |-
+{{ $value | indent 4 }}
+{{- end }}

--- a/stable/graphite/values.yaml
+++ b/stable/graphite/values.yaml
@@ -992,3 +992,29 @@ configMaps:
     # missing, all metrics will pass through.
     # This file is reloaded automatically when changes are made
     .*
+
+statsdConfigMaps:
+  config_tcp.js: |-
+    {
+      "graphiteHost": "127.0.0.1",
+      "graphitePort": 2003,
+      "port": 8125,
+      "flushInterval": 10000,
+      "servers": [{
+        "server": "./servers/tcp",
+        "address": "0.0.0.0",
+        "port": 8125
+      }]
+    }
+  config_udp.js: |-
+    {
+      "graphiteHost": "127.0.0.1",
+      "graphitePort": 2003,
+      "port": 8125,
+      "flushInterval": 10000,
+      "servers": [{
+        "server": "./servers/udp",
+        "address": "0.0.0.0",
+        "port": 8125
+      }]
+    }

--- a/stable/graphite/values.yaml
+++ b/stable/graphite/values.yaml
@@ -1018,3 +1018,6 @@ statsdConfigMaps:
         "port": 8125
       }]
     }
+
+statsd:
+  interface: UDP


### PR DESCRIPTION
**What this PR does / why we need it**:

The primary purpose of this PR is to allow `statsd` configuration files to be provided to the running container. There is also a bug fix and additional cosmetic tweaks.


#### Allow customizing statsd configuration.

This is particularly useful for setting additional `percentThreshold` values for Timers.

The default values for `config_udp.js` and `config_tcp.js` are taken from the default files inside the `graphiteapp/graphite-statsd` container. However, these values are not valid `JSON`, so they have also been tweaked to pass standard lint tests.

Note that because these config files are contained in a single `/opt/statsd` directory alongside the statsd app files, `subPath` must be used. As per the [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) docs:

> Note: A container using a ConfigMap as a subPath volume will not receive ConfigMap updates.


#### Fix a bug when setting custom resources values.

Currently, because of a) a dangling, empty `resource` block and b) incorrect nesting of `resources` under `volumes`, the following error occurs when setting resource values:

```sh
$ helm install .
Error: YAML parse error on graphite/templates/deployment.yaml: error converting YAML to JSON: yaml: line 68: did not find expected '-' indicator
```

Here is a snippet of the resulting (incorrect) yaml:

```
        - name: statsd
          containerPort: 8125
        - name: statsd-admin
          containerPort: 8126
          livenessProbe:
            httpGet:
              path: /
              port: graphite-gui
          readinessProbe:
            httpGet:
              path: /
              port: graphite-gui
          resources:
        volumeMounts:
          - name: loitering-mite-graphite-configmap
            mountPath: /opt/graphite/conf/
          - name: loitering-mite-graphite-pvc
            mountPath: /opt/graphite/storage/
      volumes:
        - name: loitering-mite-graphite-configmap
          configMap:
            name: loitering-mite-graphite-configmap
        - name: loitering-mite-graphite-pvc
          persistentVolumeClaim:
            claimName: loitering-mite-graphite-pvc
        resources:
          limits:
            cpu: 100m
            memory: 512Mi
          requests:
            cpu: 100m
            memory: 512Mi

```

This fix moves `resources` under the primary container, and also adjusts indentation of `livenessProbe` and `readinessProbe` blocks, since these are being excluded from the resulting manifest.

@monotek