### PR TITLE
[stable/datadog] Set dnsPolicy for using hostNetwork

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.0.3
+version: 1.0.4
 appVersion: 6.3.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       {{- if .Values.daemonset.useHostNetwork }}
       hostNetwork: {{ .Values.daemonset.useHostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       {{- if .Values.daemonset.useHostPID }}
       hostPID: {{ .Values.daemonset.useHostPID }}


### PR DESCRIPTION
**What this PR does / why we need it**:

When using hostNetwork, ```dnsPolicy``` needs to be set ```ClusterFirstWithHostNet```.
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy