### PR TITLE
[incubator/elasticsearch] Add support for Prometheus Operator / Exporter

### DIFF
--- a/incubator/elasticsearch/Chart.yaml
+++ b/incubator/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.8.2
+version: 1.9.0
 appVersion: 6.4.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/incubator/elasticsearch/README.md
+++ b/incubator/elasticsearch/README.md
@@ -60,60 +60,81 @@ $ kubectl delete pvc -l release=my-release,component=data
 
 The following table lists the configurable parameters of the elasticsearch chart and their default values.
 
-|              Parameter               |                             Description                             |               Default                |
-| ------------------------------------ | ------------------------------------------------------------------- | ------------------------------------ |
-| `appVersion`                         | Application Version (Elasticsearch)                                 | `6.4.2`                              |
-| `image.repository`                   | Container image name                                                | `docker.elastic.co/elasticsearch/elasticsearch-oss` |
-| `image.tag`                          | Container image tag                                                 | `6.4.2`                              |
-| `image.pullPolicy`                   | Container pull policy                                               | `Always`                             |
-| `cluster.name`                       | Cluster name                                                        | `elasticsearch`                      |
-| `cluster.xpackEnable`                | Writes the X-Pack configuration options to the configuration file   | `false`                              |
-| `cluster.config`                     | Additional cluster config appended                                  | `{}`                                 |
-| `cluster.keystoreSecret`             | Name of secret holding secure config options in an es keystore      | `nil`                                |
-| `cluster.env`                        | Cluster environment variables                                       | `{MINIMUM_MASTER_NODES: "2"}`        |
-| `client.name`                        | Client component name                                               | `client`                             |
-| `client.replicas`                    | Client node replicas (deployment)                                   | `2`                                  |
-| `client.resources`                   | Client node resources requests & limits                             | `{} - cpu limit must be an integer`  |
-| `client.priorityClassName`           | Client priorityClass                                                | `nil`                                |
-| `client.heapSize`                    | Client node heap size                                               | `512m`                               |
-| `client.podAnnotations`              | Client Deployment annotations                                       | `{}`                                 |
-| `client.nodeSelector`                | Node labels for client pod assignment                               | `{}`                                 |
-| `client.tolerations`                 | Client tolerations                                                  | `[]`                                 |
-| `client.serviceAnnotations`          | Client Service annotations                                          | `{}`                                 |
-| `client.serviceType`                 | Client service type                                                 | `ClusterIP`                          |
-| `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                 |
-| `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                 |
-| `master.exposeHttp`                  | Expose http port 9200 on master Pods for monitoring, etc            | `false`                              |
-| `master.name`                        | Master component name                                               | `master`                             |
-| `master.replicas`                    | Master node replicas (deployment)                                   | `2`                                  |
-| `master.resources`                   | Master node resources requests & limits                             | `{} - cpu limit must be an integer`  |
-| `master.priorityClassName`           | Master priorityClass                                                | `nil`                                |
-| `master.podAnnotations`              | Master Deployment annotations                                       | `{}`                                 |
-| `master.nodeSelector`                | Node labels for master pod assignment                               | `{}`                                 |
-| `master.tolerations`                 | Master tolerations                                                  | `[]`                                 |
-| `master.heapSize`                    | Master node heap size                                               | `512m`                               |
-| `master.name`                        | Master component name                                               | `master`                             |
-| `master.persistence.enabled`         | Master persistent enabled/disabled                                  | `true`                               |
-| `master.persistence.name`            | Master statefulset PVC template name                                | `data`                               |
-| `master.persistence.size`            | Master persistent volume size                                       | `4Gi`                                |
-| `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                |
-| `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                      |
-| `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                              |
-| `data.replicas`                      | Data node replicas (statefulset)                                    | `2`                                  |
-| `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`  |
-| `data.priorityClassName`             | Data priorityClass                                                  | `nil`                                |
-| `data.heapSize`                      | Data node heap size                                                 | `1536m`                              |
-| `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                               |
-| `data.persistence.name`              | Data statefulset PVC template name                                  | `data`                               |
-| `data.persistence.size`              | Data persistent volume size                                         | `30Gi`                               |
-| `data.persistence.storageClass`      | Data persistent volume Class                                        | `nil`                                |
-| `data.persistence.accessMode`        | Data persistent Access Mode                                         | `ReadWriteOnce`                      |
-| `data.podAnnotations`                | Data StatefulSet annotations                                        | `{}`                                 |
-| `data.nodeSelector`                  | Node labels for data pod assignment                                 | `{}`                                 |
-| `data.tolerations`                   | Data tolerations                                                    | `[]`                                 |
-| `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                               |
-| `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                               |
-| `extraInitContainers`                | Additional init container passed through the tpl 	                 | ``                                   |
+| Parameter                                      | Description                                                                                                | Default                                             |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `appVersion`                                   | Application Version (Elasticsearch)                                                                        | `6.4.2`                                             |
+| `image.repository`                             | Container image name                                                                                       | `docker.elastic.co/elasticsearch/elasticsearch-oss` |
+| `image.tag`                                    | Container image tag                                                                                        | `6.4.2`                                             |
+| `image.pullPolicy`                             | Container pull policy                                                                                      | `Always`                                            |
+| `cluster.name`                                 | Cluster name                                                                                               | `elasticsearch`                                     |
+| `cluster.xpackEnable`                          | Writes the X-Pack configuration options to the configuration file                                          | `false`                                             |
+| `cluster.config`                               | Additional cluster config appended                                                                         | `{}`                                                |
+| `cluster.keystoreSecret`                       | Name of secret holding secure config options in an es keystore                                             | `nil`                                               |
+| `cluster.env`                                  | Cluster environment variables                                                                              | `{MINIMUM_MASTER_NODES: "2"}`                       |
+| `client.name`                                  | Client component name                                                                                      | `client`                                            |
+| `client.replicas`                              | Client node replicas (deployment)                                                                          | `2`                                                 |
+| `client.resources`                             | Client node resources requests & limits                                                                    | `{} - cpu limit must be an integer`                 |
+| `client.priorityClassName`                     | Client priorityClass                                                                                       | `nil`                                               |
+| `client.heapSize`                              | Client node heap size                                                                                      | `512m`                                              |
+| `client.podAnnotations`                        | Client Deployment annotations                                                                              | `{}`                                                |
+| `client.nodeSelector`                          | Node labels for client pod assignment                                                                      | `{}`                                                |
+| `client.tolerations`                           | Client tolerations                                                                                         | `[]`                                                |
+| `client.serviceAnnotations`                    | Client Service annotations                                                                                 | `{}`                                                |
+| `client.serviceType`                           | Client service type                                                                                        | `ClusterIP`                                         |
+| `client.loadBalancerIP`                        | Client loadBalancerIP                                                                                      | `{}`                                                |
+| `client.loadBalancerSourceRanges`              | Client loadBalancerSourceRanges                                                                            | `{}`                                                |
+| `master.exposeHttp`                            | Expose http port 9200 on master Pods for monitoring, etc                                                   | `false`                                             |
+| `master.name`                                  | Master component name                                                                                      | `master`                                            |
+| `master.replicas`                              | Master node replicas (deployment)                                                                          | `2`                                                 |
+| `master.resources`                             | Master node resources requests & limits                                                                    | `{} - cpu limit must be an integer`                 |
+| `master.priorityClassName`                     | Master priorityClass                                                                                       | `nil`                                               |
+| `master.podAnnotations`                        | Master Deployment annotations                                                                              | `{}`                                                |
+| `master.nodeSelector`                          | Node labels for master pod assignment                                                                      | `{}`                                                |
+| `master.tolerations`                           | Master tolerations                                                                                         | `[]`                                                |
+| `master.heapSize`                              | Master node heap size                                                                                      | `512m`                                              |
+| `master.name`                                  | Master component name                                                                                      | `master`                                            |
+| `master.persistence.enabled`                   | Master persistent enabled/disabled                                                                         | `true`                                              |
+| `master.persistence.name`                      | Master statefulset PVC template name                                                                       | `data`                                              |
+| `master.persistence.size`                      | Master persistent volume size                                                                              | `4Gi`                                               |
+| `master.persistence.storageClass`              | Master persistent volume Class                                                                             | `nil`                                               |
+| `master.persistence.accessMode`                | Master persistent Access Mode                                                                              | `ReadWriteOnce`                                     |
+| `data.exposeHttp`                              | Expose http port 9200 on data Pods for monitoring, etc                                                     | `false`                                             |
+| `data.replicas`                                | Data node replicas (statefulset)                                                                           | `2`                                                 |
+| `data.resources`                               | Data node resources requests & limits                                                                      | `{} - cpu limit must be an integer`                 |
+| `data.priorityClassName`                       | Data priorityClass                                                                                         | `nil`                                               |
+| `data.heapSize`                                | Data node heap size                                                                                        | `1536m`                                             |
+| `data.persistence.enabled`                     | Data persistent enabled/disabled                                                                           | `true`                                              |
+| `data.persistence.name`                        | Data statefulset PVC template name                                                                         | `data`                                              |
+| `data.persistence.size`                        | Data persistent volume size                                                                                | `30Gi`                                              |
+| `data.persistence.storageClass`                | Data persistent volume Class                                                                               | `nil`                                               |
+| `data.persistence.accessMode`                  | Data persistent Access Mode                                                                                | `ReadWriteOnce`                                     |
+| `data.podAnnotations`                          | Data StatefulSet annotations                                                                               | `{}`                                                |
+| `data.nodeSelector`                            | Node labels for data pod assignment                                                                        | `{}`                                                |
+| `data.tolerations`                             | Data tolerations                                                                                           | `[]`                                                |
+| `data.terminationGracePeriodSeconds`           | Data termination grace period (seconds)                                                                    | `3600`                                              |
+| `data.antiAffinity`                            | Data anti-affinity policy                                                                                  | `soft`                                              |
+| `extraInitContainers`                          | Additional init container passed through the tpl                                                           | ``                                                  |
+| `prometheus.exporter.enabled`                  | Whether or not to create an Elasticsearch Exporter                                                         | `false`                                             |
+| `prometheus.exporter.replicaCount`             | Desidered number of exporter pods                                                                          | `1`                                                 |
+| `prometheus.exporter.podAnnotations`           | Exporter pods annotations                                                                                  | `{}`                                                |
+| `prometheus.exporter.priorityClassName`        | Exporter priorityClassName                                                                                 | `nil`                                               |
+| `prometheus.exporter.nodeSelector`             | Exporter node labels for pod assignment                                                                    | `{}`                                                |
+| `prometheus.exporter.tolerations`              | Exporter node tolerations for pod assignment                                                               | `{}`                                                |
+| `prometheus.exporter.restartPolicy`            | Exporter container restart policy                                                                          | `Always`                                            |
+| `prometheus.exporter.image.repository`         | Exporter container image repository                                                                        | `justwatch/elasticsearch_exporter`                  |
+| `prometheus.exporter.image.tag`                | Exporter container image tag                                                                               | `1.0.2`                                             |
+| `prometheus.exporter.image.pullPolicy`         | Exporter container pull policy                                                                             | `IfNotPresent`                                      |
+| `prometheus.exporter.service.type`             | Type of service to create for the exporter                                                                 | `ClusterIP`                                         |
+| `prometheus.exporter.service.httpPort`         | HTTP port for the exporter service                                                                         | `9108`                                              |
+| `prometheus.exporter.service.annotations`      | Annotations for the exporter service                                                                       | `{}`                                                |
+| `prometheus.exporter.es.all`                   | If `true`, query stats for all nodes in the cluster, rather than just the node we connect to               | `true`                                              |
+| `prometheus.exporter.es.indices`               | If `true`, query stats for all indices in the cluster                                                      | `true`                                              |
+| `prometheus.exporter.es.timeout`               | Timeout for trying to get stats from Elasticsearch                                                         | `30s`                                               |
+| `prometheus.exporter.resources`                | Exporter resource requests and limits                                                                      | `{}`                                                |
+| `prometheus.operator.enabled`                  | If `true`, creates a Prometheus Operator ServiceMonitor                                                    | `false`                                             |
+| `prometheus.operator.interval`                 | Interval that Prometheus scrapes Elasticsearch metrics                                                     | `10s`                                               |
+| `prometheus.operator.serviceMonitor.namespace` | Namespace which Prometheus is running in                                                                   | `monitoring`                                        |
+| `prometheus.operator.serviceMonitor.selector`  | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install | `{ prometheus: kube-prometheus }`                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -210,3 +231,17 @@ The `tpl` function allows us to pass string values from `values.yaml` through th
 * `extraInitContainers`
 
 It is important that these values be configured as strings. Otherwise, installation will fail.
