### PR TITLE
[stable/prometheus-operator] Correct prometheus-operator app version

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,8 +9,8 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 0.1.1
-appVersion: "0.22.2"
+version: 0.1.2
+appVersion: "0.24.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:
 - operator


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix the version of Prometheus Operator used in the chart. The default versions for prometheus and alertmanager match what the operator uses as defaults already.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
