### PR TITLE
updating locust to use Locust v0.9.0

### DIFF
--- a/stable/locust/Chart.yaml
+++ b/stable/locust/Chart.yaml
@@ -1,7 +1,7 @@
 name: locust
 description: A modern load testing framework
-version: 0.3.0
-appVersion: 0.7.5
+version: 0.4.0
+appVersion: 0.9.0
 maintainers:
   - name: so0k
     email: vincent.drl@gmail.com

--- a/stable/locust/README.md
+++ b/stable/locust/README.md
@@ -5,7 +5,7 @@ testing using Kubernetes.
 
 ## Pre Requisites:
 
-* Requires (and tested with) helm `v2.1.2` or above.
+* Requires (and tested with) helm `v2.10.2` or above.
 
 ## Chart details
 
@@ -21,20 +21,20 @@ This chart will do the following:
 To install the chart with the release name `locust-nymph` in the default namespace:
 
 ```bash
-helm install -n locust-nymph --set master.config.target-host=http://site.example.com stable/locust
+helm install -n locust-nymph --set master.config.target-url=http://site.example.com stable/locust
 ```
 
 | Parameter                    | Description                             | Default                                               |
 | ---------------------------- | ----------------------------------      | ----------------------------------------------------- |
 | `Name`                       | Locust master name                      | `locust`                                              |
-| `image.repository`           | Locust container image name             | `quay.io/honestbee/locust`                            |
+| `image.repository`           | Locust container image name             | `garland/locust`                            |
 | `image.tag`                  | Locust Container image tag              | `0.7.5`                                               |
 | `image.pullSecrets`          | Locust Container image registry secret  | `None`                                                |
 | `service.type`               | k8s service type exposing master        | `NodePort`                                            |
 | `service.nodePort`           | Port on cluster to expose master        | `0`                                                   |
 | `service.annotations`        | KV containing custom annotations        | `{}`                                                  |
-| `service.extraLabels`        | KV containing extra labels              | `{}`                                                  |
-| `master.config.target-host`  | locust target host                      | `http://site.example.com`                             |
+| `service.extraLabels`        | KV containing extra labels              | `{}`                                                  |\
+| `master.config.target-url`   | locust target host                      | `http://site.example.com`                             |
 | `worker.config.locust-script`| locust script to run                    | `/locust-tasks/tasks.py`                              |
 | `worker.replicaCount`        | Number of workers to run                | `2`                                                   |
 

--- a/stable/locust/templates/master-deploy.yaml
+++ b/stable/locust/templates/master-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locust.master" . }}
@@ -10,6 +10,10 @@ metadata:
     component: master
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      component: master
+      app: {{ template "locust.fullname" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -30,6 +34,7 @@ spec:
       - name: locust
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: ["-f", "$(LOCUSTFILE_PATH)", "-H", "$(TARGET_URL)", "--master"]
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
         env:
@@ -37,9 +42,7 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
-        - name: LOCUST_MODE
-          value: "master"
-        - name: LOCUST_SCRIPT
+        - name: LOCUSTFILE_PATH
           value: {{ index .Values.worker.config "locust-script" | quote }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/stable/locust/templates/worker-deploy.yaml
+++ b/stable/locust/templates/worker-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "locust.worker" . }}
@@ -10,6 +10,10 @@ metadata:
     component: worker
 spec:
   replicas: {{ default 2 .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      component: worker
+      app: {{ template "locust.fullname" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -29,6 +33,7 @@ spec:
       - name: locust
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: ["-f", "$(LOCUST_SCRIPT)", "-H", "$(TARGET_URL)", "--slave", "--master-host=$(LOCUST_MASTER_HOST)", "--master-port=5557"]
         volumeMounts:
           - name: locust-tasks
             mountPath: /locust-tasks/
@@ -37,14 +42,10 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
-        - name: LOCUST_MODE
-          value: "worker"
-        - name: LOCUST_MASTER
+        - name: LOCUST_MASTER_HOST
           value: {{ template "locust.master-svc" . }}
-        - name: LOCUST_MASTER_WEB
-          value: "{{ .Values.service.internalPort }}"
-        - name: TARGET_HOST
-          value: {{ index .Values.master.config "target-host" | quote }}
+        - name: TARGET_URL
+          value: {{ index .Values.master.config "target-url" | quote }}
         resources:
 {{ toYaml .Values.worker.resources | indent 10 }}
       restartPolicy: Always

--- a/stable/locust/values.yaml
+++ b/stable/locust/values.yaml
@@ -1,8 +1,8 @@
 Name: locust
 
 image:
-  repository: quay.io/honestbee/locust
-  tag: 0.7.5
+  repository: garland/locust
+  tag: 0.9.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -16,7 +16,7 @@ service:
   extraLabels: {}
 master:
   config:
-    target-host: https://site.example.com
+    target-url: https://site.example.com
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
#### What this PR does / why we need it:
This updates Locust to the latest v0.9.0.  It also uses the Dockerfile in the Locust Github repo as the standard image.  

#### Which issue this PR fixes
none