### PR TITLE
remark for github org and team separation

### DIFF
--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -299,7 +299,7 @@ concourse:
           user:
           ## List of whitelisted GitHub orgs
           org:
-          ## List of whitelisted GitHub teams
+          ## List of whitelisted GitHub teams (GitHub org and team separated by colon)
           team:
         ## Authentication (Main Team) (GitLab)
         gitlab:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Syntax of authentication using GitHub teams changed with Concourse 4.x.
In Concourse 3.x teams have been specified using a slash, e.g. `my-org/my-team`
With Concourse 4.x you must use a colon, e.g. `my-org:my-team`.

It took me quite some time to figure this out !
