### PR TITLE
[incubator/schema-registry]: Feat: Adding Support for Plain SASL_SSL

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.0.2
+version: 1.0.3
 appVersion: 4.1.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -68,6 +68,13 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `configurationOverrides` | `SchemaRegistry` [configuration setting](https://github.com/confluentinc/schema-registry/blob/master/docs/config.rst#configuration-options) overrides in the dictionary format `setting.name: value` | `{}` |
 | `kafkaOpts` | Additional Java arguments to pass to Kafka. | ` ` |
 | `sasl.configPath` | where to store config for sasl configurations | `/etc/kafka-config` |
+| `sasl.plain.enabled` | wether sasl plain is enabled | `false` |
+| `sasl.plain.username` | the sasl plain username to use to authenticate to kafka`| `''` |
+| `sasl.plain.password` | the sasl plain password to use to asuthenticate to kafka | `''` |
+| `sasl.plain.useExistingSecret.password` | override to use the name of this password secret as the secret | `undefined` |
+| `sasl.plain.init.image` | which image to use for initializing sasl plain | `confluentinc/cp-schema-registry` |
+| `sasl.plain.init.imageTag` | which version/tag to use for sasl plain init | `4.0.0` |
+| `sasl.plain.init.imagePullPolicy` | the sasl plain init pull policy | `IfNotPresent` |
 | `sasl.scram.enabled` | whether sasl-scam is enabled | `false` |
 | `sasl.scram.init.image` | which image to use for initializing sasl scram | `confluentinc/cp-schema-registry` |
 | `sasl.scram.init.imageTag` | which version/tag to use for sasl scram init | `4.0.0` |

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -57,6 +57,36 @@ spec:
         - name: jaasconfig
           mountPath: {{ .Values.sasl.configPath | quote }}
     {{- end }}
+    {{- if .Values.sasl.plain.enabled }}
+      initContainers:
+      ## ref: https://github.com/Yolean/kubernetes-kafka/blob/master/kafka/50kafka.yml
+      - name: init-sasl
+        image: "{{ .Values.sasl.plain.init.image }}:{{ .Values.sasl.plain.init.imageTag }}"
+        imagePullPolicy: "{{ .Values.sasl.plain.init.imagePullPolicy }}"
+        command:
+          - sh
+          - -euc
+          - |
+            sed "s \$SASL_USERNAME ${SASL_USERNAME} g; s \$SASL_PASSWORD ${SASL_PASSWORD} g;" /tmp/kafka-template/kafka_client_jaas.conf > /etc/kafka-config/kafka_client_jaas.conf
+        env:
+          - name: SASL_USERNAME
+            value: {{ .Values.sasl.plain.username }}
+          - name: SASL_PASSWORD
+            {{- if (hasKey .Values.sasl.plain "useExistingSecret") }}
+            valueFrom: 
+{{ toYaml .Values.sasl.plain.useExistingSecret.password | indent 14 -}}
+            {{- else }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "schema-registry.fullname" . }}-sasl-plain-secret
+                key: sasl-password
+            {{- end }}
+        volumeMounts:
+        - name: jaastemplate
+          mountPath: "/tmp/kafka-template"
+        - name: jaasconfig
+          mountPath: {{ .Values.sasl.configPath | quote }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -107,6 +137,12 @@ spec:
           - name: SCHEMA_REGISTRY_{{ $configName | replace "." "_" | upper }}
             value: {{ $configValue | quote }}
           {{ end }}
+          {{- if or .Values.sasl.plain.enabled }}
+          - name: SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM
+            value: "PLAIN"
+          - name: SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL
+            value: "SASL_SSL"
+          {{- end }}
           {{- if .Values.schemaRegistryOpts }}
           # The pre-flight checks use KAFKA_OPTS instead of SCHEMA_REGISTRY_OPTS.
           - name: KAFKA_OPTS
@@ -117,12 +153,12 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
-          {{- if .Values.sasl.scram.enabled }}
+          {{- if or .Values.sasl.scram.enabled .Values.sasl.plain.enabled }}
           - name: jaasconfig
             mountPath: {{ .Values.sasl.configPath | quote }}
           {{- end }}
       volumes:
-      {{- if .Values.sasl.scram.enabled }}
+      {{- if or .Values.sasl.scram.enabled .Values.sasl.plain.enabled }}
       - name: jaasconfig
         emptyDir: { medium: "Memory" }
       - name: jaastemplate

--- a/incubator/schema-registry/templates/sasl-plain-config-map.yaml
+++ b/incubator/schema-registry/templates/sasl-plain-config-map.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.sasl.plain.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "schema-registry.fullname" . }}
+  labels:
+    app: {{ include "schema-registry.name" . | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+
+data:
+  kafka_client_jaas.conf: |-
+    // Info for third-party clients to connect to Kafka
+    KafkaClient {
+        org.apache.kafka.common.security.plain.PlainLoginModule required
+        username="$SASL_USERNAME"
+        password="$SASL_PASSWORD";
+    };
+{{- end }}

--- a/incubator/schema-registry/templates/sasl-plain-secret.yaml
+++ b/incubator/schema-registry/templates/sasl-plain-secret.yaml
@@ -1,0 +1,14 @@
+{{-  if and .Values.sasl.plain.enabled (not (hasKey .Values.sasl.plain "useExistingSecret")) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "schema-registry.fullname" . }}-sasl-plain-secret
+  labels:
+    app: {{ template "schema-registry.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  sasl-password: {{ .Values.sasl.plain.password | b64enc }}
+{{- end -}}

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -60,6 +60,16 @@ readinessProbe:
 # Options for connecting to SASL kafka brokers
 sasl:
   configPath: "/etc/kafka-config"
+
+  plain:
+    enabled: false
+    init:
+      image: "confluentinc/cp-schema-registry"
+      imageTag: "4.0.0"
+      imagePullPolicy: "IfNotPresent"
+    username: ""
+    password: ""
+
   scram:
     enabled: false
     init:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR adds support for SASL_SSL via the plain mechanism which is the default for usage w/ confluent-cloud. The API key would be the sasl username and the the secret would be the sasl password.

Bumped version 2 because I assumed this one would go in first
https://github.com/helm/charts/pull/8398

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
