### PR TITLE
Spinnaker inline script in values

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.1.3
+version: 1.1.4
 appVersion: 1.9.1
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -109,8 +109,8 @@ spinnaker@cd-spinnaker-halyard-0:/workdir$ hal version list
 ### Automated
 If you have known set of commands that you'd like to run after the base config steps or if
 you'd like to override some settings before the Spinnaker deployment is applied, you can enable
-the `halyard.additionalConfig.enabled` flag. You will need to create a config map that contains a key
-containing the `hal` commands you'd like to run. You can set the key via the config map name via `halyard.additionalConfig.configMapName` and the key via `halyard.additionalConfig.configMapKey`. The `DAEMON_ENDPOINT` environment variable can be used in your custom commands to
+the `halyard.additionalScripts.enabled` flag. You will need to create a config map that contains a key
+containing the `hal` commands you'd like to run. You can set the key via the config map name via `halyard.additionalScripts.configMapName` and the key via `halyard.additionalScripts.configMapKey`. The `DAEMON_ENDPOINT` environment variable can be used in your custom commands to
 get a prepopulated URL that points to your Halyard daemon within the cluster. The `HAL_COMMAND` environment variable does this for you. For example:
 
 ```shell
@@ -118,13 +118,22 @@ hal --daemon-endpoint $DAEMON_ENDPOINT config security authn oauth2 enable
 $HAL_COMMAND config security authn oauth2 enable
 ```
 
-If you would rather the chart make the config file for you, you can set `halyard.additionalConfig.createConfig` to `true` and then populate `halyard.additionalConfig.bashScript` with the bash script you'd like to run:
+If you would rather the chart make the config file for you, you can set `halyard.additionalScripts.create` to `true` and then populate `halyard.additionalScripts.data.SCRIPT_NAME.sh` with the bash script you'd like to run. If you need associated configmaps or secrets you can configure those to be created as well:
 
 ```yaml
 halyard:
-  additionalConfig:
-    createConfig: true
-    bashScript: |
-      echo "Setting oauth2 security"
-      $HAL_COMMAND config security authn oauth2 enable
+  additionalScripts:
+    create: true
+    data: 
+      enable_oauth.sh: |-
+        echo "Setting oauth2 security"
+        $HAL_COMMAND config security authn oauth2 enable
+  additionalSecrets:
+    create: true
+    data:
+      password.txt: aHVudGVyMgo=    
+  additionalConfigMaps:
+    create: true
+    data:
+      metadata.xml: <xml><username>admin</username></xml>
 ```

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -111,8 +111,20 @@ If you have known set of commands that you'd like to run after the base config s
 you'd like to override some settings before the Spinnaker deployment is applied, you can enable
 the `halyard.additionalConfig.enabled` flag. You will need to create a config map that contains a key
 containing the `hal` commands you'd like to run. You can set the key via the config map name via `halyard.additionalConfig.configMapName` and the key via `halyard.additionalConfig.configMapKey`. The `DAEMON_ENDPOINT` environment variable can be used in your custom commands to
-get a prepopulated URL that points to your Halyard daemon within the cluster. For example:
+get a prepopulated URL that points to your Halyard daemon within the cluster. The `HAL_COMMAND` environment variable does this for you. For example:
 
 ```shell
 hal --daemon-endpoint $DAEMON_ENDPOINT config security authn oauth2 enable
+$HAL_COMMAND config security authn oauth2 enable
+```
+
+If you would rather the chart make the config file for you, you can set `halyard.additionalConfig.createConfig` to `true` and then populate `halyard.additionalConfig.bashScript` with the bash script you'd like to run:
+
+```yaml
+halyard:
+  additionalConfig:
+    createConfig: true
+    bashScript: |
+      echo "Setting oauth2 security"
+      $HAL_COMMAND config security authn oauth2 enable
 ```

