### PR TITLE
logstash: volumes fix

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.9.2
+version: 0.9.3
 appVersion: 6.4.1
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/templates/statefulset.yaml
+++ b/incubator/logstash/templates/statefulset.yaml
@@ -110,10 +110,6 @@ spec:
 {{ toYaml .Values.exporter.logstash.resources | indent 12 }}
 {{- end }}
 
-    {{- with .Values.volumes }}
-      volumes:
-{{ toYaml . | indent 8 }}
-    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -134,6 +130,9 @@ spec:
         - name: pipeline
           configMap:
             name: {{ template "logstash.fullname" . }}-pipeline
+    {{- with .Values.volumes }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
 {{- if not .Values.persistence.enabled }}
         - name: data
           emptyDir: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a fix in the Logstash chart in which there are two defined `volumes` blocks in the statefulset, causing the defined volumes in the `values.yaml` to be ignored. This PR combines the two blocks into one, allowing user-added volumes to be acknowledged.

This is ultimately an oversight from a previous PR I submitted (#7778). After building and testing the new chart, I can confirm this successfully allows users to add new volumes and functions as originally intended.

**Which issue this PR fixes**:
None

**kubectl describe pod output**
The below output shows I was able to configure 2 extra volumes in the pod (tls and certificate-authorities) on top of the default volumes (data, patterns, pipeline).
```
Volumes:
  data:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  data-logstash-1
    ReadOnly:   false
  patterns:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      logstash-patterns
    Optional:  false
  pipeline:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      logstash-pipeline
    Optional:  false
  tls:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  tls
    Optional:    false
  certificate-authorities:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  certificate-authorities
    Optional:    false
  default-token-qslrm:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-qslrm
    Optional:    false
```