### PR TITLE
nexus/clusterIP-headlessService

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.13.0
+version: 1.14.0
 appVersion: 3.13.0-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 
 | Parameter                                   | Description                         | Default                                 |
 | ------------------------------------------  | ----------------------------------  | ----------------------------------------|
+| `statefulset.enabled`                       | Use statefulset instead of deployment | `false` |
 | `replicaCount`                              | Number of Nexus service replicas    | `1`                                     |
 | `deploymentStrategy`                        | Deployment Strategy     |  `rollingUpdate` |
 | `nexus.imageName`                           | Nexus image                         | `quay.io/travelaudience/docker-nexus`   |
@@ -172,6 +173,10 @@ By default a PersistentVolumeClaim is created and mounted into the `/nexus-data`
 you can change the `values.yaml` to disable persistence which will use an `emptyDir` instead.
 
 > *"An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node. When a Pod is removed from a node for any reason, the data in the emptyDir is deleted forever."*
+
+
+You must enable StatefulSet (`statefulset.enabled=true`) for true data persistence. If using Deployment approach, you can not recover data after restart or delete of helm chart. Statefulset will make sure that it picks up the same old volume which was used by the previous life of the nexus pod, helping you recover your data. When enabling statefulset, its required to enable the persistence.
+
 
 ### Recommended settings
 

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -71,7 +71,8 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.resources`                           | Nexus resource requests and limits  | `{}`                                    |
 | `nexus.dockerPort`                          | Port to access docker               | `5003`                                  |
 | `nexus.nexusPort`                           | Internal port for Nexus service     | `8081`                                  |
-| `nexus.serviceType`                         | Service for Nexus                   | `NodePort`                              |
+| `nexus.service.type`                        | Service for Nexus                   |`NodePort`                                |
+| `nexus.service.clusterIp`                   | Specific cluster IP when service type is cluster IP. Use None for headless service |`nil`   |
 | `nexus.securityContext`                     | Security Context (for enabling official image use `fsGroup: 2000`) | `{}`     |
 | `nexus.labels`                              | Service labels                      | `{}`                                    |
 | `nexus.podAnnotations`                      | Pod Annotations                     | `{}`

--- a/stable/sonatype-nexus/templates/backup-pv.yaml
+++ b/stable/sonatype-nexus/templates/backup-pv.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.statefulset.enabled }}
 {{- if .Values.nexusBackup.persistence.pdName -}}
 apiVersion: v1
 kind: PersistentVolume
@@ -16,4 +17,5 @@ spec:
   gcePersistentDisk:
     pdName: {{ .Values.nexusBackup.persistence.pdName }}
     fsType: {{ .Values.nexusBackup.persistence.fsType }}
+{{- end }}
 {{- end }}

--- a/stable/sonatype-nexus/templates/backup-pvc.yaml
+++ b/stable/sonatype-nexus/templates/backup-pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.statefulset.enabled }}
 {{- if and .Values.nexusBackup.enabled (and .Values.nexusBackup.persistence.enabled (not .Values.nexusBackup.persistence.existingClaim)) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -23,4 +24,4 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-
+{{- end }}

--- a/stable/sonatype-nexus/templates/deployment-statefulset.yaml
+++ b/stable/sonatype-nexus/templates/deployment-statefulset.yaml
@@ -1,5 +1,10 @@
+{{- if .Values.statefulset.enabled }}
+apiVersion: apps/v1beta1
+kind: StatefulSet
+{{- else }}
 apiVersion: apps/v1beta2
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ template "nexus.fullname" . }}
   labels:
@@ -13,6 +18,13 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.statefulset.enabled }}
+  {{- if .Values.nexusProxy.svcName }}
+  serviceName: {{ .Values.nexusProxy.svcName }}
+  {{- else }}
+  serviceName: {{ template "nexus.fullname" . }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.deploymentStrategy }}
   strategy:
 {{ toYaml .Values.deploymentStrategy | indent 4 }}
@@ -84,9 +96,9 @@ spec:
             {{- end }}
           volumeMounts:
             - mountPath: /nexus-data
-              name: nexus-data
+              name: {{ template "nexus.fullname" . }}-data
             - mountPath: /nexus-data/backup
-              name: nexus-backup
+              name: {{ template "nexus.fullname" . }}-backup
             {{- if .Values.config.enabled }}
             - mountPath: {{ .Values.config.mountPath }}
               name: {{ template "nexus.name" . }}-conf
@@ -180,9 +192,9 @@ spec:
               value: .backup
           volumeMounts:
             - mountPath: /nexus-data
-              name: nexus-data
+              name: {{ template "nexus.fullname" . }}-data
             - mountPath: /nexus-data/backup
-              name: nexus-backup
+              name: {{ template "nexus.fullname" . }}-backup
         {{- end }}
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 8 }}
@@ -197,20 +209,32 @@ spec:
           secret:
             secretName: {{ template "nexus.proxy-ks.name" . }}
         {{- end }}
-        - name: nexus-data
+
+        {{- if .Values.statefulset.enabled }}
+        {{- if not .Values.persistence.enabled }}
+        - name: {{ template "nexus.fullname" . }}-data
+          emptyDir: {}
+        {{- end }}
+        {{- if not (and .Values.nexusBackup.enabled .Values.nexusBackup.persistence.enabled) }}
+        - name: {{ template "nexus.fullname" . }}-backup
+          emptyDir: {}
+        {{- end }}
+        {{- else }}
+        - name: {{ template "nexus.fullname" . }}-data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" (include "nexus.fullname" .) "data") }}
           {{- else }}
           emptyDir: {}
           {{- end }}
-        - name: nexus-backup
+        - name: {{ template "nexus.fullname" . }}-backup
           {{- if and .Values.nexusBackup.enabled (.Values.nexusBackup.persistence.enabled) }}
           persistentVolumeClaim:
             claimName: {{ .Values.nexusBackup.persistence.existingClaim | default (printf "%s-%s" (include "nexus.fullname" .) "backup") }}
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- if .Values.config.enabled }}
         - name: {{ template "nexus.name" . }}-conf
           configMap:
@@ -228,3 +252,56 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+
+
+## create pvc in case of statefulsets
+  {{- if .Values.statefulset.enabled }}
+  volumeClaimTemplates:
+    {{- if .Values.persistence.enabled }}
+    - metadata:
+        name: {{ template "nexus.fullname" . }}-data
+        labels:
+{{ include "nexus.labels" . | indent 10 }}
+        {{- if .Values.persistence.annotations }}
+        annotations:
+{{ toYaml .Values.persistence.annotations | indent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.storageSize | quote }}
+        {{- if .Values.persistence.storageClass }}
+        {{- if (eq "-" .Values.persistence.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ .Values.persistence.storageClass }}"
+        {{- end }}
+        {{- end }}
+    {{- end }}
+
+    {{- if and .Values.nexusBackup.enabled (.Values.nexusBackup.persistence.enabled) }}
+    - metadata:
+        name: {{ template "nexus.fullname" . }}-backup
+        labels:
+{{ include "nexus.labels" . | indent 10 }}
+        {{- if .Values.nexusBackup.persistence.annotations }}
+        annotations:
+{{ toYaml .Values.nexusBackup.persistence.annotations | indent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          - {{ .Values.nexusBackup.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.nexusBackup.persistence.storageSize | quote }}
+        {{- if .Values.nexusBackup.persistence.storageClass }}
+        {{- if (eq "-" .Values.nexusBackup.persistence.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ .Values.nexusBackup.persistence.storageClass }}"
+        {{- end }}
+        {{- end }}
+    {{- end }}
+  {{- end }}

--- a/stable/sonatype-nexus/templates/proxy-svc.yaml
+++ b/stable/sonatype-nexus/templates/proxy-svc.yaml
@@ -28,8 +28,6 @@ spec:
     app: {{ template "nexus.name" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.nexus.service.type }}
-  {{- if eq .Values.nexus.service.type "ClusterIP" }}
-  {{- if .Values.nexus.service.clusterIP }}
+  {{- if and (eq .Values.nexus.service.type "ClusterIP") .Values.nexus.service.clusterIP }}
   clusterIP: {{ .Values.nexus.service.clusterIP }}
-  {{- end }}
   {{- end }}

--- a/stable/sonatype-nexus/templates/proxy-svc.yaml
+++ b/stable/sonatype-nexus/templates/proxy-svc.yaml
@@ -27,4 +27,9 @@ spec:
   selector:
     app: {{ template "nexus.name" . }}
     release: {{ .Release.Name }}
-  type: {{ .Values.nexus.serviceType }}
+  type: {{ .Values.nexus.service.type }}
+  {{- if eq .Values.nexus.service.type "ClusterIP" }}
+  {{- if .Values.nexus.service.clusterIP }}
+  clusterIP: {{ .Values.nexus.service.clusterIP }}
+  {{- end }}
+  {{- end }}

--- a/stable/sonatype-nexus/templates/pv.yaml
+++ b/stable/sonatype-nexus/templates/pv.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.statefulset.enabled }}
 {{- if .Values.persistence.pdName -}}
 apiVersion: v1
 kind: PersistentVolume
@@ -16,4 +17,5 @@ spec:
   gcePersistentDisk:
     pdName: {{ .Values.persistence.pdName }}
     fsType: {{ .Values.persistence.fsType }}
+{{- end }}
 {{- end }}

--- a/stable/sonatype-nexus/templates/pvc.yaml
+++ b/stable/sonatype-nexus/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.statefulset.enabled }}
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -20,6 +21,7 @@ spec:
   storageClassName: ""
 {{- else }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -1,3 +1,5 @@
+statefulset:
+  enabled: false
 replicaCount: 1
 # By default deploymentStrategy is set to rollingUpdate with maxSurge of 25% and maxUnavailable of 25% . you can change type to `Recreate` or can uncomment `rollingUpdate` specification and adjust them to your usage.
 deploymentStrategy: {}

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -30,7 +30,9 @@ nexus:
   # The ports should only be changed if the nexus image uses a different port
   dockerPort: 5003
   nexusPort: 8081
-  serviceType: NodePort
+  service:
+    type: NodePort
+    # clusterIP: None
   # annotations: {}
   # labels: {}
   # securityContext:


### PR DESCRIPTION
support for clusterIP services with specific cluster IP or None for headless service.
support for statefulsets (while keeping backward compatibility with development)

Signed-off-by: Arvind Gupta <guptaarvindk@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

if ingress controller is used its better to use headless service behind ingress.

it doesn't make sense to use deployment with static pv/pvc. Every time helm chart is deleted or new deployment created it will use new volume resulting not able to really be persistence across failures/re-starts/re-installs. Better way is to use statefulsets so that volume is truly persistence across failures/re-starts/re-installs. Ideally we dont need Deployment, but for backward compatibility I have kept the deployment as well. User have choice to select one. I have kept deployment as default but StatefulSet should be preferred choice. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md