### PR TITLE
[stable/redis] NetworkPolicy podSelector should also match "release"

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.1.2
+version: 4.1.3
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/networkpolicy.yaml
+++ b/stable/redis/templates/networkpolicy.yaml
@@ -12,6 +12,7 @@ spec:
   podSelector:
     matchLabels:
       app: {{ template "redis.name" . }}
+      release: "{{ .Release.Name }}"
   ingress:
     # Allow inbound connections
     - ports:


### PR DESCRIPTION
Currently, the `NetworkPolicy` created for the "redis" charts, only selects via the `app` label.

However, this does not only match Redis pods created by the respective release, but matches
Redis pods of _all_ releases of that Chart (which is -- I'm assuming -- not the intended behaviour).

This PR fixes that issue by adding the `release` label to the network policy's `podSelector`.

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] ~~Variables are documented in the README.md~~