### PR TITLE
[stable/kube-slack] Upgrade image version to the latest

### DIFF
--- a/stable/kube-slack/Chart.yaml
+++ b/stable/kube-slack/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-slack
-version: 0.2.0
-appVersion: v3.4.0
+version: 0.3.0
+appVersion: v3.5.0
 apiVersion: v1
 description: Chart for kube-slack, a monitoring service for Kubernetes
 keywords:

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -6,7 +6,7 @@ notReadyMinTime: 60000  # in ms
 ## Configuration for the deployment:
 image:
   repository: willwill/kube-slack
-  tag: v3.4.0
+  tag: v3.5.0
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
Latest version of kube-slack is v3.5.0 (https://github.com/wongnai/kube-slack/releases). This PR upgrades kube-slack image to latest version