### PR TITLE
[incubator/kafka] allow exporter to be scheduled with kafka

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.9.6
+version: 0.9.7
 appVersion: 4.1.2
 keywords:
 - kafka

--- a/incubator/kafka/templates/deployment-kafka-exporter.yaml
+++ b/incubator/kafka/templates/deployment-kafka-exporter.yaml
@@ -35,4 +35,16 @@ spec:
           - containerPort: {{ .Values.prometheus.kafka.port }}
         resources:
 {{ toYaml .Values.prometheus.kafka.resources | indent 10 }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This simply reuses the tolerations, node selector, and affinity values set for the kafka stateful set deployment. It didn't seem necessary to create new values when the exporter would be deployed as part of a kafka cluster deployment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #7835 

**Special notes for your reviewer**:
Tested this in our local deployment and the items were set correctly and the exporter was then able to be scheduled.

@faraazkhan @h0tbird @benjigoldberg 