### PR TITLE
 [stable/kong] Cassandra, "wait-for-db" initContainer failed to start: Error: [postgres error] could not retrieve server_version: connection refused

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -11,4 +11,4 @@ name: kong
 sources:
 - https://github.com/Kong/kong
 version: 0.5.0
-appVersion: 0.14.1
+appVersion: 0.14.2

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.14.2

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
         - name: KONG_CASSANDRA_CONTACT_POINTS
           value: {{ template "kong.cassandra.fullname" . }}
         {{- end }}
+        {{- range $key, $val := .Values.env }}
+        - name: KONG_{{ $key | upper}}
+          value: {{ $val | quote }}
+        {{- end}}        
         command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop" ]
       containers:
       - name: {{ template "kong.name" . }}

--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,8 +5,8 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 2.2.3
-appVersion: 4.0.8-r0
+version: 2.2.4
+appVersion: 4.0.11-r1
 description: Highly available Redis cluster with multiple sentinels and standbys.
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
 maintainers:

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -24,7 +24,7 @@ podAntiAffinity:
   server: soft
 
 ## Redis image version
-redis_image: quay.io/smile/redis:4.0.8r0
+redis_image: quay.io/smile/redis:4.0.11-r1
 ## replicas number for each component
 replicas:
   servers: 3


### PR DESCRIPTION
**What this PR does / why we need it:**
Fixed issue when **env.database=cassandra** and **cassandra.enabled=true**, but "wait-for-db" initContainer failed to start: Error: [postgres error] could not retrieve server_version: connection refused. So we explicitly set KONG_DATABASE variable for 'wait-for-db' initContainer as it was already done for main kong container.

```
kubectl get all -n kong
NAME                             READY     STATUS      RESTARTS   AGE
pod/kong-cassandra-0             1/1       Running     0          32m
pod/kong-cassandra-1             1/1       Running     0          30m
pod/kong-cassandra-2             1/1       Running     0          28m
pod/kong-kong-ddc97bf6f-lvmm7    0/1       Init:0/1    0          32m
pod/kong-kong-migrations-jx9vd   0/1       Completed   5          32m

NAME                      TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                                        AGE
service/kong-cassandra    ClusterIP   None           <none>        7000/TCP,7001/TCP,7199/TCP,9042/TCP,9160/TCP   32m
service/kong-kong-admin   NodePort    10.233.9.69    <none>        8444:32712/TCP                                 32m
service/kong-kong-proxy   NodePort    10.233.2.163   <none>        8443:30707/TCP                                 32m

NAME                        DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/kong-kong   1         1         1            0           32m

NAME                                  DESIRED   CURRENT   READY     AGE
replicaset.apps/kong-kong-ddc97bf6f   1         1         0         32m

NAME                              DESIRED   CURRENT   AGE
statefulset.apps/kong-cassandra   3         3         32m

NAME                             DESIRED   SUCCESSFUL   AGE
job.batch/kong-kong-migrations   1         1            32m
```
```
kubectl exec -it kong-kong-ddc97bf6f-lvmm7 -c wait-for-db -n kong /bin/sh
/ # kong start
Error: [postgres error] could not retrieve server_version: connection refused
```
Thanks !

#### Which issue this PR fixes
Issue was introduced by following commit https://github.com/helm/charts/commit/0283024f05c30ae9ca6c4b7e50366d0834414878 (@shashiranjan84)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md