### PR TITLE
Adding node-problem-detector stable chart

### DIFF
--- a/stable/node-problem-detector/.helmignore
+++ b/stable/node-problem-detector/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,0 +1,19 @@
+name: node-problem-detector
+version: "1.0"
+appVersion: v0.5.0
+home: https://github.com/kubernetes/node-problem-detector
+description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes
+icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
+keywords:
+- node
+- problem
+- detector
+- monitoring
+sources:
+- https://github.com/kubernetes/charts/stable/node-problem-detector
+- https://github.com/kubernetes/node-problem-detector
+- https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+maintainers:
+- name: max-rocket-internet
+  email: max.williams@deliveryhero.com
+engine: gotpl

--- a/stable/node-problem-detector/OWNERS
+++ b/stable/node-problem-detector/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- max-rocket-internet
+reviewers:
+- max-rocket-internet

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -34,20 +34,21 @@ Custom System log monitor config files can be created, see [here](https://github
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter                          | Description                     | Default                                                     |
-| ---------------------------------- | --------------------------------|-------------------------------------------------------------|
-| `annotations`                      | Optional daemonset annotations  | `{}`                                                        |
-| `affinity`                         | Map of node/pod affinities      | `{}`                                                        |
-| `settings.log_monitors`            | System log monitor config files | `/config/kernel-monitor.json`,`/config/docker-monitor.json` |
-| `image.repository`                 | Image                           | `k8s.gcr.io/node-problem-detector`                          |
-| `image.tag`                        | Image tag                       | `v0.5.0`                                                    |
-| `image.pullPolicy`                 | Image pull policy               | `IfNotPresent`                                              |
-| `rbac.create`                      | RBAC                            | `true`                                                      |
-| `resources.limits.cpu`             | CPU limit                       | `200m`                                                      |
-| `resources.limits.memory`          | Memory limit                    | `100Mi`                                                     |
-| `resources.requests.cpu`           | CPU request                     | `20m`                                                       |
-| `resources.requests.memory`        | Memory request                  | `20Mi`                                                      |
-| `tolerations`                      | Optional daemonset tolerations  | `{}`                                                        |
+| Parameter               | Description                                | Default                                                      |
+| ------------------------|--------------------------------------------|--------------------------------------------------------------|
+| `affinity`              | Map of node/pod affinities                 | `{}`                                                         |
+| `annotations`           | Optional daemonset annotations             | `{}`                                                         |
+| `fullnameOverride`      | Override the fullname of the chart         | `nil`                                                        |
+| `image.pullPolicy`      | Image pull policy                          | `IfNotPresent`                                               |
+| `image.repository`      | Image                                      | `k8s.gcr.io/node-problem-detector`                           |
+| `image.tag`             | Image tag                                  | `v0.5.0`                                                     |
+| `nameOverride`          | Override the name of the chart             | `nil`                                                        |
+| `rbac.create`           | RBAC                                       | `true`                                                       |
+| `resources`             | Pod resource requests and limits           | `{}`                                                         |
+| `settings.log_monitors` | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
+| `serviceAccount.create` | Whether a ServiceAccount should be created | `true`                                                       |
+| `serviceAccount.name`   | Name of the ServiceAccount to create       | Generated value from template                                |
+| `tolerations`           | Optional daemonset tolerations             | `[]`                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -37,6 +37,7 @@ The following table lists the configurable parameters for this chart and their d
 | Parameter                          | Description                     | Default                                                     |
 | ---------------------------------- | --------------------------------|-------------------------------------------------------------|
 | `annotations`                      | Optional daemonset annotations  | `NULL`                                                      |
+| `affinity`                         | Map of node/pod affinities      | `{}`                                                        |
 | `settings.log_monitors`            | System log monitor config files | `/config/kernel-monitor.json`,`/config/docker-monitor.json` |
 | `image.repository`                 | Image                           | `k8s.gcr.io/node-problem-detector`                          |
 | `image.tag`                        | Image tag                       | `v0.5.0`                                                    |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -36,7 +36,7 @@ The following table lists the configurable parameters for this chart and their d
 
 | Parameter                          | Description                     | Default                                                     |
 | ---------------------------------- | --------------------------------|-------------------------------------------------------------|
-| `annotations`                      | Optional daemonset annotations  | `NULL`                                                      |
+| `annotations`                      | Optional daemonset annotations  | `{}`                                                        |
 | `affinity`                         | Map of node/pod affinities      | `{}`                                                        |
 | `settings.log_monitors`            | System log monitor config files | `/config/kernel-monitor.json`,`/config/docker-monitor.json` |
 | `image.repository`                 | Image                           | `k8s.gcr.io/node-problem-detector`                          |
@@ -47,7 +47,7 @@ The following table lists the configurable parameters for this chart and their d
 | `resources.limits.memory`          | Memory limit                    | `100Mi`                                                     |
 | `resources.requests.cpu`           | CPU request                     | `20m`                                                       |
 | `resources.requests.memory`        | Memory request                  | `20Mi`                                                      |
-| `tolerations`                      | Optional daemonset tolerations  | `NULL`                                                      |
+| `tolerations`                      | Optional daemonset tolerations  | `{}`                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -1,0 +1,55 @@
+# Kubernetes Node Problem Detector
+
+This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
+
+## TL;DR;
+
+```console
+$ helm install stable/node-problem-detector
+```
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` and default configuration:
+
+```console
+$ helm install --name my-release stable/node-problem-detector
+```
+
+## Uninstalling the Chart
+
+To delete the chart:
+
+```console
+$ helm delete my-release
+```
+
+## Configuration
+
+Custom System log monitor config files can be created, see [here](https://github.com/kubernetes/node-problem-detector/tree/master/config) for examples.
+
+The following table lists the configurable parameters for this chart and their default values.
+
+| Parameter                          | Description                     | Default                                                     |
+| ---------------------------------- | --------------------------------|-------------------------------------------------------------|
+| `annotations`                      | Optional daemonset annotations  | `NULL`                                                      |
+| `settings.log_monitors`            | System log monitor config files | `/config/kernel-monitor.json`,`/config/docker-monitor.json` |
+| `image.repository`                 | Image                           | `k8s.gcr.io/node-problem-detector`                          |
+| `image.tag`                        | Image tag                       | `v0.5.0`                                                    |
+| `image.pullPolicy`                 | Image pull policy               | `IfNotPresent`                                              |
+| `rbac.create`                      | RBAC                            | `true`                                                      |
+| `resources.limits.cpu`             | CPU limit                       | `200m`                                                      |
+| `resources.limits.memory`          | Memory limit                    | `100Mi`                                                     |
+| `resources.requests.cpu`           | CPU request                     | `20m`                                                       |
+| `resources.requests.memory`        | Memory request                  | `20Mi`                                                      |
+| `tolerations`                      | Optional daemonset tolerations  | `NULL`                                                      |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
+
+```console
+$ helm install --name my-release stable/node-problem-detector --values values.yaml
+```

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -10,7 +10,7 @@ $ helm install stable/node-problem-detector
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.9+ with Beta APIs enabled
 
 ## Installing the Chart
 

--- a/stable/node-problem-detector/templates/NOTES.txt
+++ b/stable/node-problem-detector/templates/NOTES.txt
@@ -1,3 +1,3 @@
 To verify that the node-problem-detector pods have started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ .Chart.Name }},release={{ .Release.Name }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "node-problem-detector.name" . }},release={{ .Release.Name }}"

--- a/stable/node-problem-detector/templates/NOTES.txt
+++ b/stable/node-problem-detector/templates/NOTES.txt
@@ -1,3 +1,3 @@
 To verify that the node-problem-detector pods have started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "node-problem-detector.name" . }},release={{ .Release.Name }}"
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "node-problem-detector.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/stable/node-problem-detector/templates/NOTES.txt
+++ b/stable/node-problem-detector/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that the node-problem-detector pods have started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ .Chart.Name }},release={{ .Release.Name }}"

--- a/stable/node-problem-detector/templates/_helpers.tpl
+++ b/stable/node-problem-detector/templates/_helpers.tpl
@@ -28,3 +28,12 @@ release: {{.Release.Name }}
 {{ toYaml .Values.podLabels }}
 {{- end }}
 {{- end }}
+
+{{/* Create the name of the service account to use */}}
+{{- define "node-problem-detector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "node-problem-detector.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/node-problem-detector/templates/_helpers.tpl
+++ b/stable/node-problem-detector/templates/_helpers.tpl
@@ -1,4 +1,5 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{/*
 Expand the name of the chart.
 */}}
@@ -9,14 +10,26 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "node-problem-detector.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if ne $name .Release.Name -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "node-problem-detector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* Generate basic labels */}}
@@ -32,8 +45,8 @@ release: {{.Release.Name }}
 {{/* Create the name of the service account to use */}}
 {{- define "node-problem-detector.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "node-problem-detector.fullname" .) .Values.serviceAccount.name }}
+{{ default (include "node-problem-detector.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+{{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/stable/node-problem-detector/templates/_helpers.tpl
+++ b/stable/node-problem-detector/templates/_helpers.tpl
@@ -1,0 +1,30 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "node-problem-detector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "node-problem-detector.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if ne $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "node-problem-detector.labels" }}
+app: {{ template "node-problem-detector.name" . }}
+heritage: {{.Release.Service }}
+release: {{.Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}

--- a/stable/node-problem-detector/templates/_helpers.tpl
+++ b/stable/node-problem-detector/templates/_helpers.tpl
@@ -32,16 +32,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/* Generate basic labels */}}
-{{- define "node-problem-detector.labels" }}
-app: {{ template "node-problem-detector.name" . }}
-heritage: {{.Release.Service }}
-release: {{.Release.Name }}
-{{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels }}
-{{- end }}
-{{- end }}
-
 {{/* Create the name of the service account to use */}}
 {{- define "node-problem-detector.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}

--- a/stable/node-problem-detector/templates/clusterrole.yaml
+++ b/stable/node-problem-detector/templates/clusterrole.yaml
@@ -4,10 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "node-problem-detector.fullname" . }}
   labels:
-    app: {{ template "node-problem-detector.name" . }}
-    chart: {{ template "node-problem-detector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/node-problem-detector/templates/clusterrole.yaml
+++ b/stable/node-problem-detector/templates/clusterrole.yaml
@@ -5,11 +5,13 @@ metadata:
   name: {{ template "node-problem-detector.fullname" . }}
   labels:
     app: {{ template "node-problem-detector.name" . }}
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
+    chart: {{ template "node-problem-detector.chart" . }}
     release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
 - apiGroups:
   - ""

--- a/stable/node-problem-detector/templates/clusterrole.yaml
+++ b/stable/node-problem-detector/templates/clusterrole.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}
+  labels:
+    app: {{ template "node-problem-detector.name" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+{{- end -}}

--- a/stable/node-problem-detector/templates/clusterrolebinding.yaml
+++ b/stable/node-problem-detector/templates/clusterrolebinding.yaml
@@ -5,11 +5,13 @@ metadata:
   name: {{ template "node-problem-detector.fullname" . }}
   labels:
     app: {{ template "node-problem-detector.name" . }}
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
+    chart: {{ template "node-problem-detector.chart" . }}
     release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 subjects:
 - kind: ServiceAccount
   name: {{ template "node-problem-detector.fullname" . }}

--- a/stable/node-problem-detector/templates/clusterrolebinding.yaml
+++ b/stable/node-problem-detector/templates/clusterrolebinding.yaml
@@ -4,17 +4,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "node-problem-detector.fullname" . }}
   labels:
-    app: {{ template "node-problem-detector.name" . }}
-    chart: {{ template "node-problem-detector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "node-problem-detector.fullname" . }}
+  name: {{ template "node-problem-detector.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/stable/node-problem-detector/templates/clusterrolebinding.yaml
+++ b/stable/node-problem-detector/templates/clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}
+  labels:
+    app: {{ template "node-problem-detector.name" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "node-problem-detector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "node-problem-detector.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -16,12 +16,11 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
     spec:
-      serviceAccountName: {{ template "node-problem-detector.fullname" . }}
+      serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
       containers:
       - name: npd
         image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-
         command:
         - "/bin/sh"
         - "-c"

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -1,15 +1,26 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  labels: {{ include "node-problem-detector.labels" . | indent 4 }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  name: {{ template "node-problem-detector.fullname" . }}
+  name: {{ include "node-problem-detector.fullname" . }}
+  labels:
+    app: {{ template "node-problem-detector.name" . }}
+    chart: {{ template "node-problem-detector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   selector:
-    matchLabels: {{ include "node-problem-detector.labels" . | indent 8 }}
+    matchLabels:
+      app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      labels: {{ include "node-problem-detector.labels" . | indent 8 }}
+      labels:
+        app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
 {{- if .Values.annotations }}
@@ -18,7 +29,7 @@ spec:
     spec:
       serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
       containers:
-      - name: npd
+      - name: {{ .Chart.Name }}
         image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         command:
@@ -53,3 +64,5 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
+      affinity:
+{{ toYaml . | indent 8 }}

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -3,10 +3,6 @@ kind: DaemonSet
 metadata:
   name: {{ include "node-problem-detector.fullname" . }}
   labels:
-    app: {{ template "node-problem-detector.name" . }}
-    chart: {{ template "node-problem-detector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "node-problem-detector.fullname" . }}

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -25,40 +25,42 @@ spec:
     spec:
       serviceAccountName: {{ template "node-problem-detector.serviceAccountName" . }}
       containers:
-      - name: {{ .Chart.Name }}
-        image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-        command:
-        - "/bin/sh"
-        - "-c"
-        - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }}"
-        securityContext:
-          privileged: true
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-        volumeMounts:
-        - name: log
-          mountPath: /var/log
-        - name: localtime
-          mountPath: /etc/localtime
-          readOnly: true
-      terminationGracePeriodSeconds: 30
-      volumes:
-      - name: log
-        hostPath:
-          path: /var/log/
-      - name: localtime
-        hostPath:
-          path: /etc/localtime
-          type: "FileOrCreate"
-{{- if .Values.tolerations }}
-      tolerations:
-{{ toYaml .Values.tolerations | indent 6 }}
-{{- end }}
+        - name: {{ .Chart.Name }}
+          image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }}"
+          securityContext:
+            privileged: true
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: log
+              mountPath: /var/log
+            - name: localtime
+              mountPath: /etc/localtime
+              readOnly: true
+          terminationGracePeriodSeconds: 30
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: log
+          hostPath:
+            path: /var/log/
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+            type: "FileOrCreate"

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -1,0 +1,56 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels: {{ include "node-problem-detector.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "node-problem-detector.fullname" . }}
+spec:
+  selector:
+    matchLabels: {{ include "node-problem-detector.labels" . | indent 8 }}
+  template:
+    metadata:
+      labels: {{ include "node-problem-detector.labels" . | indent 8 }}
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "node-problem-detector.fullname" . }}
+      containers:
+      - name: npd
+        image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }}"
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: log
+          mountPath: /var/log
+        - name: localtime
+          mountPath: /etc/localtime
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: log
+        hostPath:
+          path: /var/log/
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+          type: "FileOrCreate"
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}

--- a/stable/node-problem-detector/templates/serviceaccount.yaml
+++ b/stable/node-problem-detector/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,3 +10,4 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- end -}}

--- a/stable/node-problem-detector/templates/serviceaccount.yaml
+++ b/stable/node-problem-detector/templates/serviceaccount.yaml
@@ -5,9 +5,11 @@ metadata:
   name: {{ template "node-problem-detector.fullname" . }}
   labels:
     app: {{ template "node-problem-detector.name" . }}
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
+    chart: {{ template "node-problem-detector.chart" . }}
     release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/stable/node-problem-detector/templates/serviceaccount.yaml
+++ b/stable/node-problem-detector/templates/serviceaccount.yaml
@@ -2,12 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "node-problem-detector.fullname" . }}
+  name: {{ template "node-problem-detector.serviceAccountName" . }}
   labels:
-    app: {{ template "node-problem-detector.name" . }}
-    chart: {{ template "node-problem-detector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/node-problem-detector/templates/serviceaccount.yaml
+++ b/stable/node-problem-detector/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "node-problem-detector.fullname" . }}
+  labels:
+    app: {{ template "node-problem-detector.name" . }}
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -8,6 +8,9 @@ image:
   tag: v0.5.0
   pullPolicy: IfNotPresent
 
+nameOverride: ""
+fullnameOverride: ""
+
 rbac:
   create: true
 
@@ -32,3 +35,5 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+affinity: {}

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -25,3 +25,10 @@ tolerations: {}
   # - key: node-role.kubernetes.io/master
   #   operator: Exists
   #   effect: NoSchedule
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -14,20 +14,11 @@ fullnameOverride: ""
 rbac:
   create: true
 
-resources:
-  limits:
-    cpu: "200m"
-    memory: "100Mi"
-  requests:
-    cpu: "20m"
-    memory: "20Mi"
+resources: {}
 
 annotations: {}
 
-tolerations: {}
-  # - key: node-role.kubernetes.io/master
-  #   operator: Exists
-  #   effect: NoSchedule
+tolerations: []
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -1,0 +1,27 @@
+settings:
+  log_monitors:
+    - /config/kernel-monitor.json
+    - /config/docker-monitor.json
+
+image:
+  repository: k8s.gcr.io/node-problem-detector
+  tag: v0.5.0
+  pullPolicy: IfNotPresent
+
+rbac:
+  create: true
+
+resources:
+  limits:
+    cpu: "200m"
+    memory: "100Mi"
+  requests:
+    cpu: "20m"
+    memory: "20Mi"
+
+annotations: {}
+
+tolerations: {}
+  # - key: node-role.kubernetes.io/master
+  #   operator: Exists
+  #   effect: NoSchedule


### PR DESCRIPTION
I would like to add a chart for the node-problem-detector:
https://github.com/kubernetes/node-problem-detector

This tool is already in the [cluster addons repo](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/node-problem-detector) for some time now.

