### PR TITLE
allowing annotations on core and worker deployments

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,5 +1,5 @@
 name: anchore-engine
-version: 0.2.3
+version: 0.2.4
 appVersion: 0.2.4
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/templates/core_deployment.yaml
+++ b/stable/anchore-engine/templates/core_deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: "{{ template "fullname" . }}"
         component: core
+{{- if .Values.coreConfig.annotations }}
+      annotations:
+{{ toYaml .Values.coreConfig.annotations | indent 8 }}
+{{- end }}
     spec:
       volumes:
         - name: config-volume

--- a/stable/anchore-engine/templates/worker_deployment.yaml
+++ b/stable/anchore-engine/templates/worker_deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: "{{ template "worker.fullname" . }}"
         component: worker
+{{- if .Values.workerConfig.annotations }}
+      annotations:
+{{ toYaml .Values.workerConfig.annotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: {{ .Chart.Name }}-worker

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -206,6 +206,8 @@ coreConfig:
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
+  annotations: {}
+
   nodeSelector: {}
 
   tolerations: []
@@ -253,6 +255,8 @@ workerConfig:
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
+  annotations: {}
+
   nodeSelector: {}
 
   tolerations: []


### PR DESCRIPTION
Signed-off-by: Raza Jhaveri <razajhaveri@googlemail.com>

#### What this PR does / why we need it:

Allows custom annotations on the Core and Worker pods, this is useful for stuff like annotating iam roles for kube2iam 


#### Checklist
- [ X ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ X ] Chart Version bumped
- [ X ] Variables are documented in the README.md
