### PR TITLE
loadBalancerSourceRanges support for securing elb access

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.11.1
+version: 0.11.2
 appVersion: 4.1.2
 keywords:
 - kafka

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -40,6 +40,12 @@ metadata:
     pod: {{ $responsiblePod | quote }}
 spec:
   type: {{ $root.Values.external.type }}
+  loadBalancerSourceRanges:
+  {{- if eq $root.Values.external.type "LoadBalancer"}}
+    {{- range $v := $root.Values.loadBalancerSourceRanges }}
+    - {{ $v }}
+    {{- end }}
+  {{- end }}
   ports:
     - name: external-broker
       {{- if and (eq $root.Values.external.type "LoadBalancer") (not $root.Values.external.distinct) }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -152,6 +152,11 @@ external:
     imageTag: "0.4"
     imagePullPolicy: "IfNotPresent"
 
+loadBalancerSourceRanges:
+  ## Used in conjunction with the LoadBalancer service type.  Specify a list of CIDR ranges here.
+  # - "192.168.1.0/24"
+  # - "172.16.0.0/16"
+
 # Annotation to be added to Kafka pods
 podAnnotations: {}
 

--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,6 +1,6 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 1.2.0
+version: 1.2.1
 appVersion: 3.4.10
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.

--- a/incubator/zookeeper/templates/service.yaml
+++ b/incubator/zookeeper/templates/service.yaml
@@ -13,6 +13,12 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  loadBalancerSourceRanges:
+  {{- if eq .Values.service.type "LoadBalancer"}}
+    {{- range .Values.loadBalancerSourceRanges }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
   ports:
   {{- range $key, $value := .Values.service.ports }}
     - name: {{ $key }}

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -28,7 +28,7 @@ image:
 service:
   type: ClusterIP  # Exposes zookeeper on a cluster-internal IP.
   annotations: {}  # Arbitrary non-identifying metadata for zookeeper service.
-    ## AWS example for use with LoadBalancer service type.
+    ## AWS example for use with LoadBalancer service type. See loadBalancerSourceRanges below for sg support.
     # external-dns.alpha.kubernetes.io/hostname: zookeeper.cluster.local
     # service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
@@ -37,6 +37,11 @@ service:
       port: 2181  # Service port number for client port.
       targetPort: client  # Service target port for client port.
       protocol: TCP  # Service port protocol for client port.
+
+loadBalancerSourceRanges:
+  ## Used in conjunction with the LoadBalancer service type.  Specify a list of CIDR ranges here.
+  # - "192.168.1.0/24"
+  # - "172.16.0.0/16"
 
 ## Headless service.
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:
adds support for elb security group lockdown

#### Special notes for your reviewer:
@benjigoldberg nothing too special here.  Just trying to provide a way to limit networks from accessing external resources

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x ] Chart Version bumped
- [ ] Variables are documented in the README.md

Signed-off-by: Derrik Mildh<dmildh@illumina.com>