### PR TITLE
[stable/influx] ready: allow influxdb https config

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 0.10.0
+version: 0.11.0
 appVersion: 1.4
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -49,12 +49,14 @@ spec:
         {{- end }}
         livenessProbe:
           httpGet:
+            scheme: HTTPS
             path: /ping
             port: api
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
+            scheme: HTTPS
             path: /ping
             port: api
           initialDelaySeconds: 5
@@ -64,7 +66,18 @@ spec:
           mountPath: {{ .Values.config.storage_directory }}
         - name: config
           mountPath: /etc/influxdb
+        - name: ssl
+          mountPath: /etc/ssl/
+          readOnly: true
       volumes:
+      - name: ssl
+        secret:
+          secretName: example-com-tls
+          items:
+            - key: tls.key
+              path: influxdb.key
+            - key: tls.crt
+              path: influxdb.crt
       - name: data
       {{- if .Values.persistence.enabled }}
         {{- if not (empty .Values.persistence.name) }}

--- a/stable/influxdb/templates/deployment.yaml
+++ b/stable/influxdb/templates/deployment.yaml
@@ -49,14 +49,18 @@ spec:
         {{- end }}
         livenessProbe:
           httpGet:
+            {{ if .Values.config.http.https_enabled -}}
             scheme: HTTPS
+            {{ end -}}
             path: /ping
             port: api
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
+            {{ if .Values.config.http.https_enabled -}}
             scheme: HTTPS
+            {{ end -}}
             path: /ping
             port: api
           initialDelaySeconds: 5
@@ -66,18 +70,13 @@ spec:
           mountPath: {{ .Values.config.storage_directory }}
         - name: config
           mountPath: /etc/influxdb
-        - name: ssl
-          mountPath: /etc/ssl/
-          readOnly: true
+        {{ if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 8}}
+        {{ end }}
       volumes:
-      - name: ssl
-        secret:
-          secretName: example-com-tls
-          items:
-            - key: tls.key
-              path: influxdb.key
-            - key: tls.crt
-              path: influxdb.crt
+      {{ if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 6}}
+      {{ end }}
       - name: data
       {{- if .Values.persistence.enabled }}
         {{- if not (empty .Values.persistence.name) }}

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -112,6 +112,26 @@ env:
   # - name: INFLUXDB_DB
   #   value: "demo"
 
+## Option to attach more volumes to the pod. Primarily useful when
+## attaching HTTPS certificates via kubernetes secrets.
+volumes:
+  # - name: ssl
+  #   secret:
+  #     secretName: influxdb_tls_certs
+  #     items:
+  #     - key: tls.key
+  #       path: influxdb.key
+  #     - key: tls.crt
+  #       path: influxdb.crt
+
+## Option to specify InfluxDB pod volumeMounts. Primarily useful when
+## attaching HTTPS certificates via kubernetes secrets.
+volumeMounts:
+  # volumeMounts:
+  #  - name: ssl
+  #    mountPath: /etc/ssl/
+  #    readOnly: true
+
 ## Change InfluxDB configuration parameters below:
 ## Defaults are indicated
 ## ref: https://docs.influxdata.com/influxdb/v1.1/administration/config/


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: This PR (after the static values are converted to templated values) will allow users of **stable/influxdb** to attach a volume containing HTTPS certificates via K8S secrets. It will also correct the liveness and readiness checks to use HTTPS when HTTPS is enabeled.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #7403 

**Special notes for your reviewer**:
