### PR TITLE
traefik - enabled dash port on prometheus condition

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.43.0
+version: 1.43.1
 appVersion: 1.6.6
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -114,7 +114,7 @@ spec:
           hostPort: 443
           {{- end }}
           protocol: TCP
-        {{- if .Values.dashboard.enabled }}
+        {{- if or .Values.dashboard.enabled .Values.metrics.prometheus.enabled }}
         - name: dash
           containerPort: 8080
           {{- if .Values.deployment.hostPort.dashboardEnabled }}


### PR DESCRIPTION
**What this PR does / why we need it**:
In case we enable prometheus and not the dashboard, the dash port is not open (8080) so prometheus is not accessible.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
