### PR TITLE
Add option to set time key for elasticsearch

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.9.0
+version: 0.10.0
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -39,6 +39,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `backend.es.port`          | TCP port of the target Elasticsearch instance. | `9200` |
 | `backend.es.index`         | Elastic Index name | `kubernetes_cluster` |
 | `backend.es.type`          | Elastic Type name | `flb_type` |
+| `backend.es.time_key`          | Elastic Time Key | `@timestamp` |
 | `backend.es.logstash_prefix`  | Index Prefix. If Logstash_Prefix is equals to 'mydata' your index will become 'mydata-YYYY.MM.DD'. | `kubernetes_cluster` |
 | `backend.es.http_user`        | Optional username credential for Elastic X-Pack access. | `` |
 | `backend.es.http_passwd:`     | Password for user defined in HTTP_User. | `` |

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -70,6 +70,9 @@ data:
         Logstash_Format On
         Retry_Limit False
         Type  {{ .Values.backend.es.type }}
+{{- if .Values.backend.es.time_key }}
+        Time_Key {{ .Values.backend.es.time_key }}
+{{- end }}
 {{ else if eq .Values.backend.type "splunk" }}
     [OUTPUT]
         Name  splunk

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -30,6 +30,7 @@ backend:
     index: kubernetes_cluster
     type: flb_type
     logstash_prefix: kubernetes_cluster
+    time_key: "@timestamp"
     # Optional username credential for Elastic X-Pack access
     http_user:
     # Password for user defined in HTTP_User


### PR DESCRIPTION
Signed-off-by: Thomas Draebing <thomas.draebing@sap.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

The PR adds an option to change the time key for the elasticsearch backend in the fluent-bit helm chart. This allows to set a time_key other than the default (`@timestamp`), which could lead to errors, when merging JSON logs into the log structure, if the logs also contained a `@timestamp`-key (e.g. kibana).

**Which issue this PR fixes** 

When using `filter.mergeJSONLog: true`, while some other application also used the default time key `@timestamp`, JSON logs could not be merged correctly, resulting in errors.

**Special notes for your reviewer**:
