### PR TITLE
[stable/postgresql] Allow extra environment variables

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 1.0.0
+version: 1.0.1
 appVersion: 9.6.2
 description: Object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/deployment.yaml
+++ b/stable/postgresql/templates/deployment.yaml
@@ -85,6 +85,11 @@ spec:
               name: {{ template "postgresql.secretName" . }}
               key: postgres-password
         {{- end }}
+        {{- if .Values.env }}
+        {{- with .Values.env }}
+        {{- toYaml . | indent 8 }}
+        {{- end }}
+        {{- end }}
         - name: POD_IP
           valueFrom: { fieldRef: { fieldPath: status.podIP } }
 {{- if .Values.extraEnv }}

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -60,6 +60,12 @@ usePasswordFile: false
 #   host all all localhost trust
 #   host mydatabase mysuser 192.168.0.0/24 md5
 
+## Specify content for extra env variables to be passed to the deployment
+## Default: no additional variables
+## env: 
+##   - name: EXTRA_VAR_1
+##     value: SomeNewValue
+
 ## Persist data to a persistent volume
 persistence:
   enabled: true

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -62,7 +62,7 @@ usePasswordFile: false
 
 ## Specify content for extra env variables to be passed to the deployment
 ## Default: no additional variables
-## env: 
+## env:
 ##   - name: EXTRA_VAR_1
 ##     value: SomeNewValue
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows extra variables to be specified in values.yaml to configure the PostgreSQL image.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
