### PR TITLE
Add support for loadBalancerSourceRanges to stable/selenium

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.9.2
+version: 0.10.0
 appVersion: 3.14.0
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.9.1
+version: 0.9.2
 appVersion: 3.14.0
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/README.md
+++ b/stable/selenium/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `hub.resources` | The resources for the hub container, defaults to minimum half a cpu and maximum 1,000 mb RAM | `{"limits":{"cpu":".5", "memory":"1000Mi"}}` |
 | `hub.serviceType` | The Service type | `NodePort` |
 | `hub.serviceLoadBalancerIP` | The Public IP for the Load Balancer | `nil` |
+| `hub.loadBalancerSourceRanges` | A list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
 | `hub.serviceSessionAffinity` | The session affinity for the hub service| `None` |
 | `hub.gridNewSessionWaitTimeout` | | `nil` |
 | `hub.gridJettyMaxThreads` | | `nil` |

--- a/stable/selenium/templates/hub-service.yaml
+++ b/stable/selenium/templates/hub-service.yaml
@@ -16,6 +16,10 @@ spec:
   {{- if .Values.hub.serviceLoadBalancerIP }}
   loadBalancerIP: {{ .Values.hub.serviceLoadBalancerIP | quote }}
   {{- end }}
+{{- if .Values.hub.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.hub.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
   sessionAffinity: {{ .Values.hub.serviceSessionAffinity | quote }}
   ports:
   - name: hub

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -59,6 +59,7 @@ hub:
   ## The LoadBalancer IP Address
   ## ref: https://kubernetes.io/docs/user-guide/services/
   ## serviceLoadBalancerIP: "40.121.183.52"
+  loadBalancerSourceRanges: []
 
   ## Control where client requests go, to the same pod or round-robin
   ##   Values: ClientIP or None


### PR DESCRIPTION
@flah00 @diemol 

**What this PR does / why we need it**:
Adding support for loadBalancerSourceRanges allows us to easily restrict access to the selenium hub.
