### PR TITLE
[stable/prometheus-statsd-exporter]: Initial commit.

### DIFF
--- a/stable/prometheus-statsd-exporter/.helmignore
+++ b/stable/prometheus-statsd-exporter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/prometheus-statsd-exporter/Chart.yaml
+++ b/stable/prometheus-statsd-exporter/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+name: prometheus-statsd-exporter
+home: https://github.com/prometheus/statsd_exporter
+description: StatsD to Prometheus metrics exporter.
+version: 0.1.0
+appVersion: "v0.7.0"
+keywords:
+- statsd
+- prometheus
+- metrics
+- graphite
+maintainers:
+- name: niclic
+  email: rfallon@360incentives.com

--- a/stable/prometheus-statsd-exporter/README.md
+++ b/stable/prometheus-statsd-exporter/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the `prometheus-statsd-
 | `nodeSelector`                      | Node labels for pod assignment           | `{}`                                      |
 | `affinity`                          | Node affinity for pod assignment         | `{}`                                      |
 | `tolerations`                       | Node tolerations for pod assignment      | `[]`                                      |
-| `statsdMappingConfig`               | `statsd-exporter` mappings               | `""`                                      |
+| `statsdMappingConfig`               | `statsd-exporter` mappings               | Defaults for `timer_type`, buckets, quantiles, and `match_type`. These will be used by all mappings that do not define them.|
 
 
 Specify each parameter you'd like to override using a YAML file.

--- a/stable/prometheus-statsd-exporter/README.md
+++ b/stable/prometheus-statsd-exporter/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the `prometheus-statsd-
 | `nodeSelector`                      | Node labels for pod assignment           | `{}`                                      |
 | `affinity`                          | Node affinity for pod assignment         | `{}`                                      |
 | `tolerations`                       | Node tolerations for pod assignment      | `[]`                                      |
-| `statsdMappingConfig`               | `statsd-exporter` mappings               | Defaults for `timer_type`, buckets, quantiles, and `match_type`. These will be used by all mappings that do not define them.|
+| `statsdMappingConfig`               | `statsd-exporter` mappings               | `timer_type: histogram`                   |
 
 
 Specify each parameter you'd like to override using a YAML file.
@@ -68,3 +68,7 @@ You can also override specific values by using the `--set key=value[,key=value]`
 ```sh
 $ helm install stable/prometheus-statsd-exporter --name my-release --set udpPort=8125
 ```
