### PR TITLE
Prometheus: Fix AlertManager discovery if chart name is not the default

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 7.1.0
+version: 7.1.1
 appVersion: 2.4.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -35,7 +35,7 @@ data:
           regex: {{ $root.Release.Namespace }}
           action: keep
         - source_labels: [__meta_kubernetes_pod_label_app]
-          regex: prometheus
+          regex: {{ template "prometheus.name" $root }}
           action: keep
         - source_labels: [__meta_kubernetes_pod_label_component]
           regex: alertmanager


### PR DESCRIPTION
**What this PR does / why we need it**:

If you deploy Prometheus by passing `--nameOverride=something` to Helm, AlertManager discovery for the Prometheus server stops working - as the `app` label used in the filtering rules were hardcoded to use `prometheus` (the default, if no `--nameOverride` is set).

**Special notes for your reviewer**:

We ran into this issue due to deploying multiple instances of Prometheus to the same cluster here, passing `--nameOverride=[source_branch]` to differentiate them. We discovered that AlertManager was receiving no alerts from Prometheus from our configured alerts, even though they were not triggering - and tracked the issue down to this PR. I've deployed my branch to our test environment, and verified that we're now successfully discovering AlertManager and getting alert notifications as expected.