### PR TITLE
[incubator/elasticsearch] Pre-stop-hook and post-start-hook drain scripts are now optional

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.12.0
+version: 1.13.0
 appVersion: 6.4.2
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -110,6 +110,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.resources`                     | Data node resources requests & limits                               | `{} - cpu limit must be an integer`                 |
 | `data.priorityClassName`             | Data priorityClass                                                  | `nil`                                               |
 | `data.heapSize`                      | Data node heap size                                                 | `1536m`                                             |
+| `data.hooks.drain.enabled            | Data nodes: Enable drain pre-stop and post-start hook               | `true`                                              |
 | `data.persistence.enabled`           | Data persistent enabled/disabled                                    | `true`                                              |
 | `data.persistence.name`              | Data statefulset PVC template name                                  | `data`                                              |
 | `data.persistence.size`              | Data persistent volume size                                         | `30Gi`                                              |

--- a/stable/elasticsearch/templates/configmap.yaml
+++ b/stable/elasticsearch/templates/configmap.yaml
@@ -119,6 +119,7 @@ data:
     logger.searchguard.name = com.floragunn
     logger.searchguard.level = info
 {{- end }}
+{{- if .Values.data.hooks.drain.enabled }}
   pre-stop-hook.sh: |-
     #!/bin/bash
     exec &> >(tee -a "/var/log/elasticsearch-hooks.log")
@@ -155,3 +156,4 @@ data:
       }"
     fi
     echo "Node ${NODE_NAME} is ready to be used"
+{{- end }}

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -138,18 +138,19 @@ spec:
           name: config
           subPath: log4j2.properties
 {{- end }}
-        - name: config
-          mountPath: /pre-stop-hook.sh
-          subPath: pre-stop-hook.sh
-        - name: config
-          mountPath: /post-start-hook.sh
-          subPath: post-start-hook.sh
 {{- if .Values.cluster.keystoreSecret }}
         - name: keystore
           mountPath: "/usr/share/elasticsearch/config/elasticsearch.keystore"
           subPath: elasticsearch.keystore
           readOnly: true
 {{- end }}
+{{- if .Values.data.hooks.drain.enabled }}
+        - name: config
+          mountPath: /pre-stop-hook.sh
+          subPath: pre-stop-hook.sh
+        - name: config
+          mountPath: /post-start-hook.sh
+          subPath: post-start-hook.sh
         lifecycle:
           preStop:
             exec:
@@ -157,6 +158,7 @@ spec:
           postStart:
             exec:
               command: ["/bin/bash","/post-start-hook.sh"]
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.data.terminationGracePeriodSeconds }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -148,6 +148,9 @@ data:
     maxUnavailable: 1
   updateStrategy:
     type: OnDelete
+  hooks:  # post-start and pre-stop hooks
+    drain:  # drain the node before stopping it and re-integrate it into the cluster after start
+      enabled: true
 
 ## Additional init containers
 extraInitContainers: |


### PR DESCRIPTION
#### What this PR does / why we need it:
Pre-stop-hook and post-start-hook drain scripts are now optional
We don't need to always drain a data node that is restarting.

#### Which issue this PR fixes
  - fixes #8618 

#### Special notes for your reviewer:
  - Enabled by default for backward compatibility

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
