### PR TITLE
stable/kibana: Fix logic on JSON test, clarify log messages

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.16.3
+version: 0.16.4
 appVersion: 6.4.2
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/ci/dashboard-values.yaml
+++ b/stable/kibana/ci/dashboard-values.yaml
@@ -1,0 +1,21 @@
+---
+# enable the dashboard init container with dashboard embedded in configmap
+
+dashboardImport:
+  dashboards:
+    1_create_index: |-
+      {
+        "version": "6.4.2",
+        "objects": [
+          {
+            "id": "a88738e0-d3c1-11e8-b38e-a37c21cf8c95",
+            "version": 2,
+            "attributes": {
+              "title": "logstash-*",
+              "timeFieldName": "@timestamp",
+              "fields": "[{\"name\":\"@timestamp\",\"type\":\"date\",\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true}]"
+            }
+          }
+        ]
+      }
+

--- a/stable/kibana/ci/url_dashboard-values.yaml
+++ b/stable/kibana/ci/url_dashboard-values.yaml
@@ -1,0 +1,6 @@
+---
+# enable the dashboard init container with dashboard retrieved from an URL
+
+dashboardImport:
+  dashboards:
+    k8s: https://raw.githubusercontent.com/monotek/kibana-dashboards/master/k8s-fluentd-elasticsearch.json

--- a/stable/kibana/templates/configmap-dashboardimport.yaml
+++ b/stable/kibana/templates/configmap-dashboardimport.yaml
@@ -30,14 +30,14 @@ data:
     for DASHBOARD_FILE in *; do
       echo -e "Importing ${DASHBOARD_FILE} dashboard..."
 
-      if [ ! "$(python -c 'import sys, json; print json.load(sys.stdin)' < ${DASHBOARD_FILE} &> /dev/null)" ]; then
-        echo "${DASHBOARD_FILE} is no valid json. Trying to import from url..."
+      if ! python -c 'import sys, json; print json.load(sys.stdin)' < "${DASHBOARD_FILE}" &> /dev/null ; then
+        echo "${DASHBOARD_FILE} is not valid JSON, assuming it's an URL..."
         TMP_FILE="$(mktemp)"
         curl -s $(cat ${DASHBOARD_FILE}) > ${TMP_FILE}
         curl -v {{ if .Values.dashboardImport.xpackauth.enabled }}--user {{ .Values.dashboardImport.xpackauth.username }}:{{ .Values.dashboardImport.xpackauth.password }}{{ end }} -s --connect-timeout 60 --max-time 60 -XPOST localhost:5601/api/kibana/dashboards/import?force=true -H 'kbn-xsrf:true' -H 'Content-type:application/json' -d @${TMP_FILE}
         rm ${TMP_FILE}
       else
-        echo "Importing from json file..."
+        echo "Valid JSON found in ${DASHBOARD_FILE}, importing..."
         curl -v {{ if .Values.dashboardImport.xpackauth.enabled }}--user {{ .Values.dashboardImport.xpackauth.username }}:{{ .Values.dashboardImport.xpackauth.password }}{{ end }} -s --connect-timeout 60 --max-time 60 -XPOST localhost:5601/api/kibana/dashboards/import?force=true -H 'kbn-xsrf:true' -H 'Content-type:application/json' -d @./${DASHBOARD_FILE}
       fi
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The test for correct JSON in a kibana dashboard that runs as a part of the init container isn't working, as the test subshell is wrapped in quotes, and a non-empty string is always `true` in shell.

This patchset fixes the JSON validity check.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
