### PR TITLE
[stable/owncloud] Simplify ingress configuration for cert-manager

### DIFF
--- a/stable/owncloud/Chart.yaml
+++ b/stable/owncloud/Chart.yaml
@@ -1,5 +1,5 @@
 name: owncloud
-version: 3.0.2
+version: 3.1.0
 appVersion: 10.0.10
 description: A file sharing server that puts the control and security of your own data back into your hands.
 keywords:

--- a/stable/owncloud/README.md
+++ b/stable/owncloud/README.md
@@ -47,46 +47,52 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the ownCloud chart and their default values.
 
-|              Parameter              |                Description                |                   Default                               |
-|-------------------------------------|-------------------------------------------|-------------------------------------------------------- |
-| `image.registry`                    | ownCloud image registry                   | `docker.io`                                             |
-| `image.repository`                  | ownCloud Image name                       | `bitnami/owncloud`                                      |
-| `image.tag`                         | ownCloud Image tag                        | `{VERSION}`                                             |
-| `image.pullPolicy`                  | Image pull policy                         | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `image.pullSecrets`                 | Specify image pull secrets                | `nil`                                                   |
-| `ingress.enabled`                   | Enable use of ingress controllers         | `false`                                                 |
-| `ingress.servicePort`               | Ingress' backend servicePort              | `http`                                                  |
-| `ingress.annotations`               | An array of service annotations           | `nil`                                                   |
-| `ingress.tls`                       | Ingress TLS configuration                 | `[]`                                                    |
-| `networkPolicyApiVersion`           | The kubernetes network API version        | `extensions/v1beta1`                                    |
-| `owncloudHost`                      | ownCloud host to create application URLs  | `nil`                                                   |
-| `owncloudLoadBalancerIP`            | `loadBalancerIP` for the owncloud Service | `nil`                                                   |
-| `owncloudUsername`                  | User of the application                   | `user`                                                  |
-| `owncloudPassword`                  | Application password                      | Randomly generated                                      |
-| `owncloudEmail`                     | Admin email                               | `user@example.com`                                      |
-| `externalDatabase.host`             | Host of the external database             | `nil`                                                   |
-| `allowEmptyPassword`                | Allow DB blank passwords                  | `yes`                                                   |
-| `externalDatabase.host`             | Host of the external database             | `nil`                                                   |
-| `externalDatabase.port`             | Port of the external database             | `3306`                                                  |
-| `externalDatabase.database`         | Name of the existing database             | `bitnami_owncloud`                                      |
-| `externalDatabase.user`             | Existing username in the external db      | `bn_owncloud`                                           |
-| `externalDatabase.password`         | Password for the above username           | `nil`                                                   |
-| `mariadb.db.name`           | Database name to create                   | `bitnami_owncloud`                                      |
-| `mariadb.enabled`                   | Whether to use the MariaDB chart          | `true`                                                  |
-| `mariadb.db.password`           | Password for the database                 | `nil`                                                   |
-| `mariadb.db.user`               | Database user to create                   | `bn_owncloud`                                           |
-| `mariadb.rootUser.password`       | MariaDB admin password                    | `nil`                                                   |
-| `serviceType`                       | Kubernetes Service type                   | `LoadBalancer`                                          |
-| `persistence.enabled`               | Enable persistence using PVC              | `true`                                                  |
-| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume       | `nil` (uses alpha storage class annotation)             |
-| `persistence.apache.existingClaim`  | An Existing PVC name for Apache volume    | `nil` (uses alpha storage class annotation)             |
-| `persistence.apache.accessMode`     | PVC Access Mode for Apache volume         | `ReadWriteOnce`                                         |
-| `persistence.apache.size`           | PVC Storage Request for Apache volume     | `1Gi`                                                   |
-| `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume     | `nil` (uses alpha storage class annotation)             |
-| `persistence.owncloud.existingClaim`| An Existing PVC name for ownCloud volume  | `nil` (uses alpha storage class annotation)             |
-| `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume       | `ReadWriteOnce`                                         |
-| `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume   | `8Gi`                                                   |
-| `resources`                         | CPU/Memory resource requests/limits       | Memory: `512Mi`, CPU: `300m`                            |
+|              Parameter              |                Description                 |                   Default                               |
+|-------------------------------------|--------------------------------------------|-------------------------------------------------------- |
+| `image.registry`                    | ownCloud image registry                    | `docker.io`                                             |
+| `image.repository`                  | ownCloud Image name                        | `bitnami/owncloud`                                      |
+| `image.tag`                         | ownCloud Image tag                         | `{VERSION}`                                             |
+| `image.pullPolicy`                  | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
+| `image.pullSecrets`                 | Specify image pull secrets                 | `nil`                                                   |
+| `ingress.enabled`                   | Enable ingress controller resource         | `false`                                                 |
+| `ingress.hosts[0].name`             | Hostname to your ownCloud installation     | `owncloud.local`                                        |
+| `ingress.hosts[0].path`             | Path within the url structure              | `/`                                                     |
+| `ingress.hosts[0].tls`              | Utilize TLS backend in ingress             | `false`                                                 |
+| `ingress.hosts[0].certManager`      | Add annotations for cert-manager           | `false`                                                 |
+| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                  | `owncloud.local-tls-secret`                             |
+| `ingress.hosts[0].annotations`      | Annotations for this host's ingress record | `[]`                                                    |
+| `ingress.secrets[0].name`           | TLS Secret Name                            | `nil`                                                   |
+| `ingress.secrets[0].certificate`    | TLS Secret Certificate                     | `nil`                                                   |
+| `ingress.secrets[0].key`            | TLS Secret Key                             | `nil`                                                   |
+| `networkPolicyApiVersion`           | The kubernetes network API version         | `extensions/v1beta1`                                    |
+| `owncloudHost`                      | ownCloud host to create application URLs   | `nil`                                                   |
+| `owncloudLoadBalancerIP`            | `loadBalancerIP` for the owncloud Service  | `nil`                                                   |
+| `owncloudUsername`                  | User of the application                    | `user`                                                  |
+| `owncloudPassword`                  | Application password                       | Randomly generated                                      |
+| `owncloudEmail`                     | Admin email                                | `user@example.com`                                      |
+| `externalDatabase.host`             | Host of the external database              | `nil`                                                   |
+| `allowEmptyPassword`                | Allow DB blank passwords                   | `yes`                                                   |
+| `externalDatabase.host`             | Host of the external database              | `nil`                                                   |
+| `externalDatabase.port`             | Port of the external database              | `3306`                                                  |
+| `externalDatabase.database`         | Name of the existing database              | `bitnami_owncloud`                                      |
+| `externalDatabase.user`             | Existing username in the external db       | `bn_owncloud`                                           |
+| `externalDatabase.password`         | Password for the above username            | `nil`                                                   |
+| `mariadb.db.name`                   | Database name to create                    | `bitnami_owncloud`                                      |
+| `mariadb.enabled`                   | Whether to use the MariaDB chart           | `true`                                                  |
+| `mariadb.db.password`               | Password for the database                  | `nil`                                                   |
+| `mariadb.db.user`                   | Database user to create                    | `bn_owncloud`                                           |
+| `mariadb.rootUser.password`         | MariaDB admin password                     | `nil`                                                   |
+| `serviceType`                       | Kubernetes Service type                    | `LoadBalancer`                                          |
+| `persistence.enabled`               | Enable persistence using PVC               | `true`                                                  |
+| `persistence.apache.storageClass`   | PVC Storage Class for Apache volume        | `nil` (uses alpha storage class annotation)             |
+| `persistence.apache.existingClaim`  | An Existing PVC name for Apache volume     | `nil` (uses alpha storage class annotation)             |
+| `persistence.apache.accessMode`     | PVC Access Mode for Apache volume          | `ReadWriteOnce`                                         |
+| `persistence.apache.size`           | PVC Storage Request for Apache volume      | `1Gi`                                                   |
+| `persistence.owncloud.storageClass` | PVC Storage Class for ownCloud volume      | `nil` (uses alpha storage class annotation)             |
+| `persistence.owncloud.existingClaim`| An Existing PVC name for ownCloud volume   | `nil` (uses alpha storage class annotation)             |
+| `persistence.owncloud.accessMode`   | PVC Access Mode for ownCloud volume        | `ReadWriteOnce`                                         |
+| `persistence.owncloud.size`         | PVC Storage Request for ownCloud volume    | `8Gi`                                                   |
+| `resources`                         | CPU/Memory resource requests/limits        | Memory: `512Mi`, CPU: `300m`                            |
 
 The above parameters map to the env variables defined in [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud). For more information please refer to the [bitnami/owncloud](http://github.com/bitnami/bitnami-docker-owncloud) image documentation.
 

--- a/stable/owncloud/templates/_helpers.tpl
+++ b/stable/owncloud/templates/_helpers.tpl
@@ -43,3 +43,10 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 {{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
 {{- default (include "owncloud.serviceIP" .) $host -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "owncloud.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/owncloud/templates/deployment.yaml
+++ b/stable/owncloud/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "owncloud.fullname" . }}
   labels:
     app: {{ template "owncloud.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "owncloud.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         app: {{ template "owncloud.fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ template "owncloud.chart" . }}
         release: "{{ .Release.Name }}"
     spec:
       {{- if .Values.image.pullSecrets }}

--- a/stable/owncloud/templates/ingress.yaml
+++ b/stable/owncloud/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
     app: {{ template "owncloud.fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    chart: {{ template "owncloud.chart" $ }}
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
   annotations:

--- a/stable/owncloud/templates/ingress.yaml
+++ b/stable/owncloud/templates/ingress.yaml
@@ -1,28 +1,39 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: {{ required "A valid .Values.networkPolicyApiVersion entry required!" .Values.networkPolicyApiVersion }}
+{{- range .Values.ingress.hosts }}
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "owncloud.fullname" . }}
+  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
-    app: {{ template "owncloud.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-{{- if .Values.ingress.annotations }}
+    app: {{ template "owncloud.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
-{{- end }}
+    {{- if .tls }}
+    ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   rules:
-  - host: {{ .Values.owncloudHost }}
+  - host: {{ .name }}
     http:
       paths:
-      - path: /
-        backend:
-          serviceName: {{ template "owncloud.fullname" . }}
-          servicePort: {{ .Values.ingress.servicePort }}
-{{- if .Values.ingress.tls }}
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "owncloud.fullname" $ }}
+            servicePort: 80
+{{- if .tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-{{- end -}}
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
 {{- end }}

--- a/stable/owncloud/templates/secrets.yaml
+++ b/stable/owncloud/templates/secrets.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "owncloud.fullname" . }}
   labels:
     app: {{ template "owncloud.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "owncloud.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/owncloud/templates/svc.yaml
+++ b/stable/owncloud/templates/svc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "owncloud.fullname" . }}
   labels:
     app: {{ template "owncloud.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "owncloud.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -38,7 +38,7 @@ ingress:
     ## A side effect of this will be that the backend owncloud service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/stable/owncloud/values.yaml
+++ b/stable/owncloud/values.yaml
@@ -21,19 +21,51 @@ image:
 ## For Kubernetes v1.7, use 'networking.k8s.io/v1'
 networkPolicyApiVersion: extensions/v1beta1
 
-## Allowing use of ingress controllers
-## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+## Configure the ingress resource that allows you to access the
+## ownCloud installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
+  ## Set to true to enable ingress record generation
   enabled: false
-  servicePort: http
-  annotations:
-    # kubernetes.io/ingress.class: nginx
-    # ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/24,172.10.0.1"
-  tls:
-    # - secretName: owncloud.cluster.local
-    #   hosts:
-    #     - owncloud.cluster.local
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: owncloud.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    ## A side effect of this will be that the backend owncloud service will be connected at port 443
+    tls: false
+
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: owncloud.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: owncloud.local-tls
+  #   key:
+  #   certificate:
 
 ## ownCloud host to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -181,7 +181,7 @@ ingress:
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so