### PR TITLE
[stable/dokuwiki] Fix chart not being upgradable

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: dokuwiki
-version: 2.1.0
+version: 3.0.0
 appVersion: 0.20180422.201805030840
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/stable/dokuwiki/README.md
+++ b/stable/dokuwiki/README.md
@@ -118,3 +118,14 @@ The [Bitnami DokuWiki](https://github.com/bitnami/bitnami-docker-dokuwiki) image
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Configuration](#configuration) section to configure the PVC or to disable persistence.
+
+## Upgrading
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is dokuwiki:
+
+```console
+$ kubectl patch deployment dokuwiki-dokuwiki --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
+```

--- a/stable/dokuwiki/templates/deployment.yaml
+++ b/stable/dokuwiki/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "dokuwiki.name" . }}
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
What this PR does / why we need it:
Add spec.selector.matchLabels without the chart label.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #5657
Chart was not being upgradable