### PR TITLE
[stable/redis] support redis docker library image

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.3.1
+version: 5.0.0
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/ci/default-values.yaml
+++ b/stable/redis/ci/default-values.yaml
@@ -1,0 +1,354 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
+## Bitnami Redis image version
+## ref: https://hub.docker.com/r/bitnami/redis/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/redis
+  ## Bitnami Redis image tag
+  ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
+  ##
+  tag: 4.0.11
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: Always
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+## Cluster settings
+cluster:
+  enabled: true
+  slaveCount: 1
+
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Redis is listening
+  ## on. When true, Redis will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  # allowExternal: true
+
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  ##
+  create: false
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name:
+
+rbac:
+  ## Specifies whether RBAC resources should be created
+  ##
+  create: false
+
+  role:
+    ## Rules to create. It follows the role specification
+    # rules:
+    #  - apiGroups:
+    #    - extensions
+    #    resources:
+    #      - podsecuritypolicies
+    #    verbs:
+    #      - use
+    #    resourceNames:
+    #      - gce.unprivileged
+    rules: []
+
+## Use password authentication
+usePassword: true
+## Redis password (both master and slave)
+## Defaults to a random 10-character alphanumeric string if not set and usePassword is true
+## ref: https://github.com/bitnami/bitnami-docker-redis#setting-the-server-password-on-first-run
+##
+password:
+## Use existing secret (ignores previous password)
+# existingSecret:
+
+## Persist data to a persistent volume
+persistence: {}
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
+##
+## Redis Master parameters
+##
+master:
+  ## Redis port
+  port: 6379
+  ## Redis command arguments
+  ##
+  ## Can be used to specify command line arguments, for example:
+  ##
+  command:
+  - "/run.sh"
+  ## Redis additional command line flags
+  ##
+  ## Can be used to specify command line flags, for example:
+  ##
+  ## extraFlags:
+  ##  - "--maxmemory-policy volatile-ttl"
+  ##  - "--repl-backlog-size 1024mb"
+  extraFlags: []
+  ## Comma-separated list of Redis commands to disable
+  ##
+  ## Can be used to disable Redis commands for security reasons.
+  ## Commands will be completely disabled by renaming each to an empty string.
+  ## ref: https://redis.io/topics/security#disabling-of-specific-commands
+  ##
+  disableCommands:
+  - FLUSHDB
+  - FLUSHALL
+
+  ## Redis Master additional pod labels and annotations
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+  podAnnotations: {}
+
+  ## Redis Master resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 100m
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName:
+
+  ## Configure extra options for Redis Master liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+
+  ## Redis Master Node selectors and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  ##
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
+  # tolerations: []
+  ## Redis Master pod/node affinity/anti-affinity
+  ##
+  affinity: {}
+
+  ## Redis Master Service properties
+  service:
+    ##  Redis Master Service type
+    type: ClusterIP
+    port: 6379
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort:
+
+    ## Provide any additional annotations which may be required. This can be used to
+    ## set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    annotations: {}
+    loadBalancerIP:
+
+  ## Redis Master Pod Security Context
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## The path the volume will be mounted at, useful when using different
+    ## Redis images.
+    path: /data
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    subPath: ""
+    ## redis data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+    - ReadWriteOnce
+    size: 8Gi
+
+  ## Update strategy, can be set to RollingUpdate or onDelete by default.
+  ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
+  statefulset:
+    updateStrategy: RollingUpdate
+    ## Partition update strategy
+    ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+    # rollingUpdatePartition:
+
+
+##
+## Redis Slave properties
+## Note: service.type is a mandatory parameter
+## The rest of the parameters are either optional or, if undefined, will inherit those declared in Redis Master
+##
+slave:
+  ## Slave Service properties
+  service:
+    ## Redis Slave Service type
+    type: ClusterIP
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort:
+
+    ## Provide any additional annotations which may be required. This can be used to
+    ## set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    annotations: {}
+    loadBalancerIP:
+
+  ## Redis port
+  # port: 6379
+  ## Redis extra flags
+  # extraFlags: []
+  ## List of Redis commands to disable
+  # disableCommands: []
+
+  ## Redis Slave pod/node affinity/anti-affinity
+  ##
+  affinity: {}
+
+  ## Configure extra options for Redis Slave liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
+  # livenessProbe:
+  #   enabled: true
+  #   initialDelaySeconds: 30
+  #   periodSeconds: 10
+  #   timeoutSeconds: 5
+  #   successThreshold: 1
+  #   failureThreshold: 5
+  # readinessProbe:
+  #   enabled: true
+  #   initialDelaySeconds: 5
+  #   periodSeconds: 10
+  #   timeoutSeconds: 10
+  #   successThreshold: 1
+  #   failureThreshold: 5
+
+  ## Redis slave Resource
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 100m
+
+  ## Redis slave selectors and tolerations for pod assignment
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
+  # tolerations: []
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName:
+
+  ## Redis slave pod Annotation and Labels
+  # podLabels: {}
+  # podAnnotations: {}
+
+  ## Redis slave pod Security Context
+  # securityContext:
+  #   enabled: true
+  #   fsGroup: 1001
+  #   runAsUser: 1001
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: false
+
+  image:
+    registry: docker.io
+    repository: oliver006/redis_exporter
+    tag: v0.20.2
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+
+  service:
+    type: ClusterIP
+    ## Use serviceLoadBalancerIP to request a specific static IP,
+    ## otherwise leave blank
+    # loadBalancerIP:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9121"
+
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  # resources: {}
+
+  ## Extra arguments for Metrics exporter, for example:
+  ## extraArgs:
+  ##   check-keys: myKey,myOtherKey
+  # extraArgs: {}
+
+  ## Metrics exporter labels and tolerations for pod assignment
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
+  # tolerations: []
+
+  ## Metrics exporter pod Annotation and Labels
+  # podAnnotations: {}
+  # podLabels: {}
+
+##
+## Init containers parameters:
+## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
+##
+volumePermissions:
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: latest
+    pullPolicy: IfNotPresent
+
+## Redis config file
+## ref: https://redis.io/topics/config
+##
+configmap: |-
+  # maxmemory-policy volatile-lru

