### PR TITLE
[stable/kiam] Adding Prometheus metrics service endpoints

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kiam
-version: 2.0.1-rc5
+version: 2.0.1-rc6
 appVersion: 3.0-rc1
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/templates/agent-service.yaml
+++ b/stable/kiam/templates/agent-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agent.enabled -}}
+{{- if and .Values.agent.enabled .Values.agent.prometheus.scrape -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,14 +16,8 @@ spec:
     component: "{{ .Values.agent.name }}"
     release: {{ .Release.Name }}
   ports:
-    {{- if Values.agent.prometheus.scrape }}
     - name: metrics
-      port: {{ Values.agent.prometheus.port }}
-      targetPort: {{ Values.agent.prometheus.port }}
-      protocol: TCP
-    {{- end }}
-    - name: grpc
-      port: {{ .Values.agent.service.port }}
-      targetPort: {{ .Values.agent.service.targetPort }}
+      port: {{ .Values.agent.prometheus.port }}
+      targetPort: {{ .Values.agent.prometheus.port }}
       protocol: TCP
 {{- end }}

--- a/stable/kiam/templates/agent-service.yaml
+++ b/stable/kiam/templates/agent-service.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.agent.enabled .Values.agent.prometheus.scrape -}}
+{{- if .Values.agent.enabled -}}
+{{- if .Values.agent.prometheus.scrape -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,4 +21,5 @@ spec:
       port: {{ .Values.agent.prometheus.port }}
       targetPort: {{ .Values.agent.prometheus.port }}
       protocol: TCP
+{{- end -}}
 {{- end }}

--- a/stable/kiam/templates/agent-service.yaml
+++ b/stable/kiam/templates/agent-service.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.agent.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.agent.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kiam.fullname" . }}-agent
+spec:
+  clusterIP: None
+  selector:
+    app: {{ template "kiam.name" . }}
+    component: "{{ .Values.agent.name }}"
+    release: {{ .Release.Name }}
+  ports:
+    {{- if Values.agent.prometheus.scrape }}
+    - name: metrics
+      port: {{ Values.agent.prometheus.port }}
+      targetPort: {{ Values.agent.prometheus.port }}
+      protocol: TCP
+    {{- end }}
+    - name: grpc
+      port: {{ .Values.agent.service.port }}
+      targetPort: {{ .Values.agent.service.targetPort }}
+      protocol: TCP
+{{- end }}

--- a/stable/kiam/templates/server-service.yaml
+++ b/stable/kiam/templates/server-service.yaml
@@ -16,10 +16,10 @@ spec:
     component: "{{ .Values.server.name }}"
     release: {{ .Release.Name }}
   ports:
-    {{- if Values.server.prometheus.scrape }}
+    {{- if .Values.server.prometheus.scrape }}
     - name: metrics
-      port: {{ Values.server.prometheus.port }}
-      targetPort: {{ Values.server.prometheus.port }}
+      port: {{ .Values.server.prometheus.port }}
+      targetPort: {{ .Values.server.prometheus.port }}
       protocol: TCP
     {{- end }}
     - name: grpclb

--- a/stable/kiam/templates/server-service.yaml
+++ b/stable/kiam/templates/server-service.yaml
@@ -16,6 +16,12 @@ spec:
     component: "{{ .Values.server.name }}"
     release: {{ .Release.Name }}
   ports:
+    {{- if Values.server.prometheus.scrape }}
+    - name: metrics
+      port: {{ Values.server.prometheus.port }}
+      targetPort: {{ Values.server.prometheus.port }}
+      protocol: TCP
+    {{- end }}
     - name: grpclb
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Adds `metrics` endpoints for the Kiam agent and server headless services. This is done to enable Prometheus operator to scrape Kiam via a `ServiceMonitor` resource.

**Which issue this PR fixes**: This fixes https://github.com/coreos/prometheus-operator/issues/1899, which I initially raised because this Kiam chart doesn't provide the `metrics` endpoints out of the box to work wtih Prometheus operator setups. 

**Special notes for your reviewer**: If you have a working Prometheus operator setup, the following `ServiceMonitor` definitions are useful for verifying that the changes in this PR work. The values in the `ServiceMonitor` resources below will work with a default setup of [kube-prometheus](https://github.com/coreos/prometheus-operator/tree/master/helm/kube-prometheus).

```yaml
---
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: kiam-server
  namespace: monitoring
  labels:
    prometheus: kube-prometheus
spec:
  jobLabel: kiam-server
  selector:
    matchLabels:
      app: kiam
      component: server
      release: kiam
  namespaceSelector:
    matchNames:
    - monitoring
  endpoints:
  - interval: 15s
    path: /metrics
    port: metrics
---
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: kiam-agent
  namespace: monitoring
  labels:
    prometheus: kube-prometheus
spec:
  jobLabel: kiam-agent
  selector:
    matchLabels:
      app: kiam
      component: agent
      release: kiam
  namespaceSelector:
    matchNames:
    - monitoring
  endpoints:
  - interval: 15s
    path: /metrics
    port: metrics
```

Verification that it works when installed via the Helm chart changes in this PR:

<img width="1155" alt="kiam-prometheus" src="https://user-images.githubusercontent.com/8792243/45634710-6747e280-baa3-11e8-90dd-4e44b0d4c3d4.png">