### PR TITLE
[hl-composer] Add Composer chart

### DIFF
--- a/stable/hl-composer/.helmignore
+++ b/stable/hl-composer/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+
+# OWNERS file for Helm repository
+OWNERS

--- a/stable/hl-composer/Chart.yaml
+++ b/stable/hl-composer/Chart.yaml
@@ -1,17 +1,19 @@
 apiVersion: v1
 description: Hyperledger Composer REST Server chart
 name: hl-composer
-version: 1.0.8
+version: 1.0.9
 appVersion: 0.20.0
 keywords:
   - blockchain
   - hyperledger
   - fabric
   - composer
-home: https://github.com/aidtechnology/deployer/
+home: https://hyperledger.github.io/composer
 sources:
-  - https://github.com/aidtechnology/deployer/
+  - https://github.com/hyperledger/composer
 maintainers:
-  - name: Alejandro (Sasha) Vicente Grabovetsky
+  - name: alexvicegrab
     email: sasha@aid.technology
-icon: https://pbs.twimg.com/profile_images/710954968749121537/4BuyZq1v_400x400.jpg
+  - name: nicolapaoli
+    email: nicola@aid.technology
+icon: https://www.hyperledger.org/wp-content/uploads/2018/04/composer-logo.png

--- a/stable/hl-composer/Chart.yaml
+++ b/stable/hl-composer/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+description: Hyperledger Composer REST Server chart
+name: hl-composer
+version: 1.0.8
+appVersion: 0.20.0
+keywords:
+  - blockchain
+  - hyperledger
+  - fabric
+  - composer
+home: https://github.com/aidtechnology/deployer/
+sources:
+  - https://github.com/aidtechnology/deployer/
+maintainers:
+  - name: Alejandro (Sasha) Vicente Grabovetsky
+    email: sasha@aid.technology
+icon: https://pbs.twimg.com/profile_images/710954968749121537/4BuyZq1v_400x400.jpg

--- a/stable/hl-composer/OWNERS
+++ b/stable/hl-composer/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- alexvicegrab
+- nicolapaoli
+reviewers:
+- alexvicegrab
+- nicolapaoli

