### PR TITLE
[stable/nats] Remove distro tag

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,5 +1,5 @@
 name: nats
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.3.0
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/nats
-  tag: 1.3.0-debian-9
+  tag: 1.3.0
   pullPolicy: Always
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/nats
-  tag: 1.3.0-debian-9
+  tag: 1.3.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

As part of the Debian 8 to 9 migration, we started using the "debian-9" tag.
At this moment, we should remove them and use the main version only.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
