### PR TITLE
[stable/elastalert] only conditionally include certs

### DIFF
--- a/stable/elastalert/Chart.yaml
+++ b/stable/elastalert/Chart.yaml
@@ -1,6 +1,6 @@
 description: ElastAlert is a simple framework for alerting on anomalies, spikes, or other patterns of interest from data in Elasticsearch.
 name: elastalert
-version: 0.8.1
+version: 0.8.2
 appVersion: 0.1.35
 home: https://github.com/Yelp/elastalert
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg

--- a/stable/elastalert/templates/config.yaml
+++ b/stable/elastalert/templates/config.yaml
@@ -31,8 +31,14 @@ data:
     writeback_index: {{ .Values.writebackIndex }}
     use_ssl: {{ .Values.elasticsearch.useSsl }}
     verify_certs: {{ .Values.elasticsearch.verifyCerts }}
+{{- if .Values.elasticsearch.clientCert }}
     client_cert: {{ .Values.elasticsearch.clientCert }}
+{{- end }}
+{{- if .Values.elasticsearch.clientKey }}
     client_key: {{ .Values.elasticsearch.clientKey }}
+{{- end }}
+{{- if .Values.elasticsearch.caCerts }}
     ca_certs: {{ .Values.elasticsearch.caCerts }}
+{{- end }}
     alert_time_limit:
       minutes: {{ .Values.alertRetryLimitMins }}

--- a/stable/elastalert/values.yaml
+++ b/stable/elastalert/values.yaml
@@ -45,12 +45,13 @@ elasticsearch:
   password: ""
   # whether or not to verify TLS certificates
   verifyCerts: "True"
+  # Enable certificate based authentication
   # path to a PEM certificate to use as the client certificate
-  clientCert: "/certs/client.pem"
+  # clientCert: "/certs/client.pem"
   # path to a private key file to use as the client key
-  clientKey: "/certs/client-key.pem"
+  # clientKey: "/certs/client-key.pem"
   # path to a CA cert bundle to use to verify SSL connections
-  caCerts: "/certs/ca.pem"
+  # caCerts: "/certs/ca.pem"
   # # certs volumes, required to mount ssl certificates when elasticsearch has tls enabled
   # certsVolumes:
   #   - name: es-certs


### PR DESCRIPTION
**What this PR does / why we need it**:
There is currently no way to disable the SSL auth options so if these are not in use Elastalert will not start. This implements a check and only includes items if they are defined values so that the Elastalert container will not crash as mentioned in the linked issue.

**Which issue this PR fixes**
fixes #7721 

**Special notes for your reviewer**:
@jertel 