### PR TITLE
[stable/testlink] Improve getting LoadBalancer address in NOTES.txt

### DIFF
--- a/stable/testlink/Chart.yaml
+++ b/stable/testlink/Chart.yaml
@@ -1,5 +1,5 @@
 name: testlink
-version: 3.0.1
+version: 3.0.2
 appVersion: 1.9.17
 description: Web-based test management system that facilitates software quality assurance.
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png
@@ -12,6 +12,6 @@ home: http://www.testlink.org/
 sources:
 - https://github.com/bitnami/bitnami-docker-testlink
 maintainers:
-- name: bitnami-bot
+- name: Bitnami
   email: containers@bitnami.com
 engine: gotpl

--- a/stable/testlink/templates/NOTES.txt
+++ b/stable/testlink/templates/NOTES.txt
@@ -12,7 +12,7 @@
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "fullname" . }}'
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "TestLink URL: http://$SERVICE_IP/"
 
 {{- else if contains "ClusterIP"  .Values.serviceType }}


### PR DESCRIPTION
Testing a K8s cluster where LoadBalancer service returns `hostname` and not `ip`.
This PR change our current approach in bitnami helm charts where we report IP by doing 
```
-o jsonpath='{.status.loadBalancer.ingress[0].ip}'
``` 
The new approach is to use
```
--template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"
```
where the `.` returns value for whatever field is in the map.

_Source: https://github.com/helm/charts/issues/84#issuecomment-257754892_
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
