### PR TITLE
Add es prometheus exporter

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.8.2
+version: 1.8.3
 appVersion: 6.4.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.8.3
+version: 1.9.0
 appVersion: 6.4.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -113,6 +113,17 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.tolerations`                   | Data tolerations                                                    | `[]`                                 |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
+| `prometheusExporter.repository`      | Prometheus exporter image                                           | `justwatch/elasticsearch_exporter`   |
+| `prometheusExporter.tag`             | Prometheus exporter image tag                                       | `1.0.2`                              |
+| `prometheusExporter.pullPolicy`      | Prometheus exporter image pull policy                               | `"IfNotPresent"`                     |
+| `prometheusExporter.clientName`      | Name given to sidecar container and port, used by servicemonitor    | `client-exporter`                    |
+| `prometheusExporter.internalPort`    | Internal port to sidecar container                                  | `9108`                               |
+| `prometheusExporter.externalPort`    | External port to sidecar container                                  | `9108`                               |
+| `prometheusExporter.metricsEndpoint` | Path for exported metrics (`http://localhost:9108/metrics`)         | `/metrics`                           |
+| `serviceMonitor.enabled`             | If true, servicemonitor object is deployed with chart               | `false`                              |
+| `serviceMonitor.interval`            | Interval at which the servicemonitor scrapes for metrics            | `15s`                                |
+| `serviceMonitor.namespace`           | Namespace to which the servicemonitor is deployed to                | `monitoring`                         |
+| `serviceMonitor.labels.prometheus`   | This label is necessary for recognition by the prometheus operator  | `kube-prometheus`                    |
 | `extraInitContainers`                | Additional init container passed through the tpl 	                 | ``                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
@@ -179,6 +190,15 @@ cluster.env.XPACK_MONITORING_ENABLED: true
 
 Note: to see these changes you will need to update your kibana repo to `image.repository: docker.elastic.co/kibana/kibana` instead of the `oss` version
 
+## Enabling elasticsearch prometheus monitoring
+
+Works with `oss` repository defined. Prometheus is an open source tool for monitoring metrics.
+
+Prometheus works by having an operator instance look for servicemonitor objects, which enable the communication between prometheus exporters and the prometheus operator.
+
+The prometheus exporter runs as a sidecar container within elasticsearch client pod. It translates elasticsearch metrics to ones that prometheus can read.
+
+By default, the servicemonitor object is disabled. If you would like to connect internal metrics from elasticsearch to prometheus, set `serviceMonitor.enabled: true`.
 
 ## Select right storage class for SSD volumes
 

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -131,6 +131,7 @@ spec:
           subPath: elasticsearch.keystore
           readOnly: true
 {{- end }}
+{{- if .Values.prometheusExporter.enabled }}
       - name: {{ .Values.prometheusExporter.clientName }}
         image: "{{ .Values.prometheusExporter.repository }}:{{ .Values.prometheusExporter.tag }}"
         imagePullPolicy: {{ .Values.prometheusExporter.pullPolicy }}
@@ -142,6 +143,7 @@ spec:
           - "-web.listen-address=:{{ .Values.prometheusExporter.internalPort }}"
           - "-web.telemetry-path={{ .Values.prometheusExporter.metricsEndpoint }}"
           - "-es.timeout=30s"
+{{- end }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range $pullSecret := .Values.image.pullSecrets }}

--- a/incubator/elasticsearch/templates/client-deployment.yaml
+++ b/incubator/elasticsearch/templates/client-deployment.yaml
@@ -131,6 +131,17 @@ spec:
           subPath: elasticsearch.keystore
           readOnly: true
 {{- end }}
+      - name: {{ .Values.prometheusExporter.clientName }}
+        image: "{{ .Values.prometheusExporter.repository }}:{{ .Values.prometheusExporter.tag }}"
+        imagePullPolicy: {{ .Values.prometheusExporter.pullPolicy }}
+        ports:
+          - containerPort: {{ .Values.prometheusExporter.internalPort }}
+        args:
+          - "-es.all=true"
+          - "-es.indices=true"
+          - "-web.listen-address=:{{ .Values.prometheusExporter.internalPort }}"
+          - "-web.telemetry-path={{ .Values.prometheusExporter.metricsEndpoint }}"
+          - "-es.timeout=30s"
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range $pullSecret := .Values.image.pullSecrets }}

