### PR TITLE
[stable/keycloak] parameterize path to docker-entrypoint script

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.0.0
+version: 4.0.1
 appVersion: 4.5.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 3.4.2
+version: 3.4.3
 appVersion: 4.2.1.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -93,6 +93,7 @@ Parameter | Description | Default
 `keycloak.persistence.dbPort` | The database host port (if `deployPostgres=false`) | `5432`
 `keycloak.persistence.dbUser` |The database user (if `deployPostgres=false`) | `keycloak`
 `keycloak.persistence.dbPassword` |The database password (if `deployPostgres=false`) | `""`
+`keycloak.scriptPath` | Path to the docker-entrypoint script | `/opt/jboss`
 `postgresql.postgresUser` | The PostgreSQL user (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
 `postgresql.postgresPassword` | The PostgreSQL password (if `keycloak.persistence.deployPostgres=true`) | `""`
 `postgresql.postgresDatabase` | The PostgreSQL database (if `keycloak.persistence.deployPostgres=true`) | `keycloak`

--- a/stable/keycloak/templates/configmap.yaml
+++ b/stable/keycloak/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
 {{ . | indent 4 }}
   {{- end }}
 
-    exec /opt/jboss/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} --server-config standalone-ha.xml{{ end }}
+    exec {{ .Values.keycloak.scriptPath }}/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} --server-config standalone-ha.xml{{ end }}
     exit "$?"
 
   keycloak.cli: |

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -42,8 +42,8 @@ keycloak:
   extraArgs: ""
 
   ## Path to the docker-entrypoint script
-  ## Setting this to '/opt/jboss/tools' is needed from version 4.4.0.Final onwards
-  scriptPath: /opt/jboss
+  ## Setting this to '/opt/jboss' is needed for keycloak versions under 4.4.0.Final
+  scriptPath: /opt/jboss/tools
 
   ## Username for the initial Keycloak admin user
   username: keycloak

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -39,6 +39,10 @@ keycloak:
   ## Additional arguments to start command e.g. -Dkeycloak.import= to load a realm
   extraArgs: ""
 
+  ## Path to the docker-entrypoint script
+  ## Setting this to '/opt/jboss/tools' is needed from version 4.4.0.Final onwards
+  scriptPath: /opt/jboss
+
   ## Username for the initial Keycloak admin user
   username: keycloak
 


### PR DESCRIPTION
#### What this PR does / why we need it:
After updating keycloak version to 4.5.0.Final, it becomes useful to parameterize the path to the docker-entrypoint script to make easier for the chart to work with previous versions of keycloak

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
