### PR TITLE
[stable/nginx-ingress] enhance --publish-service use

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.28.2
+version: 0.28.3
 appVersion: 0.19.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-deployment.yaml
+++ b/stable/nginx-ingress/templates/controller-deployment.yaml
@@ -48,8 +48,10 @@ spec:
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ if .Values.defaultBackend.enabled }}{{ .Release.Namespace }}/{{ template "nginx-ingress.defaultBackend.fullname" . }}{{ else }}{{ .Values.controller.defaultBackendService }}{{ end }}
-          {{- if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+          {{- if and ((semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled) .Values.controller.publishService.pathOverride }}
             - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
+          {{- else if and (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) .Values.controller.publishService.enabled }}
+            - --publish-service={{ .Release.Namespace }}/{{ template "nginx-ingress.controller.fullname" . }}
           {{- end }}
           {{- if (semverCompare ">=0.9.0-beta.1" .Values.controller.image.tag) }}
             - --election-id={{ .Values.controller.electionID }}


### PR DESCRIPTION
Signed-off-by: Shane Nayler <Shane.Nayler@data61.csiro.au>

@jackzampolin 
@mgoodness 
@chancez 

**What this PR does / why we need it**:

The default deployment needs to have the publish-service option enabled to work, otherwise new ingress resources get assigned a node IP instead of an External IP.

This PR will automatically assign the most likely to be correct publishServicePath automatically, without removing the option to override it if somebody needs to do that.

It may be worth also changing the default in values.yaml to set .Values.controller.publishService.enabled to be true by default. I am happy to add that if it seems necessary to others.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #7595 

**Special notes for your reviewer**:

This has been tested in a GCE cluster, but I do not have other environments to test the changes in. If somebody is able to check it in other non-GCE environments for the unlikely case that there is something quirky about the specific environment that could be causing trouble it may be worth it for peace of mind. See the steps to replicate the issue this PR is attempting to fix in #7595 