### PR TITLE
fluent-bit: Allows configuration of Logstash_DateFormat for elasticse…

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.9.0
+version: 0.9.2
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -84,6 +84,7 @@ data:
 
 {{- if .Values.backend.es.logstash_prefix }}
         Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}
+        Logstash_DateFormat {{ .Values.backend.es.logstash_dateformat }}
 {{ else if .Values.backend.es.index }}
         Index {{ .Values.backend.es.index }}
 {{- end }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -30,6 +30,7 @@ backend:
     index: kubernetes_cluster
     type: flb_type
     logstash_prefix: kubernetes_cluster
+    logstash_dateformat: "%Y.%m.%d"
     # Optional username credential for Elastic X-Pack access
     http_user:
     # Password for user defined in HTTP_User


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows for the configuration of elasticsearch Logstash_DateFormat, for configuring the ES index used by FluentBit.

see: https://fluentbit.io/documentation/0.13/output/elasticsearch.html

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NONE.

**Special notes for your reviewer**:
Included inside the Logstash_Prefix check.