### PR TITLE
sentry: bump postgres and redis charts

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 0.4.0
+version: 0.4.1
 appVersion: 9.0
 keywords:
   - debugging

--- a/stable/sentry/requirements.lock
+++ b/stable/sentry/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.15.0
+  version: 0.18.0
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.6.5
-digest: sha256:a49afdaa300dbb31e1661762b2779af0f74520661b044b9ac495df6c3309eb92
-generated: 2018-07-21T16:50:40.000327793+09:00
+  version: 3.8.1
+digest: sha256:bb223efbf7741e16ea4090893c70d8f6a600b53e43ecb91c37c02d7c9205702c
+generated: 2018-09-05T20:53:38.493142607-07:00

--- a/stable/sentry/requirements.yaml
+++ b/stable/sentry/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: postgresql
-    version: 0.15.0
+    version: 0.18.0
     repository: https://kubernetes-charts.storage.googleapis.com/
   - name: redis
-    version: 3.6.5
+    version: 3.8.1
     repository: https://kubernetes-charts.storage.googleapis.com/


### PR DESCRIPTION
bring in the latest stable postgres and redis charts and bump the sentry
chart version to v0.4.1.

postgres chart v0.15.0 -> v0.18.0
redis chart v3.6.5 -> v3.8.1
sentry (this) chart v0.4.0 -> v0.4.1

Signed-off-by: fallwith <fallwith@gmail.com>