### PR TITLE
[stable/dmarc2logstash] upgrade image to prevent crashloop on bad dmarc report; upgrade filebeat

### DIFF
--- a/stable/dmarc2logstash/Chart.yaml
+++ b/stable/dmarc2logstash/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.0.0"
+appVersion: "1.0.2"
 description: Provides a POP3-polled DMARC XML report injector into Elasticsearch via Logstash and Filebeat
 name: dmarc2logstash
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/jertel/dmarc2logstash
 sources:
 - https://github.com/jertel/dmarc2logstash

--- a/stable/dmarc2logstash/README.md
+++ b/stable/dmarc2logstash/README.md
@@ -27,10 +27,10 @@ The command removes all the Kubernetes components associated with the chart and 
 setting                           | description                                                                                                           | default
 ----------------------------------|-----------------------------------------------------------------------------------------------------------------------|----------
 dmarc2logstash.image.repository   | dmarc2logstash Docker image repository                                                                                | jertel/dmarc2logstash
-dmarc2logstash.image.tag          | dmarc2logstash image tag, typically the version, of the Docker image                                                  | 1.0.0
+dmarc2logstash.image.tag          | dmarc2logstash image tag, typically the version, of the Docker image                                                  | 1.0.2
 dmarc2logstash.image.pullPolicy   | dmarc2logstash Kubernetes image pull policy                                                                           | IfNotPresent
 filebeat.image.repository         | Elastic filebeat Docker image repository                                                                              | docker.elastic.co/beats/filebeat
-filebeat.image.tag                | Elastic filebeat tag, typically the version, of the Docker image                                                      | 6.2.1
+filebeat.image.tag                | Elastic filebeat tag, typically the version, of the Docker image                                                      | 6.2.4
 filebeat.image.pullPolicy         | Elastic filebeat Kubernetes image pull policy                                                                         | IfNotPresent
 filebeat.logstash.host            | Logstash service host; ex: logstash (this value must be provided)                                                     | ""
 filebeat.logstash.port            | Logstash service port                                                                                                 | 5000

--- a/stable/dmarc2logstash/values.yaml
+++ b/stable/dmarc2logstash/values.yaml
@@ -1,7 +1,7 @@
 dmarc2logstash:
   image:
     repository: jertel/dmarc2logstash
-    tag: 1.0.1
+    tag: 1.0.2
     pullPolicy: IfNotPresent
   resources: {}
   nodeSelector: {}
@@ -11,7 +11,7 @@ dmarc2logstash:
 filebeat:
   image:
     repository: docker.elastic.co/beats/filebeat
-    tag: 6.2.1
+    tag: 6.2.4
     pullPolicy: IfNotPresent
   logstash:
     host: ""


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Upgrades the primary pod image to the latest dmarc2logstash image which prevents the pod from crashing when a DMARC report contains missing elements. Also upgrades filebeat to a newer version.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
