### PR TITLE
Fix spark zeppelin storageclass

### DIFF
--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark
-version: 0.2.0
+version: 0.2.1
 appVersion: 1.5.1
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/stable/spark/README.md
+++ b/stable/spark/README.md
@@ -76,28 +76,28 @@ The following table lists the configurable parameters of the Spark chart and the
 
 ### Zeppelin
 
-|       Parameter                          |           Description                |                         Default            |
-|------------------------------------------|--------------------------------------|--------------------------------------------|
-| `Zeppelin.Name`                          | Zeppelin name                        | `zeppelin-controller`                      |
-| `Zeppelin.Image`                         | Container image name                 | `apache/zeppelin`                          |
-| `Zeppelin.ImageTag`                      | Container image tag                  | `0.7.3`                                    |
-| `Zeppelin.Replicas`                      | k8s deployment replicas              | `1`                                        |
-| `Zeppelin.Component`                     | k8s selector key                     | `zeppelin`                                 |
-| `Zeppelin.Cpu`                           | container requested cpu              | `100m`                                     |
-| `Zeppelin.ServicePort`                   | k8s service port                     | `8080`                                     |
-| `Zeppelin.ContainerPort`                 | Container listening port             | `8080`                                     |
-| `Zeppelin.Ingress.Enabled`               | if `true`, an ingress is created     | `false`                                    |
-| `Zeppelin.Ingress.Annotations`           | annotations for the ingress          | `{}`                                       |
-| `Zeppelin.Ingress.Path`                  | the ingress path                     | `/`                                        |
-| `Zeppelin.Ingress.Hosts`                 | a list of ingress hosts              | `[zeppelin.example.com]`                   |
-| `Zeppelin.Ingress.Tls`                   | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
-| `Zeppelin.ServiceType `                  | Kubernetes Service type              | `LoadBalancer`                             |
-| `Zeppelin.Persistence.Config.Enabled`    | Enable Persistence for configuration | `false`                                    |
-| `Zeppelin.Persistence.Config.Size`       | Configuration Persistence Size       | `10G`                                      |
-| `Zeppelin.Persistence.Config.Size`       | Configuration Persistence AccessMode | `ReadWriteOnce`                            |
-| `Zeppelin.Persistence.Notebook.Enabled`  | Enable Persistence for notebook      | `false`                                    |
-| `Zeppelin.Persistence.Notebook.Size`     | Notebook Persistence Size            | `10G`                                      |
-| `Zeppelin.Persistence.Notebook.Size`     | Notebook Persistence AccessMode      | `ReadWriteOnce`                            |
+|       Parameter                            |           Description                |                         Default            |
+|--------------------------------------------|--------------------------------------|--------------------------------------------|
+| `Zeppelin.Name`                            | Zeppelin name                        | `zeppelin-controller`                      |
+| `Zeppelin.Image`                           | Container image name                 | `apache/zeppelin`                          |
+| `Zeppelin.ImageTag`                        | Container image tag                  | `0.7.3`                                    |
+| `Zeppelin.Replicas`                        | k8s deployment replicas              | `1`                                        |
+| `Zeppelin.Component`                       | k8s selector key                     | `zeppelin`                                 |
+| `Zeppelin.Cpu`                             | container requested cpu              | `100m`                                     |
+| `Zeppelin.ServicePort`                     | k8s service port                     | `8080`                                     |
+| `Zeppelin.ContainerPort`                   | Container listening port             | `8080`                                     |
+| `Zeppelin.Ingress.Enabled`                 | if `true`, an ingress is created     | `false`                                    |
+| `Zeppelin.Ingress.Annotations`             | annotations for the ingress          | `{}`                                       |
+| `Zeppelin.Ingress.Path`                    | the ingress path                     | `/`                                        |
+| `Zeppelin.Ingress.Hosts`                   | a list of ingress hosts              | `[zeppelin.example.com]`                   |
+| `Zeppelin.Ingress.Tls`                     | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
+| `Zeppelin.ServiceType `                    | Kubernetes Service type              | `LoadBalancer`                             |
+| `Zeppelin.Persistence.Config.Enabled`      | Enable Persistence for configuration | `false`                                    |
+| `Zeppelin.Persistence.Config.Size`         | Configuration Persistence Size       | `10G`                                      |
+| `Zeppelin.Persistence.Config.AccessMode`   | Configuration Persistence AccessMode | `ReadWriteOnce`                            |
+| `Zeppelin.Persistence.Notebook.Enabled`    | Enable Persistence for notebook      | `false`                                    |
+| `Zeppelin.Persistence.Notebook.Size`       | Notebook Persistence Size            | `10G`                                      |
+| `Zeppelin.Persistence.Notebook.AccessMode` | Notebook Persistence AccessMode      | `ReadWriteOnce`                            |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/spark/README.md
+++ b/stable/spark/README.md
@@ -76,28 +76,30 @@ The following table lists the configurable parameters of the Spark chart and the
 
 ### Zeppelin
 
