### PR TITLE
[stable/sonarqube] added parameter for custom mysql parameters

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.9.1
+version: 0.10.1
 appVersion: 6.7.3
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `mysql.mysqlUser`                           | Mysql database user                       | `sonarUser`                                |
 | `mysql.mysqlPassword`                       | Mysql database password                   | `sonarPass`                                |
 | `mysql.mysqlDatabase`                       | Mysql database name                       | `sonarDB`                                  |
+| `mysql.mysqlParams`                         | Mysql parameters for JDBC connection string     | `{}`                                 |
 | `mysql.service.port`                        | Mysql port                                | `3306`                                     |
 | `resources`                                 | Sonarqube Pod resource requests & limits  | `{}`                                       |
 | `affinity`                                  | Node / Pod affinities                     | `{}`                                       |

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -101,7 +101,7 @@ spec:
               {{- if eq .Values.database.type "postgresql" }}
               value: "jdbc:postgresql://{{ template "postgresql.hostname" . }}:{{- .Values.postgresql.service.port -}}/{{- .Values.postgresql.postgresDatabase -}}"
               {{- else if eq .Values.database.type "mysql" }}
-              value: "jdbc:mysql://{{ template "mysql.hostname" . }}:{{ .Values.mysql.service.port }}/{{ .Values.mysql.mysqlDatabase }}?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true"
+              value: "jdbc:mysql://{{ template "mysql.hostname" . }}:{{ .Values.mysql.service.port }}/{{ .Values.mysql.mysqlDatabase }}?useUnicode=true&characterEncoding=utf8&rewriteBatchedStatements=true{{- range $key, $value := .Values.mysql.mysqlParams }}&{{ $key }}={{ $value }}{{- end }}"
               {{- end }}
           livenessProbe:
             httpGet:

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -139,6 +139,8 @@ mysql:
   mysqlUser: "sonarUser"
   mysqlPassword: "sonarPass"
   mysqlDatabase: "sonarDB"
+  # mysqlParams:
+  #   useSSL: "true"
   # Specify the TCP port that mySQL should use
   service:
     port: 3306


### PR DESCRIPTION
Signed-off-by: Raza Jhaveri <razajhaveri@googlemail.com>


#### What this PR does / why we need it:
Allows adding additional parameters to the JDBC connection string for SonarQube. This is useful to add options such as `useSSL=true` when connecting to a remote DB

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ x ] Chart Version bumped
- [ x ] Variables are documented in the README.md
