### PR TITLE
[stable/phabricator] Simplify ingress configuration for cert-manager

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,5 +1,5 @@
 name: phabricator
-version: 3.0.6
+version: 3.1.0
 appVersion: 2018.40.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/README.md
+++ b/stable/phabricator/README.md
@@ -77,12 +77,16 @@ The following table lists the configurable parameters of the Phabricator chart a
 | `persistence.phabricator.accessMode`   | PVC Access Mode for Phabricator volume       | `ReadWriteOnce`                                          |
 | `persistence.phabricator.size`         | PVC Storage Request for Phabricator volume   | `8Gi`                                                    |
 | `resources`                            | CPU/Memory resource requests/limits          | Memory: `512Mi`, CPU: `300m`                             |
-| `ingress.enabled`                      | enable ingress                               | `false`                                                  |
-| `ingress.path`                         | path to expose on ingress                    | `nil`                                                    |
-| `ingress.hosts`                        | listss of accepted hostnames                 | `nil`                                                    |
-| `ingress.annotations`                  | annotations to use on the ingress            | `nil`                                                    |
-| `ingress.tls.secretName`               | tls secret name                              | `nil`                                                    |
-| `ingress.tls.hosts`                    | hostnames the secret applies to              | `nil`                                                    |
+| `ingress.enabled`                      | Enable ingress controller resource           | `false`                                                  |
+| `ingress.hosts[0].name`                | Hostname to your Phabricator installation    | `phabricator.local`                                      |
+| `ingress.hosts[0].path`                | Path within the url structure                | `/`                                                      |
+| `ingress.hosts[0].tls`                 | Utilize TLS backend in ingress               | `false`                                                  |
+| `ingress.hosts[0].certManager`         | Add annotations for cert-manager             | `false`                                                  |
+| `ingress.hosts[0].tlsSecret`           | TLS Secret (certificates)                    | `phabricator.local-tls-secret`                           |
+| `ingress.hosts[0].annotations`         | Annotations for this host's ingress record   | `[]`                                                     |
+| `ingress.secrets[0].name`              | TLS Secret Name                              | `nil`                                                    |
+| `ingress.secrets[0].certificate`       | TLS Secret Certificate                       | `nil`                                                    |
+| `ingress.secrets[0].key`               | TLS Secret Key                               | `nil`                                                    |
 
 The above parameters map to the env variables defined in [bitnami/phabricator](http://github.com/bitnami/bitnami-docker-phabricator). For more information please refer to the [bitnami/phabricator](http://github.com/bitnami/bitnami-docker-phabricator) image documentation.
 

--- a/stable/phabricator/templates/ingress.yaml
+++ b/stable/phabricator/templates/ingress.yaml
@@ -1,33 +1,40 @@
-{{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "phabricator.fullname" . -}}
-{{- $ingressPath := .Values.ingress.path -}}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
+  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
-    app: {{ template "phabricator.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ template "phabricator.fullname" . }}
+    app: {{ template "phabricator.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
+    {{- if .tls }}
+    ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $serviceName }}
-              servicePort: 80
-    {{- end -}}
-  {{- if .Values.ingress.tls }}
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "phabricator.fullname" $ }}
+            servicePort: 80
+{{- if .tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end -}}
-{{- end -}}
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}
 

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -133,20 +133,51 @@ persistence:
     accessMode: ReadWriteOnce
     size: 8Gi
 
+## Configure the ingress resource that allows you to access the
+## Phabricator installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
 ingress:
+  ## Set to true to enable ingress record generation
   enabled: false
-  # path: /
-  # Used to create an Ingress record.
-  # hosts:
-    # - chart-example.local
-  # annotations:
-  #   kubernetes.io/ingress.class: nginx
-  #   kubernetes.io/tls-acme: "true"
-  # tls:
-  #   Secrets must be manually created in the namespace.
-  #   - secretName: chart-example-tls
-  #     hosts:
-  #       - chart-example.local
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: phabricator.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    ## A side effect of this will be that the backend phabricator service will be connected at port 443
+    tls: false
+
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: phabricator.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: phabricator.local-tls
+  #   key:
+  #   certificate:
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -150,7 +150,7 @@ ingress:
     ## A side effect of this will be that the backend phabricator service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -181,7 +181,7 @@ ingress:
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:
This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so