### PR TITLE
[stable/cockroachdb] Added a Tolerations option for Pods in StatefulSet

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 1.2.3
+version: 1.2.4
 appVersion: 2.0.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | `Secure.RequestCertsImageTag`  | Image tag to use for requesting TLS certificates | `0.3`                                     |
 | `Secure.ServiceAccount.Create` | Whether to create a new RBAC service account     | `true`                                    |
 | `Secure.ServiceAccount.Name`   | Name of RBAC service account to use              | ``                                        |
+| `Tolerations` | [Kubernetes tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) to label the pods in the StatefulSet with | `` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -237,6 +237,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.NodeSelector | indent 8 }}
       {{- end }}
+{{- if .Values.Tolerations }}
+      tolerations:
+{{ toYaml .Values.Tolerations | indent 8 }}
+{{- end }}
       containers:
       - name: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
         image: "{{ .Values.Image }}:{{ .Values.ImageTag }}"

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -51,6 +51,7 @@ PodManagementPolicy: Parallel
 UpdateStrategy:
   type: RollingUpdate
 NodeSelector: {}
+Tolerations: {}
 Secure:
   Enabled: false
   RequestCertsImage: "cockroachdb/cockroach-k8s-request-cert"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Because this chart already has its own affinity baked in, I need another way to make sure cockroachdb pods get assigned to nodes in an instance group aside from using nodeLabels, which are slated to be discontinued in a future version of Kubernetes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

My first k8s related contribution.  I signed the Linux Foundation CLA, but let me know if I didn't do something right and I'll take care of it.