### PR TITLE
[stable/datadog] makes container name configurable

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.5.1
+version: 1.5.2
 appVersion: 6.5.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `image.pullSecrets`         | Image pull secrets                 |  `nil`                                    |
 | `rbac.create`               | If true, create & use RBAC resources | `true`                                  |
 | `rbac.serviceAccount`       | existing ServiceAccount to use (ignored if rbac.create=true) | `default`       |
+| `datadog.name`              | Container name if Deamonset or Deployment | `datadog`                          |
 | `datadog.env`               | Additional Datadog environment variables | `nil`                               |
 | `datadog.logsEnabled`       | Enable log collection              | `nil`                                     |
 | `datadog.logsConfigContainerCollectAll` | Collect logs from all containers | `nil`                           |
@@ -80,6 +81,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `kube-state-metrics.rbac.serviceAccount` | existing ServiceAccount to use (ignored if rbac.create=true) for kube-state-metrics | `default` |
 | `clusterAgent.enabled`                   | Use the cluster-agent for cluster metrics (Kubernetes 1.10+ only) | `false`                           |
 | `clusterAgent.token`                     | A cluster-internal secret for agent-to-agent communication. Must be 32+ characters a-zA-Z | `Nil` You must provide your own token|
+| `clusterAgent.containerName`             | The container name for the Cluster Agent  | `cluster-agent`                           |
 | `clusterAgent.image.repository`          | The image repository for the cluster-agent | `datadog/cluster-agent`                           |
 | `clusterAgent.image.tag`                 | The image tag to pull              | `0.10.0`                                   |
 | `clusterAgent.image.pullPolicy`          | Image pull policy                  | `IfNotPresent`                            |

--- a/stable/datadog/templates/agent-deployment.yaml
+++ b/stable/datadog/templates/agent-deployment.yaml
@@ -24,7 +24,7 @@ spec:
 {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
       {{- end }}
       containers:
-      - name: {{ default .Chart.Name .Values.datadog.name }}
+      - name: {{ .Values.clusterAgent.containerName }}
         image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag }}"
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         resources:

--- a/stable/datadog/templates/agent-deployment.yaml
+++ b/stable/datadog/templates/agent-deployment.yaml
@@ -24,7 +24,7 @@ spec:
 {{ toYaml .Values.clusterAgent.image.pullSecrets | indent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
+      - name: {{ default .Chart.Name .Values.datadog.name }}
         image: "{{ .Values.clusterAgent.image.repository }}:{{ .Values.clusterAgent.image.tag }}"
         imagePullPolicy: {{ .Values.clusterAgent.image.pullPolicy }}
         resources:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
+      - name: {{ default .Chart.Name .Values.datadog.name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
+      - name: {{ default .Chart.Name .Values.datadog.name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -87,6 +87,7 @@ kubeStateMetrics:
 # the external metrics API so you can autoscale HPAs based on datadog
 # metrics
 clusterAgent:
+  containerName: cluster-agent
   image:
     repository: datadog/cluster-agent
     tag: 0.10.0
@@ -123,7 +124,8 @@ datadog:
   ## Use existing Secret which stores APP key instead of creating a new one
   # appKeyExistingSecret:
 
-  ## dd-agent container name
+  ## Daemonset/Deployment container name
+  ## See clusterAgent.containerName if clusterAgent.enabled = true
   ##
   name: datadog
 

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -125,7 +125,7 @@ datadog:
 
   ## dd-agent container name
   ##
-  name: dd-agent
+  name: datadog
 
   ## Set logging verbosity.
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables


### PR DESCRIPTION
#### What this PR does / why we need it:
The values.yaml already has `datadog.name` and is supposed to be the container name but is never used; always uses `.Chart.Name`. This PR should now make use of the value in `datadog.name` as the container name (`clusterAgent.containerName` if for the cluster-agent).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
