### PR TITLE
[stable/concourse] Fix postgres and ldap deployment variables

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 2.0.0
+version: 2.0.1
 appVersion: 4.2.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -187,12 +187,14 @@ spec:
               value: {{ .Values.concourse.web.postgres.sslmode }}
             {{- end }}
             {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
-            - name: CONCOURSE_VAULT_CA_CERT
+            - name: CONCOURSE_POSTGRES_CA_CERT
               value: "/concourse-postgresql/ca.cert"
+            {{- if eq .Values.concourse.web.postgres.sslmode "required" }}
             - name: CONCOURSE_POSTGRES_CLIENT_CERT
               value: "/concourse-postgresql/client.cert"
             - name: CONCOURSE_POSTGRES_CLIENT_KEY
               value: "/concourse-postgresql/client.key"
+            {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.postgres.connectTimeout }}
             - name: CONCOURSE_POSTGRES_CONNECT_TIMEOUT

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -642,7 +642,7 @@ spec:
             {{- end }}
 
             {{- if .Values.concourse.web.auth.ldap.enabled }}
-            {{- if .Values.web.BindDn }}
+            {{- if .Values.concourse.web.auth.ldap.bindDn }}
             - name: CONCOURSE_LDAP_BIND_DN
               value: {{ .Values.concourse.web.auth.ldap.bindDn }}
             {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

During upgrade concourse cluster I've found couple of typos in web-deployment.yaml env variables

**Which issue this PR fixes**: fixes #8142, fixes #8237
