### PR TITLE
[stable/odoo] Remove distro tag

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,5 +1,5 @@
 name: odoo
-version: 3.2.1
+version: 3.2.2
 appVersion: 11.0.20181015
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/values.yaml
+++ b/stable/odoo/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/odoo
-  tag: 11.0.20181015-debian-9
+  tag: 11.0.20181015
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

As part of the Debian 8 to 9 migration, we started using the "debian-9" tag.
At this moment, we should remove them and use the main version only.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
