### PR TITLE
[stable/mongodb-replicaset] Add OU to cert

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.6.1
+version: 3.6.2
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -137,7 +137,7 @@ configmap:
     port: 27017
     ssl:
       mode: requireSSL
-      CAFile: /ca/tls.crt
+      CAFile: /data/configdb/tls.crt
       PEMKeyFile: /work-dir/mongo.pem
   replication:
     replSetName: rs0

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -137,7 +137,7 @@ EOL
 
     # Generate the certs
     openssl genrsa -out mongo.key 2048
-    openssl req -new -key mongo.key -out mongo.csr -subj "/CN=$my_hostname" -config openssl.cnf
+    openssl req -new -key mongo.key -out mongo.csr -subj "/OU=MongoDB/CN=$my_hostname" -config openssl.cnf
     openssl x509 -req -in mongo.csr \
         -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial \
         -out mongo.crt -days 3650 -extensions v3_req -extfile openssl.cnf


### PR DESCRIPTION
#### What this PR does / why we need it:

When you set `security.clusterAuthMode: x509` as recommended by the
README the nodes will fail to authenticate with the following error:

    2018-10-08T13:06:12.767+0000 I ACCESS   [conn7]  authenticate db: $external { authenticate: 1, mechanism: "MONGODB-X509", user: "CN=circleci-mongodb-1" }
    2018-10-08T13:06:12.767+0000 I ACCESS   [conn7] Failed to authenticate CN=circleci-mongodb-1@$external with mechanism MONGODB-X509: UserNotFound: Could not find user CN=circleci-mongodb-1@$external
    2018-10-08T13:06:12.768+0000 I ACCESS   [conn7] Unauthorized: not authorized on admin to execute command { replSetHeartbeat: "rs0", configVersion: 3, from: "circleci-mongodb-1.circleci-mongodb.default.svc.cluster.local:27017", fromId: 1, term: 12 }

This is because the MongoDB docs state the following:

> The Distinguished Name (DN), found in the member certificate’s
> subject, must specify a non-empty value for at least one of the
> following attributes: Organization (O), the Organizational Unit (OU)
> or the Domain Component (DC).

https://docs.mongodb.com/manual/tutorial/configure-x509-member-authentication/#certificate-requirements

Setting the OU to the name of the product seems like the most generic
solution to this without suggesting that the cert belongs to MongoDB the
company.

#### Which issue this PR fixes

  - fixes #7417

#### Special notes for your reviewer:

N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
