### PR TITLE
[stable/mm-te] Bump version to 5.4.0

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 1.1.2
-appVersion: 5.3.1
+version: 1.2.0
+appVersion: 5.4.0
 keywords:
 - mattermost
 - communication

--- a/stable/mattermost-team-edition/README.md
+++ b/stable/mattermost-team-edition/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the Mattermost Team Edi
 Parameter                 | Description                       | Default
 ---                       | ---                               | ---
 `image.repository`        | container image repository        | `mattermost/mattermost-team-edition`
-`image.tag`               | container image tag               | `5.3.1`
+`image.tag`               | container image tag               | `5.4.0`
 `revisionHistoryLimit`    | How many old ReplicaSets for Mattermost Deployment you want to retain   | `1`
 `config.SiteUrl`          | The URL that users will use to access Mattermost. ie `https://mattermost.mycompany.com`       |  ``
 `config.SiteName`         | Name of service shown in login screens and UI         | `Mattermost`

--- a/stable/mattermost-team-edition/values.yaml
+++ b/stable/mattermost-team-edition/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mattermost/mattermost-team-edition
-  tag: 5.3.1
+  tag: 5.4.0
   imagePullPolicy: IfNotPresent
 
 ## How many old ReplicaSets for Mattermost Deployment you want to retain


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump Mattermost to version 5.4.0

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
