### PR TITLE
[stable/oauth2-proxy] Deprecates oauth2-proxy

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,9 +1,12 @@
 name: oauth2-proxy
-version: 0.5.1
+version: 0.5.2
+# This chart is deprecated and no longer maintained as it's upstream has been abandoned.
+# For details deprecation, including how to un-deprecate a chart see the PROCESSES.md file.
+deprecated: true
 apiVersion: v1
 appVersion: 2.2
 home: http://www.videntity.com/
-description: A reverse proxy that provides authentication with Google, Github or other providers
+description: DEPRECATED A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
 - kubernetes
 - oauth
@@ -11,9 +14,6 @@ keywords:
 - authentication
 - google
 - github
-maintainers:
-- name: compleatang
-  email: casey@monax.io
 sources:
 - https://github.com/bitly/oauth2_proxy
 engine: gotpl

--- a/stable/oauth2-proxy/OWNERS
+++ b/stable/oauth2-proxy/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- compleatang
-reviewers:
-- compleatang

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -1,5 +1,7 @@
 # oauth2-proxy
 
+**N.B., this chart is deprecated and is no longer maintained as it's upstream [has been abandoned](https://github.com/bitly/oauth2_proxy/issues/628#issuecomment-417121636).**
+
 [oauth2-proxy](https://github.com/bitly/oauth2_proxy) is a reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
 
 **Note - at this time, there is a known incompatibility between `oauth2-proxy` version 2.2 (which is its latest release) and `nginx-ingress` versions >= 0.9beta12. To utilize this chart at this time please use nginx-ingress version 0.9beta11**

--- a/stable/oauth2-proxy/templates/NOTES.txt
+++ b/stable/oauth2-proxy/templates/NOTES.txt
@@ -1,3 +1,1 @@
-To verify that oauth2-proxy has started, run:
-
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "oauth2-proxy.fullname" . }}"
+Note this chart is deprecated and is no longer maintained because upstream was abandoned. 


### PR DESCRIPTION
Upstream for this project (which has not worked in ages against anything close to a current implementation of ingress controllers) has been abandoned. See https://github.com/bitly/oauth2_proxy/issues/628#issuecomment-417121636

My company has moved to cloudflare access for our needs in this area. Currently it appears that the community is seeking to reconsolidate around another fork and to merge the various pull requests and keep the project alive. However that will take time.

For now, I'm removing myself from the chart and deprecating it. If another maintainer wants to pick up the work once the upstream community restabilizes itself then they should do so and follow the undeprecation processes [here](https://github.com/helm/charts/blob/master/PROCESSES.md#un-deprecating-a-chart).