### PR TITLE
Add basePath option for Jaeger

### DIFF
--- a/incubator/jaeger/Chart.yaml
+++ b/incubator/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.4.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.7.0
+version: 0.7.1
 keywords:
   - jaeger
   - opentracing

--- a/incubator/jaeger/README.md
+++ b/incubator/jaeger/README.md
@@ -181,6 +181,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `provisionDataStore.elasticsearch`       | Provision Elasticsearch Data Store  |  false                                 |
 | `query.service.annotations`              | Annotations for Query SVC           |  nil                                   |
 | `query.cmdlineParams`                    | Additional command line parameters  |  nil                                   |
+| `query.basePath`                         | Base path of Query UI               |  /                                     |
 | `query.image`                            | Image for Jaeger Query UI           |  jaegertracing/jaeger-query            |
 | `query.ingress.enabled`                  | Allow external traffic access       |  false                                 |
 | `query.podAnnotations`                   | Annotations for Query pod           |  nil                                   |

--- a/incubator/jaeger/templates/common-cm.yaml
+++ b/incubator/jaeger/templates/common-cm.yaml
@@ -27,6 +27,7 @@ data:
   span-storage.type: {{ .Values.storage.type | quote }}
   query.health-check-http-port: {{ .Values.query.healthCheckPort | quote }}
   query.port: {{ .Values.query.service.targetPort | quote }}
+  query.base-path: {{ .Values.query.basePath | quote }}
   # Not implemented
   # cassandra.archive.connections-per-host:
   # cassandra.archive.keyspace:

--- a/incubator/jaeger/templates/query-deploy.yaml
+++ b/incubator/jaeger/templates/query-deploy.yaml
@@ -88,6 +88,11 @@ spec:
               configMapKeyRef:
                 name: {{ template "jaeger.fullname" . }}
                 key: query.port
+          - name: QUERY_BASE_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "jaeger.fullname" . }}
+                key: query.base-path
           - name: QUERY_HEALTH_CHECK_HTTP_PORT
             valueFrom:
               configMapKeyRef:

--- a/incubator/jaeger/values.yaml
+++ b/incubator/jaeger/values.yaml
@@ -160,6 +160,7 @@ query:
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
   healthCheckPort: 16687
+  basePath: /
   replicaCount: 1
   service:
     annotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Jaeger has added a new option to set the base path of the query UI, which makes it usable behind reverse proxies. This option should also be exposed in the chart as well.

PR which added this support: https://github.com/jaegertracing/jaeger/pull/748
Docs on set up: https://www.jaegertracing.io/docs/deployment/#ui-base-path

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #7489

**Special notes for your reviewer**: