### PR TITLE
logstash: Adding volumes configuration property for Logstash statefulset

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.9.0
+version: 0.9.1
 appVersion: 6.4.0
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -100,6 +100,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `persistence.accessMode`        | Access mode for PVCs                               | `ReadWriteOnce`                                  |
 | `persistence.size`              | Size for PVCs                                      | `2Gi`                                            |
 | `volumeMounts`                  | Volume mounts to configure for logstash container  | (see `values.yaml`)                              |
+| `volumes`                       | Volumes to configure for logstash container        | []                              |
 | `terminationGracePeriodSeconds` | Duration the pod needs to terminate gracefully     | `30`
 | `exporter.logstash`             | Prometheus logstash-exporter settings              | (see `values.yaml`)                              |
 | `exporter.logstash.enabled`     | Enables Prometheus logstash-exporter               | `false`                                          |

--- a/incubator/logstash/templates/statefulset.yaml
+++ b/incubator/logstash/templates/statefulset.yaml
@@ -77,8 +77,6 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 12 }}
-          volumes:
-{{ toYaml .Values.volumes | indent 12 }}
 
 {{- if .Values.exporter.logstash.enabled }}
         ## logstash-exporter
@@ -112,6 +110,10 @@ spec:
 {{ toYaml .Values.exporter.logstash.resources | indent 12 }}
 {{- end }}
 
+    {{- with .Values.volumes }}
+      volumes:
+{{ toYaml .Values.volumes | indent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/incubator/logstash/templates/statefulset.yaml
+++ b/incubator/logstash/templates/statefulset.yaml
@@ -112,7 +112,7 @@ spec:
 
     {{- with .Values.volumes }}
       volumes:
-{{ toYaml .Values.volumes | indent 8 }}
+{{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/incubator/logstash/templates/statefulset.yaml
+++ b/incubator/logstash/templates/statefulset.yaml
@@ -77,6 +77,8 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 12 }}
+          volumes:
+{{ toYaml .Values.volumes | indent 12 }}
 
 {{- if .Values.exporter.logstash.enabled }}
         ## logstash-exporter

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -143,7 +143,7 @@ volumeMounts:
   - name: pipeline
     mountPath: /usr/share/logstash/pipeline
 
-volumes:
+volumes: []
   # - name: tls
   #   secret:
   #     secretName: logstash-tls

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -143,6 +143,17 @@ volumeMounts:
   - name: pipeline
     mountPath: /usr/share/logstash/pipeline
 
+volumes:
+  # - name: tls
+  #   secret:
+  #     secretName: logstash-tls
+  # - name: pipeline
+  #   configMap:
+  #     name: logstash-pipeline
+  # - name: certs
+  #   hostPath:
+  #     path: /tmp
+
 exporter:
   logstash:
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows users of the Logstash chart to specify `volumes` they wish to define in the Logstash statefulset. This functionality would allow a user to, for example, place custom certificate authorities and configure Logstash to use them.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
None

**Special notes for your reviewer**:
None