### PR TITLE
[stable/rabbitmq-ha] Fix health checks

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.4
-version: 1.11.0
+version: 1.11.1
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -101,26 +101,24 @@ spec:
               protocol: TCP
               containerPort: 5671
             {{- end }}
+          {{- $managementCredentials := printf "%s:%s" .Values.managementUsername .Values.managementPassword | b64enc }}
+          {{- $managementHeader := printf "Authorization: Basic %s" $managementCredentials }}
           livenessProbe:
-            httpGet:
-              path: /api/healthchecks/node
-              port: 15672
-              scheme: HTTP
-              httpHeaders:
-              - name: Authorization
-                value: Basic {{ printf "%s:%s" .Values.managementUsername .Values.managementPassword | b64enc }}
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - 'wget -O - -q --header "{{ $managementHeader }}" http://localhost:15672/api/healthchecks/node | grep -qF "{\"status\":\"ok\"}"'
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
-            httpGet:
-              path: /api/healthchecks/node
-              port: 15672
-              scheme: HTTP
-              httpHeaders:
-              - name: Authorization
-                value: Basic {{ printf "%s:%s" .Values.managementUsername .Values.managementPassword | b64enc }}
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - 'wget -O - -q --header "{{ $managementHeader }}" http://localhost:15672/api/healthchecks/node | grep -qF "{\"status\":\"ok\"}"'
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -228,8 +228,8 @@ resources: {}
   # requests:
   #   cpu: 100mm
   #   memory: 1Gi
-initContainer: {}
-  # resources:
+initContainer:
+  resources: {}
   #   limits:
   #     cpu: 100mm
   #     memory: 128Mi
@@ -322,7 +322,7 @@ livenessProbe:
 
 readinessProbe:
   failureThreshold: 6
-  initialDelaySeconds: 10
+  initialDelaySeconds: 20
   timeoutSeconds: 3
   periodSeconds: 5
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes regression in rabbitmq health checks introduced in my previous PR. See ticket for details.
Also bumps the initial readiness probe to avoid failing initially before rabbitmq is fully up.

#### Which issue this PR fixes
  - fixes #7752

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
