### PR TITLE
Issue-7911 setting the gcp credentials value

### DIFF
--- a/stable/pachyderm/Chart.yaml
+++ b/stable/pachyderm/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - reproducibility
   - distributed
   - processing
-version: 0.1.7
+version: 0.1.8
 appVersion: 1.7.3
 home: "https://pachyderm.io"
 sources:

--- a/stable/pachyderm/README.md
+++ b/stable/pachyderm/README.md
@@ -77,6 +77,7 @@ Google Cloud
 | Parameter                | Description           | Default           |
 |--------------------------|-----------------------|-------------------|
 | `google.bucketName`      | GCS bucket name       | `""`              |
+| `google.credentials`     | GCP credentials       | `""`              |
 
 
 Amazon Web Services

--- a/stable/pachyderm/templates/pachd_secret.yaml
+++ b/stable/pachyderm/templates/pachd_secret.yaml
@@ -19,6 +19,7 @@ data:
   minio-signature: {{ toString .Values.s3.signature | b64enc | quote }}
   {{- else if eq .Values.credentials "google" }}
   google-bucket: {{ .Values.google.bucketName | b64enc | quote }}
+  google-cred: {{ .Values.google.credentials | b64enc | quote }}
   {{- else if eq .Values.credentials "amazon" }}
   amazon-bucket: {{ .Values.amazon.bucketName | b64enc | quote }}
   amazon-distribution: {{ .Values.amazon.distribution | b64enc | quote }}

--- a/stable/pachyderm/values.yaml
+++ b/stable/pachyderm/values.yaml
@@ -21,6 +21,7 @@ s3:
 ## Google Cloud credentials
 google:
  bucketName: ""
+ credentials: ""
 
 ## Amazon Web Services credentials
 amazon:


### PR DESCRIPTION
#### What this PR does / why we need it:
Issue 7921 where the credentials file is not set for the pachyderm chart.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
    - fixes #7921

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
