### PR TITLE
[stable/joomla] Simplify ingress configuration for cert-manager

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 3.1.1
+version: 3.2.0
 appVersion: 3.8.13
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -77,13 +77,14 @@ The following table lists the configurable parameters of the Joomla! chart and t
 | `mariadb.root.password`              | MariaDB admin password                                      | `nil`                                          |
 | `service.type`                       | Kubernetes Service type                                     | `LoadBalancer`                                 |
 | `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                        | `nil`                                          |
-| `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Cluster`                                        |
+| `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Cluster`                                      |
 | `service.nodePorts.http`             | Kubernetes http node port                                   | `""`                                           |
 | `service.nodePorts.https`            | Kubernetes https node port                                  | `""`                                           |
 | `ingress.enabled`                    | Enable ingress controller resource                          | `false`                                        |
 | `ingress.hosts[0].name`              | Hostname to your Joomla! installation                       | `joomla.local`                                 |
 | `ingress.hosts[0].path`              | Path within the url structure                               | `/`                                            |
 | `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                              | `false`                                        |
+| `ingress.hosts[0].certManager `      | Add annotations for cert-manager                            | `false`                                        |
 | `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                   | `joomla.local-tls-secret`                      |
 | `ingress.hosts[0].annotations`       | Annotations for this host's ingress record                  | `[]`                                           |
 | `ingress.secrets[0].name`            | TLS Secret Name                                             | `nil`                                          |

--- a/stable/joomla/templates/ingress.yaml
+++ b/stable/joomla/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
+    {{- if .certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
     {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -167,7 +167,7 @@ ingress:
     ## A side effect of this will be that the backend joomla service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -167,20 +167,20 @@ ingress:
     ## A side effect of this will be that the backend joomla service will be connected at port 443
     tls: false
 
+    ## Set this to true in order to add the corresponding annontations for cert-manager
+    certManager: false
+
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
     tlsSecret: joomla.local-tls
 
     ## Ingress annotations done as key:value pairs
-    ## If you're using kube-lego, you will want to add:
-    ## kubernetes.io/tls-acme: true
-    ##
     ## For a full list of possible ingress annotations, please see
     ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
     ##
+    ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
     ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
     annotations:
     #  kubernetes.io/ingress.class: nginx
-    #  kubernetes.io/tls-acme: true
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets
@@ -188,7 +188,7 @@ ingress:
   ## -----BEGIN RSA PRIVATE KEY-----
   ##
   ## name should line up with a tlsSecret set further up
-  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
   ##
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -181,7 +181,7 @@ ingress:
     ## A side effect of this will be that the backend wordpress service will be connected at port 443
     tls: false
 
-    ## Set this to true in order to add the corresponding annontations for cert-manager
+    ## Set this to true in order to add the corresponding annotations for cert-manager
     certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to configure the proper annotations when using cert-manager to handle TLS certificates in an easy way. The user just needs to setup a boolean to true to do so
