### PR TITLE
[stable/gocd] Removed extra char from role config instructions

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.3.6
+
+* [b7d596e](https://github.com/helm/charts/pull/7476/commits/b7d596e): Fixed role configuration instructions in README file.
+
 ### 1.3.5
 
 * [eab7388](https://github.com/kubernetes/charts/commit/eab7388): Fix typo and whitespace in the README file.

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.3.5
+version: 1.3.6
 appVersion: 18.7.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -29,7 +29,7 @@ $ minikube start --bootstrapper kubeadm
 
 ```bash
 
-$ kubectl create clusterrolebinding clusterRoleBinding \                                                                                                               1 ↵
+$ kubectl create clusterrolebinding clusterRoleBinding \
   --clusterrole=cluster-admin \
   --serviceaccount=kube-system:default
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed an extra character from the role setup instructions in the GoCD chart readme.  

I believe this extra character got added by mistake when a person copied the command from their command line.

Allows users to copy this command into their terminal and not encounter a bug when they run it.

**Special notes for your reviewer**:
N/A
