### PR TITLE
[incubator/cassandra] Add backup CronJob

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.5.3
+version: 0.5.4
 appVersion: 3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.5.4
+version: 0.6.0
 appVersion: 3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -117,7 +117,6 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
 | `backup.enabled`                     | Enable backup on chart installation             | `false`                                                    |
 | `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
-| `backup.history`                     | Backup CronJob history configuration            | successfulJobs: `1`, failedJobs: `3`                       |
 | `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |
 | `backup.image.repo`                  | Backup image repository                         | `maorfr/cain`                                              |
 | `backup.image.tag`                   | Backup image tag                                | `latest`                                                   |

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -115,6 +115,15 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `readinessProbe.timeoutSeconds`      | When the probe times out                        | `5`                                                        |
 | `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
 | `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
+| `backup.enabled`                     | Enable backup on chart installation             | `false`                                                    |
+| `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
+| `backup.history`                     | Backup CronJob history configuration            | successfulJobs: `1`, failedJobs: `3`                       |
+| `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |
+| `backup.image.repo`                  | Backup image repository                         | `maorfr/cain`                                              |
+| `backup.image.tag`                   | Backup image tag                                | `latest`                                                   |
+| `backup.env`                         | Backup environment variables                    | AWS_REGION: `us-east-1`                                    |
+| `backup.resources`                   | Backup CPU/Memory resource requests/limits      | Memory: `1Gi`, CPU: `1`                                    |
+| `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |
 
 ## Scale cassandra
 When you want to change the cluster size of your cassandra, you can use the helm upgrade command.

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -115,11 +115,14 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `readinessProbe.timeoutSeconds`      | When the probe times out                        | `5`                                                        |
 | `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
 | `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `3` |
+| `rbac.create`                        | Specifies whether RBAC resources should be created                                                  | `true` |
+| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                               | `false` |
+| `serviceAccount.name`                | The name of the ServiceAccount to use           |                                                            |
 | `backup.enabled`                     | Enable backup on chart installation             | `false`                                                    |
 | `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
 | `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |
 | `backup.image.repo`                  | Backup image repository                         | `maorfr/cain`                                              |
-| `backup.image.tag`                   | Backup image tag                                | `latest`                                                   |
+| `backup.image.tag`                   | Backup image tag                                | `0.1.0`                                                    |
 | `backup.env`                         | Backup environment variables                    | AWS_REGION: `us-east-1`                                    |
 | `backup.resources`                   | Backup CPU/Memory resource requests/limits      | Memory: `1Gi`, CPU: `1`                                    |
 | `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |

--- a/incubator/cassandra/templates/_helpers.tpl
+++ b/incubator/cassandra/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "cassandra.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cassandra.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cassandra.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/cassandra/templates/backup/cronjob.yaml
+++ b/incubator/cassandra/templates/backup/cronjob.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.backup.enabled }}
+{{- $release := .Release }}
+{{- $values := .Values }}
+{{- $backup := $values.backup }}
+{{- range $index, $schedule := $backup.schedule }}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "cassandra.fullname" $ }}-backup-{{ $schedule.keyspace }}
+  labels:
+    app: {{ template "cassandra.name" $ }}
+    chart: {{ template "cassandra.chart" $ }}
+    release: "{{ $release.Name }}"
+    heritage: "{{ $release.Service }}"
+spec:
+  schedule: {{ $schedule.cron | quote }}
+  successfulJobsHistoryLimit: {{ $backup.history.successfulJobs }}
+  failedJobsHistoryLimit: {{ $backup.history.failedJobs }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            {{ toYaml $backup.annotations }}
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ template "cassandra.fullname" $ }}-backup
+          containers:
+          - name: cassandra-backup
+            image: "{{ $backup.image.repos }}:{{ $backup.image.tag }}"
+            command: ["cain"]
+            args:
+            - backup
+            - --namespace
+            - {{ $release.Namespace }}
+            - --selector
+            - release={{ $release.Name }}
+            - --keyspace
+            - {{ $schedule.keyspace }}
+            - --dst
+            - {{ $backup.destination }}
+            - --parallel
+            - "0"
+          {{- with $backup.env }}
+            env:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with $backup.resources }}
+            resources:
+{{ toYaml . | indent 14 }}
+          {{- end }}
+        affinity:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - {{ template "cassandra.fullname" $ }}
+                - key: release
+                  operator: In
+                  values:
+                  - {{ $release.Name }}
+              topologyKey: "kubernetes.io/hostname"
+      {{- with $values.tolerations }}
+        tolerations:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/cassandra/templates/backup/cronjob.yaml
+++ b/incubator/cassandra/templates/backup/cronjob.yaml
@@ -15,8 +15,6 @@ metadata:
     heritage: "{{ $release.Service }}"
 spec:
   schedule: {{ $schedule.cron | quote }}
