### PR TITLE
[stable/stellar-friendbot]: Release 1.0.0 (initial release)

### DIFF
--- a/stable/stellar-friendbot/Chart.yaml
+++ b/stable/stellar-friendbot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "0.13.0"
 description: Friendbot that sends money in the Stellar cryptocurrency (testnet) network.
-name: stellar-testnet
+name: stellar-friendbot
 version: 1.0.0
 icon: https://www.stellar.org/developers/images/favicon/rocket-180x180.png
 home: https://www.stellar.org
@@ -14,6 +14,7 @@ sources:
 keywords:
   - stellar
   - stellar-friendbot
+  - testnet
   - cryptocurrency
   - blockchain
 engine: gotpl

--- a/stable/stellar-friendbot/Chart.yaml
+++ b/stable/stellar-friendbot/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: "0.13.0"
+description: Friendbot that sends money in the Stellar cryptocurrency (testnet) network.
+name: stellar-testnet
+version: 1.0.0
+icon: https://www.stellar.org/developers/images/favicon/rocket-180x180.png
+home: https://www.stellar.org
+maintainers:
+  - name: andrenarchy
+    email: andre.extern@satoshipay.io
+    url: https://github.com/andrenarchy
+sources:
+  - https://github.com/satoshipay/docker-stellar-friendbot/
+keywords:
+  - stellar
+  - stellar-friendbot
+  - cryptocurrency
+  - blockchain
+engine: gotpl

--- a/stable/stellar-friendbot/OWNERS
+++ b/stable/stellar-friendbot/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- andrenarchy
+reviewers:
+- andrenarchy

