### PR TITLE
[stable/datadog] Add support for mapping Kubernetes Labels and Annotations to Datadog Tags

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.7.0
+version: 1.7.1
 appVersion: 6.5.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -174,13 +174,16 @@ Please read [the official documentation](https://docs.datadoghq.com/agent/kubern
 
 ### Kubernetes Labels and Annotations
 
-To map Kubernetes pod labels and annotations to Datadog tags, provide a string-based
-dictionary of mapped keys such as:
+To map Kubernetes pod labels and annotations to Datadog tags, provide a dictionary with kubernetes labels/annotations as keys and datadog tags as values:
 
 ```yaml
-podAnnotationsAsTags: '{"cni.projectcalico.org/podIP":"kube_podip"}'
+podAnnotationsAsTags:
+  cni.projectcalico.org/podIP: kube_podip
+  iam.amazonaws.com/role: kube_iamrole
 ```
 
 ```yaml
-podLabelsAsTags: '{"app":"kube_app","release":"helm_release"}'
+podLabelsAsTags:
+  app: kube_app
+  release: helm_release
 ```

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -178,7 +178,6 @@ To map Kubernetes pod labels and annotations to Datadog tags, provide a dictiona
 
 ```yaml
 podAnnotationsAsTags:
-  cni.projectcalico.org/podIP: kube_podip
   iam.amazonaws.com/role: kube_iamrole
 ```
 

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -61,6 +61,8 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.tags`              | Set host tags                      | `nil`                                     |
 | `datadog.volumes`           | Additional volumes for the daemonset or deployment | `nil`                     |
 | `datadog.volumeMounts`      | Additional volumeMounts for the daemonset or deployment | `nil`                |
+| `datadog.podAnnotationsAsTags` | Kubernetes Annotations to Datadog Tags mapping | `nil`                      |
+| `datadog.podLabelsAsTags`   | Kubernetes Labels to Datadog Tags mapping      | `nil`                         |
 | `datadog.resources.requests.cpu` | CPU resource requests         | `200m`                                    |
 | `datadog.resources.limits.cpu` | CPU resource limits             | `200m`                                    |
 | `datadog.resources.requests.memory` | Memory resource requests   | `256Mi`                                   |
@@ -169,3 +171,16 @@ For more details, please refer to [the documentation](https://docs.datadoghq.com
 To enable event collection, you will need to set the `datadog.leaderElection`, `datadog.collectEvents` and `rbac.create` options to `true`.
 
 Please read [the official documentation](https://docs.datadoghq.com/agent/kubernetes/event_collection/) for more context.
+
+### Kubernetes Labels and Annotations
+
+To map Kubernetes pod labels and annotations to Datadog tags, provide a string-based
+dictionary of mapped keys such as:
+
+```yaml
+podAnnotationsAsTags: '{"cni.projectcalico.org/podIP":"kube_podip"}'
+```
+
+```yaml
+podLabelsAsTags: '{"app":"kube_app","release":"helm_release"}'
+```

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -108,6 +108,14 @@ spec:
           {{- end }}
           - name: KUBERNETES
             value: "yes"
+          {{- if .Values.datadog.podLabelsAsTags }}
+          - name: DD_KUBERNETES_POD_LABELS_AS_TAGS
+            value: {{ .Values.datadog.podLabelsAsTags }}
+          {{- end }}
+          {{- if .Values.datadog.podAnnotationsAsTags }}
+          - name: DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS
+            value: {{ .Values.datadog.podAnnotationsAsTags }}
+          {{- end }}
           {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
           - name: DD_KUBERNETES_KUBELET_HOST
             valueFrom:

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -110,11 +110,11 @@ spec:
             value: "yes"
           {{- if .Values.datadog.podLabelsAsTags }}
           - name: DD_KUBERNETES_POD_LABELS_AS_TAGS
-            value: {{ .Values.datadog.podLabelsAsTags }}
+            value: '{{ toJson .Values.datadog.podLabelsAsTags }}'
           {{- end }}
           {{- if .Values.datadog.podAnnotationsAsTags }}
           - name: DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS
-            value: {{ .Values.datadog.podAnnotationsAsTags }}
+            value: '{{ toJson .Values.datadog.podAnnotationsAsTags }}'
           {{- end }}
           {{- if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion }}
           - name: DD_KUBERNETES_KUBELET_HOST

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -231,6 +231,15 @@ datadog:
   ## This is supported starting from agent 6.6.0
   # criSocketPath: /var/run/containerd/containerd.sock
 
+  ## Provide a mapping of Kubernetes Labels to Datadog Tags
+  # podLabelsAsTags:
+  #     app: kube_app
+  #     release: helm_release
+
+  ## Provide a mapping of Kubernetes Annotations to Datadog Tags
+  # podAnnotationsAsTags:
+  #     iam.amazonaws.com/role: kube_iamrole
+
   ## datadog-agent resource requests and limits
   ## Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
#### What this PR does / why we need it:

Provide a facility for Chart operators to specify `DD_KUBERNETES_POD_LABELS_AS_TAGS` and `DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS` envvars as strings, as documented [in the Datadog Docker docs](https://docs.datadoghq.com/agent/basic_agent_usage/docker/#tagging).

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Ian Levesque <ian@quantopian.com>

/cc @hkaj @irabinovitch @xvello 