-|       Parameter                            |           Description                |                         Default            |
-|--------------------------------------------|--------------------------------------|--------------------------------------------|
-| `Zeppelin.Name`                            | Zeppelin name                        | `zeppelin-controller`                      |
-| `Zeppelin.Image`                           | Container image name                 | `apache/zeppelin`                          |
-| `Zeppelin.ImageTag`                        | Container image tag                  | `0.7.3`                                    |
-| `Zeppelin.Replicas`                        | k8s deployment replicas              | `1`                                        |
-| `Zeppelin.Component`                       | k8s selector key                     | `zeppelin`                                 |
-| `Zeppelin.Cpu`                             | container requested cpu              | `100m`                                     |
-| `Zeppelin.ServicePort`                     | k8s service port                     | `8080`                                     |
-| `Zeppelin.ContainerPort`                   | Container listening port             | `8080`                                     |
-| `Zeppelin.Ingress.Enabled`                 | if `true`, an ingress is created     | `false`                                    |
-| `Zeppelin.Ingress.Annotations`             | annotations for the ingress          | `{}`                                       |
-| `Zeppelin.Ingress.Path`                    | the ingress path                     | `/`                                        |
-| `Zeppelin.Ingress.Hosts`                   | a list of ingress hosts              | `[zeppelin.example.com]`                   |
-| `Zeppelin.Ingress.Tls`                     | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
-| `Zeppelin.ServiceType `                    | Kubernetes Service type              | `LoadBalancer`                             |
-| `Zeppelin.Persistence.Config.Enabled`      | Enable Persistence for configuration | `false`                                    |
-| `Zeppelin.Persistence.Config.Size`         | Configuration Persistence Size       | `10G`                                      |
-| `Zeppelin.Persistence.Config.AccessMode`   | Configuration Persistence AccessMode | `ReadWriteOnce`                            |
-| `Zeppelin.Persistence.Notebook.Enabled`    | Enable Persistence for notebook      | `false`                                    |
-| `Zeppelin.Persistence.Notebook.Size`       | Notebook Persistence Size            | `10G`                                      |
-| `Zeppelin.Persistence.Notebook.AccessMode` | Notebook Persistence AccessMode      | `ReadWriteOnce`                            |
+|          Parameter                           |           Description                |                         Default            |
+|----------------------------------------------|--------------------------------------|--------------------------------------------|
+| `Zeppelin.Name`                              | Zeppelin name                        | `zeppelin-controller`                      |
+| `Zeppelin.Image`                             | Container image name                 | `apache/zeppelin`                          |
+| `Zeppelin.ImageTag`                          | Container image tag                  | `0.7.3`                                    |
+| `Zeppelin.Replicas`                          | k8s deployment replicas              | `1`                                        |
+| `Zeppelin.Component`                         | k8s selector key                     | `zeppelin`                                 |
+| `Zeppelin.Cpu`                               | container requested cpu              | `100m`                                     |
+| `Zeppelin.ServicePort`                       | k8s service port                     | `8080`                                     |
+| `Zeppelin.ContainerPort`                     | Container listening port             | `8080`                                     |
+| `Zeppelin.Ingress.Enabled`                   | if `true`, an ingress is created     | `false`                                    |
+| `Zeppelin.Ingress.Annotations`               | annotations for the ingress          | `{}`                                       |
+| `Zeppelin.Ingress.Path`                      | the ingress path                     | `/`                                        |
+| `Zeppelin.Ingress.Hosts`                     | a list of ingress hosts              | `[zeppelin.example.com]`                   |
+| `Zeppelin.Ingress.Tls`                       | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
+| `Zeppelin.ServiceType `                      | Kubernetes Service type              | `LoadBalancer`                             |
+| `Zeppelin.Persistence.Config.Enabled`        | Enable Persistence for configuration | `false`                                    |
+| `Zeppelin.Persistence.Config.StorageClass`   | Volume storageClassName              | `-` (no dynamic provisioning)              |
+| `Zeppelin.Persistence.Config.Size`           | Configuration Persistence Size       | `10G`                                      |
+| `Zeppelin.Persistence.Config.AccessMode`     | Configuration Persistence AccessMode | `ReadWriteOnce`                            |
+| `Zeppelin.Persistence.Notebook.Enabled`      | Enable Persistence for notebook      | `false`                                    |
+| `Zeppelin.Persistence.Notebook.StorageClass` | Volume storageClassName              | `-` (no dynamic provisioning)              |
+| `Zeppelin.Persistence.Notebook.Size`         | Notebook Persistence Size            | `10G`                                      |
+| `Zeppelin.Persistence.Notebook.AccessMode`   | Notebook Persistence AccessMode      | `ReadWriteOnce`                            |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/spark/templates/_helpers.tpl
+++ b/stable/spark/templates/_helpers.tpl
@@ -29,3 +29,4 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.Zeppelin.Name -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+

