### PR TITLE
add optional ingress for selenium chart

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.10.0
+version: 0.11.0
 appVersion: 3.14.0
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/README.md
+++ b/stable/selenium/README.md
@@ -64,6 +64,11 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `hub.seOpts` | Command line arguments to pass to hub | `nil` |
 | `hub.timeZone` | The time zone for the container | `nil` |
 | `hub.nodeselector` | Node label to use for scheduling of the hub if set this takes precedence over the global value | `nil` |
+| `hub.ingress.enabled` | Configure an ingress for the selenium hub | `false` |
+| `hub.ingress.annotations` | Annotations for the ingress for the selenium hub | `nil` |
+| `hub.ingress.path` | The path for this ingress from which to route the traffic to the selenium hub | `/` |
+| `hub.ingress.hosts` | The list hosts for which this ingress should resolve the selenium hub | `[selenium-hub.local]` |
+| `hub.ingress.tls` | The tls secret to configure ssl for this ingress | `[]` |
 | `chrome.enabled` | Schedule a chrome node pod | `false` |
 | `chrome.image` | The selenium node chrome image | `selenium/node-chrome` |
 | `chrome.tag` | The selenium node chrome tag | `3.14.0` |

--- a/stable/selenium/templates/ingress.yaml
+++ b/stable/selenium/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.hub.ingress.enabled -}}
+{{- $fullName := include "selenium.hub.fullname" . -}}
+{{- $ingressPath := .Values.hub.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "selenium.hub.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- with .Values.hub.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.hub.ingress.tls }}
+  tls:
+  {{- range .Values.hub.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.hub.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: hub
+  {{- end }}
+{{- end }}

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -90,6 +90,18 @@ hub:
   ## NodeSelector to be used for the hub
   nodeSelector:
   #  label: value
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    path: /
+    hosts:
+      - selenium-hub.local
+    tls: []
+    #  - secretName: selenium-hub-tls
+    #    hosts:
+    #      - selenium-hub.local
 
 
 chrome:


### PR DESCRIPTION
Signed-off-by: Arnaud Deprez <arnaudeprez@gmail.com>

#### What this PR does / why we need it:
Hi, this PR add an optional ingress for the selenium hub which is useful when deploying in non-cloud kubernetes instance such as openshift on premise, minikube, minishift, etc.

#### Which issue this PR fixes
No issue was created before. Please tell me if you need it.

#### Special notes for your reviewer:
This has been tested on minikube with the following command on minikube with nginx ingress controller: 
`helm template --name selenium --set hub.ingress.enabled=true --set hub.ingress.hosts={"hub-selenium.$(minikube ip).nip.io"} selenium | kubectl apply -n selenium -f -`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
