### PR TITLE
[stable/grafana] Allow for customisation of livenessProbe and readinessProbe.

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.14.8
+version: 1.16.0
 appVersion: 5.2.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -33,6 +33,8 @@ The command removes all the Kubernetes components associated with the chart and 
 |---------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | `replicas`                      | Number of nodes                               | `1`                                                     |
 | `deploymentStrategy`            | Deployment strategy                           | `RollingUpdate`                                         |
+| `livenessProbe`            | Liveness Probe settings                           | `{ "httpGet": { "path": "/api/health", "port": 3000 } }`                                         |
+| `readinessProbe`            | Rediness Probe settings                           | `{ "httpGet": { "path": "/api/health", "port": 3000 } "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10, "periodSeconds": 10 }`                                         |
 | `securityContext`               | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
 | `image.repository`              | Image repository                              | `grafana/grafana`                                       |
 | `image.tag`                     | Image tag. (`Must be >= 5.0.0`)               | `5.2.4`                                                 |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -199,17 +199,9 @@ spec:
                 name: {{ .Values.envFromSecret }}
           {{- end }}
           livenessProbe:
-            httpGet:
-              path: /api/health
-              port: 3000
+{{ toYaml .Values.livenessProbe | indent 12 }}
           readinessProbe:
-            httpGet:
-              path: /api/health
-              port: 3000
-            initialDelaySeconds: 60
-            timeoutSeconds: 30
-            failureThreshold: 10
-            periodSeconds: 10
+{{ toYaml .Values.readinessProbe | indent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -9,6 +9,20 @@ replicas: 1
 
 deploymentStrategy: RollingUpdate
 
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 60
+  timeoutSeconds: 30
+  failureThreshold: 10
+  periodSeconds: 10
+
 image:
   repository: grafana/grafana
   tag: 5.2.4


### PR DESCRIPTION
Signed-off-by: Globegitter <markus.padourek@ecosia.org>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it: 
We have noticed that with out config grafana often takes a bit longer to start so the livenessProbe relatively frequently kills the pod at start, on the flip-side the readinessProbe seems a bit too slow for us with the 60s, so I thought it is best if it can just be fully customised

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer: I bumped the chart version with https://github.com/helm/charts/pull/8111 in mind, i.e. that this PR will get merged first.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
