### PR TITLE
[stable/grafana] Add namespace for grafana sidecar configmap scan.

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.14.6
+version: 1.14.7
 appVersion: 5.2.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -72,6 +72,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podAnnotations`                | Pod annotations                               | `{}`                                                    |
 | `sidecar.dashboards.enabled`    | Enabled the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
 | `sidecar.dashboards.label`      | Label that config maps with dashboards should have to be added | `false`                                |
+| `sidecar.dashboards.namespace`  | Namespace that will search for config-maps, defaults to where grafana runs, can specify ALL | `current` |
 | `sidecar.datasources.enabled`   | Enabled the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |
 | `sidecar.datasources.label`     | Label that config maps with datasources should have to be added | `false`                               |
 | `smtp.existingSecret`           | The name of an existing secret containing the SMTP credentials, this must have the keys `user` and `password`. | `""` |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
               value: "{{ .Values.sidecar.dashboards.label }}"
             - name: FOLDER
               value: "{{ .Values.sidecar.dashboards.folder }}"
+            {{- if .Values.sidecar.dashboards.namespace }}
+            - name: NAMESPACE
+              value: "{{ .Values.sidecar.dashboards.namespace }}"
+            {{- end }}
           resources:
 {{ toYaml .Values.sidecar.resources | indent 12 }}
           volumeMounts:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -239,7 +239,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:0.0.3
+  image: kiwigrid/k8s-sidecar:0.0.6
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:
@@ -254,6 +254,8 @@ sidecar:
     label: grafana_dashboard
     # folder in the pod that should hold the collected dashboards
     folder: /tmp/dashboards
+    # namespace that will search for config-maps, defaults to where grafana runs, can specify ALL
+    # namespace: ALL
   datasources:
     enabled: false
     # label that the configmaps with datasources are marked with


### PR DESCRIPTION
In order to be able to run against specific namespace or `ALL` https://github.com/kiwigrid/k8s-sidecar#configuration-environment-variables