### PR TITLE
[fluent-bit]: changed capability detection

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.11.0
+version: 0.11.1
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/_helpers.tpl
+++ b/stable/fluent-bit/templates/_helpers.tpl
@@ -19,10 +19,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the appropriate apiVersion for RBAC APIs.
 */}}
 {{- define "rbac.apiVersion" -}}
-{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion -}}
-"rbac.authorization.k8s.io/v1"
+{{- if .Capabilities.APIVersions.Has "v1" -}}
+rbac.authorization.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "v1beta1" -}}
+rbac.authorization.k8s.io/v1beta1
 {{- else -}}
-"rbac.authorization.k8s.io/v1beta1"
+rbac.authorization.k8s.io/v1alpha1
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Some of us don't run valid k8s semvers (\o/), so the helm chart breaks. This style of capability detection circumvents such issues. It is not very likely that the version will bump higher (at 1 now), but in that case this file needs to reflect the new capability and be updated. Good trade off? I think so.
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: