### PR TITLE
Rendering values.yaml to jobs fails

### DIFF
--- a/stable/jenkins/templates/jobs.yaml
+++ b/stable/jenkins/templates/jobs.yaml
@@ -4,5 +4,5 @@ kind: ConfigMap
 metadata:
   name: {{ template "jenkins.fullname" . }}-jobs
 data:
-{{ .Values.Master.Jobs | indent 2 }}
+{{ toYaml .Values.Master.Jobs | indent 2 }}
 {{- end -}}


### PR DESCRIPTION
due to missing toYaml directive

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Following the ability to add predefined jobs to Jenkins chart, It appears that without the toYaml directive the job description cannot be rendered to jobs.yaml

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
