### PR TITLE
[stable/opencart] Add global registry option

### DIFF
--- a/stable/opencart/Chart.yaml
+++ b/stable/opencart/Chart.yaml
@@ -1,5 +1,5 @@
 name: opencart
-version: 3.0.4
+version: 3.1.0
 appVersion: 3.0.2-0
 description: A free and open source e-commerce platform for online merchants. It provides
   a professional and reliable foundation for a successful online store.

--- a/stable/opencart/README.md
+++ b/stable/opencart/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the OpenCart chart and 
 
 |              Parameter              |                Description                |                         Default                          |
 |-------------------------------------|-------------------------------------------|----------------------------------------------------------|
+| `global.imageRegistry`              | Global Docker image registry              | `nil`                                                    |
 | `image.registry`                    | OpenCart image registry                   | `docker.io`                                              |
 | `image.repository`                  | OpenCart Image name                       | `bitnami/opencart`                                       |
 | `image.tag`                         | OpenCart Image tag                        | `{VERSION}`                                              |
@@ -72,7 +73,7 @@ The following table lists the configurable parameters of the OpenCart chart and 
 | `externalDatabase.database`         | Name of the existing database             | `bitnami_opencart`                                       |
 | `mariadb.enabled`                   | Whether to use MariaDB chart              | `true`                                                   |
 | `mariadb.db.name`           | Database name to create                   | `bitnami_opencart`                                       |
-| `mariadb.db.user`               | Database user to create                   | `bn_opencart`                                            | 
+| `mariadb.db.user`               | Database user to create                   | `bn_opencart`                                            |
 | `mariadb.db.password`           | Password for the database                 | `nil`                                                    |
 | `mariadb.rootUser.password`       | MariaDB admin password                    | `nil`                                                    |
 | `serviceType`                       | Kubernetes Service type                   | `LoadBalancer`                                           |

--- a/stable/opencart/requirements.lock
+++ b/stable/opencart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.4
+  version: 5.2.0
 digest: sha256:0593b73b2163fbbbae061de1aa2b8280d43f8a423a91e1c7375c0b6c86784b1c
-generated: 2018-09-25T11:43:52.539515518+02:00
+generated: 2018-10-16T08:49:13.828477+02:00

--- a/stable/opencart/templates/_helpers.tpl
+++ b/stable/opencart/templates/_helpers.tpl
@@ -43,3 +43,26 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 {{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
 {{- default (include "opencart.serviceIP" .) $host -}}
 {{- end -}}
+
+{{/*
+Return the proper Opencart image name
+*/}}
+{{- define "opencart.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}

--- a/stable/opencart/templates/deployment.yaml
+++ b/stable/opencart/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "opencart.fullname" . }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ template "opencart.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
         - name: ALLOW_EMPTY_PASSWORD

--- a/stable/opencart/values.yaml
+++ b/stable/opencart/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
 ## Bitnami OpenCart image version
 ## ref: https://hub.docker.com/r/bitnami/opencart/tags/
 ##
@@ -77,6 +83,8 @@ externalDatabase:
 
 ##
 ## MariaDB chart configuration
+##
+## https://github.com/helm/charts/blob/master/stable/mariadb/values.yaml
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of the dependency in the main `values.yaml` chart (in the section of the dependency options).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
