### PR TITLE
set kapacitor to 1.5.1

### DIFF
--- a/stable/kapacitor/Chart.yaml
+++ b/stable/kapacitor/Chart.yaml
@@ -1,6 +1,6 @@
 name: kapacitor
-version: 1.0.0
-appVersion: 1.6.2
+version: 1.1.0
+appVersion: 1.5.1
 description: InfluxDB's native data processing engine. It can process both stream
   and batch data from InfluxDB.
 keywords:

--- a/stable/kapacitor/README.md
+++ b/stable/kapacitor/README.md
@@ -2,7 +2,7 @@
 
 ##  An Open-Source Time Series ETL and Alerting Engine
 
-[Kapacitor](https://github.com/influxdata/kapacitor) is an open-source framework built by the folks over at [InfluxData](https://influxdata.com) and written in Go for processing, monitoring, and alerting on time series data 
+[Kapacitor](https://github.com/influxdata/kapacitor) is an open-source framework built by the folks over at [InfluxData](https://influxdata.com) and written in Go for processing, monitoring, and alerting on time series data
 
 ## QuickStart
 
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Kapacitor chart and
 | Parameter               | Description                           | Default                                                    |
 | ----------------------- | ----------------------------------    | ---------------------------------------------------------- |
 | `image.repository` | Kapacitor image | `kapacitor` |
-| `image.tag` | Kapacitor image version | `1.6.2-alpine` |
+| `image.tag` | Kapacitor image version | `1.5.1-alpine` |
 | `image.pullPolicy` | Kapacitor image pull policy |  `IfNotPresent` |
 | `service.type` | Kapacitor web service type  | `ClusterIP` |
 | `persistence.enabled` | Enable Kapacitor persistence using Persistent Volume Claims | `false` |

--- a/stable/kapacitor/values.yaml
+++ b/stable/kapacitor/values.yaml
@@ -3,7 +3,7 @@
 ##
 image:
   repository: "kapacitor"
-  tag: "1.6.2-alpine"
+  tag: "1.5.1-alpine"
   pullPolicy: "IfNotPresent"
 
 ## Specify a service type, defaults to NodePort


### PR DESCRIPTION
**What this PR does / why we need it**:
version 1.6.2 looks like was a mistake and it disappears from docker hub. Setting that to 1.5.1




thanks, @cypressious for pointing this out
