### PR TITLE
[stable/rabbitmq] Fix ports on svc-headless.yaml

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 3.3.5
+version: 3.3.6
 appVersion: 3.7.8
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/svc-headless.yaml
+++ b/stable/rabbitmq/templates/svc-headless.yaml
@@ -14,13 +14,13 @@ spec:
     port: 4369
     targetPort: epmd
   - name: amqp
-    port: {{ .Values.rabbitmq.nodePort }}
+    port: {{ .Values.rabbitmq.amqpPort }}
     targetPort: amqp
     {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.rabbitmq.nodePort))) }}
     nodePort: {{ .Values.rabbitmq.nodePort }}
     {{- end }}
   - name: dist
-    port: {{ .Values.rabbitmq.nodePort | add 20000 }}
+    port: {{ .Values.rabbitmq.distPort }}
     targetPort: dist
   - name: stats
     port: {{ .Values.rabbitmq.managerPort }}


### PR DESCRIPTION
#### What this PR does / why we need it:

There's a bug on **svc-headless.yaml** port configuration.

#### Which issue this PR fixes
- fixes https://github.com/helm/charts/issues/8222