--- a/stable/redis/ci/dev-values.yaml
+++ b/stable/redis/ci/dev-values.yaml
@@ -1,0 +1,9 @@
+master:
+  persistence:
+    enabled: false
+
+cluster:
+  enabled: true
+  slaveCount: 1
+
+usePassword: false

--- a/stable/redis/ci/production-values.yaml
+++ b/stable/redis/ci/production-values.yaml
@@ -1,0 +1,355 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
+## Bitnami Redis image version
+## ref: https://hub.docker.com/r/bitnami/redis/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/redis
+  ## Bitnami Redis image tag
+  ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
+  ##
+  tag: 4.0.11
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+## Cluster settings
+cluster:
+  enabled: true
+  slaveCount: 3
+
+networkPolicy:
+  ## Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: true
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port Redis is listening
+  ## on. When true, Redis will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  # allowExternal: true
+
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  ##
+  create: false
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name:
+
+rbac:
+  ## Specifies whether RBAC resources should be created
+  ##
+  create: false
+
+  role:
+    ## Rules to create. It follows the role specification
+    # rules:
+    #  - apiGroups:
+    #    - extensions
+    #    resources:
+    #      - podsecuritypolicies
+    #    verbs:
+    #      - use
+    #    resourceNames:
+    #      - gce.unprivileged
+    rules: []
+
+## Use password authentication
+usePassword: true
+## Redis password (both master and slave)
+## Defaults to a random 10-character alphanumeric string if not set and usePassword is true
+## ref: https://github.com/bitnami/bitnami-docker-redis#setting-the-server-password-on-first-run
+##
+password:
+## Use existing secret (ignores previous password)
+# existingSecret:
+
+## Persist data to a persistent volume
+persistence: {}
+  ## A manually managed Persistent Volume and Claim
+  ## Requires persistence.enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # existingClaim:
+
+##
+## Redis Master parameters
+##
+master:
+  ## Redis port
+  port: 6379
+  ## Redis command arguments
+  ##
+  ## Can be used to specify command line arguments, for example:
+  ##
+  # command:
+  #  - "redis-server"
+  ## Redis additional command line flags
+  ##
+  ## Can be used to specify command line flags, for example:
+  ##
+  ## extraFlags:
+  ##  - "--maxmemory-policy volatile-ttl"
+  ##  - "--repl-backlog-size 1024mb"
+  extraFlags: []
+  ## Comma-separated list of Redis commands to disable
+  ##
+  ## Can be used to disable Redis commands for security reasons.
+  ## Commands will be completely disabled by renaming each to an empty string.
+  ## ref: https://redis.io/topics/security#disabling-of-specific-commands
+  ##
+  disableCommands:
+  - FLUSHDB
+  - FLUSHALL
+
+  ## Redis Master additional pod labels and annotations
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+  podAnnotations: {}
+
+  ## Redis Master resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 100m
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName:
+
+  ## Configure extra options for Redis Master liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+
+  ## Redis Master Node selectors and tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  ##
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
+  # tolerations: []
+  ## Redis Master pod/node affinity/anti-affinity
+  ##
+  affinity: {}
+
+  ## Redis Master Service properties
+  service:
+    ##  Redis Master Service type
+    type: ClusterIP
+    port: 6379
+
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort:
+
+    ## Provide any additional annotations which may be required. This can be used to
+    ## set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    annotations: {}
+    loadBalancerIP:
+
+  ## Redis Master Pod Security Context
+  ##
+  securityContext:
+    enabled: true
+    fsGroup: 1001
+    runAsUser: 1001
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## The path the volume will be mounted at, useful when using different
+    ## Redis images.
+    path: /bitnami/redis/data
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    subPath: ""
+    ## redis data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+    - ReadWriteOnce
+    size: 8Gi
+
+  ## Update strategy, can be set to RollingUpdate or onDelete by default.
+  ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
+  statefulset:
+    updateStrategy: RollingUpdate
+    ## Partition update strategy
+    ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+    # rollingUpdatePartition:
+
+
+##
+## Redis Slave properties
+## Note: service.type is a mandatory parameter
+## The rest of the parameters are either optional or, if undefined, will inherit those declared in Redis Master
+##
+slave:
+  ## Slave Service properties
+  service:
+    ## Redis Slave Service type
+    type: ClusterIP
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    # nodePort:
+
+    ## Provide any additional annotations which may be required. This can be used to
+    ## set the LoadBalancer service type to internal only.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    annotations: {}
+    loadBalancerIP:
+
+  ## Redis port
+  # port: 6379
+  ## Redis extra flags
+  # extraFlags: []
+  ## List of Redis commands to disable
+  # disableCommands: []
+
+  ## Redis Slave pod/node affinity/anti-affinity
+  ##
+  affinity: {}
+
+  ## Configure extra options for Redis Slave liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
+  # livenessProbe:
+  #   enabled: true
+  #   initialDelaySeconds: 30
+  #   periodSeconds: 10
+  #   timeoutSeconds: 5
+  #   successThreshold: 1
+  #   failureThreshold: 5
+  # readinessProbe:
+  #   enabled: true
+  #   initialDelaySeconds: 5
+  #   periodSeconds: 10
+  #   timeoutSeconds: 10
+  #   successThreshold: 1
+  #   failureThreshold: 5
+
+  ## Redis slave Resource
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 100m
+
+  ## Redis slave selectors and tolerations for pod assignment
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
+  # tolerations: []
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName:
+
+  ## Redis slave pod Annotation and Labels
+  # podLabels: {}
+  # podAnnotations: {}
+
+  ## Redis slave pod Security Context
+  # securityContext:
+  #   enabled: true
+  #   fsGroup: 1001
+  #   runAsUser: 1001
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: true
+
+  image:
+    registry: docker.io
+    repository: oliver006/redis_exporter
+    tag: v0.20.2
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+
+  service:
+    type: ClusterIP
+    ## Use serviceLoadBalancerIP to request a specific static IP,
+    ## otherwise leave blank
+    # loadBalancerIP:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9121"
+
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  # resources: {}
+
+  ## Extra arguments for Metrics exporter, for example:
+  ## extraArgs:
+  ##   check-keys: myKey,myOtherKey
+  # extraArgs: {}
+
+  ## Metrics exporter labels and tolerations for pod assignment
+  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
+  # tolerations: []
+
+  ## Metrics exporter pod Annotation and Labels
+  # podAnnotations: {}
+  # podLabels: {}
+
+##
+## Init containers parameters:
+## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
+##
+volumePermissions:
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: latest
+    pullPolicy: IfNotPresent
+
+## Redis config file
+## ref: https://redis.io/topics/config
+##
+configmap: |-
+  # maxmemory-policy volatile-lru

