### PR TITLE
[stable/postgresql] Multiple dbs, users & data import support

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.18.2
+version: 0.19.0
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 0.18.1
+version: 0.18.2
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -58,6 +58,8 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `existingSecret`           | Use Existing secret for Admin password          | `nil`                                                      |
 | `postgresConfig`           | Runtime Config Parameters                       | `nil`                                                      |
 | `pgHbaConf`                | Content of pg\_hba.conf                         | `nil (do not create pg_hba.conf)`                          |
+| `initdbdSecret`            | Secret containing initdb.d files                | `nil`                                                      |
+| `initdbdMountPath`         | initdb.d files mount path                       | `/docker-entrypoint-initdb.d`                              |
 | `persistence.enabled`      | Use a PVC to persist data                       | `true`                                                     |
 | `persistence.existingClaim`| Provide an existing PersistentVolumeClaim       | `nil`                                                      |
 | `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `postgresConfig`           | Runtime Config Parameters                       | `nil`                                                      |
 | `pgHbaConf`                | Content of pg\_hba.conf                         | `nil (do not create pg_hba.conf)`                          |
 | `initdbdSecret`            | Secret containing initdb.d files                | `nil`                                                      |
-| `initdbdMountPath`         | initdb.d files mount path                       | `/docker-entrypoint-initdb.d`                              |
+| `initdbdMountPath`         | initdb.d files mount path. Only used if initdbdSecret is set | `/docker-entrypoint-initdb.d`                 |
 | `persistence.enabled`      | Use a PVC to persist data                       | `true`                                                     |
 | `persistence.existingClaim`| Provide an existing PersistentVolumeClaim       | `nil`                                                      |
 | `persistence.storageClass` | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -121,6 +121,11 @@ spec:
           mountPath: /pg_hba
           readOnly: true
         {{- end }}
+        {{- if .Values.initdbdSecret }}
+        - name: {{ .Values.initdbdSecret }}
+          mountPath: {{ .Values.initdbdMountPath }}
+          readOnly: true
+        {{- end }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
@@ -180,6 +185,12 @@ spec:
           items:
             - key: pg_hba.conf
               path: pg_hba.conf
+      {{- end }}
+      {{- if .Values.initdbdSecret }}
+      - name: {{ .Values.initdbdSecret }}
+        secret:
+          secretName: {{ .Values.initdbdSecret }}
+          defaultMode: 0744
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -55,6 +55,13 @@ usePasswordFile: false
 #   host all all localhost trust
 #   host mydatabase mysuser 192.168.0.0/24 md5
 
+## Specify a secret containing initdb.d files
+# initdbdSecret:
+
+## Specify initdb.d files mount path
+## Default: /docker-entrypoint-initdb.d
+initdbdMountPath: /docker-entrypoint-initdb.d
+
 ## Persist data to a persistent volume
 persistence:
   enabled: true

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -59,6 +59,7 @@ usePasswordFile: false
 # initdbdSecret:
 
 ## Specify initdb.d files mount path
+## Only used if initdbdSecret is set
 ## Default: /docker-entrypoint-initdb.d
 initdbdMountPath: /docker-entrypoint-initdb.d
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The current PostgreSQL Helm chart supports the creation of one database and one user.

However, it is common to require multiple databases and multiple users, for example
* if multiple applications are using the same PostgreSQL instance
* if different users are used for applications and schema updates

The official PostgreSQL Docker image supports setting up multiple databases, users (as well data import) by adding one or more *.sql, *.sql.gz, or *.sh scripts under /docker-entrypoint-initdb.d.
(see https://hub.docker.com/_/postgres, section "How to extend this image")

This PR allows the users of this chart to perform additional initialization using the above mechanism.
To do so, 2 new values were introduced:
initdbdSecret: Secret containing initdb.d files
initdbdMountPath: initdb.d files mount path 

Example usage:
1) Create a secret containing the initdb.d files:
```
kind: Secret
apiVersion: v1
metadata:
  name: my-initdbd-files
data:
  setup.sh: {{ include "setup.sh" . | b64enc | quote }}
{{- define "setup.sh" }}
#!/bin/bash
set -e
psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
	CREATE USER docker;
	CREATE DATABASE docker;
	GRANT ALL PRIVILEGES ON DATABASE docker TO docker;
EOSQL
{{- end }}
```
2) Set the value of initdbdSecret: --set initdbdSecret=my-initdbd-files 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
    - fixes #8074 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md