### PR TITLE
[stable/stellar-horizon]: Release 1.0.0 (initial release)

### DIFF
--- a/stable/stellar-horizon/Chart.yaml
+++ b/stable/stellar-horizon/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: "0.14.2"
+description: Client-facing API server for the Stellar cryptocurrency network.
+name: stellar-horizon
+version: 1.0.0
+icon: https://www.stellar.org/developers/images/favicon/rocket-180x180.png
+home: https://www.stellar.org
+maintainers:
+  - name: andrenarchy
+    email: andre.extern@satoshipay.io
+    url: https://github.com/andrenarchy
+sources:
+  - https://github.com/satoshipay/docker-stellar-horizon/
+keywords:
+  - stellar
+  - stellar-horizon
+  - cryptocurrency
+  - blockchain
+engine: gotpl

--- a/stable/stellar-horizon/OWNERS
+++ b/stable/stellar-horizon/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- andrenarchy
+reviewers:
+- andrenarchy

--- a/stable/stellar-horizon/README.md
+++ b/stable/stellar-horizon/README.md
@@ -49,7 +49,7 @@ The following table lists the configurable parameters of the Stellar Horizon cha
 | `service.type`                               | HTTP endpoint service type                                             | `ClusterIP`                                      |
 | `service.port`                               | HTTP endpoint TCP port                                                 | `80`                                             |
 | `ingress.enabled`                            | Enable ingress controller resource                                     | `false`                                          |
-| `ingress.hosts[0].name`                      | Hostname to your WordPress installation                                | `stellar-horizon.local`                          |
+| `ingress.hosts[0].name`                      | Hostname to your Horizon installation                                  | `stellar-horizon.local`                          |
 | `ingress.hosts[0].path`                      | Path within the url structure                                          | `/`                                              |
 | `ingress.hosts[0].tlsSecret`                 | TLS Secret (certificates)                                              | `stellar-horizon.local-tls-secret`               |
 | `ingress.hosts[0].annotations`               | Annotations for this host's ingress record                             | `[]`                                             |

--- a/stable/stellar-horizon/README.md
+++ b/stable/stellar-horizon/README.md
@@ -34,7 +34,7 @@ The following table lists the configurable parameters of the Stellar Horizon cha
 | `existingDatabase`                           | Provide existing database (used if `postgresql.enabled` is `false`)    |                                                  |
 | `existingDatabase.passwordSecret`            | Existing secret with the database password                             | `{name: 'postgresql-horizon', value: 'password'}`|
 | `existingDatabase.url`                       | Existing database URL (use `$(DATABASE_PASSWORD` as the password)      | Not set                                          |
-| `stellar-core.enabled`                       | Enable Stellar Core                                                    | `false`                                          |
+| `stellar-core.enabled`                       | Enable Stellar Core                                                    | `true`                                           |
 | `stellar-core.nodeSeed`                      | Node seed for Stellar Core                                             | Not set                                          |
 | `stellar-core.*`                             | Any Stellar Core option, see `stellar-core` chart                      |                                                  |
 | `stellar-core.postgresql.*`                  | Any PostgreSQL option (for Stellar Core)                               |                                                  |

