### PR TITLE
[stable/datadog] Bump datadog/agent and kube-state-metrics versions

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 name: datadog
-version: 1.1.0
-appVersion: 6.3.2
+version: 1.2.0
+appVersion: 6.4.2
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -42,7 +42,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.apiKey`            | Your Datadog API key               |  `Nil` You must provide your own key      |
 | `datadog.apiKeyExistingSecret` | If set, use the secret with a provided name instead of creating a new one |`nil` |
 | `image.repository`          | The image repository to pull from  | `datadog/agent`                           |
-| `image.tag`                 | The image tag to pull              | `6.3.2`                                   |
+| `image.tag`                 | The image tag to pull              | `6.4.2`                                   |
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
 | `image.pullSecrets`         | Image pull secrets                 |  `nil`                                    |
 | `rbac.create`               | If true, create & use RBAC resources | `true`                                  |

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.8.0
-digest: sha256:4ebca30814dc7e891340df400f2babc2bc3c99fd14fdbae3327996c6cfe0ab5c
-generated: 2018-06-21T11:11:12.986791382+02:00
+  version: 0.9.0
+digest: sha256:3375a4cf1bc5c4c4dea05d3a9592360b5ffac63ab8fec76c77d45df23194098e
+generated: 2018-09-11T23:58:12.463953326+02:00

--- a/stable/datadog/requirements.yaml
+++ b/stable/datadog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
-    version: ~0.8.0
+    version: ~0.9.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: kubeStateMetrics.enabled

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -3,7 +3,7 @@ image:
   # This chart is compatible with different images, please choose one
   repository: datadog/agent               # Agent6
   # repository: datadog/dogstatsd         # Standalone DogStatsD6
-  tag: 6.3.2  # Use 6.3.2-jmx to enable jmx fetch collection
+  tag: 6.4.2  # Use 6.4.2-jmx to enable jmx fetch collection
   pullPolicy: IfNotPresent
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod


### PR DESCRIPTION
To 6.4.2 and 0.9.0/v1.4.0 respectively

Signed-off-by: Torbjørn Vatn <torbjorn.vatn@unacast.com>

**What this PR does / why we need it**:

It bumps both datadog/agent and kube-state-metrics versions to the most up to date ones
