### PR TITLE
[stable/gocd] Add service account to GoCD agent deployment

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.4
+
+* [9a41c6f1](https://github.com/kubernetes/charts/commit/9a41c6f1): Add service account to agent spec.
+
 ### 1.4.3
 
 * [52120886](https://github.com/kubernetes/charts/commit/52120886): Add extra volumes and volumeMounts options on the server and agents

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.4.3
+version: 1.4.4
 appVersion: 18.9.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -138,7 +138,7 @@ For accessing repositories over SSH in GoCD server, you need to add SSH keys to 
 Generate a new keypair, fetch the host key for the [host] you want to connect to and create the secret.
 The secret is structured to hold the entire contents of the .ssh folder on the GoCD server.
 
- ```bash
+```bash
 $ ssh-keygen -t rsa -b 4096 -C "user@example.com" -f gocd-server-ssh -P ''
 $ ssh-keyscan [host] > gocd_known_hosts
 $ kubectl create secret generic gocd-server-ssh \
@@ -167,6 +167,7 @@ $ kubectl create secret generic gocd-server-ssh \
 | `agent.env.goAgentBootstrapperJvmArgs`    | GoCD Agent Bootstrapper JVM Args.                                                                                                                                                | `nil`                        |
 | `agent.env.extraEnvVars`                  | GoCD Agent extra Environment variables                                                                       | `nil`               |
 | `agent.privileged`                        | Run container in privileged mode (needed for DinD, Docker-in-Docker agents)                                                                                                      | `false`                      |
+| `agent.serviceAccountName`                | Kubernetes Service Account name to use (when agents need to access the Kubernetes API and `rbac.roleRef` isn't enough)                                                     | `nil`                      |
 | `agent.healthCheck.enabled`               | Enable use of GoCD agent health checks.                                                                                                                                          | `false`                      |
 | `agent.healthCheck.initialDelaySeconds`   | GoCD agent start up time.                                                                                                                                                        | `60`                         |
 | `agent.healthCheck.periodSeconds`         | GoCD agent health check interval period.                                                                                                                                          | `60`                         |

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -10,9 +10,6 @@ metadata:
     component: agent
 spec:
   replicas: {{ .Values.agent.replicaCount }}
-  {{- if .Values.serviceAccount.create }}
-  serviceAccountName: {{ template "gocd.serviceAccountName" . }}
-  {{- end }}
   selector:
     matchLabels:
       app: {{ template "gocd.name" . }}
@@ -25,6 +22,9 @@ spec:
         release: {{ .Release.Name | quote }}
         component: agent
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "gocd.serviceAccountName" . }}
+      {{- end }}
       {{- if or .Values.agent.persistence.enabled .Values.agent.security.ssh.enabled }}
       volumes:
       {{- end }}

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -22,7 +22,9 @@ spec:
         release: {{ .Release.Name | quote }}
         component: agent
     spec:
-      {{- if .Values.serviceAccount.create }}
+      {{- if .Values.agent.serviceAccountName }}
+      serviceAccountName: {{ .Values.agent.serviceAccountName }}
+      {{- else if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "gocd.serviceAccountName" . }}
       {{- end }}
       {{- if or .Values.agent.persistence.enabled .Values.agent.security.ssh.enabled }}

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     component: agent
 spec:
   replicas: {{ .Values.agent.replicaCount }}
+  {{- if .Values.serviceAccount.create }}
+  serviceAccountName: {{ template "gocd.serviceAccountName" . }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "gocd.name" . }}

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -241,6 +241,9 @@ agent:
   # agent.privileged is needed for running Docker-in-Docker (DinD) agents
   privileged: false
 
+  # agent.serviceAccountName is used for when GoCD agents needs a custom service account to access the Kubernetes API. Otherwise rbac.roleRef can be used.
+  serviceAccountName:
+
   healthCheck:
    # agent.healthCheck.enable is the toggle for GoCD agent health checks
     enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds service account to the GoCD agent pod(s) (with `spec.serviceAccountName`) so that GoCD agents can control Kubernetes if desired.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
