### PR TITLE
[stable/postgresql] Create ConfigMap only when necessary

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.18.0
+version: 0.19.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/configmap.yaml
+++ b/stable/postgresql/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.metrics.customMetrics .Values.pgHbaConf }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
   {{- if .Values.pgHbaConf }}
   pg_hba.conf: {{ .Values.pgHbaConf | quote }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Create the ConfigMap only when it is necessary.

Default values are `pgHbaConf: nil` and `metrics.enabled: false` in which case the ConfigMap is not necessary since it has nothing in `data:`. This change is backwards compatible for people who customize `metrics.customMetric` or `pgHbaConf`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I ran into the https://github.com/helm/helm/issues/1193 bug when upgrading the stable/postgresql chart and it created an new empty ConfigMap. I see no advantage to create the ConfigMap is nothing is in `data`