### PR TITLE
Add TIMEOUT environment variable

### DIFF
--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.4.4
+version: 0.5.0
 appVersion: 1.0.0
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.4.3
+version: 0.4.4
 appVersion: 1.0.0
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/README.md
+++ b/stable/newrelic-infrastructure/README.md
@@ -6,20 +6,21 @@ This chart will deploy the New Relic Infrastructure agent as a Daemonset.
 
 ## Configuration
 
-| Parameter             | Description                                                  | Default                    |
-| ------------------    | ------------------------------------------------------------ | -------------------------- |
-| `cluster`             | The cluster name for the Kubernetes cluster.                 |                          |
-| `licenseKey`          | The [license key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key)  for your New Relic Account. | |
-| `config`              | A `newrelic.yml` file if you wish to provide.                |                         |
-| `kubeStateMetricsUrl` | If provided, the discovery process for kube-state-metrics endpoint won't be triggered. Example: http://172.17.0.3:8080 | |
-| `image.name`          | The container to pull.                                       | `newrelic/infrastructure`  |
-| `image.pullPolicy`    | The pull policy.                                             | `IfNotPresent`             |
-| `image.tag`           | The version of the container to pull.                        | `1.0.0`            |
-| `resources`           | Any resources you wish to assign to the pod.                 | See Resources below        |
-| `verboseLog`          | Should the agent log verbosely. (Boolean)                    | `false`                    |
-| `nodeSelector`        | Node label to use for scheduling                             | `nil`                      |
-| `tolerations`         | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`                      |
-| `updateStrategy`      | Strategy for DaemonSet updates (requires Kubernetes >= 1.6)  | `RollingUpdate`            |
+| Parameter                 | Description                                                  | Default                    |
+| ------------------------- | ------------------------------------------------------------ | -------------------------- |
+| `cluster`                 | The cluster name for the Kubernetes cluster.                 |                          |
+| `licenseKey`              | The [license key](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/license-key)  for your New Relic Account. | |
+| `config`                  | A `newrelic.yml` file if you wish to provide.                |                         |
+| `kubeStateMetricsUrl`     | If provided, the discovery process for kube-state-metrics endpoint won't be triggered. Example: http://172.17.0.3:8080 |
+| `kubeStateMetricsTimeout` | Timeout for accessing kube-state-metrics in milliseconds. If not set the newrelic default is 5000 | |
+| `image.name`              | The container to pull.                                       | `newrelic/infrastructure`  |
+| `image.pullPolicy`        | The pull policy.                                             | `IfNotPresent`             |
+| `image.tag`               | The version of the container to pull.                        | `1.0.0`            |
+| `resources`               | Any resources you wish to assign to the pod.                 | See Resources below        |
+| `verboseLog`              | Should the agent log verbosely. (Boolean)                    | `false`                    |
+| `nodeSelector`            | Node label to use for scheduling                             | `nil`                      |
+| `tolerations`             | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`                      |
+| `updateStrategy`          | Strategy for DaemonSet updates (requires Kubernetes >= 1.6)  | `RollingUpdate`            |
 
 ## Example
 

--- a/stable/newrelic-infrastructure/templates/daemonset.yaml
+++ b/stable/newrelic-infrastructure/templates/daemonset.yaml
@@ -43,6 +43,10 @@ spec:
             - name: "KUBE_STATE_METRICS_URL"
               value: "{{ .Values.kubeStateMetricsUrl }}"
            {{- end }}
+           {{- if .Values.kubeStateMetricsTimeout }}
+            - name: TIMEOUT
+              value: {{ .Values.kubeStateMetricsTimeout | quote }}
+           {{- end }}
             - name: "NRIA_DISPLAY_NAME"
               valueFrom:
                 fieldRef:
@@ -54,7 +58,7 @@ spec:
                   apiVersion: "v1"
                   fieldPath: "spec.nodeName"
             - name: "NRIA_PASSTHROUGH_ENVIRONMENT"
-              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL"
+              value: "KUBERNETES_SERVICE_HOST,KUBERNETES_SERVICE_PORT,CLUSTER_NAME,CADVISOR_PORT,NRK8S_NODE_NAME,KUBE_STATE_METRICS_URL,TIMEOUT"
             {{- if .Values.verboseLog }}
             - name: NRIA_VERBOSE
               value: "1"


### PR DESCRIPTION
#### What this PR does / why we need it:

When the cluster is big enough, Newrelic agent will timeout trying to
get metrics from kube-state-metrics and some data will not make it to
the Newrelic database.

The default timeout for queries to kube-state-metrics is 5000ms which is
not long enough for big cluster (100 nodes+).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Maxime Belanger <maxime.b.belanger@gmail.com>