### PR TITLE
lower the name if the chart custom name have uppercases

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.28.1
+version: 0.28.2
 appVersion: 0.19.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/_helpers.tpl
+++ b/stable/nginx-ingress/templates/_helpers.tpl
@@ -13,9 +13,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "nginx-ingress.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- .Release.Name | lower | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | lower | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -26,9 +26,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "nginx-ingress.controller.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Values.controller.name | lower | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.controller.name | lower | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -54,9 +54,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "nginx-ingress.defaultBackend.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | lower | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | lower | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Lower the names when the user set a custom chart name deployment with uppercase


**Which issue this PR fixes** : fixes https://github.com/helm/charts/issues/7544

**Special notes for your reviewer**:
