### PR TITLE
[stable/kube-ops-view] use a stable tag

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -12,5 +12,5 @@ icon: https://raw.githubusercontent.com/hjacobs/kube-ops-view/master/kube-ops-vi
 sources:
 - https://github.com/hjacobs/kube-ops-view
 maintainers:
-- name: Henning Jacobs
+- name: hjacobs
   email: henning@jacobs1.de

--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-ops-view
-version: 0.4.2
-appVersion: 1.0.0
+version: 0.4.3
+appVersion: 0.8.1
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters
 keywords:

--- a/stable/kube-ops-view/values.yaml
+++ b/stable/kube-ops-view/values.yaml
@@ -2,7 +2,7 @@
 replicaCount: 1
 image:
   repository: hjacobs/kube-ops-view
-  tag: latest
+  tag: 0.8.1
   pullPolicy: IfNotPresent
 service:
   # annotations:


### PR DESCRIPTION
Use a stable tag instead of relying on latest - which is also unstable when combined with the default pull-policy of IfNotPresent