### PR TITLE
[Incubator/Cassandra] fix couldn't lookup host issue with headless service 

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.7.0
+version: 0.7.1
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/templates/service.yaml
+++ b/incubator/cassandra/templates/service.yaml
@@ -7,9 +7,12 @@ metadata:
     chart: {{ template "cassandra.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   clusterIP: None
   type: {{ .Values.service.type }}
+  publishNotReadyAddresses: true
   ports:
   - name: intra
     port: 7000


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This PR fix the deploy issue when using dns service discovery (coredns) with kubernetes, by default it only publish ns record after pods are ready, cause seed provider fail to lookup host.

Use `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` and `publishNotReadyAddresses: true` at the same time to make it compatiable with early version. 

