### PR TITLE
Adding Fluentd Splunk HEC stable chart

### DIFF
--- a/stable/fluentd-splunk-hec/Chart.yaml
+++ b/stable/fluentd-splunk-hec/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-splunk-hec
-version: 1.0
+version: "1.0"
 appVersion: v0.12.43
 home: https://www.fluentd.org
 description: Creates fluentd daemonset that runs the splunk HEC plugin for sending logs to a Splunk HTTP event collector

--- a/stable/fluentd-splunk-hec/Chart.yaml
+++ b/stable/fluentd-splunk-hec/Chart.yaml
@@ -1,0 +1,20 @@
+name: fluentd-splunk-hec
+version: 1.0
+appVersion: v0.12.43
+home: https://www.fluentd.org
+description: Creates fluentd daemonset that runs the splunk HEC plugin for sending logs to a Splunk HTTP event collector
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- splunk
+- multiline
+- logging
+sources:
+- https://github.com/kubernetes/charts/stable/fluentd-splunk-hec
+- https://github.com/fluent/fluentd-kubernetes-daemonset
+- https://github.com/fluent/fluent-plugin-splunk/blob/master/README.hec.md
+- https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset/
+maintainers:
+- name: max-rocket-internet
+  email: max.williams@deliveryhero.com
+engine: gotpl

--- a/stable/fluentd-splunk-hec/OWNERS
+++ b/stable/fluentd-splunk-hec/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- max-rocket-internet
+reviewers:
+- max-rocket-internet

--- a/stable/fluentd-splunk-hec/README.md
+++ b/stable/fluentd-splunk-hec/README.md
@@ -1,0 +1,69 @@
+# Fluentd Splunk HEC
+
+This chart installs a [Fluentd](https://www.fluentd.org/) daemonset containing the [Splunk HEC plugin](https://github.com/fluent/fluent-plugin-splunk). This is for sending logs to a [Splunk HTTP events collector](http://docs.splunk.com/Documentation/Splunk/latest/Data/AboutHEC). It is meant to be a drop in replacement for for the default logging daemonset on a cluster, e.g. for fluentd-gcp on GKE.
+
+## TL;DR;
+
+```console
+$ helm install stable/fluentd-splunk-hec
+```
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` and default configuration:
+
+```console
+$ helm install --name my-release stable/fluentd-splunk-hec
+```
+
+You will likely want to set at least set `splunk_hec.host` and `splunk_hec.token`:
+
+```console
+helm install --name my-release stable/fluentd-splunk-hec --set splunk_hec.host=my-splunk-endpoint.my-domain.com --set splunk_hec.token=abcdefg-1234-1234-abcd-abcdefg
+```
+
+## Uninstalling the Chart
+
+To delete the chart:
+
+```console
+$ helm delete my-release
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Fluentd splunk-hec chart and their default values.
+
+| Parameter                          | Description                                        | Default                               |
+| ---------------------------------- | -------------------------------------------------- | --------------------------------------|
+| `annotations`                      | Optional daemonset annotations                     | `NULL`                                |
+| `ssl_cert_bundle_path`             | Path to SSL certificates bundle on the node        | `/etc/ssl/certs/ca-bundle.crt`        |
+| `fluentd_settings.uid`             | UID that fluentd will use                          | `0`                                   |
+| `fluentd_settings.args`            | Arguments for fluentd                              | `--no-supervisor -q`                  |
+| `splunk_hec.host`                  | Your Splunk HEC endpoint host                      | `hec.example.com`                     |
+| `splunk_hec.port`                  | Your Splunk HEC endpoint port                      | `8088`                                |
+| `splunk_hec.token`                 | Your Splunk HEC token                              | `change_me`                           |
+| `splunk_hec.use_ssl`               | Whether to use SSL                                 | `true`                                |
+| `splunk_hec.ssl_verify`            | Whether to verify the SSL cert of the HEC endpoint | `true`                                |
+| `splunk_hec.source_name`           | Splunk source name                                 | `fluentd-splunk-hec`                  |
+| `splunk_hec.source_type`           | Splunk source type                                 | `fluentd-splunk-hec`                  |
+| `image.repository`                 | Image                                              | `fluent/fluentd-kubernetes-daemonset` |
+| `image.tag`                        | Image tag                                          | `v0.12.43-splunkhec`                  |
+| `image.pullPolicy`                 | Image pull policy                                  | `IfNotPresent`                        |
+| `rbac.create`                      | RBAC                                               | `true`                                |
+| `resources.limits.cpu`             | CPU limit                                          | `100m`                                |
+| `resources.limits.memory`          | Memory limit                                       | `500Mi`                               |
+| `resources.requests.cpu`           | CPU request                                        | `100m`                                |
+| `resources.requests.memory`        | Memory request                                     | `200Mi`                               |
+| `livenessProbe.enabled`            | Whether to enable livenessProbe                    | `true`                                |   
+| `tolerations`                      | Optional daemonset tolerations                     | `NULL`                                |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
+
+```console
+$ helm install --name my-release stable/fluentd-splunk-hec --values values.yaml
+```

--- a/stable/fluentd-splunk-hec/templates/NOTES.txt
+++ b/stable/fluentd-splunk-hec/templates/NOTES.txt
@@ -1,0 +1,6 @@
+To verify that the fluentd pods have started run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ .Chart.Name }},release={{ .Release.Name }}"
+
+Fluentd sends all console output from containers to your Splunk installation. This could include
+things that might be identifying such as IP addresses, container images and log data.

