### PR TITLE
[stable/phpbb] Remove distro tag

### DIFF
--- a/stable/phpbb/Chart.yaml
+++ b/stable/phpbb/Chart.yaml
@@ -1,5 +1,5 @@
 name: phpbb
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.2.3
 description: Community forum that supports the notion of users and groups, file attachments,
   full-text search, notifications and more.

--- a/stable/phpbb/values.yaml
+++ b/stable/phpbb/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/phpbb
-  tag: 3.2.3-debian-9
+  tag: 3.2.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

As part of the Debian 8 to 9 migration, we started using the "debian-9" tag.
At this moment, we should remove them and use the main version only.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
