### PR TITLE
[stable/wordpress] Remove distro tag

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 3.2.0
+version: 3.2.1
 appVersion: 4.9.8
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/values-production.yaml
+++ b/stable/wordpress/values-production.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 4.9.8-debian-9
+  tag: 4.9.8
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/stable/wordpress/values.yaml
+++ b/stable/wordpress/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 4.9.8-debian-9
+  tag: 4.9.8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

As part of the Debian 8 to 9 migration, we started using the "debian-9" tag.
At this moment, we should remove them and use the main version only.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
