### PR TITLE
[stable/sonatype-nexus] Added Pod annotations for Nexus Helm Chart

### DIFF
--- a/stable/sonatype-nexus/Chart.yaml
+++ b/stable/sonatype-nexus/Chart.yaml
@@ -1,5 +1,5 @@
 name: sonatype-nexus
-version: 1.12.1
+version: 1.13.0
 appVersion: 3.13.0-01
 description: Sonatype Nexus is an open source repository manager
 keywords:

--- a/stable/sonatype-nexus/README.md
+++ b/stable/sonatype-nexus/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `nexus.serviceType`                         | Service for Nexus                   | `NodePort`                              |
 | `nexus.securityContext`                     | Security Context (for enabling official image use `fsGroup: 2000`) | `{}`     |
 | `nexus.labels`                              | Service labels                      | `{}`                                    |
+| `nexus.podAnnotations`                      | Pod Annotations                     | `{}`
 | `nexus.livenessProbe.initialDelaySeconds`   | LivenessProbe initial delay         | 30                                      |
 | `nexus.livenessProbe.periodSeconds`         | Seconds between polls               | 30                                      |
 | `nexus.livenessProbe.failureThreshold`      | Number of attempts before failure   | 6                                       |

--- a/stable/sonatype-nexus/templates/deployment.yaml
+++ b/stable/sonatype-nexus/templates/deployment.yaml
@@ -23,13 +23,17 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+    {{- if .Values.nexus.podAnnotations }}
+      annotations:
+{{ toYaml .Values.nexus.podAnnotations | indent 8}}
+    {{- end }}
       labels:
         app: {{ template "nexus.name" . }}
         release: {{ .Release.Name }}
     spec:
       {{- if .Values.deployment.initContainers }}
       initContainers:
-{{ toYaml .Values.deployment.initContainers | indent 6 }}      
+{{ toYaml .Values.deployment.initContainers | indent 6 }}
       {{- end }}
       {{- if .Values.nexus.nodeSelector }}
       nodeSelector:
@@ -181,7 +185,7 @@ spec:
               name: nexus-backup
         {{- end }}
         {{- if .Values.deployment.additionalContainers }}
-{{ toYaml .Values.deployment.additionalContainers | indent 8 }}      
+{{ toYaml .Values.deployment.additionalContainers | indent 8 }}
         {{- end }}
       {{- if .Values.nexus.securityContext }}
       securityContext:
@@ -218,7 +222,7 @@ spec:
             secretName: {{ template "nexus.name" . }}-secret
         {{- end }}
         {{- if .Values.deployment.additionalVolumes }}
-{{ toYaml .Values.deployment.additionalVolumes | indent 8 }}      
+{{ toYaml .Values.deployment.additionalVolumes | indent 8 }}
         {{- end }}
     {{- with .Values.tolerations }}
       tolerations:

--- a/stable/sonatype-nexus/values.yaml
+++ b/stable/sonatype-nexus/values.yaml
@@ -35,6 +35,7 @@ nexus:
   # labels: {}
   # securityContext:
   #   fsGroup: 2000
+  podAnnotations: {}
   livenessProbe:
     initialDelaySeconds: 30
     periodSeconds: 30


### PR DESCRIPTION
This PR added PodAnnotations, for example, it's useful if you are using  Kube2iam or Kiam, and you want to have S3 blob storage on AWS.