### PR TITLE
[incubator/zookeeper] Backwards compatibility after revamp from v0.* to v1.*

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 1.2.0
+version: 1.3.0
 appVersion: 3.4.10
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/README.md
+++ b/incubator/zookeeper/README.md
@@ -8,6 +8,30 @@ This helm chart provides an implementation of the ZooKeeper [StatefulSet](http:/
 * A dynamic provisioner for the PersistentVolumes
 * A familiarity with [Apache ZooKeeper 3.4.x](https://zookeeper.apache.org/doc/current/)
 
+## Changes from chart version 0.* to 1.*
+
+Due to breaking changes, you can override those changes by passing the following values.
+
+```sh
+helm upgrade -i kafka . --set 'claimName=datadir,statefulsetLabels='
+# if you used a release name that is different than `zookeeper`, you will need to override that as well
+helm upgrade -i kafka . --set 'claimName=datadir,statefulsetLabels=,fullnameOverride=RELEASE-zookeeper'
+```
+
+Then delete one pod at a time while making sure that data has been synced over.
+You can test that with
+
+```sh
+kubectl delete pod kafka-zookeeper-0
+# periodically check that leader instance's zk_synced_followers are all back
+kubectl exec -it kafka-zookeeper-1 -- zkMetrics.sh
+kubectl exec -it kafka-zookeeper-2 -- zkMetrics.sh
+# check that the data is correct
+kubectl exec -it kafka-zookeeper-0 -- zkCli.sh -server localhost:2181 ls /
+```
+
+Once all instances are deleted, the migration is complete.
+
 ## Chart Components
 This chart will do the following:
 

--- a/incubator/zookeeper/templates/poddisruptionbudget.yaml
+++ b/incubator/zookeeper/templates/poddisruptionbudget.yaml
@@ -13,5 +13,10 @@ spec:
     matchLabels:
       app: {{ template "zookeeper.name" . }}
       release: {{ .Release.Name }}
-      component: server
+    {{- if .Values.statefulsetLabels }}
+      ## Custom statefulset labels
+      {{- range $key, $value := .Values.statefulsetLabels }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -7,7 +7,12 @@ metadata:
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: server
+  {{- if .Values.statefulsetLabels }}
+    ## Custom statefulset labels
+    {{- range $key, $value := .Values.statefulsetLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   serviceName: {{ template "zookeeper.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
@@ -15,7 +20,12 @@ spec:
     matchLabels:
       app: {{ template "zookeeper.name" . }}
       release: {{ .Release.Name }}
-      component: server
+    {{- if .Values.statefulsetLabels }}
+      ## Custom statefulset labels
+      {{- range $key, $value := .Values.statefulsetLabels }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
   updateStrategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   template:
@@ -84,7 +94,7 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
-            - name: data
+            - name: {{ .Values.claimName }}
               mountPath: /var/lib/zookeeper
             {{- range $secret := .Values.secrets }}
               {{- if $secret.mountPath }}
@@ -186,7 +196,7 @@ spec:
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
-        name: data
+        name: {{ .Values.claimName }}
       spec:
         accessModes:
           - {{ .Values.persistence.accessMode | quote }}

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -89,6 +89,9 @@ podLabels: {}  # Key/value pairs that are attached to zookeeper pods.
   # team: "developers"
   # service: "zookeeper"
 
+statefulsetLabels:  # Key/value pairs that are attached to statefulset and pdb selector
+  component: "server"
+
 livenessProbe:
   exec:
     command:
@@ -142,6 +145,11 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 5Gi
+
+## For backwards compatibility with pre 1.x versions, you need to override the
+## volumeclaim prefix name. You can pass a custom volume name that would map to new ## pvc names.
+## For backwards compatibility, change this to `claimName: datadir`
+claimName: data
 
 ## Exporters query apps for metrics and make those metrics available for
 ## Prometheus to scrape.


### PR DESCRIPTION
#### What this PR does / why we need it:

Ever since zookeeper was revamped in PR #4931, upgrading from v0.* to v1.* became impossible due to limitations in statefulsets described in issue below.

#### Which issue this PR fixes
  - fixes #8400 

#### Special notes for your reviewer:

@lachie83 @kow3ns

The upgrade with these changes were tested on my own cluster using k8s 1.11.3 and helm 2.9.1.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
