### PR TITLE
Allow for keycloak to be hosted at a path other then 'auth'

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 3.2.0
+version: 3.3.0
 appVersion: 4.2.1.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -48,6 +48,7 @@ Parameter | Description | Default
 `keycloak.image.tag` | The Keycloak image tag | `4.2.1.Final`
 `keycloak.image.pullPolicy` | The Keycloak image pull policy | `IfNotPresent`
 `keycloak.image.pullSecrets` | Image pull secrets | `[]`
+`keycloak.basepath` | Path keycloak is hosted at | `auth`
 `keycloak.username` | Username for the initial Keycloak admin user | `keycloak`
 `keycloak.password` | Password for the initial Keycloak admin user. If not set, a random 10 characters password is created | `""`
 `keycloak.extraInitContainers` | Additional init containers, e. g. for providing themes, etc. Passed through the `tpl` funtion and thus to be configured a string | `""`

--- a/stable/keycloak/templates/configmap.yaml
+++ b/stable/keycloak/templates/configmap.yaml
@@ -27,6 +27,14 @@ data:
   keycloak.cli: |
     embed-server {{- if $highAvailability }} --server-config=standalone-ha.xml{{ end }} --std-out=echo
 
+{{- if ne .Values.keycloak.basepath "auth" }}
+    # Changes the base path to be /keycloak.basepath instead of /auth
+    /subsystem=keycloak-server:write-attribute(name=web-context,value={{ if eq .Values.keycloak.basepath "" }}ROOT{{ else }}{{ .Values.keycloak.basepath }}{{ end }})
+    {{- if eq .Values.keycloak.basepath "" }}
+    /subsystem=undertow/server=default-server/host=default-host:write-attribute(name=default-web-module,value=keycloak-server.war)
+    {{- end }}
+{{ end }}
+
 {{- with .Values.keycloak.cli }}
 
 {{ .nodeIdentifier | indent 4 }}

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -79,13 +79,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /auth/
+              path: /{{ .Values.keycloak.basepath }}
               port: http
             initialDelaySeconds: {{ .Values.keycloak.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.keycloak.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
-              path: /auth/
+              path: /{{ .Values.keycloak.basepath }}
               port: http
             initialDelaySeconds: {{ .Values.keycloak.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.keycloak.readinessProbe.timeoutSeconds }}

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -24,6 +24,9 @@ keycloak:
     fsGroup: 1000
     runAsNonRoot: true
 
+  ## The path keycloak will be served from. To serve keycloak from the root path, use two quotes (e.g. "").
+  basepath: auth
+
   ## Additional init containers, e. g. for providing custom themes
   extraInitContainers: |
 


### PR DESCRIPTION
Signed-off-by Ed Clement <ed.clement@gmail.com>

**What this PR does / why we need it**:
By default, when keycloak is deployed it is hosted from the `/auth` endpoint. The current helm chart implementation does not allow this to be changed even though keycloak does support being hosted from a different path or simply the root path.

**Which issue this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a