### PR TITLE
[stable/ghost] Simplify ingress configuration for cert-manager

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 5.0.3
+version: 5.1.0
 appVersion: 2.1.4
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -47,38 +47,48 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Ghost chart and their default values.
 
-| Parameter                     | Description                                                   | Default                                                  |
-|-------------------------------|---------------------------------------------------------------|----------------------------------------------------------|
-| `image.registry`              | Ghost image registry                                          | `docker.io`                                              |
-| `image.repository`            | Ghost Image name                                              | `bitnami/ghost`                                          |
-| `image.tag`                   | Ghost Image tag                                               | `{VERSION}`                                              |
-| `image.pullPolicy`            | Image pull policy                                             | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
-| `image.pullSecrets`           | Specify image pull secrets                                    | `nil`                                                    |
-| `ghostHost`                   | Ghost host to create application URLs                         | `nil`                                                    |
-| `ghostPath`                   | Ghost path to create application URLs                         | `nil`                                                    |
-| `ghostPort`                   | Ghost port to create application URLs along with host         | `80`                                                     |
-| `ghostLoadBalancerIP`         | `loadBalancerIP` for the Ghost Service                        | `nil`                                                    |
-| `ghostUsername`               | User of the application                                       | `user@example.com`                                       |
-| `ghostPassword`               | Application password                                          | Randomly generated                                       |
-| `ghostEmail`                  | Admin email                                                   | `user@example.com`                                       |
-| `ghostBlogTitle`              | Ghost Blog name                                               | `User's Blog`                                            |
-| `allowEmptyPassword`          | Allow DB blank passwords                                      | `yes`                                                    |
-| `externalDatabase.host`       | Host of the external database                                 | `nil`                                                    |
-| `externalDatabase.port`       | Port of the external database                                 | `nil`                                                    |
-| `externalDatabase.user`       | Existing username in the external db                          | `bn_ghost`                                               |
-| `externalDatabase.password`   | Password for the above username                               | `nil`                                                    |
-| `externalDatabase.database`   | Name of the existing database                                 | `bitnami_ghost`                                          |
-| `mariadb.enabled`             | Whether or not to install MariaDB (disable if using external) | `true`                                                   |
-| `mariadb.rootUser.password` | MariaDB admin password                                        | `nil`                                                    |
-| `mariadb.db.name`     | MariaDB Database name to create                               | `bitnami_ghost`                                          |
-| `mariadb.db.user`         | MariaDB Database user to create                               | `bn_ghost`                                               |
-| `mariadb.db.password`     | MariaDB Password for user                                     | _random 10 character long alphanumeric string_           |
-| `serviceType`                 | Kubernetes Service type                                       | `LoadBalancer`                                           |
-| `persistence.enabled`         | Enable persistence using PVC                                  | `true`                                                   |
-| `persistence.storageClass`    | PVC Storage Class for Ghost volume                            | `nil` (uses alpha storage annotation)                    |
-| `persistence.accessMode`      | PVC Access Mode for Ghost volume                              | `ReadWriteOnce`                                          |
-| `persistence.size`            | PVC Storage Request for Ghost volume                          | `8Gi`                                                    |
-| `resources`                   | CPU/Memory resource requests/limits                           | Memory: `512Mi`, CPU: `300m`                             |
+| Parameter                        | Description                                                   | Default                                                  |
+|----------------------------------|---------------------------------------------------------------|----------------------------------------------------------|
+| `image.registry`                 | Ghost image registry                                          | `docker.io`                                              |
+| `image.repository`               | Ghost Image name                                              | `bitnami/ghost`                                          |
+| `image.tag`                      | Ghost Image tag                                               | `{VERSION}`                                              |
+| `image.pullPolicy`               | Image pull policy                                             | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
+| `image.pullSecrets`              | Specify image pull secrets                                    | `nil`                                                    |
+| `ghostHost`                      | Ghost host to create application URLs                         | `nil`                                                    |
+| `ghostPath`                      | Ghost path to create application URLs                         | `nil`                                                    |
+| `ghostPort`                      | Ghost port to create application URLs along with host         | `80`                                                     |
+| `ghostLoadBalancerIP`            | `loadBalancerIP` for the Ghost Service                        | `nil`                                                    |
+| `ghostUsername`                  | User of the application                                       | `user@example.com`                                       |
+| `ghostPassword`                  | Application password                                          | Randomly generated                                       |
+| `ghostEmail`                     | Admin email                                                   | `user@example.com`                                       |
+| `ghostBlogTitle`                 | Ghost Blog name                                               | `User's Blog`                                            |
+| `allowEmptyPassword`             | Allow DB blank passwords                                      | `yes`                                                    |
+| `serviceType`                    | Kubernetes Service type                                       | `LoadBalancer`                                           |
+| `ingress.enabled`                | Enable ingress controller resource                            | `false`                                                  |
+| `ingress.hosts[0].name`          | Hostname to your Ghost installation                           | `ghost.local`                                            |
+| `ingress.hosts[0].path`          | Path within the url structure                                 | `/`                                                      |
+| `ingress.hosts[0].tls`           | Utilize TLS backend in ingress                                | `false`                                                  |
+| `ingress.hosts[0].certManager`   | Add annotations for cert-manager                              | `false`                                                  |
+| `ingress.hosts[0].tlsSecret`     | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
+| `ingress.hosts[0].annotations`   | Annotations for this host's ingress record                    | `[]`                                                     |
+| `ingress.secrets[0].name`        | TLS Secret Name                                               | `nil`                                                    |
+| `ingress.secrets[0].certificate` | TLS Secret Certificate                                        | `nil`                                                    |
+| `ingress.secrets[0].key`         | TLS Secret Key                                                | `nil`                                                    |
+| `externalDatabase.host`          | Host of the external database                                 | `nil`                                                    |
+| `externalDatabase.port`          | Port of the external database                                 | `nil`                                                    |
+| `externalDatabase.user`          | Existing username in the external db                          | `bn_ghost`                                               |
+| `externalDatabase.password`      | Password for the above username                               | `nil`                                                    |
+| `externalDatabase.database`      | Name of the existing database                                 | `bitnami_ghost`                                          |
+| `mariadb.enabled`                | Whether or not to install MariaDB (disable if using external) | `true`                                                   |
+| `mariadb.rootUser.password`      | MariaDB admin password                                        | `nil`                                                    |
+| `mariadb.db.name`                | MariaDB Database name to create                               | `bitnami_ghost`                                          |
+| `mariadb.db.user`                | MariaDB Database user to create                               | `bn_ghost`                                               |
+| `mariadb.db.password`            | MariaDB Password for user                                     | _random 10 character long alphanumeric string_           |
+| `persistence.enabled`            | Enable persistence using PVC                                  | `true`                                                   |
+| `persistence.storageClass`       | PVC Storage Class for Ghost volume                            | `nil` (uses alpha storage annotation)                    |
+| `persistence.accessMode`         | PVC Access Mode for Ghost volume                              | `ReadWriteOnce`                                          |
+| `persistence.size`               | PVC Storage Request for Ghost volume                          | `8Gi`                                                    |
+| `resources`                      | CPU/Memory resource requests/limits                           | Memory: `512Mi`, CPU: `300m`                             |
 
 The above parameters map to the env variables defined in [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost). For more information please refer to the [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost) image documentation.
 

--- a/stable/ghost/templates/ingress.yaml
+++ b/stable/ghost/templates/ingress.yaml
@@ -1,39 +1,36 @@
-{{- if .Values.ingress.enabled -}}
-{{- $fullName := include "ghost.fullname" . -}}
-{{- $servicePort := .Values.ghostPort -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
-    app: {{ template "ghost.name" . }}
-    chart: {{ template "ghost.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-{{- with .Values.ingress.annotations }}
+    app: {{ template "ghost.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
-  {{- end }}
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "ghost.fullname" $ }}
+            servicePort: 80
+{{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
 {{- end }}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -167,18 +167,47 @@ resources:
     memory: 512Mi
     cpu: 300m
 
-## Configure ingress resource
-## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+## Configure the ingress resource that allows you to access the
+## Ghost installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
+  ## Set to true to enable ingress record generation
   enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  path: /
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
   hosts:
-    - ghost.local
-  tls: []
-  #  - secretName: ghost-tls
-  #    hosts:
-  #      - ghost.local
+  - name: ghost.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    ## A side effect of this will be that the backend ghost service will be connected at port 443
+    tls: false
+
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: ghost.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: ghost.local-tls
+  #   key:
+  #   certificate:

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -184,7 +184,7 @@ ingress:
     ## A side effect of this will be that the backend ghost service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -181,7 +181,7 @@ ingress:
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so