### PR TITLE
[stable/dex] Fix default issuer for dex

### DIFF
--- a/stable/dex/Chart.yaml
+++ b/stable/dex/Chart.yaml
@@ -1,5 +1,5 @@
 name: dex
-version: 0.3.0
+version: 0.3.1
 appVersion: 2.10.0
 description: CoreOS Dex
 keywords:

--- a/stable/dex/values.yaml
+++ b/stable/dex/values.yaml
@@ -77,7 +77,7 @@ serviceAccount:
   name:
 
 config:
-  issuer: https://dex.io
+  issuer: http://dex.io:8080
   storage:
     type: kubernetes
     config:


### PR DESCRIPTION
The default issuer is setup using https but the service listens on http on port 8080.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
