### PR TITLE
[stable/mysql] Fix secret naming convention

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.10.1
+version: 0.10.2
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mysql.fullname" . }}
+              name: {{ template "mysql.secretName" . }}
               key: mysql-root-password
         command: [ 'sh', '-c', 'DATA_SOURCE_NAME="root:$MYSQL_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter' ]
         {{- end }}


### PR DESCRIPTION
I believe https://github.com/helm/charts/pull/5783 missed this secret name update 
(it is using mysql.fullname instead of mysql.secretname)

**What this PR does / why we need it**:
https://github.com/helm/charts/pull/5783 introduced a new parameter "existingSecret" and a template to generate it's name "mysql.secretname".
However, it seems that there was one reference to the secret that didn't get changed and is still using "mysql.fullname" template.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/helm/charts/pull/5783

**Special notes for your reviewer**:
