### PR TITLE
[stable/mariadb] Expose securityContext parameters in values yaml files

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.0.9
+version: 5.1.0
 appVersion: 10.1.36
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -55,24 +55,27 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `image.pullPolicy`                        | MariaDB image pull policy                           | `Always` if `imageTag` is `latest`, else `IfNotPresent`           |
 | `image.pullSecrets`                       | Specify image pull secrets                          | `nil` (does not add image pull secrets to deployed pods)          |
 | `service.type`                            | Kubernetes service type                             | `ClusterIP`                                                       |
-| `service.clusterIp`                       | Specific cluster IP when service type is cluster IP. Use None for headless service | `nil`                                                                  |
-| `service.port`                            | MySQL service port                                  | `3306`                                                             |
+| `service.clusterIp`                       | Specific cluster IP when service type is cluster IP. Use None for headless service | `nil`                              |
+| `service.port`                            | MySQL service port                                  | `3306`                                                            |
+| `securityContext.enabled`                 | Enable security context                             | `true`                                                            |
+| `securityContext.fsGroup`                 | Group ID for the container                          | `1001`                                                            |
+| `securityContext.runAsUser`               | User ID for the container                           | `1001`                                                            |
 | `rootUser.password`                       | Password for the `root` user                        | _random 10 character alphanumeric string_                         |
 | `rootUser.forcePassword`                  | Force users to specify a password                   | `false`                                                           |
 | `db.user`                                 | Username of new user to create                      | `nil`                                                             |
 | `db.password`                             | Password for the new user                           | _random 10 character alphanumeric string if `db.user` is defined_ |
 | `db.name`                                 | Name for new database to create                     | `my_database`                                                     |
-| `replication.enabled`                     | MariaDB replication enabled                         | `true`                                                             |
-| `replication.user`                        | MariaDB replication user                            | `replicator`                                                       |
+| `replication.enabled`                     | MariaDB replication enabled                         | `true`                                                            |
+| `replication.user`                        | MariaDB replication user                            | `replicator`                                                      |
 | `replication.password`                    | MariaDB replication user password                   | _random 10 character alphanumeric string_                         |
-| `master.annotations[].key`                | key for the the annotation list item                |  `nil`                                                  |
-| `master.annotations[].value`              | value for the the annotation list item              |  `nil`                                                  |
+| `master.annotations[].key`                | key for the the annotation list item                |  `nil`                                                            |
+| `master.annotations[].value`              | value for the the annotation list item              |  `nil`                                                            |
 | `master.affinity`                         | Master affinity (in addition to master.antiAffinity when set)  | `{}`                                                   |
 | `master.antiAffinity`                     | Master pod anti-affinity policy                     | `soft`                                                            |
 | `master.tolerations`                      | List of node taints to tolerate (master)            | `[]`                                                              |
 | `master.persistence.enabled`              | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
-| `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`  | `nil`
-| `master.persistence.mountPath`            | Configure existing `PersistentVolumeClaim` mount path  | `""`  
+| `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`         | `nil`                                                             |
+| `master.persistence.mountPath`            | Configure existing `PersistentVolumeClaim` mount path  | `""`                                                           |
 | `master.persistence.annotations`          | Persistent Volume Claim annotations                 | `{}`                                                              |
 | `master.persistence.storageClass`         | Persistent Volume Storage Class                     | ``                                                                |
 | `master.persistence.accessModes`          | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |
@@ -92,8 +95,8 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `master.readinessProbe.successThreshold`  | Minimum consecutive successes for the probe (master)| `1`                                                               |
 | `master.readinessProbe.failureThreshold`  | Minimum consecutive failures for the probe (master) | `3`                                                               |
 | `slave.replicas`                          | Desired number of slave replicas                    | `1`                                                               |
-| `slave.annotations[].key`                 | key for the the annotation list item                | `nil`                                                   |
-| `slave.annotations[].value`               | value for the the annotation list item              | `nil`                                                   |
+| `slave.annotations[].key`                 | key for the the annotation list item                | `nil`                                                             |
+| `slave.annotations[].value`               | value for the the annotation list item              | `nil`                                                             |
 | `slave.affinity`                          | Slave affinity (in addition to slave.antiAffinity when set) | `{}`                                                      |
 | `slave.antiAffinity`                      | Slave pod anti-affinity policy                      | `soft`                                                            |
 | `slave.tolerations`                       | List of node taints to tolerate for (slave)         | `[]`                                                              |
@@ -117,10 +120,10 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `slave.readinessProbe.successThreshold`   | Minimum consecutive successes for the probe (slave) | `1`                                                               |
 | `slave.readinessProbe.failureThreshold`   | Minimum consecutive failures for the probe (slave)  | `3`                                                               |
 | `metrics.enabled`                         | Start a side-car prometheus exporter                | `false`                                                           |
