### PR TITLE
[stable/datadog] Upgrade to latest app version

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,6 +1,6 @@
 name: datadog
-version: 1.4.1
-appVersion: 6.4.2
+version: 1.5.0
+appVersion: 6.5.2
 description: DataDog Agent
 keywords:
 - monitoring

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.appKey`            | Datadog APP key required to use metricsProvider |  `Nil` You must provide your own key      |
 | `datadog.appKeyExistingSecret` | If set, use the secret with a provided name instead of creating a new one |`nil` |
 | `image.repository`          | The image repository to pull from  | `datadog/agent`                           |
-| `image.tag`                 | The image tag to pull              | `6.4.2`                                   |
+| `image.tag`                 | The image tag to pull              | `6.5.2`                                   |
 | `image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
 | `image.pullSecrets`         | Image pull secrets                 |  `nil`                                    |
 | `rbac.create`               | If true, create & use RBAC resources | `true`                                  |
@@ -81,7 +81,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `clusterAgent.enabled`                   | Use the cluster-agent for cluster metrics (Kubernetes 1.10+ only) | `false`                           |
 | `clusterAgent.token`                     | A cluster-internal secret for agent-to-agent communication. Must be 32+ characters a-zA-Z | `Nil` You must provide your own token|
 | `clusterAgent.image.repository`          | The image repository for the cluster-agent | `datadog/cluster-agent`                           |
-| `clusterAgent.image.tag`                 | The image tag to pull              | `0.9.1`                                   |
+| `clusterAgent.image.tag`                 | The image tag to pull              | `0.10.0`                                   |
 | `clusterAgent.image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |
 | `clusterAgent.image.pullSecrets`         | Image pull secrets                 |  `nil`                                    |
 | `clusterAgent.metricsProvider.enabled`   | Enable Datadog metrics as a source for HPA scaling |  `false`                  |
@@ -127,7 +127,7 @@ However, you can use manually created secret by setting the `datadog.apiKeyExist
 
 The Datadog [entrypoint
 ](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/entrypoint/89-copy-customfiles.sh)
-will copy files with a `.yaml` extension found in `/conf.d` and files with `.py` extension in 
+will copy files with a `.yaml` extension found in `/conf.d` and files with `.py` extension in
 `/check.d` to `/etc/datadog-agent/conf.d` and `/etc/datadog-agent/checks.d` respectively. The keys for
 `datadog.confd` and `datadog.checksd` should mirror the content found in their
 respective ConfigMaps, ie

--- a/stable/datadog/templates/agent-clusterrole.yaml
+++ b/stable/datadog/templates/agent-clusterrole.yaml
@@ -47,7 +47,7 @@ rules:
   resourceNames:
   - datadog-leader-election  # Leader election token
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
-  - datadog-hpa
+  - datadog-custom-metrics
 {{- end }}
   verbs:
   - get

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -3,7 +3,7 @@ image:
   # This chart is compatible with different images, please choose one
   repository: datadog/agent               # Agent6
   # repository: datadog/dogstatsd         # Standalone DogStatsD6
-  tag: 6.4.2  # Use 6.4.2-jmx to enable jmx fetch collection
+  tag: 6.5.2  # Use 6.5.2-jmx to enable jmx fetch collection
   pullPolicy: IfNotPresent
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -68,7 +68,6 @@ deployment:
   # Tolerations for pod assignment
   # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
-
   # If you're using a NodePort-type service and need a fixed port, set this parameter.
   # dogstatsdNodePort: 8125
   # traceNodePort: 8126
@@ -91,7 +90,7 @@ kubeStateMetrics:
 clusterAgent:
   image:
     repository: datadog/cluster-agent
-    tag: 0.9.1
+    tag: 0.10.0
     pullPolicy: IfNotPresent
   enabled: false
   ## This needs to be at least 32 characters a-zA-z


### PR DESCRIPTION
Simple upgrade from 6.4.2 to 6.5.2 for the node agent and 0.9.2 to 0.10.0 for the cluster agent.