### PR TITLE
[stable/moodle] Remove distro tag

### DIFF
--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,5 +1,5 @@
 name: moodle
-version: 3.2.0
+version: 3.2.1
 appVersion: 3.5.2
 description: Moodle is a learning platform designed to provide educators, administrators
   and learners with a single robust, secure and integrated system to create personalised

--- a/stable/moodle/values.yaml
+++ b/stable/moodle/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/moodle
-  tag: 3.5.2-debian-9
+  tag: 3.5.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

As part of the Debian 8 to 9 migration, we started using the "debian-9" tag.
At this moment, we should remove them and use the main version only.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
