### PR TITLE
incubator/elasticsearch: Don't use `localhost` in hooks

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.7.0
+version: 1.7.1
 appVersion: 6.4.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.7.1
+version: 1.7.2
 appVersion: 6.4.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/templates/configmap.yaml
+++ b/incubator/elasticsearch/templates/configmap.yaml
@@ -121,7 +121,7 @@ data:
     NODE_NAME=${HOSTNAME}
     echo "Prepare to migrate data of the node ${NODE_NAME}"
     echo "Move all data from node ${NODE_NAME}"
-    curl -s -XPUT -H 'Content-Type: application/json' 'localhost:9200/_cluster/settings' -d "{
+    curl -s -XPUT -H 'Content-Type: application/json' '{{ template "elasticsearch.client.fullname" . }}:9200/_cluster/settings' -d "{
       \"transient\" :{
           \"cluster.routing.allocation.exclude._name\" : \"${NODE_NAME}\"
       }
@@ -130,7 +130,7 @@ data:
 
     while true ; do
       echo -e "Wait for node ${NODE_NAME} to become empty"
-      SHARDS_ALLOCATION=$(curl -s -XGET 'http://localhost:9200/_cat/shards')
+      SHARDS_ALLOCATION=$(curl -s -XGET 'http://{{ template "elasticsearch.client.fullname" . }}:9200/_cat/shards')
       if ! echo "${SHARDS_ALLOCATION}" | grep -E "${NODE_NAME}"; then
         break
       fi
@@ -141,10 +141,10 @@ data:
     #!/bin/bash
     exec &> >(tee -a "/var/log/elasticsearch-hooks.log")
     NODE_NAME=${HOSTNAME}
-    CLUSTER_SETTINGS=$(curl -s -XGET "http://localhost:9200/_cluster/settings")
+    CLUSTER_SETTINGS=$(curl -s -XGET "http://{{ template "elasticsearch.client.fullname" . }}:9200/_cluster/settings")
     if echo "${CLUSTER_SETTINGS}" | grep -E "${NODE_NAME}"; then
       echo "Activate node ${NODE_NAME}"
-      curl -s -XPUT -H 'Content-Type: application/json' "http://localhost:9200/_cluster/settings" -d "{
+      curl -s -XPUT -H 'Content-Type: application/json' "http://{{ template "elasticsearch.client.fullname" . }}:9200/_cluster/settings" -d "{
         \"transient\" :{
             \"cluster.routing.allocation.exclude._name\" : null
         }

--- a/incubator/elasticsearch/templates/configmap.yaml
+++ b/incubator/elasticsearch/templates/configmap.yaml
@@ -117,6 +117,7 @@ data:
 {{- end }}
   pre-stop-hook.sh: |-
     #!/bin/bash
+    exec &> >(tee -a "/var/log/elasticsearch-hooks.log")
     NODE_NAME=${HOSTNAME}
     echo "Prepare to migrate data of the node ${NODE_NAME}"
     echo "Move all data from node ${NODE_NAME}"
@@ -138,6 +139,7 @@ data:
     echo "Node ${NODE_NAME} is ready to shutdown"
   post-start-hook.sh: |-
     #!/bin/bash
+    exec &> >(tee -a "/var/log/elasticsearch-hooks.log")
     NODE_NAME=${HOSTNAME}
     CLUSTER_SETTINGS=$(curl -s -XGET "http://localhost:9200/_cluster/settings")
     if echo "${CLUSTER_SETTINGS}" | grep -E "${NODE_NAME}"; then


### PR DESCRIPTION
Log hook script output to a file, and use the `Service` to connect to Elasticsearch instead of `localhost` because the latter may not (yet) be available when hooks are executed.

Fixes: https://github.com/helm/charts/issues/7771

Note: this does not include the `set -e` and `curl` retry loop as hinted in #7771.