--- a/stable/stellar-horizon/README.md
+++ b/stable/stellar-horizon/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-This chart bootstraps a [Stellar Horizon](https://github.com/stellar/stellar-core/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. By default the deployment includes a PostgreSQL database and a Stellar Core node (which in turn includes another PostgreSQL database). The chart is based on the Kubernetes-ready [Stellar Horizon images provided by SatoshiPay](https://github.com/satoshipay/docker-stellar-horizon/).
+This chart bootstraps a [Stellar Horizon](https://github.com/stellar/go/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. By default the deployment includes a PostgreSQL database and a Stellar Core node (which in turn includes another PostgreSQL database). The chart is based on the Kubernetes-ready [Stellar Horizon images provided by SatoshiPay](https://github.com/satoshipay/docker-stellar-horizon/).
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ This chart bootstraps a [Stellar Horizon](https://github.com/stellar/stellar-cor
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release incubator/stellar-horizon
+$ helm install --name my-release stable/stellar-horizon
 ```
 
 ## Configuration

--- a/stable/stellar-horizon/README.md
+++ b/stable/stellar-horizon/README.md
@@ -1,0 +1,70 @@
+# Stellar Horizon
+
+[Stellar](https://www.stellar.org) is an open-source and distributed payments infrastructure. Stellar Horizon is a HTTP REST API server that allows applications to interact with the Stellar network. Stellar Horizon needs access to a Stellar Core node. For more information see the [Stellar network overview](https://www.stellar.org/developers/guides/get-started/).
+
+## Introduction
+
+This chart bootstraps a [Stellar Horizon](https://github.com/stellar/stellar-core/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. By default the deployment includes a PostgreSQL database and a Stellar Core node (which in turn includes another PostgreSQL database). The chart is based on the Kubernetes-ready [Stellar Horizon images provided by SatoshiPay](https://github.com/satoshipay/docker-stellar-horizon/).
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+- PV provisioner support in the underlying infrastructure (Only when persisting data)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release incubator/stellar-horizon
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Stellar Horizon chart and their default values.
+
+| Parameter                                    | Description                                                            | Default                                          |
+| -----------------------                      | ---------------------------------------------                          | ---------------------------------------------    |
+| `postgresql.enabled`                         | Enable PostgreSQL database                                             | `true`                                           |
+| `postgresql.postgresDatabase`                | PostgreSQL database name                                               | `stellar-core`                                   |
+| `postgresql.postgresUser`                    | PostgreSQL username                                                    | `postgres`                                       |
+| `postgresql.postgresPassword`                | PostgreSQL password                                                    | Random password (see PostgreSQL chart)           |
+| `postgresql.persistence`                     | PostgreSQL persistence options                                         | See PostgreSQL chart                             |
+| `postgresql.*`                               | Any PostgreSQL option                                                  | See PostgreSQL chart                             |
+| `existingDatabase`                           | Provide existing database (used if `postgresql.enabled` is `false`)    |                                                  |
+| `existingDatabase.passwordSecret`            | Existing secret with the database password                             | `{name: 'postgresql-horizon', value: 'password'}`|
+| `existingDatabase.url`                       | Existing database URL (use `$(DATABASE_PASSWORD` as the password)      | Not set                                          |
+| `stellar-core.enabled`                       | Enable Stellar Core                                                    | `false`                                          |
+| `stellar-core.nodeSeed`                      | Node seed for Stellar Core                                             | Not set                                          |
+| `stellar-core.*`                             | Any Stellar Core option, see `stellar-core` chart                      |                                                  |
+| `stellar-core.postgresql.*`                  | Any PostgreSQL option (for Stellar Core)                               |                                                  |
+| `existingStellarCore`                        | Provide existing Stellar Core (used if `stellar-core.enabled` is false)|                                                  |
+| `existingStellarCore.url`                    | URL for HTTP admin endpoint of Stellar Core                            | Not set                                          |
+| `existingStellarCore.databaseUrl`            | URL for Stellar Core PostgreSQL                                        | Not set                                          |
+| `existingStellarCore.databasePasswordSecret` | Existing secret with the Stellar Core PostgreSQL password              | `{name: 'postgresql-core', value: 'password'}`   |
+| `environment`                                | Additional environment variables for Stellar Horizon                   | `{}`                                             |
+| `image.repository`                           | `stellar-horizon` image repository                                     | `satoshipay/stellar-horizon`                     |
+| `image.tag`                                  | `stellar-horizon` image tag                                            | `0.14.2`                                         |
+| `image.pullPolicy`                           | Image pull policy                                                      | `IfNotPresent`                                   |
+| `service.type`                               | HTTP endpoint service type                                             | `ClusterIP`                                      |
+| `service.port`                               | HTTP endpoint TCP port                                                 | `80`                                             |
+| `ingress.enabled`                            | Enable ingress controller resource                                     | `false`                                          |
+| `ingress.hosts[0].name`                      | Hostname to your WordPress installation                                | `stellar-horizon.local`                          |
+| `ingress.hosts[0].path`                      | Path within the url structure                                          | `/`                                              |
+| `ingress.hosts[0].tlsSecret`                 | TLS Secret (certificates)                                              | `stellar-horizon.local-tls-secret`               |
+| `ingress.hosts[0].annotations`               | Annotations for this host's ingress record                             | `[]`                                             |
+| `ingress.secrets[0].name`                    | TLS Secret Name                                                        | `nil`                                            |
+| `ingress.secrets[0].certificate`             | TLS Secret Certificate                                                 | `nil`                                            |
+| `ingress.secrets[0].key`                     | TLS Secret Key                                                         | `nil`                                            |
+| `resources`                                  | CPU/Memory resource requests/limits                                    | Requests: `512Mi` memory, `100m` CPU             |
+| `nodeSelector`                               | Node labels for pod assignment                                         | {}                                               |
+| `tolerations`                                | Toleration labels for pod assignment                                   | []                                               |
+| `affinity`                                   | Affinity settings for pod assignment                                   | {}                                               |
+| `serviceAccount.create`                      | Specifies whether a ServiceAccount should be created                   | `true`                                           |
+| `serviceAccount.name`                        | The name of the ServiceAccount to create                               | Generated using the fullname template            |
+
+## Persistence
+
+If PostgreSQL is enabled (`postgresql.enabled` is `true`) or if Stellar Core is enabled (`stellar-core.enabled` is `true`), they need to store data and thus this chart creates [Persistent Volumes](http://kubernetes.io/docs/user-guide/persistent-volumes/) by default. Make sure to size them properly for your needs and use an appropriate storage class, e.g. SSDs.
+
+You can also use existing claims with the `postgresql.persistence.existingClaim` and `stellar-core.persistence.existingClaim` options.

--- a/stable/stellar-horizon/requirements.lock
+++ b/stable/stellar-horizon/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.19.0
+- name: stellar-core
+  repository: file://../stellar-core
+  version: 1.0.0
+digest: sha256:6b6f8201c0b6644fe02597968184fdfcc0a5d7b448ebfdb0cb48b9461b94cd68
+generated: 2018-10-09T17:56:00.687835552+02:00

--- a/stable/stellar-horizon/requirements.yaml
+++ b/stable/stellar-horizon/requirements.yaml
@@ -5,5 +5,5 @@ dependencies:
   condition: postgresql.enabled
 - name: stellar-core
   version: ^1.0.0
-  repository: "file://../stellar-core"
+  repository: "https://kubernetes-charts.storage.googleapis.com/"
   condition: stellar-core.enabled

--- a/stable/stellar-horizon/requirements.yaml
+++ b/stable/stellar-horizon/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  version: ^0.19.0
+  repository: "https://kubernetes-charts.storage.googleapis.com/"
+  condition: postgresql.enabled
+- name: stellar-core
+  version: ^1.0.0
+  repository: "file://../stellar-core"
+  condition: stellar-core.enabled

--- a/stable/stellar-horizon/templates/NOTES.txt
+++ b/stable/stellar-horizon/templates/NOTES.txt
@@ -1,0 +1,33 @@
+1. Wait until Stellar Horizon is ready (i.e., ingested all requested data
+   from Stellar Core
+
+2. Get the Stellar Horizon URL:
+
+{{- if .Values.ingress.enabled }}
+
+  You should be able to access your new Stellar Horizon installation through
+
+  {{- range .Values.ingress.hosts }}
+  {{ if .tls }}https{{ else }}http{{ end }}://{{ .name }}/
+  {{- end }}
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "stellar-horizon.fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "stellar-horizon.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "Stellar Core URL: http://$SERVICE_IP:{{ .Values.service.port }}/"
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+  echo "Stellar Core URL: http://127.0.0.1/"
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "stellar-horizon.fullname" . }} 8080:{{ .Values.service.port }}
+
+{{- else if contains "NodePort" .Values.service.port }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "stellar-horizon.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "Stellar Core URL: http://$NODE_IP:$NODE_PORT/"
+
+{{- end }}

--- a/stable/stellar-horizon/templates/_helpers.tpl
+++ b/stable/stellar-horizon/templates/_helpers.tpl
@@ -1,0 +1,96 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stellar-horizon.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stellar-horizon.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "stellar-horizon.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stellar-horizon.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "stellar-horizon.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "stellar-horizon.postgresql.fullname" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "stellar-horizon.stellar-core.fullname" -}}
+{{- $stellarCore := index .Values "stellar-core" -}}
+{{- if $stellarCore.fullnameOverride -}}
+{{- $stellarCore.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "stellar-core" $stellarCore.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "stellar-horizon.stellar-core.postgresql.fullname" -}}
+{{- $postgresql := index .Values "stellar-core" "postgresql" -}}
+{{- if $postgresql.fullnameOverride -}}
+{{- $postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "postgresql" $postgresql.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/stellar-horizon/templates/deployment.yaml
+++ b/stable/stellar-horizon/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "stellar-horizon.fullname" . }}
+  labels:
+    app: {{ template "stellar-horizon.name" . }}
+    chart: {{ template "stellar-horizon.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ template "stellar-horizon.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "stellar-horizon.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: "{{ template "stellar-horizon.serviceAccountName" . }}"
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            {{- if .Values.postgresql.enabled }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "stellar-horizon.postgresql.fullname" . }}
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgres://{{ .Values.postgresql.postgresUser }}:$(DATABASE_PASSWORD)@{{ template "stellar-horizon.postgresql.fullname" . }}/{{ .Values.postgresql.postgresDatabase }}?sslmode=disable
+            {{- else }}
+            {{- with .Values.existingDatabase.passwordSecret }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name | quote }}
+                  key: {{ .key | quote }}
+            {{- end }}
+            - name: DATABASE_URL
+              value: {{ .Values.existingDatabase.url }}
+            {{- end }}
+
+            {{- if index .Values "stellar-core" "enabled" }}
+            - name: STELLAR_CORE_URL
+              value: http://{{ template "stellar-horizon.stellar-core.fullname" . }}-http:11626
+            - name: STELLAR_CORE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "stellar-horizon.stellar-core.postgresql.fullname" . }}
+                  key: postgres-password
+            - name: STELLAR_CORE_DATABASE_URL
+              value: postgres://postgres:$(STELLAR_CORE_DATABASE_PASSWORD)@{{ template "stellar-horizon.stellar-core.postgresql.fullname" . }}/stellar-core?sslmode=disable
+            {{- else }}
+            - name: STELLAR_CORE_URL
+              value: {{ .Values.existingStellarCore.url }}
+            {{- with .Values.existingStellarCore.databasePasswordSecret }}
+            - name: STELLAR_CORE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name | quote }}
+                  key: {{ .key | quote }}
+            {{- end }}
+            - name: STELLAR_CORE_DATABASE_URL
+              value: {{ .Values.existingStellarCore.databaseUrl }}
+            {{- end }}
+
+{{- range $key, $val := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+{{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            exec:
+              command: [ /ready.sh ]
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/stellar-horizon/templates/ingress.yaml
+++ b/stable/stellar-horizon/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
+  labels:
+    app: {{ template "fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+  annotations:
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  - host: {{ .name }}
+    http:
+      paths:
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ template "stellar-horizon.fullname" $ }}
+            servicePort: http
+{{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/stable/stellar-horizon/templates/service.yaml
+++ b/stable/stellar-horizon/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "stellar-horizon.fullname" . }}
+  labels:
+    app: {{ template "stellar-horizon.name" . }}
+    chart: {{ template "stellar-horizon.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "stellar-horizon.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/stellar-horizon/templates/serviceaccount.yaml
+++ b/stable/stellar-horizon/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "stellar-horizon.serviceAccountName" . }}
+  labels:
+    app: {{ template "stellar-horizon.name" . }}
+    chart: {{ template "stellar-horizon.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/stable/stellar-horizon/templates/tls-secrets.yaml
+++ b/stable/stellar-horizon/templates/tls-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/stable/stellar-horizon/values.yaml
+++ b/stable/stellar-horizon/values.yaml
@@ -45,19 +45,6 @@ service:
 
 ingress:
   enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  path: /
-  hosts:
-    - chart-example.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-ingress:
-  enabled: false
 
   ## The list of hostnames to be covered with this ingress record.
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array

--- a/stable/stellar-horizon/values.yaml
+++ b/stable/stellar-horizon/values.yaml
@@ -1,0 +1,110 @@
+postgresql:
+  enabled: true
+  nameOverride: postgresql-horizon
+  postgresDatabase: stellar-horizon
+  postgresUser: postgres
+  # options from https://github.com/helm/charts/tree/master/stable/postgresql
+  # postgresPassword:
+
+## NOTE:
+## existingDatabase is only used if postgresql.enabled is false
+existingDatabase:
+  passwordSecret:
+    name: postgresql-horizon
+    key: password
+  ## NOTE:
+  ## $(DATABASE_PASSWORD) is automatically replaced with the value of the passwordSecret
+  # url: postgres://postgres:$(DATABASE_PASSWORD)@postgresql-horizon/stellar-horizon?sslmode=disable
+
+stellar-core:
+  enabled: true
+  # nodeSeed: SDUFQA7YL3KTWZNKOXX7XXIYU4R5R6JKELMREKHDQOYY2WPUGXFVJN52
+
+  postgresql:
+    nameOverride: postgresql-core
+
+## NOTE:
+## existingStellarCore is only used if stellar-core.enabled is false
+existingStellarCore:
+  url: http://stellar-core:11626
+  databaseUrl: postgres://postgres:$(DATABASE_PASSWORD)@postgresql-core/stellar-core?sslmode=disable
+  databasePasswordSecret:
+    name: postgresql-core
+    key: password
+
+environment: {}
+
+image:
+  repository: satoshipay/stellar-horizon
+  tag: '0.14.2'
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+ingress:
+  enabled: false
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: stellar-horizon.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    tls: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: stellar-horizon.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## If you're using kube-lego, you will want to add:
+    ## kubernetes.io/tls-acme: true
+    ##
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+    #  kubernetes.io/tls-acme: true
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: stellar-horizon.local-tls
+  #   key:
+  #   certificate:
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceAccount:
+  create: true
+  name:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds a chart for running a [Stellar Horizon](https://www.stellar.org/developers/reference/) server for the [Stellar network](https://www.stellar.org). It provides an HTTP API for querying the network and submitting transactions.

#### Special notes for your reviewer:

Horizon needs to be deployed with a [Stellar Core](https://github.com/stellar/stellar-core) node and needs access to its database. To make the chart work out of the box, this chart depends on the [stable/stellar-core](https://github.com/helm/charts/tree/master/stable/stellar-core) chart by default. If an existing Stellar Core node should be used users can configure this by setting `stellar-core.enabled` to `false` and providing `existingStellarCore`. The same holds for the Postgresql database which can be configured with `postgresql.enabled` and `existingDatabase`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Variables are documented in the README.md

#### Remarks

This chart is based on the popular SatoshiPay images for Stellar Horizon that are well-suited for Kubernetes. The chart was developed by me at SatoshiPay where it is used in production for several months now. Since SatoshiPay wishes to contribute the chart to the community, I have permission to release the chart under Apache License 2 and to keep maintaining it.