### PR TITLE
[stable/concourse] Fix Broken Tutorial Link

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 2.0.1
+version: 2.0.2
 appVersion: 4.2.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -33,7 +33,7 @@
     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.concourse.atcPort }}
     {{- end }}
   {{- end }}
-* If this is your first time using Concourse, follow the tutorial at https://concourse-ci.org/hello-world.html
+* If this is your first time using Concourse, follow the tutorials at https://concourse-ci.org/tutorials.html
 {{- if contains "naive" .Values.concourse.worker.baggageclaim.driver }}
 
 *******************


### PR DESCRIPTION
The Concourse docs have a new section with a list of tutorials rather than a single hello-world

#### What this PR does / why we need it:
Fixes the a link in the message printed when a user starts 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped