### PR TITLE
[prometheus-adapter] Allow prometheus servers that use a route-prefix

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.1.2
+version: v0.1.3
 appVersion: v0.2.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
 | `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
 | `prometheus.port`               | Port of where we can find the Prometheus service                                | `9090`                                      |
+| `prometheus.route-prefix`       | Prefix used by the Prometheus server                                            | ``                                          |
 | `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
 | `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - --cert-dir=/tmp/cert
 {{- end }}
         - --logtostderr=true
-        - --prometheus-url={{ .Values.prometheus.url }}:{{ .Values.prometheus.port }}
+        - --prometheus-url={{ .Values.prometheus.url }}:{{ .Values.prometheus.port }}{{ index .Values.prometheus "route-prefix" }}
         - --metrics-relist-interval={{ .Values.metricsRelistInterval }}
         - --v={{ .Values.logLevel }}
         - --config=/etc/adapter/config.yaml

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -16,6 +16,7 @@ nodeSelector: {}
 prometheus:
   url: http://prometheus.default.svc
   port: 9090
+  route-prefix:
 
 replicas: 1
 


### PR DESCRIPTION

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
