### PR TITLE
[stable/rabbitmq] Fix chart not being upgradable by removing mutable label from VolumeClaimTemplate

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 3.0.1
+version: 3.1.0
 appVersion: 3.7.8
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -160,7 +160,6 @@ spec:
         name: data
         labels:
           app: {{ template "rabbitmq.name" . }}
-          chart: {{ template "rabbitmq.chart" .  }}
           release: "{{ .Release.Name }}"
           heritage: "{{ .Release.Service }}"
       spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Major version bump: Fix chart not being upgradable by removing 'chart' label from  spec.VolumeClaimTemplate.

**Special notes for your reviewer**:

See ~~https://github.com/helm/charts/issues/7680~~ https://github.com/helm/charts/issues/7803.

cc @prydonius @tompizmor @sameersbn @carrodher @juan131