### PR TITLE
Adds support for nodeSelectors

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 2.3.0
+version: 2.3.1
 appVersion: 1.5.6
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -83,3 +83,7 @@ spec:
       volumes:
 {{ tpl . $ | indent 6 }}
 {{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | trim | indent 8}}
+{{- end }}

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -41,6 +41,8 @@ resources:
     memory: 64Mi
     cpu: 50m
 
+nodeSelector: {}
+
 metrics:
   ## Expose memcached metrics in Prometheus format
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables the use of nodeSelector for scheduling pods

**Special notes for your reviewer**:
We use this pretty extensively in our clusters for scheduling things.  We find it useful even when `nodeAffinity` is available. 

Signed-off-by: Jeff Fouchard <jeff@fouchard.org>