+
+
+## Metric Mapping and Configuration
+This chart provides a minimal default configuration. To create a custom mapping configuration and review default settings, consult the [official docs](https://github.com/prometheus/statsd_exporter#metric-mapping-and-configuration).

--- a/stable/prometheus-statsd-exporter/README.md
+++ b/stable/prometheus-statsd-exporter/README.md
@@ -1,0 +1,70 @@
+# prometheus-statsd-exporter
+
+The [prometheus-statsd-exporter](https://github.com/prometheus/statsd_exporter) receives StatsD metrics and exports them as Prometheus metrics.
+
+## Introduction
+
+This chart creates a `prometheus-statsd-exporter` deployment using the [Helm](https://helm.sh) package manager.
+
+
+## Prerequisites
+
+- Kubernetes 1.9
+- `prometheus-statsd-exporter` `v0.7.0`
+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` and default values:
+
+```sh
+$ helm install --name my-release stable/prometheus-statsd-exporter
+```
+
+
+## Uninstalling the Chart
+
+To uninstall/delete `my-release`:
+
+```sh
+$ helm delete --purge my-release
+```
+
+
+## Configuration
+
+The following table lists the configurable parameters of the `prometheus-statsd-exporter` chart and their default values.
+
+
+|             Parameter               |            Description                   |                    Default                |
+|-------------------------------------|------------------------------------------|-------------------------------------------|
+| `replicaCount`                      | Number of pods to run                    | `1`                                       |
+| `image.repository`                  | The docker image to run                  | `prom/statsd-exporter`                    |
+| `image.tag`                         | The image tag to pull                    | `v0.7.0`                                  |
+| `image.pullPolicy`                  | Image pull policy                        | `IfNotPresent`                            |
+| `service.type`                      | Type of kubernetes service               | `ClusterIP`                               |
+| `webPort`                           | Web port for metrics endpoint            | `9102`                                    |
+| `udpPort`                           | UDP port to receive statsd metrics       | `9125`                                    |
+| `tcpPort`                           | TCP port to receive statsd metrics       | `9125`                                    |
+| `podAnnotations`                    | Annotations to add to pods               | `{}`                                      |
+| `priorityClassName`                 | Priority class name                      | `""`                                      |
+| `resources`                         | Pod resource requests & limits           | `{}`                                      |
+| `nodeSelector`                      | Node labels for pod assignment           | `{}`                                      |
+| `affinity`                          | Node affinity for pod assignment         | `{}`                                      |
+| `tolerations`                       | Node tolerations for pod assignment      | `[]`                                      |
+| `statsdMappingConfig`               | `statsd-exporter` mappings               | `""`                                      |
+
+
+Specify each parameter you'd like to override using a YAML file.
+
+```sh
+$ helm install --name my-release stable/prometheus-statsd-exporter -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+You can also override specific values by using the `--set key=value[,key=value]` argument to `helm install`. For example, to change the `udpPort` to `8125`:
+
+```sh
+$ helm install stable/prometheus-statsd-exporter --name my-release --set udpPort=8125
+```

--- a/stable/prometheus-statsd-exporter/templates/NOTES.txt
+++ b/stable/prometheus-statsd-exporter/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-statsd-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "prometheus-statsd-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-statsd-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.webPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-statsd-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl port-forward $POD_NAME {{ .Values.webPort }}:{{ .Values.webPort }} --namespace {{ .Release.Namespace }}
+  echo "Visit http://127.0.0.1:{{ .Values.webPort }} to use your application"
+{{- end }}

--- a/stable/prometheus-statsd-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-statsd-exporter/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-statsd-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-statsd-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-statsd-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/prometheus-statsd-exporter/templates/configmap.yaml
+++ b/stable/prometheus-statsd-exporter/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "prometheus-statsd-exporter.fullname" . }}-mapping-config
+  labels:
+    app: {{ template "prometheus-statsd-exporter.name" . }}
+    chart: {{ template "prometheus-statsd-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  statsd-mapping.conf: |-
+{{ .Values.statsdMappingConfig | indent 4 }}

--- a/stable/prometheus-statsd-exporter/templates/deployment.yaml
+++ b/stable/prometheus-statsd-exporter/templates/deployment.yaml
@@ -49,9 +49,11 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: /
+            path: /metrics
             port: web
             scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 30
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:

--- a/stable/prometheus-statsd-exporter/templates/deployment.yaml
+++ b/stable/prometheus-statsd-exporter/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "prometheus-statsd-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-statsd-exporter.name" . }}
+    chart: {{ template "prometheus-statsd-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-statsd-exporter.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "prometheus-statsd-exporter.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end}}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      containers:
+      - name: {{ template "prometheus-statsd-exporter.name" . }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - --web.listen-address=:{{ .Values.webPort }}
+        - --web.telemetry-path=/metrics
+        - --statsd.listen-udp=:{{ .Values.udpPort }}
+        - --statsd.listen-tcp=:{{ .Values.tcpPort }}
+        - --statsd.mapping-config=/etc/{{ template "prometheus-statsd-exporter.name" . }}/statsd-mapping.conf
+        ports:
+        - name: web
+          containerPort: {{ .Values.webPort }}
+          protocol: TCP
+        - name: statsd-udp
+          containerPort: {{ .Values.udpPort }}
+          protocol: UDP
+        - name: statsd-tcp
+          containerPort: {{ .Values.tcpPort }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: web
+            scheme: HTTP
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: statsd-mapping-config
+          mountPath: /etc/{{ template "prometheus-statsd-exporter.name" . }}
+      volumes:
+      - name: statsd-mapping-config
+        configMap:
+          name: {{ template "prometheus-statsd-exporter.fullname" . }}-mapping-config
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/prometheus-statsd-exporter/templates/service.yaml
+++ b/stable/prometheus-statsd-exporter/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "prometheus-statsd-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-statsd-exporter.name" . }}
+    chart: {{ template "prometheus-statsd-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: web
+    port: {{ .Values.webPort }}
+    protocol: TCP
+    targetPort: {{ .Values.webPort }}
+  - name: statsd-udp
+    port: {{ .Values.udpPort }}
+    protocol: UDP
+    targetPort: {{ .Values.udpPort }}
+  - name: statsd-tcp
+    port: {{ .Values.tcpPort }}
+    protocol: TCP
+    targetPort: {{ .Values.tcpPort }}
+  selector:
+    app: {{ template "prometheus-statsd-exporter.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/prometheus-statsd-exporter/values.yaml
+++ b/stable/prometheus-statsd-exporter/values.yaml
@@ -28,4 +28,9 @@ affinity: {}
 
 tolerations: []
 
-statsdMappingConfig: ""
+statsdMappingConfig: |-
+  defaults:
+    timer_type: histogram
+    buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
+    match_type: glob
+  mappings: []

--- a/stable/prometheus-statsd-exporter/values.yaml
+++ b/stable/prometheus-statsd-exporter/values.yaml
@@ -31,13 +31,3 @@ tolerations: []
 statsdMappingConfig: |-
   defaults:
     timer_type: histogram
-    buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
-    quantiles:
-    - quantile: 0.99
-      error: 0.001
-    - quantile: 0.9
-      error: 0.01
-    - quantile: 0.5
-      error: 0.05
-    match_type: glob
-  mappings: []

--- a/stable/prometheus-statsd-exporter/values.yaml
+++ b/stable/prometheus-statsd-exporter/values.yaml
@@ -1,0 +1,31 @@
+# Default values for prometheus-statsd-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: prom/statsd-exporter
+  tag: v0.7.0
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+
+webPort: 9102
+udpPort: 9125
+tcpPort: 9125
+
+podAnnotations: {}
+
+priorityClassName: ""
+
+resources: {}
+
+nodeSelector: {}
+
+affinity: {}
+
+tolerations: []
+
+statsdMappingConfig: ""

--- a/stable/prometheus-statsd-exporter/values.yaml
+++ b/stable/prometheus-statsd-exporter/values.yaml
@@ -32,5 +32,12 @@ statsdMappingConfig: |-
   defaults:
     timer_type: histogram
     buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
+    quantiles:
+    - quantile: 0.99
+      error: 0.001
+    - quantile: 0.9
+      error: 0.01
+    - quantile: 0.5
+      error: 0.05
     match_type: glob
   mappings: []


### PR DESCRIPTION
### What this PR does / why we need it:

This chart installs the [prometheus-statsd-exporter](https://github.com/prometheus/statsd_exporter).

The `prometheus-statsd-exporter` receives StatsD metrics and exports them as Prometheus metrics. It is useful when migrating from statsd and [Graphite](https://github.com/helm/charts/tree/master/stable/graphite) to Prometheus, which is a common use case when moving workloads into Kubernetes.

This is a stateless application, so the chart only creates a `Deployment` and a `Service`. A `ConfigMap` is used for defining the mapping configuration that can be used to define rules for metric translation.
