### PR TITLE
fix conflict between mounting a file and mounting a folder

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.14.2
+version: 1.14.3
 appVersion: 5.2.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -134,7 +134,8 @@ spec:
             - name: sc-dashboard-volume
               mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
             - name: sc-dashboard-provider
-              mountPath: "/etc/grafana/provisioning/dashboards"
+              mountPath: "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml"
+              subPath: provider.yaml
 {{- end}}
 {{- if .Values.sidecar.datasources.enabled }}
             - name: sc-datasources-volume
@@ -271,4 +272,3 @@ spec:
           secret:
             secretName: {{ .secretName }}
       {{- end }}
-


### PR DESCRIPTION
**What this PR does / why we need it**:

When using the _sidecar container to fetch dashboards_ together with a configured _dashboardProviders configmap_ a conflict came up, because the sidecar tried to mount it's whole configmap into the folder where dashboardProviders mounted its contents into a file already.