### PR TITLE
Add persistent Github link to point to Trafik docs

### DIFF
--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -335,7 +335,7 @@ acme:
 
 #### Example: AWS Route 53
 
-Route 53 requires the [following configuration variables to be set](values.yaml#L98-L101):
+Route 53 requires the [following configuration variables to be set](https://github.com/helm/charts/blob/68da43ea17582b6c74d8b8956b1b20ee49d8d420/stable/traefik/values.yaml#L230-L232):
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_REGION`

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -335,7 +335,7 @@ acme:
 
 #### Example: AWS Route 53
 
-Route 53 requires the [following configuration variables to be set](https://github.com/helm/charts/blob/68da43ea17582b6c74d8b8956b1b20ee49d8d420/stable/traefik/values.yaml#L230-L232):
+Route 53 requires the [following configuration variables to be set](https://docs.traefik.io/configuration/acme/#provider):
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_REGION`


### PR DESCRIPTION
#### What this PR does / why we need it:
I noticed this link which hadn't stood the test of time while trying to fiddle with traefik myself, and figured I'd just fix it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed (At least I believe I've done this)
