### PR TITLE
[stable/rabbitmq-ha]: Service should get a ClusterIP by default.

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.4
-version: 1.9.1
+version: 1.9.2
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -15,7 +15,9 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.service.clusterIP }}
   clusterIP: "{{ .Values.service.clusterIP }}"
+{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -15,9 +15,7 @@ metadata:
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.service.clusterIP }}
   clusterIP: "{{ .Values.service.clusterIP }}"
-{{- end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -192,7 +192,7 @@ terminationGracePeriodSeconds: 10
 
 service:
   annotations: {}
-  clusterIP: None
+  clusterIP: ""
 
   ## List of IP addresses at which the service is available
   ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips


### PR DESCRIPTION
**What this PR does / why we need it**:

The `Service` resource is _headless_ by default, unless the user provides their own IP address or a value of `""`. The default behaviour should be to assign a cluster-internal IP from the `service-cluster-ip-range`.

I'm not sure this value is even required in the `service.yaml` template, but rather than remove it, I made it conditional.

Alteratively, I _could_ just change the default value from `None` to `""`, but I think this way is more explicit.

Note: The discovery service created by `service-discovery.yaml` is headless by design.

**Notice for reviewers**:
Bumped chart version but current version may change depending on order of merges for outstanding PRs.