### PR TITLE
[hlf-peer] Update to Fabric 1.2.0, add TLS certificate secret option

### DIFF
--- a/stable/hlf-peer/Chart.yaml
+++ b/stable/hlf-peer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Hyperledger Fabric Peer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-peer
-version: 1.0.9
-appVersion: 1.1.0
+version: 1.1.0
+appVersion: 1.2.0
 keywords:
   - blockchain
   - hyperledger

--- a/stable/hlf-peer/README.md
+++ b/stable/hlf-peer/README.md
@@ -95,6 +95,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `secrets.channel`                  | Secret containing Channel tx for peer to create/join | ``                                                         |
 | `secrets.adminCert`                | Secret containing Peer Org admin certificate         | ``                                                         |
 | `secrets.adminCert`                | Secret containing Peer Org admin private key         | ``                                                         |
+| `secrets.caServerTls`              | Secret containing CA Server TLS certificate      | `ca--tls`                                                  |
 | `resources`                        | CPU/Memory resource requests/limits                  | `{}`                                                       |
 | `nodeSelector`                     | Node labels for pod assignment                       | `{}`                                                       |
 | `tolerations`                      | Toleration labels for pod assignment                 | `[]`                                                       |

--- a/stable/hlf-peer/templates/deployment.yaml
+++ b/stable/hlf-peer/templates/deployment.yaml
@@ -118,8 +118,13 @@ spec:
               # Create TLS certificate for Peer
               if [ ! -f ${CORE_PEER_TLS_PRIVATEKEY} ]
               then
-                echo ">\033[0;35m fabric-ca-client enroll -d --enrollment.profile tls -u http://${CA_USERNAME}:${CA_PASSWORD}@http://${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-peer.fullname" . }} \033[0m"
+                {{- if .Values.secrets.caServerTls }}
+                echo ">\033[0;35m fabric-ca-client enroll -d --enrollment.profile tls -u https://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-peer.fullname" . }} --tls.certfiles /hl_config/ca_server/tls/tls.crt \033[0m"
+                fabric-ca-client enroll -d --enrollment.profile tls -u https://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-peer.fullname" . }} --tls.certfiles /hl_config/ca_server/tls/tls.crt
+                {{- else }}
+                echo ">\033[0;35m fabric-ca-client enroll -d --enrollment.profile tls -u http://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-peer.fullname" . }} \033[0m"
                 fabric-ca-client enroll -d --enrollment.profile tls -u http://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M /tmp/tls --csr.hosts {{ include "hlf-peer.fullname" . }}
+                {{- end }}
 
                 mkdir -p $(dirname $CORE_PEER_TLS_PRIVATEKEY)
                 cp /tmp/tls/keystore/* $CORE_PEER_TLS_PRIVATEKEY

--- a/stable/hlf-peer/templates/deployment.yaml
+++ b/stable/hlf-peer/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
           secret:
             secretName: {{ .Values.secrets.adminKey }}
         {{- end }}
+        {{- if .Values.secrets.caServerTls }}
+        - name: ca-server-tls
+          secret:
+            secretName: {{ .Values.secrets.caServerTls }}
+        {{- end }}
       containers:
         - name: peer
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -85,8 +90,13 @@ spec:
 
               while [ ! -f ${CORE_PEER_MSPCONFIGPATH}/signcerts/cert.pem ];
               do
+                {{- if .Values.secrets.caServerTls }}
+                echo ">\033[0;35m fabric-ca-client enroll -d -u https://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M ${CORE_PEER_MSPCONFIGPATH} --tls.certfiles /hl_config/ca_server/tls/tls.crt \033[0m"
+                fabric-ca-client enroll -d -u https://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M ${CORE_PEER_MSPCONFIGPATH} --tls.certfiles /hl_config/ca_server/tls/tls.crt
+                {{- else }}
                 echo ">\033[0;35m fabric-ca-client enroll -d -u http://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M ${CORE_PEER_MSPCONFIGPATH} \033[0m"
                 fabric-ca-client enroll -d -u http://${CA_USERNAME}:${CA_PASSWORD}@${CA_ADDRESS} -M ${CORE_PEER_MSPCONFIGPATH}
+                {{- end }}
 
                 if [ ! -f ${CORE_PEER_MSPCONFIGPATH}/signcerts/cert.pem ]
                 then
@@ -154,6 +164,10 @@ spec:
             {{- if .Values.secrets.adminKey }}
             - mountPath: /hl_config/admin/keystore
               name: admin-key
+            {{- end }}
+            {{- if .Values.secrets.caServerTls }}
+            - mountPath: /hl_config/ca_server/tls
+              name: ca-server-tls
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/stable/hlf-peer/values.yaml
+++ b/stable/hlf-peer/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: hyperledger/fabric-peer
-  tag: x86_64-1.1.0
+  tag: 1.2.0
   pullPolicy: IfNotPresent
 
 service:
@@ -39,7 +39,7 @@ caUsername: peer1
 
 peer:
   # Tools version
-  hlfToolsVersion: 1.1.0
+  hlfToolsVersion: 1.2.0
   # Type of database ("goleveldb" or "CouchDB"):
   databaseType: goleveldb
   # If CouchDB is used, which chart holds it
@@ -58,6 +58,8 @@ secrets: {}
   ## This should contain the Private Key of the Peer Organisation admin
   ## This is necessary to successfully join a channel
   # adminKey: hlf--peer-adminkey
+  ## This should contain the CA server's TLS details under the key tls.crt (e.g. a Let's Encrypt Certificate PEM)
+  # caServerTls: ca--tls
 
 resources: {}
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Signed-off-by: Alejandro Vicente Grabovetsky <sasha@aid.technology>

#### What this PR does / why we need it:

#### Which issue this PR fixes

Updates from Fabric 1.1.0 to Fabric 1.2.0. Adds TLS certificate option necessary for using with Fabric CA Client 1.2

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md