### PR TITLE
[kafka] Fix incorrect producer consumer address in notes template

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.11.0
+version: 0.11.1
 appVersion: 4.1.2
 keywords:
 - kafka

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -27,12 +27,12 @@ To create a new topic:
 
 To listen for messages on a topic:
 
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-consumer --bootstrap-server {{ .Release.Name }}:9092 --topic test1 --from-beginning
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-consumer --bootstrap-server {{ include "kafka.fullname" . }}:9092 --topic test1 --from-beginning
 
 To stop the listener session above press: Ctrl+C
 
 To start an interactive message producer session:
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-producer --broker-list {{ .Release.Name }}-headless:9092 --topic test1
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-producer --broker-list {{ include "kafka.fullname" . }}-headless:9092 --topic test1
 
 To create a message in the above session, simply type the message and press "enter"
 To end the producer session try: Ctrl+C

--- a/incubator/kafka/templates/NOTES.txt
+++ b/incubator/kafka/templates/NOTES.txt
@@ -27,12 +27,12 @@ To create a new topic:
 
 To listen for messages on a topic:
 
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-consumer --bootstrap-server {{ .Release.Name }}-kafka:9092 --topic test1 --from-beginning
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-consumer --bootstrap-server {{ .Release.Name }}:9092 --topic test1 --from-beginning
 
 To stop the listener session above press: Ctrl+C
 
 To start an interactive message producer session:
-  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-producer --broker-list {{ .Release.Name }}-kafka-headless:9092 --topic test1
+  kubectl -n {{ .Release.Namespace }} exec -ti testclient -- /usr/bin/kafka-console-producer --broker-list {{ .Release.Name }}-headless:9092 --topic test1
 
 To create a message in the above session, simply type the message and press "enter"
 To end the producer session try: Ctrl+C


### PR DESCRIPTION
#### What this PR does / why we need it:

The current notes template incorrectly renders the bootstrap server and broker in the notes, see below. There are one too may `-kafka` strings appended to the addresses.

```
To listen for messages on a topic:

  kubectl -n kafka exec -ti testclient -- /usr/bin/kafka-console-consumer --bootstrap-server my-kafka-kafka:9092 --topic test1 --from-beginning

To stop the listener session above press: Ctrl+C

To start an interactive message producer session:
  kubectl -n kafka exec -ti testclient -- /usr/bin/kafka-console-producer --broker-list my-kafka-kafka-headless:9092 --topic test1
```
#### Which issue this PR fixes

n/a

#### Special notes for your reviewer:

none 
#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
