### PR TITLE
[stable/phpmyadmin] Add global registry option

### DIFF
--- a/stable/phpmyadmin/Chart.yaml
+++ b/stable/phpmyadmin/Chart.yaml
@@ -1,5 +1,5 @@
 name: phpmyadmin
-version: 1.1.2
+version: 1.2.0
 appVersion: 4.8.2
 description: phpMyAdmin is an mysql administration frontend
 keywords:

--- a/stable/phpmyadmin/README.md
+++ b/stable/phpmyadmin/README.md
@@ -48,20 +48,20 @@ The following table lists the configurable parameters of the phpMyAdmin chart an
 |----------------------------|------------------------------------------|---------------------------------------------------------|
 | `global.imageRegistry`     | Global Docker image registry             | `nil`                                                   |
 | `image.registry`           | phpMyAdmin image registry                | `docker.io`                                             |
-| `image.repository`         | phpMyAdmin Image name                    | `bitnami/phpmyadmin`                                    |
-| `image.tag`                | phpMyAdmin Image tag                     | `{VERSION}`                                             |
+| `image.repository`         | phpMyAdmin image name                    | `bitnami/phpmyadmin`                                    |
+| `image.tag`                | phpMyAdmin image tag                     | `{VERSION}`                                             |
 | `image.pullPolicy`         | Image pull policy                        | `IfNotPresent`                                          |
 | `image.pullSecrets`        | Specify image pull secrets               | `nil`                                                   |
-| `service.type`             | type of service for phpMyAdmin frontend  | `ClusterIP`                                             |
-| `service.port`             | port to expose service                   | `80`                                                    |
-| `db.port`                  | database port to use to connect          | `3306`                                                  |
+| `service.type`             | Type of service for phpMyAdmin frontend  | `ClusterIP`                                             |
+| `service.port`             | Port to expose service                   | `80`                                                    |
+| `db.port`                  | Database port to use to connect          | `3306`                                                  |
 | `db.chartName`             | Database suffix if included in the same release | `nil`                                            |
-| `db.host`                  | database host to connect to              | `nil`                                                   |
-| `ingress.enabled`          | ingress resource to be added             | `false`                                                 |
-| `ingress.annotations`      | ingress annotations                      | `{ingress.kubernetes.io/rewrite-target: /,    nginx.ingress.kubernetes.io/rewrite-target: /}`          |
-| `ingress.path`             | path to access frontend                  | `/`                                                     |
-| `ingress.host`             | ingress host                             | `nil`                                                   |
-| `ingress.tls`              | tls for ingress                          | `[]`                                                    |
+| `db.host`                  | Database host to connect to              | `nil`                                                   |
+| `ingress.enabled`          | Ingress resource to be added             | `false`                                                 |
+| `ingress.annotations`      | Ingress annotations                      | `{ingress.kubernetes.io/rewrite-target: /,    nginx.ingress.kubernetes.io/rewrite-target: /}`          |
+| `ingress.path`             | Path to access frontend                  | `/`                                                     |
+| `ingress.host`             | Ingress host                             | `nil`                                                   |
+| `ingress.tls`              | TLS for ingress                          | `[]`                                                    |
 | `resources`                | CPU/Memory resource requests/limits      | `{}`                                                    |
 | `nodeSelector`             | Node labels for pod assignment           | `{}`                                                    |
 | `tolerations`              | List of node taints to tolerate          | `[]`                                                    |

--- a/stable/phpmyadmin/README.md
+++ b/stable/phpmyadmin/README.md
@@ -44,27 +44,28 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the phpMyAdmin chart and their default values.
 
