### PR TITLE
Updating Locust to v0.9.0 and using official Dockerfile

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 name: locust
 description: A modern load testing framework
-version: 0.3.0
-appVersion: 0.7.5
+version: 0.4.0
+appVersion: 0.9.0
 maintainers:
   - name: so0k
     email: vincent.drl@gmail.com

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -28,7 +28,7 @@ helm install -n locust-nymph --set master.config.target-url=http://site.example.
 | ---------------------------- | ----------------------------------      | ----------------------------------------------------- |
 | `Name`                       | Locust master name                      | `locust`                                              |
 | 'createTestScripts'          | Use Helm to create the test scripts     | 'true'                                                |
-| `image.repository`           | Locust container image name             | `quay.io/honestbee/locust`                            |
+| `image.repository`           | Locust container image name             | `garland/locust          `                            |
 | `image.tag`                  | Locust Container image tag              | `0.7.5`                                               |
 | `image.pullSecrets`          | Locust Container image registry secret  | `None`                                                |
 | 'ingress.enable'             | Enable ingress to expose the master     | 'false'                                               |

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -21,7 +21,7 @@ This chart will do the following:
 To install the chart with the release name `locust-nymph` in the default namespace:
 
 ```bash
-helm install -n locust-nymph --set master.config.target-host=http://site.example.com stable/locust
+helm install -n locust-nymph --set master.config.target-url=http://site.example.com stable/locust
 ```
 
 | Parameter                    | Description                             | Default                                               |
@@ -34,7 +34,7 @@ helm install -n locust-nymph --set master.config.target-host=http://site.example
 | `service.nodePort`           | Port on cluster to expose master        | `0`                                                   |
 | `service.annotations`        | KV containing custom annotations        | `{}`                                                  |
 | `service.extraLabels`        | KV containing extra labels              | `{}`                                                  |
-| `master.config.target-host`  | locust target host                      | `http://site.example.com`                             |
+| `master.config.target-url`  | locust target host                      | `http://site.example.com`                             |
 | `worker.config.locust-script`| locust script to run                    | `/locust-tasks/tasks.py`                              |
 | `worker.replicaCount`        | Number of workers to run                | `2`                                                   |
 

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -5,7 +5,7 @@ testing using Kubernetes.
 
 ## Pre Requisites:
 
-* Requires (and tested with) helm `v2.1.2` or above.
+* Requires (and tested with) helm `v2.10.0` or above.
 
 ## Chart details
 
@@ -27,14 +27,18 @@ helm install -n locust-nymph --set master.config.target-url=http://site.example.
 | Parameter                    | Description                             | Default                                               |
 | ---------------------------- | ----------------------------------      | ----------------------------------------------------- |
 | `Name`                       | Locust master name                      | `locust`                                              |
+| 'createTestScripts'          | Use Helm to create the test scripts     | 'true'                                                |
 | `image.repository`           | Locust container image name             | `quay.io/honestbee/locust`                            |
 | `image.tag`                  | Locust Container image tag              | `0.7.5`                                               |
 | `image.pullSecrets`          | Locust Container image registry secret  | `None`                                                |
+| 'ingress.enable'             | Enable ingress to expose the master     | 'false'                                               |
+| `master.config.target-url`   | locust target host                      | `http://site.example.com`                             |
+| 'master.nodeSelectors.enable'| Enable nodeSelector usage               | 'false'                                               |
+| 'master.tolerations.enable'  | Enable tolerations/taint usage          | 'false'                                               |
 | `service.type`               | k8s service type exposing master        | `NodePort`                                            |
 | `service.nodePort`           | Port on cluster to expose master        | `0`                                                   |
 | `service.annotations`        | KV containing custom annotations        | `{}`                                                  |
 | `service.extraLabels`        | KV containing extra labels              | `{}`                                                  |
-| `master.config.target-url`  | locust target host                      | `http://site.example.com`                             |
 | `worker.config.locust-script`| locust script to run                    | `/locust-tasks/tasks.py`                              |
 | `worker.replicaCount`        | Number of workers to run                | `2`                                                   |
 

--- a/stable/locust/tasks/tasks.py
+++ b/stable/locust/tasks/tasks.py
@@ -27,10 +27,6 @@ class WebsiteTasks(TaskSet):
     def tour(self):
         self.client.get("/tour")
 
