### PR TITLE
[stable/spotify-docker-gc] add ability to define resources on container in daemonset

### DIFF
--- a/stable/spotify-docker-gc/Chart.yaml
+++ b/stable/spotify-docker-gc/Chart.yaml
@@ -1,6 +1,6 @@
 name: spotify-docker-gc
 home: https://github.com/spotify/docker-gc
-version: 0.2.0
+version: 0.3.0
 appVersion: latest
 description: A simple Docker container and image garbage collection script.
 sources:

--- a/stable/spotify-docker-gc/README.md
+++ b/stable/spotify-docker-gc/README.md
@@ -21,18 +21,19 @@ The following table lists the configurable parameters of the Spotify Docker GC c
 
 See the [spotify/docker-gc GitHub repository][] for more settings which may be added to this chart as needed.
 
-| Parameter                         | Description                              | Default                                 |
-| --------------------------------- | ---------------------------------------- | --------------------------------------- |
-| `cron.schedule`                   | cron schedule                            | `0 0 * * *` (daily at 12:00AM UTC)      |
-| `cron.log`                        | cron log name                            | `/var/logs/cron.log`                    |
-| `env.gracePeriodSeconds`          | grace period in seconds before gc occurs | `0`                                     |
-| `env.dockerAPIVersion`            | Docker API Version for docker-gc client  | Not set                                 |
-| `exclude.images`                  | images to be excluded                    | Not set                                 |
-| `exclude.containers`              | containers to be excluded                | Not set                                 |
-| `serviceAccount`                  | service account to attach to deamonset   | Not set                                 |
-| `imagePullSecrets`                | Specify image pull secrets               | Not set                                 |
-| `tolerations`                     | Daemonset tolerations                    | Not set                                 |
-| `nodeSelector`                    | Node labels for daemonset pod assignment | Not set                                 |
+| Parameter                         | Description                                  | Default                            |
+| --------------------------------- | -------------------------------------------- | ---------------------------------- |
+| `cron.schedule`                   | cron schedule                                | `0 0 * * *` (daily at 12:00AM UTC) |
+| `cron.log`                        | cron log name                                | `/var/logs/cron.log`               |
+| `env.gracePeriodSeconds`          | grace period in seconds before gc occurs     | `0`                                |
+| `env.dockerAPIVersion`            | Docker API Version for docker-gc client      | Not set                            |
+| `exclude.images`                  | images to be excluded                        | Not set                            |
+| `exclude.containers`              | containers to be excluded                    | Not set                            |
+| `serviceAccount`                  | service account to attach to daemonset       | Not set                            |
+| `imagePullSecrets`                | Specify image pull secrets                   | Not set                            |
+| `tolerations`                     | Daemonset tolerations                        | Not set                            |
+| `nodeSelector`                    | Node labels for daemonset pod assignment     | Not set                            |
+| `resources`                       | Resources for the container in the daemonset | Not set                            | 
 
 ## Design/Evolution
 

--- a/stable/spotify-docker-gc/templates/daemonset.yaml
+++ b/stable/spotify-docker-gc/templates/daemonset.yaml
@@ -41,6 +41,10 @@ spec:
         volumeMounts:
         - name: docker-socket
           mountPath: /var/run/docker.sock
+        {{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        {{- end }}
       volumes:
       - name: docker-socket
         hostPath:

--- a/stable/spotify-docker-gc/values.yaml
+++ b/stable/spotify-docker-gc/values.yaml
@@ -32,6 +32,11 @@ env:
 # imagePullSecrets:
 #   - name: myRegistryKeySecretName
 
+## Resource requirements for spotify-docker-gc container
+## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+##
+resources: {}
+
 ## Node tolerations for spotify-docker-gc scheduling to nodes with taints
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Currently the `spotify-docker-gc` chart does not allow us to define the resource requests and limits on the container defined in the daemonset. It is currently considered best practice to define resource requests and limits [1]. This PR adds the ability to set the values if an operator chooses to do so. 

References:
1. https://cloudplatform.googleblog.com/2018/05/Kubernetes-best-practices-Resource-requests-and-limits.html

cc: @vdice 