### PR TITLE
Allow statefulSet updates

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 0.2.2
+version: 0.2.3
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 0.2.3
+version: 0.3.0
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 0.3.0
+version: 1.0.0
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/README.md
+++ b/incubator/couchdb/README.md
@@ -67,6 +67,23 @@ $ helm delete my-release
 The command removes all the Kubernetes components associated with the chart and
 deletes the release.
 
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v0.2.3 -> v1.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### 1.0.0
+
+This version removes the `chart` and `heritage` labels from the
+`volumeClaimTemplates` which is immutable and prevents chart from being upgraded
+(see https://github.com/helm/charts/issues/7803 for details).
+
+In order to upgrade, delete the CouchDB StatefulSet before upgrading:
+
+```bash
+$ kubectl delete statefulsets --cascade=false my-release-couchdb
+```
+
 ## Configuration
 
 The following table lists the most commonly configured parameters of the

--- a/incubator/couchdb/templates/statefulset.yaml
+++ b/incubator/couchdb/templates/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "couchdb.fullname" . }}
   labels:
     app: {{ template "couchdb.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -133,7 +133,7 @@ spec:
         name: database-storage
         labels:
           app: {{ template "couchdb.name" . }}
-          chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+          chart: {{ .Chart.Name }}
           release: {{ .Release.Name }}
           heritage: {{ .Release.Service }}
       spec:

--- a/incubator/couchdb/templates/statefulset.yaml
+++ b/incubator/couchdb/templates/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "couchdb.fullname" . }}
   labels:
     app: {{ template "couchdb.name" . }}
-    chart: {{ .Chart.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -133,9 +133,7 @@ spec:
         name: database-storage
         labels:
           app: {{ template "couchdb.name" . }}
-          chart: {{ .Chart.Name }}
           release: {{ .Release.Name }}
-          heritage: {{ .Release.Service }}
       spec:
         accessModes:
         {{- range .Values.persistentVolume.accessModes }}


### PR DESCRIPTION
This fixes CouchDB updates by removing ~Version part from StatefulSet label, as Kubernetes don't allow updates to any other fields but 'replicas', 'template', and 'updateStrategy',~ the `chart` and `heritage` labels from the`volumeClaimTemplates` which is immutable and therefore updating CouchDB service would be impossible. 

**Update:** To update from current state ~use `--force` flag (see https://docs.helm.sh/helm/helm_upgrade/ for details). This will cause `StatefulSet` recreation, therefore downtime, but as long as you use persistent storage, the data will be preserved.~ delete the CouchDB StatefulSet before upgrading:
 ```bash
$ kubectl delete statefulsets --cascade=false my-release-couchdb
```