### PR TITLE
[incubator/elasticsearch] Fix "config is not a table" helm warning + fix wrong cluster.env default value in README

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.6.1
+version: 1.6.2
 appVersion: 6.4.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.6.0
+version: 1.6.1
 appVersion: 6.4.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `cluster.xpackEnable`                | Writes the X-Pack configuration options to the configuration file   | `false`                              |
 | `cluster.config`                     | Additional cluster config appended                                  | `{}`                                 |
 | `cluster.keystoreSecret`             | Name of secret holding secure config options in an es keystore      | `nil`                                |
-| `cluster.env`                        | Cluster environment variables                                       | `{}`                                 |
+| `cluster.env`                        | Cluster environment variables                                       | `{MINIMUM_MASTER_NODES: "2"}`        |
 | `client.name`                        | Client component name                                               | `client`                             |
 | `client.replicas`                    | Client node replicas (deployment)                                   | `2`                                  |
 | `client.resources`                   | Client node resources requests & limits                             | `{} - cpu limit must be an integer`  |

--- a/incubator/elasticsearch/templates/configmap.yaml
+++ b/incubator/elasticsearch/templates/configmap.yaml
@@ -73,8 +73,8 @@ data:
     gateway.recover_after_time: ${RECOVER_AFTER_TIME:5m}
     gateway.recover_after_master_nodes: ${RECOVER_AFTER_MASTER_NODES:2}
     gateway.recover_after_data_nodes: ${RECOVER_AFTER_DATA_NODES:1}
-{{- if .Values.cluster.config }}
-{{ toYaml .Values.cluster.config | indent 4 }}
+{{- with .Values.cluster.config }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 {{- if hasPrefix "2." .Values.image.tag }}
   logging.yml: |-

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -20,7 +20,7 @@ cluster:
   # Some settings must be placed in a keystore, so they need to be mounted in from a secret.
   # Use this setting to specify the name of the secret
   # keystoreSecret: eskeystore
-  config:
+  config: {}
   env:
     # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes
     # To prevent data loss, it is vital to configure the discovery.zen.minimum_master_nodes setting so that each master-eligible


### PR DESCRIPTION
…by adding {} value to cluster.config.

Also change if .Values.something -> with .Values.something
Also fix wrong cluster.env default value in readme.
