### PR TITLE
[stable/testlink] Fix chart not being upgradable

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 2.1.0
+version: 3.0.0
 appVersion: 1.9.17
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/stable/testlink/README.md
+++ b/stable/testlink/README.md
@@ -108,3 +108,15 @@ The [Bitnami TestLink](https://github.com/bitnami/bitnami-docker-testlink) image
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is testlink:
+
+```console
+$ kubectl patch deployment testlink-testlink --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+$ kubectl delete statefulset testlink-mariadb --cascade=false
+```

--- a/stable/testlink/templates/deployment.yaml
+++ b/stable/testlink/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #5657
Chart was not being upgradable

