### PR TITLE
Fix kafka version number from mistaken merge

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.9.0
+version: 0.9.9
 appVersion: 4.1.2
 keywords:
 - kafka


### PR DESCRIPTION
@davidkarlsen Fixes bad version merge from https://github.com/helm/charts/pull/7233/files -- I mistakenly thought I had already tested the branch, and added the LGTM label. I then added the /ok-to-test label thinking it would automatically test before merging the code. Unfortunately, that is not the case and it merged the code before the tests returned. Meaning the version broke. This PR simply bumps the version up to 0.9.9.