### PR TITLE
[stable/keycloak] parameterize path of the docker-entrypoint script

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.0.0
+version: 4.0.1
 appVersion: 4.5.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -94,6 +94,7 @@ Parameter | Description | Default
 `keycloak.persistence.dbPort` | The database host port (if `deployPostgres=false`) | `5432`
 `keycloak.persistence.dbUser` |The database user (if `deployPostgres=false`) | `keycloak`
 `keycloak.persistence.dbPassword` |The database password (if `deployPostgres=false`) | `""`
+`keycloak.scriptPath` | Path to the docker-entrypoint script | `/opt/jboss/tools`
 `postgresql.postgresUser` | The PostgreSQL user (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
 `postgresql.postgresPassword` | The PostgreSQL password (if `keycloak.persistence.deployPostgres=true`) | `""`
 `postgresql.postgresDatabase` | The PostgreSQL database (if `keycloak.persistence.deployPostgres=true`) | `keycloak`

--- a/stable/keycloak/templates/configmap.yaml
+++ b/stable/keycloak/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
 {{ . | indent 4 }}
   {{- end }}
 
-    exec /opt/jboss/tools/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ end }}
+    exec {{ .Values.keycloak.scriptPath }}/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ end }}
     exit "$?"
 
   keycloak.cli: |

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -44,6 +44,10 @@ keycloak:
   ## Username for the initial Keycloak admin user
   username: keycloak
 
+  ## Path to the docker-entrypoint script
+  ## setting this to "/opt/jboss" is needed for keycloak versions lower than 4.4.0.Final
+  scriptPath: /opt/jboss/tools
+
   ## Password for the initial Keycloak admin user
   ## If not set, a random 10 characters password will be used
   password: ""


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miguel.ruiz.developer@gmail.com>

#### What this PR does / why we need it:
After updating keycloak version to 4.5.0.Final, it becomes useful to parameterize the path to the docker-entrypoint script to make easier for the chart to work with previous versions of keycloak

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
