### PR TITLE
Initial Release for vSphere Cloud Controller Manager Helm Chart

### DIFF
--- a/incubator/vsphere-ccm/Chart.yaml
+++ b/incubator/vsphere-ccm/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+appVersion: 0.1.0
+description: A vSphere Cloud Controller Manager (CCM) Helm chart for Kubernetes
+name: vsphere-ccm
+version: 0.1.0
+keywords:
+  - vsphere
+  - vmware
+  - cloud
+  - provider
+home: https://github.com/kubernetes/cloud-provider-vsphere
+icon: https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/docs/vmware_logo.png
+sources:
+  - http://gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager
+maintainers:
+  - name: dvonthenen
+    email: vonthenend@vmware.com

--- a/incubator/vsphere-ccm/OWNERS
+++ b/incubator/vsphere-ccm/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- dvonthenen
+reviewers:
+- dvonthenen

--- a/incubator/vsphere-ccm/README.md
+++ b/incubator/vsphere-ccm/README.md
@@ -1,0 +1,88 @@
+# vSphere Cloud Controller Manager (CCM)
+
+[vSphere Cloud Controller Manager](https://github.com/kubernetes/cloud-provider-vsphere) handles cloud specific functionality for VMware vSphere infrastructure running on Kubernetes.
+
+## Introduction
+
+This chart deploys all components required to run the external vSphere CCM as described on it's [GitHub page](https://github.com/kubernetes/cloud-provider-vsphere).
+
+## Prerequisites
+
+- Has been tested on Kubernetes 1.11.X+
+- Assumes your Kubernetes cluster has been configured to use the external `vsphere` cloud controller manager. Please take a look at configuration guidelines located in the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager).
+
+## Installing the Chart
+
+To install this chart with the release name `myrel` and by providing a vCenter information/credentials, run the following command:
+
+```bash
+$ helm install incubator/vsphere-ccm --name myrel --set cfg.enabled=true --set cfg.vcenter=<vCenter IP> --set cfg.username=<vCenter Username> --set cfg.password=<vCenter Password> --set cfg.datacenter=<vCenter Datacenter>
+```
+
+> **Tip**: List all releases using `helm list --all`
+
+If you want to provide your own `vsphere.conf` and Kubernetes secret `vsphereccm` in the `kube-system` namespace (to handle multple datacenters or multiple vCenters), you can learn more about the `vsphere.conf` and `vsphereccm` secret by reading the following [doucmentation](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/deploying_cloud_provider_vsphere_with_rbac.md) and then running the following command:
+
+```bash
+$ helm install incubator/vsphere-ccm --name myrel
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `myrel` deployment:
+
+```bash
+$ helm delete myrel
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+> **Tip**: To permanently remove the release, run `helm delete --purge myrel`
+
+## Configuration
+
+The following table lists the configurable parameters of the vSphere CCM chart and their default values.
+
+|             Parameter                    |            Description              |                  Default               |
+|------------------------------------------|-------------------------------------|----------------------------------------|
+| `ccm.annotations`                        | Annotations for CCM pod             |  nil                                   |
+| `ccm.image`                              | Image for vSphere CCM               |  gcr.io/cloud-provider-vsphere/        |
+|                                          |                                     |       vsphere-cloud-controller-manager |
+| `ccm.tag`                                | Tag for vSphere CCM                 |  latest                                |
+| `ccm.pullPolicy`                         | CCM image pullPolicy                |  IfNotPresent                          |
+| `ccm.dnsPolicy`                          | CCM dnsPolicy                       |  ClusterFirst                          |
+| `ccm.cmdline.logging`                    | Logging level                       |  2                                     |
+| `ccm.cmdline.cloudConfig.dir`            | vSphere conf directory              |  /etc/cloud                            |
+| `ccm.cmdline.cloudConfig.file`           | vSphere conf filename               |  vsphere.conf                          |
+| `ccm.cmdline.kubeConfig.configMap`       | Use a configMap for kubeConfig      |  nil                                   |
+| `ccm.cmdline.kubeConfig.dir`             | kubeConfig directory                |  /etc/kubernetes                       |
+| `ccm.cmdline.kubeConfig.file`            | kubeConfig filename                 |  controller-manager.conf               |
+| `ccm.cmdline.caCerts.configMap`          | Use a configMap for caCerts         |  nil                                   |
+| `ccm.cmdline.caCerts.dir`                | caCerts directory                   |  /etc/ssl/certs                        |
+| `ccm.cmdline.k8sCerts.configMap`         | Use a configMap for k8sCerts        |  nil                                   |
+| `ccm.cmdline.k8sCerts.dir`               | k8sCerts directory                  |  /etc/kubernetes/pki                   |
+| `ccm.resources`                          | Node resources                      | `[]`                                   |
+| `ccm.podAnnotations`                     | Annotations for CCM pod             |  nil                                   |
+| `ccm.podLabels`                          | Labels for CCM pod                  |  nil                                   |
+| `ccm.service.enabled`                    | Enabled the CCM API endpoint        |  false                                 |
+| `ccm.service.annotations`                | Annotations for API service         |  nil                                   |
+| `ccm.service.type`                       | Service type                        |  ClusterIP                             |
+| `ccm.service.loadBalancerSourceRanges`   | list of IP CIDRs allowed access     | `[]`                                   |
+| `ccm.service.endpointPort`               | External accessible port            |  43001                                 |
+| `ccm.service.targetPort`                 | Internal API port                   |  43001                                 |
+| `ccm.ingress.enabled`                    | Allow external traffic access       |  false                                 |
+| `ccm.ingress.annotations`                | Annotations for Ingress             |  nil                                   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name myrel \
+    --set ccm.pullPolicy=Always \
+    incubator/vsphere-ccm
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart.
+
+### Image tags
+
+vSphere CCM offers a multitude of [tags](https://github.com/kubernetes/cloud-provider-vsphere/releases) for the various components used in this chart.

--- a/incubator/vsphere-ccm/templates/NOTES.txt
+++ b/incubator/vsphere-ccm/templates/NOTES.txt
@@ -1,0 +1,27 @@
+The vSphere Cloud Controller Manager API over gRPC exists at the following location:
+
+{{- if not .Values.ccm.service.enabled }}
+
+  vSphere CCM API is disabled
+
+{{- else if contains "NodePort" .Values.ccm.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "ccm.fullname" . }}-query)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo h$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.ccm.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "sphere-ccm.fullname" . }}-query'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "sphere-ccm.fullname" . }}-query -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo $SERVICE_IP:50051
+
+{{- else if contains "ClusterIP"  .Values.ccm.service.type }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }},component=cloud-controller-manager" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 43001:43001
+
+{{- end }}

--- a/incubator/vsphere-ccm/templates/_helpers.tpl
+++ b/incubator/vsphere-ccm/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ccm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ccm.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified daemondset name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "ccm.daemonset.name" -}}
+{{- $nameGlobalOverride := printf "%s-daemonset" (include "ccm.fullname" .) -}}
+{{- if .Values.daemonset.fullnameOverride -}}
+{{- printf "%s" .Values.daemonset.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $nameGlobalOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "api.binding" -}}
+{{- printf ":%.0f" .Values.ccm.service.endpointPort | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Configure list of IP CIDRs allowed access to load balancer (if supported)
+*/}}
+{{- define "loadBalancerSourceRanges" -}}
+{{- if .service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/incubator/vsphere-ccm/templates/common-cm.yaml
+++ b/incubator/vsphere-ccm/templates/common-cm.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "ccm.fullname" . }}
+  labels:
+    app: {{ template "ccm.name" . }}
+    vsphere-ccm-infra: common-configmap
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+data:
+  api.binding: "{{ template "api.binding" . }}"

--- a/incubator/vsphere-ccm/templates/vsphere-ccm-cm.yaml
+++ b/incubator/vsphere-ccm/templates/vsphere-ccm-cm.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.cfg.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-config
+  namespace: kube-system
+data:
+  vsphere.conf: |
+    [Global]
+    # properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    port = "443" #Optional
+    insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
+    # settings for using k8s secret
+    secret-name = "vsphereccm"
+    secret-namespace = "kube-system"
+
+    [VirtualCenter "{{ .Values.cfg.vcenter }}"]
+    datacenters = "{{ .Values.cfg.datacenter }}"
+    # port, insecure-flag will be used from Global section.
+{{- end -}}

