### PR TITLE
7552 | Change path of health checks and add init delay

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.11.1
+version: 0.11.0
 appVersion: 3.14.0
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.11.0
+version: 0.11.1
 appVersion: 3.14.0
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -38,7 +38,7 @@ spec:
             httpGet:
               path: /wd/hub/status
               port: {{ .Values.hub.port }}
-            initialDelaySeconds: 15
+            initialDelaySeconds: {{ .Values.hub.readinessDelay }}
             timeoutSeconds: {{ .Values.hub.readinessTimeout }}
           env:
             - name: JAVA_TOOL_OPTIONS

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -29,15 +29,16 @@ spec:
               name: http
           livenessProbe:
             httpGet:
-              path: /grid/console
+              path: /wd/hub/status
               port: {{ .Values.hub.port }}
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: {{ .Values.hub.livenessTimeout }}
           readinessProbe:
             httpGet:
-              path: /grid/console
+              path: /wd/hub/status
               port: {{ .Values.hub.port }}
+            initialDelaySeconds: 15
             timeoutSeconds: {{ .Values.hub.readinessTimeout }}
           env:
             - name: JAVA_TOOL_OPTIONS

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -21,10 +21,13 @@ hub:
   ## The port which the hub listens on
   port: 4444
 
-  ## Timeout for probe Hub readiness via HTTP request on Hub console
+  ## Timeout for probe Hub readiness via HTTP request on Hub status
   readinessTimeout: 1
 
-  ## Timeout for probe Hub liveness via HTTP request on Hub console
+  ## Initial delay before performing the first readinessProbe
+  readinessDelay: 15
+
+  ## Timeout for probe Hub liveness via HTTP request on Hub status
   livenessTimeout: 1
 
   ## Set the JAVA_TOOL_OPTIONS environment variable


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

selenium-hub fails its health-checks and is restarted. This can cause subsquent/concurrent tests to fail because the nodes are disconnected from the hub.

Selenium Developers reccomended using the health endpoint: /wd/hub/status and NOT: /grid/console.

This is because: "I do notice /grid/console hangs for a bit after a node loses connection." and "...when a node dies the grid server stalls for a while..." and finally "...registering and unregistering lots nodes is an expensive operation for the Grid, it tends to block it."

**Which issue this PR fixes**:
Fixes #7552

**Special notes for your reviewer**:
Thanks!