### PR TITLE
[Stable/Redis-ha] fix the internal server name to access redis

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 2.2.1
+version: 2.2.2
 appVersion: 4.0.8-r0
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/NOTES.txt
+++ b/stable/redis-ha/templates/NOTES.txt
@@ -18,9 +18,9 @@ To connect to your Redis server:
 {{- else }}
 1. Run a Redis pod that you can use as a client:
 
-   kubectl exec -it $(kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {.status.containerStatuses[0].state}{"\n"}{end}' -l redis-role=master | grep running | awk '{print $1}') bash
+   kubectl exec -n {{ .Release.Namespace }} -it $(kubectl get pod -n {{ .Release.Namespace }} -o jsonpath='{range .items[*]}{.metadata.name} {.status.containerStatuses[0].state}{"\n"}{end}' -l redis-role=master | grep running | awk '{print $1}') bash
 
 2. Connect using the Redis CLI:
 
-  redis-cli -h {{ template "redis-ha.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  redis-cli -h {{ template "redis-ha.fullname" . }}-slave-svc.{{ .Release.Namespace }}.svc.cluster.local
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes the server name to access redis in the note.txt

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes https://github.com/helm/charts/issues/6828

**Special notes for your reviewer**:
n/a