### PR TITLE
Add env value to etcd

### DIFF
--- a/incubator/etcd/Chart.yaml
+++ b/incubator/etcd/Chart.yaml
@@ -1,6 +1,6 @@
 name: etcd
 home: https://github.com/coreos/etcd
-version: 0.4.1
+version: 0.5.0
 appVersion: 2.2.5
 description: Distributed reliable key-value store for the most critical data of a
   distributed system.

--- a/incubator/etcd/README.md
+++ b/incubator/etcd/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the etcd chart and thei
 | `affinity`              | affinity settings for pod assignment | `{}`                                               |
 | `nodeSelector`          | Node labels for pod assignment       | `{}`                                               |
 | `tolerations`           | Toleration labels for pod assignment | `[]`                                               |
+| `extraEnv`              | Optional environment variables       | `[]`                                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/incubator/etcd/templates/statefulset.yaml
+++ b/incubator/etcd/templates/statefulset.yaml
@@ -47,6 +47,9 @@ spec:
           value: {{ .Values.replicas | quote }}
         - name: SET_NAME
           value: {{ template "etcd.fullname" . }}
+{{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+{{- end }}
         volumeMounts:
         - name: datadir
           mountPath: /var/run/etcd

--- a/incubator/etcd/values.yaml
+++ b/incubator/etcd/values.yaml
@@ -41,3 +41,4 @@ persistentVolume:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+extraEnv: []


### PR DESCRIPTION
Allow to set custom env via the etcd chart values which allows to pass
custom etcd options

**What this PR does / why we need it**:

This adds `env` to the values that will be appended to the container env values. This allows us to configure etcd better (for example auto compactation) in the values. 
