### PR TITLE
 [stable/kubernetes-dashboard] Create Role and RoleBinding in "kube-system" namespace

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubernetes-dashboard
-version: 0.10.2
+version: 0.10.3
 appVersion: 1.10.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:

--- a/stable/kubernetes-dashboard/templates/role.yaml
+++ b/stable/kubernetes-dashboard/templates/role.yaml
@@ -8,7 +8,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  # Dashboard doesn't respect the namespace where the pod is deployed and
+  # still tries to create & access 'kubernetes-dashboard-key-holder' secret and
+  # 'kubernetes-dashboard-settings' configmap in the 'kube-system' namespace
+  namespace: kube-system
 rules:
   # Allow Dashboard to create 'kubernetes-dashboard-key-holder' secret.
 - apiGroups:

--- a/stable/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/stable/kubernetes-dashboard/templates/rolebinding.yaml
@@ -30,7 +30,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "kubernetes-dashboard.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  # Dashboard doesn't respect the namespace where the pod is deployed and
+  # still tries to create & access 'kubernetes-dashboard-key-holder' secret and
+  # 'kubernetes-dashboard-settings' configmap in the 'kube-system' namespace
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Fixes https://github.com/helm/charts/issues/3104

Kubernetes dashboard has `kube-system` namespace hardcoded in several places. So it doesn't respect the namespace where the pod is actually deployed and still tries to create & access `kubernetes-dashboard-key-holder` secret and `kubernetes-dashboard-settings` configmap in the `kube-system` namespace.

The issue on `kubernetes/dashboard` side: https://github.com/kubernetes/dashboard/issues/2655
The fix is still in the WIP state: https://github.com/kubernetes/dashboard/pull/3197
