### PR TITLE
[incubator/logstash] Allow explicit setting the clusterIP on service

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.9.3
+version: 0.9.4
 appVersion: 6.4.1
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -81,6 +81,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `service.annotations`           | Service annotations                                | `{}`                                             |
 | `service.ports`                 | Ports exposed by service                           | beats                                            |
 | `service.loadBalancerIP`        | The load balancer IP for the service               | unset                                            |
+| `service.clusterIP`             | The cluster IP for the service                     | unset                                            |
 | `ports`                         | Ports exposed by logstash container                | beats                                            |
 | `ingress.enabled`               | Enables Ingress                                    | `false`                                          |
 | `ingress.annotations`           | Ingress annotations                                | `{}`                                             |

--- a/incubator/logstash/templates/service.yaml
+++ b/incubator/logstash/templates/service.yaml
@@ -24,3 +24,6 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}
+{{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+{{- end }}

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -18,6 +18,7 @@ image:
 
 service:
   type: ClusterIP
+  # clusterIP: None
   annotations: {}
     ## AWS example for use with LoadBalancer service type.
     # external-dns.alpha.kubernetes.io/hostname: logstash.cluster.local


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
When configuring an ELK stack with e.g. beats contacting logstash with persistent TCP connections, it makes sence to use internal load-balancing. By using a [headless servce](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) this is possible. An headless service is set by specifying the clusterIP of the service.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
