### PR TITLE
[stable/redis] Major version bump: Fix chart not being upgradable

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 3.10.0
+version: 4.0.0
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/metrics-deployment.yaml
+++ b/stable/redis/templates/metrics-deployment.yaml
@@ -9,6 +9,11 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+        release: "{{ .Release.Name }}"
+        role: metrics
+        app: {{ template "redis.name" . }}
   template:
     metadata:
       labels:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     matchLabels:
       release: "{{ .Release.Name }}"
-      chart: {{ template "redis.chart" . }}
       role: master
       app: {{ template "redis.name" . }}
   serviceName: "redis-master"
@@ -161,7 +160,6 @@ spec:
         name: redis-data
         labels:
           app: "{{ template "redis.name" . }}"
-          chart: {{ template "redis.chart" . }}
           component: "master"
           release: {{ .Release.Name | quote }}
           heritage: {{ .Release.Service | quote }}

--- a/stable/redis/templates/redis-slave-deployment.yaml
+++ b/stable/redis/templates/redis-slave-deployment.yaml
@@ -12,6 +12,11 @@ spec:
 {{- if .Values.cluster.slaveCount }}
   replicas: {{ .Values.cluster.slaveCount }}
 {{- end }}
+  selector:
+    matchLabels:
+        release: "{{ .Release.Name }}"
+        role: slave
+        app: {{ template "redis.name" . }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Major version bump: Fix chart not being upgradable by removing 'chart' label from spec.selector or spec.VolumeClaimTemplate.

Since this is a breaking change, take this opportunity to also update labels to match the recommendations from Helm: https://github.com/helm/helm/blob/master/docs/chart_best_practices/labels.md

Also set a selector to all Deployments.

**Special notes for your reviewer**:

See https://github.com/helm/charts/issues/7680 and https://github.com/helm/charts/issues/7803 for explanations.

See https://github.com/helm/charts/pull/7692 for ongoing work to update Review Guidelines.

cc @prydonius @tompizmor @sameersbn @carrodher @juan131