### PR TITLE
[stable/kubernetes-dashboard] Use the target port number instead of a name

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.7.3
+version: 0.7.4
 appVersion: 1.10.0
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -19,7 +19,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - port: {{ .Values.service.externalPort }}
-    targetPort: https
+    targetPort: 8443
 {{- if hasKey .Values.service "nodePort" }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}


### PR DESCRIPTION
Older (but still actual) versions of some Network Policy providers don't support named ports as
a value of `targetPort` field in the Service spec:
- Calico < 3.0.0: https://github.com/projectcalico/felix/issues/1685
- Contour < 0.4.0: https://github.com/heptio/contour/issues/175

Changing it to the number shouldn't break the UX for existing installations because port 8443 is still hard-coded here: https://github.com/helm/charts/blob/e46936db682127cd503bc5eaa27d0600dcb43986/stable/kubernetes-dashboard/templates/deployment.yaml#L40

P.s. Usually the upgrade of CNI / Network Policy provider is not trivial (see https://github.com/kubernetes/kops/pull/5102), so I would suggest the official helm charts to be compatible with wider scope of use-cases and don't use named ports in `targetPort` field unless it's really needed.