### PR TITLE
[stable/prometheus] Drop disabled cadvisor metrics

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 7.1.3
+version: 7.1.4
 appVersion: 2.4.2
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -932,6 +932,11 @@ serverFiles:
             regex: (.+)
             target_label: __metrics_path__
             replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+        metric_relabel_configs:
+          - regex: (container_network_(tcp|udp)_usage_total|container_tasks_state)
+            source_labels: [__name__]
+            action: drop
+
 
       # Scrape config for service endpoints.
       #


### PR DESCRIPTION
@mgoodness @gianrubio

#### What this PR does / why we need it:

Kubernetes disables some cAdvisor metrics by default. These always
return 0, and in a larger cluster this can put a heavy burden on
prometheus. In a larger cluster, dropping these metrics dropped the
memory usage from 12GiB to 9GiB.

See https://github.com/kubernetes/kubernetes/issues/60279

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
