### PR TITLE
[stable/mattermost-team-edition] Fix automatic restarts on config change

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 1.1.0
+version: 1.1.1
 appVersion: 5.3.1
 keywords:
 - mattermost

--- a/stable/mattermost-team-edition/templates/deployment.yaml
+++ b/stable/mattermost-team-edition/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/config.tpl") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
       labels:
         app: {{ template "mattermost-team-edition.fullname" . }}
         release: {{ .Release.Name }}


### PR DESCRIPTION
The deployment will restart the pods it controls if the pod spec
annotation changes. By hashing the config and annotating the pod spec
with the hash, the pods will restart whenever the config is changed. The
issue right now is that it did not work to reference config.tpl, but it
does work to reference configmap-config.yaml. When referencing
config.tpl, we only get the first line from the template for some
reason, so only if we would change the first line (`\n`) of config.tpl
we would get a new hash and restart the pods.

Signed-off-by: Erik Sundell <erik.i.sundell@gmail.com>

#### What this PR does / why we need it:
It fixes the bug of not restarting when changing values rendered in the `configmap-config.yaml`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
