### PR TITLE
[stable/grafana] Fix deployment strategy when changing from rollingUpdate

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.14.3
+version: 1.14.4
 appVersion: 5.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       release: {{ .Release.Name }}
   strategy:
     type: {{ .Values.deploymentStrategy }}
+  {{- if ne .Values.deploymentStrategy "RollingUpdate" }}
+    rollingUpdate: null
+  {{- end }}    
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**: 
* Deployment is failing when stratey is changed from RollingUpdate to Recreate.
```
"Error: UPGRADE FAILED: Deployment.apps \"grafana\" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'"
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
https://github.com/rancher/rancher/issues/13584#issuecomment-393753794
