### PR TITLE
[stable/sysdig] Fix error in ClusterRoleBinding's roleRef

### DIFF
--- a/stable/sysdig/CHANGELOG.md
+++ b/stable/sysdig/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Sysdig Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v1.0.3
+
+### Minor Changes
+
+* Fixed error in ClusterRoleBinding's roleRef
+
 ## v1.0.2
 
 ### Minor Changes

--- a/stable/sysdig/Chart.yaml
+++ b/stable/sysdig/Chart.yaml
@@ -1,5 +1,5 @@
 name: sysdig
-version: 1.0.2
+version: 1.0.3
 appVersion: 0.81.0
 description: Sysdig Monitor and Secure agent
 keywords:

--- a/stable/sysdig/templates/clusterrolebinding.yaml
+++ b/stable/sysdig/templates/clusterrolebinding.yaml
@@ -15,4 +15,5 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: {{ template "sysdig.fullname" .}}
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: When `rbac.enabled` is `true`, the `ClusterRoleBinding` definition causes a validation error:

```
Error: UPGRADE FAILED: error validating "": error validating data: field roleRef.apiGroup for v1beta1.RoleRef is required
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**Special notes for your reviewer**: I've observed this on a 1.9 cluster with RBAC enabled. Not sure if/how it affects other versions, but I'd guess so, so long as the `rbac.authorization.k8s.io/v1beta1` version is being used.