### PR TITLE
[incubator/elassandra] Add an elassandra chart

### DIFF
--- a/incubator/elassandra/.helmignore
+++ b/incubator/elassandra/.helmignore
@@ -1,0 +1,16 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/elassandra/Chart.yaml
+++ b/incubator/elassandra/Chart.yaml
@@ -1,6 +1,6 @@
 name: elassandra
 version: 1.0.0
-appVersion: 6.2.3.8
+appVersion: 6.2.3.9
 description: Elassandra is a fork of Elasticsearch modified to run on top of Apache Cassandra in a scalable and
   resilient peer-to-peer architecture. Elasticsearch code is embedded in Cassanda nodes providing advanced
   search features on Cassandra tables and Cassandra serve as an Elasticsearch data and configuration store.

--- a/incubator/elassandra/Chart.yaml
+++ b/incubator/elassandra/Chart.yaml
@@ -1,0 +1,20 @@
+name: elassandra
+version: 0.1
+appVersion: 6.2.3.7
+description: Elassandra is a fork of Elasticsearch modified to run on top of Apache Cassandra in a scalable and 
+  resilient peer-to-peer architecture. Elasticsearch code is embedded in Cassanda nodes providing advanced 
+  search features on Cassandra tables and Cassandra serve as an Elasticsearch data and configuration store. 
+icon: https://github.com/strapdata/elassandra.io/blob/gh-pages/elassandra.svg
+keywords:
+- cassandra
+- elasticsearch
+- elassandra
+- database
+- nosql
+home: http://www.elassandra.io
+maintainers:
+- name: Vincent Royer
+  email: vroyer@strapdata.com
+- name: Barthelemy Delemotte
+  email: barth@strapdata.com
+engine: gotpl

--- a/incubator/elassandra/Chart.yaml
+++ b/incubator/elassandra/Chart.yaml
@@ -1,6 +1,6 @@
 name: elassandra
 version: 1.0.0
-appVersion: 6.2.3.7
+appVersion: 6.2.3.8
 description: Elassandra is a fork of Elasticsearch modified to run on top of Apache Cassandra in a scalable and
   resilient peer-to-peer architecture. Elasticsearch code is embedded in Cassanda nodes providing advanced
   search features on Cassandra tables and Cassandra serve as an Elasticsearch data and configuration store.

--- a/incubator/elassandra/Chart.yaml
+++ b/incubator/elassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: elassandra
-version: 0.1
+version: 1.0.0
 appVersion: 6.2.3.7
 description: Elassandra is a fork of Elasticsearch modified to run on top of Apache Cassandra in a scalable and 
   resilient peer-to-peer architecture. Elasticsearch code is embedded in Cassanda nodes providing advanced 

--- a/incubator/elassandra/Chart.yaml
+++ b/incubator/elassandra/Chart.yaml
@@ -1,9 +1,9 @@
 name: elassandra
 version: 1.0.0
 appVersion: 6.2.3.7
-description: Elassandra is a fork of Elasticsearch modified to run on top of Apache Cassandra in a scalable and 
-  resilient peer-to-peer architecture. Elasticsearch code is embedded in Cassanda nodes providing advanced 
-  search features on Cassandra tables and Cassandra serve as an Elasticsearch data and configuration store. 
+description: Elassandra is a fork of Elasticsearch modified to run on top of Apache Cassandra in a scalable and
+  resilient peer-to-peer architecture. Elasticsearch code is embedded in Cassanda nodes providing advanced
+  search features on Cassandra tables and Cassandra serve as an Elasticsearch data and configuration store.
 icon: https://github.com/strapdata/elassandra.io/blob/gh-pages/elassandra.svg
 keywords:
 - cassandra
@@ -13,8 +13,8 @@ keywords:
 - nosql
 home: http://www.elassandra.io
 maintainers:
-- name: Vincent Royer
+- name: vroyer
   email: vroyer@strapdata.com
-- name: Barthelemy Delemotte
+- name: DBarthe
   email: barth@strapdata.com
 engine: gotpl

--- a/incubator/elassandra/OWNERS
+++ b/incubator/elassandra/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- vincent-royer
+- barthelemy-delemotte
+reviewers:
+- vincent-royer
+- barthelemy-delemotte

--- a/incubator/elassandra/OWNERS
+++ b/incubator/elassandra/OWNERS
@@ -1,6 +1,6 @@
 approvers:
-- vincent-royer
-- barthelemy-delemotte
+- vroyer
+- DBarthe
 reviewers:
-- vincent-royer
-- barthelemy-delemotte
+- vroyer
+- DBarthe

