### PR TITLE
[stable/jenkins] Add environment variable option for Jenkins Agent

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.28.2
+version: 0.28.3
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -91,17 +91,18 @@ The following tables list the configurable parameters of the Jenkins chart and t
 
 ### Jenkins Agent
 
-| Parameter                  | Description                                     | Default                |
-| -------------------------- | ----------------------------------------------- | ---------------------- |
-| `Agent.AlwaysPullImage`    | Always pull agent container image before build  | `false`                |
-| `Agent.CustomJenkinsLabels`| Append Jenkins labels to the agent              | `{}`                   |
-| `Agent.Enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
-| `Agent.Image`              | Agent image name                                | `jenkinsci/jnlp-slave` |
-| `Agent.ImagePullSecret`    | Agent image pull secret                         | Not set                |
-| `Agent.ImageTag`           | Agent image tag                                 | `3.27-1`                 |
-| `Agent.Privileged`         | Agent privileged container                      | `false`                |
-| `Agent.resources`          | Resources allocation (Requests and Limits)      | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}`|
-| `Agent.volumes`            | Additional volumes                              | `nil`                  |
+| Parameter                  | Description                                       | Default                |
+| -------------------------- | ------------------------------------------------- | ---------------------- |
+| `Agent.AlwaysPullImage`    | Always pull agent container image before build    | `false`                |
+| `Agent.CustomJenkinsLabels`| Append Jenkins labels to the agent                | `{}`                   |
+| `Agent.Enabled`            | Enable Kubernetes plugin jnlp-agent podTemplate   | `true`                 |
+| `Agent.Image`              | Agent image name                                  | `jenkinsci/jnlp-slave` |
+| `Agent.ImagePullSecret`    | Agent image pull secret                           | Not set                |
+| `Agent.ImageTag`           | Agent image tag                                   | `2.62`                 |
+| `Agent.Privileged`         | Agent privileged container                        | `false`                |
+| `Agent.resources`          | Resources allocation (Requests and Limits)        | `{requests: {cpu: 200m, memory: 256Mi}, limits: {cpu: 200m, memory: 256Mi}}`|
+| `Agent.ContainerEnv`       | Environment variables for Jenkins Agent Container | Not set                |
+| `Agent.volumes`            | Additional volumes                                | `nil`                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -82,19 +82,24 @@ data:
                   <resourceRequestMemory>{{.Values.Agent.Memory | default .Values.Agent.resources.requests.memory}}</resourceRequestMemory>
                   <resourceLimitCpu>{{.Values.Agent.Cpu | default .Values.Agent.resources.limits.cpu}}</resourceLimitCpu>
                   <resourceLimitMemory>{{.Values.Agent.Memory | default .Values.Agent.resources.limits.memory}}</resourceLimitMemory>
-                  <envVars>
-                    <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
-                      <key>JENKINS_URL</key>
-{{- if .Values.Master.SlaveKubernetesNamespace }}
-                      <value>http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
-{{- else }}
-                      <value>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
-{{- end }}
-                    </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
-                  </envVars>
                 </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
               </containers>
-              <envVars/>
+              <envVars>
+                <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                  <key>JENKINS_URL</key>
+{{- if .Values.Master.SlaveKubernetesNamespace }}
+                  <value>http://{{ template "jenkins.fullname" . }}.{{.Release.Namespace}}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
+{{- else }}
+                  <value>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
+{{- end }}
+                </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+{{- range $index, $env := .Values.Agent.ContainerEnv }}
+                <org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+                  <key>{{ $env.key }}</key>
+                  <value>{{ $env.value }}</value>
+                </org.csanchez.jenkins.plugins.kubernetes.model.KeyValueEnvVar>
+{{- end }}
+              </envVars>
               <annotations/>
 {{- if .Values.Agent.ImagePullSecret }}
               <imagePullSecrets>

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -165,6 +165,10 @@ Agent:
     limits:
       cpu: "200m"
       memory: "256Mi"
+  # Custom environment variables that will be placed in agent container
+  # ContainerEnv:
+  #   - key: APPLICATION_ENVIRONMENT
+  #     value: staging
   # You may want to change this to true while testing a new image
   AlwaysPullImage: false
   # Controls how slave pods are retained after the Jenkins build completes


### PR DESCRIPTION
Signed-off-by: Halil Kaya <halil.kaya@metglobal.com>

#### What this PR does / why we need it:
This PR adds a value set of environment variable(s) to Jenkins agent container. It also fixes the place of existing environment variable which is deprecated.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Agent containers might need some custom environment variables. It can only be added after the installation manually. With this PR, they will be put in the container in the Helm chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
