### PR TITLE
enable flag for hostNetwork

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.77.1
 description: Home Assistant
 name: home-assistant
-version: 0.2.1
+version: 0.3.0
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -45,6 +45,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `service.externalIPs`   | External IPs for the home-assistant GUI | `[]` |
 | `service.loadBalancerIP`   | Loadbalance IP for the home-assistant GUI | `` |
 | `service.loadBalancerSourceRanges`   | Loadbalance client IP restriction range for the home-assistant GUI | `[]` |
+| `hostNetwork`              | Enable hostNetwork - might be needed for discovery to work | `false` |
 | `service.nodePort`   | nodePort to listen on for the home-assistant GUI | `` |
 | `ingress.enabled`              | Enables Ingress | `false` |
 | `ingress.annotations`          | Ingress annotations | `{}` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         app: {{ template "home-assistant.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }} 
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -36,6 +36,8 @@ ingress:
   #    hosts:
   #      - home-assistant.local
 
+hostNetwork: false
+
 persistence:
   enabled: true
   ## home-assistant data Persistent Volume Storage Class


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>


#### What this PR does / why we need it:
Have a flag to conditionally enable hostNetworking.
Default false for backwards compatibility. 
Hostnetworking is required for discovery of devices on the host network.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
