### PR TITLE
[stable/prometheus] add option to configure hostNetwork/hostPID for node-exporter pods

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 7.1.2
+version: 7.1.3
 appVersion: 2.4.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -173,6 +173,8 @@ Parameter | Description | Default
 `nodeExporter.extraArgs` | Additional node-exporter container arguments | `{}`
 `nodeExporter.extraHostPathMounts` | Additional node-exporter hostPath mounts | `[]`
 `nodeExporter.extraConfigmapMounts` | Additional node-exporter configMap mounts | `[]`
+`nodeExporter.hostNetwork` | If true, node-exporter pods share the host network namespace | `true`
+`nodeExporter.hostPID` | If true, node-exporter pods share the host PID namespace | `true`
 `nodeExporter.nodeSelector` | node labels for node-exporter pod assignment | `{}`
 `nodeExporter.podAnnotations` | annotations to be added to node-exporter pods | `{}`
 `nodeExporter.pod.labels` | labels to be added to node-exporter pods | `{}`

--- a/stable/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/prometheus/templates/node-exporter-daemonset.yaml
@@ -73,8 +73,12 @@ spec:
               mountPath: {{ .mountPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+    {{- if .Values.nodeExporter.hostNetwork }}
       hostNetwork: true
+    {{- end }}
+    {{- if .Values.nodeExporter.hostPID }}
       hostPID: true
+    {{- end }}
     {{- if .Values.nodeExporter.tolerations }}
       tolerations:
 {{ toYaml .Values.nodeExporter.tolerations | indent 8 }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -347,6 +347,14 @@ nodeExporter:
   ##
   enabled: true
 
+  ## If true, node-exporter pods share the host network namespace
+  ##
+  hostNetwork: true
+
+  ## If true, node-exporter pods share the host PID namespace
+  ##
+  hostPID: true
+
   ## node-exporter container name
   ##
   name: node-exporter


### PR DESCRIPTION
Signed-off-by: Ludovic Cavajani <lcavajani@suse.com>

**What this PR does / why we need it**:
Adding nodeExporter.hostNetwork and nodeExporter.hostPID allow us to manage what host namespaces the node-exporter pods will share. It is currently not possible to configure these options and it can be a security issue to expose the metrics on the host IP address or to share the host PID namespace (privileged escalation). 

With "hostNetwork: false", Prometheus can scrape the node on the pod IP address.
With "hostPID: false", node-exporter is able to get the metrics with the default configuration.

**Which issue this PR fixes**

**Special notes for your reviewer**:
The values are set to true by default so this add is not disruptive. I think this should be set to false by default in the future as there is no specific reason to share these NS with the host.