### PR TITLE
[stable/datadog] Add support for Kubernetes priorityClassName

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.5.2
+version: 1.5.3
 appVersion: 6.5.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -71,11 +71,13 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `daemonset.useHostNetwork`  | If true, use the host's network    | `nil`                                     |
 | `daemonset.useHostPID`.     | If true, use the host's PID namespace    | `nil`                               |
 | `daemonset.useHostPort`     | If true, use the same ports for both host and container  | `nil`               |
+| `daemonset.priorityClassName` | Which Priority Class to associate with the daemonset| `nil`                  |
 | `datadog.leaderElection`    | Enable the leader Election feature | `false`                                   |
 | `datadog.leaderLeaseDuration`| The duration for which a leader stays elected.| `nil`                         |
 | `datadog.collectEvents`     | Enable Kubernetes event collection. Requires leader election. | `false`        |
 | `deployment.affinity`       | Node / Pod affinities              | `{}`                                      |
 | `deployment.tolerations`    | List of node taints to tolerate    | `[]`                                      |
+| `deployment.priorityClassName` | Which Priority Class to associate with the deployment | `nil`               |
 | `kubeStateMetrics.enabled`  | If true, create kube-state-metrics | `true`                                    |
 | `kube-state-metrics.rbac.create`| If true, create & use RBAC resources for kube-state-metrics | `true`       |
 | `kube-state-metrics.rbac.serviceAccount` | existing ServiceAccount to use (ignored if rbac.create=true) for kube-state-metrics | `default` |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -34,6 +34,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.daemonset.priorityClassName }}
+      priorityClassName: {{ .Values.daemonset.priorityClassName }}
+      {{- end }}
       containers:
       - name: {{ default .Chart.Name .Values.datadog.name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
       {{- end }}
+      {{- if .Values.deployment.priorityClassName }}
+      priorityClassName: {{ .Values.deployment.priorityClassName }}
+      {{- end }}
       containers:
       - name: {{ default .Chart.Name .Values.datadog.name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -55,6 +55,9 @@ daemonset:
   ## ref: https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
   # updateStrategy: RollingUpdate
 
+  ## Sets PriorityClassName if defined
+  # priorityClassName:
+
 # Apart from DaemonSet, deploy Datadog agent pods and related service for
 # applications that want to send custom metrics. Provides DogStasD service.
 #
@@ -75,6 +78,9 @@ deployment:
   service:
     type: ClusterIP
     annotations: {}
+
+  ## Sets PriorityClassName if defined
+  # priorityClassName:
 
 ## deploy the kube-state-metrics deployment
 ## ref: https://github.com/kubernetes/charts/tree/master/stable/kube-state-metrics


### PR DESCRIPTION
#### What this PR does / why we need it:
Enables users to specify a [priorityClassName](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass) for DaemonSet/Deployment templates. 

#### Special notes for your reviewer:
Since Kubernetes 1.11, the Kubernetes scheduler defaults to using a Pod's Priority Class to determine preemption and scheduling priority relative to other Pods running in the cluster. This change allows the operator to specify a priority for Datadog-deployed Pods.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Ian Levesque <ian@quantopian.com>

/cc @hkaj @irabinovitch @xvello 