### PR TITLE
[stable/prometheus] Support tmpl files which are not YAML (#6798)

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 7.1.4
+version: 7.1.5
 appVersion: 2.4.3
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/alertmanager-configmap.yaml
+++ b/stable/prometheus/templates/alertmanager-configmap.yaml
@@ -12,7 +12,11 @@ metadata:
 data:
 {{- $root := . -}}
 {{- range $key, $value := .Values.alertmanagerFiles }}
-  {{ $key }}: |
+  {{- if $key | regexMatch ".*\\.ya?ml$" }}
+  {{ $key }}: | 
 {{ toYaml $value | default "{}" | indent 4 }}
+  {{- else }}
+  {{ $key }}: {{ toYaml $value | indent 4 }}
+  {{- end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Brooks Garrett <brooks@respond-software.com>

#### What this PR does / why we need it:
Supports differentiating between yaml *alertmanagerFiles* and templates. Files that end in *.yaml* will be included with and added | as front matter. Other files will be included verbatim since they already have a string literal '|' in their content in the values yaml file.

#### Which issue this PR fixes
  - fixes #6798

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
