### PR TITLE
Cloudwatch exporter - Support custom service labels and portName

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.2.0
+version: 0.2.1
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -50,8 +50,10 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `image.pullPolicy`          | Image pull policy                                      | `IfNotPresent`             |
 | `service.type`              | Service type                                           | `ClusterIP`                |
 | `service.port`              | The service port                                       | `80`                       |
+| `service.portName`          | The name of the service port                           | `http`                     |
 | `service.targetPort`        | The target port of the container                       | `9100`                     |
 | `service.annotations`       | Custom annotations for service                         | `{}`                       |
+| `service.labels`            | Additional custom labels for the service               | `{}`                       |
 | `resources`                 |                                                        | `{}`                       |
 | `aws.region`                | AWS Cloudwatch region                                  | `eu-west-1`                |
 | `aws.role`                  | AWS IAM Role To Use                                    |                            |

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -48,13 +48,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
+            - name: {{ .Values.service.portName }}
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthy/
-              port: http
+              port: {{ .Values.service.portName }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds}}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -63,7 +63,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /ready/
-              port: http
+              port: {{ .Values.service.portName }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds}}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/prometheus-cloudwatch-exporter/templates/service.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/service.yaml
@@ -9,13 +9,16 @@ metadata:
     chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
-      name: http
+      name: {{ .Values.service.portName }}
   selector:
     app: {{ template "prometheus-cloudwatch-exporter.name" . }}
     release: {{ .Release.Name }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -13,7 +13,9 @@ service:
   type: ClusterIP
   port: 80
   targetPort: 9100
+  portName: http
   annotations: {}
+  labels: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
#### What this PR does / why we need it:

Added support for add additional k8s `labels` on the `service` object and for overriding the `portName`.

This allows, for example, easier integration with `prometheus-operator` configurations, which scrape exporters based on custom labels and portNames.



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md


/CC @gianrubio
