### PR TITLE
[stable/prometheus-postgres-exporter] Added flag for disabling default metrics

### DIFF
--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.6"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 0.4.0
+version: 0.4.1
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/Chart.yaml
+++ b/stable/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.6"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 0.4.1
+version: 0.5.0
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/stable/prometheus-postgres-exporter/README.md
+++ b/stable/prometheus-postgres-exporter/README.md
@@ -47,6 +47,7 @@ The following table lists the configurable parameters of the postgres Exporter c
 | `resources`          |                                  |                    `{}`                                  |
 | `config.datasource`                 | Postgresql datasource configuration                      |                                     |
 | `config.queries`                | SQL queries that the exporter will run | [postgres exporter defaults](https://github.com/wrouesnel/postgres_exporter/blob/master/queries.yaml) |
+| `config.disableDefaultMetrics`  | Specifies whether to use only metrics from `queries.yaml`| `false` |
 | `rbac.create`                   | Specifies whether RBAC resources should be created.| `true` |
 | `rbac.pspEnabled`               | Specifies whether a PodSecurityPolicy should be created.| `true` |
 | `serviceAccount.create`         | Specifies whether a service account should be created.| `true` |

--- a/stable/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/stable/prometheus-postgres-exporter/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         - name: {{ .Chart.Name }}
           args:
           - "--extend.query-path=/etc/config.yaml"
+          {{- if .Values.config.disableDefaultMetrics }}
+          - "--disable-default-metrics"
+          {{- end }}
           env:
             - name: DATA_SOURCE_NAME
               valueFrom:

--- a/stable/prometheus-postgres-exporter/values.yaml
+++ b/stable/prometheus-postgres-exporter/values.yaml
@@ -46,6 +46,7 @@ config:
     port: "5432"
     database: ''
     sslmode: disable
+  disableDefaultMetrics: false
   # this are the defaults queries that the exporter will run, extracted from: https://github.com/wrouesnel/postgres_exporter/blob/master/queries.yaml
   queries: |-
     pg_replication:


### PR DESCRIPTION
#### What this PR does / why we need it:
Exposes the `disable-default-metrics` flag of the `postgres-exporter` container as defined here:
https://github.com/wrouesnel/postgres_exporter#flags

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
