### PR TITLE
jenkins chart avoid lint errors when adding Values.Ingress.Annotations

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.21
+version: 0.16.22
 appVersion: 2.121.3
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -117,7 +117,7 @@ Master:
 
   Ingress:
     ApiVersion: extensions/v1beta1
-    Annotations:
+    Annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
 


### PR DESCRIPTION
When overriding the empty `.Values.Ingress.Annotations`, helm complains with the following lint errors:

```
2018/08/29 14:16:27 warning: destination for Annotations is a table. Ignoring non-table value <nil>
2018/08/29 14:16:27 warning: destination for Annotations is a table. Ignoring non-table value <nil>
2018/08/29 14:16:27 warning: destination for Annotations is a table. Ignoring non-table value <nil>
2018/08/29 14:16:27 warning: destination for Annotations is a table. Ignoring non-table value <nil>
```

Fixes #6882 in similar fashion to #3025.
