### PR TITLE
[stable/redis] Do not set annotation field if there is no annotation in master service

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.0.0
+version: 4.0.1
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-svc.yaml
+++ b/stable/redis/templates/redis-master-svc.yaml
@@ -7,9 +7,9 @@ metadata:
     chart: {{ template "redis.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- with .Values.master.service.annotations }}
   annotations:
-{{- if .Values.master.service.annotations }}
-{{ toYaml .Values.master.service.annotations | indent 4 }}
+{{ toYaml . | indent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.master.service.type }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Annotation field in master service is always set even if empty. This does not validate against validation tools like kubeval.
