### PR TITLE
[stable/postgresql] Fix metrics volume arguments

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.18.1
+version: 0.18.2
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -128,11 +128,14 @@ spec:
         env:
         - name: DATA_SOURCE_NAME
           value: postgresql://{{ default "postgres" .Values.postgresUser }}@127.0.0.1:5432?sslmode=disable
+        {{- if .Values.metrics.customMetrics }}
+        - name: PG_EXPORTER_EXTEND_QUERY_PATH
+          value: /conf/custom-metrics.yaml
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 9187
         {{- if .Values.metrics.customMetrics }}
-        args: ["-extend.query-path", "/conf/custom-metrics.yaml"]
         volumeMounts:
           - name: custom-metrics
             mountPath: /conf


### PR DESCRIPTION
**What this PR does / why we need it**:

"-extend.query-path" is invalid argument to postgres_exporter since 0.4.x version due to cli library update (ref: https://github.com/wrouesnel/postgres_exporter/issues/147)

Currently, as a result of invalid argument, metrics container fails to start.

This commit fixes the issue by replacing broken command line argument with the corresponding environment variable, as they are more consistent.

Refs:
- https://github.com/helm/charts/pull/6652

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
