### PR TITLE
Update Image pull policy

### DIFF
--- a/incubator/kubernetes-vault/values.yaml
+++ b/incubator/kubernetes-vault/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 3
 image:
   repository: boostport/kubernetes-vault
   tag: v0.5.2
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 app: kubernetes-vault
 service:
   dummyPort: 80

--- a/stable/chronograf/values.yaml
+++ b/stable/chronograf/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: "docker.io/chronograf"
   tag: "1.3-alpine"
-  pullPolicy: "Always"
+  pullPolicy: "IfNotPresent"
 
 ## Specify a service type
 ## ClusterIP is default

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -6,7 +6,7 @@
 Name: "cockroachdb"
 Image: "cockroachdb/cockroach"
 ImageTag: "v2.0.5"
-ImagePullPolicy: "Always"
+ImagePullPolicy: "IfNotPresent"
 Replicas: 3
 MaxUnavailable: 1
 Component: "cockroachdb"

--- a/stable/consul/values.yaml
+++ b/stable/consul/values.yaml
@@ -22,7 +22,7 @@ Component: "consul"
 Replicas: 3
 Image: "consul"
 ImageTag: "1.0.0"
-ImagePullPolicy: "Always"
+ImagePullPolicy: "IfNotPresent"
 Resources: {}
  # requests:
  #   cpu: "100m"

--- a/stable/etcd-operator/values.yaml
+++ b/stable/etcd-operator/values.yaml
@@ -44,7 +44,7 @@ etcdOperator:
   image:
     repository: quay.io/coreos/etcd-operator
     tag: v0.9.2
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   resources:
     cpu: 100m
     memory: 128Mi
@@ -76,7 +76,7 @@ backupOperator:
   image:
     repository: quay.io/coreos/etcd-operator
     tag: v0.9.2
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   resources:
     cpu: 100m
     memory: 128Mi
@@ -99,7 +99,7 @@ restoreOperator:
   image:
     repository: quay.io/coreos/etcd-operator
     tag: v0.9.2
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   port: 19999
   resources:
     cpu: 100m
@@ -125,7 +125,7 @@ etcdCluster:
   image:
     repository: quay.io/coreos/etcd
     tag: v3.2.13
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   enableTLS: false
   # TLS configs
   tls:

--- a/stable/factorio/templates/deployment.yaml
+++ b/stable/factorio/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - name: {{ template "factorio.fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:

--- a/stable/filebeat/templates/daemonset.yaml
+++ b/stable/filebeat/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       initContainers:
       - name: "load-es-template"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: "Always"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         command:
         - /bin/bash
         - -c

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -6,7 +6,7 @@ image:
   fluent_bit:
     repository: fluent/fluent-bit
     tag: 0.13.0
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 # When enabled, exposes json and prometheus metrics on {{ .Release.Name }}-metrics service
 metrics:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -12,7 +12,7 @@ Master:
   Name: jenkins-master
   Image: "jenkins/jenkins"
   ImageTag: "lts"
-  ImagePullPolicy: "Always"
+  ImagePullPolicy: "IfNotPresent"
 # ImagePullSecret: jenkins
   Component: "jenkins-master"
   UseSecurity: true

--- a/stable/kubewatch/values.yaml
+++ b/stable/kubewatch/values.yaml
@@ -34,7 +34,7 @@ image:
   registry: "docker.io"
   repository: "bitnami/kubewatch"
   tag: "0.0.4"
-  pullPolicy: "Always"
+  pullPolicy: "IfNotPresent"
 
 rbac:
   # If true, create & use RBAC resources

--- a/stable/lamp/templates/deployment.yaml
+++ b/stable/lamp/templates/deployment.yaml
@@ -363,7 +363,7 @@ spec:
       {{- if .Values.php.fpmEnabled }}
       - name: "httpd"
         image: "httpd:2.4.29-alpine"
-        imagePullPolicy: "Always"
+        imagePullPolicy: "IfNotPresent"
         ports:
         - containerPort: 80
         volumeMounts:

--- a/stable/lamp/values.yaml
+++ b/stable/lamp/values.yaml
@@ -102,7 +102,7 @@ mysql:
   tag: 5.7
 
   ## mysql.imagePullPolicy Image pull policy
-  imagePullPolicy: Always
+  imagePullPolicy: IfNotPresent
 
   ## mysql.sockets Enables communication between MySQL and PHP via sockets instead of TCP
   sockets: true

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -9,7 +9,7 @@ image:
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -13,7 +13,7 @@ image:
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -13,7 +13,7 @@ image:
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -5,7 +5,7 @@ image:
   registry: docker.io
   repository: bitnami/nats
   tag: 1.1.0
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -9,7 +9,7 @@ image:
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/stable/pachyderm/values.yaml
+++ b/stable/pachyderm/values.yaml
@@ -47,7 +47,7 @@ pachd:
  image:
   repository: pachyderm/pachd
   tag: 1.7.3
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
  worker:
   repository: pachyderm/worker
   tag: 1.7.3

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -12,7 +12,7 @@ image:
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
What this PR does / why we need it:
Specify a imagePullPolicy: 'Always' and imageTag is not 'latest', which cause always pull image from registry regardless of whether the local image exists