### PR TITLE
Move gogs to 0.11.66 image

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.7.0
-appVersion: 0.11.29
+version: 0.7.1
+appVersion: 0.11.66
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico
 keywords:

--- a/incubator/gogs/README.md
+++ b/incubator/gogs/README.md
@@ -44,7 +44,7 @@ chart and their default values.
 | Parameter                        | Description                                                  | Default                                                    |
 | -----------------------          | ----------------------------------                           | ---------------------------------------------------------- |
 | `image.repository`                | Gogs image                                                   | `gogs/gogs`                                                |
-| `image.tag`                       | Gogs image tag                                           | `0.11.29`                                                  |
+| `image.tag`                       | Gogs image tag                                           | `0.11.66`                                                  |
 | `image.pullPolicy`                | Gogs image pull policy                                       | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
 | `postgresql.install`             | Weather or not to install PostgreSQL dependency              | `true`                                                     |
 | `postgresql.postgresHost`        | PostgreSQL host (if `postgresql.install == false`)           | `nil`                                                      |

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -11,7 +11,7 @@ replicaCount: 1
 
 image:
   repository: gogs/gogs
-  tag: 0.11.29
+  tag: 0.11.66
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Signed-off-by: Sonny Van <sv@gatech.edu>

#### What this PR does / why we need it:
Updates gogs image to 0.11.66

#### Checklist
- [x ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x ] Chart Version bumped