--- a/incubator/elasticsearch/templates/client-svc.yaml
+++ b/incubator/elasticsearch/templates/client-svc.yaml
@@ -18,6 +18,10 @@ spec:
     - name: http
       port: 9200
       targetPort: http
+    - name: {{ .Values.prometheusExporter.clientName }}
+      port: {{ .Values.prometheusExporter.externalPort }}
+      targetPort: {{ .Values.prometheusExporter.internalPort }}
+      protocol: TCP
   selector:
     app: {{ template "elasticsearch.name" . }}
     component: "{{ .Values.client.name }}"

--- a/incubator/elasticsearch/templates/client-svc.yaml
+++ b/incubator/elasticsearch/templates/client-svc.yaml
@@ -18,10 +18,12 @@ spec:
     - name: http
       port: 9200
       targetPort: http
+{{- if .Values.prometheusExporter.enabled }}
     - name: {{ .Values.prometheusExporter.clientName }}
       port: {{ .Values.prometheusExporter.externalPort }}
       targetPort: {{ .Values.prometheusExporter.internalPort }}
       protocol: TCP
+{{- end }}
   selector:
     app: {{ template "elasticsearch.name" . }}
     component: "{{ .Values.client.name }}"

--- a/incubator/elasticsearch/templates/servicemonitor.yaml
+++ b/incubator/elasticsearch/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "elasticsearch.name" . }}-{{ .Release.Name }}
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.serviceMonitor.labels }}
+{{ toYaml .Values.serviceMonitor.labels | indent 4 }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | squote }}
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+    - port: {{ .Values.prometheusExporter.clientName }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      path: {{ .Values.prometheusExporter.metricsEndpoint }}
+{{- end -}}

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -120,5 +120,25 @@ data:
   updateStrategy:
     type: OnDelete
 
+prometheusExporter:
+  # The values within here are responsible for setting up service ports and sidecar exporter containers.
+  repository: justwatch/elasticsearch_exporter
+  tag: 1.0.2
+  pullPolicy: "IfNotPresent"
+  clientName: client-exporter
+  internalPort: 9108
+  externalPort: 9108
+  metricsEndpoint: /metrics
+
+serviceMonitor:
+  enabled: false
+  interval: 15s
+  namespace: monitoring
+  # This installs your ServiceMonitor in a different namespace from the Release.
+  # This field is optional. If this field resolves to false, the Release's namespace is used.
+  labels:
+    prometheus: kube-prometheus
+    # This is the default `spec.serviceMonitorSelector` for the kube-prometheus Prometheus resource
+
 ## Additional init containers
 extraInitContainers: |

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -122,6 +122,7 @@ data:
 
 prometheusExporter:
   # The values within here are responsible for setting up service ports and sidecar exporter containers.
+  enabled: false
   repository: justwatch/elasticsearch_exporter
   tag: 1.0.2
   pullPolicy: "IfNotPresent"
@@ -130,6 +131,10 @@ prometheusExporter:
   externalPort: 9108
   metricsEndpoint: /metrics
 
+# operator which listens to servicemonitor objects:
+# https://github.com/coreos/prometheus-operator
+# article describing how to use servicemonitors:
+# https://devops.college/prometheus-operator-how-to-monitor-an-external-service-3cb6ac8d5acb
 serviceMonitor:
   enabled: false
   interval: 15s


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR creates a sidecar Prometheus exporter container to the Elasticsearch client service. It also adds a servicemonitor that can be enabled in order to communicate with Prometheus. 

This PR is very useful because it makes it easy to connect Elasticsearch to Prometheus. Prometheus can be used to consolidate logging of all services and applications, including ones outside of the elastic stack. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

This is more of an additional feature than a bug fix. I think it's useful to provide people to an array of monitoring options. This PR adds an additional monitoring option for people who want to monitor their deployment of the elasticsearch helm chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