--- a/stable/fluentd-splunk-hec/templates/_helpers.tpl
+++ b/stable/fluentd-splunk-hec/templates/_helpers.tpl
@@ -1,0 +1,30 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd-splunk-hec.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fluentd-splunk-hec.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "fluentd-splunk-hec.labels" }}
+app: {{ template "fluentd-splunk-hec.name" . }}
+heritage: {{.Release.Service }}
+release: {{.Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}

--- a/stable/fluentd-splunk-hec/templates/clusterrole.yaml
+++ b/stable/fluentd-splunk-hec/templates/clusterrole.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "fluentd-splunk-hec.fullname" . }}
+  labels:
+    app: {{ template "fluentd-splunk-hec.name" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  - "pods"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+{{- end -}}

--- a/stable/fluentd-splunk-hec/templates/clusterrolebinding.yaml
+++ b/stable/fluentd-splunk-hec/templates/clusterrolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "fluentd-splunk-hec.fullname" . }}
+  labels:
+    app: {{ template "fluentd-splunk-hec.name" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd-splunk-hec.fullname" . }}
+  apiGroup: ""
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fluentd-splunk-hec.fullname" . }}
+  apiGroup: "rbac.authorization.k8s.io"
+{{- end -}}

--- a/stable/fluentd-splunk-hec/templates/daemonset.yaml
+++ b/stable/fluentd-splunk-hec/templates/daemonset.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  labels: {{ include "fluentd-splunk-hec.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "fluentd-splunk-hec.fullname" . }}
+spec:
+  selector:
+    matchLabels: {{ include "fluentd-splunk-hec.labels" . | indent 8 }}
+  template:
+    metadata:
+      labels: {{ include "fluentd-splunk-hec.labels" . | indent 8 }}
+      # This annotation ensures that fluentd does not get evicted if the node
+      # supports critical pod annotation based priority scheme.
+      # Note that this does not guarantee admission on the nodes (#40573).
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "fluentd-splunk-hec.fullname" . }}
+      containers:
+      - name: fluentd
+        image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+        env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: FLUENTD_ARGS
+          value: "{{ .Values.fluentd_settings.args }}"
+        - name: FLUENT_UID
+          value: "{{ .Values.fluentd_settings.uid }}"
+        - name: FLUENT_SPLUNK_HEC_CA_FILE
+          value: "{{ .Values.ssl_cert_bundle_path }}"
+        - name: FLUENT_SPLUNK_HEC_HOST
+          value: "{{ .Values.splunk_hec.host }}"
+        - name: FLUENT_SPLUNK_HEC_PORT
+          value: "{{ .Values.splunk_hec.port }}"
+        - name: FLUENT_SPLUNK_HEC_SOURCE
+          value: "{{ .Values.splunk_hec.source_name }}"
+        - name: FLUENT_SPLUNK_HEC_SOURCE_TYPE
+          value: "{{ .Values.splunk_hec.source_type }}"
+        - name: FLUENT_SPLUNK_HEC_USE_SSL
+          value: "{{ .Values.splunk_hec.use_ssl }}"
+        - name: FLUENT_SPLUNK_HEC_SSL_VERIFY
+          value: "{{ .Values.splunk_hec.ssl_verify }}"
+        - name: FLUENT_SPLUNK_HEC_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fluentd-splunk-hec.fullname" . }}
+              key: token
+{{- range $key, $value := .Values.environment }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: {{ .Values.ssl_cert_bundle_path }}
+          readOnly: true
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+{{- if .Values.livenessProbe.enabled }}
+        # Liveness probe is aimed to help in situarions where fluentd
+        # silently hangs for no apparent reasons until manual restart.
+        # The idea of this probe is that if fluentd is not queueing or
+        # flushing chunks for 5 minutes, something is not right. If
+        # you want to change the fluentd configuration, reducing amount of
+        # logs fluentd collects, consider changing the threshold or turning
+        # liveness probe off completely.
+        livenessProbe:
+          initialDelaySeconds: 600
+          periodSeconds: 60
+          exec:
+            command:
+            - '/bin/sh'
+            - '-c'
+            - >
+              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+              STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
+              if [ ! -e /var/log/fluentd-buffers ];
+              then
+                exit 1;
+              fi;
+              touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
+              if [[ -z "$(find /var/log/fluentd-buffers -type f -newer /tmp/marker-stuck -print -quit)" ]];
+              then
+                rm -rf /var/log/fluentd-buffers;
+                exit 1;
+              fi;
+              touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
+              if [[ -z "$(find /var/log/fluentd-buffers -type f -newer /tmp/marker-liveness -print -quit)" ]];
+              then
+                exit 1;
+              fi;
+{{- end }}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: ssl-certs
+        hostPath:
+          path: "{{ .Values.ssl_cert_bundle_path }}"
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}

--- a/stable/fluentd-splunk-hec/templates/secret.yaml
+++ b/stable/fluentd-splunk-hec/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fluentd-splunk-hec.fullname" . }}
+  labels:
+    app: {{ template "fluentd-splunk-hec.name" . }}
+    addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  token: {{ .Values.splunk_hec.token | b64enc | quote }}

--- a/stable/fluentd-splunk-hec/templates/serviceaccount.yaml
+++ b/stable/fluentd-splunk-hec/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fluentd-splunk-hec.fullname" . }}
+  labels:
+    app: {{ template "fluentd-splunk-hec.name" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}

--- a/stable/fluentd-splunk-hec/values.yaml
+++ b/stable/fluentd-splunk-hec/values.yaml
@@ -1,0 +1,54 @@
+image:
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: v0.12.43-splunkhec
+  pullPolicy: IfNotPresent
+
+rbac:
+  create: true
+
+# Path to the SSL CA bundle file
+# GKE
+# ssl_cert_bundle_path: /etc/srv/kubernetes/pki/ca-certificates.crt
+# kops
+# ssl_cert_bundle_path: /etc/ssl/certs/ca-certificates.crt
+# EKS
+# ssl_cert_bundle_path: /etc/ssl/certs/ca-bundle.crt
+ssl_cert_bundle_path: /etc/ssl/certs/ca-bundle.crt
+
+fluentd_settings:
+  uid: 0
+  args: '--no-supervisor -q'
+
+splunk_hec:
+  host: hec.example.com
+  port: 8088
+  token: change_me
+  use_ssl: "true"
+  ssl_verify: "true"
+  source_name: fluentd-splunk-hec
+  source_type: fluentd-splunk-hec
+
+# Any extra environment variables
+# See here for some optional settings:
+#   https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/docker-image/v0.12/alpine-splunkhec/conf/fluent.conf
+environment: {}
+#   VARIABLE_1: VALUE_1
+#   VARIABLE_2: VALUE_2
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 500Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+
+annotations: {}
+
+tolerations: {}
+  # - key: node-role.kubernetes.io/master
+  #   operator: Exists
+  #   effect: NoSchedule
+
+livenessProbe:
+  enabled: true


### PR DESCRIPTION
I would like to add a chart for fluentd with the Splunk HEC plugin. This installs a daemonset to collect logs and forward them to a Splunk HTTP event collector.