### PR TITLE
[stable/prometheus-adapter] Fixing warning when overriding rules.custom

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.1.0
+version: v0.1.1
 appVersion: v0.2.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
 | `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
-| `rules.custom`                  | A list of custom configmap rules                                                | `{}`                                        |
+| `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -40,7 +40,7 @@ resources:
 
 rules:
   default: true
-  custom: {}
+  custom: []
 # - seriesQuery: '{__name__=~"^some_metric_count$"}'
 #   resources:
 #     template: <<.Resource>>


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `warning: cannot overwrite table with non table for custom (map[])`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #7585 

**Special notes for your reviewer**:

Signed-off-by: Dave Henderson <dhenderson@gmail.com>