### PR TITLE
[stable/gocd] Agent was using Server resources (fixed typo)

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5.2
+
+* [9d64206c](https://github.com/kubernetes/charts/commit/9d64206c): Fix agent kube resources typo.
+
 ### 1.5.1
 
 * [b22b9d6](https://github.com/kubernetes/charts/commit/b22b9d6):

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.5.1
+version: 1.5.2
 appVersion: 18.10.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           resources:
-{{ toYaml .Values.server.resources | indent 12 }}
+{{ toYaml .Values.agent.resources | indent 12 }}
           env:
             - name: GO_SERVER_URL
             {{- if .Values.agent.env.goServerUrl }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
GoCD agent deployment was using `server.resources` value, but should use `agent.resources`. 

This typo is now fixed.

@varshavaradarajan @arvindsv @GaneshSPatil 

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
