### PR TITLE
[stable/chaoskube] update to v0.11.0 and related changes

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: chaoskube
-version: 0.10.0
-appVersion: 0.10.0
+version: 0.11.0
+appVersion: 0.11.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube
 sources:

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -41,7 +41,7 @@ $ helm install stable/chaoskube --set dryRun=false
 |---------------------------|-----------------------------------------------------|----------------------------------|
 | `name`                    | container name                                      | chaoskube                        |
 | `image`                   | docker image                                        | quay.io/linki/chaoskube          |
-| `imageTag`                | docker image tag                                    | v0.10.0                          |
+| `imageTag`                | docker image tag                                    | v0.11.0                          |
 | `replicas`                | number of replicas to run                           | 1                                |
 | `interval`                | interval between pod terminations                   | 10m                              |
 | `labels`                  | label selector to filter pods by                    | "" (matches everything)          |
@@ -60,7 +60,8 @@ $ helm install stable/chaoskube --set dryRun=false
 | `nodeSelector`            | Node labels for pod assignment                      | `{}`                             |
 | `tolerations`             | Toleration labels for pod assignment                | `[]`                             |
 | `affinity`                | Affinity settings for pod assignment                | `{}`                             |
-| `minimumAge`              | Set minimum pod age to filter pod by                | `0s`                             |
+| `minimumAge`              | Set minimum pod age to filter pods by               | `0s` (matches all pods)          |
+| `gracePeriod`             | grace period to give pods when terminating them     | `-1s` (pod decides)              |
 
 Setting label and namespaces selectors from the shell can be tricky but is possible (example with zsh):
 

--- a/stable/chaoskube/templates/clusterrole.yaml
+++ b/stable/chaoskube/templates/clusterrole.yaml
@@ -6,11 +6,10 @@ metadata:
 {{ include "labels.standard" . | indent 4 }}
   name: {{ printf "%s-%s" .Release.Name .Values.name }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - list
-      - delete
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
 {{- end -}}

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -38,8 +38,15 @@ spec:
             - --debug
             {{- end }}
             - --minimum-age={{ .Values.minimumAge }}
+            - --grace-period={{ .Values.gracePeriod }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
 {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
 {{- end }}

--- a/stable/chaoskube/templates/role.yaml
+++ b/stable/chaoskube/templates/role.yaml
@@ -6,11 +6,10 @@ metadata:
 {{ include "labels.standard" . | indent 4 }}
   name: {{ printf "%s-%s" .Release.Name .Values.name }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - list
-      - delete
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
 {{- end -}}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -5,7 +5,7 @@ name: chaoskube
 image: quay.io/linki/chaoskube
 
 # docker image tag
-imageTag: v0.10.0
+imageTag: v0.11.0
 
 # number of replicas to run
 replicas: 1
@@ -40,7 +40,11 @@ excludedDaysOfYear:
 # Set specific Timezone for Actions to take place
 timezone: UTC
 
+# minimum lifetime of a pod before it's considered for termination (0: immediately)
 minimumAge: 0s
+
+# grace period to give pods when terminating them (negative: pod decides)
+gracePeriod: -1s
 
 priorityClassName: ""
 


### PR DESCRIPTION
Updates `chaoskube` to `v0.11.0` with the following changes:
* emitting events when terminating pods (https://github.com/linki/chaoskube/pull/105)
  * needs additional rbac rules to allow writing events
* specifying a grace period for pod termination (https://github.com/linki/chaoskube/pull/110)
* more locked-down `securityContext`