--- a/stable/hl-composer/README.md
+++ b/stable/hl-composer/README.md
@@ -1,0 +1,133 @@
+# Hyperledger Composer
+
+[Hyperledger Composer](https://hyperledger.github.io/composer) is a set of tools to aid in the development of Blockchain solutions using the [Hyperledger](https://www.hyperledger.org/) Fabric permissioned blockchain framework.
+
+## TL;DR;
+
+```bash
+$ helm install stable/hl-composer
+```
+
+## Introduction
+
+The deployments included in this chart include a Command-Line Interface (CLI), Playground and REST server.
+
+## Prerequisites
+
+- Kubernetes 1.9+
+- PV provisioner support in the underlying infrastructure.
+- Four K8S secrets containing:
+    - the Composer Blockchain Network Archive to deploy and use
+    - the Composer Connection JSON file, specifying the locations of the
+    - the certificate of the Peer Organisation Admin
+    - the private key of the Peer Organisation Admin (needed to join the channel)
+- A running Hyperledger Fabric network, either on the cluster (e.g. using the `hlf-ca`, `hlf-ord`, `hlf-peer` and optionally hlf-couchdb charts) or elsewhere.
+
+## Installing the Chart
+
+To install the chart with the release name `hlc`:
+
+```bash
+$ helm install stable/hl-composer --name hlc
+```
+
+The command deploys the Hyperledger Composer chart on the Kubernetes cluster in the default configuration. The [Configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Custom parameters
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```bash
+$ helm install stable/hl-composer --name hlc --set persistence.enabled=true,presistence.storageClass=azurefile
+```
+
+The above command specifies that we wish to use a persistent volume and use the `azurefile` Storage Class to enable the volume to be shared.
+
+Alternatively, a YAML file can be provided while installing the chart. This file specifies values to override those provided in the defualt values.yaml. For example,
+
+```bash
+$ helm install stable/hl-composer --name hlc -f my-values.yaml
+```
+
+## Updating the chart
+
+When updating the chart, make sure you provide the `rest.config.apiKey`, otherwise `helm update` will generate a new random API key.
+
+```bash
+$ export COMPOSER_APIKEY=$(kubectl get secret --namespace {{ .Release.Namespace }} hlc-hl-composer-rest -o jsonpath="{.data.COMPOSER_APIKEY}" | base64 --decode; echo)
+$ helm upgrade hlc stable/hlf-ca --set rest.config.apiKey=$COMPOSER_APIKEY
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `hlc` deployment:
+
+```bash
+$ helm delete hlc
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Hyperledger Composer chart and default values.
+
+| Parameter                            | Description                                          | Default                                                    |
+| ------------------------------------ | ---------------------------------------------------- | ---------------------------------------------------------- |
+| `persistence.enabled`                | Is persistence enabled for this chart?               | `false`                                                    |
+| `persistence.accessMode`             | Read and Write permissions to the volume             | `ReadWriteMany`                                            |
+| `persistence.annotations`            | Persistent Volume annotations                        | `{}`                                                       |
+| `persistence.size`                   | Size of data volume (adjust for production!)         | `1Gi`                                                      |
+| `persistence.storageClass`           | Storage class of backing PVC                         | ``                                                         |
+| `cli.image.repository`               | `hl-composer` CLI image repository                   | `hyperledger/composer-cli`                                 |
+| `cli.image.tag`                      | `hl-composer` CLI image tag                          | `0.20.0`                                                   |
+| `cli.image.pullPolicy`               | Image pull policy                                    | `IfNotPresent`                                             |
+| `cli.secrets.blockchainNetwork`      | Secret containing Blockchain Network Archive         | ``                                                         |
+| `cli.secrets.adminCert`              | Secret containing Peer Org admin certificate         | ``                                                         |
+| `cli.secrets.adminKey`               | Secret containing Peer Org admin private key         | ``                                                         |
+| `cli.secrets.hlcConnection`          | Secret containing Composer Connection JSON           | ``                                                         |
+| `cli.resources`                      | CPU/Memory resource requests/limits                  | `{}`                                                       |
+| `cli.nodeSelector`                   | Node labels for pod assignment                       | `{}`                                                       |
+| `cli.tolerations`                    | Toleration labels for pod assignment                 | `[]`                                                       |
+| `cli.affinity`                       | Affinity settings for pod assignment                 | `{}`                                                       |
+| `rest.image.repository`              | `hl-composer` REST image repository                  | `hyperledger/composer-rest-server`                         |
+| `rest.image.tag`                     | `hl-composer` REST image tag                         | `0.20.0`                                                   |
+| `rest.image.pullPolicy`              | Image pull policy                                    | `IfNotPresent`                                             |
+| `rest.service.port`                  | TCP port                                             | `3000`                                                     |
+| `rest.service.type`                  | K8S service type exposing ports, e.g. `ClusterIP`    | `ClusterIP`                                                |
+| `rest.ingress.enabled`               | If true, Ingress will be created                     | `false`                                                    |
+| `rest.ingress.annotations`           | Ingress annotations                                  | `{}`                                                       |
+| `rest.ingress.path`                  | Ingress path                                         | `/`                                                        |
+| `rest.ingress.hosts`                 | Ingress hostnames                                    | `[]`                                                       |
+| `rest.ingress.tls`                   | Ingress TLS configuration                            | `[]`                                                       |
+| `rest.config.apiKey`                 | API key for the REST server                          | ``                                                         |
+| `rest.config.composerRestServerCard` | Card to use to initialise the REST server            | ``                                                          |
+| `rest.resources`                     | CPU/Memory resource requests/limits                  | `{}`                                                       |
+| `rest.nodeSelector`                  | Node labels for pod assignment                       | `{}`                                                       |
+| `rest.tolerations`                   | Toleration labels for pod assignment                 | `[]`                                                       |
+| `rest.affinity`                      | Affinity settings for pod assignment                 | `{}`                                                       |
+| `pg.image.repository`                | `hl-composer` Playground image repository            | `hyperledger/composer-playground`                          |
+| `pg.image.tag`                       | `hl-composer` Playground image tag                   | `0.20.0`                                                   |
+| `pg.image.pullPolicy`                | Image pull policy                                    | `IfNotPresent`                                             |
+| `pg.service.port`                    | TCP port                                             | `8080`                                                     |
+| `pg.service.type`                    | K8S service type exposing ports, e.g. `ClusterIP`    | `ClusterIP`                                                |
+| `pg.ingress.enabled`                 | If true, Ingress will be created                     | `false`                                                    |
+| `pg.ingress.annotations`             | Ingress annotations                                  | `{}`                                                       |
+| `pg.ingress.path`                    | Ingress path                                         | `/`                                                        |
+| `pg.ingress.hosts`                   | Ingress hostnames                                    | `[]`                                                       |
+| `pg.ingress.tls`                     | Ingress TLS configuration                            | `[]`                                                       |
+| `pg.resources`                       | CPU/Memory resource requests/limits                  | `{}`                                                       |
+| `pg.nodeSelector`                    | Node labels for pod assignment                       | `{}`                                                       |
+| `pg.tolerations`                     | Toleration labels for pod assignment                 | `[]`                                                       |
+| `pg.affinity`                        | Affinity settings for pod assignment                 | `{}`                                                       |
+
+
+## Persistence
+
+The volume stores the Hyperledger Composer data and configurations at the `/home/composer/.composer` path of the containers.
+
+The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning through a PersistentVolumeClaim managed by the chart.
+
+## Feedback and feature requests
+
+This is a work in progress and we are happy to accept feature requests. We are even happier to accept pull requests implementing improvements :-)

--- a/stable/hl-composer/templates/NOTES.txt
+++ b/stable/hl-composer/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.rest.ingress.enabled }}
+{{- range .Values.rest.ingress.hosts }}
+  http{{ if $.Values.rest.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.rest.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.rest.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hl-composer.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.rest.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "hl-composer.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "hl-composer.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.rest.service.port }}
+{{- else if contains "ClusterIP" .Values.rest.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "hl-composer.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:3000
+{{- end }}
+
+2. Obtain COMPOSER_APIKEY to connect to REST server:
+  export COMPOSER_APIKEY=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "hl-composer.fullname" . }}-hl-composer-rest -o jsonpath="{.data.COMPOSER_APIKEY}" | base64 --decode; echo)

