### PR TITLE
[stable/minio] Fix after-install help NOTES

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 1.8.2
+version: 1.8.3
 appVersion: RELEASE.2018-09-12T18-49-56Z
 keywords:
 - storage

--- a/stable/minio/templates/_helpers.tpl
+++ b/stable/minio/templates/_helpers.tpl
@@ -19,7 +19,7 @@ If release name contains chart name it will be used as a full name.
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This commit fixes the NOTES in the steps to access the new installed Minio in localhost.

It was not constructing the right release parameter in the command:
``
export POD_NAME=$(kubectl get pods --namespace default -l "release=RELEASE_NAME" -o jsonpath="{.items[0].metadata.name}")
``

#### Special notes for your reviewer:

#### Checklist
- [x ] Chart Version bumped