-|              Parameter               |               Description                |                         Default                         |
-|--------------------------------------|------------------------------------------|---------------------------------------------------------|
-| `image.registry`                     | phpMyAdmin image registry                 | `docker.io`                                             |
-| `image.repository`                   | phpMyAdmin Image name                     | `bitnami/phpmyadmin`                                     |
-| `image.tag`                          | phpMyAdmin Image tag                      | `{VERSION}`                                             |
-| `image.pullPolicy`                   | Image pull policy                        |   `IfNotPresent` |
-| `image.pullSecrets`                  | Specify image pull secrets               | `nil`                                                   |
-| `service.type`            | type of service for phpMyAdmin frontend             | `ClusterIP`                                                  |
-| `service.port`        | port to expose service                   | `80`                                                   |
-| `db.port`            | database port to use to connect                  | `3306`                                     |
-| `db.chartName`                | Database suffix if included in the same release                  | `nil`                                          |
-| `db.host`            | database host to connect to               | `nil`          |
-| `ingress.enabled`            | ingress resource to be added              | `false`          |
-| `ingress.annotations`            | ingress annotations              | `{ingress.kubernetes.io/rewrite-target: /,    nginx.ingress.kubernetes.io/rewrite-target: /}`          |
-| `ingress.path`            | path to access frontend               | `/`          |
-| `ingress.host`            | ingress host               | `nil`          |
-| `ingress.tls`            | tls for ingress               | `[]`          |
-| `resources`                          | CPU/Memory resource requests/limits      | `{}`      |
-| `nodeSelector`                   | Node labels for pod assignment             | `{}`                                                    |
-| `tolerations`                    | List of node taints to tolerate            | `[]`                                                    |
-| `affinity`                       | Map of node/pod affinities                 | `{}`                                                    |
+|         Parameter          |               Description                |                         Default                         |
+|----------------------------|------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`     | Global Docker image registry             | `nil`                                                   |
+| `image.registry`           | phpMyAdmin image registry                | `docker.io`                                             |
+| `image.repository`         | phpMyAdmin Image name                    | `bitnami/phpmyadmin`                                    |
+| `image.tag`                | phpMyAdmin Image tag                     | `{VERSION}`                                             |
+| `image.pullPolicy`         | Image pull policy                        | `IfNotPresent`                                          |
+| `image.pullSecrets`        | Specify image pull secrets               | `nil`                                                   |
+| `service.type`             | type of service for phpMyAdmin frontend  | `ClusterIP`                                             |
+| `service.port`             | port to expose service                   | `80`                                                    |
+| `db.port`                  | database port to use to connect          | `3306`                                                  |
+| `db.chartName`             | Database suffix if included in the same release | `nil`                                            |
+| `db.host`                  | database host to connect to              | `nil`                                                   |
+| `ingress.enabled`          | ingress resource to be added             | `false`                                                 |
+| `ingress.annotations`      | ingress annotations                      | `{ingress.kubernetes.io/rewrite-target: /,    nginx.ingress.kubernetes.io/rewrite-target: /}`          |
+| `ingress.path`             | path to access frontend                  | `/`                                                     |
+| `ingress.host`             | ingress host                             | `nil`                                                   |
+| `ingress.tls`              | tls for ingress                          | `[]`                                                    |
+| `resources`                | CPU/Memory resource requests/limits      | `{}`                                                    |
+| `nodeSelector`             | Node labels for pod assignment           | `{}`                                                    |
+| `tolerations`              | List of node taints to tolerate          | `[]`                                                    |
+| `affinity`                 | Map of node/pod affinities               | `{}`                                                    |
 
 For more information please refer to the [bitnami/phpmyadmin](http://github.com/bitnami/bitnami-docker-Phpmyadmin) image documentation.
 

--- a/stable/phpmyadmin/templates/_helpers.tpl
+++ b/stable/phpmyadmin/templates/_helpers.tpl
@@ -40,11 +40,24 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Return the proper image name
+Return the proper PHPMyAdmin image name
 */}}
 {{- define "phpmyadmin.image" -}}
-{{- $registryName :=  .Values.image.registry -}}
+{{- $registryName := .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
-{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}

--- a/stable/phpmyadmin/templates/deployment.yaml
+++ b/stable/phpmyadmin/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ template "phpmyadmin.image" . }}"
+          image: {{ template "phpmyadmin.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DATABASE_PORT_NUMBER

--- a/stable/phpmyadmin/values.yaml
+++ b/stable/phpmyadmin/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry: 
+
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/phpmyadmin/tags/
 ##

--- a/stable/phpmyadmin/values.yaml
+++ b/stable/phpmyadmin/values.yaml
@@ -2,7 +2,7 @@
 ## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
 ##
 # global:
-#   imageRegistry: 
+#   imageRegistry:
 
 ## Bitnami WordPress image version
 ## ref: https://hub.docker.com/r/bitnami/phpmyadmin/tags/


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of the dependency in the main `values.yaml` chart (in the section of the dependency options).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