--- a/stable/hl-composer/templates/_helpers.tpl
+++ b/stable/hl-composer/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hl-composer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hl-composer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hl-composer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- /*
+Credit: @technosophos
+https://github.com/technosophos/common-chart/
+labels.standard prints the standard Helm labels.
+The standard labels are frequently used in metadata.
+*/ -}}
+{{- define "labels.standard" -}}
+app: {{ include "hl-composer.name" . }}
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+chart: {{ include "hl-composer.chart" . }}
+{{- end -}}

--- a/stable/hl-composer/templates/hl-composer-cli-deployment.yaml
+++ b/stable/hl-composer/templates/hl-composer-cli-deployment.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "hl-composer.fullname" . }}-cli
+  labels:
+    name: {{ include "hl-composer.fullname" . }}-cli
+{{ include "labels.standard" . | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "hl-composer.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ include "hl-composer.fullname" . }}-cli
+      labels:
+        name: {{ include "hl-composer.fullname" . }}-cli
+{{ include "labels.standard" . | indent 8 }}
+    spec:
+      volumes:
+        - name: persistent-volume
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "hl-composer.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.cli.secrets.blockchainNetwork }}
+        - name: blockchain-network
+          secret:
+            secretName: {{ .Values.cli.secrets.blockchainNetwork }}
+        {{- end }}
+        {{- if .Values.cli.secrets.adminCert }}
+        - name: admin-cert
+          secret:
+            secretName: {{ .Values.cli.secrets.adminCert }}
+        {{- end }}
+        {{- if .Values.cli.secrets.adminKey }}
+        - name: admin-key
+          secret:
+            secretName: {{ .Values.cli.secrets.adminKey }}
+        {{- end }}
+        {{- if .Values.cli.secrets.hlcConnection }}
+        - name: hlc-connection
+          configMap:
+            name: {{ .Values.cli.secrets.hlcConnection }}
+        {{- end }}
+      containers:
+        - name: cli
+          image: "{{ .Values.cli.image.repository }}:{{ .Values.cli.image.tag }}"
+          imagePullPolicy: {{ .Values.cli.image.pullPolicy }}
+        # TODO: Add liveness and readiness probes
+        # Run infinitely
+          command:
+            - sh
+            - -c
+            - |
+              tail -f /dev/null
+          volumeMounts:
+            - mountPath: /home/composer/.composer
+              name: persistent-volume
+            {{- if .Values.cli.secrets.blockchainNetwork }}
+            - mountPath: /hl_config/blockchain_network
+              name: blockchain-network
+            {{- end }}
+            {{- if .Values.cli.secrets.adminCert }}
+            - mountPath: /hl_config/admin/signcerts
+              name: admin-cert
+            {{- end }}
+            {{- if .Values.cli.secrets.adminKey }}
+            - mountPath: /hl_config/admin/keystore
+              name: admin-key
+            {{- end }}
+            {{- if .Values.cli.secrets.hlcConnection }}
+            - mountPath: /hl_config/hlc-connection
+              name: hlc-connection
+            {{- end }}
+          resources:
+{{ toYaml .Values.cli.resources | indent 12 }}
+    {{- with .Values.cli.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.cli.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.cli.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/hl-composer/templates/hl-composer-pg-deployment.yaml
+++ b/stable/hl-composer/templates/hl-composer-pg-deployment.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.pg.enabled -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "hl-composer.fullname" . }}-pg
+  labels:
+    name: {{ include "hl-composer.fullname" . }}-pg
+{{ include "labels.standard" . | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "hl-composer.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ include "hl-composer.fullname" . }}-pg
+      labels:
+        name: {{ include "hl-composer.fullname" . }}-pg
+{{ include "labels.standard" . | indent 8 }}
+    spec:
+      volumes:
+        - name: persistent-volume
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "hl-composer.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      containers:
+        - name: composer-playground
+          image: "{{ .Values.pg.image.repository }}:{{ .Values.pg.image.tag }}"
+          imagePullPolicy: {{ .Values.pg.image.pullPolicy }}
+          # TODO: Add liveness and readiness probes
+          volumeMounts:
+            - mountPath: /home/composer/.composer
+              name: persistent-volume
+          resources:
+{{ toYaml .Values.pg.resources | indent 12 }}
+    {{- with .Values.pg.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.pg.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.pg.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/stable/hl-composer/templates/hl-composer-pg-ingress.yaml
+++ b/stable/hl-composer/templates/hl-composer-pg-ingress.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.pg.enabled .Values.pg.ingress.enabled -}}
+{{- $fullName := include "hl-composer.fullname" . -}}
+{{- $ingressPath := .Values.pg.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-pg
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+{{- with .Values.pg.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.pg.ingress.tls }}
+  tls:
+  {{- range .Values.pg.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.pg.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}-pg
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/stable/hl-composer/templates/hl-composer-pg-service.yaml
+++ b/stable/hl-composer/templates/hl-composer-pg-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.pg.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hl-composer.fullname" . }}-pg
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+spec:
+  type: {{ .Values.pg.service.type }}
+  ports:
+    - port: {{ .Values.pg.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    name: {{ include "hl-composer.fullname" . }}-pg
+    app: {{ include "hl-composer.name" . }}
+    release: {{ .Release.Name }}
+{{- end}}

--- a/stable/hl-composer/templates/hl-composer-pvc.yaml
+++ b/stable/hl-composer/templates/hl-composer-pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "hl-composer.fullname" . }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/hl-composer/templates/hl-composer-rest-deployment.yaml
+++ b/stable/hl-composer/templates/hl-composer-rest-deployment.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "hl-composer.fullname" . }}-rest
+  labels:
+    name: {{ include "hl-composer.fullname" . }}-rest
+{{ include "labels.standard" . | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "hl-composer.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      name: {{ include "hl-composer.fullname" . }}-rest
+      labels:
+        name: {{ include "hl-composer.fullname" . }}-rest
+{{ include "labels.standard" . | indent 8 }}
+    spec:
+      volumes:
+        - name: persistent-volume
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "hl-composer.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      containers:
+        - name: rest-server
+          image: "{{ .Values.rest.image.repository }}:{{ .Values.rest.image.tag }}"
+          imagePullPolicy: {{ .Values.rest.image.pullPolicy }}
+          # TODO: Add liveness and readiness probes
+          envFrom:
+            - secretRef:
+                name: {{ include "hl-composer.fullname" . }}-rest
+          env:
+            - name: COMPOSER_CARD
+              value: {{ .Values.rest.config.composerRestServerCard }}
+            - name: COMPOSER_NAMESPACES
+              value: never
+          volumeMounts:
+            - name: persistent-volume
+              mountPath: /home/composer/.composer
+          resources:
+{{ toYaml .Values.rest.resources | indent 12 }}
+    {{- with .Values.rest.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.rest.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.rest.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/hl-composer/templates/hl-composer-rest-ingress.yaml
+++ b/stable/hl-composer/templates/hl-composer-rest-ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.rest.ingress.enabled -}}
+{{- $fullName := include "hl-composer.fullname" . -}}
+{{- $ingressPath := .Values.rest.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-rest
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+{{- with .Values.rest.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.rest.ingress.tls }}
+  tls:
+  {{- range .Values.rest.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.rest.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}-rest
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/stable/hl-composer/templates/hl-composer-rest-secret.yaml
+++ b/stable/hl-composer/templates/hl-composer-rest-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "hl-composer.fullname" . }}-rest
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+type: Opaque
+data:
+  {{ if .Values.rest.config.apiKey }}
+  COMPOSER_APIKEY:  {{ .Values.rest.config.apiKey | b64enc | quote }}
+  {{ else }}
+  COMPOSER_APIKEY: {{ randAlphaNum 24 | b64enc | quote }}
+  {{ end }}

--- a/stable/hl-composer/templates/hl-composer-rest-service.yaml
+++ b/stable/hl-composer/templates/hl-composer-rest-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hl-composer.fullname" $ }}-rest
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+spec:
+  type: {{ .Values.rest.service.type }}
+  ports:
+    - port: {{ .Values.rest.service.port }}
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    name: {{ include "hl-composer.fullname" . }}-rest
+    app: {{ include "hl-composer.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/hl-composer/values.yaml
+++ b/stable/hl-composer/values.yaml
@@ -1,0 +1,145 @@
+# Default values for hl-composer.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+persistence:
+  # By default we must set this to false to enable chart to pass tests
+  # However, in a proper deployment, you should set this to "true", so that the different components can share data
+  enabled: false
+  annotations: {}
+  capacity: 1Gi
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  storageClass: ""
+  accessMode: ReadWriteMany
+
+cli:
+  image:
+    repository: hyperledger/composer-cli
+    tag: 0.20.0
+    pullPolicy: IfNotPresent
+
+  secrets: {}
+    # This should contain the packaged .bna network file.
+    # blockchainNetwork: bc--bna
+    # We need a secret for the Organisation certificate and key
+    # adminCert: hl--peer-admincert
+    # adminKey: hl--peer-adminkey
+    # Composer Connection JSON
+    # hlcConnection: hl--connection
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+rest:
+  image:
+    repository: hyperledger/composer-rest-server
+    tag: 0.20.0
+    pullPolicy: IfNotPresent
+
+  service:
+    # Cluster IP or LoadBalancer
+    type: ClusterIP
+    port: 3000
+
+  # Ingress for Composer REST
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # certmanager.k8s.io/cluster-issuer: "letsencrypt-staging"
+    path: /
+    hosts: []
+    #  - hl-composer-rest.local
+    tls: []
+    #  - secretName: hl-composer-rest-tls
+    #    hosts:
+    #      - hl-composer-rest.local
+
+  config:
+    # Composer REST server API key
+    #apiKey:
+    # Card for network connection
+    composerRestServerCard: admin@test-network
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+pg:
+  enabled: true
+
+  image:
+    repository: hyperledger/composer-playground
+    tag: 0.20.0
+    pullPolicy: IfNotPresent
+
+  service:
+    # Cluster IP or LoadBalancer
+    type: ClusterIP
+    port: 8080
+
+  # Ingress for Composer PlayGround
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # certmanager.k8s.io/cluster-issuer: "letsencrypt-staging"
+    path: /
+    hosts: []
+    #  - hl-composer-pg.local
+    tls: []
+    #  - secretName: hl-composer-pg-tls
+    #    hosts:
+    #      - hl-composer-pg.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}

--- a/stable/hl-composer/values.yaml
+++ b/stable/hl-composer/values.yaml
@@ -77,7 +77,7 @@ rest:
 
   config:
     # Composer REST server API key
-    #apiKey:
+    # apiKey:
     # Card for network connection
     composerRestServerCard: admin@test-network
 


### PR DESCRIPTION
Signed-off-by: Alejandro Vicente Grabovetsky <sasha@aid.technology>

**What this PR does / why we need it**:

Implements the new chart needed for a Hyperledger Composer Deployment, the HL Composer

**Special notes for your reviewer**:

Chart requires setting four external secrets (a BNA [Business Network Archive], the Composer Connection JSON file and the certificate and key of the Peer organisation).

A correctly functioning chart also requires a shared volume, but here it is disabled (`peristence.enabled: false`) by default to enable the chart to pass the unit tests on the CI/CD.

E.g. on Azure I needed to extend the `azurefile` Storage Class to implement a fully functional chart.