### PR TITLE
[incubator/elasticsearch] Add nodeAffinity parameters

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.8.2
+version: 1.9.0
 appVersion: 6.4.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -83,6 +83,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.serviceType`                 | Client service type                                                 | `ClusterIP`                          |
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                 |
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                 |
+| `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                               |
 | `master.exposeHttp`                  | Expose http port 9200 on master Pods for monitoring, etc            | `false`                              |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.replicas`                    | Master node replicas (deployment)                                   | `2`                                  |
@@ -98,6 +99,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.persistence.size`            | Master persistent volume size                                       | `4Gi`                                |
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
+| `master.antiAffinity`                | Master anti-affinity policy                                         | `soft`                               |
 | `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                              |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `2`                                  |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -84,6 +84,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                 |
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                 |
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                               |
+| `client.nodeAffinity`                | Client node affinity policy                                         | `{}`                                 |
 | `master.exposeHttp`                  | Expose http port 9200 on master Pods for monitoring, etc            | `false`                              |
 | `master.name`                        | Master component name                                               | `master`                             |
 | `master.replicas`                    | Master node replicas (deployment)                                   | `2`                                  |
@@ -100,6 +101,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
 | `master.antiAffinity`                | Master anti-affinity policy                                         | `soft`                               |
+| `master.nodeAffinity`                | Master node affinity policy                                         | `{}`                                 |
 | `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                              |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `2`                                  |
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
@@ -115,6 +117,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.tolerations`                   | Data tolerations                                                    | `[]`                                 |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
+| `data.nodeAffinity`                  | Data node affinity policy                                           | `{}`                                 |
 | `extraInitContainers`                | Additional init container passed through the tpl 	                 | ``                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -26,8 +26,10 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1000
-      {{- if eq .Values.client.antiAffinity "hard" }}
+      {{- if or .Values.client.antiAffinity .Values.client.nodeAffinity }}
       affinity:
+      {{- end }}
+      {{- if eq .Values.client.antiAffinity "hard" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
@@ -37,7 +39,6 @@ spec:
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.client.name }}"
       {{- else if eq .Values.client.antiAffinity "soft" }}
-      affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -48,6 +49,10 @@ spec:
                   app: "{{ template "elasticsearch.name" . }}"
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.client.name }}"
+      {{- end }}
+      {{- with .Values.client.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
       {{- end }}
 {{- if .Values.client.nodeSelector }}
       nodeSelector:

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -27,8 +27,10 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1000
-      {{- if eq .Values.data.antiAffinity "hard" }}
+      {{- if or .Values.data.antiAffinity .Values.data.nodeAffinity }}
       affinity:
+      {{- end }}
+      {{- if eq .Values.data.antiAffinity "hard" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
@@ -38,7 +40,6 @@ spec:
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.data.name }}"
       {{- else if eq .Values.data.antiAffinity "soft" }}
-      affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -49,6 +50,10 @@ spec:
                   app: "{{ template "elasticsearch.name" . }}"
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.data.name }}"
+      {{- end }}
+      {{- with .Values.data.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
       {{- end }}
 {{- if .Values.data.nodeSelector }}
       nodeSelector:

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -27,8 +27,10 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1000
-      {{- if eq .Values.master.antiAffinity "hard" }}
+      {{- if or .Values.master.antiAffinity .Values.master.nodeAffinity }}
       affinity:
+      {{- end }}
+      {{- if eq .Values.master.antiAffinity "hard" }}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: "kubernetes.io/hostname"
@@ -38,7 +40,6 @@ spec:
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.master.name }}"
       {{- else if eq .Values.master.antiAffinity "soft" }}
-      affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
@@ -49,6 +50,10 @@ spec:
                   app: "{{ template "elasticsearch.name" . }}"
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.master.name }}"
+      {{- end }}
+      {{- with .Values.master.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
       {{- end }}
 {{- if .Values.master.nodeSelector }}
       nodeSelector:

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -37,6 +37,7 @@ client:
 #    example: client-svc-foo
   heapSize: "512m"
   antiAffinity: "soft"
+  nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
   resources:
@@ -67,6 +68,7 @@ master:
     size: "4Gi"
     # storageClass: "ssd"
   antiAffinity: "soft"
+  nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
   resources:
@@ -100,6 +102,7 @@ data:
     # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"
+  nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows to specify an `affinity.nodeAffinity` parameter to client, master, data, empty by default.

Also fix missing antiAffinity parameters in README.