### PR TITLE
[stable/mongodb-replicaset] fix: mongo init issues

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.5.6
+version: 3.5.7
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -116,7 +116,11 @@ for peer in "${peers[@]}"; do
     if mongo admin --host "$peer" "${admin_creds[@]}" "${ssl_args[@]}" --eval "rs.isMaster()" | grep '"ismaster" : true'; then
         log "Found master: $peer"
         log "Adding myself ($service_name) to replica set..."
-        mongo admin --host "$peer" "${admin_creds[@]}" "${ssl_args[@]}" --eval "rs.add('$service_name')"
+        if mongo admin --host "$peer" "${admin_creds[@]}" "${ssl_args[@]}" --eval "rs.add('$service_name')" | grep 'Quorum check failed'; then
+            log 'Quorum check failed, unable to join replicaset. Exiting prematurely.'
+            shutdown_mongo
+            exit 1
+        fi
 
         sleep 3
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes init issues that cause the init container to wait indefinitely. From testing, this seems to occur because the init container has launched a `mongod` process that is now handling requests being made to the service and returns a `Quorum check failed` when the init script attempts to `rs.add` (which does not get handled properly).

This PR adds a simple check to handle the quorum check failure and exit when it occurs. This allows the init container to try again and successfully join the replicaset.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #6522 

**Special notes for your reviewer**: