### PR TITLE
Celo adjustments

### DIFF
--- a/stable/ethereum/templates/geth-miner.deployment.yaml
+++ b/stable/ethereum/templates/geth-miner.deployment.yaml
@@ -27,9 +27,16 @@ spec:
         image: {{ .Values.geth.image.repository }}:{{ .Values.geth.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        args: 
+        args:
         - "-c"
-        - "geth --bootnodes=`cat /root/.ethereum/bootnodes` --mine --etherbase=0 --networkid=${NETWORK_ID} --ethstats=${HOSTNAME}:${ETHSTATS_SECRET}@${ETHSTATS_SVC} --verbosity=5"
+        - "geth --bootnodes=`cat /root/.ethereum/bootnodes` \
+          --password=/root/.ethereum/account/accountSecret \
+          --unlock=${ACCOUNT_ADDRESS} \
+          --mine \
+          --etherbase=0 \
+          --networkid=${NETWORK_ID} \
+          --ethstats=${HOSTNAME}:${ETHSTATS_SECRET}@${ETHSTATS_SVC} \
+          --verbosity=5"
         env:
         - name: ETHSTATS_SVC
           value: {{ template "ethereum.fullname" . }}-ethstats.{{ .Release.Namespace }}
@@ -38,6 +45,8 @@ spec:
             secretKeyRef:
               name: {{ template "ethereum.fullname" . }}-ethstats
               key: WS_SECRET
+        - name: ACCOUNT_ADDRESS
+          value: {{ .Values.geth.account.address }}
         - name: NETWORK_ID
           valueFrom:
             configMapKeyRef:
@@ -52,6 +61,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /root/.ethereum
+        - name: account
+          readOnly: true
+          mountPath: /root/.ethereum/account
       initContainers:
       - name: init-genesis
         image: {{ .Values.geth.image.repository }}:{{ .Values.geth.image.tag }}

--- a/stable/ethereum/templates/geth-tx.deployment.yaml
+++ b/stable/ethereum/templates/geth-tx.deployment.yaml
@@ -27,9 +27,19 @@ spec:
         image: {{ .Values.geth.image.repository }}:{{ .Values.geth.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        args: 
+        args:
         - "-c"
-        - "geth --bootnodes=`cat /root/.ethereum/bootnodes` --rpc --rpcaddr 0.0.0.0 --rpcapi=eth,net,web3 --rpccorsdomain='*' --ws --networkid=${NETWORK_ID} --ethstats=${HOSTNAME}:${ETHSTATS_SECRET}@${ETHSTATS_SVC} --verbosity=5"
+        - "geth --bootnodes=`cat /root/.ethereum/bootnodes` \
+          --rpc \
+          --rpcaddr 0.0.0.0 \
+          --rpcapi=eth,net,web3 \
+          --rpccorsdomain='*' \
+          --ws \
+          --lightserv 90 \
+          --lightpeers 20 \
+          --networkid=${NETWORK_ID} \
+          --ethstats=${HOSTNAME}:${ETHSTATS_SECRET}@${ETHSTATS_SVC} \
+          --verbosity=5"
         env:
         - name: ETHSTATS_SVC
           value: {{ template "ethereum.fullname" . }}-ethstats.{{ .Release.Namespace }}

--- a/stable/ethereum/templates/geth.configmap.yaml
+++ b/stable/ethereum/templates/geth.configmap.yaml
@@ -13,18 +13,32 @@ data:
     {
         "config": {
             "chainId": {{ .Values.geth.genesis.networkId }},
-            "homesteadBlock": 0,
-            "eip150Block": 0,
-            "eip155Block": 0,
-            "eip158Block": 0
+            "homesteadBlock": 1,
+            "eip150Block": 2,
+            "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "eip155Block": 3,
+            "eip158Block": 3,
+            "byzantiumBlock": 4,
+            "clique": {
+                "period": 5,
+                "epoch": 30000
+            }
         },
-        "difficulty":  {{ .Values.geth.genesis.difficulty | quote }},
-        "gasLimit": {{ .Values.geth.genesis.gasLimit | quote }},
+        "nonce": "0x0",
+        "timestamp": "0x5b843511",
+        "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000{{ .Values.geth.account.address }}0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "gasLimit": "0x47b760",
+        "difficulty": "0x1",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "coinbase": "0x0000000000000000000000000000000000000000",
         "alloc": {
             {{- if .Values.geth.account.address }}
             {{ .Values.geth.account.address | quote }}: {
                 "balance": "1000000000000000000000000"
             }
             {{- end }}
+        },
+        "number": "0x0",
+        "gasUsed": "0x0",
+        "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
         }
-    }


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR changes the configuration from  Proof of Work to Proof of Authority and allows us to serve light clients. In truffle config, you'll wanna use the `truffle-privatekey-provider` with the private key that you used to deploy this chart.

**Special notes for your reviewer**:

Outstanding items are:
- How do we approach private keys. One option would be to agree upon a private/public keypair for test purposes and hard code it for now in `values.yaml`

Future Items:
- expose the tx-service under a subdomain instead of an ip address