### PR TITLE
[stable/postgresql] Add global registry option and remove some quotes

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 2.0.0
+version: 2.1.0
 appVersion: 10.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -47,8 +47,9 @@ The following tables lists the configurable parameters of the PostgreSQL chart a
 
 |         Parameter          |                Description                |                            Default                        |
 |----------------------------|-------------------------------------------|---------------------------------------------------------- |
+| `global.imageRegistry`     | Global Docker image registry              | `nil`                                                     |
 | `image.registry`           | PostgreSQL image registry                 | `docker.io`                                               |
-| `image.repository`         | PostgreSQL Image name                     | `stable/postgresql`                                      |
+| `image.repository`         | PostgreSQL Image name                     | `stable/postgresql`                                       |
 | `image.tag`                | PostgreSQL Image tag                      | `{VERSION}`                                               |
 | `image.pullPolicy`         | PostgreSQL image pull policy              | `Always`                                                  |
 | `image.pullSecrets`        | Specify image pull secrets                | `nil` (does not add image pull secrets to deployed pods)  |

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -50,10 +50,25 @@ Create chart name and version as used by the chart label.
 Return the proper PostgreSQL image name
 */}}
 {{- define "postgresql.image" -}}
-{{- $registryName :=  default "docker.io" .Values.image.registry -}}
-{{- $tag := default "latest" .Values.image.tag | toString -}}
-{{- printf "%s/%s:%s" $registryName .Values.image.repository $tag -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
+{{- end -}}
+
 
 {{/*
 Return the proper PostgreSQL metrics image name

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -20,9 +20,9 @@ spec:
       role: slave
   template:
     metadata:
-      name: "{{ template "postgresql.fullname" . }}"
+      name: {{ template "postgresql.fullname" . }}
       labels:
-        app: "{{ template "postgresql.name" . }}"
+        app: {{ template "postgresql.name" . }}
         chart: {{ template "postgresql.chart" . }}
         release: {{ .Release.Name | quote }}
         heritage: {{ .Release.Service | quote }}
@@ -48,8 +48,8 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       containers:
-      - name: "{{ template "postgresql.fullname" . }}"
-        image: "{{ template "postgresql.image" . }}"
+      - name: {{ template "postgresql.fullname" . }}
+        image: {{ template "postgresql.image" . }}
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         resources:
 {{ toYaml .Values.Resources | indent 10 }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
-  name: "{{ template "postgresql.master.fullname" . }}"
+  name: {{ template "postgresql.master.fullname" . }}
   labels:
     app: {{ template "postgresql.name" . }}
     chart: {{ template "postgresql.chart" . }}
@@ -19,7 +19,7 @@ spec:
       role: master
   template:
     metadata:
-      name: "{{ template "postgresql.fullname" . }}"
+      name: {{ template "postgresql.fullname" . }}
       labels:
         app: {{ template "postgresql.name" . }}
         chart: {{ template "postgresql.chart" . }}
@@ -50,8 +50,8 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
       containers:
-      - name: "{{ template "postgresql.fullname" . }}"
-        image: "{{ template "postgresql.image" . }}"
+      - name: {{ template "postgresql.fullname" . }}
+        image: {{ template "postgresql.image" . }}
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         resources:
 {{ toYaml .Values.Resources | indent 10 }}

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+### Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+###
+## global:
+##   imageRegistry:
+
 ## Bitnami PostgreSQL image version
 ## ref: https://hub.docker.com/r/bitnami/postgresql/tags/
 ##

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+### Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+###
+## global:
+##   imageRegistry:
+
 ## Bitnami PostgreSQL image version
 ## ref: https://hub.docker.com/r/bitnami/postgresql/tags/
 ##


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

- Add `global.registry` at the top of `values.yaml` (commented out at the beginning).
- Add the required logic to use the global value if it is defined.
- Add a link to the `values.yaml` of the dependency in the main `values.yaml` chart (in the section of the dependency options).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md