### PR TITLE
[stable/superset] Use the target port number instead of a name

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,6 +1,6 @@
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 1.1.4
+version: 1.1.5
 appVersion: "0.28.1"
 keywords:
 - bi

--- a/stable/superset/templates/svc.yaml
+++ b/stable/superset/templates/svc.yaml
@@ -36,7 +36,7 @@ spec:
   ports:
     - name: http
       port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 8088
       protocol: TCP
       {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{.Values.service.nodePort}}


### PR DESCRIPTION
Older (but still actual) versions of some Network Policy providers don't support named ports as
a value of `targetPort` field in the Service spec:
- Calico < 3.0.0: https://github.com/projectcalico/felix/issues/1685
- Contour < 0.4.0: https://github.com/heptio/contour/issues/175

Changing it to the number shouldn't break the UX for existing installations because the container port 8088 is still hard-coded here: https://github.com/helm/charts/blob/6b518cef4528b96a169f63b2cd086073c8bd08b6/stable/superset/templates/deployment.yaml#L57
