### PR TITLE
[stable/datadog] allow configmaps to use templates

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.2.1
+version: 1.3.0
 appVersion: 6.4.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.2.0
+version: 1.2.1
 appVersion: 6.4.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/checksd-configmap.yaml
+++ b/stable/datadog/templates/checksd-configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:
-    checksum/checksd-config: {{ toYaml .Values.datadog.checksd | sha256sum }}
+    checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
 data:
-{{ toYaml .Values.datadog.checksd | indent 2 }}
+{{ tpl (toYaml .Values.datadog.checksd) . | indent 2 }}
 {{- end -}}

--- a/stable/datadog/templates/confd-configmap.yaml
+++ b/stable/datadog/templates/confd-configmap.yaml
@@ -9,17 +9,17 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:
-    checksum/confd-config: {{ toYaml .Values.datadog.confd | sha256sum }}
-    checksum/autoconf-config: {{ toYaml .Values.datadog.autoconf | sha256sum }}
+    checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
+    checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
 data:
 {{/*
 Merge the legacy autoconf dict before so confd static configurations
 override duplicates
 */}}
 {{- if .Values.datadog.autoconf }}
-{{ toYaml .Values.datadog.autoconf | indent 2 }}
+{{ tpl (toYaml .Values.datadog.autoconf) . | indent 2 }}
 {{- end -}}
 {{- if .Values.datadog.confd }}
-{{ toYaml .Values.datadog.confd | indent 2 }}
+{{ tpl (toYaml .Values.datadog.confd) . | indent 2 }}
 {{- end -}}
 {{- end -}}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -16,9 +16,9 @@ spec:
         app: {{ template "datadog.fullname" . }}
       name: {{ template "datadog.fullname" . }}
       annotations:
-        checksum/autoconf-config: {{ toYaml .Values.datadog.autoconf | sha256sum }}
-        checksum/confd-config: {{ toYaml .Values.datadog.confd | sha256sum }}
-        checksum/checksd-config: {{ toYaml .Values.datadog.checksd | sha256sum }}
+        checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
+        checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
+        checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
       {{- if .Values.daemonset.podAnnotations }}
 {{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
       {{- end }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -18,9 +18,9 @@ spec:
         type: deployment
       name: {{ template "datadog.fullname" . }}
       annotations:
-        checksum/autoconf-config: {{ toYaml .Values.datadog.autoconf | sha256sum }}
-        checksum/confd-config: {{ toYaml .Values.datadog.confd | sha256sum }}
-        checksum/checksd-config: {{ toYaml .Values.datadog.checksd | sha256sum }}
+        checksum/autoconf-config: {{ tpl (toYaml .Values.datadog.autoconf) . | sha256sum }}
+        checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
+        checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
@hkaj @irabinovitch @xvello

What this PR does / why we need it:

This PR allows for the configmaps used by Datadog to configure plugins to process templates embedded in values passed from parent charts.

This is needed to allow Datadog to use K8S DNS discovery for the common use case
of a pod/service name including {{ .Release.Namespace }} or {{ .Release.Name }} as part of the pod
or service name.

For other examples of templating of values in stable helm charts, see
`stable/mysql/templates/deployment.yaml`
`stable/consul/templates/consul-statefulset.yaml`
