### PR TITLE
[stable/rabbitmq] Fix chart not being upgradable

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 2.2.0
+version: 3.0.0
 appVersion: 3.7.7
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -130,3 +130,14 @@ The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/pers
 ```bash
 $ helm install --set persistence.existingClaim=PVC_NAME rabbitmq
 ```
+
+## Upgrading
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is opencart:
+
+```console
+$ kubectl delete statefulset rabbitmq --cascade=false
+```

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -14,7 +14,6 @@ spec:
     matchLabels:
       app: {{ template "rabbitmq.name" . }}
       release: "{{ .Release.Name }}"
-      chart: {{ template "rabbitmq.chart" .  }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #5657
Chart was not being upgradable

