### PR TITLE
[stable/mongodb-replicaset] Fix regression when using passwords with spaces

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.6.2
+version: 3.6.3
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -117,6 +117,18 @@ keys `user` and `password`, that for the key file must contain `key.txt`.  The u
 full `root` permissions but is restricted to the `admin` database for security purposes. It can be
 used to create additional users with more specific permissions.
 
+To connect to the mongo shell with authentication enabled, use a command similar to the following (substituting values as appropriate):
+
+```shell
+kubectl exec -it mongodb-replicaset-0 -- mongo mydb -u admin -p password --authenticationDatabase admin
+```
+
+To connect to the mongodb replica set via an application, use a mongo URI similar to:
+
+```
+mongodb://admin:password@mongodb-replicaset:27017/mydb?authSource=admin&replicaSet=rs0
+```
+
 ## TLS support
 
 To enable full TLS encryption set `tls.enabled` to `true`. It is recommended to create your own CA by executing:

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -123,12 +123,6 @@ To connect to the mongo shell with authentication enabled, use a command similar
 kubectl exec -it mongodb-replicaset-0 -- mongo mydb -u admin -p password --authenticationDatabase admin
 ```
 
-To connect to the mongodb replica set via an application, use a mongo URI similar to:
-
-```
-mongodb://admin:password@mongodb-replicaset:27017/mydb?authSource=admin&replicaSet=rs0
-```
-
 ## TLS support
 
 To enable full TLS encryption set `tls.enabled` to `true`. It is recommended to create your own CA by executing:

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `persistentVolume.accessMode`       | Persistent volume access modes                                            | `[ReadWriteOnce]`                                   |
 | `persistentVolume.size`             | Persistent volume size                                                    | `10Gi`                                              |
 | `persistentVolume.annotations`      | Persistent volume annotations                                             | `{}`                                                |
+| `terminationGracePeriodSeconds`     | Duration in seconds the pod needs to terminate gracefully                 | `30`                                                |
 | `tls.enabled`                       | Enable MongoDB TLS support including authentication                       | `false`                                             |
 | `tls.cacert`                        | The CA certificate used for the members                                   | Our self signed CA certificate                      |
 | `tls.cakey`                         | The CA key used for the members                                           | Our key for the self signed CA certificate          |

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -43,15 +43,14 @@ retry_until() {
     local host="${1}"
     local command="${2}"
     local expected="${3}"
-    local creds="${admin_creds[@]}"
+    local creds=("${admin_creds[@]}")
 
     # Don't need credentials for admin user creation and pings that run on localhost
     if [[ "${host}" =~ ^localhost ]]; then
-        creds=
+        creds=()
     fi
 
-    until [[ $(mongo admin --host "${host}" ${creds} "${ssl_args[@]}" --quiet --eval "${command}") == "${expected}" ]]; do
-        log "Retrying ${command}"
+    until [[ $(mongo admin --host "${host}" "${creds[@]}" "${ssl_args[@]}" --quiet --eval "${command}") == "${expected}" ]]; do
         sleep 1
 
         if (! ps "${pid}" &>/dev/null); then
@@ -62,6 +61,8 @@ retry_until() {
             log "Timed out after ${timeout}s attempting to bootstrap mongod"
             exit 1
         fi
+
+        log "Retrying ${command} on ${host}"
     done
 }
 

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: copy-config
           image: busybox

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -93,6 +93,8 @@ persistentVolume:
 # Annotations to be added to the service
 serviceAnnotations: {}
 
+terminationGracePeriodSeconds: 30
+
 tls:
   # Enable or disable MongoDB TLS support
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
- Fixes a regression in my previous [PR](https://github.com/helm/charts/pull/8115) when authenticating with a password that contains spaces. I did not properly handle the bash array that contained the credentials.
- Adds ability to customize the terminationGracePeriodSeconds, defaulting to Kubernetes default value of [30](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#podspec-v1-core). This is to help workaround #8512 for heavily loaded environments that need a little more time to shutdown cleanly before killing the pod.
- Documents how to connect when using authentication to address question #8657

#### Which issue this PR fixes
  - fixes #8657

#### Special notes for your reviewer:
Before my changes, the first replica would come up but subsequent replicas would retry indefinitely to find the primary but fail due to authentication. Reproduce using this command:

```shell
helm install --name mongo --set replicas=3 --set auth.enabled=true --set auth.adminUser=mongo --set auth.adminPassword="my password" --set auth.key=foobar .
```

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
