### PR TITLE
[stable/sonatype-nexus] add annotations for proxy-svc

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.6.0
+version: 1.7.0
 appVersion: 3.12.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.6.0
+version: 1.6.1
 appVersion: 3.12.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.6.1
+version: 1.6.0
 appVersion: 3.12.1-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/templates/proxy-svc.yaml
+++ b/stable/sonatype-nexus/templates/proxy-svc.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "nexus.fullname" . }}
   labels:
 {{ include "nexus.labels" . | indent 4 }}
+{{- if .Values.nexus.annotations }}
+  annotations:
+{{ toYaml .Values.nexus.annotations | indent 4 }}
+{{- end }}
 spec:
   ports:
     - name: {{ .Values.nexusProxy.name }}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -25,6 +25,7 @@ nexus:
   dockerPort: 5003
   nexusPort: 8081
   serviceType: NodePort
+  # annotations: {}
   # securityContext:
   #   fsGroup: 2000
   livenessProbe:


### PR DESCRIPTION


**What this PR does / why we need it**:
when we change the service type to LoadBalancer, we need to add annotations to set up LoadBalancer information from Cloud Provider like aws

```
dns.alpha.kubernetes.io/external:
service.beta.kubernetes.io/aws-load-balancer-backend-protocol
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
