### PR TITLE
Upgrade cluster-autoscaler to v1.12.0

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.7.0
-appVersion: 1.2.2
+version: 0.7.1
+appVersion: 1.12.0
 home: https://github.com/kubernetes/autoscaler
 sources:
 - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler

--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.7.1
+version: 0.8.0
 appVersion: 1.12.0
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -78,6 +78,7 @@ rules:
   - apiGroups:
     - apps
     resources:
+    - replicasets
     - statefulsets
     verbs:
     - watch

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -34,7 +34,7 @@ cloudConfigPath: /etc/gce.conf
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v1.2.2
+  tag: v1.12.0
   pullPolicy: IfNotPresent
 
 tolerations: []


### PR DESCRIPTION
This is a requirement for the newest version of the cluster autoscaler `v1.12.0`