### PR TITLE
[incubator/elasticsearch] Fix "tolerations" default values {} -> [].

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.6.2
+version: 1.6.3
 appVersion: 6.4.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.heapSize`                    | Client node heap size                                               | `512m`                               |
 | `client.podAnnotations`              | Client Deployment annotations                                       | `{}`                                 |
 | `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
-| `client.tolerations`                 | Client tolerations                                                  | `{}`                                 |
+| `client.tolerations`                 | Client tolerations                                                  | `[]`                                 |
 | `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                 |
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                          |
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                 |
@@ -91,7 +91,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.priorityClassName`           | Master priorityClass                                                | `nil`                                |
 | `master.podAnnotations`              | Master Deployment annotations                                       | `{}`                                 |
 | `master.nodeSelector`                | Node labels for master pod assignment                               | `{}`                                 |
-| `master.tolerations`                 | Master tolerations                                                  | `{}`                                 |
+| `master.tolerations`                 | Master tolerations                                                  | `[]`                                 |
 | `master.heapSize`                    | Master node heap size                                               | `512m`                               |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
@@ -111,7 +111,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |
 | `data.podAnnotations`                | Data StatefulSet annotations                                        | `{}`                                 |
 | `data.nodeSelector`                  | Node labels for data pod assignment                                 | `{}`                                 |
-| `data.tolerations`                   | Data tolerations                                                    | `{}`                                 |
+| `data.tolerations`                   | Data tolerations                                                    | `[]`                                 |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
 

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -39,7 +39,7 @@ client:
   heapSize: "512m"
   antiAffinity: "soft"
   nodeSelector: {}
-  tolerations: {}
+  tolerations: []
   resources:
     limits:
       cpu: "1"
@@ -69,7 +69,7 @@ master:
     # storageClass: "ssd"
   antiAffinity: "soft"
   nodeSelector: {}
-  tolerations: {}
+  tolerations: []
   resources:
     limits:
       cpu: "1"
@@ -100,7 +100,7 @@ data:
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"
   nodeSelector: {}
-  tolerations: {}
+  tolerations: []
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
**What this PR does / why we need it:**
Fix "tolerations" default values {} -> [].
In order to avoid frightening warnings like "warning: cannot overwrite table with non table for tolerations (map[])".