--- a/incubator/vsphere-ccm/templates/vsphere-ccm-ds.yaml
+++ b/incubator/vsphere-ccm/templates/vsphere-ccm-ds.yaml
@@ -1,0 +1,125 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "ccm.name" . }}
+  labels:
+    app: {{ template "ccm.name" . }}
+    vsphere-ccm-infra: vsphere-ccm-daemonset
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+{{- if .Values.ccm.annotations }}
+  annotations:
+{{ toYaml .Values.ccm.annotations | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "ccm.name" . }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+{{- if .Values.ccm.podAnnotations }}
+      annotations:
+{{ toYaml .Values.ccm.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ template "ccm.name" . }}
+        component: cloud-controller
+        release: {{ .Release.Name }}
+        vsphere-ccm-infra: vsphere-ccm-daemonset
+{{- if .Values.ccm.podLabels }}
+{{ toYaml .Values.ccm.podLabels | indent 8 }}
+{{- end }}
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsUser: 0
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: {{ .Values.ccm.serviceAccountName }}
+      {{- if .Values.ccm.useHostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      dnsPolicy: {{ .Values.ccm.dnsPolicy }}
+      containers:
+      - name: {{ template "ccm.name" . }}
+        image: {{ .Values.ccm.image }}:{{ .Values.ccm.tag }}
+        imagePullPolicy: {{ .Values.ccm.pullPolicy }}
+        args:
+          - /bin/vsphere-cloud-controller-manager
+          - --cloud-provider=vsphere
+          - --address=127.0.0.1
+          - --v={{ .Values.ccm.cmdline.logging }}
+          - --cloud-config={{ .Values.ccm.cmdline.cloudConfig.dir }}/{{ .Values.ccm.cmdline.cloudConfig.file }}
+          - --kubeconfig={{ .Values.ccm.cmdline.kubeConfig.dir }}/{{ .Values.ccm.cmdline.kubeConfig.file }}
+          {{- range $key, $value := .Values.ccm.cmdline.additionalParams }}
+          - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+          {{- end }}
+        {{- if .Values.ccm.service.enabled }}
+        env:
+          - name: VSPHERE_API_DISABLE
+            value: "true"
+          - name: VSPHERE_API_BINDING
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "ccm.fullname" . }}
+                key: api.binding
+        ports:
+        - containerPort: {{ .Values.ccm.service.endpointPort }}
+          protocol: TCP
+        {{- end }}
+        volumeMounts:
+          - mountPath: {{ .Values.ccm.cmdline.k8sCerts.dir }}
+            name: k8s-certs
+            readOnly: true
+          - mountPath: {{ .Values.ccm.cmdline.caCerts.dir }}
+            name: ca-certs
+            readOnly: true
+          - mountPath: {{ .Values.ccm.cmdline.kubeConfig.dir }}/{{ .Values.ccm.cmdline.kubeConfig.file }}
+            name: kubeconfig
+            readOnly: true
+          - mountPath: {{ .Values.ccm.cmdline.cloudConfig.dir }}
+            name: vsphere-config-volume
+            readOnly: true
+        resources:
+{{ toYaml .Values.ccm.resources | indent 10 }}
+      volumes:
+        - name: k8s-certs
+        {{- if .Values.ccm.cmdline.k8sCerts.configMap }}
+          configMap:
+            name: {{ .Values.ccm.cmdline.k8sCerts.configMap }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.ccm.cmdline.k8sCerts.dir }}
+            type: DirectoryOrCreate
+        {{- end }}
+        - name: ca-certs
+        {{- if .Values.ccm.cmdline.caCerts.configMap }}
+          configMap:
+            name: {{ .Values.ccm.cmdline.caCerts.configMap }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.ccm.cmdline.caCerts.dir }}
+            type: DirectoryOrCreate
+        {{- end }}
+        - name: kubeconfig
+        {{- if .Values.ccm.cmdline.kubeConfig.configMap }}
+          configMap:
+            name: {{ .Values.ccm.cmdline.kubeConfig.configMap }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.ccm.cmdline.kubeConfig.dir }}/{{ .Values.ccm.cmdline.kubeConfig.file }}
+            type: FileOrCreate
+        {{- end }}
+        - name: vsphere-config-volume
+          configMap:
+            name: cloud-config