-    @task
-    def api(self):
-        self.client.get('/api?action=setUserAttributes&apiVersion=1.0.6.&appId=app_WHWSfAt5LCeLRxWuRaBEiawqkr2vhSG62ZbfyyqAPcE&clientKey=dev_XeURceHkZ4jEfzOBAQD7Fv9j148eByWfxxvzr7eqlrE&userId=99e4f0ee79b3680e&userAttributes={"email":"praveen+20180806@leanplum.com", "horoscope_sign":"leo", "plum_pod":"dataPlatform", "favorite_color":"turquoise"}')
-
 class WebsiteUser(HttpLocust):
     task_set = WebsiteTasks
     min_wait = 5000

--- a/stable/locust/tasks/tasks.py
+++ b/stable/locust/tasks/tasks.py
@@ -1,33 +1,11 @@
-# from locust import HttpLocust, TaskSet, task
-#
-# class ElbTasks(TaskSet):
-#   @task
-#   def status(self):
-#       self.client.get('/api?action=setUserAttributes&apiVersion=1.0.6.&appId=app_WHWSfAt5LCeLRxWuRaBEiawqkr2vhSG62ZbfyyqAPcE&clientKey=dev_XeURceHkZ4jEfzOBAQD7Fv9j148eByWfxxvzr7eqlrE&userId=99e4f0ee79b3680e&userAttributes={"email":"praveen+20180806@leanplum.com", "horoscope_sign":"leo", "plum_pod":"dataPlatform", "favorite_color":"turquoise"}')
-#
-# class ElbWarmer(HttpLocust):
-#   task_set = ElbTasks
-#   min_wait = 1000
-#   max_wait = 3000
-
 from locust import HttpLocust, TaskSet, task
 
-class WebsiteTasks(TaskSet):
-    # def on_start(self):
-    #     self.client.post("/login", {
-    #         "username": "test_user",
-    #         "password": ""
-    #     })
+class ElbTasks(TaskSet):
+  @task
+  def status(self):
+      self.client.get("/status")
 
-    @task
-    def index(self):
-        self.client.get("/")
-
-    @task
-    def tour(self):
-        self.client.get("/tour")
-
-class WebsiteUser(HttpLocust):
-    task_set = WebsiteTasks
-    min_wait = 5000
-    max_wait = 15000
+class ElbWarmer(HttpLocust):
+  task_set = ElbTasks
+  min_wait = 1000
+  max_wait = 3000

--- a/stable/locust/tasks/tasks.py
+++ b/stable/locust/tasks/tasks.py
@@ -1,11 +1,37 @@
+# from locust import HttpLocust, TaskSet, task
+#
+# class ElbTasks(TaskSet):
+#   @task
+#   def status(self):
+#       self.client.get('/api?action=setUserAttributes&apiVersion=1.0.6.&appId=app_WHWSfAt5LCeLRxWuRaBEiawqkr2vhSG62ZbfyyqAPcE&clientKey=dev_XeURceHkZ4jEfzOBAQD7Fv9j148eByWfxxvzr7eqlrE&userId=99e4f0ee79b3680e&userAttributes={"email":"praveen+20180806@leanplum.com", "horoscope_sign":"leo", "plum_pod":"dataPlatform", "favorite_color":"turquoise"}')
+#
+# class ElbWarmer(HttpLocust):
+#   task_set = ElbTasks
+#   min_wait = 1000
+#   max_wait = 3000
+
 from locust import HttpLocust, TaskSet, task
 
-class ElbTasks(TaskSet):
-  @task
-  def status(self):
-      self.client.get("/status")
+class WebsiteTasks(TaskSet):
+    # def on_start(self):
+    #     self.client.post("/login", {
+    #         "username": "test_user",
+    #         "password": ""
+    #     })
 
-class ElbWarmer(HttpLocust):
-  task_set = ElbTasks
-  min_wait = 1000
-  max_wait = 3000
+    @task
+    def index(self):
+        self.client.get("/")
+
+    @task
+    def tour(self):
+        self.client.get("/tour")
+
+    @task
+    def api(self):
+        self.client.get('/api?action=setUserAttributes&apiVersion=1.0.6.&appId=app_WHWSfAt5LCeLRxWuRaBEiawqkr2vhSG62ZbfyyqAPcE&clientKey=dev_XeURceHkZ4jEfzOBAQD7Fv9j148eByWfxxvzr7eqlrE&userId=99e4f0ee79b3680e&userAttributes={"email":"praveen+20180806@leanplum.com", "horoscope_sign":"leo", "plum_pod":"dataPlatform", "favorite_color":"turquoise"}')
+
+class WebsiteUser(HttpLocust):
+    task_set = WebsiteTasks
+    min_wait = 5000
+    max_wait = 15000

