### PR TITLE
[stable/moodle] Improve getting LoadBalancer address in NOTES.txt

### DIFF
--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,5 +1,5 @@
 name: moodle
-version: 3.0.1
+version: 3.0.2
 appVersion: 3.5.2
 description: Moodle is a learning platform designed to provide educators, administrators
   and learners with a single robust, secure and integrated system to create personalised

--- a/stable/moodle/templates/NOTES.txt
+++ b/stable/moodle/templates/NOTES.txt
@@ -27,7 +27,7 @@
 ** Please ensure an external IP is associated to the {{ template "moodle.fullname" . }} service before proceeding **
 ** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "moodle.fullname" . }} **
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "moodle.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "moodle.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "Moodle URL: http://$SERVICE_IP/"
 
 {{- else if contains "ClusterIP"  .Values.serviceType }}


### PR DESCRIPTION
Testing a K8s cluster where LoadBalancer service returns `hostname` and not `ip`.
This PR change our current approach in bitnami helm charts where we report IP by doing 
```
-o jsonpath='{.status.loadBalancer.ingress[0].ip}'
``` 
The new approach is to use
```
--template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"
```
where the `.` returns value for whatever field is in the map.

_Source: https://github.com/helm/charts/issues/84#issuecomment-257754892_
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
