### PR TITLE
Added option for custom environment variables for PostgreSQL.

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.19.0
+version: 1.0.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -92,6 +92,7 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `probes.readiness.failureThreshold` | Readiness probe failure threshold      | `5`                                                        |
 | `podAnnotations`           | Annotations for the postgresql pod              | {}                                                         |
 | `deploymentAnnotations`    | Annotations for the postgresql deployment       | {}                                                         |
+| `extraEnv`                 | Any extra environment variables you would like to pass on to the pod | {}                                    |
 
 The above parameters map to the env variables defined in [postgres](http://github.com/docker-library/postgres). For more information please refer to the [postgres](http://github.com/docker-library/postgres) image documentation.
 

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -87,6 +87,9 @@ spec:
         {{- end }}
         - name: POD_IP
           valueFrom: { fieldRef: { fieldPath: status.podIP } }
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+{{- end }}
         ports:
         - name: postgresql
           containerPort: 5432

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -159,3 +159,6 @@ podAnnotations: {}
 ## Deployment pods replace strategy
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 # strategy: {}
+
+# Define custom environment variables to pass to the image here
+extraEnv: {}


### PR DESCRIPTION
This commit enables the user to specify additional environment
variables in the stable/postgres chart.


**What this PR does / why we need it**:
This is especially important for custom Postgres images which might have different environment variables for different options or for enabling additional features.

**Special notes for your reviewer**:
Nothing special here, really, the same pattern for adding variables is also used in other charts.