--- a/incubator/elassandra/README.md
+++ b/incubator/elassandra/README.md
@@ -1,0 +1,226 @@
+# Elassandra
+
+An [Elassandra](http://www.elassandra.io) Chart for Kubernetes.
+
+## Install Chart
+
+To install the Elassandra Chart into your Kubernetes cluster (This Chart requires persistent volume by default, you may need to create a storage class before install chart. To create storage class, see Persist data section)
+
+```bash
+helm install --namespace "default" -n "elassandra" incubator/elassandra
+```
+
+After installation succeeds, you can get a status of Chart
+
+```bash
+helm status "elassandra"
+```
+
+As show below, the Elassandra chart creates 2 clustered service for elasticsearch and cassandra. This allow to deploy elasticsearch and cassandra applications in their default configuration.
+
+```bash
+kubectl get all -o wide -n elassandra
+NAME                          READY     STATUS    RESTARTS   AGE
+pod/elassandra-0              1/1       Running   0          51m
+pod/elassandra-1              1/1       Running   0          50m
+pod/elassandra-2              1/1       Running   0          49m
+
+NAME                    TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                                                          AGE
+service/cassandra       ClusterIP   10.0.174.13    <none>        9042/TCP,9160/TCP                                                51m
+service/elassandra      ClusterIP   None           <none>        7199/TCP,7000/TCP,7001/TCP,9300/TCP,9042/TCP,9160/TCP,9200/TCP   51m
+service/elasticsearch   ClusterIP   10.0.131.15    <none>        9200/TCP                                                         51m
+
+NAME                          DESIRED   CURRENT   AGE
+statefulset.apps/elassandra   3         3         51m
+```
+
+If you want to delete your Chart, use this command
+
+```bash
+helm delete  --purge "elassandra"
+```
+
+## Enable/Disable elasticsearch
+
+You can enable/disable the elasticsearch service by setting the following values in `values.yaml`
+
+```yaml
+elasticsearch:
+  enabled: true
+```
+
+## Persist data
+You need to create `StorageClass` before able to persist data in persistent volume.
+To create a `StorageClass` on Google Cloud, run the following
+
+```bash
+kubectl create -f sample/create-storage-gce.yaml
+```
+
+And set the following values in `values.yaml`
+
+```yaml
+persistence:
+  enabled: true
+```
+
+If you want to create a `StorageClass` on other platform, please see documentation here [https://kubernetes.io/docs/user-guide/persistent-volumes/](https://kubernetes.io/docs/user-guide/persistent-volumes/)
+
+If you want to use SSD managed disk on Microsoft Azure, set `persistence.storageClassName: "managed-premium"` in `values.yaml`.
+
+When running a cluster without persistence, the termination of a pod will first initiate a decommissioning of that pod.
+Depending on the amount of data stored inside the cluster this may take a while. In order to complete a graceful
+termination, pods need to get more time for it. Set the following values in `values.yaml`:
+
+```yaml
+podSettings:
+  terminationGracePeriodSeconds: 1800
+```
+
+## Install Chart with specific cluster size
+By default, this Chart will create an elassandra with 3 nodes. If you want to change the cluster size during installation, you can use `--set config.cluster_size={value}` argument. Or edit `values.yaml`
+
+For example:
+Set cluster size to 5
+
+```bash
+helm install --namespace "elassandra" -n "elassandra" --set config.cluster_size=5 incubator/elassandra/
+```
+
+## Install Chart with specific resource size
+
+By default, this Chart will create a cassandra with CPU 2 vCPU and 4Gi of memory which is suitable for development environment.
+If you want to use this Chart for production, I would recommend to update the CPU to 4 vCPU and 16Gi. Also increase size of `max_heap_size` and `heap_new_size`.
+To update the settings, edit `values.yaml`
+
+## Configuration
+
+The following table lists the configurable parameters of the Cassandra chart and their default values.
+
+| Parameter                  | Description                                     | Default                                                    |
+| -----------------------    | ---------------------------------------------   | ---------------------------------------------------------- |
+| `image.repo`                         | `elassandra` image repository                   | `strapdata/elassandra`                                    |
+| `image.tag`                          | `elassandra` image tag                          | `6.2.3.7`                                                  |
+| `image.pullPolicy`                   | Image pull policy                               | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `image.pullSecrets`                  | Image pull secrets                              | `nil`                                                      |
+| `elasticsearch.enabled`              | Enable elasticsearch service                    | `true`                                                     |
+| `config.cluster_name`                | The name of the cluster.                        | `elassandra`                                               |
+| `config.cluster_size`                | The number of nodes in the cluster.             | `3`                                                        |
+| `config.seed_size`                   | The number of seed nodes used to bootstrap new clients joining the cluster.                            | `2` |
+| `config.num_tokens`                  | Initdb Arguments                                | `16`                                                       |
+| `config.dc_name`                     | Initdb Arguments                                | `DC1`                                                      |
+| `config.rack_name`                   | Initdb Arguments                                | `RAC1`                                                     |
+| `config.endpoint_snitch`             | Initdb Arguments                                | `GossipingPropertyFileSnitch`                              |
+| `config.max_heap_size`               | Initdb Arguments                                | `4096M`                                                    |
+| `config.heap_new_size`               | Initdb Arguments                                | `512M`                                                     |
+| `config.ports.cql`                   | Initdb Arguments                                | `9042`                                                     |
+| `config.ports.thrift`                | Initdb Arguments                                | `9160`                                                     |
+| `config.ports.elasticsearch`         | Initdb Arguments                                | `9200`                                                     |
+| `config.ports.transport`             | Initdb Arguments                                | `9300`                                                     |
+| `config.ports.agent`                 | The port of the JVM Agent (if any)              | `nil`                                                      |
+| `config.start_rpc`                   | Initdb Arguments                                | `false`                                                    |
+| `persistence.enabled`                | Use a PVC to persist data                       | `true`                                                     |
+| `persistence.storageClass`           | Storage class of backing PVC                    | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`             | Use volume as ReadOnly or ReadWrite             | `ReadWriteOnce`                                            |
+| `persistence.size`                   | Size of data volume                             | `10Gi`                                                     |
+| `resources`                          | CPU/Memory resource requests/limits             | Memory: `4Gi`, CPU: `2`                                    |
+| `podManagementPolicy`                | podManagementPolicy of the StatefulSet          | `OrderedReady`                                             |
+| `updateStrategy.type`                | UpdateStrategy of the StatefulSet               | `RollingUpdate`                                            |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated        | `30`                                                       |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                  | `5`                                                       |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                        | `5`                                                        |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `10` |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated       | `30`                                                       |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                  | `5`                                                       |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                        | `5`                                                        |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed.           | `1` |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.             | `10` |
+
+### Scale elassandra
+When you want to change the cluster size of your cassandra, you can use the helm upgrade command.
+
+```bash
+helm upgrade --set config.cluster_size=5 elassandra incubator/elassandra
+```
+
+### Switch form Elassandra / Cassandra
+You can switch from Elassandra (Elasticsearch enabled) to pure Cassandra (Elasticsearch disabled) by setting the `elasticsearch.enabled` to `true` or `false`, this change java main class. 
+
+**WARNING**: As soon as you have created one elasticsearch index in your elassandra cluster, the CQL schema requires that all nodes runs the elassandra binaries. Running a node with standard cassandra binaries will causes a *ClassNotFounException* when trying to instanciate the elasticsearch custom secondary index.
+
+### Get elassandra status
+
+You can get your elassandra cluster status by running the command
+
+```bash
+kubectl exec -it --namespace elassandra $(kubectl get pods --namespace elassandra -l app=elassandra-elassandra -o jsonpath='{.items[0].metadata.name}') nodetool status
+```
+
+Output
+```bash
+Datacenter: asia-east1
+======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address    Load       Tokens       Owns (effective)  Host ID                               Rack
+UN  10.8.1.11  108.45 KiB  256          66.1%             410cc9da-8993-4dc2-9026-1dd381874c54  a
+UN  10.8.4.12  84.08 KiB  256          68.7%             96e159e1-ef94-406e-a0be-e58fbd32a830  c
+UN  10.8.3.6   103.07 KiB  256          65.2%             1a42b953-8728-4139-b070-b855b8fff326  b
+```
+To check the elasticsearch cluster status:
+
+```bash
+kubectl exec -it -n elassandra $(kubectl get pods -n elassandra -l app=elassandra,release=elassandra -o jsonpath='{.items[0].metadata.name}') curl http://localhost:9200/_cluster/state?pretty
+```
+
+To check elasticsearch nodes status:
+
+```bash
+kubectl exec -it -n elassandra $(kubectl get pods -n elassandra -l app=elassandra,release=elassandra -o jsonpath='{.items[0].metadata.name}') curl http://localhost:9200/_cat/nodes
+```
+
+To check Elasticsearch indices:
+
+```bash
+kubectl exec -it -n elassandra $(kubectl get pods -n elassandra -l app=elassandra,release=elassandra -o jsonpath='{.items[0].metadata.name}') curl http://localhost:9200/_cat/indices?v
+health status index uuid                   pri rep docs.count docs.deleted store.size pri.store.size
+green  open   test  kVpEHykCR7CT_Xnlastq7A   3   0          1            0      3.5kb          3.5kb
+```
+
+## Deploy Kibana
+
+To install the Kibana chart with the release name `elassandra`:
+
+```console
+$ helm install --namespace "elassandra" --name kibana --set image.tag=6.2.3  stable/kibana
+```
+
+To forward the kibana port to POD localhost:5601 run the following:
+
+```console
+kubectl port-forward -n elassandra $(kubectl get pods -n elassandra -l app=kibana -o jsonpath='{ .items[0].metadata.name }') 5601:5601
+```
+
+## Benchmark
+You can use [cassandra-stress](https://docs.datastax.com/en/cassandra/3.0/cassandra/tools/toolsCStress.html) tool to run the benchmark on the cluster by the following command
+
+```bash
+kubectl exec -it --namespace elassandra $(kubectl get pods --namespace elassandra -l app=elassandra-elassandra -o jsonpath='{.items[0].metadata.name}') cassandra-stress
+```
+
+Example of `cassandra-stress` argument
+ - Run both read and write with ration 9:1
+ - Operator total 1 million keys with uniform distribution
+ - Use QUORUM for read/write
+ - Generate 50 threads
+ - Generate result in graph
+ - Use NetworkTopologyStrategy with replica factor 2
+
+```bash
+cassandra-stress mixed ratio\(write=1,read=9\) n=1000000 cl=QUORUM -pop dist=UNIFORM\(1..1000000\) -mode native cql3 -rate threads=50 -log file=~/mixed_autorate_r9w1_1M.log -graph file=test2.html title=test revision=test2 -schema "replication(strategy=NetworkTopologyStrategy, factor=2)"
+```
+
+## Acknowledgment
+
+This HELM chart is largely based from the [cassandra charts](https://github.com/strapdata/charts/tree/master/incubator/cassandra) maintained by **KongZ**.

--- a/incubator/elassandra/README.md
+++ b/incubator/elassandra/README.md
@@ -16,7 +16,7 @@ After installation succeeds, you can get a status of Chart
 helm status "elassandra"
 ```
 
-As show below, the Elassandra chart creates 2 clustered service for elasticsearch and cassandra. This allow to deploy elasticsearch and cassandra applications in their default configuration.
+As show below, the Elassandra chart creates 2 clustered service for elasticsearch and cassandra.
 
 ```bash
 kubectl get all -o wide -n elassandra
@@ -25,10 +25,10 @@ pod/elassandra-0              1/1       Running   0          51m
 pod/elassandra-1              1/1       Running   0          50m
 pod/elassandra-2              1/1       Running   0          49m
 
-NAME                    TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                                                          AGE
-service/cassandra       ClusterIP   10.0.174.13    <none>        9042/TCP,9160/TCP                                                51m
-service/elassandra      ClusterIP   None           <none>        7199/TCP,7000/TCP,7001/TCP,9300/TCP,9042/TCP,9160/TCP,9200/TCP   51m
-service/elasticsearch   ClusterIP   10.0.131.15    <none>        9200/TCP                                                         51m
+NAME                               TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                                                          AGE
+service/elassandra                 ClusterIP   None           <none>        7199/TCP,7000/TCP,7001/TCP,9300/TCP,9042/TCP,9160/TCP,9200/TCP   51m
+service/elassandra-cassandra       ClusterIP   10.0.174.13    <none>        9042/TCP,9160/TCP                                                51m
+service/elassandra-elasticsearch   ClusterIP   10.0.131.15    <none>        9200/TCP                                                         51m
 
 NAME                          DESIRED   CURRENT   AGE
 statefulset.apps/elassandra   3         3         51m
@@ -106,7 +106,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `elasticsearch.enabled`              | Enable elasticsearch service                    | `true`                                                     |
 | `config.cluster_name`                | The name of the cluster.                        | `elassandra`                                               |
 | `config.cluster_size`                | The number of nodes in the cluster.             | `3`                                                        |
-| `config.seed_size`                   | The number of seed nodes used to bootstrap new clients joining the cluster.                            | `2` |
+| `config.seed_size`                   | The number of seed nodes used to bootstrap new clients joining the cluster.                            | `1` |
 | `config.num_tokens`                  | Initdb Arguments                                | `16`                                                       |
 | `config.dc_name`                     | Initdb Arguments                                | `DC1`                                                      |
 | `config.rack_name`                   | Initdb Arguments                                | `RAC1`                                                     |
@@ -193,7 +193,7 @@ green  open   test  kVpEHykCR7CT_Xnlastq7A   3   0          1            0      
 To install the Kibana chart with the release name `elassandra`:
 
 ```console
-$ helm install --namespace "elassandra" --name kibana --set image.tag=6.2.3  stable/kibana
+$ helm install --namespace "elassandra" --name kibana --set image.tag=6.2.3 --set env.ELASTICSEARCH_URL="http://elassandra-elasticsearch:9200" stable/kibana
 ```
 
 To forward the kibana port to POD localhost:5601 run the following:

--- a/incubator/elassandra/sample/create-storage-gce.yaml
+++ b/incubator/elassandra/sample/create-storage-gce.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: generic
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/incubator/elassandra/templates/NOTES.txt
+++ b/incubator/elassandra/templates/NOTES.txt
@@ -1,0 +1,27 @@
+Elassandra can be accessed through CQL ({{ .Values.config.ports.cql }}/tcp) and HTTP Elasticsearch (9200/tcp) on the clustered services cassandra and elasticsearch or on each node {{ template "elassandra.fullname" . }}-<index>.
+
+Check your cassandra cluster status:
+kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "elassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{.items[0].metadata.name}') -- nodetool status
+
+Check your Elasticsearch cluster status, nodes or indices:
+kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "elassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{.items[0].metadata.name}') -- curl http://localhost:9200/_cluster/state?pretty
+kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "elassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{.items[0].metadata.name}') -- curl http://localhost:9200/_cat/nodes
+kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "elassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{.items[0].metadata.name}') -- curl http://localhost:9200/_cat/indices?v
+
+To index a JSON document in Elassandra, run:
+kubectl exec -it -n elassandra $(kubectl get pods -n elassandra -l app=elassandra,release=elassandra -o jsonpath='{.items[0].metadata.name}') -- curl -XPUT -H "Content-Type: application/json" http://localhost:9200/test/mytype/1 -d '{ "foo":"bar" }'
+
+If you want to connect to the Cassandra CQL run the following:
+kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l "app={{ template "elassandra.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}") -- cqlsh
+
+Elassandra pod logs:
+kubectl logs -f -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "elassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{ .items[0].metadata.name }')
+
+To forward the API port to localhost:9042 run the following:
+- kubectl port-forward -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "elassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{ .items[0].metadata.name }') 9042:{{ .Values.config.ports.cql }}
+
+{{- if not .Values.persistence.enabled }}
+Note that the cluster is running with node-local storage instead of PersistentVolumes. In order to prevent data loss,
+pods will be decommissioned upon termination. Decommissioning may take some time, so you might also want to adjust the
+pod termination gace period, which is currently set to {{ .Values.podSettings.terminationGracePeriodSeconds }} seconds.
+{{- end}}

--- a/incubator/elassandra/templates/NOTES.txt
+++ b/incubator/elassandra/templates/NOTES.txt
@@ -9,7 +9,7 @@ kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.N
 kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "elassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{.items[0].metadata.name}') -- curl http://localhost:9200/_cat/indices?v
 
 To index a JSON document in Elassandra, run:
-kubectl exec -it -n elassandra $(kubectl get pods -n elassandra -l app=elassandra,release=elassandra -o jsonpath='{.items[0].metadata.name}') -- curl -XPUT -H "Content-Type: application/json" http://localhost:9200/test/mytype/1 -d '{ "foo":"bar" }'
+kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l app={{ template "elassandra.name" . }},release={{ .Release.Name }} -o jsonpath='{.items[0].metadata.name}') -- curl -XPUT -H "Content-Type: application/json" http://localhost:9200/test/mytype/1 -d '{ "foo":"bar" }'
 
 If you want to connect to the Cassandra CQL run the following:
 kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -l "app={{ template "elassandra.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}") -- cqlsh

--- a/incubator/elassandra/templates/_helpers.tpl
+++ b/incubator/elassandra/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elassandra.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "elassandra.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "elassandra.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/elassandra/templates/service-cassandra.yaml
+++ b/incubator/elassandra/templates/service-cassandra.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "cassandra"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "elassandra.name" . }}
+    chart: {{ template "elassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: cql
+    port: {{ default 9042 .Values.config.ports.cql }}
+    targetPort: {{ default 9042 .Values.config.ports.cql }}
+  - name: thrift
+    port: {{ default 9160 .Values.config.ports.thrift }}
+    targetPort: {{ default 9160 .Values.config.ports.thrift }}
+  selector:
+    app: {{ template "elassandra.name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/elassandra/templates/service-cassandra.yaml
+++ b/incubator/elassandra/templates/service-cassandra.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "cassandra"
+  name: {{ .Release.Name }}-cassandra
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "elassandra.name" . }}

--- a/incubator/elassandra/templates/service-elasticsearch.yaml
+++ b/incubator/elassandra/templates/service-elasticsearch.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.elasticsearch.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "elasticsearch"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "elassandra.name" . }}
+    chart: {{ template "elassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: elasticsearch
+    port: {{ default 9200 .Values.config.ports.elasticsearch }}
+    targetPort: {{ default 9200 .Values.config.ports.elasticsearch }}
+  selector:
+    app: {{ template "elassandra.name" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/incubator/elassandra/templates/service-elasticsearch.yaml
+++ b/incubator/elassandra/templates/service-elasticsearch.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "elasticsearch"
+  name: {{ .Release.Name }}-elasticsearch
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "elassandra.name" . }}

--- a/incubator/elassandra/templates/service.yaml
+++ b/incubator/elassandra/templates/service.yaml
@@ -1,4 +1,4 @@
-zapiVersion: v1
+apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "elassandra.fullname" . }}

--- a/incubator/elassandra/templates/service.yaml
+++ b/incubator/elassandra/templates/service.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "elassandra.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # https://github.com/kubernetes/examples/issues/89
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  labels:
+    app: {{ template "elassandra.name" . }}
+    chart: {{ template "elassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+  - name: jmx
+    port: 7199
+    targetPort: 7199
+  - name: intra
+    port: 7000
+    targetPort: 7000
+  - name: tls
+    port: 7001
+    targetPort: 7001
+  - name: transport
+    port: {{ default 9300 .Values.config.ports.transport }}
+    targetPort: {{ default 9300 .Values.config.ports.transport }}
+  - name: cql
+    port: {{ default 9042 .Values.config.ports.cql }}
+    targetPort: {{ default 9042 .Values.config.ports.cql }}
+  - name: thrift
+    port: {{ default 9160 .Values.config.ports.thrift }}
+    targetPort: {{ default 9160 .Values.config.ports.thrift }}
+  - name: elasticsearch
+    port: {{ default 9200 .Values.config.ports.elasticsearch }}
+    targetPort: {{ default 9200 .Values.config.ports.elasticsearch }}
+  selector:
+    app: {{ template "elassandra.name" . }}
+    release: {{ .Release.Name }}

--- a/incubator/elassandra/templates/service.yaml
+++ b/incubator/elassandra/templates/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+zapiVersion: v1
 kind: Service
 metadata:
   name: {{ template "elassandra.fullname" . }}
@@ -35,6 +35,11 @@ spec:
   - name: elasticsearch
     port: {{ default 9200 .Values.config.ports.elasticsearch }}
     targetPort: {{ default 9200 .Values.config.ports.elasticsearch }}
+{{- if .Values.debug.enabled }}
+  - name: jdwp
+    port: {{ default 4242 .Values.debug.port }}
+    targetPort: {{ default 4242 .Values.debug.port }}
+{{- end }}
   selector:
     app: {{ template "elassandra.name" . }}
     release: {{ .Release.Name }}

--- a/incubator/elassandra/templates/statefulset.yaml
+++ b/incubator/elassandra/templates/statefulset.yaml
@@ -1,0 +1,173 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ template "elassandra.fullname" . }}
+  labels:
+    app: {{ template "elassandra.name" . }}
+    chart: {{ template "elassandra.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  serviceName: {{ template "elassandra.fullname" . }}
+  replicas: {{ .Values.config.cluster_size }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ template "elassandra.name" . }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.selector }}
+{{ toYaml .Values.selector | indent 6 }}
+{{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ default 999 .Values.securityContext.fsGroup }}
+        runAsUser: {{ default 999 .Values.securityContext.runAsUser }}
+      {{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+      initContainers:
+      - name: increase-vm-max-map-count
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["sysctl", "-w", "vm.max_map_count=1048575"]
+        securityContext:
+          privileged: true
+      - name: increase-ulimit
+        image: busybox
+        command: [ "sh","-c","ulimit -l unlimited" ]
+        securityContext:
+          privileged: true
+      containers:
+      - name: {{ template "elassandra.fullname" . }}
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        terminationMessagePolicy: "FallbackToLogsOnError"
+        securityContext:
+          privileged: false
+          # applying fix in: https://github.com/kubernetes/kubernetes/issues/3595#issuecomment-287692878 
+          # https://docs.docker.com/engine/reference/run/#operator-exclusive-options
+          capabilities:
+            add: ["IPC_LOCK", "SYS_RESOURCE"]
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        {{- $seed_size := default 1 .Values.config.seed_size | int -}}
+        {{- $global := . }}
+        - name: CASSANDRA_SEEDS
+          value: "{{- range $i, $e := until $seed_size }}{{ template "elassandra.fullname" $global }}-{{ $i }}.{{ template "elassandra.fullname" $global }}.{{ $global.Release.Namespace }}.svc.cluster.local{{- if (lt ( add1 $i ) $seed_size ) }},{{- end }}{{- end }}"
+        - name: MAX_HEAP_SIZE
+          value: {{ default "8192M" .Values.config.max_heap_size | quote }}
+        - name: HEAP_NEWSIZE
+          value: {{ default "200M" .Values.config.heap_new_size | quote }}
+        - name: CASSANDRA_ENDPOINT_SNITCH
+          value: {{ default "GossipingPropertyFileSnitch" .Values.config.endpoint_snitch | quote }}
+        - name: CASSANDRA_CLUSTER_NAME
+          value: {{ default "Elassandra" .Values.config.cluster_name | quote }}
+        - name: CASSANDRA_DC
+          value: {{ default "DC1" .Values.config.dc_name | quote }}
+        - name: CASSANDRA_RACK
+          value: {{ default "RAC1" .Values.config.rack_name | quote }}
+        - name: CASSANDRA_START_RPC
+          value: {{ default "false" .Values.config.start_rpc | quote }}
+        - name: CASSANDRA_DAEMON
+          value: {{- if .Values.elasticsearch.enabled }} "org.apache.cassandra.service.ElassandraDaemon" {{ else }} "org.apache.cassandra.service.CassandraDaemon" {{- end }}
+        - name: LOGBACK_org_elassandra_discovery
+          value: "DEBUG"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath:  metadata.namespace
+        livenessProbe:
+          tcpSocket:
+            port: 7000
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        readinessProbe:
+          exec:
+            command: [ "/bin/bash", "-c", "/ready-probe.sh" ]
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        ports:
+        - name: intra
+          containerPort: 7000
+        - name: tls
+          containerPort: 7001
+        - name: jmx
+          containerPort: 7199
+        - name: cql
+          containerPort: {{ default 9042 .Values.config.ports.cql }}
+        - name: thrift
+          containerPort: {{ default 9160 .Values.config.ports.thrift }}
+        - name: elasticsearch
+          containerPort: {{ default 9200 .Values.config.ports.elasticsearch }}
+        - name: transport
+          containerPort: {{ default 9300 .Values.config.ports.transport }}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/cassandra
+        {{- if not .Values.persistence.enabled }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "exec nodetool decommission"]
+        {{ else }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "exec nodetool drain"]
+        {{- end }}
+      terminationGracePeriodSeconds: {{ default 30 .Values.podSettings.terminationGracePeriodSeconds }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecrets }}
+      {{- end }}
+{{- if not .Values.persistence.enabled }}
+      volumes:
+      - name: data
+        emptyDir: {}
+{{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        app: {{ template "elassandra.name" . }}
+        chart: {{ template "elassandra.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    spec:
+      accessModes:
+        - {{ .Values.persistence.accessMode | quote }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+    {{- if .Values.persistence.storageClass }}
+    {{- if (eq "-" .Values.persistence.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.persistence.storageClass }}"
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/incubator/elassandra/templates/statefulset.yaml
+++ b/incubator/elassandra/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
         - name: CASSANDRA_SEEDS
           value: "{{- range $i, $e := until $seed_size }}{{ template "elassandra.fullname" $global }}-{{ $i }}.{{ template "elassandra.fullname" $global }}.{{ $global.Release.Namespace }}.svc.cluster.local{{- if (lt ( add1 $i ) $seed_size ) }},{{- end }}{{- end }}"
         - name: MAX_HEAP_SIZE
-          value: {{ default "8192M" .Values.config.max_heap_size | quote }}
+          value: {{ default "2048M" .Values.config.max_heap_size | quote }}
         - name: HEAP_NEWSIZE
           value: {{ default "200M" .Values.config.heap_new_size | quote }}
         - name: CASSANDRA_ENDPOINT_SNITCH
@@ -80,8 +80,8 @@ spec:
           value: {{ default "false" .Values.config.start_rpc | quote }}
         - name: CASSANDRA_DAEMON
           value: {{- if .Values.elasticsearch.enabled }} "org.apache.cassandra.service.ElassandraDaemon" {{ else }} "org.apache.cassandra.service.CassandraDaemon" {{- end }}
-        - name: LOGBACK_org_elassandra_discovery
-          value: "DEBUG"
+        - name: JVM_DEBUG_PORT
+          value: {{ default "4242" .Values.debug.port | quote }}
         - name: POD_IP
           valueFrom:
             fieldRef:
@@ -94,6 +94,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath:  metadata.namespace
+        {{- range $key, $val := .Values.env }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+        {{- end }}
         livenessProbe:
           tcpSocket:
             port: 7000
@@ -125,6 +129,11 @@ spec:
           containerPort: {{ default 9200 .Values.config.ports.elasticsearch }}
         - name: transport
           containerPort: {{ default 9300 .Values.config.ports.transport }}
+{{- if .Values.debug.enabled }}
+        - name: jdwp
+          containerPort: {{ default 4242 .Values.debug.port }}
+        args: ["-f", "-d" ]
+{{- end }}
         volumeMounts:
         - name: data
           mountPath: /var/lib/cassandra

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -38,7 +38,7 @@ resources: {}
 ## Change cassandra configuration parameters below:
 ## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html
 ## Recommended max heap size is 1/2 of system memory
-## Recommeneed heap new size is 1/4 of max heap size
+## Recommended heap new size is 1/4 of max heap size
 ## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/operations/opsTuneJVM.html
 config:
   cluster_name: elassandra

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/cassandra/
 image:
   repo: "strapdata/elassandra"
-  tag: "6.2.3.7"
+  tag: "6.2.3.9"
   pullPolicy: Always
   ## Specify ImagePullSecrets for Pods
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -74,16 +74,16 @@ debug:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 livenessProbe:
   initialDelaySeconds: 30
-  periodSeconds: 5
+  periodSeconds: 15
   timeoutSeconds: 5
   successThreshold: 1
-  failureThreshold: 10
+  failureThreshold: 4
 readinessProbe:
   initialDelaySeconds: 30
-  periodSeconds: 5
+  periodSeconds: 15
   timeoutSeconds: 5
   successThreshold: 1
-  failureThreshold: 10
+  failureThreshold: 4
 
 ## Additional pod-level settings
 podSettings:
@@ -99,7 +99,8 @@ securityContext:
   runAsUser: 999
 
 # Additional env variables
-env: {}
+env:
+  JVM_OPTS: "-Dcassandra.ring_delay_ms=60000 -XX:+ExitOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=2"
 
 ## Additional pod labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -52,7 +52,7 @@ config:
   dc_name: DC1
   rack_name: RAC1
   endpoint_snitch: GossipingPropertyFileSnitch
-  max_heap_size: 4096M
+  max_heap_size: 2048M
   heap_new_size: 512M
   start_rpc: false
   ports:

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -1,0 +1,123 @@
+## Cassandra image version
+## ref: https://hub.docker.com/r/library/cassandra/
+image:
+  repo: "strapdata/elassandra"
+  tag: "6.2.3.7"
+  pullPolicy: Always
+  ## Specify ImagePullSecrets for Pods
+  ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  # pullSecrets: myregistrykey
+
+## Persist data to a persistent volume
+persistence:
+  enabled: true
+  ## cassandra data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## Minimum memory for development is 4GB and 2 CPU cores
+## Minimum memory for production is 8GB and 4 CPU cores
+## ref: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/architecture/architecturePlanningHardware_c.html
+resources: {}
+  # requests:
+  #   memory: 4Gi
+  #   cpu: 2
+  # limits:
+  #   memory: 4Gi
+  #   cpu: 2
+
+## Change cassandra configuration parameters below:
+## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html
+## Recommended max heap size is 1/2 of system memory
+## Recommeneed heap new size is 1/4 of max heap size
+## ref: http://docs.datastax.com/en/cassandra/3.0/cassandra/operations/opsTuneJVM.html
+config:
+  cluster_name: elassandra
+  cluster_size: 3
+  seed_size: 2
+  num_tokens: 16
+  # If you want Cassandra to use this datacenter and rack name,
+  # you need to set endpoint_snitch to GossipingPropertyFileSnitch.
+  # Otherwise, these values are ignored and datacenter1 and rack1
+  # are used.
+  dc_name: DC1
+  rack_name: RAC1
+  endpoint_snitch: GossipingPropertyFileSnitch
+  max_heap_size: 4096M
+  heap_new_size: 512M
+  start_rpc: false
+  ports:
+    cql: 9042
+    thrift: 9160
+    # If a JVM Agent is in place
+    # agent: 61621
+
+## Elasticsearch enable/disabled by setting the java main class to org.apache.cassandra.service.ElassandraDaemon/org.apache.cassandra.service.CassandraDaemon
+elasticsearch:
+  enabled: true
+
+## Liveness and Readiness probe values.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 10
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 10
+
+## Additional pod-level settings
+podSettings:
+  # Change this to give pods more time to properly leave the cluster when not using persistent storage.
+  terminationGracePeriodSeconds: 300
+
+podManagementPolicy: OrderedReady
+
+## Pod Security Context
+securityContext:
+  enabled: false
+  fsGroup: 999
+  runAsUser: 999
+
+## Additional pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+#podLabels: {}
+
+## Configure node selector. Edit code below for adding selector to pods
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+# selector:
+  # nodeSelector:
+    # cloud.google.com/gke-nodepool: pool-db
+#selector:
+#  nodeSelector:
+#    node-role.kubernetes.io/node: "true"
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+#affinity:
+#  podAntiAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#    - labelSelector:
+#        matchExpressions:
+#        - key: app
+#          operator: In
+#          values:
+#          - elassandra
+#      topologyKey: "kubernetes.io/hostname"
+
+
+

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -43,7 +43,7 @@ resources: {}
 config:
   cluster_name: elassandra
   cluster_size: 3
-  seed_size: 2
+  seed_size: 1
   num_tokens: 16
   # If you want Cassandra to use this datacenter and rack name,
   # you need to set endpoint_snitch to GossipingPropertyFileSnitch.

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/cassandra/
 image:
   repo: "strapdata/elassandra"
-  tag: "6.2.3.7"
+  tag: "6.2.3.8"
   pullPolicy: Always
   ## Specify ImagePullSecrets for Pods
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -65,6 +65,11 @@ config:
 elasticsearch:
   enabled: true
 
+# Enable JDWP for java debugging
+debug:
+  enabled: false
+  port: 4242
+
 ## Liveness and Readiness probe values.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
 livenessProbe:
@@ -93,9 +98,12 @@ securityContext:
   fsGroup: 999
   runAsUser: 999
 
+# Additional env variables
+env: {}
+
 ## Additional pod labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-# podLabels: {}
+podLabels: {}
 
 ## Configure node selector. Edit code below for adding selector to pods
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -18,7 +18,7 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: "-"
+  storageClass: ""
   accessMode: ReadWriteOnce
   size: 10Gi
 

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/cassandra/
 image:
   repo: "strapdata/elassandra"
-  tag: "6.2.3.8"
+  tag: "6.2.3.7"
   pullPolicy: Always
   ## Specify ImagePullSecrets for Pods
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/incubator/elassandra/values.yaml
+++ b/incubator/elassandra/values.yaml
@@ -95,29 +95,26 @@ securityContext:
 
 ## Additional pod labels
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-#podLabels: {}
+# podLabels: {}
 
 ## Configure node selector. Edit code below for adding selector to pods
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 # selector:
   # nodeSelector:
     # cloud.google.com/gke-nodepool: pool-db
-#selector:
-#  nodeSelector:
-#    node-role.kubernetes.io/node: "true"
+# selector:
+#   nodeSelector:
+#     node-role.kubernetes.io/node: "true"
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-#affinity:
-#  podAntiAffinity:
-#    requiredDuringSchedulingIgnoredDuringExecution:
-#    - labelSelector:
-#        matchExpressions:
-#        - key: app
-#          operator: In
-#          values:
+# affinity:
+#   podAntiAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#     - labelSelector:
+#         matchExpressions:
+#         - key: app
+#           operator: In
+#           values:
 #          - elassandra
-#      topologyKey: "kubernetes.io/hostname"
-
-
-
+#       topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR provides an [elassandra](https://github.com/strapdata/elassandra) chart. It basically deploys a k8s statefulset of cassandra+elasticsearch nodes. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
This chart use the public [elassandra docker image](https://hub.docker.com/r/strapdata/elassandra/) based on [elassandra](https://github.com/strapdata/elassandra) and [docker-elassandra](https://github.com/strapdata/docker-elassandra). The cluster expose 3 kubernetes services:
* a headless service for elassandra nodes
* a service for cassandra on port 9042 (cql) and 9160 (thrift)
* a service for elasticsearch on port 9200 (elasticsearch http).
When elasticsearch is disabled in values.yaml, elassandra runs vanilla apache cassandra.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md

