### PR TITLE
[stable/opencart] Remove distro tag

### DIFF
--- a/stable/opencart/Chart.yaml
+++ b/stable/opencart/Chart.yaml
@@ -1,5 +1,5 @@
 name: opencart
-version: 3.1.0
+version: 3.1.1
 appVersion: 3.0.2-0
 description: A free and open source e-commerce platform for online merchants. It provides
   a professional and reliable foundation for a successful online store.

--- a/stable/opencart/values.yaml
+++ b/stable/opencart/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/opencart
-  tag: 3.0.2-0-debian-9
+  tag: 3.0.2-0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

As part of the Debian 8 to 9 migration, we started using the "debian-9" tag.
At this moment, we should remove them and use the main version only.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
