### PR TITLE
[stable/mongodb] Use .Values.existingSecret for standalone deployments

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 4.3.4
+version: 4.3.5
 appVersion: 4.0.2
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -55,7 +55,7 @@ spec:
         - name: MONGODB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mongodb.fullname" . }}
+              name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
               key: mongodb-root-password
         {{- end }}
         - name: MONGODB_USERNAME
@@ -64,7 +64,7 @@ spec:
         - name: MONGODB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mongodb.fullname" . }}
+              name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
               key: mongodb-password
         {{- end }}
         - name: MONGODB_DATABASE


### PR DESCRIPTION
**What this PR does / why we need it**:
When installing the chart without `.Values.replicaSet.enabled==true`, `.Values.existingSecret` is ignored and the chart attempts to use the name of the chart as the secretKeyRef name.

**Which issue this PR fixes**
Should fix #7169 #6340 #7047 

**Special notes for your reviewer**:
@prydonius @tompizmor @sameersbn @carrodher @juan131 
Let me know if there is anything that needs to be different. This is using the same logic as [statefulset-primary-rs.yaml](https://github.com/helm/charts/blob/26fc524ac4d6c59bec04875c01b1e5edc65043d4/stable/mongodb/templates/statefulset-primary-rs.yaml#L76).
