### PR TITLE
[stable/jasperreports] Improve getting LoadBalancer address in NOTES.txt

### DIFF
--- a/stable/jasperreports/Chart.yaml
+++ b/stable/jasperreports/Chart.yaml
@@ -1,5 +1,5 @@
 name: jasperreports
-version: 3.0.1
+version: 3.0.2
 appVersion: 7.1.0
 description: The JasperReports server can be used as a stand-alone or embedded reporting
   and BI server that offers web-based reporting, analytic tools and visualization,
@@ -15,7 +15,7 @@ home: http://community.jaspersoft.com/project/jasperreports-server
 sources:
 - https://github.com/bitnami/bitnami-docker-jasperreports
 maintainers:
-- name: bitnami-bot
+- name: Bitnami
   email: containers@bitnami.com
 engine: gotpl
 icon: https://bitnami.com/assets/stacks/jasperserver/img/jasperserver-stack-110x117.png

--- a/stable/jasperreports/templates/NOTES.txt
+++ b/stable/jasperreports/templates/NOTES.txt
@@ -14,7 +14,7 @@
 ** Please ensure an external IP is associated to the {{ template "jasperreports.fullname" . }} service before proceeding **
 ** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jasperreports.fullname" . }} **
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jasperreports.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jasperreports.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "JasperReports URL: http://$SERVICE_IP/jasperserver/"
 
 {{- else if contains "ClusterIP"  .Values.serviceType }}


### PR DESCRIPTION
Testing a K8s cluster where LoadBalancer service returns `hostname` and not `ip`.
This PR change our current approach in bitnami helm charts where we report IP by doing 
```
-o jsonpath='{.status.loadBalancer.ingress[0].ip}'
``` 
The new approach is to use
```
--template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"
```
where the `.` returns value for whatever field is in the map.

_Source: https://github.com/helm/charts/issues/84#issuecomment-257754892_
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
