### PR TITLE
[stable/mariadb] Use proper env. variable on slaves for Master root user&password

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.0.0
+version: 5.0.1
 appVersion: 10.1.36
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -99,9 +99,9 @@ spec:
           value: {{ template "mariadb.fullname" . }}
         - name: MARIADB_MASTER_PORT
           value: "3306"
-        - name: MARIADB_MASTER_USER
+        - name: MARIADB_MASTER_ROOT_USER
           value: "root"
-        - name: MARIADB_MASTER_PASSWORD
+        - name: MARIADB_MASTER_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mariadb.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

We're not using the right env. variable to set on slaves to configure what credentials to use to connect to master nodes.

Check https://github.com/bitnami/bitnami-docker-mariadb#10121-r2
