### PR TITLE
[stable/prometheus-adapter] Allow the prometheus-adapter to read deployments to enable Object metrics for deployments

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.1.2
+version: v0.1.3
 appVersion: v0.2.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-resource-reader-cluster-role.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-resource-reader-cluster-role.yaml
@@ -11,7 +11,9 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - extensions
   resources:
+  - deployments
   - namespaces
   - pods
   - services


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
In order to implement `Object` metrics on a `Deployment` object, the adapter needs to be able to read them.

In our case, we wanted to associate a metric with the deployment (e.g. add a `jobs_in_the_queue` metric tied to the deployment that works that queue) and so we made this change on our fork. Figured it would be worth trying to get it back in upstream.

Check out the #7700 for more details!

#### Which issue this PR fixes

    - fixes #7700

#### Special notes for your reviewer:
- Wasn't sure if we wanted this to be more configurable, but since we were already allowing `Service` resources to be read, I figured this was ok.

#### Checklist

- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
