### PR TITLE
bump minio and redis charts and also update the spinnaker version

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.0.0
-appVersion: 1.8.5
+version: 1.1.0
+appVersion: 1.9.1
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/stable/spinnaker/requirements.lock
+++ b/stable/spinnaker/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.6.4
+  version: 3.8.0
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.5.0
-digest: sha256:e97bb4b0f7878f6fc3a375b6fca43bcfd778b6629db7dd46cd508b932548de02
-generated: 2018-07-18T13:48:10.143246511-05:00
+  version: 1.6.3
+digest: sha256:91008508c9ab75698d9ceadd02362d9169582065a185de15ccb41c78a12d1818
+generated: 2018-08-31T13:53:57.346842993+02:00

--- a/stable/spinnaker/requirements.yaml
+++ b/stable/spinnaker/requirements.yaml
@@ -1,8 +1,8 @@
 dependencies:
 - name: redis
-  version: 3.6.4
+  version: 3.8.0
   repository: https://kubernetes-charts.storage.googleapis.com/
 - name: minio
-  version: 1.5.0
+  version: 1.6.3
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: minio.enabled

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -1,8 +1,8 @@
 halyard:
-  spinnakerVersion: 1.8.5
+  spinnakerVersion: 1.9.1
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
-    tag: stable
+    tag: 1.9.1
   # Provide a config map with Hal commands that will be run the core config (storage)
   # The config map should contain a script in the config.sh key
   additionalConfig:


### PR DESCRIPTION
**What this PR does / why we need it**:
bump minio and redis and also use the latest spinnaker release
the old release of minio set the storageclass which should be commented out. the new release fix that

**Which issue this PR fixes**: fixes https://github.com/helm/charts/issues/7444

**Special notes for your reviewer**:
n/a