### PR TITLE
[stable/metricbeat] Set dnsPolicy explicitly to ClusterFirstWithHostNet

### DIFF
--- a/stable/metricbeat/Chart.yaml
+++ b/stable/metricbeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with metricbeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: metricbeat
-version: 0.3.1
+version: 0.3.2
 appVersion: 6.4.2
 home: https://www.elastic.co/products/beats/metricbeat
 sources:

--- a/stable/metricbeat/templates/daemonset.yaml
+++ b/stable/metricbeat/templates/daemonset.yaml
@@ -109,6 +109,7 @@ spec:
       terminationGracePeriodSeconds: 60
       serviceAccountName: {{ template "metricbeat.serviceAccountName" . }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow metricbeat installs to work properly when outputting to cluster-local destination.

#### Which issue this PR fixes
  - fixes #8083

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

