### PR TITLE
[stable/mediawiki] Add global registry option

### DIFF
--- a/stable/mediawiki/Chart.yaml
+++ b/stable/mediawiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: mediawiki
-version: 4.1.0
+version: 4.2.0
 appVersion: 1.31.1
 description: Extremely powerful, scalable software and a feature-rich wiki implementation
   that uses PHP to process and display data stored in a database.

--- a/stable/mediawiki/README.md
+++ b/stable/mediawiki/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the MediaWiki chart and
 
 |              Parameter               |               Description                                   |                         Default                         |
 |--------------------------------------|-------------------------------------------------------------|---------------------------------------------------------|
+| `global.imageRegistry`               | Global Docker image registry                                | `nil`                                                   |
 | `image.registry`                     | MediaWiki image registry                                    | `docker.io`                                             |
 | `image.repository`                   | MediaWiki Image name                                        | `bitnami/mediawiki`                                     |
 | `image.tag`                          | MediaWiki Image tag                                         | `{VERSION}`                                             |

--- a/stable/mediawiki/requirements.lock
+++ b/stable/mediawiki/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.0.4
+  version: 5.2.0
 digest: sha256:7043c28f05b6aac3615a61e609bddc958b51bea717afa81455d7d34641cdd906
-generated: 2018-09-25T11:40:02.188164295+02:00
+generated: 2018-10-16T08:48:39.403302+02:00

--- a/stable/mediawiki/templates/_helpers.tpl
+++ b/stable/mediawiki/templates/_helpers.tpl
@@ -26,8 +26,23 @@ Create chart name and version as used by the chart label.
 Return the proper Mediawiki image name
 */}}
 {{- define "mediawiki.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/mediawiki/values.yaml
+++ b/stable/mediawiki/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
 ## Bitnami DokuWiki image version
 ## ref: https://hub.docker.com/r/bitnami/mediawiki/tags/
 ##
@@ -72,6 +78,8 @@ externalDatabase:
 
 ##
 ## MariaDB chart configuration
+##
+## https://github.com/helm/charts/blob/master/stable/mariadb/values.yaml
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of the dependency in the main `values.yaml` chart (in the section of the dependency options).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
