### PR TITLE
Fixes config for elastic search.  Broken with PR #7064

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -70,18 +70,6 @@ data:
         Logstash_Format On
         Retry_Limit False
         Type  {{ .Values.backend.es.type }}
-{{ else if eq .Values.backend.type "splunk" }}
-    [OUTPUT]
-        Name  splunk
-        Match *
-        Host  {{ .Values.backend.splunk.host }}
-        Port  {{ .Values.backend.splunk.port }}
-        Splunk_Token  {{ .Values.backend.splunk.token }}
-        Splunk_Send_Raw {{ .Values.backend.splunk.send_raw}}
-        TLS   {{ .Values.backend.splunk.tls }}
-        TLS.Verify   {{ .Values.backend.splunk.tls_verify }}
-        Message_Key   {{ .Values.backend.splunk.message_key }}
-
 {{- if .Values.backend.es.logstash_prefix }}
         Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}
 {{ else if .Values.backend.es.index }}
@@ -98,6 +86,18 @@ data:
 {{- if .Values.backend.es.tls_ca }}
         tls.ca_file /secure/es-tls-ca.crt
 {{- end }}
+{{ else if eq .Values.backend.type "splunk" }}
+    [OUTPUT]
+        Name  splunk
+        Match *
+        Host  {{ .Values.backend.splunk.host }}
+        Port  {{ .Values.backend.splunk.port }}
+        Splunk_Token  {{ .Values.backend.splunk.token }}
+        Splunk_Send_Raw {{ .Values.backend.splunk.send_raw}}
+        TLS   {{ .Values.backend.splunk.tls }}
+        TLS.Verify   {{ .Values.backend.splunk.tls_verify }}
+        Message_Key   {{ .Values.backend.splunk.message_key }}
+
 {{- end }}
 
 {{ else if eq .Values.backend.type "http" }}


### PR DESCRIPTION
**What this PR does / why we need it**:
#7064 broke the elasticsearch config when using tls.  This PR fixes that by moving the splunk config outside of the elasticsearch config end-if.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
