### PR TITLE
[stable/oauth2-proxy] Add email authentication file support

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.5.2
+version: 0.6.0
 # This chart is deprecated and no longer maintained as it's upstream has been abandoned.
 # For details deprecation, including how to un-deprecate a chart see the PROCESSES.md file.
 deprecated: true

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -43,6 +43,9 @@ The following table lists the configurable parameters of the oauth2-proxy chart 
 Parameter | Description | Default
 --- | --- | ---
 `affinity` | node/pod affinities | None
+`authenticatedEmailsFile.enabled` | Enables authorize individual email addresses | `false`
+`authenticatedEmailsFile.template` | Name of the configmap what is handled outside of that chart | `""`
+`authenticatedEmailsFile.restricted_access | (email addresses)[https://github.com/bitly/oauth2_proxy#email-authentication] list config | `""`
 `config.clientID` | oauth client ID | `""`
 `config.clientSecret` | oauth client secret | `""`
 `config.cookieSecret` | server specific cookie for the secret; create a new one with `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'` | `""`

--- a/stable/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
+++ b/stable/oauth2-proxy/templates/configmap-authenticated-emails-file.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.authenticatedEmailsFile.enabled }}
+{{- if .Values.authenticatedEmailsFile.restricted_access }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}-accesslist
+data:
+  restricted_user_access: {{ .Values.authenticatedEmailsFile.restricted_access | quote }}
+{{- end }}
+{{- end }}

--- a/stable/oauth2-proxy/templates/deployment.yaml
+++ b/stable/oauth2-proxy/templates/deployment.yaml
@@ -44,6 +44,13 @@ spec:
         {{- if .Values.config.configFile }}
           - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
         {{- end }}
+        {{- if .Values.authenticatedEmailsFile.enabled }}
+        {{- if .Values.authenticatedEmailsFile.template }}
+          - --authenticated-emails-file=/etc/oauth2-proxy/{{ .Values.authenticatedEmailsFile.template }}
+        {{- else }}
+          - --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails-list
+        {{- end }}
+        {{- end }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:
@@ -74,15 +81,38 @@ spec:
             port: http
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-{{- if .Values.config.configFile }}
         volumeMounts:
+{{- if .Values.config.configFile }}
         - mountPath: /etc/oauth2_proxy
           name: {{ template "oauth2-proxy.fullname" . }}-configmap
+{{- end }}
+{{- if .Values.authenticatedEmailsFile.enabled }}
+        - mountPath: /etc/oauth2-proxy
+          name: {{ template "oauth2-proxy.fullname" . }}-configaccesslist
+          readOnly: true
+{{- end }}
       volumes:
+{{- if .Values.config.configFile }}
       - configMap:
           defaultMode: 420
           name: {{ template "oauth2-proxy.fullname" . }}
         name: {{ template "oauth2-proxy.fullname" . }}-configmap
+{{- end }}
+{{- if .Values.authenticatedEmailsFile.enabled }}
+      - configMap:
+{{- if .Values.authenticatedEmailsFile.template }}
+          name: {{ .Values.authenticatedEmailsFile.template }}
+{{- else }}
+          name: {{ template "oauth2-proxy.fullname" . }}-accesslist
+{{- end }}
+          items:
+          - key: restricted_user_access
+{{- if .Values.authenticatedEmailsFile.template }}
+            path: {{ .Values.authenticatedEmailsFile.template }}
+{{- else }}
+            path: authenticated-emails-list
+{{- end }}
+        name: {{ template "oauth2-proxy.fullname" . }}-configaccesslist
 {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -29,6 +29,23 @@ extraArgs:
   upstream: "file:///dev/null"
   http-address: "0.0.0.0:4180"
 
+# To authorize individual email addresses
+# That is part of extraArgs but since this needs special treatment we need to do a separate section
+authenticatedEmailsFile:
+  enabled: false
+  # template is the name of the configmap what contains the email user list but has been configured without this chart.
+  # It's a simpler way to maintain only one configmap (user list) instead changing it for each oauth2-proxy service.
+  # Be aware the value name in the extern config map in data needs to be named to "restricted_user_access".
+  template: ""
+  # One email per line
+  # example:
+  # restricted_access: |-
+  #   name1@domain
+  #   name2@domain
+  # If you override the config with restricted_access it will configure a user list within this chart what takes care of the
+  # config map resource.
+  restricted_access: ""
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
As a request we need to downsize the access limit to certain peoples. We don't want to have that our whole company has access to our services.
Since the OpenID Connect Provider doesn't take care of that itself only domain based and oauth2-proxy supports a list of email addresses to restrict that I implemented that in this charts. 
  * Refer: https://github.com/bitly/oauth2_proxy#email-authentication

Actually that belongs to extraArgs and since it needs more configuration than a key, value pair I put that to an extra section.
