### PR TITLE
[stable/drupal] Simplify ingress configuration for cert-manager

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 2.0.3
+version: 2.1.0
 appVersion: 8.6.1
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -47,45 +47,51 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Drupal chart and their default values.
 
-| Parameter                         | Description                           | Default                                                   |
-| --------------------------------- | ------------------------------------- | --------------------------------------------------------- |
-| `image.registry`                  | Drupal image registry                 | `docker.io`                                               |
-| `image.repository`                | Drupal Image name                     | `bitnami/drupal`                                          |
-| `image.tag`                       | Drupal Image tag                      | `{VERSION}`                                               |
-| `image.pullPolicy`                | Drupal image pull policy              | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
-| `image.pullSecrets`               | Specify image pull secrets            | `nil` (does not add image pull secrets to deployed pods)  |
-| `drupalProfile`                   | Drupal installation profile           | `standard`                                                |
-| `drupalUsername`                  | User of the application               | `user`                                                    |
-| `drupalPassword`                  | Application password                  | _random 10 character long alphanumeric string_            |
-| `drupalEmail`                     | Admin email                           | `user@example.com`                                        |
-| `allowEmptyPassword`              | Allow DB blank passwords              | `yes`                                                     |
-| `extraVars`                       | Extra environment variables           | `nil`                                                     |
-| `ingress.annotations`             | Specify ingress class                 | `kubernetes.io/ingress.class: nginx`                      |
-| `ingress.enabled`                 | Enable ingress controller resource    | `false`                                                   |
-| `ingress.hostname`                | URL for your Drupal installation      | `drupal.local`                                            |
-| `ingress.tls`                     | Ingress TLS configuration             | `[]`                                                      |
-| `externalDatabase.host`           | Host of the external database         | `nil`                                                     |
-| `externalDatabase.user`           | Existing username in the external db  | `bn_drupal`                                               |
-| `externalDatabase.password`       | Password for the above username       | `nil`                                                     |
-| `externalDatabase.database`       | Name of the existing database         | `bitnami_drupal`                                          |
-| `mariadb.enabled`                 | Whether to use the MariaDB chart      | `true`                                                    |
-| `mariadb.rootUser.password`       | MariaDB admin password                | `nil`                                                     |
-| `mariadb.db.name`                 | Database name to create               | `bitnami_drupal`                                          |
-| `mariadb.db.user`                 | Database user to create               | `bn_drupal`                                               |
-| `mariadb.db.password`             | Password for the database             | _random 10 character long alphanumeric string_            |
-| `serviceType`                     | Kubernetes Service type               | `LoadBalancer`                                            |
-| `persistence.enabled`             | Enable persistence using PVC          | `true`                                                    |
-| `persistence.apache.storageClass` | PVC Storage Class for Apache volume   | `nil` (uses alpha storage class annotation)               |
-| `persistence.apache.accessMode`   | PVC Access Mode for Apache volume     | `ReadWriteOnce`                                           |
-| `persistence.apache.size`         | PVC Storage Request for Apache volume | `1Gi`                                                     |
-| `persistence.drupal.storageClass` | PVC Storage Class for Drupal volume   | `nil` (uses alpha storage class annotation)               |
-| `persistence.drupal.accessMode`   | PVC Access Mode for Drupal volume     | `ReadWriteOnce`                                           |
-| `persistence.drupal.existingClaim`| An Existing PVC name                  | `nil`                                                     |
-| `persistence.drupal.hostPath`     | Host mount path for Drupal volume     | `nil` (will not mount to a host path)                     |
-| `persistence.drupal.size`         | PVC Storage Request for Drupal volume | `8Gi`                                                     |
-| `resources`                       | CPU/Memory resource requests/limits   | Memory: `512Mi`, CPU: `300m`                              |
-| `volumeMounts.drupal.mountPath`   | Drupal data volume mount path         | `/bitnami/drupal`                                         |
-| `volumeMounts.apache.mountPath`   | Apache data volume mount path         | `/bitnami/apache`                                         |
+| Parameter                         | Description                                | Default                                                   |
+| --------------------------------- | ------------------------------------------ | --------------------------------------------------------- |
+| `image.registry`                  | Drupal image registry                      | `docker.io`                                               |
+| `image.repository`                | Drupal Image name                          | `bitnami/drupal`                                          |
+| `image.tag`                       | Drupal Image tag                           | `{VERSION}`                                               |
+| `image.pullPolicy`                | Drupal image pull policy                   | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
+| `image.pullSecrets`               | Specify image pull secrets                 | `nil` (does not add image pull secrets to deployed pods)  |
+| `drupalProfile`                   | Drupal installation profile                | `standard`                                                |
+| `drupalUsername`                  | User of the application                    | `user`                                                    |
+| `drupalPassword`                  | Application password                       | _random 10 character long alphanumeric string_            |
+| `drupalEmail`                     | Admin email                                | `user@example.com`                                        |
+| `allowEmptyPassword`              | Allow DB blank passwords                   | `yes`                                                     |
+| `extraVars`                       | Extra environment variables                | `nil`                                                     |
+| `ingress.enabled`                 | Enable ingress controller resource         | `false`                                                   |
+| `ingress.hosts[0].name`           | Hostname to your Drupal installation       | `drupal.local`                                            |
+| `ingress.hosts[0].path`           | Path within the url structure              | `/`                                                       |
+| `ingress.hosts[0].tls`            | Utilize TLS backend in ingress             | `false`                                                   |
+| `ingress.hosts[0].certManager`    | Add annotations for cert-manager           | `false`                                                   |
+| `ingress.hosts[0].tlsSecret`      | TLS Secret (certificates)                  | `drupal.local-tls-secret`                                 |
+| `ingress.hosts[0].annotations`    | Annotations for this host's ingress record | `[]`                                                      |
+| `ingress.secrets[0].name`         | TLS Secret Name                            | `nil`                                                     |
+| `ingress.secrets[0].certificate`  | TLS Secret Certificate                     | `nil`                                                     |
+| `ingress.secrets[0].key`          | TLS Secret Key                             | `nil`                                                     |
+| `externalDatabase.host`           | Host of the external database              | `nil`                                                     |
+| `externalDatabase.user`           | Existing username in the external db       | `bn_drupal`                                               |
+| `externalDatabase.password`       | Password for the above username            | `nil`                                                     |
+| `externalDatabase.database`       | Name of the existing database              | `bitnami_drupal`                                          |
+| `mariadb.enabled`                 | Whether to use the MariaDB chart           | `true`                                                    |
+| `mariadb.rootUser.password`       | MariaDB admin password                     | `nil`                                                     |
+| `mariadb.db.name`                 | Database name to create                    | `bitnami_drupal`                                          |
+| `mariadb.db.user`                 | Database user to create                    | `bn_drupal`                                               |
+| `mariadb.db.password`             | Password for the database                  | _random 10 character long alphanumeric string_            |
+| `serviceType`                     | Kubernetes Service type                    | `LoadBalancer`                                            |
+| `persistence.enabled`             | Enable persistence using PVC               | `true`                                                    |
+| `persistence.apache.storageClass` | PVC Storage Class for Apache volume        | `nil` (uses alpha storage class annotation)               |
+| `persistence.apache.accessMode`   | PVC Access Mode for Apache volume          | `ReadWriteOnce`                                           |
+| `persistence.apache.size`         | PVC Storage Request for Apache volume      | `1Gi`                                                     |
+| `persistence.drupal.storageClass` | PVC Storage Class for Drupal volume        | `nil` (uses alpha storage class annotation)               |
+| `persistence.drupal.accessMode`   | PVC Access Mode for Drupal volume          | `ReadWriteOnce`                                           |
+| `persistence.drupal.existingClaim`| An Existing PVC name                       | `nil`                                                     |
+| `persistence.drupal.hostPath`     | Host mount path for Drupal volume          | `nil` (will not mount to a host path)                     |
+| `persistence.drupal.size`         | PVC Storage Request for Drupal volume      | `8Gi`                                                     |
+| `resources`                       | CPU/Memory resource requests/limits        | Memory: `512Mi`, CPU: `300m`                              |
+| `volumeMounts.drupal.mountPath`   | Drupal data volume mount path              | `/bitnami/drupal`                                         |
+| `volumeMounts.apache.mountPath`   | Apache data volume mount path              | `/bitnami/apache`                                         |
 
 The above parameters map to the env variables defined in [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal). For more information please refer to the [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal) image documentation.
 

--- a/stable/drupal/templates/_helpers.tpl
+++ b/stable/drupal/templates/_helpers.tpl
@@ -22,3 +22,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "drupal.mariadb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "drupal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/drupal/templates/apache-pvc.yaml
+++ b/stable/drupal/templates/apache-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "drupal.fullname" . }}-apache
   labels:
     app: {{ template "drupal.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "drupal.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/drupal/templates/deployment.yaml
+++ b/stable/drupal/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "drupal.fullname" . }}
   labels:
     app: {{ template "drupal.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "drupal.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
         app: {{ template "drupal.fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ template "drupal.chart" . }}
         release: "{{ .Release.Name }}"
     spec:
       {{- if .Values.image.pullSecrets }}

--- a/stable/drupal/templates/drupal-pvc.yaml
+++ b/stable/drupal/templates/drupal-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "drupal.fullname" . }}-drupal
   labels:
     app: {{ template "drupal.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "drupal.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/drupal/templates/ingress.yaml
+++ b/stable/drupal/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
     app: {{ template "drupal.fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "drupal.chart" $ }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
   annotations:

--- a/stable/drupal/templates/ingress.yaml
+++ b/stable/drupal/templates/ingress.yaml
@@ -1,28 +1,38 @@
 {{- if .Values.ingress.enabled -}}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "drupal.fullname" . }}
+  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
-    app: {{ template "drupal.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: {{ template "drupal.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ .name }}
       http:
         paths:
-          - path: /
+          - path: {{ default "/" .path }}
             backend:
-              serviceName: {{ template "drupal.fullname" . }}
+              serviceName: {{ template "drupal.fullname" $ }}
               servicePort: 80
-{{- if .Values.ingress.tls }}
+{{- if .tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-{{- end -}}
-{{- end -}}
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
+
+

--- a/stable/drupal/templates/secrets.yaml
+++ b/stable/drupal/templates/secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "drupal.fullname" . }}
   labels:
     app: {{ template "drupal.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "drupal.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/drupal/templates/svc.yaml
+++ b/stable/drupal/templates/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "drupal.fullname" . }}
   labels:
     app: {{ template "drupal.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "drupal.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -124,7 +124,7 @@ ingress:
     ## A side effect of this will be that the backend drupal service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/stable/drupal/values.yaml
+++ b/stable/drupal/values.yaml
@@ -39,7 +39,7 @@ drupalUsername: user
 drupalEmail: user@example.com
 
 ## Set to `yes` to allow the container to be started with blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## ref: https://github.com/bitnami/bitnami-docker-drupal#environment-variables
 allowEmptyPassword: "yes"
 
 ##
@@ -107,27 +107,36 @@ mariadb:
 ##
 serviceType: LoadBalancer
 
-## Configure Ingress resource that allow you to access the Drupal installation
-## Set up the URL
+## Configure the ingress resource that allows you to access the
+## Drupal installation. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
+  ## Set to true to enable ingress record generation
   enabled: false
-  # Used to create Ingress record (should used with ServiceType: ClusterIP).
-  # hostname: drupal.local
 
-  ## Ingress annotations
-  ##
-  # annotations:
-  #   kubernetes.io/ingress.class: nginx
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: drupal.local
 
-  ## Ingress TLS configuration
-  ## Secrets must be manually created in the namespace
-  ##
-  # tls:
-  #   - secretName: wordpress.local-tls
-  #     hosts:
-  #       - drupal.local
+    ## Set this to true in order to enable TLS on the ingress record
+    ## A side effect of this will be that the backend drupal service will be connected at port 443
+    tls: false
+
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: drupal.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -181,7 +181,7 @@ ingress:
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so