### PR TITLE
[stable/nginx-ingress] add default values for autoscaler

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.28.1
+version: 0.28.2
 appVersion: 0.19.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -145,10 +145,10 @@ controller:
 
   autoscaling:
     enabled: false
-  #  minReplicas: 1
-  #  maxReplicas: 11
-  #  targetCPUUtilizationPercentage: 50
-  #  targetMemoryUtilizationPercentage: 50
+    minReplicas: 1
+    maxReplicas: 11
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 50
 
   ## Override NGINX template
   customTemplate:


### PR DESCRIPTION
When using HorizontalPodAutoscaler it should have sane defaults
so that enabling should work out of the box.  Previously you had to
set the values that are commented out as well as setting enable to true.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>
