### PR TITLE
AD-HOC chore (incubator/fluentd): Bump version of container

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 0.1.5
-appVersion: 0.12
+version: 0.1.6
+appVersion: 1.2.4
 home: https://www.fluentd.org/
 sources:
 - https://quay.io/repository/coreos/fluentd-kubernetes

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: gcr.io/google-containers/fluentd-elasticsearch
-  tag: v2.0.4
+  tag: v2.3.1
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - secret1


### PR DESCRIPTION
**What this PR does / why we need it**:

The container that is stored in this repository is version "v2.0.4".
The upstream container has been upgraded several times, though no major
breaking changes are anticipated.

**Special notes for your reviewer**:

The upstream has been updated to include the mutual TLS authentication
feature in fluentd 1.1.1. Future work will build upon this patch to implement
the required secret/configuration
