### PR TITLE
[stable/phpbb] Fix chart not being upgradable

### DIFF
--- a/stable/phpbb/Chart.yaml
+++ b/stable/phpbb/Chart.yaml
@@ -1,5 +1,5 @@
 name: phpbb
-version: 2.0.4
+version: 3.0.0
 appVersion: 3.2.3
 description: Community forum that supports the notion of users and groups, file attachments,
   full-text search, notifications and more.

--- a/stable/phpbb/README.md
+++ b/stable/phpbb/README.md
@@ -105,3 +105,15 @@ The [Bitnami phpBB](https://github.com/bitnami/bitnami-docker-phpbb) image store
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is phpbb:
+
+```console
+$ kubectl patch deployment phpbb-phpbb --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl delete statefulset phpbb-mariadb --cascade=false
+```

--- a/stable/phpbb/templates/deployment.yaml
+++ b/stable/phpbb/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "phpbb.fullname" . }}
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #5657
Chart was not being upgradable

Special notes for your reviewer:

