### PR TITLE
[stable/fluent-bit] Fix issue with fluent-bit ES TLS config settings

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.11.1
+version: 0.11.2
 appVersion: 0.13.0
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -76,18 +76,6 @@ data:
 {{- if .Values.backend.es.time_key }}
         Time_Key {{ .Values.backend.es.time_key }}
 {{- end }}
-{{ else if eq .Values.backend.type "splunk" }}
-    [OUTPUT]
-        Name  splunk
-        Match *
-        Host  {{ .Values.backend.splunk.host }}
-        Port  {{ .Values.backend.splunk.port }}
-        Splunk_Token  {{ .Values.backend.splunk.token }}
-        Splunk_Send_Raw {{ .Values.backend.splunk.send_raw}}
-        TLS   {{ .Values.backend.splunk.tls }}
-        TLS.Verify   {{ .Values.backend.splunk.tls_verify }}
-        Message_Key   {{ .Values.backend.splunk.message_key }}
-
 {{- if .Values.backend.es.logstash_prefix }}
         Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}
 {{ else if .Values.backend.es.index }}
@@ -104,6 +92,17 @@ data:
 {{- if .Values.backend.es.tls_ca }}
         tls.ca_file /secure/es-tls-ca.crt
 {{- end }}
+{{ else if eq .Values.backend.type "splunk" }}
+    [OUTPUT]
+       Name  splunk
+       Match *
+       Host  {{ .Values.backend.splunk.host }}
+       Port  {{ .Values.backend.splunk.port }}
+       Splunk_Token  {{ .Values.backend.splunk.token }}
+       Splunk_Send_Raw {{ .Values.backend.splunk.send_raw }}
+       TLS   {{ .Values.backend.splunk.tls }}
+       TLS.Verify   {{ .Values.backend.splunk.tls_verify }}
+       Message_Key   {{ .Values.backend.splunk.message_key }}
 {{- end }}
 
 {{ else if eq .Values.backend.type "http" }}


### PR DESCRIPTION
**What this PR does / why we need it**: With PR #7064, Splunk support was added. Unfortunately, the Splunk template section added to `config.yaml` was placed in the middle of the ES section, and inadvertently absorbed the `backend.es.tls` and `es.tls_ca` blocks.

**Which issue this PR fixes**: fixes #7632

**Special notes for your reviewer**: N/A

_Relevant maintainers_: @kfox1111 @edsiper