--- a/stable/redis/ci/redis-lib-values.yaml
+++ b/stable/redis/ci/redis-lib-values.yaml
@@ -1,0 +1,11 @@
+## Redis library image
+## ref: https://hub.docker.com/r/library/redis/
+##
+image:
+  registry: docker.io
+  repository: redis
+  tag: '4.0.11'
+
+master:
+  command:
+  - "redis-server"

--- a/stable/redis/ci/redisgraph-module-values.yaml
+++ b/stable/redis/ci/redisgraph-module-values.yaml
@@ -1,0 +1,8 @@
+image:
+  registry: docker.io
+  repository: redislabs/redisgraph
+  tag: '1.0.0'
+
+master:
+  command:
+  - "redis-server"

--- a/stable/redis/templates/configmap.yaml
+++ b/stable/redis/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.configmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,5 +9,22 @@ metadata:
   name: {{ template "redis.fullname" . }}
 data:
   redis.conf: |-
+{{- if .Values.configmap }}
+    # User-supplied configuration:
 {{ .Values.configmap | indent 4 }}
+{{- end }}
+  master.conf: |-
+    dir {{ .Values.master.persistence.path }}
+{{- if .Values.master.disableCommands }}
+{{- range .Values.master.disableCommands }}
+    rename-command {{ . }} ""
+{{- end }}
+{{- end }}
+  replica.conf: |-
+    dir /data
+{{- $replicaDisabledCommands := default .Values.master.disableCommands .Values.slave.disableCommands }}
+{{- if $replicaDisabledCommands }}
+{{- range $replicaDisabledCommands }}
+    rename-command {{ . }} ""
+{{- end }}
 {{- end }}

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -63,10 +63,24 @@ spec:
       - name: {{ template "redis.fullname" . }}
         image: "{{ template "redis.image" . }}"
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
-        {{- if .Values.master.args }}
-        args:
-{{ toYaml .Values.master.args | indent 10 }}
+        {{- if .Values.master.command }}
+        command:
+{{ toYaml .Values.master.command | indent 10 }}
         {{- end }}
