### PR TITLE
Fix Traefik configmap for Zookeeper prefix

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.52.2
+version: 1.52.3
 appVersion: 1.7.3
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 data:
   traefik.toml: |
     # traefik.toml
@@ -70,7 +70,7 @@ data:
       {{- if not .Values.ssl.upstream }}
         [entryPoints.https.tls]
           {{- if .Values.ssl.tlsMinVersion }}
-          minVersion = "{{ .Values.ssl.tlsMinVersion }}"
+          minVersion = {{ .Values.ssl.tlsMinVersion | quote }}
           {{- end }}
           {{- if .Values.ssl.cipherSuites }}
           {{ template "traefik.ssl.cipherSuites" . }}
@@ -139,14 +139,14 @@ data:
     {{- end}}
     {{- if .Values.traefikLogFormat }}
     [traefikLog]
-      format = "{{ .Values.traefikLogFormat }}"
+      format = {{ .Values.traefikLogFormat | quote }}
     {{- end }}
     {{- if .Values.accessLogs.enabled }}
     [accessLog]
     {{- if .Values.accessLogs.filePath }}
-    filePath = "{{ .Values.accessLogs.filePath }}"
+    filePath = {{ .Values.accessLogs.filePath | quote }}
     {{- end}}
-      format = "{{ .Values.accessLogs.format }}"
+      format = {{ .Values.accessLogs.format | quote }}
     [accessLog.fields]
       defaultMode = {{ .Values.accessLogs.fields.defaultMode | quote }}
     [accessLog.fields.names]
@@ -162,9 +162,9 @@ data:
     {{- end}}
     {{- if .Values.kvprovider.etcd }}
     [etcd]
-    endpoint = "{{ .Values.kvprovider.etcd.endpoint }}"
+    endpoint = {{ .Values.kvprovider.etcd.endpoint | quote }}
     watch = {{ .Values.kvprovider.etcd.watch }}
-    prefix = "{{ .Values.kvprovider.etcd.prefix }}"
+    prefix = {{ .Values.kvprovider.etcd.prefix | quote }}
     useAPIV3 = {{ .Values.kvprovider.etcd.useAPIV3 }}
     {{- if .Values.kvprovider.etcd.username }}username = {{ .Values.kvprovider.etcd.username }}{{- end }}
     {{- if .Values.kvprovider.etcd.password }}password = {{ .Values.kvprovider.etcd.password }}{{- end }}
@@ -191,7 +191,7 @@ data:
     {{- end }}
     {{- if .Values.kvprovider.boltdb }}
     [boltdb]
-    endpoint = "{{ .Values.kvprovider.boltdb.endpoint }}"
+    endpoint = {{ .Values.kvprovider.boltdb.endpoint | quote }}
     watch = {{ .Values.kvprovider.boltdb.watch }}
     prefix = {{ .Values.kvprovider.boltdb.prefix }}
     {{- if .Values.kvprovider.boltdb.username }}username = {{ .Values.kvprovider.boltdb.username }}{{- end }}
@@ -205,9 +205,9 @@ data:
     {{- end }}
     {{- if .Values.kvprovider.zookeeper }}
     [zookeeper]
-    endpoint = "{{ .Values.kvprovider.zookeeper.endpoint }}"
+    endpoint = {{ .Values.kvprovider.zookeeper.endpoint | quote }}
     watch = {{ .Values.kvprovider.zookeeper.watch }}
-    prefix = "{{ .Values.kvprovider.zookeeper.prefix }}"
+    prefix = {{ .Values.kvprovider.zookeeper.prefix | quote }}
     {{- if .Values.kvprovider.zookeeper.username }}username = {{ .Values.kvprovider.zookeeper.username }}{{- end }}
     {{- if .Values.kvprovider.zookeeper.password }}password = {{ .Values.kvprovider.zookeeper.password }}{{- end }}
       {{- if .Values.kvprovider.zookeeper.tls }}
@@ -219,7 +219,7 @@ data:
     {{- end }}
     {{- if .Values.acme.enabled }}
     [acme]
