### PR TITLE
[stable/docker-registry] Add securitycontext to satisfy podsecuritypolicy

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.5.2
+version: 1.5.3
 appVersion: 2.6.2
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/templates/NOTES.txt
+++ b/stable/docker-registry/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-  http://{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "docker-registry.fullname" . }})

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -103,6 +103,11 @@ configData:
       interval: 10s
       threshold: 3
 
+securityContext:
+  enabled: true
+  runAsUser: 1000
+  fsGroup: 1000 
+
 priorityClassName: ""
 
 nodeSelector: {}

--- a/stable/docker-registry/values.yaml
+++ b/stable/docker-registry/values.yaml
@@ -106,7 +106,7 @@ configData:
 securityContext:
   enabled: true
   runAsUser: 1000
-  fsGroup: 1000 
+  fsGroup: 1000
 
 priorityClassName: ""
 


### PR DESCRIPTION
Signed-off-by: Bart Verwilst <bart@verwilst.be>

**What this PR does / why we need it**: On a cluster that has PodSecurityPolicies enabled, the Helm chart fails to start the pod because it's started as root. This fixes it.