### PR TITLE
[stable/mongodb-replicaset] Fix CAFile in README

### DIFF
--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -128,7 +128,7 @@ configmap:
     port: 27017
     ssl:
       mode: requireSSL
-      CAFile: /ca/tls.crt
+      CAFile: /data/configdb/tls.crt
       PEMKeyFile: /work-dir/mongo.pem
   replication:
     replSetName: rs0


### PR DESCRIPTION
#### What this PR does / why we need it:

The `/ca` directory doesn't exist when the `bootstrap` container is run
and this causes the `on-start.sh` script to fail. Whereas the
`/data/configdb` directory does existing throughout the process and is
the path that people have reported using in other issues.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed

