### PR TITLE
[traefik] Add a README header for basic auth

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.52.0
+version: 1.52.1
 appVersion: 1.7.2
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -272,6 +272,8 @@ Given you have:
 Then you are good to migrate your old certs into the kvprovider and run traefik in HA/Cluster-Mode.
 
 
+### Dashboard Basic Auth
+
 [Basic auth](https://docs.traefik.io/toml/#api-backend) can be specified via `dashboard.auth.basic` as a map of usernames to passwords as below.
 See the linked Traefik documentation for accepted passwords encodings.
 It is advised to single quote passwords to avoid issues with special characters:


### PR DESCRIPTION
This is a re-do of #6184, with DCO sign-off + a chart version bump.

#### What this PR does / why we need it:

Traefik's basic auth instructions seemed to be incorrectly part of the Clustering section. This adds a new header to the README to differentiate them.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