-    email = "{{ .Values.acme.email }}"
+    email = {{ .Values.acme.email | quote }}
     {{- if .Values.kvprovider.storeAcme }}
     storage = "traefik/acme/account"
     {{- if .Values.kvprovider.importAcme }}
@@ -238,7 +238,7 @@ data:
     {{- end }}
     {{- if eq .Values.acme.challengeType "dns-01" }}
       [acme.dnsChallenge]
-      provider = "{{ .Values.acme.dnsProvider.name }}"
+      provider = {{ .Values.acme.dnsProvider.name | quote }}
       {{- if .Values.acme.delayBeforeCheck }}
       delayBeforeCheck = {{ .Values.acme.delayBeforeCheck }}
       {{- end }}

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -207,7 +207,7 @@ data:
     [zookeeper]
     endpoint = "{{ .Values.kvprovider.zookeeper.endpoint }}"
     watch = {{ .Values.kvprovider.zookeeper.watch }}
-    prefix = {{ .Values.kvprovider.zookeeper.prefix }}
+    prefix = "{{ .Values.kvprovider.zookeeper.prefix }}"
     {{- if .Values.kvprovider.zookeeper.username }}username = {{ .Values.kvprovider.zookeeper.username }}{{- end }}
     {{- if .Values.kvprovider.zookeeper.password }}password = {{ .Values.kvprovider.zookeeper.password }}{{- end }}
       {{- if .Values.kvprovider.zookeeper.tls }}

--- a/stable/traefik/templates/dashboard-ingress.yaml
+++ b/stable/traefik/templates/dashboard-ingress.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   {{- if .Values.dashboard.ingress }}
   {{- range $key, $value := .Values.dashboard.ingress.labels }}
     {{ $key }}: {{ $value | quote }}

--- a/stable/traefik/templates/dashboard-service.yaml
+++ b/stable/traefik/templates/dashboard-service.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
   {{- if .Values.dashboard.service }}
   {{- range $key, $value := .Values.dashboard.service.annotations }}

--- a/stable/traefik/templates/default-cert-secret.yaml
+++ b/stable/traefik/templates/default-cert-secret.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
   tls.crt: {{ .Values.ssl.defaultCert }}

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -9,8 +9,8 @@ metadata:
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   replicas: {{ default 1 .Values.replicas }}
   selector:
@@ -34,8 +34,8 @@ spec:
       labels:
         app: {{ template "traefik.name" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
-        heritage: "{{ .Release.Service }}"
+        release: {{ .Release.Name | quote }}
+        heritage: {{ .Release.Service | quote }}
     spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "traefik.fullname" . }}
@@ -56,11 +56,11 @@ spec:
         name: {{ template "traefik.fullname" . }}
         resources:
           requests:
-            cpu: "{{ .Values.cpuRequest }}"
-            memory: "{{ .Values.memoryRequest }}"
+            cpu: {{ .Values.cpuRequest | quote }}
+            memory: {{ .Values.memoryRequest | quote }}
           limits:
-            cpu: "{{ .Values.cpuLimit }}"
-            memory: "{{ .Values.memoryLimit }}"
+            cpu: {{ .Values.cpuLimit | quote }}
+            memory: {{ .Values.memoryLimit | quote }}
         readinessProbe:
           tcpSocket:
             port: 80

--- a/stable/traefik/templates/dns-provider-secret.yaml
+++ b/stable/traefik/templates/dns-provider-secret.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
 {{- range $k, $v := (index .Values.acme.dnsProvider .Values.acme.dnsProvider.name) }}

--- a/stable/traefik/templates/poddisruptionbudget.yaml
+++ b/stable/traefik/templates/poddisruptionbudget.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   selector:
     matchLabels:

--- a/stable/traefik/templates/service.yaml
+++ b/stable/traefik/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app: {{ template "traefik.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   {{- if .Values.service }}
   {{- range $key, $value := .Values.service.labels }}
     {{ $key }}: {{ $value | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Without these quotation marks I was getting:

`2018/10/22 18:14:26 Error reading TOML config file /config/traefik.toml : Near line 27 (last key parsed 'zookeeper.prefix'): expected value but found "traefik" instead`

It is likely that the prefix strings for the other KV stores will need this fix as well. I'm happy to resubmit this with these fixes as well.


