### PR TITLE
[incubator/elastic-stack] Use stable version of fluentd-elasticsearch for elastic-stack

### DIFF
--- a/incubator/elastic-stack/Chart.yaml
+++ b/incubator/elastic-stack/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for ELK
 home: https://www.elastic.co/products
 icon: https://www.elastic.co/assets/bltb35193323e8f1770/logo-elastic-stack-lt.svg
 name: elastic-stack
-version: 0.9.1
+version: 0.9.2
 appVersion: 6.0
 maintainers:
 - name: rendhalver

--- a/incubator/elastic-stack/requirements.lock
+++ b/incubator/elastic-stack/requirements.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: elasticsearch
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 1.7.2
+  version: 1.8.1
 - name: kibana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.13.1
+  version: 0.14.6
 - name: logstash
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.6.3
-- name: fluentd
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.1.4
+  version: 0.9.3
+- name: fluentd-elasticsearch
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 1.0.2
 - name: fluent-bit
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.6.0
+  version: 0.11.1
 - name: nginx-ldapauth-proxy
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.1.2
 - name: elasticsearch-curator
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  version: 0.2.4
-digest: sha256:5a93301ce089e04837d2cd7ef0a547735388460186d9b0de2f62d982831df02b
-generated: 2018-07-09T13:53:58.299283141-04:00
+  version: 0.4.1
+digest: sha256:661607892e7f03703ed13fc246650bd9bd37bad3316fb248c14a294bd1fc7e63
+generated: 2018-09-28T15:03:07.747602126+03:00

--- a/incubator/elastic-stack/requirements.yaml
+++ b/incubator/elastic-stack/requirements.yaml
@@ -9,10 +9,10 @@ dependencies:
   version: ^0.6.0
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: logstash.enabled
-- name: fluentd
-  version: ^0.1.0
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  condition: fluentd.enabled
+- name: fluentd-elasticsearch
+  version: ^1.0.2
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  condition: fluentd-elasticsearch.enabled
 - name: fluent-bit
   version: ^0.6.0
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/incubator/elastic-stack/values.yaml
+++ b/incubator/elastic-stack/values.yaml
@@ -9,7 +9,7 @@ kibana:
 logstash:
   enabled: true
 
-fluentd:
+fluentd-elasticsearch:
   enabled: false
 
 fluent-bit:


### PR DESCRIPTION
@rendhalver @jar361 @christian-roggia 

#### What this PR does / why we need it:

stable/fluentd-elasticsearch is better than incubator/fluentd because it creates DaemonSet and works out of box without much additional configuration.

#### Special notes for your reviewer:

I tested this chart on our cluster.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
