### PR TITLE
[stable/nats] Fix chart not being upgradable

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,5 +1,5 @@
 name: nats
-version: 0.1.1
+version: 1.0.0
 appVersion: 1.3.0
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -163,3 +163,14 @@ To horizontally scale this chart, run the following command to scale the number 
 ```console
 $ kubectl scale statefulset my-release-nats --replicas=3
 ```
+
+## Upgrading
+
+### To 1.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 1.0.0. The following example assumes that the release name is nats:
+
+```console
+$ kubectl delete statefulset nats-nats --cascade=false
+```

--- a/stable/nats/templates/statefulset.yaml
+++ b/stable/nats/templates/statefulset.yaml
@@ -19,7 +19,6 @@ spec:
   selector:
     matchLabels:
       app: "{{ template "nats.name" . }}"
-      chart: "{{ template "nats.chart" . }}"
       release: {{ .Release.Name | quote }}
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #5657
Chart was not being upgradable

