### PR TITLE
[stable/chartmuseum] Make port-forward hint in NOTES.txt namespace-aware

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 1.6.0
+version: 1.6.1
 appVersion: 0.7.1
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/stable/chartmuseum/templates/NOTES.txt
+++ b/stable/chartmuseum/templates/NOTES.txt
@@ -25,6 +25,6 @@ OR
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "chartmuseum.name" . }}" -l "release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8080{{ .Values.env.open.CONTEXT_PATH }}/
-  kubectl port-forward $POD_NAME 8080:8080
+  kubectl port-forward $POD_NAME 8080:8080 --namespace {{ .Release.Namespace }}
 
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

When deploying chartmuseum to namespace other than `default`, the NOTES.txt output is wrong, as the port-forward command will not find the pod without specifying the namespace. This PR fixes that.
