### PR TITLE
[stable/kiam] Kiam 3.0 command format

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,6 +1,6 @@
 name: kiam
-version: 1.2.0
-appVersion: 2.8
+version: 2.0.0
+appVersion: 3.0
 description: Integrate AWS IAM with Kubernetes
 keywords:
   - kiam

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -62,7 +62,12 @@ spec:
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           command:
+          {{- if (semverCompare ">=3.0" .Values.agent.image.tag) }}
+            - /kiam
+            - agent
+          {{- else }}
             - /agent
+          {{- end }}
           args:
             {{- if .Values.agent.host.iptables }}
             - --iptables

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -62,7 +62,7 @@ spec:
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           command:
-          {{- if (semverCompare ">=3.0" .Values.agent.image.tag) }}
+          {{- if semverCompare ">=3.0.0-0" .Values.agent.image.tag }}
             - /kiam
             - agent
           {{- else }}

--- a/stable/kiam/templates/server-daemonset.yaml
+++ b/stable/kiam/templates/server-daemonset.yaml
@@ -51,7 +51,7 @@ spec:
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
-          {{- if (semverCompare ">=3.0" .Values.server.image.tag) }}
+          {{- if semverCompare ">=3.0.0-0" .Values.server.image.tag }}
             - /kiam
             - server
           {{- else }}
@@ -103,7 +103,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                {{- if (semverCompare ">=3.0" .Values.server.image.tag) }}
+                {{- if semverCompare ">=3.0.0-0" .Values.server.image.tag }}
                 - /kiam
                 - health
                 {{- else }}
@@ -122,7 +122,7 @@ spec:
           readinessProbe:
             exec:
               command:
-                {{- if (semverCompare ">=3.0" .Values.server.image.tag) }}
+                {{- if semverCompare ">=3.0.0-0" .Values.server.image.tag }}
                 - /kiam
                 - health
                 {{- else }}

--- a/stable/kiam/templates/server-daemonset.yaml
+++ b/stable/kiam/templates/server-daemonset.yaml
@@ -51,7 +51,12 @@ spec:
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
+          {{- if (semverCompare ">=3.0" .Values.server.image.tag) }}
+            - /kiam
+            - server
+          {{- else }}
             - /server
+          {{- end }}
           args:
             {{- if .Values.server.log.jsonOutput }}
             - --json-log
@@ -98,7 +103,12 @@ spec:
           livenessProbe:
             exec:
               command:
+                {{- if (semverCompare ">=3.0" .Values.server.image.tag) }}
+                - /kiam
+                - health
+                {{- else }}
                 - /health
+                {{- end }}
                 - --cert=/etc/kiam/tls/cert
                 - --key=/etc/kiam/tls/key
                 - --ca=/etc/kiam/tls/ca
@@ -112,7 +122,12 @@ spec:
           readinessProbe:
             exec:
               command:
+                {{- if (semverCompare ">=3.0" .Values.server.image.tag) }}
+                - /kiam
+                - health
+                {{- else }}
                 - /health
+                {{- end }}
                 - --cert=/etc/kiam/tls/cert
                 - --key=/etc/kiam/tls/key
                 - --ca=/etc/kiam/tls/ca


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: Upgrades the Kiam chart to use the 3.0 format of the binary. The Helm chart checks what image tag the user specifies (if any), and does a `semverCompare` to change the `command` that is run.

**Which issue this PR fixes**: Fixes https://github.com/uswitch/kiam/issues/156, which was an issue I opened up upon finding that Kiam 2.8 does not export all Prometheus metrics. As of Kiam 3.0, the three separate binaries (`agent`, `server`, `health`) are now subcommands of a single `kiam` binary.

**Special notes for your reviewer**:
* I put the chart version of 2.0.0 since technically this is a breaking change. However, using the `semverCompare` technically does allow backwards compatibility. I'll leave it up to you to determine which version the Helm chart should have.
* This probably should be held until https://github.com/helm/charts/pull/7762 is merged, but it's up to you.