### PR TITLE
[stable/datadog] Add support for disabling Docker socket mount requirement

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.8.0
+version: 1.9.0
 appVersion: 6.5.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.confd`             | Additional check configurations (static and Autodiscovery) | `nil`             |
 | `datadog.criSocketPath`     | Path to the container runtime socket (if different from Docker) | `nil`        |
 | `datadog.tags`              | Set host tags                      | `nil`                                     |
+| `datadog.useCriSocketPathVolume` | Enable mounting the container runtime socket in Agent containers | `True` |
 | `datadog.volumes`           | Additional volumes for the daemonset or deployment | `nil`                     |
 | `datadog.volumeMounts`      | Additional volumeMounts for the daemonset or deployment | `nil`                |
 | `datadog.podAnnotationsAsTags` | Kubernetes Annotations to Datadog Tags mapping | `nil`                      |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -138,9 +138,11 @@ spec:
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}
         volumeMounts:
+          {{- if .Values.datadog.useCriSocketVolume }}
           - name: runtimesocket
             mountPath: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
             readOnly: true
+          {{- end }}
           - name: procdir
             mountPath: /host/proc
             readOnly: true
@@ -176,9 +178,11 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 5
       volumes:
+        {{- if .Values.datadog.useCriSocketVolume }}
         - hostPath:
             path: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
           name: runtimesocket
+        {{- end }}
         - hostPath:
             path: /proc
           name: procdir

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -80,9 +80,11 @@ spec:
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}
         volumeMounts:
+          {{- if .Values.datadog.useCriSocketVolume }}
           - name: runtimesocket
             mountPath: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
             readOnly: true
+          {{- end }}
           - name: procdir
             mountPath: /host/proc
             readOnly: true
@@ -109,9 +111,11 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 5
       volumes:
+        {{- if .Values.datadog.useCriSocketVolume }}
         - hostPath:
             path: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
           name: runtimesocket
+        {{- end }}
         - hostPath:
             path: /proc
           name: procdir

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -147,6 +147,9 @@ datadog:
   ##
   # nonLocalTraffic: true
 
+  ## Enable container runtime socket volume mounting
+  useCriSocketVolume: True
+
   ## Set host tags.
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
   ##

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -148,7 +148,7 @@ datadog:
   # nonLocalTraffic: true
 
   ## Enable container runtime socket volume mounting
-  useCriSocketVolume: True
+  useCriSocketVolume: true
 
   ## Set host tags.
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables


### PR DESCRIPTION
#### What this PR does / why we need it:
Provide users with the option to disable mounting the Docker socket into Datadog Agent containers.

#### Special notes for your reviewer:
Our security posture disallows mounting the Docker socket inside containers. This change enables us to use the Helm chart for institutional deployments.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Ian Levesque <ian@quantopian.com>

/cc @hkaj @irabinovitch @xvello 