### PR TITLE
Bugfix: jaeger-operator should use own serviceAccount

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.7.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/templates/deployment.yaml
+++ b/stable/jaeger-operator/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "jaeger-operator.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: {{ include "jaeger-operator.fullname" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Created jaeger-operator service account is not used by the deployment. This mean that it runs with a namespace default one. When running in the namaspace `jaeger` with RBAC enabled, following failure is reported.

```
ERROR: logging before flag.Parse: E1011 11:14:09.793048       1 reflector.go:205] github.com/jaegertracing/jaeger-operator/vendor/github.com/operator-framework/operator-sdk/pkg/sdk/informer.go:84: 
Failed to list *unstructured.Unstructured: jaegers.io.jaegertracing is forbidden: User "system:serviceaccount:jaeger:default" cannot list jaegers.io.jaegertracing in the namespace "jaeger"
```      
