### PR TITLE
[hlf-ord] Update to Fabric 1.2.0, add TLS certificate secret option

### DIFF
--- a/stable/hlf-ord/Chart.yaml
+++ b/stable/hlf-ord/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Hyperledger Fabric Orderer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-ord
-version: 1.0.10
-appVersion: 1.1.0
+version: 1.1.0
+appVersion: 1.2.0
 keywords:
   - blockchain
   - hyperledger

--- a/stable/hlf-ord/README.md
+++ b/stable/hlf-ord/README.md
@@ -102,6 +102,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `ord.mspID`                        | ID of MSP the Orderer belongs to                 | `OrdererMSP`                                               |
 | `secrets.genesis`                  | Secret containing Genesis Block for orderer      | `hlf--genesis`                                             |
 | `secrets.adminCert`                | Secret containing Orderer Org admin certificate  | `hlf--ord-admincert`                                       |
+| `secrets.caServerTls`              | Secret containing CA Server TLS certificate      | `ca--tls`                                                  |
 | `resources`                        | CPU/Memory resource requests/limits              | `{}`                                                       |
 | `nodeSelector`                     | Node labels for pod assignment                   | `{}`                                                       |
 | `tolerations`                      | Toleration labels for pod assignment             | `[]`                                                       |

--- a/stable/hlf-ord/templates/deployment.yaml
+++ b/stable/hlf-ord/templates/deployment.yaml
@@ -111,8 +111,15 @@ spec:
               # Create TLS certificate for Orderer
               if [ ! -f ${ORDERER_GENERAL_TLS_PRIVATEKEY} ]
               then
-                echo ">\033[0;35m fabric-ca-client enroll -d --enrollment.profile tls -u http://${CA_USERNAME}:${CA_PASSWORD}@http://${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-ord.fullname" . }} \033[0m"
+
+                {{- if .Values.secrets.caServerTls }}
+                echo ">\033[0;35m fabric-ca-client enroll -d --enrollment.profile tls -u https://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-ord.fullname" . }} --tls.certfiles /hl_config/ca_server/tls/tls.crt \033[0m"
+                fabric-ca-client enroll -d --enrollment.profile tls -u https://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-ord.fullname" . }} --tls.certfiles /hl_config/ca_server/tls/tls.crt
+                {{- else }}
+                echo ">\033[0;35m fabric-ca-client enroll -d --enrollment.profile tls -u http://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-ord.fullname" . }} \033[0m"
                 fabric-ca-client enroll -d --enrollment.profile tls -u http://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-ord.fullname" . }}
+                {{- end }}
+
 
                 mkdir -p $(dirname $ORDERER_GENERAL_TLS_PRIVATEKEY)
                 cp /tmp/tls/keystore/* $ORDERER_GENERAL_TLS_PRIVATEKEY

--- a/stable/hlf-ord/templates/deployment.yaml
+++ b/stable/hlf-ord/templates/deployment.yaml
@@ -23,12 +23,22 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+        {{- if .Values.secrets.genesis }}
         - name: genesis
           secret:
             secretName: {{ .Values.secrets.genesis }}
+        {{- end }}
+        {{- if .Values.secrets.adminCert }}
         - name: admin-cert
           secret:
             secretName: {{ .Values.secrets.adminCert }}
+        {{- end }}
+
+        {{- if .Values.secrets.caServerTls }}
+        - name: ca-server-tls
+          secret:
+            secretName: {{ .Values.secrets.caServerTls }}
+        {{- end }}
       containers:
         - name: orderer
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -73,8 +83,13 @@ spec:
 
               while [ ! -f ${ORDERER_GENERAL_LOCALMSPDIR}/signcerts/cert.pem ];
               do
+                {{- if .Values.secrets.caServerTls }}
+                echo ">\033[0;35m fabric-ca-client enroll -d -u https://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M ${ORDERER_GENERAL_LOCALMSPDIR} --tls.certfiles /hl_config/ca_server/tls/tls.crt \033[0m"
+                fabric-ca-client enroll -d -u https://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M ${ORDERER_GENERAL_LOCALMSPDIR} --tls.certfiles /hl_config/ca_server/tls/tls.crt
+                {{- else }}
                 echo ">\033[0;35m fabric-ca-client enroll -d -u http://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M ${ORDERER_GENERAL_LOCALMSPDIR} \033[0m"
                 fabric-ca-client enroll -d -u http://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M ${ORDERER_GENERAL_LOCALMSPDIR}
+                {{- end }}
 
                 if [ ! -f ${ORDERER_GENERAL_LOCALMSPDIR}/signcerts/cert.pem ]
                 then
@@ -124,12 +139,20 @@ spec:
           volumeMounts:
             - mountPath: /var/hyperledger
               name: data
+            {{- if .Values.secrets.genesis }}
             - mountPath: /hl_config/genesis
               name: genesis
+            {{- end }}
+            {{- if .Values.secrets.adminCert }}
             - mountPath: /hl_config/admin/admincerts
               name: admin-cert
             - mountPath: /hl_config/admin/signcerts
               name: admin-cert
+            {{- end }}
+            {{- if .Values.secrets.caServerTls }}
+            - mountPath: /hl_config/ca_server/tls
+              name: ca-server-tls
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/hlf-ord/values.yaml
+++ b/stable/hlf-ord/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: hyperledger/fabric-orderer
-  tag: x86_64-1.1.0
+  tag: 1.2.0
   pullPolicy: IfNotPresent
 
 service:
@@ -38,7 +38,7 @@ caUsername: ord1
 
 ord:
   # Tools version
-  hlfToolsVersion: 1.1.0
+  hlfToolsVersion: 1.2.0
   ## Type of Orderer, `solo` or `kafka`
   type: solo
   ## MSP ID of the Orderer
@@ -51,6 +51,8 @@ secrets: {}
   ## This should contain the Certificate of the Orderer Organisation admin
   ## This is necessary to successfully run the orderer
   # adminCert: hlf--ord-admincert
+  ## This should contain the CA server's TLS details under the key tls.crt (e.g. a Let's Encrypt Certificate PEM)
+  # caServerTls: ca--tls
 
 resources: {}
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Signed-off-by: Alejandro Vicente Grabovetsky <sasha@aid.technology>

#### What this PR does / why we need it:

#### Which issue this PR fixes

Updates from Fabric 1.1.0 to Fabric 1.2.0. Adds TLS certificate option necessary for using with Fabric CA Client 1.2

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
