### PR TITLE
nginx-ingress: do not set service clusterIP to ""

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.29.1
+version: 0.29.2
 appVersion: 0.20.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-metrics-service.yaml
+++ b/stable/nginx-ingress/templates/controller-metrics-service.yaml
@@ -16,7 +16,9 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-metrics
 spec:
+{{- if .Values.controller.metrics.service.clusterIP }}
   clusterIP: "{{ .Values.controller.metrics.service.clusterIP }}"
+{{- end }}
 {{- if .Values.controller.metrics.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.controller.metrics.service.externalIPs | indent 4 }}

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -18,7 +18,9 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
+{{- if .Values.controller.service.clusterIP }}
   clusterIP: "{{ .Values.controller.service.clusterIP }}"
+{{- end }}
 {{- if .Values.controller.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.controller.service.externalIPs | indent 4 }}

--- a/stable/nginx-ingress/templates/controller-stats-service.yaml
+++ b/stable/nginx-ingress/templates/controller-stats-service.yaml
@@ -16,7 +16,9 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}-stats
 spec:
+{{- if .Values.controller.stats.service.clusterIP }}
   clusterIP: "{{ .Values.controller.stats.service.clusterIP }}"
+{{- end }}
 {{- if .Values.controller.stats.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.controller.stats.service.externalIPs | indent 4 }}

--- a/stable/nginx-ingress/templates/default-backend-service.yaml
+++ b/stable/nginx-ingress/templates/default-backend-service.yaml
@@ -16,7 +16,9 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
 spec:
+{{- if .Values.defaultBackend.service.clusterIP }}
   clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
+{{- end }}
 {{- if .Values.defaultBackend.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.defaultBackend.service.externalIPs | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

The nginx-ingress chart sets clusterIP values for it's Services to the empty string `""`. This causes a situation where you cannot `apply` the yaml twice in a row cleanly, since apply will attempt to set clusterIP back to "" after a controller has updated the value to an IP (a move that is not possible as the field is immutable).

This change guards the clusterIP key with a check to ignore it if not
set.


