### PR TITLE
[stable/kong] Add imagePullSecrets Option

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.5.2
+version: 0.5.3
 appVersion: 0.14.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -53,6 +53,7 @@ and their default values.
 | image.repository                  | Kong image                                                             | `kong`                |
 | image.tag                         | Kong image version                                                     | `0.14.1`              |
 | image.pullPolicy                  | Image pull policy                                                      | `IfNotPresent`        |
+| image.pullSecrets                 | Image pull secrets                                                     | `null`                |
 | replicaCount                      | Kong instance count                                                    | `1`                   |
 | admin.useTLS                      | Secure Admin traffic                                                   | `true`                |
 | admin.servicePort                 | TCP port on which the Kong admin service is exposed                    | `8444`                |

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -26,6 +26,12 @@ spec:
         release: {{ .Release.Name }}
         component: app
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       initContainers:
       - name: wait-for-db
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -18,6 +18,12 @@ spec:
         release: "{{ .Release.Name }}"
         component: migrations
     spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.postgresql.enabled }}
       initContainers:
       - name: wait-for-postgres

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -5,6 +5,12 @@ image:
   repository: kong
   tag: 0.14.1
   pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
 
 # Specify Kong admin and proxy services configurations
 admin:


### PR DESCRIPTION
Adds an `imagePullSecrets` option to enable private Docker registry usage.