--- a/incubator/vsphere-ccm/templates/vsphere-ccm-ing.yaml
+++ b/incubator/vsphere-ccm/templates/vsphere-ccm-ing.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ccm.ingress.enabled -}}
+{{- $servicePort := .Values.ccm.service.endpointPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "ccm.name" . }}
+  labels:
+    app: {{ template "ccm.name" . }}
+    vsphere-ccm-infra: vsphere-ccm-ingress
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+  {{- if .Values.ccm.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ccm.ingress.annotations | indent 4 }}
+  {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ccm.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "ccm.name" $ }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ccm.ingress.tls }}
+  tls:
+{{ toYaml .Values.ccm.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/incubator/vsphere-ccm/templates/vsphere-ccm-r.yaml
+++ b/incubator/vsphere-ccm/templates/vsphere-ccm-r.yaml
@@ -1,0 +1,71 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:{{ .Values.ccm.serviceAccountName }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/incubator/vsphere-ccm/templates/vsphere-ccm-rb.yaml
+++ b/incubator/vsphere-ccm/templates/vsphere-ccm-rb.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:{{ .Values.ccm.serviceAccountName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:{{ .Values.ccm.serviceAccountName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.ccm.serviceAccountName }}
+  namespace: kube-system
+- kind: User
+  name: {{ .Values.ccm.serviceAccountName }}

--- a/incubator/vsphere-ccm/templates/vsphere-ccm-s.yaml
+++ b/incubator/vsphere-ccm/templates/vsphere-ccm-s.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.cfg.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphereccm
+  namespace: kube-system
+data:
+  {{ .Values.cfg.vcenter }}.username: {{ .Values.cfg.username | b64enc }}
+  {{ .Values.cfg.vcenter }}.password: {{ .Values.cfg.password | b64enc }}
+{{- end -}}

--- a/incubator/vsphere-ccm/templates/vsphere-ccm-sa.yaml
+++ b/incubator/vsphere-ccm/templates/vsphere-ccm-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.ccm.serviceAccountName }}
+  namespace: kube-system

--- a/incubator/vsphere-ccm/templates/vsphere-ccm-svc.yaml
+++ b/incubator/vsphere-ccm/templates/vsphere-ccm-svc.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ccm.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ccm.name" . }}
+  labels:
+    app: {{ template "ccm.name" . }}
+    vsphere-ccm-infra: vsphere-ccm-service
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: kube-system
+{{- if .Values.ccm.service.annotations }}
+  annotations:
+{{ toYaml .Values.ccm.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - name: ccm-api
+    port: {{ .Values.ccm.service.endpointPort }}
+    protocol: TCP
+    targetPort: {{ .Values.ccm.service.targetPort }}
+  selector:
+    app: {{ template "ccm.name" . }}
+    component: cloud-controller
+    release: {{ .Release.Name }}
+    vsphere-ccm-infra: vsphere-ccm-daemonset
+  type: {{ .Values.ccm.service.type }}
+{{- template "loadBalancerSourceRanges" .Values.ccm }}
+{{- end -}}

--- a/incubator/vsphere-ccm/values.yaml
+++ b/incubator/vsphere-ccm/values.yaml
@@ -1,0 +1,78 @@
+# Default values for vSphere-CCM.
+# This is a YAML-formatted file.
+# vSohere-CCM values are grouped by component
+
+cfg:
+  enabled: false
+  vcenter: "10.0.0.1"
+  username: "user"
+  password: "pass"
+  datacenter: "dc"
+
+ccm:
+  annotations: {}
+  image: gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager
+  tag: v0.1.0
+  pullPolicy: IfNotPresent
+  dnsPolicy: ClusterFirst
+  cmdline:
+    logging: 2
+    # Location of the cloud configmap to be mounted on the filesystem
+    cloudConfig:
+      dir: "/etc/cloud"
+      file: "vsphere.conf"
+    # kubeConfigConfigMap defined the ConfigMap name in place of using volume
+    # containing the Kubeconfig file
+    kubeConfig:
+      configMap: null
+      dir: "/etc/kubernetes"
+      file: "controller-manager.conf"
+    # caCertsConfigMap defined the ConfigMap name in place of using volume
+    # containing the CACerts file
+    caCerts:
+      configMap: null
+      dir: /etc/ssl/certs
+    # k8sCerts to be used to access the kubernetes api server
+    k8sCerts:
+      configMap: null
+      dir: /etc/kubernetes/pki
+    additionalParams: {}
+  replicaCount: 1
+  serviceAccountName: cloud-controller-manager
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #    cpu: 256m
+    #    memory: 128Mi
+  podAnnotations: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  service:
+    enabled: false
+    annotations: {}
+    type: ClusterIP
+    # List of IP ranges that are allowed to access the load balancer (if supported)
+    loadBalancerSourceRanges: []
+    # endpointPort: externally accessible port for UI and API
+    endpointPort: 43001
+    # targetPort: the internal port the UI and API are exposed on
+    targetPort: 43001
+
+  ingress:
+    enabled: false
+    annotations: {}
+    # Used to create an Ingress record.
+    # hosts:
+    #   - chart-example.local
+    # annotations:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local


### PR DESCRIPTION
#### What this PR does / why we need it:
This introduces the initial release for the vSphere Cloud Controller Manager (CCM) located at https://github.com/kubernetes/cloud-provider-vsphere. There is a move to take all the cloud providers from in-tree to out-of-tree (link: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/0019-cloud-provider-documentation.md). This Helm Chart will enable users to consume the out-of-tree CCM easier by providing a simple deployment mechanism via Helm.

#### Special notes for your reviewer:
Tested using:
- vSphere CCM image 0.1.0
- Kubernetes cluster 1.11.3, 1.12.2, and 1.13.1 configured for an external cloud provider
- vSphere 6.5 and 6.7

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] ~Chart Version bumped~ Initial release
- [x] Variables are documented in the README.md
