### PR TITLE
[stable/prometheus-mysql-exporter] values file missing quotes

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.2.0
+version: 0.2.1
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/values.yaml
+++ b/stable/prometheus-mysql-exporter/values.yaml
@@ -36,7 +36,7 @@ affinity: {}
 annotations:
   prometheus.io/scrape: "true"
   prometheus.io/path: "/metrics"
-  prometheus.io/port: 9104
+  prometheus.io/port: "9104"
 
 # mysql connection params which build the DATA_SOURCE_NAME env var of the docker container
 mysql:


### PR DESCRIPTION
#### What this PR does / why we need it:
The default values file for `stable/prometheus-mysql-exporter` causes a helm install error when not explicitly overriding the prometheus port number value with a quoted equivalent.
```
$> helm install . --name mysql-exporter

Error: release mysql-exporter failed: Deployment in version "v1beta2" cannot be handled as a Deployment: v1beta2.Deployment: Spec: v1beta2.DeploymentSpec: Template: v1.PodTemplateSpec: ObjectMeta: v1.ObjectMeta: Annotations: ReadString: expects " or n, but found 9, error found in #10 byte of ...|io/port":9104,"prome|..., bigger context ...|metheus.io/path":"/metrics","prometheus.io/port":9104,"prometheus.io/scrape":"true"},"labels":{"app"|...
```
#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped