### PR TITLE
[stable/prometheus-adapter] Add checksum of configMap as annotation

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.1.3
+version: v0.2.0
 appVersion: v0.2.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.1.2
+version: v0.1.3
 appVersion: v0.2.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -21,6 +21,8 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
       name: {{ template "k8s-prometheus-adapter.name" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/custom-metrics-configmap.yaml") . | sha256sum }}
     spec:
       securityContext:
         allowPrivilegeEscalation: false


### PR DESCRIPTION

#### What this PR does / why we need it:
- This adds `checksum/config` to the annotations which has `sha256sum` of
  the file `custom-metrics-configmap.yaml`
- This does the rolling update of the deployment when user does helm
  upgrade and there are changes to the `configMap`, so the adapter will
  pick up the latest changes in the config file
- ref:
  https://docs.helm.sh/charts_tips_and_tricks/#automatically-roll-deployments-when-configmaps-or-secrets-change
- Bump chart version

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
- Deploy with custom config i.e. set `rules.default: false`
- Make changes in the `rules.custom`
- Run `helm upgrade`
- Check if it rolling updates the adapter Pod

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped