### PR TITLE
[stable/osclass] Add global registry option

### DIFF
--- a/stable/osclass/Chart.yaml
+++ b/stable/osclass/Chart.yaml
@@ -1,5 +1,5 @@
 name: osclass
-version: 3.0.4
+version: 3.1.0
 appVersion: 3.7.4
 description: Osclass is a php script that allows you to quickly create and manage
   your own free classifieds site.

--- a/stable/osclass/README.md
+++ b/stable/osclass/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Osclass chart and t
 
 |             Parameter              |               Description                |                   Default                               |
 |------------------------------------|------------------------------------------|-------------------------------------------------------- |
+| `global.imageRegistry`             | Global Docker image registry             | `nil`                                                   |
 | `image.registry`                   | Osclass image registry                   | `docker.io`                                             |
 | `image.repository`                 | Osclass Image name                       | `bitnami/osclass`                                       |
 | `image.tag`                        | Osclass Image tag                        | `{VERSION}`                                             |

--- a/stable/osclass/requirements.lock
+++ b/stable/osclass/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.4
+  version: 5.2.0
 digest: sha256:0593b73b2163fbbbae061de1aa2b8280d43f8a423a91e1c7375c0b6c86784b1c
-generated: 2018-09-25T11:48:30.289513274+02:00
+generated: 2018-10-16T08:49:33.513575+02:00

--- a/stable/osclass/templates/_helpers.tpl
+++ b/stable/osclass/templates/_helpers.tpl
@@ -43,3 +43,26 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 {{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
 {{- default (include "osclass.serviceIP" .) $host -}}
 {{- end -}}
+
+{{/*
+Return the proper Osclass image name
+*/}}
+{{- define "osclass.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}

--- a/stable/osclass/templates/deployment.yaml
+++ b/stable/osclass/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "osclass.fullname" . }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ template "osclass.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD

--- a/stable/osclass/values.yaml
+++ b/stable/osclass/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
 ## Bitnami Osclass image version
 ## ref: https://hub.docker.com/r/bitnami/osclass/tags/
 ##
@@ -91,6 +97,8 @@ externalDatabase:
 
 ##
 ## MariaDB chart configuration
+##
+## https://github.com/helm/charts/blob/master/stable/mariadb/values.yaml
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of the dependency in the main `values.yaml` chart (in the section of the dependency options).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
