### PR TITLE
[stable/mariadb] Increasing 'initialDelaySeconds' to avoid unnecessary resets

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.0.3
+version: 5.0.4
 appVersion: 10.1.36
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -81,7 +81,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `master.livenessProbe.successThreshold`   | Minimum consecutive successes for the probe (master)| `1`                                                               |
 | `master.livenessProbe.failureThreshold`   | Minimum consecutive failures for the probe (master) | `3`                                                               |
 | `master.readinessProbe.enabled`           | Turn on and off readiness probe (master)            | `true`                                                            |
-| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master) | `15`                                                              |
+| `master.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (master) | `30`                                                              |
 | `master.readinessProbe.periodSeconds`     | How often to perform the probe (master)             | `10`                                                              |
 | `master.readinessProbe.timeoutSeconds`    | When the probe times out (master)                   | `1`                                                               |
 | `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)| `1`                                                               |
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `slave.livenessProbe.successThreshold`    | Minimum consecutive successes for the probe (slave) | `1`                                                               |
 | `slave.livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
 | `slave.readinessProbe.enabled`            | Turn on and off readiness probe (slave)             | `true`                                                            |
-| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)   | `15`                                                              |
+| `slave.readinessProbe.initialDelaySeconds`| Delay before readiness probe is initiated (slave)   | `45`                                                              |
 | `slave.readinessProbe.periodSeconds`      | How often to perform the probe (slave)              | `10`                                                              |
 | `slave.readinessProbe.timeoutSeconds`     | When the probe times out (slave)                    | `1`                                                               |
 | `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave) | `1`                                                               |

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -165,7 +165,7 @@ master:
     failureThreshold: 3
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 15
+    initialDelaySeconds: 30
     ##
     ## Default Kubernetes values
     periodSeconds: 10
@@ -250,7 +250,7 @@ slave:
     failureThreshold: 3
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 15
+    initialDelaySeconds: 45
     ##
     ## Default Kubernetes values
     periodSeconds: 10


### PR DESCRIPTION
#### What this PR does / why we need it:

Our current 'initialDelaySeconds' on ReadinessProbes is too tight. I installed the MariaDB chart several times and it takes around **25** seconds for MariaDB to be ready on master nodes and around **40** seconds for slaves (since they wait for master to be ready).
 
That's making the charts to restart the slaves several times (since they're waiting for the master to be ready). That's not a desired behaviour and we can avoid by increasing the initial delay accordingly.