### PR TITLE
[stable/traefik] Replaced toml block for traefik logs

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.49.0
+version: 1.50.0
 appVersion: 1.7.2
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -15,10 +15,6 @@ data:
     {{- else }}
     logLevel = "INFO"
     {{- end }}
-    {{- if .Values.traefikLogFormat }}
-    [traefikLog]
-      format = "{{ .Values.traefikLogFormat }}"
-    {{- end }}
     {{- if .Values.sendAnonymousUsage }}
     sendAnonymousUsage = true
     {{- end }}
@@ -138,6 +134,10 @@ data:
         {{- end}}
       {{- end}}
     {{- end}}
+    {{- if .Values.traefikLogFormat }}
+    [traefikLog]
+      format = "{{ .Values.traefikLogFormat }}"
+    {{- end }}
     {{- if .Values.accessLogs.enabled }}
     [accessLog]
     {{- if .Values.accessLogs.filePath }}


### PR DESCRIPTION
Signed-off-by: Oleksandr Stepanov <alexandrst88@gmail.com>

This PR fixes https://github.com/helm/charts/pull/7849, seems like Traefik needs to set log format configuration at the end of the config
