### PR TITLE
[incubator/elasticsearch] local only liveness

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.10.0
+version: 1.10.1
 appVersion: 6.4.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -106,7 +106,7 @@ spec:
           initialDelaySeconds: 5
         livenessProbe:
           httpGet:
-            path: /_cluster/health
+            path: /_cluster/health?local=true
             port: 9200
           initialDelaySeconds: 90
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Elasticsearch clients can be alive as soon as the node itself can accept connection. 
It does not need to be attached to a cluster.

https://www.elastic.co/guide/en/elasticsearch/reference/6.4/cluster-state.html#cluster-state

Making the liveness probe depending on the cluster (and therefore on the state of the masters) make it difficult to start a new installation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
