### PR TITLE
[stable/elastalert] fix scope of realertIntervalMins

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,6 +1,6 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.1.35
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elastalert/templates/config.yaml
+++ b/stable/elastalert/templates/config.yaml
@@ -14,9 +14,9 @@ data:
     scan_subdirectories: false
     run_every:
       minutes: {{ .Values.runIntervalMins }}
-{{- if .Values.elasticsearch.realertIntervalMins }}
+{{- if .Values.realertIntervalMins }}
     realert:
-      minutes: {{ .Values.elasticsearch.realertIntervalMins }}
+      minutes: {{ .Values.realertIntervalMins }}
 {{- end }}
     buffer_time:
       minutes: {{ .Values.bufferTimeMins }}


### PR DESCRIPTION
**What this PR does / why we need it**:
realertIntervalMins is not an elastic search properly, it is documented and in the default values.yaml correctly, but the template looks for it as a property/sub element of 'elasticsearch'

**Special notes for your reviewer**:
@jertel 