### PR TITLE
 [stable/suitecrm] Fix chart not being upgradable

### DIFF
--- a/stable/suitecrm/Chart.yaml
+++ b/stable/suitecrm/Chart.yaml
@@ -1,5 +1,5 @@
 name: suitecrm
-version: 2.0.7
+version: 3.0.0
 appVersion: 7.10.9
 description: SuiteCRM is a completely open source enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 keywords:

--- a/stable/suitecrm/README.md
+++ b/stable/suitecrm/README.md
@@ -135,6 +135,6 @@ Backwards compatibility is not guaranteed unless you modify the labels used on t
 Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is suitecrm:
 
 ```console
-$ kubectl patch deployment suitecrm-suitecrm --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/app"}]'
+$ kubectl patch deployment suitecrm-suitecrm --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
 $ kubectl delete statefulset suitecrm-mariadb --cascade=false
 ```

--- a/stable/suitecrm/README.md
+++ b/stable/suitecrm/README.md
@@ -126,3 +126,15 @@ The [Bitnami SuiteCRM](https://github.com/bitnami/bitnami-docker-suitecrm) image
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is suitecrm:
+
+```console
+$ kubectl patch deployment suitecrm-suitecrm --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/app"}]'
+$ kubectl delete statefulset suitecrm-mariadb --cascade=false
+```

--- a/stable/suitecrm/templates/deployment.yaml
+++ b/stable/suitecrm/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #5657
Chart was not being upgradable

Special notes for your reviewer:

