### PR TITLE
[stable/mariadb] Use proper env. variable on slaves for Master port number

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.0.1
+version: 5.0.2
 appVersion: 10.1.36
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -97,7 +97,7 @@ spec:
           value: "slave"
         - name: MARIADB_MASTER_HOST
           value: {{ template "mariadb.fullname" . }}
-        - name: MARIADB_MASTER_PORT
+        - name: MARIADB_MASTER_PORT_NUMBER
           value: "3306"
         - name: MARIADB_MASTER_ROOT_USER
           value: "root"


### PR DESCRIPTION
#### What this PR does / why we need it:

We're not using the right env. variable on slaves to configure the Master port to connect to.

Check https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster