### PR TITLE
[incubator/vault] Add extraVolumeMounts to Vault pod

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.14.0
+version: 0.14.1
 appVersion: 0.11.1
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -80,8 +80,11 @@ spec:
         - name: {{ .secretName }}
           mountPath: {{ .mountPath }}
         {{- end }}
+        {{- if .Values.vault.extraVolumeMounts }}
+{{ toYaml .Values.vault.extraVolumeMounts | indent 8 }}
+        {{- end }}
 {{- if .Values.vault.extraContainers }}
-{{ toYaml .Values.vault.extraContainers | indent 6}}
+{{ toYaml .Values.vault.extraContainers | indent 6 }}
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -131,7 +134,7 @@ spec:
             secretName: {{ .secretName }}
         {{- end }}
 {{- if .Values.vault.extraVolumes }}
-{{ toYaml .Values.vault.extraVolumes | indent 8}}
+{{ toYaml .Values.vault.extraVolumes | indent 8 }}
 {{- end }}
         {{- if .Values.consulAgent.join }}
         - name: consul-data

--- a/incubator/vault/values.yaml
+++ b/incubator/vault/values.yaml
@@ -92,7 +92,23 @@ podAnnotations: {}
 # lifecycle: |
 #   postStart:
 #     exec:
-#       command: ["./unseal -s my-unseal-keys"]
+#       command:
+#       - /bin/sh
+#       - -c
+#       - |
+#         sleep 5
+#         [ -f /vault/unseal-keys/key1 ] || exit 0
+#         for key in /vault/unseal-keys/key1 /vault/unseal-keys/key2 /vault/unseal-keys/key3; do
+#           vault operator unseal -address=http://127.0.0.1:8200 `cat ${key}`
+#         done
+#
+## The example above requires a secret that may be created as such
+# kubectl create secret generic my-unseal-keys \
+#     --from-literal=key1= \
+#     --from-literal=key2= \
+#     --from-literal=key3= \
+#     --from-literal=key4= \
+#     --from-literal=key5=
 
 vault:
   # Only used to enable dev mode. When in dev mode, the rest of this config
@@ -106,28 +122,37 @@ vault:
   # the Kubernetes secret (created outside of this chart), and the mountPath
   # at which it should be mounted in the Vault container.
   customSecrets: []
-    # - secretName: vault-tls
-    #   mountPath: /vault/tls
+  # - secretName: vault-tls
+  #   mountPath: /vault/tls
   #
   # Configure additional environment variables for the Vault containers
-  extraEnv: {}
-  #   - name: VAULT_API_ADDR
-  #     value: "https://vault.internal.domain.name:8200"
-  extraContainers: {}
+  extraEnv: []
+  # - name: VAULT_API_ADDR
+  #   value: "https://vault.internal.domain.name:8200"
+  #
   ## Additional containers to be added to the Vault pod
+  extraContainers: []
   # - name: vault-sidecar
   #   image: vault-sidecar:latest
   #   volumeMounts:
   #   - name: some-mount
   #     mountPath: /some/path
-  extraVolumes: {}
+  #
+  ## Additional volumes to be added to the Vault pod
+  extraVolumes: []
+  # - name: my-unseal-keys
+  #   secret:
+  #     secretName: my-unseal-keys
+  #     optional: true
+  #
+  ## Additional volumeMounts to be added to the Vault pod
+  extraVolumeMounts: []
+  # - mountPath: /vault/unseal-keys
+  #   name: my-unseal-keys
+  #
   # Log level
   # https://www.vaultproject.io/docs/commands/server.html#log-level
   logLevel: "info"
-  ## Additional volumes to the vault pod.
-  # - name: extra-volume
-  #   secret:
-  #     secretName: some-secret
   readiness:
     readyIfSealed: false
     readyIfStandby: true


### PR DESCRIPTION
@jpds 

**What this PR does / why we need it**:

This PR adds `exrtaVolumeMounts` to the Vault pod. The field `extraVolumes` was already present but there was no way to mount them yet. Personally I would like this functionality so that I can mount my unseal-keys as an optional secret, starting the Pods even if the secret has not yet been created. The secret might not have been created yet because Vault has not yet been initialized.

**Special notes for your reviewer**:

I expanded the example `lifecycle` field to demonstrate a method that works for automatic unsealing.