### PR TITLE
[stable/mongodb] Add 'mongodbEnableIPv6' configuration to standalone …

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 4.2.2
+version: 4.2.3
 appVersion: 4.0.2
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -58,6 +58,12 @@ spec:
         {{- end }}
         - name: MONGODB_DATABASE
           value: {{ default "" .Values.mongodbDatabase | quote }}
+        - name: MONGODB_ENABLE_IPV6
+        {{- if .Values.mongodbEnableIPv6 }}
+          value: "yes"
+        {{- else }}
+          value: "no"
+        {{- end }}
         - name: MONGODB_EXTRA_FLAGS
           value: {{ default "" .Values.mongodbExtraFlags | join " " }}
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:

We already add this parameter to configure IPv6 on the replicaSet configuration mode of the chart. This PR adds the logic to the standalone deployment too.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes https://github.com/kubeapps/kubeapps/issues/577