+        args:
+        - "--port"
+        - "$(REDIS_PORT)"
+        {{- if .Values.usePassword }}
+        - "--requirepass"
+        - "$(REDIS_PASSWORD)"
+        {{- else }}
+        - "--protected-mode"
+        - "no"
+        {{- end }}
+        - "--include"
+        - "/opt/bitnami/redis/etc/redis.conf"
+        - "--include"
+        - "/opt/bitnami/redis/etc/master.conf"
         env:
         - name: REDIS_REPLICATION_MODE
           value: master
@@ -86,12 +100,6 @@ spec:
         {{- end }}
         - name: REDIS_PORT
           value: {{ .Values.master.port | quote }}
-        - name: REDIS_DISABLE_COMMANDS
-          value: {{ .Values.master.disableCommands }}
-        {{- if .Values.master.extraFlags }}
-        - name: REDIS_EXTRA_FLAGS
-          value: {{ .Values.master.extraFlags | join " " }}
-        {{- end }}
         ports:
         - name: redis
           containerPort: {{ .Values.master.port }}
@@ -131,8 +139,7 @@ spec:
           subPath: {{ .Values.master.persistence.subPath }}
         {{- if .Values.configmap }}
         - name: config
-          mountPath: /opt/bitnami/redis/etc/redis.conf
-          subPath: redis.conf
+          mountPath: /opt/bitnami/redis/etc
         {{- end }}
       {{- if and ( and .Values.master.persistence.enabled (not .Values.persistence.existingClaim) ) .Values.master.securityContext.enabled }}
       initContainers:

