### PR TITLE
[stable/drupal] Improve getting LoadBalancer address in NOTES.txt

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 2.0.1
+version: 2.0.2
 appVersion: 8.6.1
 description: One of the most versatile open source content management systems.
 keywords:
@@ -15,6 +15,6 @@ icon: https://bitnami.com/assets/stacks/drupal/img/drupal-stack-220x234.png
 sources:
 - https://github.com/bitnami/bitnami-docker-drupal
 maintainers:
-- name: bitnami-bot
+- name: Bitnami
   email: containers@bitnami.com
 engine: gotpl

--- a/stable/drupal/templates/NOTES.txt
+++ b/stable/drupal/templates/NOTES.txt
@@ -16,7 +16,7 @@
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "drupal.fullname" . }}'
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "drupal.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "drupal.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "Drupal URL: http://$SERVICE_IP/"
 
 {{- else if contains "ClusterIP"  .Values.serviceType }}


### PR DESCRIPTION
Testing a K8s cluster where LoadBalancer service returns `hostname` and not `ip`.
This PR change our current approach in bitnami helm charts where we report IP by doing 
```
-o jsonpath='{.status.loadBalancer.ingress[0].ip}'
``` 
The new approach is to use
```
--template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}"
```
where the `.` returns value for whatever field is in the map.

_Source: https://github.com/helm/charts/issues/84#issuecomment-257754892_
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
