### PR TITLE
[incubator/kubeless] Improve getting LoadBalancer address in chart NOTES…

### DIFF
--- a/incubator/kubeless/Chart.yaml
+++ b/incubator/kubeless/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubeless
-version: 1.0.5
+version: 1.0.6
 appVersion: v1.0.0-alpha.3
 description: Kubeless is a Kubernetes-native serverless framework. It runs on top of your Kubernetes cluster and allows you to deploy small unit of code without having to build container images.
 icon: https://cloud.githubusercontent.com/assets/4056725/25480209/1d5bf83c-2b48-11e7-8db8-bcd650f31297.png

--- a/incubator/kubeless/templates/NOTES.txt
+++ b/incubator/kubeless/templates/NOTES.txt
@@ -6,7 +6,7 @@
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w ui'
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kubeless.fullname" . }}-ui -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kubeless.fullname" . }}-ui --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   export SERVICE_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kubeless.fullname" . }}-ui -o jsonpath='{.spec.ports[0].port}')
   echo http://$SERVICE_IP:$SERVICE_PORT/
 {{- else if contains "ClusterIP"  .Values.ui.service.type }}


### PR DESCRIPTION
Testing a K8s cluster where LoadBalancer service returns hostname and not ip.
This PR change our current approach in bitnami helm charts where we report IP by doing
```
-o jsonpath='{.status.loadBalancer.ingress[0].ip}'
```
The new approach is to use
```
--template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"
where the . returns value for whatever field is in the map.
```
Signed-off-by: Carlos Rodriguez Hernandez crhernandez@bitnami.com

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