-  successfulJobsHistoryLimit: {{ $backup.history.successfulJobs }}
-  failedJobsHistoryLimit: {{ $backup.history.failedJobs }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 120
   jobTemplate:

--- a/incubator/cassandra/templates/backup/rbac.yaml
+++ b/incubator/cassandra/templates/backup/rbac.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cassandra.fullname" . }}-backup
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "cassandra.fullname" . }}-backup
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "cassandra.fullname" . }}-backup
+  labels:
+    app: {{ template "cassandra.name" . }}
+    chart: {{ template "cassandra.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "cassandra.fullname" . }}-backup
+subjects:
+- kind: ServiceAccount
+  name: {{ template "cassandra.fullname" . }}-backup
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/cassandra/templates/backup/rbac.yaml
+++ b/incubator/cassandra/templates/backup/rbac.yaml
@@ -1,14 +1,17 @@
 {{- if .Values.backup.enabled }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "cassandra.fullname" . }}-backup
+  name: {{ template "cassandra.serviceAccountName" . }}
   labels:
     app: {{ template "cassandra.name" . }}
     chart: {{ template "cassandra.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 ---
+{{- end }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -41,6 +44,7 @@ roleRef:
   name: {{ template "cassandra.fullname" . }}-backup
 subjects:
 - kind: ServiceAccount
-  name: {{ template "cassandra.fullname" . }}-backup
+  name: {{ template "cassandra.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/incubator/cassandra/templates/backup/rbac.yaml
+++ b/incubator/cassandra/templates/backup/rbac.yaml
@@ -8,9 +8,7 @@ metadata:
     chart: {{ template "cassandra.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -27,9 +25,7 @@ rules:
 - apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["create"]
-
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -130,7 +130,7 @@ backup:
 
   image:
     repos: maorfr/cain
-    tag: latest
+    tag: 0.1.0
 
   env:
   - name: AWS_REGION

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -123,10 +123,6 @@ backup:
   - keyspace: keyspace2
     cron: "30 7 * * *"
 
-  history:
-    successfulJobs: 1
-    failedJobs: 3
-
   annotations:
     # Example for authorization using kube2iam
     # Can also be done using environment variables

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -124,7 +124,7 @@ serviceAccount:
 ## Backup cronjob configuration
 ## Ref: https://github.com/maorfr/cain
 backup:
-  enabled: true
+  enabled: false
 
   # Schedule to run jobs. Must be in cron time format
   # Ref: https://crontab.guru/

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -124,7 +124,7 @@ serviceAccount:
 ## Backup cronjob configuration
 ## Ref: https://github.com/maorfr/cain
 backup:
-  enabled: false
+  enabled: true
 
   # Schedule to run jobs. Must be in cron time format
   # Ref: https://crontab.guru/
@@ -162,4 +162,3 @@ backup:
   # Additional support can added.
   # Ref: https://github.com/maorfr/skbn
   destination: s3://bucket/cassandra
-

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -135,7 +135,7 @@ backup:
   image:
     repos: maorfr/cain
     tag: latest
-  
+
   env:
   - name: AWS_REGION
     value: us-east-1

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -110,6 +110,17 @@ securityContext:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # name:
+
 ## Backup cronjob configuration
 ## Ref: https://github.com/maorfr/cain
 backup:
@@ -151,3 +162,4 @@ backup:
   # Additional support can added.
   # Ref: https://github.com/maorfr/skbn
   destination: s3://bucket/cassandra
+

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -132,7 +132,9 @@ backup:
     repos: maorfr/cain
     tag: 0.1.0
 
+  # Add additional environment variables
   env:
+  # Example environment variable required for AWS credentials chain
   - name: AWS_REGION
     value: us-east-1
 

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -113,7 +113,7 @@ affinity: {}
 ## Backup cronjob configuration
 ## Ref: https://github.com/maorfr/cain
 backup:
-  enabled: true
+  enabled: false
 
   # Schedule to run jobs. Must be in cron time format
   # Ref: https://crontab.guru/

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -109,3 +109,47 @@ securityContext:
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+
+## Backup cronjob configuration
+## Ref: https://github.com/maorfr/cain
+backup:
+  enabled: true
+
+  # Schedule to run jobs. Must be in cron time format
+  # Ref: https://crontab.guru/
+  schedule:
+  - keyspace: keyspace1
+    cron: "0 7 * * *"
+  - keyspace: keyspace2
+    cron: "30 7 * * *"
+
+  history:
+    successfulJobs: 1
+    failedJobs: 3
+
+  annotations:
+    # Example for authorization using kube2iam
+    # Can also be done using environment variables
+    iam.amazonaws.com/role: cain
+
+  image:
+    repos: maorfr/cain
+    tag: latest
+  
+  env:
+  - name: AWS_REGION
+    value: us-east-1
+
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: 1
+    limits:
+      memory: 1Gi
+      cpu: 1
+
+  # Destination to store the backup artifacts
+  # Currently only s3 is supported
+  # Additional support can added.
+  # Ref: https://github.com/maorfr/skbn
+  destination: s3://bucket/cassandra


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a CronJob to backup Cassandra clusters to S3 using an in-house developed tool called [Cain](https://github.com/maorfr/cain). It is written in Go, and does not use `kubectl` or `aws-cli`.

**Special notes for your reviewer**:
@KongZ  Thanks!