### PR TITLE
Deprecate JFrog charts (moved to https://github.com/jfrog/charts)

### DIFF
--- a/stable/artifactory-ha/Chart.yaml
+++ b/stable/artifactory-ha/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: artifactory-ha
 home: https://www.jfrog.com/artifactory/
-version: 0.4.0
+version: 0.4.1
 appVersion: 6.2.0
-description: Universal Repository Manager supporting all major packaging formats,
+description: DEPRECATED Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.
 keywords:
 - artifactory
@@ -11,11 +11,7 @@ keywords:
 sources:
 - https://bintray.com/jfrog/product/JFrog-Artifactory-Pro/view
 - https://github.com/jfrog/charts
-maintainers:
-- name: jainishshah17
-  email: jainishs@jfrog.com
-- name: eldada
-  email: eldada@jfrog.com
-- name: rimusz
-  email: rimasm@jfrog.com
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/jfrog/charts
+deprecated: true

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -1,4 +1,10 @@
 # JFrog Artifactory High Availability Helm Chart - DEPRECATED
+**This chart is deprecated! You can find the new chart in:**
+- **Sources:** https://github.com/jfrog/charts
+- **Charts repository:** https://charts.jfrog.io
+```bash
+helm repo add jfrog https://charts.jfrog.io
+```
 
 ## Prerequisites Details
 

--- a/stable/artifactory-ha/README.md
+++ b/stable/artifactory-ha/README.md
@@ -1,4 +1,4 @@
-# JFrog Artifactory High Availability Helm Chart
+# JFrog Artifactory High Availability Helm Chart - DEPRECATED
 
 ## Prerequisites Details
 

--- a/stable/artifactory-ha/templates/NOTES.txt
+++ b/stable/artifactory-ha/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Congratulations. You have just deployed JFrog Artifactory HA!
 
+#### THIS CHART IS DEPRECATED! ####
+
 {{- if eq .Values.artifactory.masterKey "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" }}
 
 

--- a/stable/artifactory/Chart.yaml
+++ b/stable/artifactory/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: artifactory
 home: https://www.jfrog.com/artifactory/
-version: 7.3.0
+version: 7.3.1
 appVersion: 6.1.0
-description: Universal Repository Manager supporting all major packaging formats,
+description: DEPRECATED Universal Repository Manager supporting all major packaging formats,
   build tools and CI servers.
 keywords:
 - artifactory
@@ -11,11 +11,7 @@ keywords:
 sources:
 - https://bintray.com/jfrog/product/JFrog-Artifactory-Pro/view
 - https://github.com/JFrogDev
-maintainers:
-- name: jainishshah17
-  email: jainishs@jfrog.com
-- name: eldada
-  email: eldada@jfrog.com
-- name: rimusz
-  email: rimasm@jfrog.com
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/jfrog/charts
+deprecated: true

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -1,4 +1,4 @@
-# JFrog Artifactory Helm Chart
+# JFrog Artifactory Helm Chart - DEPRECATED
 
 ## Prerequisites Details
 

--- a/stable/artifactory/README.md
+++ b/stable/artifactory/README.md
@@ -1,4 +1,10 @@
 # JFrog Artifactory Helm Chart - DEPRECATED
+**This chart is deprecated! You can find the new chart in:**
+- **Sources:** https://github.com/jfrog/charts
+- **Charts repository:** https://charts.jfrog.io
+```bash
+helm repo add jfrog https://charts.jfrog.io
+```
 
 ## Prerequisites Details
 

--- a/stable/artifactory/templates/NOTES.txt
+++ b/stable/artifactory/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Congratulations. You have just deployed JFrog Artifactory!
 
+#### THIS CHART IS DEPRECATED! ####
+
 1. Get the Artifactory URL by running these commands:
 
    {{- if .Values.ingress.enabled }}

--- a/stable/distribution/Chart.yaml
+++ b/stable/distribution/Chart.yaml
@@ -1,20 +1,16 @@
 apiVersion: v1
-description: A Helm chart for JFrog Distribution
+description: DEPRECATED A Helm chart for JFrog Distribution
 home: https://jfrog.com/platform/
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png
 keywords:
 - distribution
 - jfrog
-maintainers:
-- email: jainishs@jfrog.com
-  name: jainishshah17
-- email: eldada@jfrog.com
-  name: eldada
-- email: rimasm@jfrog.com
-  name: rimusz
 name: distribution
 sources:
 - https://bintray.com/jfrog/product/distribution/view
 - https://github.com/JFrogDev
-version: 0.4.1
+version: 0.4.2
 appVersion: 1.1.0
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/jfrog/charts
+deprecated: true

--- a/stable/distribution/README.md
+++ b/stable/distribution/README.md
@@ -1,4 +1,4 @@
-# JFrog Distribution Helm Chart
+# JFrog Distribution Helm Chart - DEPRECATED
 
 ## Prerequisites Details
 

--- a/stable/distribution/README.md
+++ b/stable/distribution/README.md
@@ -1,4 +1,10 @@
 # JFrog Distribution Helm Chart - DEPRECATED
+**This chart is deprecated! You can find the new chart in:**
+- **Sources:** https://github.com/jfrog/charts
+- **Charts repository:** https://charts.jfrog.io
+```bash
+helm repo add jfrog https://charts.jfrog.io
+```
 
 ## Prerequisites Details
 

--- a/stable/distribution/templates/NOTES.txt
+++ b/stable/distribution/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Congratulations. You have just deployed JFrog Distribution!
 
+#### THIS CHART IS DEPRECATED! ####
+
 1. Get the Distribution URL by running these commands:
 
    {{- if contains "NodePort" .Values.distribution.service.type }}

--- a/stable/mission-control/Chart.yaml
+++ b/stable/mission-control/Chart.yaml
@@ -1,20 +1,16 @@
 apiVersion: v1
-description: A Helm chart for JFrog Mission Control
+description: DEPRECATED A Helm chart for JFrog Mission Control
 home: https://jfrog.com/mission-control/
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png
 keywords:
 - mission-control
 - jfrog
-maintainers:
-- email: jainishs@jfrog.com
-  name: jainishshah17
-- email: eldada@jfrog.com
-  name: eldada
-- email: rimasm@jfrog.com
-  name: rimusz
 name: mission-control
 sources:
 - https://bintray.com/jfrog/product/mission-control/view
 - https://github.com/jfrog/charts
-version: 0.4.2
+version: 0.4.3
 appVersion: 3.1.2
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/jfrog/charts
+deprecated: true

--- a/stable/mission-control/README.md
+++ b/stable/mission-control/README.md
@@ -1,4 +1,4 @@
-# JFrog Mission-Control Helm Chart
+# JFrog Mission-Control Helm Chart - DEPRECATED
 
 ## Prerequisites Details
 

--- a/stable/mission-control/README.md
+++ b/stable/mission-control/README.md
@@ -1,4 +1,10 @@
 # JFrog Mission-Control Helm Chart - DEPRECATED
+**This chart is deprecated! You can find the new chart in:**
+- **Sources:** https://github.com/jfrog/charts
+- **Charts repository:** https://charts.jfrog.io
+```bash
+helm repo add jfrog https://charts.jfrog.io
+```
 
 ## Prerequisites Details
 

--- a/stable/mission-control/templates/NOTES.txt
+++ b/stable/mission-control/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Congratulations. You have just deployed JFrog Mission Control!
 
+#### THIS CHART IS DEPRECATED! ####
+
 1. Get the JFrog Mission Control URL by running these commands:
 
    {{- if .Values.ingress.enabled }}

--- a/stable/xray/Chart.yaml
+++ b/stable/xray/Chart.yaml
@@ -1,20 +1,16 @@
 apiVersion: v1
 name: xray
-version: 0.4.1
+version: 0.4.2
 appVersion: 2.3.0
 home: https://www.jfrog.com/xray/
-description: Universal component scan for security and license inventory and impact analysis
+description: DEPRECATED Universal component scan for security and license inventory and impact analysis
 keywords:
 - xray
 - jfrog
 sources:
 - https://bintray.com/jfrog/product/xray/view
 - https://github.com/jfrog/charts
-maintainers:
-- name: eldada
-  email: eldada@jfrog.com
-- email: jainishs@jfrog.com
-  name: jainishshah17
-- email: rimasm@jfrog.com
-  name: rimusz
 icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/jfrog/charts
+deprecated: true

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -1,4 +1,10 @@
 # JFrog Xray HA on Kubernetes Helm Chart - DEPRECATED
+**This chart is deprecated! You can find the new chart in:**
+- **Sources:** https://github.com/jfrog/charts
+- **Charts repository:** https://charts.jfrog.io
+```bash
+helm repo add jfrog https://charts.jfrog.io
+```
 
 ## Prerequisites Details
 

--- a/stable/xray/README.md
+++ b/stable/xray/README.md
@@ -1,4 +1,4 @@
-# JFrog Xray HA on Kubernetes Helm Chart
+# JFrog Xray HA on Kubernetes Helm Chart - DEPRECATED
 
 ## Prerequisites Details
 

--- a/stable/xray/templates/NOTES.txt
+++ b/stable/xray/templates/NOTES.txt
@@ -1,5 +1,7 @@
 Congratulations! JFrog Xray services are deployed!
 
+#### THIS CHART IS DEPRECATED! ####
+
 {{- if eq .Values.common.masterKey "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" }}
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deprecates all JFrog charts.
Towards a future of a more distributed nature of helm charts distributions, we (JFrog) have setup our own helm repositories:
**Sources**: https://github.com/jfrog/charts
**Charts repository**: https://charts.jfrog.io