### PR TITLE
OpenLDAP Read Only LDIF ConfigMap Fix

### DIFF
--- a/stable/openldap/Chart.yaml
+++ b/stable/openldap/Chart.yaml
@@ -1,6 +1,6 @@
 name: openldap
 home: https://www.openldap.org
-version: 0.2.2
+version: 0.2.3
 appVersion: 2.4.44
 description: Community developed LDAP software
 icon: http://www.openldap.org/images/headers/LDAPworm.gif

--- a/stable/openldap/templates/configmap-customldif.yaml
+++ b/stable/openldap/templates/configmap-customldif.yaml
@@ -20,4 +20,4 @@ data:
   {{ $key }}: |-
 {{ $val | indent 4}}
 {{- end }}
-{{- end -}}
+{{- end }}

--- a/stable/openldap/templates/deployment.yaml
+++ b/stable/openldap/templates/deployment.yaml
@@ -27,6 +27,17 @@ spec:
         app: {{ template "openldap.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.customLdifFiles }}
+      initContainers:
+      - name: {{ .Chart.Name }}-init
+        image: busybox
+        command: ['sh', '-c', 'cp /customldif/* /ldifworkingdir']
+        volumeMounts:
+        - name: customldif
+          mountPath: /customldif
+        - name: ldifworkingdir
+          mountPath: /ldifworkingdir
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -49,7 +60,7 @@ spec:
               mountPath: /etc/ldap/slapd.d
               subPath: config-data
             {{- if .Values.customLdifFiles }}
-            - name: customldif
+            - name: ldifworkingdir
               mountPath: /container/service/slapd/assets/config/bootstrap/ldif/custom
             {{- end }}
           livenessProbe:
@@ -83,6 +94,8 @@ spec:
         - name: customldif
           configMap:
             name: {{ template "openldap.fullname" . }}-customldif
+        - name: ldifworkingdir
+          emptyDir: {}
         {{- end }}
         - name: data
         {{- if .Values.persistence.enabled }}

--- a/stable/openldap/values.yaml
+++ b/stable/openldap/values.yaml
@@ -47,7 +47,7 @@ env:
 # configPassword: config
 
 # Custom openldap configuration files used to override default settings
-customLdifFiles:
+# customLdifFiles:
   # 01-default-users.ldif: |-
     # Predefine users here
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
When using the openldap container's `customLdifFiles` property the container attempts to make changes to the linked ConfigMap. This now fails due to these resources being linked as Read Only (https://github.com/coreos/bugs/issues/2384).

In this PR I added an initial container to copy resources to an EmptyDir volume to unblock the read write needs of the container. 
**Special notes for your reviewer**:
I've followed the pattern here: https://github.com/BestMile/charts/commit/c12f29d66a029750056131bac529ebd01f836c78 but this may not be the "right solution". This is my first helm contribution so love to hear if I'm holding it wrong