### PR TITLE
Allow release name override and persistence for Vault

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.12.0
+version: 0.13.0
 appVersion: 0.10.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/_helpers.tpl
+++ b/incubator/vault/templates/_helpers.tpl
@@ -11,6 +11,10 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "vault.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -122,7 +122,12 @@ spec:
           configMap:
             name: "{{ template "vault.fullname" . }}-config"
         - name: vault-root
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "vault.fullname" .) }}
+        {{- else }}
           emptyDir: {}
+        {{- end }}
         {{- range .Values.vault.customSecrets }}
         - name: {{ .secretName }}
           secret:

--- a/incubator/vault/templates/pvc.yaml
+++ b/incubator/vault/templates/pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "vault.fullname" . }}
+  labels:
+    app: {{ template "vault.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -162,3 +162,10 @@ vault:
       #   bucket: ""
       #   # Use a custom secret to mount this file.
       #   credentials_file: ""
+
+persistence:
+  enabled: false
+  accessMode: ReadWriteOnce
+  size: 200Mi
+  annotations: {}
+  #existingClaim: ""


### PR DESCRIPTION
**What this PR does / why we need it**: Allows overriding the release name, and optionally adding persistence