### PR TITLE
[stable/cockroachdb] Warn about default disk size, improve NOTES format

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.0.1
+version: 2.0.2
 appVersion: 2.0.6
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -28,6 +28,12 @@ To install the chart with the release name `my-release`:
 helm install --name my-release stable/cockroachdb
 ```
 
+Note that for a production cluster, you are very likely to want to modify the
+`Storage` and `StorageClass` parameters. This chart defaults to just 1 GiB of
+disk space per pod in order for it to work in small environments like Minikube,
+and the default persistent volume `StorageClass` in your environment may not be
+what you want for a database (e.g. on GCE the default is not SSD).
+
 If you are running in secure mode (with configuration parameter `Secure.Enabled`
 set to `true`), then you will have to manually approve the cluster's security
 certificates as the pods are created. You can see the pending

--- a/stable/cockroachdb/templates/NOTES.txt
+++ b/stable/cockroachdb/templates/NOTES.txt
@@ -1,11 +1,13 @@
-CockroachDB can be accessed via port {{ .Values.ExternalGrpcPort }}
-value to) at the following DNS name from within your cluster:
+CockroachDB can be accessed via port {{ .Values.ExternalGrpcPort }} at the
+following DNS name from within your cluster:
+
 {{ .Release.Name }}-public.{{ .Release.Namespace }}.svc.cluster.local
 
 Because CockroachDB supports the PostgreSQL wire protocol, you can connect to
 the cluster using any available PostgreSQL client.
 
 {{- if not .Values.Secure.Enabled }}
+
 For example, you can open up a SQL shell to the cluster by running:
 
     kubectl run -it --rm cockroach-client \
@@ -18,10 +20,14 @@ From there, you can interact with the SQL shell as you would any other SQL shell
 confident that any data you write will be safe and available even if parts of
 your cluster fail.
 {{- else }}
-Note that because the cluster is running in secure mode, any client application that you attempt to connect will either need to have a valid client certificate or a valid username and password. 
+
+Note that because the cluster is running in secure mode, any client application
+that you attempt to connect will either need to have a valid client certificate
+or a valid username and password. 
 {{- end }}
 
-{{ if and (.Values.NetworkPolicy.Enabled) (not .Values.NetworkPolicy.AllowExternal) }}
+{{- if and (.Values.NetworkPolicy.Enabled) (not .Values.NetworkPolicy.AllowExternal) }}
+
 Note: Since NetworkPolicy is enabled, only pods with label
 {{.Release.Name}}-{{.Values.Component}}-client=true"
 will be able to connect to this cockroachdb cluster.
@@ -33,10 +39,20 @@ local machine into one of the instances in the cluster:
     kubectl port-forward {{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}-0 {{ .Values.InternalHttpPort }}
 
 {{- if not .Values.Secure.Enabled }}
+
 Then you can access the admin UI at http://localhost:{{ .Values.InternalHttpPort }}/ in your web browser.
 {{- else }}
+
 Then you can access the admin UI at https://localhost:{{ .Values.InternalHttpPort }}/ in your web browser.
 {{- end }}
 
 For more information on using CockroachDB, please see the project's docs at
 https://www.cockroachlabs.com/docs/
+
+{{- if eq .Values.Storage "1Gi" }}
+
+WARNING: Only 1 GiB of disk space is being requested for each pod. This will
+not be enough for a production custer. Re-install with a customized "Storage"
+parameter if you woud like more disk space.
+
+{{- end }}


### PR DESCRIPTION
The default disk size of 1 GiB can cause mistakes (e.g.
https://stackoverflow.com/q/52245811/1925481), but is needed in
order to work in environments like Minikube.

And I don't know what's going on with the way that line breaks work in
NOTES.txt, but this is what makes it render properly:

> NOTES:
> CockroachDB can be accessed via port 26257 at the
> following DNS name from within your cluster:
> 
> good-arachnid-public.default.svc.cluster.local
> 
> Because CockroachDB supports the PostgreSQL wire protocol, you can connect to
> the cluster using any available PostgreSQL client.
> 
> For example, you can open up a SQL shell to the cluster by running:
> 
>     kubectl run -it --rm cockroach-client \
>         --image=cockroachdb/cockroach \
>         --restart=Never \
>         --command -- ./cockroach sql --insecure --host good-arachnid-cockroachdb-public.default
> 
> From there, you can interact with the SQL shell as you would any other SQL shell,
> confident that any data you write will be safe and available even if parts of
> your cluster fail.
> 
> Finally, to open up the CockroachDB admin UI, you can port-forward from your
> local machine into one of the instances in the cluster:
> 
>     kubectl port-forward good-arachnid-cockroachdb-0 8080
> 
> Then you can access the admin UI at http://localhost:8080/ in your web browser.
> 
> For more information on using CockroachDB, please see the project's docs at
> https://www.cockroachlabs.com/docs/
> 
> WARNING: Only 1 GiB of disk space is being requested for each pod. This will
> not be enough for a production custer. Re-install with a customized "Storage"
> parameter if you woud like more disk space.
> 