-| `metrics.image.registry`                           | Exporter image registry                                 | `docker.io` |
-`metrics.image.repository`                           | Exporter image name                                 | `prom/mysqld-exporter`                                            |
-| `metrics.image.tag`                        | Exporter image tag                                  | `v0.10.0`                                                         |
-| `metrics.image.pullPolicy`                 | Exporter image pull policy                          | `IfNotPresent`                                                    |
+| `metrics.image.registry`                  | Exporter image registry                             | `docker.io`                                                       |
+| `metrics.image.repository`                | Exporter image name                                 | `prom/mysqld-exporter`                                            |
+| `metrics.image.tag`                       | Exporter image tag                                  | `v0.10.0`                                                         |
+| `metrics.image.pullPolicy`                | Exporter image pull policy                          | `IfNotPresent`                                                    |
 | `metrics.resources`                       | Exporter resource requests/limit                    | `nil`                                                             |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -32,10 +32,10 @@ spec:
         release: "{{ .Release.Name }}"
         chart: {{ template "mariadb.chart" . }}
     spec:
-      {{- if .values.securitycontext.enabled }}
-      securitycontext:
-        fsgroup: {{ .values.securitycontext.fsgroup }}
-        runasuser: {{ .values.securitycontext.runasuser }}
+      {{- if .values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .values.securityContext.fsGroup }}
+        runAsUser: {{ .values.securityContext.runAsUser }}
       {{- end }}
       {{- if eq .Values.master.antiAffinity "hard" }}
       affinity:

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -32,10 +32,10 @@ spec:
         release: "{{ .Release.Name }}"
         chart: {{ template "mariadb.chart" . }}
     spec:
-      {{- if .values.securityContext.enabled }}
+      {{- if .Values.securityContext.enabled }}
       securityContext:
-        fsGroup: {{ .values.securityContext.fsGroup }}
-        runAsUser: {{ .values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
       {{- if eq .Values.master.antiAffinity "hard" }}
       affinity:

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -32,9 +32,11 @@ spec:
         release: "{{ .Release.Name }}"
         chart: {{ template "mariadb.chart" . }}
     spec:
-      securityContext:
-        runAsUser: 1001
-        fsGroup: 1001
+      {{- if .values.securitycontext.enabled }}
+      securitycontext:
+        fsgroup: {{ .values.securitycontext.fsgroup }}
+        runasuser: {{ .values.securitycontext.runasuser }}
+      {{- end }}
       {{- if eq .Values.master.antiAffinity "hard" }}
       affinity:
       {{- with .Values.master.affinity  }}

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -33,9 +33,11 @@ spec:
         release: "{{ .Release.Name }}"
         chart: {{ template "mariadb.chart" . }}
     spec:
-      securityContext:
-        runAsUser: 1001
-        fsGroup: 1001
+      {{- if .values.securitycontext.enabled }}
+      securitycontext:
+        fsgroup: {{ .values.securitycontext.fsgroup }}
+        runasuser: {{ .values.securitycontext.runasuser }}
+      {{- end }}
       {{- if eq .Values.slave.antiAffinity "hard" }}
       affinity:
       {{- with .Values.slave.affinity  }}

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -33,10 +33,10 @@ spec:
         release: "{{ .Release.Name }}"
         chart: {{ template "mariadb.chart" . }}
     spec:
-      {{- if .values.securityContext.enabled }}
+      {{- if .Values.securityContext.enabled }}
       securityContext:
-        fsGroup: {{ .values.securityContext.fsGroup }}
-        runAsUser: {{ .values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
       {{- if eq .Values.slave.antiAffinity "hard" }}
       affinity:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -33,10 +33,10 @@ spec:
         release: "{{ .Release.Name }}"
         chart: {{ template "mariadb.chart" . }}
     spec:
-      {{- if .values.securitycontext.enabled }}
-      securitycontext:
-        fsgroup: {{ .values.securitycontext.fsgroup }}
-        runasuser: {{ .values.securitycontext.runasuser }}
+      {{- if .values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .values.securityContext.fsGroup }}
+        runAsUser: {{ .values.securityContext.runAsUser }}
       {{- end }}
       {{- if eq .Values.slave.antiAffinity "hard" }}
       affinity:

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -29,6 +29,14 @@ service:
   #   master: 30001
   #   slave: 30002
 
+## Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
 rootUser:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -29,6 +29,14 @@ service:
   #   master: 30001
   #   slave: 30002
 
+## Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+
 rootUser:
   ## MariaDB admin password
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
The MariaDB chart was using securityContext in their statefulsets but the values were hardcoded. This PR exposes those parameters in the values yaml files.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