--- a/stable/spinnaker/templates/configmap/additional-configmaps.yaml
+++ b/stable/spinnaker/templates/configmap/additional-configmaps.yaml
@@ -1,0 +1,15 @@
+{{ if  .Values.halyard.additionalConfigMaps.create -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-additional-config-maps
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+data:
+{{- if  and .Values.halyard.additionalConfigMaps.create .Values.halyard.additionalConfigMaps.data }}
+{{- range $index, $content := .Values.halyard.additionalConfigMaps.data }}
+  {{ $index }}: |-
+{{ $content | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/spinnaker/templates/configmap/additional-scripts.yaml
+++ b/stable/spinnaker/templates/configmap/additional-scripts.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.halyard.additionalScripts.create -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-additional-scripts
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+data:
+{{- if  and .Values.halyard.additionalScripts.create .Values.halyard.additionalScripts.data }}
+{{- range $index, $content := .Values.halyard.additionalScripts.data }}
+  {{ $index }}: |-
+{{ $content | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -15,12 +15,15 @@ data:
 
     bash -xe /opt/halyard/scripts/config.sh
 
-    {{ if .Values.halyard.additionalConfig.enabled }}
-    bash /opt/halyard/additional/{{ .Values.halyard.additionalConfig.configMapKey }}
-    {{ end }}
-    {{ if  and .Values.halyard.additionalConfig.createConfig .Values.halyard.additionalConfig.bashScript }}
-    bash -xe /opt/halyard/scripts/additionalConfig.sh
-    {{ end }}
+    {{- if .Values.halyard.additionalScripts.enabled }}
+    bash /opt/halyard/additional/{{ .Values.halyard.additionalScripts.configMapKey }}
+    {{- end }}
+
+    {{- if  and .Values.halyard.additionalScripts.create .Values.halyard.additionalScripts.data }}
+    {{- range $index, $script := .Values.halyard.additionalScripts.data }}
+    bash -xe /opt/halyard/additionalScripts/{{ $index }}
+    {{- end }}
+    {{- end }}
 
     $HAL_COMMAND deploy apply
   clean.sh: |
@@ -104,7 +107,3 @@ data:
     {{- range $index, $feature := .Values.spinnakerFeatureFlags }}
     $HAL_COMMAND config features edit --{{ $feature }} true
     {{- end }}
-{{ if  and .Values.halyard.additionalConfig.createConfig .Values.halyard.additionalConfig.bashScript }}
-  additionalConfig.sh: |
-{{ .Values.halyard.additionalConfig.bashScript | indent 4 }}
-{{ end }}

--- a/stable/spinnaker/templates/configmap/halyard-config.yaml
+++ b/stable/spinnaker/templates/configmap/halyard-config.yaml
@@ -18,6 +18,9 @@ data:
     {{ if .Values.halyard.additionalConfig.enabled }}
     bash /opt/halyard/additional/{{ .Values.halyard.additionalConfig.configMapKey }}
     {{ end }}
+    {{ if  and .Values.halyard.additionalConfig.createConfig .Values.halyard.additionalConfig.bashScript }}
+    bash -xe /opt/halyard/scripts/additionalConfig.sh
+    {{ end }}
 
     $HAL_COMMAND deploy apply
   clean.sh: |
@@ -101,3 +104,7 @@ data:
     {{- range $index, $feature := .Values.spinnakerFeatureFlags }}
     $HAL_COMMAND config features edit --{{ $feature }} true
     {{- end }}
+{{ if  and .Values.halyard.additionalConfig.createConfig .Values.halyard.additionalConfig.bashScript }}
+  additionalConfig.sh: |
+{{ .Values.halyard.additionalConfig.bashScript | indent 4 }}
+{{ end }}

--- a/stable/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/stable/spinnaker/templates/hooks/install-using-hal.yaml
@@ -30,10 +30,25 @@ spec:
       - name: halyard-config
         configMap:
           name: {{ template "spinnaker.fullname" . }}-halyard-config
-      {{- if .Values.halyard.additionalConfig.enabled }}
+      {{- if .Values.halyard.additionalScripts.enabled }}
       - name: additional-config
         configMap:
-          name: {{ .Values.halyard.additionalConfig.configMapName }}
+          name: {{ .Values.halyard.additionalScripts.configMapName }}
+      {{- end }}
+      {{- if .Values.halyard.additionalSecrets.create }}
+      - name: additional-secrets
+        secret:
+          secretName: {{ template "spinnaker.fullname" . }}-additional-secrets
+      {{- end }}
+      {{- if .Values.halyard.additionalConfigMaps.create }}
+      - name: additional-config-maps
+        configMap:
+          name: {{ template "spinnaker.fullname" . }}-additional-config-maps
+      {{- end }}
+      {{- if .Values.halyard.additionalScripts.create }}
+      - name: additional-scripts
+        configMap:
+          name: {{ template "spinnaker.fullname" . }}-additional-scripts
       {{- end }}
       {{- if .Values.gcs.enabled }}
       - name: gcs-key
@@ -51,9 +66,21 @@ spec:
         volumeMounts:
         - name: halyard-config
           mountPath: /opt/halyard/scripts
-        {{- if .Values.halyard.additionalConfig.enabled }}
+        {{- if .Values.halyard.additionalScripts.enabled }}
         - name: additional-config
           mountPath: /opt/halyard/additional
+        {{- end }}
+        {{- if .Values.halyard.additionalSecrets.create }}
+        - name: additional-secrets
+          mountPath: /opt/halyard/additionalSecrets
+        {{- end }}
+        {{- if .Values.halyard.additionalConfigMaps.create }}
+        - name: additional-config-maps
+          mountPath: /opt/halyard/additionalConfigMaps
+        {{- end }}
+        {{- if .Values.halyard.additionalScripts.create }}
+        - name: additional-scripts
+          mountPath: /opt/halyard/additionalScripts
         {{- end }}
         {{- if .Values.gcs.enabled }}
         - name: gcs-key

--- a/stable/spinnaker/templates/ingress/deck.yaml
+++ b/stable/spinnaker/templates/ingress/deck.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
-  name: {{ template "spinnaker.fullname" . }}
+  name: {{ template "spinnaker.fullname" . }}-deck
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
 spec:

--- a/stable/spinnaker/templates/ingress/gate.yaml
+++ b/stable/spinnaker/templates/ingress/gate.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ingressGate.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+{{- if .Values.ingressGate.annotations }}
+  annotations:
+{{ toYaml .Values.ingressGate.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "spinnaker.fullname" . }}-gate
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+spec:
+  rules:
+  - host: {{ .Values.ingressGate.host | quote }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: spin-gate
+          servicePort: 8084
+{{- if .Values.ingressGate.tls }}
+  tls:
+{{ toYaml .Values.ingressGate.tls | indent 4 }}
+{{- end }}
+{{- end }}

--- a/stable/spinnaker/templates/secrets/additional-secrets.yaml
+++ b/stable/spinnaker/templates/secrets/additional-secrets.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.halyard.additionalSecrets.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "spinnaker.fullname" . }}-additional-secrets
+  labels:
+{{ include "spinnaker.standard-labels" . | indent 4 }}
+data:
+{{- if  and .Values.halyard.additionalSecrets.create .Values.halyard.additionalSecrets.data }}
+{{- range $index, $content := .Values.halyard.additionalSecrets.data }}
+  {{ $index }}: |-
+{{ $content | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -68,6 +68,16 @@ spec:
         secret:
           secretName: {{ template "spinnaker.fullname" . }}-s3
       {{- end }}
+      {{- if .Values.halyard.additionalSecrets.create }}
+      - name: additional-secrets
+        secret:
+          secretName: {{ template "spinnaker.fullname" . }}-additional-secrets
+      {{- end }}
+      {{- if .Values.halyard.additionalConfigMaps.create }}
+      - name: additional-config-maps
+        configMap:
+          name: {{ template "spinnaker.fullname" . }}-additional-config-maps
+      {{- end }}
       - name: halyard-config
         emptyDir: {}
       containers:
@@ -88,6 +98,14 @@ spec:
         {{- if .Values.kubeConfig.enabled }}
         - name: kube-config
           mountPath: /opt/kube
+        {{- end }}
+        {{- if .Values.halyard.additionalSecrets.create }}
+        - name: additional-secrets
+          mountPath: /opt/halyard/additionalSecrets
+        {{- end }}
+        {{- if .Values.halyard.additionalConfigMaps.create }}
+        - name: additional-config-maps
+          mountPath: /opt/halyard/additionalConfigMaps
         {{- end }}
         - name: halyard-home
           mountPath: /home/spinnaker

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -5,13 +5,19 @@ halyard:
     tag: 1.9.1
   # Provide a config map with Hal commands that will be run the core config (storage)
   # The config map should contain a script in the config.sh key
-  additionalConfig:
+  additionalScripts:
     enabled: false
     configMapName: my-halyard-config
     configMapKey: config.sh
-    # If you'd rather do an inline script, set createConfig to true and put the content in bashScript
-    createConfig: false
-    bashScript: ""
+    # If you'd rather do an inline script, set create to true and put the content in the data dict like you would a configmap
+    create: false
+    data: {}
+  additionalSecrets:
+    create: false
+    data: {}
+  additionalConfigMaps:
+    create: false
+    data: {}
 
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions
@@ -56,6 +62,18 @@ kubeConfig:
 ingress:
   enabled: false
   # host: spinnaker.example.org
+  # annotations:
+    # ingress.kubernetes.io/ssl-redirect: 'true'
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # tls:
+  #  - secretName: -tls
+  #    hosts:
+  #      - domain.com
+
+ingressGate:
+  enabled: false
+  # host: gate.spinnaker.example.org
   # annotations:
     # ingress.kubernetes.io/ssl-redirect: 'true'
     # kubernetes.io/ingress.class: nginx

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -9,6 +9,9 @@ halyard:
     enabled: false
     configMapName: my-halyard-config
     configMapKey: config.sh
+    # If you'd rather do an inline script, set createConfig to true and put the content in bashScript
+    createConfig: false
+    bashScript: ""
 
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions

--- a/stable/spinnaker/values_saml.yaml
+++ b/stable/spinnaker/values_saml.yaml
@@ -1,0 +1,72 @@
+# Configure ingress to allow access to both gate and deck from your machine:
+ingress:
+  enabled: true
+  host: spinnaker.example.com
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: 'true'
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+  tls:
+  - secretName: deck-tls
+    hosts:
+    - spinnaker.example.com
+
+ingressGate:
+  enabled: true
+  host: gate.spinnaker.example.com
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: 'true'
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+  tls:
+  - secretName: gate-tls
+    hosts:
+    - gate.spinnaker.example.com
+
+# Configure halyard to support saml
+halyard:
+  # Provide a config map with Hal commands that will be run the core config (storage)
+  # The config map should contain a script in the config.sh key
+  additionalSecrets:
+    create: true
+    data:
+      keystore.p12: aW4tc2VjcmV0cwo= # base64 encoded keystore in pkcs12 format
+      password.txt: aW4tc2VjcmV0cwo= # base64 encoded password for the keystore
+      metadata.xml: aW4tc2VjcmV0cwo= # base64 encoded metadata.xml file from your SAML authenticator
+  additionalConfigMaps:
+    create: true
+    data:
+      config.src: |-
+        KEYSTORE_ALIAS=saml # Alias in the keystore for the cert
+        GATE_URL="https://gate.spinnaker.example.com" # URL to access your gate
+        DECK_URL="https://spinnaker.example.com" # Url to access your deck
+
+        # Put the keystore, metadata, and keystore password in these files under additioanlSecrets
+        KEYSTORE_FILE=/opt/halyard/additionalSecrets/keystore.p12
+        PASSWORD_FILE=/opt/halyard/additionalSecrets/password.txt
+        METADATA_FILE=/opt/halyard/additionalSecrets/metadata.xml
+  additionalScripts:
+    create: true
+    data:
+      configure_saml.sh: |
+        # This source file contains these variables:
+        # -> GATE_URL DECK_URL KEYSTORE_FILE PASSWORD_FILE METADATA_FILE KEYSTORE_ALIAS
+        # I put config.src in additionalConfigMaps so you can break it out into a separate values.yaml file
+        # You should create both halyard.additionalConfigMaps.data.config.src AND halyard.additionalConfigMaps.create = true 
+        source /opt/halyard/additionalConfigMaps/config.src
+
+        KEYSTORE_PASSWORD="$( cat "$PASSWORD_FILE" )"
+
+        $HAL_COMMAND config security ui edit --override-base-url "$DECK_URL"
+        $HAL_COMMAND config security api edit --override-base-url "$GATE_URL"
+        $HAL_COMMAND config security authn saml edit \
+          --keystore "$KEYSTORE_FILE" \
+          --keystore-alias "$KEYSTORE_ALIAS" \
+          --keystore-password "$KEYSTORE_PASSWORD" \
+          --metadata "$METADATA_FILE" \
+          --issuer-id "$GATE_URL" \
+          --no-validate \
+          --service-address-url "$GATE_URL"
+        $HAL_COMMAND config security authn saml enable


### PR DESCRIPTION
#### What this PR does / why we need it: This allows you to configure halyard scripts, configmaps, and secrets in the values.yaml files. This is useful for fully configuring halyard from the values file. I've included a sample values_saml.yaml file to help other people configure saml auth.

#### Special notes for your reviewer: 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md