### PR TITLE
Fixed Sonarqube secrets definition

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.9.0
+version: 0.9.1
 appVersion: 6.7.3
 keywords:
   - coverage

--- a/stable/sonarqube/templates/secret.yaml
+++ b/stable/sonarqube/templates/secret.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.database.type "postgresql" -}}
-{{- if eq .Values.postgresql.enabled false -}}
+{{- if eq .Values.postgresql.enabled true -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,7 +15,7 @@ data:
 {{- end -}}
 {{- end -}}
 {{- if eq .Values.database.type "mysql" -}}
-{{- if eq .Values.mysql.enabled false -}}
+{{- if eq .Values.mysql.enabled true -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
**What is the issue?**:

When I try to install the Sonarqube chart, with a database (mysql or postgresql) enabled, I get the following error message:

```
Error: UPGRADE FAILED: no Secret with the name "yatta-toolkit-postgresql" found
```

**How to fix it**:

This is due to the https://github.com/helm/charts/blob/master/stable/sonarqube/templates/secret.yaml file which contains wrong conditions (`enabled` should be set to `true` instead of `false`).

Thank you