### PR TITLE
[kube-registry-proxy] expose on localhost only

### DIFF
--- a/incubator/kube-registry-proxy/Chart.yaml
+++ b/incubator/kube-registry-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-registry-proxy
 home: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry
-version: 0.2.2
+version: 0.3.0
 appVersion: 0.4
 description: Installs the kubernetes-registry-proxy cluster addon.
 maintainers:

--- a/incubator/kube-registry-proxy/Chart.yaml
+++ b/incubator/kube-registry-proxy/Chart.yaml
@@ -3,6 +3,3 @@ home: https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/regist
 version: 0.3.0
 appVersion: 0.4
 description: Installs the kubernetes-registry-proxy cluster addon.
-maintainers:
-- name: Deis Team
-  email: engineering@deis.com

--- a/incubator/kube-registry-proxy/README.md
+++ b/incubator/kube-registry-proxy/README.md
@@ -13,10 +13,12 @@ $ helm install --name my-release incubator/kube-registry-proxy
 
 ## Configuration
 
-| Parameter          | Description                         | Default                                      |
-|--------------------|-------------------------------------|----------------------------------------------|
-| `image.repository` | The image repository to pull from   | k8s.gcr.io/kube-registry-proxy               |
-| `image.tag`        | The image tag to pull from          | 0.4                                          |
-| `image.pullPolicy` | Image pull policy                   | IfNotPresent                                 |
-| `registry.host`    | The hostname of the target registry | "gcr.io"                                     |
-| `registry.port`    | The port of the target registry     | \<blank>                                     |
+| Parameter          | Description                                | Default                                      |
+|--------------------|--------------------------------------------|----------------------------------------------|
+| `image.repository` | The image repository to pull from          | k8s.gcr.io/kube-registry-proxy               |
+| `image.tag`        | The image tag to pull from                 | 0.4                                          |
+| `image.pullPolicy` | Image pull policy                          | IfNotPresent                                 |
+| `registry.host`    | The hostname of the target registry        | "gcr.io"                                     |
+| `registry.port`    | The port of the target registry            | \<blank>                                     |
+| `hostPort`         | The port to accept connections on the node | 5555                                         |
+| `hostIP`           | The interface address to bind on the node  | 127.0.0.1                                    |

--- a/incubator/kube-registry-proxy/templates/daemon.yaml
+++ b/incubator/kube-registry-proxy/templates/daemon.yaml
@@ -25,3 +25,4 @@ spec:
         ports:
         - containerPort: 80
           hostPort: {{ default "5555" .Values.hostPort }}
+          hostIP: {{ default "127.0.0.1" .Values.hostIP }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows running a private in-cluster Docker registry without risk when configured without auth, on a machine with public accessible IP.

#### Special notes for your reviewer:

Blocked on https://github.com/kubernetes/kubernetes/pull/66228.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
