### PR TITLE
Switch readiness and liveness probes

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.17.0
+version: 1.17.1
 appVersion: 5.3.0
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -33,14 +33,14 @@ The command removes all the Kubernetes components associated with the chart and 
 |---------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | `replicas`                      | Number of nodes                               | `1`                                                     |
 | `deploymentStrategy`            | Deployment strategy                           | `RollingUpdate`                                         |
-| `livenessProbe`            | Liveness Probe settings                           | `{ "httpGet": { "path": "/api/health", "port": 3000 } }`                                         |
-| `readinessProbe`            | Rediness Probe settings                           | `{ "httpGet": { "path": "/api/health", "port": 3000 } "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10, "periodSeconds": 10 }`                                         |
+| `livenessProbe`            | Liveness Probe settings                           | `{ "httpGet": { "path": "/api/health", "port": 3000 } "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10 }` |
+| `readinessProbe`            | Rediness Probe settings                           | `{ "httpGet": { "path": "/api/health", "port": 3000 } }`|
 | `securityContext`               | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
 | `image.repository`              | Image repository                              | `grafana/grafana`                                       |
 | `image.tag`                     | Image tag. (`Must be >= 5.0.0`)               | `5.3.0`                                                 |
 | `image.pullPolicy`              | Image pull policy                             | `IfNotPresent`                                          |
 | `service.type`                  | Kubernetes service type                       | `ClusterIP`                                             |
-| `service.port`                  | Kubernetes port where service is exposed      | `80`                                                  |
+| `service.port`                  | Kubernetes port where service is exposed      | `80`                                                    |
 | `service.annotations`           | Service annotations                           | `{}`                                                    |
 | `service.labels`                | Custom labels                                 | `{}`                                                    |
 | `ingress.enabled`               | Enables Ingress                               | `false`                                                 |

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -9,19 +9,18 @@ replicas: 1
 
 deploymentStrategy: RollingUpdate
 
-livenessProbe:
+readinessProbe:
   httpGet:
     path: /api/health
     port: 3000
 
-readinessProbe:
+livenessProbe:
   httpGet:
     path: /api/health
     port: 3000
   initialDelaySeconds: 60
   timeoutSeconds: 30
   failureThreshold: 10
-  periodSeconds: 10
 
 image:
   repository: grafana/grafana


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Apparently readiness and liveness probes were mistaken. It probably
makes more sense for the liveness probe to have an initial delay of 60
seconds. Also 10s is the default for periodSeconds.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
