### PR TITLE
Tomcat improvements

### DIFF
--- a/stable/tomcat/Chart.yaml
+++ b/stable/tomcat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: tomcat
 description: Deploy a basic tomcat application server with sidecar as web archive container
 icon: http://tomcat.apache.org/res/images/tomcat.png
-version: 0.1.0
+version: 0.2.0
 appVersion: 7.0
 home: https://github.com/yahavb
 maintainers:

--- a/stable/tomcat/README.md
+++ b/stable/tomcat/README.md
@@ -54,6 +54,8 @@ Parameter                       | Description                           | Defaul
 `service.externalPort`          | Kubernetes service port               | `80`
 `service.internalPort`          | Tomcat front port                     | `8080`
 `service.type`                  | Kubernetes service type               | `LoadBalancer`
+`readinessProbe.path`           | HTTP path to check for readiness      | `/sample`
+`livenessProbe.path`            | HTTP path to check for readiness      | `/sample`
 `resources`                     | CPU/Memory resource requests/limits   | `{}`
 `nodeSelector`                  | Node affinity                         | `{}`
 `tolerations`                   | Node tolerations                      | `{}`

--- a/stable/tomcat/README.md
+++ b/stable/tomcat/README.md
@@ -48,6 +48,7 @@ Parameter                       | Description                           | Defaul
 `image.tomcat.repository`       | Tomact image source repository name   | `tomcat`
 `image.tomcat.tag`              | `tomcat` release tag.                 | `7.0`
 `image.pullPolicy`              | Image pull policy                     | `IfNotPresent`
+`image.pullSecrets`             | Image pull secrets                    | `[]`
 `deploy.directory`              | Webarchive deployment directory       | `/usr/local/tomcat/webapps`
 `service.name`                  | Tomcat service name                   | `http`
 `service.externalPort`          | Kubernetes service port               | `80`

--- a/stable/tomcat/templates/appsrv.yaml
+++ b/stable/tomcat/templates/appsrv.yaml
@@ -44,12 +44,18 @@ spec:
             - containerPort: {{ .Values.service.internalPort }}
               hostPort: 8009
           livenessProbe:
-            exec:
-              command:
-              - cat
-              - /usr/local/tomcat/webapps/sample/index.html
-            initialDelaySeconds: 15
-            periodSeconds: 20  
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- if .Values.image.pullSecrets }}

--- a/stable/tomcat/templates/appsrv.yaml
+++ b/stable/tomcat/templates/appsrv.yaml
@@ -26,6 +26,10 @@ spec:
         - name: war
           image: {{ .Values.image.webarchive.repository }}:{{ .Values.image.webarchive.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "sh"
+            - "-c"
+            - "cp /*.war /app"
           volumeMounts:
             - name: app-volume
               mountPath: /app

--- a/stable/tomcat/templates/appsrv.yaml
+++ b/stable/tomcat/templates/appsrv.yaml
@@ -22,7 +22,7 @@ spec:
       volumes:
         - name: app-volume
           emptyDir: {}
-      containers:
+      initContainers:
         - name: war
           image: {{ .Values.image.webarchive.repository }}:{{ .Values.image.webarchive.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -33,6 +33,7 @@ spec:
           volumeMounts:
             - name: app-volume
               mountPath: /app
+      containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.tomcat.repository }}:{{ .Values.image.tomcat.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/stable/tomcat/templates/appsrv.yaml
+++ b/stable/tomcat/templates/appsrv.yaml
@@ -47,6 +47,10 @@ spec:
             periodSeconds: 20  
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+    {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/tomcat/values.yaml
+++ b/stable/tomcat/values.yaml
@@ -35,6 +35,16 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+readinessProbe:
+  path: "/sample"
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 6
+livenessProbe:
+  path: "/sample"
+  initialDelaySeconds: 60
+  periodSeconds: 30
+
 resources: {}
 #  limits:
 #    cpu: 100m

--- a/stable/tomcat/values.yaml
+++ b/stable/tomcat/values.yaml
@@ -11,6 +11,7 @@ image:
     repository: tomcat
     tag: "7.0"
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 deploy:
   directory: /usr/local/tomcat/webapps


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**This PR improves the Tomcat chart in several ways**:

- `imagePullSecret` can be specified in order to pull the sidecar image from private repos.
- Use `httpGet` as readiness and liveness probe. This is more correct than checking for the existence of a file and also works with newer Tomcat versions where the file resides under a different directory.
- `.war` files are automatically copied from the sidecar so that no `CMD` is required in the sidecar Dockerfile. Moreover sidecar is used as an `initContainer` instead of an ordinary `container`. These changes reflect the latest changes in the [official Kubernetes Tomcat example](https://github.com/kubernetes/examples/blob/master/staging/javaweb-tomcat-sidecar/README.md).