### PR TITLE
Fix elastic DNS information output.

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.9.1
+version: 1.9.2
 appVersion: 6.4.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/templates/NOTES.txt
+++ b/incubator/elasticsearch/templates/NOTES.txt
@@ -4,7 +4,7 @@ Elasticsearch can be accessed:
 
   * Within your cluster, at the following DNS name at port 9200:
 
-    {{ template "elasticsearch.client.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{ template "elasticsearch.client.fullname" . }}.{{ .Release.Namespace }}.svc
 
   * From outside the cluster, run these commands in the same shell:
     {{- if contains "NodePort" .Values.client.serviceType }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes the output DNs information for the elastic search cluster.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
