### PR TITLE
concourse: move vault auth param to secret

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 2.2.0
+version: 3.0.0
 appVersion: 4.2.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -151,6 +151,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `secrets.vaultClientCert` | Vault Client Certificate | `nil` |
 | `secrets.vaultClientKey` | Vault Client Key | `nil` |
 | `secrets.vaultClientToken` | Vault periodic client token | `nil` |
+| `secrets.vaultAuthParam` | Paramter to pass when logging in via the backend | `nil` |
 | `secrets.influxdbPassword` | Password used to authenticate with influxdb | `nil` |
 | `secrets.syslogCaCert` | SSL certificate to verify Syslog server | `nil` |
 

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -61,6 +61,7 @@ data:
   vault-client-token: {{ default "" .Values.secrets.vaultClientToken | b64enc | quote }}
   vault-client-cert: {{ default "" .Values.secrets.vaultClientCert | b64enc | quote }}
   vault-client-key: {{ default "" .Values.secrets.vaultClientKey | b64enc | quote }}
+  vault-client-auth-param: {{ default "" .Values.secrets.vaultAuthParam | b64enc | quote }}
   {{- end }}
   {{- if .Values.concourse.web.awsSsm.enabled }}
   aws-ssm-access-key: {{ default "" .Values.secrets.awsSsmAccessKey | b64enc | quote }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -303,14 +303,16 @@ spec:
               value: {{ .Values.concourse.web.vault.pathPrefix | quote }}
             - name: CONCOURSE_VAULT_AUTH_BACKEND
               value: {{ .Values.concourse.web.vault.authBackend | quote }}
+            {{- if .Values.concourse.web.vault.useCaCert }}
+            - name: CONCOURSE_VAULT_CA_CERT
+              value: "/concourse-vault/ca.cert"
+            {{- end }}
+            {{- if eq (default "" .Values.concourse.web.vault.authBackend) "token" }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: vault-client-token
-            {{- if .Values.concourse.web.vault.useCaCert }}
-            - name: CONCOURSE_VAULT_CA_CERT
-              value: "/concourse-vault/ca.cert"
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "cert" }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
@@ -318,13 +320,16 @@ spec:
             - name: CONCOURSE_VAULT_CLIENT_KEY
               value: "/concourse-vault/client.key"
             {{- end }}
+            {{- if eq (default "" .Values.concourse.web.vault.authBackend) "approle" }}
+            - name: CONCOURSE_VAULT_AUTH_PARAM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "concourse.concourse.fullname" . }}
+                  key: vault-client-auth-param
+            {{- end }}
             {{- if .Values.concourse.web.vault.authBackendMaxTtl }}
             - name: CONCOURSE_VAULT_AUTH_BACKEND_MAX_TTL
               value: {{ .Values.concourse.web.vault.authBackendMaxTtl | quote }}
-            {{- end }}
-            {{- if .Values.concourse.web.vault.authParam }}
-            - name: CONCOURSE_VAULT_AUTH_PARAM
-              value: {{ .Values.concourse.web.vault.authParam | quote }}
             {{- end }}
             {{- if .Values.concourse.web.vault.cache }}
             - name: CONCOURSE_VAULT_CACHE

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -196,8 +196,6 @@ concourse:
       retryMax: 5m
       ## The initial time between retries when logging in or reAuthing a secret.
       retryInitial: 1s
-      ## Paramter to pass when logging in via the backend. Can be specified multiple times.
-      # authParam: id=foo,secret_id=bar
     ## Don't actually do any automatic scheduling or checking.
     # noop:
     staticWorker:
@@ -1157,6 +1155,14 @@ secrets:
   ## ref: https://www.vaultproject.io/docs/concepts/tokens.html#periodic-tokens
   ##
   # vaultClientToken:
+
+  ## vault authentication parameters
+  ## Paramter to pass when logging in via the backend
+  ## Required for "approle" authenication method
+  ## e.g. "role_id=x,secret_id=x"
+  ## ref: https://concourse-ci.org/creds.html#vault-auth-param=NAME=VALUE
+  ##
+  # vaultAuthParam:
 
   ## provide the client certificate for authenticating with the [TLS](https://www.vaultproject.io/docs/auth/cert.html) backend
   ## the value will be written to /concourse-vault/client.cert


### PR DESCRIPTION
~Not ready to merge, not tested yet. I am just seeking initial feedback from e.g. @william-tran, @xtremerui. I can test this chart after hours on a live concourse cluster.~ Update: I've tested this PR on a live concourse cluster and it works for me™.

Vault auth params are sensitive credentials and should be treated as secret.

This returns auth params functionality closer to concourse chart v1.16.1, but it is a breaking change compared to that version and v2.1.0. 

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #8093

#### Special notes for your reviewer:
Because this is a breaking change, it warrants a major semver increment. Even though the breaking impact should be minor: this PR comes on the heels of the previous breaking change PR.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
