### PR TITLE
[stable/superset] support service annotations, use correct healthcheck

### DIFF
--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,6 +1,6 @@
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.24.0"
 keywords:
 - bi

--- a/stable/superset/Chart.yaml
+++ b/stable/superset/Chart.yaml
@@ -1,6 +1,6 @@
 description: Apache Superset (incubating) is a modern, enterprise-ready business intelligence web application
 name: superset
-version: 0.1.3
+version: 1.0.0
 appVersion: "0.24.0"
 keywords:
 - bi

--- a/stable/superset/templates/svc.yaml
+++ b/stable/superset/templates/svc.yaml
@@ -7,13 +7,40 @@ metadata:
     chart: {{ template "superset.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
   selector:
     app: {{ template "superset.name" . }}
     release: {{ .Release.Name }}

--- a/stable/superset/values.yaml
+++ b/stable/superset/values.yaml
@@ -96,6 +96,16 @@ service:
   type: ClusterIP
   port: 9000
 
+  ## service annotations
+  annotations: {}
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    # external-dns.alpha.kubernetes.io/hostname: "superset.domain.com"
+
+  ## loadbalancer source ranges. only used when service.type is "LoadBalancer"
+  loadBalancerSourceRanges: []
+  # - 172.31.0.0/16
+
+
 ingress:
   ## If true, superset Ingress will be created
   ##
@@ -155,7 +165,7 @@ resources: {}
 ##
 livenessProbe:
   httpGet:
-    path: /
+    path: /health
     port: http
   initialDelaySeconds: 80
   timeoutSeconds: 5
@@ -163,7 +173,7 @@ livenessProbe:
   failureThreshold: 2
 readinessProbe:
   httpGet:
-    path: /
+    path: /health
     port: http
   initialDelaySeconds: 60
   timeoutSeconds: 5


### PR DESCRIPTION
@alitari 

#### What this PR does / why we need it:
* Adds annotations to the service. E.g. this enables users to automatically configure cloud loadbalancers or assign domain names. I mostly copied this from the grafana chart which enables a lot of settings on the service.
* uses the health check that (later?) superset versions provide for liveness and readinessProbes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (explained in values.yaml)
