### PR TITLE
[stable/mongodb-replicaset] Fix various bootstrap issues

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.6.0
+version: 3.6.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `metrics.image.pullPolicy`           | Image pull policy for metrics exporter                                    | `IfNotPresent`                                      |
 | `metrics.port`                       | Port for metrics exporter                                                 | `9216`                                              |
 | `metrics.path`                       | URL Path to expose metics                                                 | `/metrics`                                          |
+| `metrics.resources`                  | Metrics pod resource requests and limits                                  | `{}`                                                |
 | `metrics.socketTimeout`              | Time to wait for a non-responding socket                                  | `3s`                                                |
 | `metrics.syncTimeout`                | Time an operation with this session will wait before returning an error   | `1m`                                                |
 | `metrics.prometheusServiceDiscovery` | Adds annotations for Prometheus ServiceDiscovery                          | `true`                                              |
@@ -77,8 +78,16 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `nodeSelector`                      | Node labels for pod assignment                                            | `{}`                                                |
 | `affinity`                          | Node/pod affinities                                                       | `{}`                                                |
 | `tolerations`                       | List of node taints to tolerate                                           | `[]`                                                |
-| `livenessProbe`                     | Liveness probe configuration                                              | See below                                           |
-| `readinessProbe`                    | Readiness probe configuration                                             | See below                                           |
+| `livenessProbe.failureThreshold`    | Liveness probe failure threshold                                          | `3`                                                 |
+| `livenessProbe.initialDelaySeconds` | Liveness probe initial delay seconds                                      | `30`                                                |
+| `livenessProbe.periodSeconds`       | Liveness probe period seconds                                             | `10`                                                |
+| `livenessProbe.successThreshold`    | Liveness probe success threshold                                          | `1`                                                 |
+| `livenessProbe.timeoutSeconds`      | Liveness probe timeout seconds                                            | `5`                                                 |
+| `readinessProbe.failureThreshold`   | Readiness probe failure threshold                                         | `3`                                                 |
+| `readinessProbe.initialDelaySeconds`| Readiness probe initial delay seconds                                     | `5`                                                 |
+| `readinessProbe.periodSeconds`      | Readiness probe period seconds                                            | `10`                                                |
+| `readinessProbe.successThreshold`   | Readiness probe success threshold                                         | `1`                                                 |
+| `readinessProbe.timeoutSeconds`     | Readiness probe timeout seconds                                           | `1`                                                 |
 | `extraVars`                         | Set environment variables for the main container                          | `{}`                                                |
 | `extraLabels`                       | Additional labels to add to resources                                     | `{}`                                                |
 
@@ -194,32 +203,6 @@ metrics:
 ```
 
 More information on [MongoDB Exporter](https://github.com/percona/mongodb_exporter) metrics available.
-
-## Readiness probe
-
-The default values for the readiness probe are:
-
-```yaml
-readinessProbe:
-  initialDelaySeconds: 5
-  timeoutSeconds: 1
-  failureThreshold: 3
-  periodSeconds: 10
-  successThreshold: 1
-```
-
-## Liveness probe
-
-The default values for the liveness probe are:
-
-```yaml
-livenessProbe:
-  initialDelaySeconds: 30
-  timeoutSeconds: 5
-  failureThreshold: 3
-  periodSeconds: 10
-  successThreshold: 1
-```
 
 ## Deep dive
 

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -26,6 +26,7 @@ spec:
 {{ toYaml .Values.extraLabels | indent 8 }}
 {{- end }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/mongodb-mongodb-configmap.yaml") . | sha256sum }}
       {{- if .Values.metrics.prometheusServiceDiscovery }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.metrics.port | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:
- Fix enabling metrics breaks upgrade for single replica (#8055)
  - Separate the find primary logic from the rs.add()/rs.initate() logic
  - Also change primary searching to include local mongo to handle single replica scenario
- Fix bootstrap pod never completes when mongod crashes (#7996)
  - We now store mongod pid and verify it is still running
- Fix bootstrap init container does not show logs (#7354)
  - peer-finder still does not return stdout, but it does return stderr so 1>&2
  - Logs don't show up until peer-finder exits unfortunately, so still append to /work-dir/log.txt as well to debug while running
- Fix bootstrap never completes when script crashes and doesn't shutdown mongod
  - One example of this is if create admin user fails then db.shutdownServer() won't have credentials to succeed
  - We now `set -e pipefail` to catch errors better and `trap shutdown_mongo EXIT` to ensure it always runs
  - Finally we `kill -TERM` mongod if all else fails
- Workaround other bootstrap hanging indefinitely issues (#6522, #7417)
  - There are numerous other ways that can cause the script to hang, so we need a general solution for retries
  - Set a max timeout of 5 minutes to retry mongo commands before exiting and let Kubernetes restart pod
- Refactor script to not duplicate user creation and retry until logic
- Automatically restart pods when configuration changes during upgrade
- Adds missing `metrics.resources` to README
- Moves probe documentation from separate section in README to values table

#### Which issue this PR fixes
- fixes #8055
- fixes #7996
- fixes #7354

#### Special notes for your reviewer:
These are the test cases I have manually tested:
- Single replica install with metrics
- Single replica install without metrics
- Single replica upgrade with metrics
- Three replica install without metrics
- Three replica upgrade with metrics
- Mongod crashing during bootstrap
- Bootstrap exceeds timeout

The commands I used to test, with the replicas and metrics.enabled varying per test case.
```shell
helm install --name mongo --set replicas=1 --set auth.enabled=true --set auth.adminUser=mongo --set auth.adminPassword=password --set auth.key=foobar stable/mongodb-replicaset
helm upgrade mongo --reuse-values --set metrics.enabled=true --set auth.metricsUser=metrics --set auth.metricsPassword=password stable/mongodb-replicaset
```
#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
