### PR TITLE
[stable/kubewatch] Add global registry option

### DIFF
--- a/stable/kubewatch/Chart.yaml
+++ b/stable/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 0.4.2
+version: 0.5.0
 apiVersion: v1
 appVersion: v0.0.4
 home: https://github.com/bitnami-labs/kubewatch

--- a/stable/kubewatch/README.md
+++ b/stable/kubewatch/README.md
@@ -39,6 +39,7 @@ The following table lists the configurable parameters of the kubewatch chart and
 
 |               Parameter                  |        Description                   |              Default              |
 | ---------------------------------------- | ------------------------------------ | --------------------------------- |
+| `global.imageRegistry`                   | Global Docker image registry         | `nil`                             |
 | `affinity`                               | node/pod affinities                  | None                              |
 | `image.registry`                         | Image registry                       | `docker.io`                       |
 | `image.repository`                       | Image repository                     | `bitnami/kubewatch`               |
@@ -50,7 +51,7 @@ The following table lists the configurable parameters of the kubewatch chart and
 | `replicaCount`                           | desired number of pods               | `1`                               |
 | `rbac.create`                            | If true, create & use RBAC resources | `true`                            |
 | `serviceAccount.create`                  | If true, create a serviceAccount     | `true`                            |
-| `serviceAccount.name`                    | existing ServiceAccount to use (ignored if rbac.create=true) | ``        | 
+| `serviceAccount.name`                    | existing ServiceAccount to use (ignored if rbac.create=true) | ``        |
 | `resources`                              | pod resource requests & limits       | `{}`                              |
 | `slack.channel`                          | Slack channel to notify              | `""`                              |
 | `slack.token`                            | Slack API token                      | `""`                              |

--- a/stable/kubewatch/templates/_helpers.tpl
+++ b/stable/kubewatch/templates/_helpers.tpl
@@ -31,7 +31,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-
 {{/*
 Create the name of the service account to use
 */}}
@@ -40,5 +39,28 @@ Create the name of the service account to use
     {{ default (include "kubewatch.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Kubewatch image name
+*/}}
+{{- define "kubewatch.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 {{- end -}}

--- a/stable/kubewatch/templates/deployment.yaml
+++ b/stable/kubewatch/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: {{ template "kubewatch.name" . }}
-        image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ template "kubewatch.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: {{ template "kubewatch.name" . }}-config-map
@@ -53,4 +53,3 @@ spec:
       - name: {{ template "kubewatch.name" . }}-config-map
         configMap:
           name: {{ template "kubewatch.fullname" . }}-config
-

--- a/stable/kubewatch/values.yaml
+++ b/stable/kubewatch/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry: 
+
 slack:
   # Slack channel to notify
   channel: "XXXX"

--- a/stable/kubewatch/values.yaml
+++ b/stable/kubewatch/values.yaml
@@ -2,7 +2,7 @@
 ## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
 ##
 # global:
-#   imageRegistry: 
+#   imageRegistry:
 
 slack:
   # Slack channel to notify


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of the dependency in the main `values.yaml` chart (in the section of the dependency options).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