--- a/stable/spark/templates/spark-zeppelin-deployment.yaml
+++ b/stable/spark/templates/spark-zeppelin-deployment.yaml
@@ -53,21 +53,21 @@ spec:
             - name: SPARK_MASTER
               value: "spark://{{ template "master-fullname" . }}:{{ .Values.Master.ServicePort }}"
           volumeMounts:
-          {{- if .Values.Zeppelin.Persistence.Config }}
+          {{- if .Values.Zeppelin.Persistence.Config.Enabled }}
             - name: {{ template "master-fullname" . }}-config
               mountPath: /zeppelin/conf
           {{- end }}
-          {{- if .Values.Zeppelin.Persistence.Notebook }}
+          {{- if .Values.Zeppelin.Persistence.Notebook.Enabled }}
             - name: {{ template "master-fullname" . }}-notebook
               mountPath: /zeppelin/notebook
           {{- end }}
       volumes:
-        {{- if .Values.Zeppelin.Persistence.Config }}
+        {{- if .Values.Zeppelin.Persistence.Config.Enabled }}
         - name: {{ template "master-fullname" . }}-config
           persistentVolumeClaim:
             claimName: {{ template "zeppelin-fullname" . }}-config
         {{- end }}
-        {{- if .Values.Zeppelin.Persistence.Notebook }}
+        {{- if .Values.Zeppelin.Persistence.Notebook.Enabled }}
         - name: {{ template "master-fullname" . }}-notebook
           persistentVolumeClaim:
             claimName: {{ template "zeppelin-fullname" . }}-notebook

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -80,13 +80,13 @@ Zeppelin:
       ## If undefined (the default) or set to null, no storageClassName spec is
       ## set, choosing the default provisioner. (gp2 on AWS, standard on
       ## GKE, AWS & OpenStack)
-      storageClass: "-"
+      StorageClass: "-"
       ## Set default PVC size
       Size: 10G
       ## Set default PVC access mode: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
       AccessMode: ReadWriteOnce
     Notebook:
       Enabled: false
-      storageClass: "-"
+      StorageClass: "-"
       Size: 10G
       AccessMode: ReadWriteOnce


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes typo in default values.xml that prevents setting storage class on Zeppelin persistent volume claims.
Also fix small typo in Readme.

**Special notes for your reviewer**:
There are two other related issues:
1. Zeppelin doesn't work without persistence enabled: https://github.com/helm/charts/issues/6784
2. Persistence doesn't work in multi-zone clusters, as PVs are created in different zones: https://github.com/helm/charts/issues/7478