### PR TITLE
[stable/ghost] Remove distro tag

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 5.3.2
+version: 5.3.3
 appVersion: 2.2.3
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/ghost
-  tag: 2.2.3-debian-9
+  tag: 2.2.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

As part of the Debian 8 to 9 migration, we started using the "debian-9" tag.
At this moment, we should remove them and use the main version only.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
