### PR TITLE
[incubator/elasticsearch] Add option to add additional ES_JAVA_OPTS parameters

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.9.2
+version: 1.10.0
 appVersion: 6.4.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `cluster.config`                     | Additional cluster config appended                                  | `{}`                                                |
 | `cluster.keystoreSecret`             | Name of secret holding secure config options in an es keystore      | `nil`                                               |
 | `cluster.env`                        | Cluster environment variables                                       | `{MINIMUM_MASTER_NODES: "2"}`                       |
+| `cluster.additionalJavaOpts`         | Cluster parameters to be added to `ES_JAVA_OPTS` environment variable | `""`                                              |
 | `client.name`                        | Client component name                                               | `client`                                            |
 | `client.replicas`                    | Client node replicas (deployment)                                   | `2`                                                 |
 | `client.resources`                   | Client node resources requests & limits                             | `{} - cpu limit must be an integer`                 |
@@ -175,7 +176,7 @@ Elasticsearch v5 terminology has updated, and now refers to a `Client Node` as a
 
 More info: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/modules-node.html#coordinating-node
 
-## Enabling elasticsearch interal monitoring 
+## Enabling elasticsearch interal monitoring
 Requires version 6.3+ and standard non `oss` repository defined. Starting with 6.3 Xpack is partially free and enabled by default. You need to set a new config to enable the collection of these internal metrics. (https://www.elastic.co/guide/en/elasticsearch/reference/6.3/monitoring-settings.html)
 
 To do this through this helm chart override with the three following changes:

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -92,7 +92,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.client.heapSize }} -Xmx{{ .Values.client.heapSize }}"
+          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.client.heapSize }} -Xmx{{ .Values.client.heapSize }} {{ .Values.cluster.additionalJavaOpts }}"
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/templates/data-statefulset.yaml
+++ b/incubator/elasticsearch/templates/data-statefulset.yaml
@@ -100,7 +100,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.data.heapSize }} -Xmx{{ .Values.data.heapSize }}"
+          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.data.heapSize }} -Xmx{{ .Values.data.heapSize }} {{ .Values.cluster.additionalJavaOpts }}"
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/templates/master-statefulset.yaml
+++ b/incubator/elasticsearch/templates/master-statefulset.yaml
@@ -104,7 +104,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ES_JAVA_OPTS
-          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.master.heapSize }} -Xmx{{ .Values.master.heapSize }}"
+          value: "-Djava.net.preferIPv4Stack=true -Xms{{ .Values.master.heapSize }} -Xmx{{ .Values.master.heapSize }} {{ .Values.cluster.additionalJavaOpts }}"
         {{- range $key, $value :=  .Values.cluster.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -25,6 +25,8 @@ cluster:
   # Use this setting to specify the name of the secret
   # keystoreSecret: eskeystore
   config: {}
+  # Custom parameters, as string, to be added to ES_JAVA_OPTS environment variable
+  additionalJavaOpts: ""
   env:
     # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes
     # To prevent data loss, it is vital to configure the discovery.zen.minimum_master_nodes setting so that each master-eligible


### PR DESCRIPTION
**What this PR does / why we need it**:

Add option to add additional ES_JAVA_OPTS parameters to the whole cluster.