### PR TITLE
[datadog] Fixing failed lint when deployment is enabled.

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.5.0
+version: 1.5.1
 appVersion: 6.5.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -8,12 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  {{- if .Values.deployment.service.annotations }}
+  {{- if .Values.service.annotations }}
   annotations:
-  {{ toYaml .Values.deployment.service.annotations | indent 4 }}
+  {{ toYaml .Values.deployment.annotations | indent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.deployment.serviceType }}
+  type: {{ .Values.service.type }}
   selector:
     app: {{ template "datadog.fullname" . }}
     type: deployment

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -8,12 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  {{- if .Values.service.annotations }}
+  {{- if .Values.deployment.service.annotations }}
   annotations:
-  {{ toYaml .Values.service.annotations | indent 4 }}
+  {{ toYaml .Values.deployment.service.annotations | indent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: {{ .Values.deployment.serviceType }}
   selector:
     app: {{ template "datadog.fullname" . }}
     type: deployment

--- a/stable/datadog/templates/service.yaml
+++ b/stable/datadog/templates/service.yaml
@@ -8,12 +8,12 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  {{- if .Values.service.annotations }}
+  {{- if .Values.deployment.service.annotations }}
   annotations:
-  {{ toYaml .Values.deployment.annotations | indent 4 }}
+  {{ toYaml .Values.deployment.service.annotations | indent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.deployment.service.type }}
   selector:
     app: {{ template "datadog.fullname" . }}
     type: deployment

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -60,7 +60,7 @@ daemonset:
 #
 # HINT: If you want to use datadog.collectEvents, keep deployment.replicas set to 1.
 deployment:
-  enabled: false
+  enabled: true
   replicas: 1
   # Affinity for pod assignment
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -76,9 +76,9 @@ deployment:
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
 ##
 
-# service:
-# type: LoadBalancer
-# annotations: {}
+  service:
+    type: ClusterIP
+    annotations: {}
 
 kubeStateMetrics:
   enabled: true

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -60,7 +60,7 @@ daemonset:
 #
 # HINT: If you want to use datadog.collectEvents, keep deployment.replicas set to 1.
 deployment:
-  enabled: true
+  enabled: false
   replicas: 1
   # Affinity for pod assignment
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -76,9 +76,9 @@ deployment:
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
 ##
 
-  service:
-    type: ClusterIP
-    annotations: {}
+service:
+  type: ClusterIP
+  annotations: {}
 
 kubeStateMetrics:
   enabled: true

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -72,13 +72,12 @@ deployment:
   # dogstatsdNodePort: 8125
   # traceNodePort: 8126
 
+  service:
+    type: ClusterIP
+    annotations: {}
+
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics
-##
-
-service:
-  type: ClusterIP
-  annotations: {}
 
 kubeStateMetrics:
   enabled: true


### PR DESCRIPTION
Fixing regression where the service values are not set when the deplo…yment is enabled.

This can be tested by `setting deployment.enabled`: true and running `helm lint`
