### PR TITLE
[stable/mailhog] add runAsUser to allow using PSP

### DIFF
--- a/stable/mailhog/Chart.yaml
+++ b/stable/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: 1.0.0
-version: 2.2.1
+version: 2.3.0
 keywords:
   - mailhog
   - mail

--- a/stable/mailhog/Chart.yaml
+++ b/stable/mailhog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: An e-mail testing tool for developers
 name: mailhog
 appVersion: 1.0.0
-version: 2.2.0
+version: 2.2.1
 keywords:
   - mailhog
   - mail

--- a/stable/mailhog/templates/deployment.yaml
+++ b/stable/mailhog/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         app: {{ template "mailhog.name" . }}
         release: {{ .Release.Name }}
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
         - name: {{ template "mailhog.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
add runAsUser to allow using PSP with `runAsNonRoot: true`

otherwise yields:

    Error: container has runAsNonRoot and image has non-numeric user (mailhog), cannot verify user is non-root
