### PR TITLE
[stable/mattermost-team-edition] fix deployment when upgrade

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 1.1.1
+version: 1.1.2
 appVersion: 5.3.1
 keywords:
 - mattermost

--- a/stable/mattermost-team-edition/README.md
+++ b/stable/mattermost-team-edition/README.md
@@ -47,6 +47,7 @@ Parameter                 | Description                       | Default
 ---                       | ---                               | ---
 `image.repository`        | container image repository        | `mattermost/mattermost-team-edition`
 `image.tag`               | container image tag               | `5.3.1`
+`revisionHistoryLimit`    | How many old ReplicaSets for Mattermost Deployment you want to retain   | `1`
 `config.SiteUrl`          | The URL that users will use to access Mattermost. ie `https://mattermost.mycompany.com`       |  ``
 `config.SiteName`         | Name of service shown in login screens and UI         | `Mattermost`
 `config.FilesAccessKey`   | The AWS Access Key, if you want store the files on S3         | ``

--- a/stable/mattermost-team-edition/templates/deployment.yaml
+++ b/stable/mattermost-team-edition/templates/deployment.yaml
@@ -8,7 +8,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "mattermost-team-edition.fullname" . }}

--- a/stable/mattermost-team-edition/values.yaml
+++ b/stable/mattermost-team-edition/values.yaml
@@ -6,6 +6,9 @@ image:
   tag: 5.3.1
   imagePullPolicy: IfNotPresent
 
+## How many old ReplicaSets for Mattermost Deployment you want to retain
+revisionHistoryLimit: 1
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ## ref: https://docs.gitlab.com/ee/install/requirements.html#storage


### PR DESCRIPTION
#### What this PR does / why we need it:
when upgrade the chart we cannot have two pods (old and new) running at same time because the volume cannot be shared
changing the strategy to recreate.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
