### PR TITLE
Enhanced ingress configuration on anchore-engine chart

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,5 +1,5 @@
 name: anchore-engine
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.2.4
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/ingress.yaml
+++ b/stable/anchore-engine/templates/ingress.yaml
@@ -14,12 +14,30 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+{{- if .Values.ingress.hosts }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $.Values.ingress.path }}
+            backend:
+              serviceName: "{{ template "fullname" $ }}"
+              servicePort: {{ $.Values.service.ports.api }}
+  {{- end }}
+{{- else }}
   backend:
     serviceName: {{ template "fullname" . }}
     servicePort: {{ .Values.service.ports.api }}
-{{- if .Values.ingress.tls }}
-  tls:
-{{ toYaml .Values.ingress.tls | indent 2 }}
 {{- end }}
-
 {{- end -}}

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -18,14 +18,19 @@ image:
 # Used to create Ingress record (should used with service.type: ClusterIP or NodePort depending on platform)
 ingress:
   enabled: false
-  annotations:
+  annotations: {}
     # kubernetes.io/ingress.allow-http: False
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: true
-
+  path: /
+  # You can bound on specific hostnames
+  # hosts:
+  #   - chart-example.local
+  tls: []
   # Secrets must be manually created in the namespace.
-  tls:
-  # - secretName: tlstestsecret
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 # Dependency on Postgresql, configure here
 postgresql:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows a better way of managing ingress configuration of the ingress for the `anchore-engine` chart.