### PR TITLE
[stable/dokuwiki] Simplify ingress configuration for cert-manager

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: dokuwiki
-version: 3.0.3
+version: 3.1.0
 appVersion: 0.20180422.201805030840
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/stable/dokuwiki/README.md
+++ b/stable/dokuwiki/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the DokuWiki chart and 
 | `ingress.hosts[0].name`              | Hostname to your DokuWiki installation                     | `dokuwiki.local`                              |
 | `ingress.hosts[0].path`              | Path within the url structure                              | `/`                                           |
 | `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                             | `false`                                       |
+| `ingress.hosts[0].certManager`       | Add annotations for cert-manager                           | `false`                                       |
 | `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                  | `dokuwiki.local-tls`                          |
 | `ingress.hosts[0].annotations`       | Annotations for this host's ingress record                 | `[]`                                          |
 | `ingress.secrets[0].name`            | TLS Secret Name                                            | `nil`                                         |

--- a/stable/dokuwiki/templates/ingress.yaml
+++ b/stable/dokuwiki/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
     {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/stable/dokuwiki/values.yaml
+++ b/stable/dokuwiki/values.yaml
@@ -83,7 +83,7 @@ ingress:
     ## A side effect of this will be that the backend dokuwiki service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/stable/dokuwiki/values.yaml
+++ b/stable/dokuwiki/values.yaml
@@ -83,19 +83,19 @@ ingress:
     ## A side effect of this will be that the backend dokuwiki service will be connected at port 443
     tls: false
 
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
     tlsSecret: dokuwiki.local-tls
 
     ## Ingress annotations done as key:value pairs
-    ## If you're using kube-lego, you will want to add:
-    ## kubernetes.io/tls-acme: true
-    ##
     ## For a full list of possible ingress annotations, please see
     ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
     ##
     ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
     annotations:
-    #  kubernetes.io/ingress.class: nginx
     #  kubernetes.io/tls-acme: true
 
   secrets:
@@ -104,7 +104,7 @@ ingress:
   ## -----BEGIN RSA PRIVATE KEY-----
   ##
   ## name should line up with a tlsSecret set further up
-  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
   ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -181,7 +181,7 @@ ingress:
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so.