### PR TITLE
[stable/falco] Resolve cluster hostnames when using hostnetwork

### DIFF
--- a/stable/falco/CHANGELOG.md
+++ b/stable/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Sysdig Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.5.1
+
+* Allow falco to resolve cluster hostnames when running with ebpf.hostNetwork: true
+
 ## v0.5.0
 
 ### Major Changes

--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.11.1
 description: Sysdig Falco
 keywords:

--- a/stable/falco/templates/daemonset.yaml
+++ b/stable/falco/templates/daemonset.yaml
@@ -18,6 +18,7 @@ spec:
       serviceAccountName: {{ template "falco.serviceAccountName" .}}
       {{- if (and .Values.ebpf.enabled .Values.ebpf.settings.hostNetwork) }}
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}


### PR DESCRIPTION

Signed-off-by: Diego Lendoiro <diego.lendoiro@gmail.com>

#### What this PR does / why we need it:

When falco runs with `.Values.ebpf.settings.hostNetwork` falco containers use the host DNS servers which, by default, prevent falco to resolve the kubernetes API server URL (kubernetes.default). Under these conditions falco is unable to report alerts with the k8s related metadata (`k8s.pod` and so on) fields correctly.

Adding to daemonset spec a `dnsPolicy` when using ebpf hostNetwork will create the falco containers injecting the correct cluster nameservers in `/etc/resolv.conf` that allow falco to connect to k8s apiserver.

@nestorsalceda 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped