### PR TITLE
[incubator/elastic-stack] Upgrade elasticsearch version of elastic-stack

### DIFF
--- a/incubator/elastic-stack/Chart.yaml
+++ b/incubator/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 0.9.0
+version: 0.9.1
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/incubator/elastic-stack/requirements.lock
+++ b/incubator/elastic-stack/requirements.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: elasticsearch
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 1.2.0
+  version: 1.7.2
 - name: kibana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.6.0
+  version: 0.13.1
 - name: logstash
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   version: 0.6.3


### PR DESCRIPTION
@rendhalver @jar361 @christian-roggia 

Upgrade of the elasticsearch requirement of elastic-stack chart is needed (for me in this case) because of this bugfix: https://github.com/helm/charts/commit/ecd2dbbd131de6cf2408250f9389620bbcc4d186
Without this fix on my kubernetes installation this chart is not usable.