+
+
+## Prometheus Stats
+
+### Prometheus Operator
+
+This chart supports the CoreOS Prometheus Operator as monitoring option. If you are
+interested in installing the Prometheus Operator please see the [CoreOS repository](https://github.com/coreos/prometheus-operator/tree/master/helm) for more information or
+read through the [CoreOS blog post introducing the Prometheus Operator](https://coreos.com/blog/the-prometheus-operator.html).
+
+### Elasticsearch Exporter
+
+The [Elasticsearch Exporter](https://github.com/justwatchcom/elasticsearch_exporter) is an exporter for various
+Elasticsearch metrics.

--- a/incubator/elasticsearch/templates/exporter-deployment.yaml
+++ b/incubator/elasticsearch/templates/exporter-deployment.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.prometheus.exporter.enabled }}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "elasticsearch.fullname" . }}-exporter
+  labels:
+    app: "{{ template "elasticsearch.name" . }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+
+spec:
+  replicas: {{ .Values.prometheus.exporter.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: "{{ .Release.Name }}"
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ template "elasticsearch.name" . }}
+        release: "{{ .Release.Name }}"
+      {{- if .Values.prometheus.exporter.podAnnotations }}
+      annotations:
+{{ toYaml .Values.prometheus.exporter.podAnnotations | indent 8 }}
+      {{- end }}
+    spec:
+{{- if .Values.prometheus.exporter.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
+      restartPolicy: {{ .Values.prometheus.exporter.restartPolicy }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: {{ template "elasticsearch.fullname" . }}-exporter
+          image: "{{ .Values.prometheus.exporter.image.repository }}:{{ .Values.prometheus.exporter.image.tag }}"
+          imagePullPolicy: {{ .Values.prometheus.exporter.image.pullPolicy }}
+          command: ["elasticsearch_exporter",
+                    "-es.uri={{ template "elasticsearch.client.fullname" . }}:9200",
+                    "-es.all={{ .Values.prometheus.exporter.es.all }}",
+                    "-es.indices={{ .Values.prometheus.exporter.es.indices }}",
+                    "-es.timeout={{ .Values.prometheus.exporter.es.timeout }}",
+                    "-web.listen-address=:{{ .Values.prometheus.exporter.service.httpPort }}",
+                    "-web.telemetry-path={{ .Values.prometheus.exporter.web.path }}"]
+          securityContext:
+            capabilities:
+              drop:
+                - SETPCAP
+                - MKNOD
+                - AUDIT_WRITE
+                - CHOWN
+                - NET_RAW
+                - DAC_OVERRIDE
+                - FOWNER
+                - FSETID
+                - KILL
+                - SETGID
+                - SETUID
+                - NET_BIND_SERVICE
+                - SYS_CHROOT
+                - SETFCAP
+            readOnlyRootFilesystem: true
+          resources:
+{{ toYaml .Values.prometheus.exporter.resources | indent 12 }}
+          ports:
+            - containerPort: {{ .Values.prometheus.exporter.service.httpPort }}
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+{{- if .Values.prometheus.exporter.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.prometheus.exporter.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.prometheus.exporter.tolerations }}
+      tolerations:
+{{ toYaml .Values.prometheus.exporter.tolerations | indent 8 }}
+{{- end }}
+
+{{- end }}

--- a/incubator/elasticsearch/templates/exporter-deployment.yaml
+++ b/incubator/elasticsearch/templates/exporter-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           image: "{{ .Values.prometheus.exporter.image.repository }}:{{ .Values.prometheus.exporter.image.tag }}"
           imagePullPolicy: {{ .Values.prometheus.exporter.image.pullPolicy }}
           command: ["elasticsearch_exporter",
-                    "-es.uri={{ template "elasticsearch.client.fullname" . }}:9200",
+                    "-es.uri=http://{{ template "elasticsearch.client.fullname" . }}:9200",
                     "-es.all={{ .Values.prometheus.exporter.es.all }}",
                     "-es.indices={{ .Values.prometheus.exporter.es.indices }}",
                     "-es.timeout={{ .Values.prometheus.exporter.es.timeout }}",

--- a/incubator/elasticsearch/templates/exporter-deployment.yaml
+++ b/incubator/elasticsearch/templates/exporter-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "elasticsearch.fullname" . }}-exporter
   labels:
-    app: "{{ template "elasticsearch.name" . }}"
+    app: {{ template "elasticsearch.fullname" . }}-exporter
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -13,7 +13,7 @@ spec:
   replicas: {{ .Values.prometheus.exporter.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "elasticsearch.name" . }}
+      app: {{ template "elasticsearch.fullname" . }}-exporter
       release: "{{ .Release.Name }}"
   strategy:
     rollingUpdate:
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "elasticsearch.name" . }}
+        app: {{ template "elasticsearch.fullname" . }}-exporter
         release: "{{ .Release.Name }}"
       {{- if .Values.prometheus.exporter.podAnnotations }}
       annotations:

--- a/incubator/elasticsearch/templates/exporter-servicemonitor.yaml
+++ b/incubator/elasticsearch/templates/exporter-servicemonitor.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ include "elasticsearch.name" . }}-exporter
+      app: {{ template "elasticsearch.fullname" . }}-exporter
       release: {{ .Release.Name }}
   endpoints:
   - port: {{ template "elasticsearch.fullname" . }}-exporter

--- a/incubator/elasticsearch/templates/exporter-servicemonitor.yaml
+++ b/incubator/elasticsearch/templates/exporter-servicemonitor.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "elasticsearch.fullname" . }}-exporter
   namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
   labels:
-{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+    {{- range $key, $value := .Values.prometheus.operator.serviceMonitor.selector }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/incubator/elasticsearch/templates/exporter-servicemonitor.yaml
+++ b/incubator/elasticsearch/templates/exporter-servicemonitor.yaml
@@ -2,14 +2,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "elasticsearch.fullname" . }}-servicemonitor
+  name: {{ include "elasticsearch.fullname" . }}-exporter
   namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
   labels:
 {{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "elasticsearch.name" . }}-servicemonitor
+      app: {{ include "elasticsearch.name" . }}-exporter
       release: {{ .Release.Name }}
   endpoints:
   - port: {{ template "elasticsearch.fullname" . }}-exporter

