### PR TITLE
fix(stable/cockroachdb): Add an explicit selector to the StatefulSet

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 1.2.6
+version: 2.0.0
 appVersion: 2.0.6
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -37,6 +37,24 @@ certificate for each node (e.g.  `default.node.eerie-horse-cockroachdb-0` and
 one client certificate for the job that initializes the cluster (e.g.
 `default.node.root`).
 
+## Upgrading
+### To 2.0.0
+Due to having no explicit selector set for the StatefulSet before version 2.0.0 of
+this chart, upgrading from any version that uses a version of kubernetes that locks
+the selector labels to any other version is impossible without deleting the StatefulSet.
+Luckily there is a way to do it without actually deleting all the resources managed
+by the StatefulSet. Use the workaround below to upgrade from versions previous to 2.0.0.
+The following example assumes that the release name is crdb:
+
+```console
+$ kubectl delete statefulset crdb-cockroachdb --cascade=false
+```
+
+Verify that no pod is deleted and then upgrade as normal. A new StatefulSet will
+be created taking over the management of the existing pods upgrading them if needed.
+
+For more information about the upgrading bug see https://github.com/helm/charts/issues/7680.
+
 ## Configuration
 
 The following table lists the configurable parameters of the CockroachDB chart and their default values.

--- a/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
+++ b/stable/cockroachdb/templates/cockroachdb-statefulset.yaml
@@ -185,6 +185,11 @@ metadata:
 spec:
   serviceName: "{{ printf "%s-%s" .Release.Name .Values.Name | trunc 56 }}"
   replicas: {{ default 3 .Values.Replicas }}
+  selector:
+    matchLabels:
+      heritage: {{ .Release.Service | quote }}
+      release: {{ .Release.Name | quote }}
+      component: "{{ .Release.Name }}-{{ .Values.Component }}"
   template:
     metadata:
       labels:


### PR DESCRIPTION
This was preventing any upgrades because kubernetes made the selector
immutable and the chart version changes between upgrades of charts.

fix #8102

Signed-off-by: Rio Kierkels <riokierkels@gmail.com>

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
