### PR TITLE
[stable/rocketchat] Fixed TLS Ingress, updated  app and deps to latest version

### DIFF
--- a/stable/rocketchat/Chart.yaml
+++ b/stable/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 name: rocketchat
-version: 0.1.4
-appVersion: 0.68.5
+version: 0.1.5
+appVersion: 0.69.1
 description: Prepare to take off with the ultimate chat platform, experience the next
   level of team communications
 keywords:
@@ -21,4 +21,5 @@ maintainers:
   email: buildmaster@rocket.chat
 - name: geekgonecrazy
 - name: pierreozoux
+- name: verwilst
 engine: gotpl

--- a/stable/rocketchat/requirements.lock
+++ b/stable/rocketchat/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.2.2
-digest: sha256:e0861bef41fadbe3d9f213bd1d103f0e266faf2c2a06d58ab11199d0dc4cfcf9
-generated: 2018-08-31T09:39:11.558129592Z
+  version: 4.3.2
+digest: sha256:ddfaec6a053a9e5944e28b808b2ef6d1dc60357e7e3bc755553881fadb946537
+generated: 2018-09-10T08:39:20.065497472Z

--- a/stable/rocketchat/requirements.yaml
+++ b/stable/rocketchat/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mongodb
-  version: 4.2.2
+  version: 4.3.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/rocketchat/templates/ingress.yaml
+++ b/stable/rocketchat/templates/ingress.yaml
@@ -14,14 +14,6 @@ metadata:
     kubernetes.io/tls-acme: "true"
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  - hosts:
-    - {{ .Values.host }}
-{{- if (ne "-" .Values.ingress.secretName) }}
-    secretName: {{ .Values.ingress.secretName | default (printf "%s-tls" (include "rocketchat.fullname" .)) }}
-{{- end }}
-{{- end }}
   rules:
   - host: {{ .Values.host }}
     http:
@@ -30,4 +22,8 @@ spec:
         backend:
           serviceName: {{ template "rocketchat.fullname" . }}
           servicePort: 3000
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end }}
 {{- end -}}

--- a/stable/rocketchat/values.yaml
+++ b/stable/rocketchat/values.yaml
@@ -1,7 +1,7 @@
 ## Rocket Chat image version
 ## ref: https://hub.docker.com/r/library/rocket.chat/tags/
 ##
-image: rocket.chat:0.68.5
+image: rocket.chat:0.69.1
 
 ## Specify a imagePullPolicy
 ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -103,6 +103,9 @@ serviceAccount:
 ###
 ingress:
   enabled: false
-  tls: false
   annotations:
     kubernetes.io/ingress.class: "nginx"
+  tls:
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local


### PR DESCRIPTION
Signed-off-by: Bart Verwilst <bart@verwilst.be>

**What this PR does / why we need it**: TLS didn't work. Updated mongodb to 4.3.x and app to latest stable.