### PR TITLE
CoreDNS: amend values.yaml to match template

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.2.0
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -17,8 +17,9 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+serviceType: "ClusterIP"
+
 service:
-  type: "ClusterIP"
 # clusterIP: ""
   annotations:
     prometheus.io/scrape: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:

The `values.yaml` does not match the structure of the data that is pulled into the service template. If the README instructions are followed directly then it's not possible to set the serviceType to anything other than default. 

This amends the values.yaml to reflect the service template https://github.com/helm/charts/blob/master/stable/coredns/templates/service.yaml#L29
