### PR TITLE
[incubator/kafka]: restart job-config OnFailure

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.10.0
+version: 0.10.1
 appVersion: 4.1.2
 keywords:
 - kafka

--- a/incubator/kafka/templates/job-config.yaml
+++ b/incubator/kafka/templates/job-config.yaml
@@ -16,7 +16,7 @@ spec:
         app: {{ template "kafka.fullname" . }}
         release: "{{ .Release.Name }}"
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This prevents the `kafka-config` job from spawning more than 1 pod by simply restarting the existing one on failure.

This behavior is 'better' than the existing one because when Kafka (and Zookeeper) have multiple replicas, the kafka-config job will most likely timeout several times and a bunch of pods (sometimes hundreds) will be created and have an Error status. With this change, whenever the job's pod timeouts, it will be restarted and try to set the configuration again. 

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
