### PR TITLE
[prometheus-blackbox-exporter] Allowing custom service annotations and labels

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.12.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/README.md
+++ b/stable/prometheus-blackbox-exporter/README.md
@@ -63,6 +63,8 @@ The following table lists the configurable parameters of the Blackbox-Exporter c
 | `podAnnotations`                       | annotations to add to each pod                  | `{}`                          |
 | `resources`                            | pod resource requests & limits                  | `{}`                          |
 | `restartPolicy`                        | container restart policy                        | `Always`                      |
+| `service.annotations`                  | annotations for the service                     | `{}`                          |
+| `service.labels`                       | additional labels for the service               | None                          |
 | `service.type`                         | type of service to create                       | `ClusterIP`                   |
 | `service.port`                         | port for the blackbox http service              | `9115`                        |
 | `service.externalIPs`                  | list of external ips                            | []                            |

--- a/stable/prometheus-blackbox-exporter/templates/service.yaml
+++ b/stable/prometheus-blackbox-exporter/templates/service.yaml
@@ -2,11 +2,18 @@ kind: Service
 apiVersion: v1
 metadata:
   name: {{ template "prometheus-blackbox-exporter.fullname" . }}
+  {{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
   labels:
     chart: {{ template "prometheus-blackbox-exporter.chart" . }}
     app: {{ template "prometheus-blackbox-exporter.name" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -24,6 +24,7 @@ resources:
   #   memory: 50Mi
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 9115
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Some other charts follow this pattern to allow custom annotations and labels to be added to the service. This adds that pattern to the `prometheus-blackbox-exporter` chart.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Dave Henderson <dhenderson@gmail.com>
