### PR TITLE
Concourse Worker livenessProbe timeout

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 1.16.1
+version: 1.16.2
 appVersion: 3.14.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -66,6 +66,7 @@ spec:
             failureThreshold: 1
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
Under high worker load the livenessProbe default timeout of 1 sec is not enough and k8s triggers a restart of the worker, even it's working properly. Setting the timeout to 5 sec to minimise unwanted restarts.