### PR TITLE
[stable/joomla] Add global registry option

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 3.2.0
+version: 3.3.0
 appVersion: 3.8.13
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Joomla! chart and t
 
 | Parameter                            | Description                                                 | Default                                        |
 | ------------------------------------ | ----------------------------------------------------------- | ---------------------------------------------- |
+| `global.imageRegistry`               | Global Docker image registry                                | `nil`                                          |
 | `image.registry`                     | Joomla! image registry                                      | `docker.io`                                    |
 | `image.repository`                   | Joomla! Image name                                          | `bitnami/joomla`                               |
 | `image.tag`                          | Joomla! Image tag                                           | `{VERSION}`                                    |

--- a/stable/joomla/requirements.lock
+++ b/stable/joomla/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 5.1.1
+  version: 5.2.0
 digest: sha256:0593b73b2163fbbbae061de1aa2b8280d43f8a423a91e1c7375c0b6c86784b1c
-generated: 2018-10-11T04:07:42.662012144Z
+generated: 2018-10-16T08:48:17.456241+02:00

--- a/stable/joomla/templates/_helpers.tpl
+++ b/stable/joomla/templates/_helpers.tpl
@@ -26,8 +26,23 @@ Create chart name and version as used by the chart label.
 Return the proper Joomla! image name
 */}}
 {{- define "joomla.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/joomla/values.yaml
+++ b/stable/joomla/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
 ## Bitnami Joomla! image version
 ## ref: https://hub.docker.com/r/bitnami/dokuwiki/tags/
 ##
@@ -68,6 +74,8 @@ externalDatabase:
 
 ##
 ## MariaDB chart configuration
+##
+## https://github.com/helm/charts/blob/master/stable/mariadb/values.yaml
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of the dependency in the main `values.yaml` chart (in the section of the dependency options).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
