### PR TITLE
Adding command property

### DIFF
--- a/incubator/logstash/Chart.yaml
+++ b/incubator/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 0.9.5
+version: 0.9.6
 appVersion: 6.4.2
 sources:
 - https://www.docker.elastic.co

--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -96,13 +96,14 @@ The following table lists the configurable parameters of the chart and its defau
 | `podLabels`                     | Pod labels                                         | `{}`                                             |
 | `livenessProbe`                 | Liveness probe settings for logstash container     | (see `values.yaml`)                              |
 | `readinessProbe`                | Readiness probe settings for logstash container    | (see `values.yaml`)                              |
+| `command`                       | Command to run when starting the logstash container| `nil`                                            |
 | `persistence.enabled`           | Enable persistence                                 | `true`                                           |
 | `persistence.storageClass`      | Storage class for PVCs                             | unset                                            |
 | `persistence.accessMode`        | Access mode for PVCs                               | `ReadWriteOnce`                                  |
 | `persistence.size`              | Size for PVCs                                      | `2Gi`                                            |
 | `volumeMounts`                  | Volume mounts to configure for logstash container  | (see `values.yaml`)                              |
-| `volumes`                       | Volumes to configure for logstash container        | []                              |
-| `terminationGracePeriodSeconds` | Duration the pod needs to terminate gracefully     | `30`
+| `volumes`                       | Volumes to configure for logstash container        | []                                               |
+| `terminationGracePeriodSeconds` | Duration the pod needs to terminate gracefully     | `30`                                             |
 | `exporter.logstash`             | Prometheus logstash-exporter settings              | (see `values.yaml`)                              |
 | `exporter.logstash.enabled`     | Enables Prometheus logstash-exporter               | `false`                                          |
 | `elasticsearch.host`            | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |

--- a/incubator/logstash/templates/statefulset.yaml
+++ b/incubator/logstash/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           args:
             - {{ toYaml .Values.command }}
           {{- end }}
-                ports:
+          ports:
             - name: monitor
               containerPort: {{ .Values.exporter.logstash.target.port }}
               protocol: TCP

--- a/incubator/logstash/templates/statefulset.yaml
+++ b/incubator/logstash/templates/statefulset.yaml
@@ -48,7 +48,12 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
+          {{- if .Values.command }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - {{ toYaml .Values.command }}
+          {{- end }}
+                ports:
             - name: monitor
               containerPort: {{ .Values.exporter.logstash.target.port }}
               protocol: TCP

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -123,6 +123,8 @@ readinessProbe:
   # failureThreshold: 6
   # successThreshold: 1
 
+# command: logstash-plugin install logstash-filter-uuid; /usr/local/bin/docker-entrypoint
+
 persistence:
   enabled: true
   ## logstash data Persistent Volume Storage Class


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the ability to execute a custom command at startup of the Logstash container. Useful for when a Logstash plugin needs to be installed prior to the container starting.

Tested locally and working.

#### Which issue this PR fixes
None

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
