### PR TITLE
[stable/kibana] Fix empty parameters to have valid Kubernetes and Helm YAML files

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.16.1
+version: 0.16.2
 appVersion: 6.4.2
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/templates/service.yaml
+++ b/stable/kibana/templates/service.yaml
@@ -10,10 +10,12 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   name: {{ template "kibana.fullname" . }}
+  {{- with .Values.service.annotations }}
   annotations:
-    {{- range $key, $value := .Values.service.annotations }}
+    {{- range $key, $value := . }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- end }}
 spec:
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
@@ -32,7 +34,7 @@ spec:
       protocol: TCP
 {{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
-{{ end }}      
+{{ end }}
 {{- if .Values.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.service.externalIPs | indent 4 }}

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -4,7 +4,7 @@ image:
   pullPolicy: "IfNotPresent"
 
 commandline:
-  args:
+  args: []
 
 env: {}
   # All Kibana configuration options are adjustable via env vars.
@@ -44,10 +44,10 @@ service:
   ## Default: nil
   ##
   # loadBalancerIP: 10.2.2.2
-  annotations:
+  annotations: {}
     # Annotation example: setup ssl with aws cert when service.type is LoadBalancer
     # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:EXAMPLE_CERT
-  labels:
+  labels: {}
     ## Label example: show service URL in `kubectl cluster-info`
     # kubernetes.io/cluster-service: "true"
   ## Limit load balancer source ips to list of CIDRs (where available)


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes non-valid kubernetes description files (although it correctly deploys, it does not validate against json schemas). Also set default values for empty list/dicts in values.yaml so that Helm does not complain.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

cc @compleatang 
