### PR TITLE
[stable/hlf-ord] Define Kafka as a dependency

### DIFF
--- a/stable/hlf-ord/Chart.yaml
+++ b/stable/hlf-ord/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Orderer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-ord
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.2.0
 keywords:
   - blockchain

--- a/stable/hlf-ord/requirements.lock
+++ b/stable/hlf-ord/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kafka
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 0.11.1
+digest: sha256:5c568dcef56106cb5bec70e2fae54a6868438114cf601b99a17dbf3c852e90f0
+generated: 2018-10-20T09:30:04.742713341-04:00

--- a/stable/hlf-ord/requirements.yaml
+++ b/stable/hlf-ord/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+  - name: kafka
+    version: ^0.11.1
+    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    condition: kafka.enabled

--- a/stable/hlf-ord/values.yaml
+++ b/stable/hlf-ord/values.yaml
@@ -1,7 +1,9 @@
+# ------------------------------------------------------------------------------
+# Fabric Orderer
+# ------------------------------------------------------------------------------
 ## Default values for hlf-ord.
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
-
 image:
   repository: hyperledger/fabric-orderer
   tag: 1.2.0
@@ -78,3 +80,62 @@ affinity: {}
   #       labelSelector:
   #         matchLabels:
   #           app: hlf-ord
+
+# ------------------------------------------------------------------------------
+# Kafka:
+# ref: https://github.com/helm/charts/blob/master/incubator/kafka/values.yaml
+# ------------------------------------------------------------------------------
+kafka:
+  enabled: false
+  # Minimum number of nodes necessary in order to exhibit crash fault tolerance
+  # With 4 brokers, you can have 1 broker go down, all channels will continue to be writeable and readable, and new channels can be created.)
+  # ref: https://hyperledger-fabric.readthedocs.io/en/release-1.1/kafka.html?highlight=orderer#bringing-up-a-kafka-based-ordering-service
+  replicas: 4
+
+  ## Configuration Overrides. Specify any Kafka settings you would like set on the StatefulSet
+  ## here in map format, as defined in the official docs.
+  ## ref: https://kafka.apache.org/documentation/#brokerconfigs
+  ##
+  configurationOverrides:
+    "offsets.topic.replication.factor": 3
+    # "auto.leader.rebalance.enable": true
+    # "controlled.shutdown.enable": true
+    # "controlled.shutdown.max.retries": 100
+    "auto.create.topics.enable": true  # Useful to enable the Node.js client to create topics as required
+
+    # NOTE: The below are required for Hyperledger Fabric orderer to work (but last one is problematic for normal setups - best to keep separate Kafka clusters for logs/HLF)
+    "default.replication.factor": 3
+    "unclean.leader.election.enable": false
+    "min.insync.replicas": 2
+    "message.max.bytes": "103809024"  # 99 * 1024 * 1024 B
+    "replica.fetch.max.bytes": "103809024"  # 99 * 1024 * 1024 B
+    "log.retention.ms": -1  # This should be only used for the HL Fabric Orderer (which needs to keep all logs)
+
+  ## Pod scheduling preferences (by default keep pods within a release on separate nodes).
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## By default we don't set affinity
+  affinity: {}
+  ## Alternatively, this typical example defines:
+  ## antiAffinity (to keep Kafka pods on separate pods)
+  ## and affinity (to encourage Kafka pods to be collocated with Zookeeper pods)
+  # affinity:
+  #   podAntiAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #     - labelSelector:
+  #         matchExpressions:
+  #         - key: app
+  #           operator: In
+  #           values:
+  #           - kafka
+  #       topologyKey: "kubernetes.io/hostname"
+  #   podAffinity:
+  #     preferredDuringSchedulingIgnoredDuringExecution:
+  #      - weight: 50
+  #        podAffinityTerm:
+  #          labelSelector:
+  #            matchExpressions:
+  #            - key: app
+  #              operator: In
+  #              values:
+  #                - zookeeper
+  #          topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
#### What this PR does / why we need it:

In the currently available releases, Fabric offers a CFT ordering service implemented with Kafka and Zookeeper. 

The `hlf-ord` chart does not define Kafka as a dependency, so to run a Fabric orderer using Kafka (production), it has to be installed independently.

#### Which issue this PR fixes

This PR define an Helm dependency to bring Kafka, and define a [default configuration](https://hyperledger-fabric.readthedocs.io/en/release-1.2/kafka.html?highlight=kafka) to run with Fabric

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
