### PR TITLE
[stable/jenkins] Move kubernetes and job plugins to latest versions

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.16.23
+version: 0.16.24
 appVersion: 2.121.3
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -84,8 +84,8 @@ Master:
   # JMXPort: 4000
   # List of plugins to be install during Jenkins master start
   InstallPlugins:
-    - kubernetes:1.12.0
-    - workflow-job:2.23
+    - kubernetes:1.12.4
+    - workflow-job:2.24
     - workflow-aggregator:2.5
     - credentials-binding:1.16
     - git:3.9.1


### PR DESCRIPTION
Move kubernetes to 1.12.4 and workflow-job to 2.24

Signed-off-by: David Currie <dcurrie@cloudbees.com>
