### PR TITLE
OpenVPN NOTES.txt - Fix label key in the pod status command (#5817)

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.9.1
+version: 3.9.2
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/templates/NOTES.txt
+++ b/stable/openvpn/templates/NOTES.txt
@@ -4,7 +4,7 @@ Please be aware that certificate generation is variable and may take some time (
 
 Check pod status with the command:
 
-  POD_NAME=$(kubectl get pods -l type=openvpn -o jsonpath='{ .items[0].metadata.name }') && kubectl log $POD_NAME --follow
+  POD_NAME=$(kubectl get pods --namespace "{{ .Release.Namespace }}" -l app=openvpn -o jsonpath='{ .items[0].metadata.name }') && kubectl log $POD_NAME --follow
 
 LoadBalancer ingress creation can take some time as well. Check service status with the command:
 


### PR DESCRIPTION
In `NOTES.txt`, the command to follow the pod's log has a label filter with the old `type` key instead of the new `app` key.

Additionally add a 'namespace' flag per https://github.com/helm/charts/pull/5817#discussion_r193873501

Note: this is a "reopening" of #5817, with the additional requested change to add the 'namespace' flag.

/CC @jfelten, @ jmymy
