### PR TITLE
Fix statefulset / use the correct endpoint for probes and update minio

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 1.7.0
-appVersion: RELEASE.2018-09-01T00-38-25Z
+version: 1.8.0
+appVersion: RELEASE.2018-09-12T18-49-56Z
 keywords:
 - storage
 - object-storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -76,10 +76,10 @@ The following table lists the configurable parameters of the Minio chart and the
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository                    | `minio/minio`                                           |
-| `image.tag`                | Minio image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).| `RELEASE.2018-09-01T00-38-25Z`|
+| `image.tag`                | Minio image tag. Possible values listed [here](https://hub.docker.com/r/minio/minio/tags/).| `RELEASE.2018-09-12T18-49-56Z`|
 | `image.pullPolicy`         | Image pull policy                   | `IfNotPresent`                                          |
 | `mcImage.repository`       | Client image repository             | `minio/mc`                                              |
-| `mcImage.tag`              | mc image tag. Possible values listed [here](https://hub.docker.com/r/minio/mc/tags/).| `RELEASE.2018-08-18T02-13-04Z`|
+| `mcImage.tag`              | mc image tag. Possible values listed [here](https://hub.docker.com/r/minio/mc/tags/).| `RELEASE.2018-09-10T23-39-12Z`|
 | `mcImage.pullPolicy`       | mc Image pull policy                | `IfNotPresent`                                          |
 | `ingress.enabled`          | Enables Ingress                     | `false`                                                 |
 | `ingress.annotations`      | Ingress annotations                 | `{}`                                                    |

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -93,7 +93,8 @@ spec:
                   key: gcs_key.json
             {{- end }}
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /minio/health/live
               port: service
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -101,7 +102,8 @@ spec:
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /minio/health/ready
               port: service
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/minio/templates/service.yaml
+++ b/stable/minio/templates/service.yaml
@@ -13,7 +13,11 @@ metadata:
 {{- end }}
 spec:
 {{- if (or (eq .Values.service.type "ClusterIP" "") (empty .Values.service.type)) }}
+  {{- if eq .Values.mode "distributed" }}
+  clusterIP: None
+  {{- else }}
   type: ClusterIP
+  {{- end }}
   {{- if not (empty .Values.service.clusterIP) }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{end}}

--- a/stable/minio/templates/statefulset.yaml
+++ b/stable/minio/templates/statefulset.yaml
@@ -63,20 +63,14 @@ spec:
                   name: {{ template "minio.fullname" . }}
                   key: secretkey
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /minio/health/live
               port: service
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          readinessProbe:
-            tcpSocket:
-              port: service
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: minio/minio
-  tag: RELEASE.2018-09-01T00-38-25Z
+  tag: RELEASE.2018-09-12T18-49-56Z
   pullPolicy: IfNotPresent
 
 ## Set default image, imageTag, and imagePullPolicy for the `mc` (the minio
@@ -10,7 +10,7 @@ image:
 ##
 mcImage:
   repository: minio/mc
-  tag: RELEASE.2018-08-18T02-13-04Z
+  tag: RELEASE.2018-09-10T23-39-12Z
   pullPolicy: IfNotPresent
 
 ## minio server mode, i.e. standalone or distributed.


### PR DESCRIPTION
**What this PR does / why we need it**:
- fix the stateful sets
- remove the readiness probe from statefull set because it will be ready only when all pods are running, so keep only the liveness probe
- use the correct endpoints for live/read probes
- update minio to the latest version

**Which issue this PR fixes** : fixes https://github.com/helm/charts/issues/7684

**Special notes for your reviewer**:
