### PR TITLE
[stable/ipfs] Allow adding shared keys

### DIFF
--- a/stable/ipfs/Chart.yaml
+++ b/stable/ipfs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the Interplanetary File System
 name: ipfs
-version: 0.2.2
+version: 0.2.3
 icon: https://raw.githubusercontent.com/ipfs/logo/master/raster-generated/ipfs-logo-128-ice-text.png
 home: https://ipfs.io/
 appVersion: v0.4.9

--- a/stable/ipfs/README.md
+++ b/stable/ipfs/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `persistence.annotations` | Extra annotations for the persistent volume claim. | `{}` |
 | `persistence.accessModes` | List of access modes for use with the persistent volume claim | `["ReadWriteOnce"]` |
 | `persistence.size` | Size of the PVC for each IPFS pod, used as persistent cache | `8Gi`  |
+| `keysSecretName` | The name of the secret which contains shared IPFS keys to use | `""` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -66,3 +67,16 @@ $ helm install --name my-release -f values.yaml stable/ipfs
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml) as a base for customization.
+
+### Installing shared IPFS keys
+
+To include pre-created shared keys in the IPFS configuration, install the keys in a Kubernetes Secret, and specify the `keysSecretName` configuration option when installing the IPFS chart. For example,
+
+```bash
+$ kubectl create secret generic ipfs-keys-secret \
+  --from-file=${HOME}/.ipfs/keystore/my-shared-key \
+  --from-file=${HOME}/.ipfs/keystore/my-other-shared-key
+$ helm install --name my-release \
+  --set keysSecretName=ipfs-keys-secret \
+    stable/ipfs
+```

--- a/stable/ipfs/templates/statefulset.yaml
+++ b/stable/ipfs/templates/statefulset.yaml
@@ -34,8 +34,26 @@ spec:
         volumeMounts:
           - name: ipfs-storage
             mountPath: /data/ipfs
+          {{- if .Values.keysSecretName }}
+          - name: ipfs-keys-volume
+            readOnly: true
+            mountPath: "/data/ipfs/keystore"
+          {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+
+  {{- if or (not .Values.persistence.enabled) .Values.keysSecretName }}
+      volumes:
+      {{- if (not .Values.persistence.enabled) }}
+        - name: ipfs-storage
+          emptyDir: {}
+      {{- end }}
+      {{- if .Values.keysSecretName }}
+        - name: ipfs-keys-volume
+          secret:
+            secretName: {{ .Values.keysSecretName }}
+      {{- end }}
+  {{- end }}
 
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
@@ -59,8 +77,4 @@ spec:
         storageClassName: "{{ .Values.persistence.storageClass }}"
       {{- end }}
       {{- end }}
-  {{- else }}
-      volumes:
-        - name: ipfs-storage
-          emptyDir: {}
   {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
An IPFS node may require pre-created shared keys in order to publish names on the IPFS network. This PR adds the `keysSecretName` configurable option for adding keys to `/data/ipfs/keystore` from Kubernetes Secrets.

**Special notes for your reviewer**:
@yuvipanda, thanks for the excellent chart. I hope my additions are useful to others as well.