### PR TITLE
[prometheus-blackbox-exporter] Fixing minor syntax error

### DIFF
--- a/stable/prometheus-blackbox-exporter/Chart.yaml
+++ b/stable/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.12.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/stable/prometheus-blackbox-exporter/values.yaml
+++ b/stable/prometheus-blackbox-exporter/values.yaml
@@ -17,7 +17,7 @@ config:
         no_follow_redirects: false
         preferred_ip_protocol: "ip4"
 
-resources:
+resources: {}
   # limits:
   #   memory: 300Mi
   # requests:


### PR DESCRIPTION
#### What this PR does / why we need it:

When setting `resources` in another values file, this warning is seen:

```
2018/10/23 22:19:42 warning: skipped value for resources: Not a table.
```

Defaulting to `{}` removes the warning.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

Signed-off-by: Dave Henderson <dhenderson@gmail.com>