### PR TITLE
[stable/mariadb] Remove unnecessary env. variable on slave pods

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.0.6
+version: 5.0.7
 appVersion: 10.1.36
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -77,22 +77,6 @@ spec:
         image: {{ template "mariadb.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
-        - name: MARIADB_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.fullname" . }}
-              key: mariadb-root-password
-        {{- if .Values.db.user }}
-        - name: MARIADB_USER
-          value: "{{ .Values.db.user }}"
-        - name: MARIADB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "mariadb.fullname" . }}
-              key: mariadb-password
-        {{- end }}
-        - name: MARIADB_DATABASE
-          value: "{{ .Values.db.name }}"
         - name: MARIADB_REPLICATION_MODE
           value: "slave"
         - name: MARIADB_MASTER_HOST
@@ -119,7 +103,7 @@ spec:
         {{- if .Values.slave.livenessProbe.enabled }}
         livenessProbe:
           exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
+            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD"]
           initialDelaySeconds: {{ .Values.slave.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.slave.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.slave.livenessProbe.timeoutSeconds }}
@@ -129,7 +113,7 @@ spec:
         {{- if .Values.slave.readinessProbe.enabled }}
         readinessProbe:
           exec:
-            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_ROOT_PASSWORD"]
+            command: ["sh", "-c", "exec mysqladmin status -uroot -p$MARIADB_MASTER_ROOT_PASSWORD"]
           initialDelaySeconds: {{ .Values.slave.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.slave.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.slave.readinessProbe.timeoutSeconds }}
@@ -151,12 +135,12 @@ spec:
         image: {{ template "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
         env:
-        - name: MARIADB_ROOT_PASSWORD
+        - name: MARIADB_MASTER_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mariadb.fullname" . }}
               key: mariadb-root-password
-        command: [ 'sh', '-c', 'DATA_SOURCE_NAME="root:$MARIADB_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter' ]
+        command: [ 'sh', '-c', 'DATA_SOURCE_NAME="root:$MARIADB_MASTER_ROOT_PASSWORD@(localhost:3306)/" /bin/mysqld_exporter' ]
         ports:
         - name: metrics
           containerPort: 9104


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:
This PR removes unnecessary env. variables on Slave pods since they're not used.