--- a/stable/redis/templates/redis-slave-deployment.yaml
+++ b/stable/redis/templates/redis-slave-deployment.yaml
@@ -67,10 +67,30 @@ spec:
       - name: {{ template "redis.fullname" . }}
         image: {{ template "redis.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | default "" | quote }}
-        {{- if (.Values.slave.args | default .Values.master.args) }}
-        args:
-{{ toYaml (.Values.slave.args | default .Values.master.args) | indent 10 }}
+{{- $command := default .Values.master.command .Values.slave.command }}
+        {{- if $command }}
+        command:
+{{ toYaml $command | indent 10 }}
         {{- end }}
+        args:
+        - "--port"
+        - "$(REDIS_PORT)"
+        - "--slaveof"
+        - "$(REDIS_MASTER_HOST)"
+        - "$(REDIS_MASTER_PORT_NUMBER)"
+        {{- if .Values.usePassword }}
+        - "--requirepass"
+        - "$(REDIS_PASSWORD)"
+        - "--masterauth"
+        - "$(REDIS_MASTER_PASSWORD)"
+        {{- else }}
+        - "--protected-mode"
+        - "no"
+        {{- end }}
+        - "--include"
+        - "/opt/bitnami/redis/etc/redis.conf"
+        - "--include"
+        - "/opt/bitnami/redis/etc/replica.conf"
         env:
         - name: REDIS_REPLICATION_MODE
           value: slave
@@ -103,12 +123,6 @@ spec:
         - name: ALLOW_EMPTY_PASSWORD
           value: "yes"
         {{- end }}
-        - name: REDIS_DISABLE_COMMANDS
-          value: {{ .Values.slave.disableCommands | default .Values.master.disableCommands }}
-        {{- if (.Values.slave.extraFlags | default .Values.master.extraFlags) }}
-        - name: REDIS_EXTRA_FLAGS
-          value: {{ .Values.slave.extraFlags | default .Values.master.extraFlags | join " " }}
-        {{- end }}
         ports:
         - name: redis
           containerPort: {{ .Values.slave.port | default .Values.master.port }}
@@ -121,10 +135,11 @@ spec:
         volumeMounts:
         - name: health
           mountPath: /health
+        - name: redis-data
+          mountPath: /data
         {{- if .Values.configmap }}
         - name: config
-          mountPath: /opt/bitnami/redis/etc/redis.conf
-          subPath: redis.conf
+          mountPath: /opt/bitnami/redis/etc
         {{- end }}
       volumes:
       - name: health
@@ -136,4 +151,6 @@ spec:
         configMap:
           name: {{ template "redis.fullname" . }}
       {{- end }}
+      - name: redis-data
+        emptyDir: {}
 {{- end }}

--- a/stable/redis/values-production.yaml
+++ b/stable/redis/values-production.yaml
@@ -96,24 +96,25 @@ master:
   ##
   ## Can be used to specify command line arguments, for example:
   ##
-  ## args:
-  ##  - "redis-server"
-  ##  - "--maxmemory-policy volatile-ttl"
-  args: []
+  # command:
+  #  - "redis-server"
   ## Redis additional command line flags
   ##
   ## Can be used to specify command line flags, for example:
   ##
-  ## redisExtraFlags:
+  ## extraFlags:
   ##  - "--maxmemory-policy volatile-ttl"
   ##  - "--repl-backlog-size 1024mb"
   extraFlags: []
   ## Comma-separated list of Redis commands to disable
   ##
   ## Can be used to disable Redis commands for security reasons.
-  ## ref: https://github.com/bitnami/bitnami-docker-redis#disabling-redis-commands
+  ## Commands will be completely disabled by renaming each to an empty string.
+  ## ref: https://redis.io/topics/security#disabling-of-specific-commands
   ##
-  disableCommands: "FLUSHDB,FLUSHALL"
+  disableCommands:
+  - FLUSHDB
+  - FLUSHALL
 
   ## Redis Master additional pod labels and annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -178,6 +179,7 @@ master:
     loadBalancerIP:
 
   ## Redis Master Pod Security Context
+  ##
   securityContext:
     enabled: true
     fsGroup: 1001
@@ -209,7 +211,7 @@ master:
   ## Update strategy, can be set to RollingUpdate or onDelete by default.
   ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
   statefulset:
-    updateStrategy: OnDelete
+    updateStrategy: RollingUpdate
     ## Partition update strategy
     ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
     # rollingUpdatePartition:
@@ -239,12 +241,10 @@ slave:
 
   ## Redis port
   # port: 6379
-  ## Redis command arguments
-  # args: []
   ## Redis extra flags
   # extraFlags: []
-  ## Comma-separated list of Redis commands to disable
-  # disableCommands: ""
+  ## List of Redis commands to disable
+  # disableCommands: []
 
   ## Redis Slave pod/node affinity/anti-affinity
   ##
@@ -361,6 +361,7 @@ volumePermissions:
     pullPolicy: IfNotPresent
 
 ## Redis config file
+## ref: https://redis.io/topics/config
 ##
 configmap: |-
-#  Redis configuration file
+  # maxmemory-policy volatile-lru

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -96,24 +96,25 @@ master:
   ##
   ## Can be used to specify command line arguments, for example:
   ##
-  ## args:
-  ##  - "redis-server"
-  ##  - "--maxmemory-policy volatile-ttl"
-  args: []
+  command:
+  - "/run.sh"
   ## Redis additional command line flags
   ##
   ## Can be used to specify command line flags, for example:
   ##
-  ## redisExtraFlags:
+  ## extraFlags:
   ##  - "--maxmemory-policy volatile-ttl"
   ##  - "--repl-backlog-size 1024mb"
   extraFlags: []
   ## Comma-separated list of Redis commands to disable
   ##
   ## Can be used to disable Redis commands for security reasons.
-  ## ref: https://github.com/bitnami/bitnami-docker-redis#disabling-redis-commands
+  ## Commands will be completely disabled by renaming each to an empty string.
+  ## ref: https://redis.io/topics/security#disabling-of-specific-commands
   ##
-  disableCommands: "FLUSHDB,FLUSHALL"
+  disableCommands:
+  - FLUSHDB
+  - FLUSHALL
 
   ## Redis Master additional pod labels and annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -136,15 +137,15 @@ master:
   ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 10
+    initialDelaySeconds: 5
+    periodSeconds: 5
     timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 5
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
-    periodSeconds: 10
+    periodSeconds: 5
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 5
@@ -190,7 +191,7 @@ master:
     enabled: true
     ## The path the volume will be mounted at, useful when using different
     ## Redis images.
-    path: /bitnami/redis/data
+    path: /data
     ## The subdirectory of the volume to mount to, useful in dev environments
     ## and one PV for multiple services.
     subPath: ""
@@ -239,16 +240,10 @@ slave:
 
   ## Redis port
   # port: 6379
-  ## Redis command arguments
-  # args: []
   ## Redis extra flags
   # extraFlags: []
-  ## Comma-separated list of Redis commands to disable
-  # disableCommands: ""
-  ## deployment update stategy
-  # updateStrategy:
-  #   rollingUpdate:
-  #     maxUnavailable: 0
+  ## List of Redis commands to disable
+  # disableCommands: []
 
   ## Redis Slave pod/node affinity/anti-affinity
   ##
@@ -365,6 +360,7 @@ volumePermissions:
     pullPolicy: IfNotPresent
 
 ## Redis config file
+## ref: https://redis.io/topics/config
 ##
 configmap: |-
-#  Redis configuration file
+  # maxmemory-policy volatile-lru


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
~This release switches the default image from [`docker.io/bitnami/redis`](https://hub.docker.com/r/bitnami/redis/) to [`docker.io/redis`](https://hub.docker.com/r/library/redis/). The bitnami image remains compatible with this chart; see `values-bitnami.yaml`.~

The default image in this release may be switched out for any image containing the `redis-server` binary. If `redis-server` is not the default image ENTRYPOINT, `master.command` must be specified. 

This allows `stable/redis` to offer a higher degree of flexibility for those who may need to run images containing [redis modules](https://redis.io/modules) or based on a different linux distribution than what is currently offered by bitnami.

#### Breaking changes:
- `master.args` and `slave.args` are removed. Use `master.command` or `slave.command` instead in order to override the image entrypoint, or `master.extraFlags` to pass additional flags to `redis-server`.
- `disableCommands` is now interpreted as an array of strings instead of a string of comma separated values.
- `master.persistence.path` now defaults to `/data`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

Related: https://github.com/bitnami/bitnami-docker-redis/issues/92

**Special notes for your reviewer**:

Several interesting test cases:
- `helm upgrade --install redis-test ./stable/redis -f ./stable/redis/values-bitnami.yaml`
- `helm upgrade --install redis-test ./stable/redis --set usePassword=false`
- `helm upgrade --install redis-test ./stable/redis --set master.persistence.enabled=false`
- `helm upgrade --install redis-test ./stable/redis --set configmap="maxmemory-policy volatile-lru"`
- `helm upgrade --install redis-test ./stable/redis --set image.repository=redislabs/rejson --set image.tag=latest`

