### PR TITLE
proper Jobs configuration in README.md for jenkins chart

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.19.1
+version: 0.19.2
 appVersion: 2.121.3
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -218,7 +218,7 @@ Below is an example of a `values.yaml` file and the directory structure created:
 #### values.yaml
 ```yaml
 Master:
-  Jobs:
+  Jobs: |-
     test-job: |-
       <?xml version='1.0' encoding='UTF-8'?>
       <project>


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR fix missing fragment `|-` in example in README.md for configuring jenkins Master.Jobs. Proper fragment was already included in `stable/jenkins/values.yaml`. Configuration without `|-` leads to exception like this:
```bash
Error: UPGRADE FAILED: render error in "jenkins/templates/jobs.yaml": template: jenkins/templates/jobs.yaml:7:32: executing "jenkins/templates/jobs.yaml" at <2>: wrong type for value; expected string; got map[string]interface {}```