### PR TITLE
[stable/moodle] Simplify ingress configuration for cert-manager

### DIFF
--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,5 +1,5 @@
 name: moodle
-version: 3.0.3
+version: 3.1.0
 appVersion: 3.5.2
 description: Moodle is a learning platform designed to provide educators, administrators
   and learners with a single robust, secure and integrated system to create personalised

--- a/stable/moodle/README.md
+++ b/stable/moodle/README.md
@@ -63,10 +63,16 @@ The following table lists the configurable parameters of the Moodle chart and th
 | `smtpUser`                            | SMTP user                                                                                    | `nil`                                                   |
 | `smtpPassword`                        | SMTP password                                                                                | `nil`                                                   |
 | `serviceType`                         | Kubernetes Service type                                                                      | `LoadBalancer`                                          |
-| `ingress.enabled`                     | If ingress should be created                                                                 | `false`                                                 |
-| `ingress.annotations`                 | Any ingress annotations                                                                      | `nil`                                                   |
-| `ingress.hosts`                       | List of Ingress hosts                                                                        | `nil`                                                   |
-| `ingress.tls`                         | List of certs. If defined, https is set                                                      | `nil`                                                   |
+| `ingress.enabled`                     | Enable ingress controller resource                                                           | `false`                                                 |
+| `ingress.hosts[0].name`               | Hostname to your Moodle installation                                                         | `moodle.local`                                          |
+| `ingress.hosts[0].path`               | Path within the url structure                                                                | `/`                                                     |
+| `ingress.hosts[0].tls`                | Utilize TLS backend in ingress                                                               | `false`                                                 |
+| `ingress.hosts[0].certManager`        | Add annotations for cert-manager                                                             | `false`                                                 |
+| `ingress.hosts[0].tlsSecret`          | TLS Secret (certificates)                                                                    | `moodle.local-tls-secret`                               |
+| `ingress.hosts[0].annotations`        | Annotations for this host's ingress record                                                   | `[]`                                                    |
+| `ingress.secrets[0].name`             | TLS Secret Name                                                                              | `nil`                                                   |
+| `ingress.secrets[0].certificate`      | TLS Secret Certificate                                                                       | `nil`                                                   |
+| `ingress.secrets[0].key`              | TLS Secret Key                                                                               | `nil`                                                   |
 | `affinity`                            | Set affinity for the moodle pods                                                             | `nil`                                                   |
 | `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                            |
 | `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                                  |
@@ -81,10 +87,10 @@ The following table lists the configurable parameters of the Moodle chart and th
 | `externalDatabase.password`           | Password for the above username                                                              | `nil`                                                   |
 | `externalDatabase.database`           | Name of the existing database                                                                | `bitnami_moodle`                                        |
 | `mariadb.enabled`                     | Whether to install the MariaDB chart                                                         | `true`                                                  |
-| `mariadb.db.name`             | Database name to create                                                                      | `bitnami_moodle`                                        |
-| `mariadb.db.user`                 | Database user to create                                                                      | `bn_moodle`                                             |
-| `mariadb.db.password`             | Password for the database                                                                    | `nil`                                                   |
-| `mariadb.rootUser.password`         | MariaDB admin password                                                                       | `nil`                                                   |
+| `mariadb.db.name`                     | Database name to create                                                                      | `bitnami_moodle`                                        |
+| `mariadb.db.user`                     | Database user to create                                                                      | `bn_moodle`                                             |
+| `mariadb.db.password`                 | Password for the database                                                                    | `nil`                                                   |
+| `mariadb.rootUser.password`           | MariaDB admin password                                                                       | `nil`                                                   |
 | `mariadb.persistence.enabled`         | Enable MariaDB persistence using PVC                                                         | `true`                                                  |
 | `mariadb.persistence.storageClass`    | PVC Storage Class for MariaDB volume                                                         | `generic`                                               |
 | `mariadb.persistence.accessMode`      | PVC Access Mode for MariaDB volume                                                           | `ReadWriteOnce`                                         |

--- a/stable/moodle/templates/_helpers.tpl
+++ b/stable/moodle/templates/_helpers.tpl
@@ -31,4 +31,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "moodle" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "moodle.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/moodle/templates/deployment.yaml
+++ b/stable/moodle/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "moodle.fullname" . }}
   labels:
     app: {{ template "moodle.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "moodle.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: {{ template "moodle.fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ template "moodle.chart" . }}
         release: "{{ .Release.Name }}"
     spec:
       {{- if .Values.affinity }}

--- a/stable/moodle/templates/ingress.yaml
+++ b/stable/moodle/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
     app: {{ template "moodle.fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "moodle.chart" $ }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
   annotations:

--- a/stable/moodle/templates/ingress.yaml
+++ b/stable/moodle/templates/ingress.yaml
@@ -1,35 +1,40 @@
-{{- if .Values.ingress.enabled -}}
-{{- $releaseName := .Release.Name -}}
-{{- $serviceName := include "moodle.fullname" . }}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-{{- if .Values.ingress.annotations }}
-  annotations:
-{{ toYaml .Values.ingress.annotations | indent 4}}
-{{- end }}
+  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
-    app: {{ template "moodle.fullname" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ template "moodle.fullname" . }}
+    app: {{ template "moodle.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+  annotations:
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: 80
-  {{- end -}}
-{{- if .Values.ingress.tls }}
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "moodle.fullname" $ }}
+            servicePort: 80
+{{- if .tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-{{- end -}}
-{{- end -}}
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
+
 
 
 

--- a/stable/moodle/templates/pvc.yaml
+++ b/stable/moodle/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "moodle.fullname" . }}
   labels:
     app: {{ template "moodle.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "moodle.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/moodle/templates/secrets.yaml
+++ b/stable/moodle/templates/secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "moodle.fullname" . }}
   labels:
     app: {{ template "moodle.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "moodle.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/moodle/templates/svc.yaml
+++ b/stable/moodle/templates/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "moodle.fullname" . }}
   labels:
     app: {{ template "moodle.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "moodle.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/moodle/values.yaml
+++ b/stable/moodle/values.yaml
@@ -139,32 +139,50 @@ mariadb:
 ##
 serviceType: LoadBalancer
 
-## Optionally, create ingress controller
+## Configure the ingress resource that allows you to access the
+## Moodle installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
 ingress:
-  ## If true, Moodle server Ingress will be created
-  ##
+  ## Set to true to enable ingress record generation
   enabled: false
 
-  ## Moodle server Ingress annotations
-  ##
-  annotations: {}
-  #   kubernetes.io/ingress.class: nginx
-  #   kubernetes.io/tls-acme: 'true'
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: moodle.local
 
-  ## Moodle server Ingress hostnames
-  ## Must be provided if Ingress is enabled
-  ##
-  hosts: []
-  #   - moodle.domain.com
+    ## Set this to true in order to enable TLS on the ingress record
+    ## A side effect of this will be that the backend moodle service will be connected at port 443
+    tls: false
 
-  ## Moodle server Ingress TLS configuration
-  ## Secrets must be manually created in the namespace
-  ## kubectl create secret tls moodle-server-tls --cert=tls.crt --key=tls.key
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: moodle.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
   ##
-  tls: []
-  #   - secretName: moodle-server-tls
-  #     hosts:
-  #       - moodle.domain.com
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: moodle.local-tls
+  #   key:
+  #   certificate:
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/stable/moodle/values.yaml
+++ b/stable/moodle/values.yaml
@@ -156,7 +156,7 @@ ingress:
     ## A side effect of this will be that the backend moodle service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -181,7 +181,7 @@ ingress:
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so.