--- a/stable/locust/templates/_helpers.tpl
+++ b/stable/locust/templates/_helpers.tpl
@@ -19,6 +19,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "worker" | trunc 63 -}}
 {{- end -}}
 
+{{- define "locust.ingress" -}}
+{{- printf "%s-%s" .Release.Name "ingress" | trunc 63 -}}
+{{- end -}}
+
 {{/*
 Create fully qualified configmap name.
 */}}

--- a/stable/locust/templates/ingres.yaml
+++ b/stable/locust/templates/ingres.yaml
@@ -13,15 +13,19 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "{{ .Values.ingress.ingressClass }}"
     # Setup Let's Encrypt Certificates
+    {{ if .Values.ingress.enableTLS }}
     kubernetes.io/tls-acme: "{{ .Values.ingress.enableTlsAcme }}"
+    {{ end }}
     {{ if .Values.ingress.annotations.enable }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.ingress.annotations.whitelistSourceRange }}"
     {{ end }}
 spec:
+  {{ if .Values.ingress.enableTLS }}
   tls:
   - hosts:
     - "{{ .Values.ingress.hostname }}"
     secretName: {{ template "locust.ingress" . }}-locust-tls
+  {{ end }}
   rules:
   - host: "{{ .Values.ingress.hostname }}"
     http:

--- a/stable/locust/templates/ingres.yaml
+++ b/stable/locust/templates/ingres.yaml
@@ -21,7 +21,7 @@ spec:
   tls:
   - hosts:
     - "{{ .Values.ingress.hostname }}"
-    secretName: {{ .Values.namePrefix }}-locust-tls
+    secretName: {{ template "locust.ingress" . }}-locust-tls
   rules:
   - host: "{{ .Values.ingress.hostname }}"
     http:

