### PR TITLE
[stable/fluent-bit] Fix configmap, some parameters should appear in both ES and Splunk

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.9.0
+version: 0.10.0
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -70,6 +70,24 @@ data:
         Logstash_Format On
         Retry_Limit False
         Type  {{ .Values.backend.es.type }}
+{{- if .Values.backend.es.logstash_prefix }}
+        Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}
+{{ else if .Values.backend.es.index }}
+        Index {{ .Values.backend.es.index }}
+{{- end }}
+{{- if .Values.backend.es.http_user }}
+        HTTP_User {{ .Values.backend.es.http_user }}
+        HTTP_Passwd {{ .Values.backend.es.http_passwd }}
+{{- end }}
+{{if eq .Values.backend.es.tls "on" }}
+        tls {{ .Values.backend.es.tls }}
+        tls.verify {{ .Values.backend.es.tls_verify }}
+        tls.debug {{ .Values.backend.es.tls_debug }}
+{{- if .Values.backend.es.tls_ca }}
+        tls.ca_file /secure/es-tls-ca.crt
+{{- end }}
+{{- end }}
+
 {{ else if eq .Values.backend.type "splunk" }}
     [OUTPUT]
         Name  splunk

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -79,7 +79,7 @@ data:
         HTTP_User {{ .Values.backend.es.http_user }}
         HTTP_Passwd {{ .Values.backend.es.http_passwd }}
 {{- end }}
-{{if eq .Values.backend.es.tls "on" }}
+{{ if eq .Values.backend.es.tls "on" }}
         tls {{ .Values.backend.es.tls }}
         tls.verify {{ .Values.backend.es.tls_verify }}
         tls.debug {{ .Values.backend.es.tls_debug }}
@@ -109,7 +109,7 @@ data:
         HTTP_User {{ .Values.backend.es.http_user }}
         HTTP_Passwd {{ .Values.backend.es.http_passwd }}
 {{- end }}
-{{if eq .Values.backend.es.tls "on" }}
+{{ if eq .Values.backend.es.tls "on" }}
         tls {{ .Values.backend.es.tls }}
         tls.verify {{ .Values.backend.es.tls_verify }}
         tls.debug {{ .Values.backend.es.tls_debug }}


### PR DESCRIPTION
When merged #7064 , `HTTP_User`, `HTTP_Password` and other parameter is only set for `splunk` backend, but it should appear in both ES and Splunk backend.