--- a/incubator/elasticsearch/templates/exporter-svc.yaml
+++ b/incubator/elasticsearch/templates/exporter-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ include "elasticsearch.fullname" . }}-exporter
   labels:
-    app: {{ include "elasticsearch.name" . }}-exporter
+    app: {{ include "elasticsearch.fullname" . }}-exporter
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -15,6 +15,6 @@ spec:
     port: {{ .Values.prometheus.exporter.service.httpPort }}
     targetPort: {{ .Values.prometheus.exporter.service.httpPort }}
   selector:
-    app: {{ include "elasticsearch.name" . }}-exporter
+    app: {{ include "elasticsearch.fullname" . }}-exporter
     release: {{ .Release.Name }}
 {{ end }}

--- a/incubator/elasticsearch/templates/exporter-svc.yaml
+++ b/incubator/elasticsearch/templates/exporter-svc.yaml
@@ -1,0 +1,20 @@
+{{ if and .Values.prometheus.exporter.enabled .Values.prometheus.operator.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elasticsearch.fullname" . }}-exporter
+  labels:
+    app: {{ include "elasticsearch.name" . }}-exporter
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+  - name: {{ template "elasticsearch.fullname" . }}-exporter
+    protocol: TCP
+    port: {{ .Values.prometheus.exporter.service.httpPort }}
+    targetPort: {{ .Values.prometheus.exporter.service.httpPort }}
+  selector:
+    app: {{ include "elasticsearch.name" . }}-exporter
+    release: {{ .Release.Name }}
+{{ end }}

--- a/incubator/elasticsearch/templates/servicemonitor.yaml
+++ b/incubator/elasticsearch/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{ if and .Values.prometheus.exporter.enabled .Values.prometheus.operator.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "elasticsearch.fullname" . }}-servicemonitor
+  namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
+  labels:
+{{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "elasticsearch.name" . }}-servicemonitor
+      release: {{ .Release.Name }}
+  endpoints:
+  - port: {{ template "elasticsearch.fullname" . }}-exporter
+    interval: {{ .Values.prometheus.operator.interval }}
+  namespaceSelector:
+    any: true
+{{ end }}

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -122,3 +122,85 @@ data:
 
 ## Additional init containers
 extraInitContainers: |
+
+## Prometheus Exporters / Metrics
+##
+prometheus:
+
+  ## Prometheus Elasticsearch Exporter: exposes stats to Prometheus
+  exporter:
+    enabled: false
+
+    ## number of exporter instances
+    replicaCount: 1
+
+    podAnnotations: {}
+
+    priorityClassName: ""
+
+    nodeSelector: {}
+
+    tolerations: {}
+
+    ## restart policy for all containers
+    restartPolicy: Always
+
+    ## The image to use for the metrics exporter
+    image:
+      repository: justwatch/elasticsearch_exporter
+      tag: 1.0.2
+      pullPolicy: IfNotPresent
+
+    service:
+      type: ClusterIP
+      httpPort: 9108
+      annotations: {}
+
+    es:
+      ## If true, query stats for all nodes in the cluster, rather than just the
+      ## node we connect to.
+      ##
+      all: true
+
+      ## If true, query stats for all indices in the cluster.
+      ##
+      indices: true
+
+      ## Timeout for trying to get stats from Elasticsearch. (ex: 20s)
+      ##
+      timeout: 30s
+
+      ssl:
+        ## If true, a secure connection to ES cluster is used (requires SSL certs below)
+        ##
+        enabled: false
+
+        ca:
+
+          ## PEM that contains trusted CAs used for setting up secure Elasticsearch connection
+          ##
+          # pem:
+
+        client:
+
+          ## PEM that contains the client cert to connect to Elasticsearch.
+          ##
+          # pem:
+
+          ## Private key for client auth when connecting to Elasticsearch
+          ##
+          # key:
+
+    web:
+      ## Path under which to expose metrics.
+      ##
+      path: /metrics
+
+    ## Resource limits
+    resources: {}
+#      limits:
+#        cpu: 200m
+#        memory: 1Gi
+#      requests:
+#        cpu: 100m
+#        memory: 100Mi

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -183,3 +183,20 @@ prometheus:
 #      requests:
 #        cpu: 100m
 #        memory: 100Mi
+
+  operator:
+    ## Are you using Prometheus Operator?
+    enabled: false
+
+    ## Interval at which Prometheus scrapes metrics
+    interval: 10s
+
+    serviceMonitor:
+      # Namespace Prometheus is installed in
+      namespace: monitoring
+
+      ## Defaults to whats used if you follow CoreOS [Prometheus Install Instructions](https://github.com/coreos/prometheus-operator/tree/master/helm#tldr)
+      ## [Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus/templates/prometheus.yaml#L65)
+      ## [Kube Prometheus Selector Label](https://github.com/coreos/prometheus-operator/blob/master/helm/kube-prometheus/values.yaml#L298)
+      selector:
+        prometheus: kube-prometheus

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -170,27 +170,6 @@ prometheus:
       ##
       timeout: 30s
 
-      ssl:
-        ## If true, a secure connection to ES cluster is used (requires SSL certs below)
-        ##
-        enabled: false
-
-        ca:
-
-          ## PEM that contains trusted CAs used for setting up secure Elasticsearch connection
-          ##
-          # pem:
-
-        client:
-
-          ## PEM that contains the client cert to connect to Elasticsearch.
-          ##
-          # pem:
-
-          ## Private key for client auth when connecting to Elasticsearch
-          ##
-          # key:
-
     web:
       ## Path under which to expose metrics.
       ##

--- a/incubator/elasticsearch/values.yaml
+++ b/incubator/elasticsearch/values.yaml
@@ -177,12 +177,12 @@ prometheus:
 
     ## Resource limits
     resources: {}
-#      limits:
-#        cpu: 200m
-#        memory: 1Gi
-#      requests:
-#        cpu: 100m
-#        memory: 100Mi
+#     requests:
+#       cpu: 100m
+#       memory: 128Mi
+#     limits:
+#       cpu: 100m
+#       memory: 128Mi
 
   operator:
     ## Are you using Prometheus Operator?


### PR DESCRIPTION
#### What this PR does / why we need it:
Add support for prometheus operator using [Elasticsearch Exporter](https://github.com/justwatchcom/elasticsearch_exporter). This PR uses the same concepts/structures used in https://github.com/helm/charts/pull/5120 to export Kafka metrics.  

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
