### PR TITLE
Updating version of the Datadog Cluster Agent

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.5.3
+version: 1.6.0
 appVersion: 6.5.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -96,7 +96,7 @@ clusterAgent:
   containerName: cluster-agent
   image:
     repository: datadog/cluster-agent
-    tag: 0.10.0
+    tag: 1.0.0
     pullPolicy: IfNotPresent
   enabled: false
   ## This needs to be at least 32 characters a-zA-z


### PR DESCRIPTION
#### What this PR does / why we need it:

Update the default version of the Datadog Cluster Agent used in the chart as [we released 1.0.0](https://www.datadoghq.com/blog/datadog-cluster-agent/) last week

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
