### PR TITLE
[stable/parse] Add global registry option

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,5 +1,5 @@
 name: parse
-version: 3.0.2
+version: 3.1.0
 appVersion: 3.0.0
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -47,6 +47,7 @@ The following table lists the configurable parameters of the Parse chart and the
 
 |             Parameter              |              Description               |                   Default                               |
 |------------------------------------|----------------------------------------|-------------------------------------------------------- |
+| `global.imageRegistry`             | Global Docker image registry           | `nil`                                                   |
 | `serviceType`                      | Kubernetes Service type                | `LoadBalancer`                                          |
 | `loadBalancerIP`                   | `loadBalancerIP` for the Parse Service | `nil`                                                   |
 | `server.image.registry`            | Parse image registry                   | `docker.io`                                             |

--- a/stable/parse/requirements.lock
+++ b/stable/parse/requirements.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.0.9
 digest: sha256:cf5e28c1a27636f9471953712706834f87e49cb40be80c303a1436ee7e5016e5
-generated: 2018-06-11T14:45:27.64207443+02:00
+generated: 2018-10-16T08:49:53.146915+02:00

--- a/stable/parse/templates/_helpers.tpl
+++ b/stable/parse/templates/_helpers.tpl
@@ -43,3 +43,26 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 {{- $host := default "" .Values.server.host -}}
 {{- default (include "parse.serviceIP" .) $host -}}
 {{- end -}}
+
+{{/*
+Return the proper Parse image name
+*/}}
+{{- define "parse.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}

--- a/stable/parse/templates/_helpers.tpl
+++ b/stable/parse/templates/_helpers.tpl
@@ -66,3 +66,49 @@ Also, we can't use a single if because lazy evaluation is not an option
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the proper Parse dashboard image name
+*/}}
+{{- define "parse.dashboard.image" -}}
+{{- $registryName := .Values.dashboard.image.registry -}}
+{{- $repositoryName := .Values.dashboard.image.repository -}}
+{{- $tag := .Values.dashboard.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Parse server client image name
+*/}}
+{{- define "parse.server.image" -}}
+{{- $registryName := .Values.server.image.registry -}}
+{{- $repositoryName := .Values.server.image.repository -}}
+{{- $tag := .Values.server.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}

--- a/stable/parse/templates/dashboard-deployment.yaml
+++ b/stable/parse/templates/dashboard-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "parse.fullname" . }}
-        image: "{{ .Values.dashboard.image.registry }}/{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}"
+        image: {{ template "parse.image" . }}
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy | quote }}
         env:
         - name: PARSE_DASHBOARD_USER

--- a/stable/parse/templates/dashboard-deployment.yaml
+++ b/stable/parse/templates/dashboard-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "parse.fullname" . }}
-        image: {{ template "parse.image" . }}
+        image: {{ template "parse.dashboard.image" . }}
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy | quote }}
         env:
         - name: PARSE_DASHBOARD_USER

--- a/stable/parse/templates/server-deployment.yaml
+++ b/stable/parse/templates/server-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "parse.fullname" . }}
-        image: "{{ .Values.server.image.registry }}/{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+        image: {{ template "parse.image" . }}
         imagePullPolicy: {{ .Values.server.image.pullPolicy | quote }}
         env:
         - name: PARSE_HOST

--- a/stable/parse/templates/server-deployment.yaml
+++ b/stable/parse/templates/server-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "parse.fullname" . }}
-        image: {{ template "parse.image" . }}
+        image: {{ template "parse.server.image" . }}
         imagePullPolicy: {{ .Values.server.image.pullPolicy | quote }}
         env:
         - name: PARSE_HOST

--- a/stable/parse/values.yaml
+++ b/stable/parse/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
 ## Kubernetes serviceType for Parse Deployment
 ## ref: http://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
 ##
@@ -122,6 +128,8 @@ persistence:
 
 ##
 ## MongoDB chart configuration
+##
+## https://github.com/helm/charts/blob/master/stable/mongodb/values.yaml
 ##
 mongodb:
   ## MongoDB Password authentication


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of the dependency in the main `values.yaml` chart (in the section of the dependency options).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
