### PR TITLE
[stable/odoo] Improve getting LoadBalancer address in NOTES.txt

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,5 +1,5 @@
 name: odoo
-version: 3.0.0
+version: 3.0.1
 appVersion: 11.0.20180915
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/templates/NOTES.txt
+++ b/stable/odoo/templates/NOTES.txt
@@ -25,7 +25,7 @@
 ** Please ensure an external IP is associated to the {{ template "odoo.fullname" . }} service before proceeding **
 ** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "odoo.fullname" . }} **
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "odoo.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "odoo.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "Odoo URL: http://$SERVICE_IP/"
 {{- else if contains "ClusterIP"  .Values.service.type }}
 


### PR DESCRIPTION
Testing a K8s cluster where LoadBalancer service returns `hostname` and not `ip`.
This PR change our current approach in bitnami helm charts where we report IP by doing 
```
-o jsonpath='{.status.loadBalancer.ingress[0].ip}'
``` 
The new approach is to use
```
--template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"
```
where the `.` returns value for whatever field is in the map.

_Source: https://github.com/helm/charts/issues/84#issuecomment-257754892_
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
