### PR TITLE
Ad hoc add tls support

### DIFF
--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 0.1.6
+version: 0.2.0
 appVersion: 1.2.4
 home: https://www.fluentd.org/
 sources:

--- a/incubator/fluentd/Chart.yaml
+++ b/incubator/fluentd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 0.1.5
-appVersion: 0.12
+version: 0.1.6
+appVersion: 1.2.4
 home: https://www.fluentd.org/
 sources:
 - https://quay.io/repository/coreos/fluentd-kubernetes

--- a/incubator/fluentd/templates/deployment.yaml
+++ b/incubator/fluentd/templates/deployment.yaml
@@ -70,12 +70,21 @@ spec:
         volumeMounts:
         - name: config-volume-{{ template "fluentd.fullname" . }}
           mountPath: /etc/fluent/config.d
+{{- if .Values.tls }}
+        - name: tls
+          mountPath: /etc/fluentd/pki
+{{- end }}
         - name: buffer
           mountPath: "/var/log/fluentd-buffers"
       volumes:
         - name: config-volume-{{ template "fluentd.fullname" . }}
           configMap:
             name: {{ template "fluentd.fullname" . }}
+{{- if .Values.tls }}
+        - name: "tls"
+          secret:
+            secretName: "{{ template "fluentd.fullname" . }}-tls"
+{{- end }}
         - name: buffer
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: gcr.io/google-containers/fluentd-elasticsearch
-  tag: v2.0.4
+  tag: v2.3.1
   pullPolicy: IfNotPresent
   # pullSecrets:
   #   - secret1

--- a/incubator/fluentd/values.yaml
+++ b/incubator/fluentd/values.yaml
@@ -42,6 +42,18 @@ ingress:
     #   hosts:
     #     - http-input.local
 
+# Used to store forwarder TLS information. This is made available in the container at /etc/fluend/tls for consumption in
+# the droppoconfiguration
+# tls: {}
+  # tls.crt: |
+  #   -----BEGIN CERTIFICATE-----
+  #   ...
+  # tls.key: |
+  #   -----BEGIN PRIVATE KEY-----
+  #   ...
+  # ca.crt: |
+  #   -----BEGIN CERTIFICATE-----
+
 configMaps:
   general.conf: |
     # Prevent fluentd from handling records containing its own logs. Otherwise
@@ -76,6 +88,17 @@ configMaps:
       @type forward
       port 24224
       bind 0.0.0.0
+
+      # If TLS mutual authentication should be enabled and certificates have been provided, uncomment the following
+      # lines:
+      #
+      #<transport tls>
+      #  client_cert_auth true
+
+      #  cert_path        /etc/fluentd/pki/tls.crt
+      #  private_key_path /etc/fluentd/pki/tls.key
+      #  ca_path          /etc/fluentd/pki/ca.crt
+      #</transport>
     </source>
   output.conf: |
     <match **>


### PR DESCRIPTION
**What this PR does / why we need it**:


AD-HOC feat (incubator/fluentd): Add support for mTLS  …
There are two problems that running `fluentd` present:

1. Ensuring that logs are transported in such a way intermediaries
   cannot read them (encryption)
2. Ensuring that only the users who are supposed to forward logs
   are able to forward logs.

Mutual TLS (mTLS, or TLS client/server authentication) provides a solution in
which this is possible, Broadly, both the client and the server must
have valid certificates to establish the TLS connection and forward
logs, and these certificates cannot be faked.

`fluentd` supports mTLS since version 1.1.1:

https://docs.fluentd.org/v1.0/articles/in_forward#how-to-enable-tls-mutual-authentication

This commit introduces the configuration required to complete mTLS:

- A new secret primitive, made available conditionally to fluentd
- Modification of the deployment based on whether this conditional is
  true

This PR depends on work completed in the PR #7575, but was submitted
separately as the other PR is useful regardless of whether this patch is
also accepted.

== Design Notes ==

=== Unstructured secret ===

The secret is deliberately unstructured, as doing it in this way allows
both TLS server identity verification only (or "normal TLS") as well as
mTLS. It additionally allows other key material, such as if fluentd was
operating as a sever in the context of receiving the logs, and as a
client in the context of forwarding them to ElasticSearch.
