### PR TITLE
[stable/redis] Improve getting LoadBalancer address in NOTES.txt

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.1.0
+version: 4.1.1
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:
@@ -11,6 +11,6 @@ icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
 sources:
 - https://github.com/bitnami/bitnami-docker-redis
 maintainers:
-- name: bitnami-bot
+- name: Bitnami
   email: containers@bitnami.com
 engine: gotpl

--- a/stable/redis/templates/NOTES.txt
+++ b/stable/redis/templates/NOTES.txt
@@ -76,7 +76,7 @@ To connect to your database from outside the cluster execute the following comma
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "redis.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "redis.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "redis.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
     redis-cli -h $SERVICE_IP -p {{ .Values.master.service.nodePort }} {{- if .Values.usePassword }} -a $REDIS_PASSWORD{{ end }}
 
 {{- else if contains "ClusterIP" .Values.master.service.type }}


### PR DESCRIPTION
Testing a K8s cluster where LoadBalancer service returns `hostname` and not `ip`.
This PR change our current approach in bitnami helm charts where we report IP by doing 
```
-o jsonpath='{.status.loadBalancer.ingress[0].ip}'
``` 
The new approach is to use
```
--template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"
```
where the `.` returns value for whatever field is in the map.

_Source: https://github.com/helm/charts/issues/84#issuecomment-257754892_
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
