### PR TITLE
[stable/mongodb] Use user defined resources in statefulsets

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 4.5.0
+version: 4.6.0
 appVersion: 4.0.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -112,6 +112,8 @@ spec:
               mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
               subPath: mongodb.conf
           {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
       volumes:
       {{- if .Values.configmap }}
         - name: config

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -133,6 +133,8 @@ spec:
               mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
               subPath: mongodb.conf
             {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
       volumes:
         {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
         - name: custom-init-scripts

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -121,6 +121,8 @@ spec:
               mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
               subPath: mongodb.conf
             {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
       volumes:
         {{- if .Values.configmap }}
         - name: config


### PR DESCRIPTION
Fixes https://github.com/helm/charts/issues/8411 & https://github.com/helm/charts/issues/7539

Respect the `resources` config from values.yaml when replicaset enabled
