### PR TITLE
[stable/joomla] Fix chart not being upgradable

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 2.0.9
+version: 3.0.0
 appVersion: 3.8.12
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -134,3 +134,15 @@ The [Bitnami Joomla!](https://github.com/bitnami/bitnami-docker-joomla) image st
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is opencart:
+
+```console
+$ kubectl patch deployment joomla-joomla --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl delete statefulset joomla-mariadb --cascade=false
+```

--- a/stable/joomla/templates/deployment.yaml
+++ b/stable/joomla/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "joomla.fullname" . }}
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #5657
Chart was not being upgradable

