### PR TITLE
 update to two spaces the list because it create the markdown when adding the github issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,7 @@ even continue reviewing your changes.
 
 #### Which issue this PR fixes
 *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
-    - fixes #
+  - fixes #
 
 #### Special notes for your reviewer:
 


### PR DESCRIPTION
#### What this PR does / why we need it:
fix the template by making it two spaces instead of 4.
with 4 spaces it is a markdown

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed

cc @davidkarlsen 