--- a/stable/stellar-friendbot/README.md
+++ b/stable/stellar-friendbot/README.md
@@ -1,0 +1,45 @@
+# Stellar Friendbot
+
+[Stellar](https://www.stellar.org) is an open-source and distributed payments infrastructure. Stellar Friendbot is a simple server that sends funds from the friendbot's account to another account. Friendbot is usually deployed in a test network.
+
+## Introduction
+
+This chart bootstraps a [Stellar Friendbot](https://github.com/stellar/go/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. The chart is based on the Kubernetes-ready [Stellar Friendbot images provided by SatoshiPay](https://github.com/satoshipay/docker-stellar-friendbot/).
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/stellar-friendbot
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Stellar Friendbot chart and their default values.
+
+| Parameter                           | Description                                                              | Default                                          |
+| -----------------------             | ---------------------------------------------                            | ---------------------------------------------    |
+| `accountSecret`                     | Friendbot's account secret (if `existingAccountSecretSecret` is not set) | Not set                                          |
+| `existingAccountSecretSecret`       | Existing secret with the account secret (if `accountSecret` is not set)  | Not set                                          |
+| `existingAccountSecretSecret.name`  | Secret containing the account secret                                     | Not set                                          |
+| `existingAccountSecretSecret.key`   | Key of the account secret in the secret                                  | Not set                                          |
+| `networkPassphrase`                 | The network the friendbot should use                                     | `Public Global Stellar Network ; September 2015` |
+| `horizonUrl`                        | URL of Stellar Horizon where the transaction should be submitted         | `https://horizon.stellar.org`                    |
+| `startingBalance`                   | Starting balance of newly funded accounts                                | `10000`                                          |
+| `environment`                       | Additional environment variables for Stellar Friendbot                   | `{}`                                             |
+| `image.repository`                  | `stellar-friendbot` image repository                                     | `satoshipay/stellar-friendbot`                   |
+| `image.tag`                         | `stellar-friendbot` image tag                                            | `0.13.0`                                         |
+| `image.pullPolicy`                  | Image pull policy                                                        | `IfNotPresent`                                   |
+| `service.type`                      | HTTP endpoint service type                                               | `ClusterIP`                                      |
+| `service.port`                      | HTTP endpoint TCP port                                                   | `80`                                             |
+| `resources`                         | CPU/Memory resource requests/limits                                      | Requests: `128Mi` memory, `10m` CPU             |
+| `nodeSelector`                      | Node labels for pod assignment                                           | {}                                               |
+| `tolerations`                       | Toleration labels for pod assignment                                     | []                                               |
+| `affinity`                          | Affinity settings for pod assignment                                     | {}                                               |
+| `serviceAccount.create`             | Specifies whether a ServiceAccount should be created                     | `true`                                           |
+| `serviceAccount.name`               | The name of the ServiceAccount to create                                 | Generated using the fullname template            |

--- a/stable/stellar-friendbot/README.md
+++ b/stable/stellar-friendbot/README.md
@@ -37,6 +37,14 @@ The following table lists the configurable parameters of the Stellar Friendbot c
 | `image.pullPolicy`                  | Image pull policy                                                        | `IfNotPresent`                                   |
 | `service.type`                      | HTTP endpoint service type                                               | `ClusterIP`                                      |
 | `service.port`                      | HTTP endpoint TCP port                                                   | `80`                                             |
+| `ingress.enabled`                   | Enable ingress controller resource                                       | `false`                                          |
+| `ingress.hosts[0].name`             | Hostname to your Friendbot installation                                  | `stellar-friendbot.local`                        |
+| `ingress.hosts[0].path`             | Path within the url structure                                            | `/`                                              |
+| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                                | `stellar-friendbot.local-tls-secret`             |
+| `ingress.hosts[0].annotations`      | Annotations for this host's ingress record                               | `[]`                                             |
+| `ingress.secrets[0].name`           | TLS Secret Name                                                          | `nil`                                            |
+| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                                   | `nil`                                            |
+| `ingress.secrets[0].key`            | TLS Secret Key                                                           | `nil`                                            |
 | `resources`                         | CPU/Memory resource requests/limits                                      | Requests: `128Mi` memory, `10m` CPU             |
 | `nodeSelector`                      | Node labels for pod assignment                                           | {}                                               |
 | `tolerations`                       | Toleration labels for pod assignment                                     | []                                               |

--- a/stable/stellar-friendbot/templates/NOTES.txt
+++ b/stable/stellar-friendbot/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "stellar-friendbot.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "stellar-friendbot.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "stellar-friendbot.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "stellar-friendbot.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/stable/stellar-friendbot/templates/_helpers.tpl
+++ b/stable/stellar-friendbot/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stellar-friendbot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stellar-friendbot.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "stellar-friendbot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stellar-friendbot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "stellar-friendbot.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/stellar-friendbot/templates/deployment.yaml
+++ b/stable/stellar-friendbot/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "stellar-friendbot.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "stellar-friendbot.name" . }}
+    helm.sh/chart: {{ include "stellar-friendbot.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "stellar-friendbot.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "stellar-friendbot.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: "{{ template "stellar-friendbot.serviceAccountName" . }}"
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- with .Values.existingAccountSecretSecret }}
+            - name: FRIENDBOT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "name of existingAccountSecretSecret is required" .name | quote }}
+                  key: {{ required "key of existingAccountSecretSecret is required" .key | quote }}
+            {{- else }}
+            - name: FRIENDBOT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "stellar-friendbot.fullname" . }}
+                  key: accountSecret
+            {{- end }}
+            - name: NETWORK_PASSPHRASE
+              value: {{ .Values.networkPassphrase | quote }}
+            - name: HORIZON_URL
+              value: {{ .Values.horizonUrl | quote }}
+            - name: STARTING_BALANCE
+              value: {{ .Values.startingBalance | quote }}
+            {{- range $key, $val := .Values.environment }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/stellar-friendbot/templates/deployment.yaml
+++ b/stable/stellar-friendbot/templates/deployment.yaml
@@ -52,13 +52,12 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          # Note: we can't use httpGet here because friendbot throws 4xx without a valid dest addr
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/stable/stellar-friendbot/templates/ingress.yaml
+++ b/stable/stellar-friendbot/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "stellar-friendbot.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "stellar-friendbot.name" . }}
+    helm.sh/chart: {{ include "stellar-friendbot.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/stable/stellar-friendbot/templates/secret.yaml
+++ b/stable/stellar-friendbot/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "stellar-friendbot.fullname" . }}
+  labels:
+    app: {{ template "stellar-friendbot.name" . }}
+    chart: {{ template "stellar-friendbot.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+{{- if not .Values.existingAccountSecretSecret }}
+  accountSecret: {{ required "accountSecret is required if existingAccountSecretSecret is not provided" .Values.accountSecret | b64enc }}
+{{- end }}
+

--- a/stable/stellar-friendbot/templates/service.yaml
+++ b/stable/stellar-friendbot/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stellar-friendbot.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "stellar-friendbot.name" . }}
+    helm.sh/chart: {{ include "stellar-friendbot.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "stellar-friendbot.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/stellar-friendbot/templates/serviceaccount.yaml
+++ b/stable/stellar-friendbot/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "stellar-friendbot.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "stellar-friendbot.name" . }}
+    helm.sh/chart: {{ include "stellar-friendbot.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/stable/stellar-friendbot/values.yaml
+++ b/stable/stellar-friendbot/values.yaml
@@ -1,0 +1,88 @@
+## WARNING: make sure to replace this in your configuration or use existingAccountSecretSecret
+accountSecret: SBZYPEOQK7TWABPRW2LSSYWDI7O7TWZQZUH4RUUNEAUGNVHKKUH4Y6QF
+# existingAccountSecretSecret:
+#   name: stellar-friendbot
+#   key: accountSecret
+
+networkPassphrase: Test SDF Network ; September 2015
+
+horizonUrl: https://horizon-testnet.stellar.org
+
+startingBalance: 10000
+
+environment: {}
+
+image:
+  repository: satoshipay/stellar-friendbot
+  tag: '0.13.0'
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+ingress:
+  enabled: false
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: stellar-friendbot.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    tls: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: stellar-friendbot.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## If you're using kube-lego, you will want to add:
+    ## kubernetes.io/tls-acme: true
+    ##
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+    #  kubernetes.io/tls-acme: true
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: stellar-friendbot.local-tls
+  #   key:
+  #   certificate:
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceAccount:
+  create: true
+  name:

--- a/stable/stellar-friendbot/values.yaml
+++ b/stable/stellar-friendbot/values.yaml
@@ -23,19 +23,6 @@ service:
 
 ingress:
   enabled: false
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  path: /
-  hosts:
-    - chart-example.local
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-ingress:
-  enabled: false
 
   ## The list of hostnames to be covered with this ingress record.
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds a Helm chart for the Stellar Friendbot that is usually deployed in test networks for sending funds to new (test) accounts. 

#### Special notes for your reviewer:

The Friendbot is a very simple standalone HTTP server that does not depend on a local Stellar Horizon instance but can connect to any Horizon instance. By default it uses the testnet Horizon of the Stellar development foundation at `https://horizon-testnet.stellar.org`. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Variables are documented in the README.md

#### Remarks

Analogous to #7266 and #8424, this chart is based on the popular SatoshiPay images for Stellar that are well-suited for Kubernetes. The chart was developed by me at SatoshiPay where it is used in production for several months now. Since SatoshiPay wishes to contribute the chart to the community, I have permission to release the chart under Apache License 2 and to keep maintaining it.