### PR TITLE
[stable/superset] Add service annotations support

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,6 +1,6 @@
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.24.0"
 keywords:
 - bi

--- a/stable/superset/templates/svc.yaml
+++ b/stable/superset/templates/svc.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ template "superset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -96,6 +96,11 @@ service:
   type: ClusterIP
   port: 9000
 
+  ## superset service annotations
+  ##
+  annotations: {}
+  #   service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+
 ingress:
   ## If true, superset Ingress will be created
   ##


### PR DESCRIPTION
Service annotations could be used very broadly, depending on the load balancer provider.

This pull-request is backward compatible, so it should not affect any existing named releases of this chart.