### PR TITLE
[stable/metrics-server] upgrade metrics-server to v0.3.0 

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.2.1
+appVersion: 0.3.0
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 1.1.0
+version: 2.0.0
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -11,9 +11,9 @@ Parameter | Description | Default
 `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
 `apiService.create` | Create the v1beta1.metrics.k8s.io API service | `true`
 `image.repository` | Image repository | `gcr.io/google_containers/metrics-server-amd64`
-`image.tag` | Image tag | `v0.2.1`
+`image.tag` | Image tag | `v0.3.0`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
-`args` | Command line arguments | --source=kubernetes.summary_api:''
+`args` | Command line arguments | `--logtostderr`
 `resources` | CPU/Memory resource requests/limits. | `{}`
 `tolerations` | List of node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -19,11 +19,13 @@ apiService:
 
 image:
   repository: gcr.io/google_containers/metrics-server-amd64
-  tag: v0.2.1
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 args:
-  - --source=kubernetes.summary_api:''
+  - --logtostderr
+# enable this if you have self-signed certificates, see: https://github.com/kubernetes-incubator/metrics-server
+#  - --kubelet-insecure-tls
 
 resources: {}
 


### PR DESCRIPTION
Note that v0.3.0 has removed the --source option - hence the major bump in chart version.