### PR TITLE
[stable/metrics-server] Use custom service account name in created ServiceAccount resource

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.0
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.0.0
+version: 2.0.1
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/templates/metrics-server-serviceaccount.yaml
+++ b/stable/metrics-server/templates/metrics-server-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "metrics-server.fullname" . }}
+  name: {{ template "metrics-server.serviceAccountName" . }}
   labels:
     app: {{ template "metrics-server.name" . }}
     chart: {{ template "metrics-server.chart" . }}


### PR DESCRIPTION
**What this PR does / why we need it**: Uses `serviceAccount.name` in the created `ServiceAccount` resource.

Presently, if you set `serviceAccount.create` to `true` and specify `serviceAccount.name`, the custom name value is used in the deployment, but not in the service account itself, which results in a broken deployment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**Special notes for your reviewer**: N/A
