### PR TITLE
[stable/ipfs] Add `profile` configurable parameter

### DIFF
--- a/stable/ipfs/Chart.yaml
+++ b/stable/ipfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Interplanetary File System
 name: ipfs
-version: 0.2.2
+version: 0.2.3
 icon: https://raw.githubusercontent.com/ipfs/logo/master/raster-generated/ipfs-logo-128-ice-text.png
 home: https://ipfs.io/
 appVersion: v0.4.9

--- a/stable/ipfs/README.md
+++ b/stable/ipfs/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `persistence.annotations` | Extra annotations for the persistent volume claim. | `{}` |
 | `persistence.accessModes` | List of access modes for use with the persistent volume claim | `["ReadWriteOnce"]` |
 | `persistence.size` | Size of the PVC for each IPFS pod, used as persistent cache | `8Gi`  |
+| `profile` | The profile to apply when creating a new IPFS configuration | none |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/ipfs/templates/statefulset.yaml
+++ b/stable/ipfs/templates/statefulset.yaml
@@ -34,6 +34,11 @@ spec:
         volumeMounts:
           - name: ipfs-storage
             mountPath: /data/ipfs
+        {{- if .Values.profile }}
+        env:
+        - name: IPFS_PROFILE
+          value: {{ .Values.profile }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The new `profile` parameter can be used to choose which IPFS profile to apply when creating a new IPFS configuration. In hosted server environments, it's important to use `ifps init --profile=server` (see e.g. ipfs/go-ipfs#4343 and ipfs/go-ipfs#5511).

**Special notes for your reviewer**:
@yuvipanda, this change requires ipfs/go-ipfs#5473 to be merged and included in a released go-ipfs Docker image.

**Update:** ipfs/go-ipfs#5473 has been merged.