--- a/stable/locust/templates/ingres.yaml
+++ b/stable/locust/templates/ingres.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.ingress.enable }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "locust.ingress" . }}
+  namespace: {{ .Values.namespace }}
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "locust.fullname" . }}
+    component: "ingress"
+  annotations:
+    kubernetes.io/ingress.class: "{{ .Values.ingress.ingressClass }}"
+    # Setup Let's Encrypt Certificates
+    kubernetes.io/tls-acme: "{{ .Values.ingress.enableTlsAcme }}"
+    {{ if .Values.ingress.annotations.enable }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.ingress.annotations.whitelistSourceRange }}"
+    {{ end }}
+spec:
+  tls:
+  - hosts:
+    - "{{ .Values.ingress.hostname }}"
+    secretName: {{ .Values.namePrefix }}-locust-tls
+  rules:
+  - host: "{{ .Values.ingress.hostname }}"
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "locust.master-svc" . }}
+          servicePort: {{ .Values.service.internalPort }}
+{{ end }}

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locust.master" . }}
@@ -10,6 +10,10 @@ metadata:
     component: master
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: master
+      app: {{ template "locust.fullname" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -64,6 +68,14 @@ spec:
           httpGet:
             path: /
             port: {{ .Values.service.internalPort }}
+      {{ if .Values.master.nodeSelectors.enable }}
+      nodeSelector:
+{{ toYaml .Values.master.nodeSelectors.items | indent 8 }}
+      {{- end }}
+      {{ if .Values.master.tolerations.enable }}
+      tolerations:
+{{ toYaml .Values.master.tolerations.items | indent 6 }}
+      {{- end }}
       volumes:
       - name: "locust-tasks"
         configMap:

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -34,6 +34,7 @@ spec:
       - name: locust
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: ["-f", "$(LOCUSTFILE_PATH)", "-H", "$(TARGET_URL)", "--master", "--loglevel=DEBUG"]
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
         env:
@@ -43,6 +44,8 @@ spec:
         {{- end }}
         - name: LOCUST_MODE
           value: "master"
+        - name: TARGET_URL
+          value: {{ index .Values.master.config "target-url" | quote }}
         - name: LOCUSTFILE_PATH
           value: {{ index .Values.worker.config "locust-script" | quote }}
         ports:

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -39,7 +39,7 @@ spec:
         {{- end }}
         - name: LOCUST_MODE
           value: "master"
-        - name: LOCUST_SCRIPT
+        - name: LOCUSTFILE_PATH
           value: {{ index .Values.worker.config "locust-script" | quote }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -34,7 +34,7 @@ spec:
       - name: locust
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: ["-f", "$(LOCUSTFILE_PATH)", "-H", "$(TARGET_URL)", "--master", "--loglevel=DEBUG"]
+        args: ["-f", "$(LOCUSTFILE_PATH)", "-H", "$(TARGET_URL)", "--master", "--loglevel=$(LOGLEVEL)"]
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
         env:
@@ -42,10 +42,10 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
-        - name: TARGET_URL
-          value: {{ index .Values.master.config "target-url" | quote }}
         - name: LOCUSTFILE_PATH
           value: {{ index .Values.worker.config "locust-script" | quote }}
+        - name: LOGLEVEL
+          value: {{ .Values.master.logLevel }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
           name: loc-master-web

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -42,8 +42,6 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
-        - name: LOCUST_MODE
-          value: "master"
         - name: TARGET_URL
           value: {{ index .Values.master.config "target-url" | quote }}
         - name: LOCUSTFILE_PATH

--- a/stable/locust/templates/worker-cm.yaml
+++ b/stable/locust/templates/worker-cm.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.createTestScripts }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,3 +11,4 @@ metadata:
     app: {{ template "locust.fullname" . }}
 data:
 {{ (.Files.Glob "tasks/*").AsConfig | indent 2 }}
+{{ end }}

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -42,12 +42,8 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
-        - name: LOCUST_MODE
-          value: "slave"
         - name: LOCUST_MASTER_HOST
           value: {{ template "locust.master-svc" . }}
-        - name: LOCUST_MASTER_WEB
-          value: "{{ .Values.service.internalPort }}"
         - name: TARGET_URL
           value: {{ index .Values.master.config "target-url" | quote }}
         - name: LOCUSTFILE_PATH

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locust.worker" . }}
@@ -10,6 +10,10 @@ metadata:
     component: worker
 spec:
   replicas: {{ default 2 .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      component: worker
+      app: {{ template "locust.fullname" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -49,6 +53,14 @@ spec:
           value: {{ index .Values.worker.config "locust-script" | quote }}
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
+      {{ if .Values.worker.nodeSelectors.enable }}
+      nodeSelector:
+{{ toYaml .Values.worker.nodeSelectors.items | indent 8 }}
+      {{- end }}
+      {{ if .Values.worker.tolerations.enable }}
+      tolerations:
+{{ toYaml .Values.worker.tolerations.items | indent 6 }}
+      {{- end }}
       restartPolicy: Always
       volumes:
         - name: "locust-tasks"

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -33,6 +33,7 @@ spec:
       - name: locust
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: ["-f", "$(LOCUSTFILE_PATH)", "-H", "$(TARGET_URL)", "--slave", "--master-host=$(LOCUST_MASTER_HOST)", "--master-port=5557", "--loglevel=DEBUG"]
         volumeMounts:
           - name: locust-tasks
             mountPath: /locust-tasks/
@@ -46,7 +47,7 @@ spec:
         - name: LOCUST_MASTER_HOST
           value: {{ template "locust.master-svc" . }}
         - name: LOCUST_MASTER_WEB
-          value: {{ .Values.service.internalPort }}"
+          value: "{{ .Values.service.internalPort }}"
         - name: TARGET_URL
           value: {{ index .Values.master.config "target-url" | quote }}
         - name: LOCUSTFILE_PATH

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -33,7 +33,7 @@ spec:
       - name: locust
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: ["-f", "$(LOCUSTFILE_PATH)", "-H", "$(TARGET_URL)", "--slave", "--master-host=$(LOCUST_MASTER_HOST)", "--master-port=5557", "--loglevel=DEBUG"]
+        args: ["-f", "$(LOCUST_SCRIPT)", "-H", "$(TARGET_URL)", "--slave", "--master-host=$(LOCUST_MASTER_HOST)", "--master-port=5557", "--loglevel=$(LOGLEVEL)"]
         volumeMounts:
           - name: locust-tasks
             mountPath: /locust-tasks/
@@ -46,8 +46,8 @@ spec:
           value: {{ template "locust.master-svc" . }}
         - name: TARGET_URL
           value: {{ index .Values.master.config "target-url" | quote }}
-        - name: LOCUSTFILE_PATH
-          value: {{ index .Values.worker.config "locust-script" | quote }}
+        - name: LOGLEVEL
+          value: {{ .Values.worker.logLevel }}
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
       {{ if .Values.worker.nodeSelectors.enable }}

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -38,13 +38,15 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         - name: LOCUST_MODE
-          value: "worker"
-        - name: LOCUST_MASTER
+          value: "slave"
+        - name: LOCUST_MASTER_HOST
           value: {{ template "locust.master-svc" . }}
         - name: LOCUST_MASTER_WEB
-          value: "{{ .Values.service.internalPort }}"
-        - name: TARGET_HOST
-          value: {{ index .Values.master.config "target-host" | quote }}
+          value: {{ .Values.service.internalPort }}"
+        - name: TARGET_URL
+          value: {{ index .Values.master.config "target-url" | quote }}
+        - name: LOCUSTFILE_PATH
+          value: {{ index .Values.worker.config "locust-script" | quote }}
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
       restartPolicy: Always

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -17,6 +17,7 @@ service:
 master:
   config:
     target-url: https://site.example.com
+  logLevel: INFO
   resources:
     limits:
       cpu: 100m
@@ -40,6 +41,7 @@ worker:
 
     # all files from tasks folder are mounted under `/locust-tasks`
     locust-script: "/locust-tasks/tasks.py"
+  logLevel: INFO
   replicaCount: 2
   resources:
     limits:

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -37,3 +37,6 @@ worker:
     requests:
       cpu: 100m
       memory: 128Mi
+
+# Flag to create the test script from this chart or not.
+createTestScripts: true

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -67,6 +67,7 @@ createTestScripts: true
 
 ingress:
   enable: false
+  enableTLS: false
   ingressClass: nginx
   enableTlsAcme: false
   hostname: locust.example.com

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -40,3 +40,12 @@ worker:
 
 # Flag to create the test script from this chart or not.
 createTestScripts: true
+
+ingress:
+  enable: false
+  ingressClass: nginx
+  enableTlsAcme: false
+  hostname: locust.example.com
+  annotations:
+    enable: false
+    whitelistSourceRange: "1.1.1.1/32,2.2.2.2/32"

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -24,6 +24,17 @@ master:
     requests:
       cpu: 100m
       memory: 128Mi
+  nodeSelectors:
+    enable: false
+    items:
+      k8s.info/application: locust
+  tolerations:
+    enable: false
+    items:
+    - key: "application"
+      operator: "Equal"
+      value: "locust"
+      effect: "NoSchedule"
 worker:
   config:
 
@@ -37,6 +48,17 @@ worker:
     requests:
       cpu: 100m
       memory: 128Mi
+  nodeSelectors:
+    enable: false
+    items:
+      k8s.info/application: locust
+  tolerations:
+    enable: false
+    items:
+    - key: "application"
+      operator: "Equal"
+      value: "locust"
+      effect: "NoSchedule"
 
 # Flag to create the test script from this chart or not.
 createTestScripts: true

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -1,8 +1,8 @@
 Name: locust
 
 image:
-  repository: quay.io/honestbee/locust
-  tag: 0.7.5
+  repository: garland/locust
+  tag: 0.9.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -16,7 +16,7 @@ service:
   extraLabels: {}
 master:
   config:
-    target-host: https://site.example.com
+    target-url: https://site.example.com
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
#### What this PR does / why we need it:
This updates Locust to the latest v0.9.0.  It also uses the Dockerfile in the Locust Github repo as the standard image.  

#### Which issue this PR fixes
none

#### Special notes for your reviewer:
Also adds in some features that we have found useful in our testing
* Options for nodeSelector/taints - to allow us to place the master/worker pods where we want them to go
* Locust log level flags
* Options to load in the Locust scripts locally and not have the chart handle this.  This allowed us to use the chart with no modifications and didnt have to download the chart repository.
* Option to create an ingress

Currently it is using the Dockerfile from Locust master branch.  They do not have an official Docker Hub repo yet.  Trying to get clarification if they are going to do this or not:  https://github.com/locustio/locust/pull/850#issuecomment-424425247 . 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@so0k 