### PR TITLE
fix installation instruction for stable/efs-provisioner

### DIFF
--- a/stable/efs-provisioner/Chart.yaml
+++ b/stable/efs-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: efs-provisioner
 description: A Helm chart for the AWS EFS external storage provisioner
-version: 0.1.1
+version: 0.1.2
 appVersion: v0.1.2
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
 sources:

--- a/stable/efs-provisioner/README.md
+++ b/stable/efs-provisioner/README.md
@@ -34,7 +34,7 @@ permission to mount EFS file systems.
 At a minimum you must the supply the EFS file system ID and the AWS region
 
 ```
-helm install stable/efs-provisioner --set efsFileSystemId=fs-12345678 --set awsRegion=us-east-2
+helm install stable/efs-provisioner --set efsProvisioner.efsFileSystemId=fs-12345678 --set efsProvisioner.awsRegion=us-east-2
 ```
 
 All the values documented below and by `helm inspect values`.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes installation instruction for stable/efs-provisioner