### PR TITLE
[sable/signalsciences] Update SignalSciences agent to 3.13.0

### DIFF
--- a/stable/signalsciences/Chart.yaml
+++ b/stable/signalsciences/Chart.yaml
@@ -1,8 +1,8 @@
 name: signalsciences
 home: https://signalsciences.com
 icon: https://dashboard.signalsciences.net/static/images/logo-icon-color.svg
-version: 0.0.1
-appVersion: 3.12.1
+version: 0.0.2
+appVersion: 3.13.0
 description: SignalSciences is a web application firewall. This chart is the installable agent.
 keywords:
 - signalsciences

--- a/stable/signalsciences/OWNERS
+++ b/stable/signalsciences/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- marccampbell
+- grantmiller
+reviewers:
+- marccampbell
+- grantmiller

--- a/stable/signalsciences/values.yaml
+++ b/stable/signalsciences/values.yaml
@@ -9,7 +9,8 @@ image:
   tag: 3.13.0
   pullPolicy: IfNotPresent
 
-daemonset: {}
+daemonset:
+  enabled: true
   ## Annotations to add to the DaemonSet's Pods
   # podAnnotations:
   #   scheduler.alpha.kubernetes.io/tolerations: '[{"key": "example", "value": "foo"}]'

--- a/stable/signalsciences/values.yaml
+++ b/stable/signalsciences/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: marc/sigsci-agent
-  tag: 3.12.1
+  tag: 3.13.0
   pullPolicy: IfNotPresent
 
 daemonset: {}


### PR DESCRIPTION
Signed-off-by: Marc Campbell <marc.e.campbell@gmail.com>

#### What this PR does / why we need it:
- Update the SignalSciences agent version to 3.13.0.
- Adds an OWNERS file.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
