### PR TITLE
[stable/mysqldump] fix to the correct name to install the chart and set the chart version to 1.0.0

### DIFF
--- a/stable/mysqldump/Chart.yaml
+++ b/stable/mysqldump/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.7.21
 description: A Helm chart to help backup MySQL databases using mysqldump
 name: mysqldump
-version: 0.1.0
+version: 1.0.0
 keywords:
 - mysql
 - mysqldump

--- a/stable/mysqldump/README.md
+++ b/stable/mysqldump/README.md
@@ -65,12 +65,12 @@ persistence.accessMode | accessMode to use for PVC | ReadWriteOnce
 persistence.storageClass | storage class to use for PVC |
 
 ```console
-$ helm install stable/nginx-ingress --name my-release \
+$ helm install stable/mysqldump --name my-release \
     --set persistentVolumeClaim=name-of-existing-pvc
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install stable/nginx-ingress --name my-release -f values.yaml
+$ helm install stable/mysqldump --name my-release -f values.yaml
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
 - Fix the name of the chart in the readme.md
 - Bump the chart version to 1.0.0 since this is in stable and was discussed in the helm chart meeting to set at least to 1.0.0 since versions 0.x.x all are breaking changes

