### PR TITLE
[stable/mediawiki] Fix chart not being upgradable

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 3.0.6
+version: 4.0.0
 appVersion: 1.31.0
 description: Extremely powerful, scalable software and a feature-rich wiki implementation
   that uses PHP to process and display data stored in a database.

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -132,3 +132,15 @@ The [Bitnami MediaWiki](https://github.com/bitnami/bitnami-docker-mediawiki) ima
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 4.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 4.0.0. The following example assumes that the release name is mediawiki:
+
+```console
+$ kubectl patch deployment mediawiki-mediawiki --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl delete statefulset mediawiki-mariadb --cascade=false
+```

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "mediawiki.fullname" . }}
+      app: {{ template "mediawiki.name" . }}
       release: "{{ .Release.Name }}"
   replicas: 1
   template:

--- a/stable/mediawiki/templates/deployment.yaml
+++ b/stable/mediawiki/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "mediawiki.fullname" . }}
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #5657
Chart was not being upgradable

Special notes for your reviewer:

