### PR TITLE
Extend container runtime support to CRI

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.6.0
+version: 1.7.0
 appVersion: 6.5.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -57,13 +57,14 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.processAgentEnabled` | Enable live process monitoring   | `nil`                                     |
 | `datadog.checksd`           | Additional custom checks as python code  | `nil`                               |
 | `datadog.confd`             | Additional check configurations (static and Autodiscovery) | `nil`             |
+| `datadog.criSocketPath`     | Path to the container runtime socket (if different from Docker) | `nil`        |
 | `datadog.tags`              | Set host tags                      | `nil`                                     |
 | `datadog.volumes`           | Additional volumes for the daemonset or deployment | `nil`                     |
 | `datadog.volumeMounts`      | Additional volumeMounts for the daemonset or deployment | `nil`                |
-| `datadog.resources.requests.cpu` | CPU resource requests              | `200m`                                    |
-| `datadog.resources.limits.cpu` | CPU resource limits                | `200m`                                    |
-| `datadog.resources.requests.memory` | Memory resource requests           | `256Mi`                                   |
-| `datadog.resources.limits.memory` | Memory resource limits             | `256Mi`                                   |
+| `datadog.resources.requests.cpu` | CPU resource requests         | `200m`                                    |
+| `datadog.resources.limits.cpu` | CPU resource limits             | `200m`                                    |
+| `datadog.resources.requests.memory` | Memory resource requests   | `256Mi`                                   |
+| `datadog.resources.limits.memory` | Memory resource limits       | `256Mi`                                   |
 | `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
 | `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |
 | `daemonset.nodeSelector`    | Node selectors                     | `nil`                                     |
@@ -161,8 +162,10 @@ datadog:
           port: 6379
 ```
 
+For more details, please refer to [the documentation](https://docs.datadoghq.com/agent/kubernetes/integrations/).
+
 ### Kubernetes event collection
 
 To enable event collection, you will need to set the `datadog.leaderElection`, `datadog.collectEvents` and `rbac.create` options to `true`.
 
-Please read [the official documentation](https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#event-collection) for more context.
+Please read [the official documentation](https://docs.datadoghq.com/agent/kubernetes/event_collection/) for more context.

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -122,12 +122,16 @@ spec:
           - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
             value: {{.Values.datadog.logsConfigContainerCollectAll | quote}}
           {{- end }}
+          {{- if .Values.datadog.criSocketPath }}
+          - name: DD_CRI_SOCKET_PATH
+            value: {{ .Values.datadog.criSocketPath | quote }}
+          {{- end }}
 {{- if .Values.datadog.env }}
 {{ toYaml .Values.datadog.env | indent 10 }}
 {{- end }}
         volumeMounts:
-          - name: dockersocket
-            mountPath: /var/run/docker.sock
+          - name: runtimesocket
+            mountPath: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
             readOnly: true
           - name: procdir
             mountPath: /host/proc
@@ -165,8 +169,8 @@ spec:
           periodSeconds: 5
       volumes:
         - hostPath:
-            path: /var/run/docker.sock
-          name: dockersocket
+            path: {{ default "/var/run/docker.sock" .Values.datadog.criSocketPath | quote }}
+          name: runtimesocket
         - hostPath:
             path: /proc
           name: procdir

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -227,6 +227,10 @@ datadog:
   # checksd:
   #   service.py: |-
 
+  ## Path to the container runtime socket (if different from Docker)
+  ## This is supported starting from agent 6.6.0
+  # criSocketPath: /var/run/containerd/containerd.sock
+
   ## datadog-agent resource requests and limits
   ## Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Extend container runtime support to CRI. This prepares the chart for the 6.6 release that will support any CRI-compliant runtime. We tested it with CRI-O and containerd. This change doesn't break the chart for 6.5:

- setting `criSocketPath` to an empty string will default to the docker socket (the docker check will run)
- setting `criSocketPath` to the docker socket will work as if the setting was commented out (the docker check will run)
- setting `criSocketPath` to a non-docker runtime socket won't add any feature, but the docker check will not run.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
