### PR TITLE
Adds a service monitor to the fluent-bit chart and associated documen…

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.16.0
+version: 0.17.0
 appVersion: 0.14.4
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -92,6 +92,9 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `image.pullPolicy`                 | Image pull policy                          | `Always`                                          |
 | `image.pullSecrets`                | Specify image pull secrets                 | `nil`                                             |
 | `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |
+| `prometheus.operator.enabled`                  | Are you using Prometheus Operator?  [Blog Post](https://coreos.com/blog/the-prometheus-operator.html) | `false`                           |
+| `prometheus.operator.serviceMonitor.selector`  | Label Selector for Prometheus to find ServiceMonitors                                                 | `{ prometheus: kube-prometheus }` |
+| `prometheus.operator.serviceMonitor.interval`  | How often Prometheus Scrapes metrics                                                                  | `10s`                             |
 | `rbac.create`                      | Specifies whether RBAC resources should be created.   | `true`                                 |
 | `serviceAccount.create`            | Specifies whether a ServiceAccount should be created. | `true`                                 |
 | `serviceAccount.name`              | The name of the ServiceAccount to use.     | `NULL`                                            |

--- a/stable/fluent-bit/templates/servicemonitor.yaml
+++ b/stable/fluent-bit/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.metrics.enabled .Values.prometheus.operator.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "fluent-bit.fullname" . }}
+  labels:
+    app: {{ template "fluent-bit.fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.prometheus.operator.serviceMonitor.selector }}
+{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "fluent-bit.fullname" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+    - path: /api/v1/metrics/prometheus
+      port: metrics
+      interval: {{ .Values.prometheus.operator.serviceMonitor.interval }}
+  namespaceSelector:
+    any: true
+{{- end }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -20,6 +20,20 @@ metrics:
     port: 2020
     type: ClusterIP
 
+prometheus:
+  operator:
+    # Prometheus is using Operator.  Setting to true will create Operator specific resources like ServiceMonitors and Alerts
+    enabled: false
+    serviceMonitor:
+      ## Interval at which Prometheus scrapes the fluent-bit pods
+      interval: 10s
+
+      ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/coreos/prometheus-operator/tree/master/helm#tldr)
+      ## [Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus/templates/prometheus.yaml#L65)
+      ## [Kube Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/kube-prometheus/values.yaml#L298)
+      selector:
+        prometheus: kube-prometheus
+
 # When enabled, fluent-bit will keep track of tailing offsets across pod restarts.
 trackOffsets: false
 


### PR DESCRIPTION
…tation

Signed-off-by: John Norwood <norwood.john.m@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR adds an optional servicemonitor to the fluent-bit chart. That chart already has the ability to expose fluent-bit's metrics port, which has a prometheus endpoint, however, this chart does not offer the ability to create a ServiceMonitor for the prometheus-operator to monitor.

**Special notes for your reviewer**:
