### PR TITLE
[stable/mediawiki] Simplify ingress configuration for cert-manager

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 4.0.4
+version: 4.1.0
 appVersion: 1.31.1
 description: Extremely powerful, scalable software and a feature-rich wiki implementation
   that uses PHP to process and display data stored in a database.

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -82,6 +82,7 @@ The following table lists the configurable parameters of the MediaWiki chart and
 | `ingress.hosts[0].name`              | Hostname to your Mediawiki installation                     | `mediawiki.local`                                       |
 | `ingress.hosts[0].path`              | Path within the url structure                               | `/`                                                     |
 | `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                              | `false`                                                 |
+| `ingress.hosts[0].certManager`       | Add annotations for cert-manager                            | `false`                                                 |
 | `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                   | `mediawiki.local-tls-secret`                            |
 | `ingress.hosts[0].annotations`       | Annotations for this host's ingress record                  | `[]`                                                    |
 | `ingress.secrets[0].name`            | TLS Secret Name                                             | `nil`                                                   |

--- a/stable/mediawiki/templates/ingress.yaml
+++ b/stable/mediawiki/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
     {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -158,7 +158,7 @@ ingress:
     ## A side effect of this will be that the backend mediawiki service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -158,20 +158,20 @@ ingress:
     ## A side effect of this will be that the backend mediawiki service will be connected at port 443
     tls: false
 
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
     tlsSecret: mediawiki.local-tls
 
     ## Ingress annotations done as key:value pairs
-    ## If you're using kube-lego, you will want to add:
-    ## kubernetes.io/tls-acme: true
-    ##
     ## For a full list of possible ingress annotations, please see
     ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
     ##
     ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
     annotations:
     #  kubernetes.io/ingress.class: nginx
-    #  kubernetes.io/tls-acme: true
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
@@ -179,7 +179,7 @@ ingress:
   ## -----BEGIN RSA PRIVATE KEY-----
   ##
   ## name should line up with a tlsSecret set further up
-  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
   ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -181,7 +181,7 @@ ingress:
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so