### PR TITLE
add sidecar container support, and the ability to route traffic throu…

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.20
+version: 0.16.21
 appVersion: 2.121.2
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -35,7 +35,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.ImageTag`                 | Master image tag                     | `lts`                                                                     |
 | `Master.ImagePullPolicy`          | Master image pull policy             | `Always`                                                                     |
 | `Master.ImagePullSecret`          | Master image pull secret             | Not set                                                                      |
-| `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
+| `Master.Component`                | k8s selector key                     | `jenkins-master`
+
+| `Master.extraContainers`          | allows sidecar containers on master                     | ``                                                             |
 | `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
 | `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
 | `Master.AdminPassword`            | Admin password (and user) created as a secret if useSecurity is true | Random value                                  |

--- a/stable/jenkins/templates/jenkins-agent-svc.yaml
+++ b/stable/jenkins/templates/jenkins-agent-svc.yaml
@@ -20,4 +20,13 @@ spec:
       name: slavelistener
   selector:
     component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
-  type: {{ .Values.Master.SlaveListenerServiceType }}
+  type: {{.Values.Master.SlaveListenerServiceType}}
+  {{if eq .Values.Master.SlaveListenerServiceType "LoadBalancer"}}
+{{- if .Values.Master.SlaveLoadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.Master.SlaveLoadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  {{if .Values.Master.SlaveLoadBalancerIP}}
+  loadBalancerIP: {{.Values.Master.SlaveLoadBalancerIP}}
+  {{end}}
+  {{end}}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -195,6 +195,9 @@ spec:
               mountPath: /usr/share/jenkins/ref/secrets/
               name: secrets-dir
               readOnly: false
+{{- with .Values.Master.extraContainers }}
+{{ tpl . $ | indent 8 }}
+{{- end }}
       volumes:
 {{- if .Values.Persistence.volumes }}
 {{ toYaml .Values.Persistence.volumes | indent 6 }}

--- a/stable/jenkins/templates/jenkins-master-svc.yaml
+++ b/stable/jenkins/templates/jenkins-master-svc.yaml
@@ -16,7 +16,7 @@ spec:
   ports:
     - port: {{.Values.Master.ServicePort}}
       name: http
-      targetPort: 8080
+      targetPort: {{ .Values.Master.BackendPort }}
       {{if (and (eq .Values.Master.ServiceType "NodePort") (not (empty .Values.Master.NodePort)))}}
       nodePort: {{.Values.Master.NodePort}}
       {{end}}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -25,6 +25,7 @@ Master:
     limits:
       cpu: "2000m"
       memory: "2048Mi"
+  # extraContainers: |
   # Environment variables that get added to the init container (useful for e.g. http_proxy)
   # InitContainerEnv:
   #   - name: http_proxy
@@ -43,6 +44,7 @@ Master:
   # RunAsUser: <defaults to 0>
   # FsGroup: <will be omitted in deployment if RunAsUser is 0>
   ServicePort: 8080
+  BackendPort: 8080
   # For minikube, set this to NodePort, elsewhere use LoadBalancer
   # Use ClusterIP if your setup includes ingress controller
   ServiceType: LoadBalancer


### PR DESCRIPTION
* Adds support for a sidecar container in addition allows for redirecting the backend port away from 8080 and to this sidecar container.  
* Also allow to expose the slave listener port through a ELB.  In my case I need to expose this outside of kubernetes into a internal network, but don't want to do this via a NodePort.

@lachie83 @viglesiasce