### PR TITLE
[stable/elastalert] upgrade to elastalert 0.1.35; add olemarkus as additional maintainer

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,7 +1,7 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.7.0
-appVersion: 0.1.33
+version: 0.8.0
+appVersion: 0.1.35
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:
@@ -10,4 +10,6 @@ sources:
 maintainers:
   - name: jertel
     email: jertel@codesim.com
+  - name: olemarkus
+    email: o.with@sportradar.com
 engine: gotpl

--- a/stable/elastalert/OWNERS
+++ b/stable/elastalert/OWNERS
@@ -1,4 +1,6 @@
 approvers:
 - jertel
+- olemarkus
 reviewers:
 - jertel
+- olemarkus

--- a/stable/elastalert/README.md
+++ b/stable/elastalert/README.md
@@ -52,7 +52,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |       Parameter          |                    Description                    |             Default             |
 | ------------------------ | ------------------------------------------------- | ------------------------------- |
 | `image.repository`       | docker image                                      | jertel/elastalert-docker        |
-| `image.tag`              | docker image tag                                  | 0.1.33                          |
+| `image.tag`              | docker image tag                                  | 0.1.35                          |
 | `image.pullPolicy`       | image pull policy                                 | IfNotPresent                    |
 | `command`                | command override for container                    | `NULL`                          |
 | `args`                   | args override for container                       | `NULL`                          |

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -28,7 +28,7 @@ image:
   # docker image
   repository: jertel/elastalert-docker
   # docker image tag
-  tag: 0.1.33
+  tag: 0.1.35
   pullPolicy: IfNotPresent
 resources: {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Upgrading to latest version of elastalert image. Also adding @olemarkus since he offered to help maintain this chart (see https://github.com/helm/charts/pull/6614#issuecomment-408167588).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # N/A

**Special notes for your reviewer**:
