### PR TITLE
[stable/redis] Avoid generating null annotations

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.2.1
+version: 4.2.2
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/metrics-svc.yaml
+++ b/stable/redis/templates/metrics-svc.yaml
@@ -8,8 +8,10 @@ metadata:
     chart: {{ template "redis.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.metrics.service.annotations }}
   annotations:
 {{ toYaml .Values.metrics.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}
   {{ if eq .Values.metrics.service.type "LoadBalancer" -}} {{ if .Values.metrics.service.loadBalancerIP -}}

--- a/stable/redis/templates/redis-slave-svc.yaml
+++ b/stable/redis/templates/redis-slave-svc.yaml
@@ -8,8 +8,8 @@ metadata:
     chart: {{ template "redis.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
 {{- if .Values.slave.service.annotations }}
+  annotations:
 {{ toYaml .Values.slave.service.annotations | indent 4 }}
 {{- end }}
 spec:


### PR DESCRIPTION
#### What this PR does / why we need it:

Avoid errors like the following by not generating empty annotations.
```
warning: destination for annotations is a table. Ignoring non-table value <nil>
```

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
