### PR TITLE
[incubator/spring-cloud-data-flow] Fixed error in templates/NOTES.txt

### DIFF
--- a/incubator/spring-cloud-data-flow/Chart.yaml
+++ b/incubator/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 0.2.6
+version: 0.2.7
 appVersion: 1.6.2.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:

--- a/incubator/spring-cloud-data-flow/templates/NOTES.txt
+++ b/incubator/spring-cloud-data-flow/templates/NOTES.txt
@@ -8,7 +8,7 @@
            You can watch the status of the server by running 'kubectl get svc -w {{ template "scdf.fullname" . }}-server'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "scdf.fullname" . }}-server -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.server.service.externalPort }}
-{{- else if contains "ClusterIP"  .Values.service.type }}
+{{- else if contains "ClusterIP"  .Values.server.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "scdf.fullname" . }}-server" -> -l "app={{ template "scdf.name" . }},release={{ .Release.Name }},component=server"
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.server.service.externalPort }}


### PR DESCRIPTION
#### What this PR does / why we need it:
NOTES.txt throws an error when `.Values.server.service.type` is not `NodePort` or `LoadBalancer`:
> Error: render error in "spring-cloud-data-flow/templates/NOTES.txt": template: spring-cloud-data-flow/templates/NOTES.txt:11:41: executing "spring-cloud-data-flow/templates/NOTES.txt" at <.Values.service.type>: can't evaluate field type in type interface {}

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped