### PR TITLE
[stable/phabricator] Remove distro tag

### DIFF
--- a/stable/phabricator/Chart.yaml
+++ b/stable/phabricator/Chart.yaml
@@ -1,5 +1,5 @@
 name: phabricator
-version: 3.2.0
+version: 3.2.1
 appVersion: 2018.40.0
 description: Collection of open source web applications that help software companies build better software.
 keywords:

--- a/stable/phabricator/values.yaml
+++ b/stable/phabricator/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/phabricator
-  tag: 2018.40.0-debian-9
+  tag: 2018.40.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

As part of the Debian 8 to 9 migration, we started using the "debian-9" tag.
At this moment, we should remove them and use the main version only.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
