### PR TITLE
[NSQ] Added charts for NSQ cluster

### DIFF
--- a/incubator/nsq/.helmignore
+++ b/incubator/nsq/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/nsq/Chart.yaml
+++ b/incubator/nsq/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+home: https://nsq.io/
+appVersion: "1.0"
+description: NSQ is a distributed PUB-SUB messaging platform
+name: nsq
+version: 0.1.0
+maintainers:
+- name: emaincourt
+  email: e.maincourt@gmail.com

--- a/incubator/nsq/README.md
+++ b/incubator/nsq/README.md
@@ -1,0 +1,113 @@
+# NSQ Chart
+
+This chart will allow you to deploy a namespaced production ready NSQ cluster. It will be made of :
+* a NSQD replicaset
+* a NSQLookupd replicaset
+* a NSQAdmin replicaset
+
+Please refer to the [official documentation](https://nsq.io/overview/design.html) for further informations about the NSQ features and internals.
+
+> Note that nsq-admin can be disabled if not needed
+
+## Prerequisites Details
+
+* Kubernetes 1.9+
+
+## Concepts
+
+* [StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+* [Headless Services](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services)
+
+## Installation
+
+```bash
+helm install --name <release-name> incubator/nsq
+```
+
+## Deletion
+
+```bash
+helm delete <release-name>
+```
+
+## Monitoring
+
+This chart has been designed with [Prometheus](https://prometheus.io/) in mind. You'll be able to add annotations all along the configuration to each items to be able to scrap monitoring data from them. You can also enable a side container to expose the NSQDs metrics.
+
+## Configuration
+
+#### NSQD
+
+|  Field |  Description |  Default  |
+|---|---|---|
+| `nsqd.antiAffinity` | The anti affinity rule to apply for the pods scheduling. Allowed values are `soft` and `hard`. | `soft` |
+| `nsqd.extraArgs` | Extra arguments to provide to the `nsqd` command | `["--max-msg-timeout=4h", "--max-req-timeout=3h"]` |
+| `nsqd.image.pullPolicy` | The pull policy to apply to the image | `Always` |
+| `nsqd.image.repository`  | The NSQ image to use  | `nsqio/nsq`  |
+| `nsqd.image.tag` |  The docker tag to use for the image | `v1.1.0`  |
+| `nsqd.name` | The name of the NSQD replicaset | `nsqd` |
+| `nsqd.nodeSelector` | The tags that will be used to select the node on which the pods should be scheduled | `{}` |
+| `nsqd.persistence.resources` | The resources to allocate for the persistence of the data | `{ requests: { storage: 10Gi } }` |
+| `nsqd.persistence.storageClass` | The storage class to use to persist the NSQD data | `gp2` |
+| `nsqd.podAnnotations` | The annotations to attach to the NSQD pods | `{}` |
+| `nsqd.podDisruptionBudget` | The minimum available NSQD pods | `{ minAvailable: 3 }` |
+| `nsqd.podManagementPolicy` |  The pod management policy of the StatefulSet | `Parallel` |
+| `nsqd.priorityClassName` | The name of the [PriorityClass](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass) to apply to the pods | *none* |
+| `nsqd.replicaCount` | The amount of NSQD replicas in the replicaset | 3 |
+| `nsqd.prometheus.enabled` |  Defines if the prometheus metrics should be exported or not | `false` |
+| `nsqd.prometheus.image.repository` |  The image of the prometheus exporter to use | `emaincourt/nsq_exporter` |
+| `nsqd.prometheus.image.tag` |  The tag to use for the prometheus exporter image | `latest` |
+| `nsqd.resources` | The resources to allocate to the pods | `{ limits: { cpu: 100m, memory: 128Mi } }` |
+| `nsqd.service.annotations` | The annotations to attach to the service in front of NSQDs | `{}` |
+| `nsqd.service.type` | The type of service that should be created in front of NSQDs | `ClusterIP` |
+| `nsqd.updateStrategy` | The update strategy of the StatefulSet | *none* |
+
+#### NSQLookupd
+
+|  Field |  Description |  Default  |
+|---|---|---|
+| `nsqlookupd.antiAffinity` | The anti affinity rule to apply for the pods scheduling. Allowed values are `soft` and `hard`. | `soft` |
+| `nsqlookupd.extraArgs` | Extra arguments to provide to the `nsqlookupd` command | `[]` |
+| `nsqlookupd.image.pullPolicy` | The pull policy to apply to the image | `Always` |
+| `nsqlookupd.image.repository`  | The NSQ image to use  | `nsqio/nsq`  |
+| `nsqlookupd.image.tag` |  The docker tag to use for the image | `v1.1.0`  |
+| `nsqlookupd.name` | The name of the NSQLookupd replicaset | `nsqlookupd` |
+| `nsqlookupd.nodeSelector` | The tags that will be used to select the node on which the pods should be scheduled | `{}` |
+| `nsqd.service.annotations` | The annotations to attach to the service in front of NSQLookupds | `{}` |
+| `nsqlookupd.podAnnotations` | The annotations to attach to the NSQLookupd pods | `{}` |
+| `nsqlookupd.podDisruptionBudget` | The minimum available NSQLookupd pods | `{ minAvailable: 2 }` |
+| `nsqlookupd.podManagementPolicy` |  The pod management policy of the StatefulSet | `Parallel` |
+| `nsqlookupd.priorityClassName` | The name of the [PriorityClass](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass) to apply to the pods | *none* |
+| `nsqlookupd.replicaCount` | The amount of NSQLookupd replicas in the replicaset | 3 |
+| `nsqlookupd.resources` | The resources to allocate to the pods | `limits: { cpu: 50m, memory: 32Mi }` |
+| `nsqlookupd.updateStrategy` | The update strategy of the StatefulSet | *none* |
+
+#### NSQAdmin
+
+|  Field |  Description |  Default  |
+|---|---|---|
+| `nsqadmin.antiAffinity` | The anti affinity rule to apply for the pods scheduling. Allowed values are `soft` and `hard`. | `soft` |
+| `nsqadmin.autoscaling.annotations` | The annotations to attach to the [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | `true` |
+| `nsqadmin.autoscaling.enabled` | Defines if the autoscaling rules should be applied to the Deployment or not | `true` |
+| `nsqadmin.autoscaling.maxReplicas` | The maximum bound of the autoscaling rule | 2 |
+| `nsqadmin.autoscaling.minReplicas` | The minimum bound of the autoscaling rule | 1 |
+| `nsqadmin.autoscaling.targetCPUUtilizationPercentage` | The target CPU utilization for each pod (in %) | 80 |
+| `nsqadmin.autoscaling.targetMemoryUtilizationPercentage` | The target mem utilization for each pod (in %) | 60 |
+| `nsqadmin.enabled` | Defines if the NSQAdmin interface should be created with the cluster or not | `true` |
+| `nsqadmin.image.pullPolicy` | The pull policy to apply to the image | `Always` |
+| `nsqadmin.image.repository`  | The NSQ image to use  | `nsqio/nsq`  |
+| `nsqadmin.image.tag` |  The docker tag to use for the image | `v1.1.0`  |
+| `nsqadmin.ingress.annotations` | The annotations to attach to the [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) | `{}` |
+| `nsqadmin.ingress.enabled` | Defines if the [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) in front of the NSQAdmin service will be created or not | `false` |
+| `nsqadmin.ingress.path` | The path that should redirect to the administration interface | `/` |
+| `nsqadmin.ingress.tls` | The hosts the routing parameters should be applied to | `/` |
+| `nsqadmin.name` | The name of the NSQAdmin replicaset | `admin` |
+| `nsqadmin.nodeSelector` | The tags that will be used to select the node on which the pods should be scheduled | `{}` |
+| `nsqadmin.podAnnotations` | The annotations to attach to the NSQAdmin pods | `{}` |
+| `nsqadmin.podDisruptionBudget` | The minimum available NSQAdmin pods | `{ minAvailable: 1 }` |
+| `nsqadmin.priorityClassName` | The name of the [PriorityClass](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass) to apply to the pods | *none* |
+| `nsqadmin.replicaCount` | The amount of NSQAdmin replicas in the replicaset | 1 |
+| `nsqadmin.resources` | The resources to allocate to the pods | `limits: { cpu: 50m, memory: 32Mi }` |
+| `nsqadmin.service.annotations` | The annotations to attach to the service in front of NSQAdmins | `{}` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/incubator/nsq/templates/NOTES.txt
+++ b/incubator/nsq/templates/NOTES.txt
@@ -1,0 +1,24 @@
+The NSQ cluster is ready to use. This cluster is made of :
+
+* a NSQD replicaset
+* a NSQLookupd replicaset
+* a NSQAdmin replicaset
+
+Your NSQD and NSQLookupd replicaset are exposed through [headless services](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) by default. In this case, each instance of your replicasets will be exposed inside of the cluster through its own url :
+
+* nsqd :
+  {{ $nsqdFulName := include "nsq.nsqd.fullname" . }}
+  {{ range $i, $e := until (atoi (printf "%d" (int64 .Values.nsqd.replicaCount))) -}}
+  * {{ $nsqdFulName }}-{{ $i }}.{{ $nsqdFulName }}
+  {{ end }}
+
+* nsqlookupd :
+  {{ $lookupdFullName := include "nsq.nsqlookupd.fullname" . }}
+  {{ range $i, $e := until (atoi (printf "%d" (int64 .Values.nsqlookupd.replicaCount))) -}}
+  * {{ $lookupdFullName }}-{{ $i }}.{{ $lookupdFullName }}
+  {{ end }}
+
+Finally, the NSQAdmin interface that allows you to monitor the topics/channels can be reached at {{ include "nsq.nsqadmin.fullname" . }}.
+If you want to access it locally without exposing it, you can run `kubectl port-forward {{ include "nsq.nsqadmin.fullname" . }} 4171:4171` and reach `localhost:4171` from your browser.
+
+Please refer to the [official documentation](https://nsq.io/overview/design.html) for further informations about the NSQ features and internals.

--- a/incubator/nsq/templates/_helpers.tpl
+++ b/incubator/nsq/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nsq.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nsq.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified nsqd name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nsq.nsqd.fullname" -}}
+{{ template "nsq.fullname" . }}-{{ .Values.nsqd.name }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified nsqlookupd name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nsq.nsqlookupd.fullname" -}}
+{{ template "nsq.fullname" . }}-{{ .Values.nsqlookupd.name }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified nsqadmin name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "nsq.nsqadmin.fullname" -}}
+{{ template "nsq.fullname" . }}-{{ .Values.nsqadmin.name }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nsq.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/nsq/templates/nsqadmin-hpa.yaml
+++ b/incubator/nsq/templates/nsqadmin-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.nsqadmin.enabled) (.Values.nsqadmin.autoscaling.enabled) }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "nsq.nsqadmin.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqadmin.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.nsqadmin.autoscaling.annotations }}
+  annotations:
+{{ toYaml . | trim | indent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "nsq.nsqadmin.fullname" . }}
+  minReplicas: {{ .Values.nsqadmin.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.nsqadmin.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.nsqadmin.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      targetAverageUtilization: {{ .Values.nsqadmin.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/incubator/nsq/templates/nsqadmin-ingress.yaml
+++ b/incubator/nsq/templates/nsqadmin-ingress.yaml
@@ -1,0 +1,39 @@
+{{ $fullname := include "nsq.nsqadmin.fullname" . }}
+{{- if and .Values.nsqadmin.enabled .Values.nsqadmin.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "nsq.nsqadmin.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqadmin.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.nsqadmin.ingress.annotations }}
+  annotations:
+{{ toYaml . | trim | indent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.nsqadmin.ingress.tls }}
+  tls:
+  {{- range .Values.nsqadmin.ingress.tls }}
+  - hosts:
+    {{- range .hosts }}
+    - {{ . | quote }}
+    {{- end }}
+    secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- $ingress := .Values.nsqadmin.ingress }}
+  {{- range .Values.nsqadmin.ingress.hosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - path: {{ $ingress.path }}
+        backend:
+          serviceName: {{ $fullname }}
+          servicePort: http
+  {{- end }}
+{{- end }}

--- a/incubator/nsq/templates/nsqadmin-pdb.yaml
+++ b/incubator/nsq/templates/nsqadmin-pdb.yaml
@@ -1,0 +1,19 @@
+{{- if and (.Values.nsqadmin.enabled) (.Values.nsqadmin.podDisruptionBudget) }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "nsq.nsqadmin.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: nsqadmin
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Values.nsqadmin.name }}
+      app.kubernetes.io/name: {{ include "nsq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ toYaml .Values.nsqadmin.podDisruptionBudget | trim | indent 2 }}
+{{- end -}}

--- a/incubator/nsq/templates/nsqadmin-service.yaml
+++ b/incubator/nsq/templates/nsqadmin-service.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.nsqadmin.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nsq.nsqadmin.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqadmin.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.nsqadmin.service.annotations }}
+  annotations:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - port: 4171
+    targetPort: http
+  selector:
+    app.kubernetes.io/component: {{ .Values.nsqadmin.name }}
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/incubator/nsq/templates/nsqadmin.deployment.yaml
+++ b/incubator/nsq/templates/nsqadmin.deployment.yaml
@@ -1,0 +1,86 @@
+{{ $global := .Values.global }}
+{{ if .Values.nsqadmin.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nsq.nsqadmin.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqadmin.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.nsqadmin.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Values.nsqadmin.name }}
+      app.kubernetes.io/name: {{ include "nsq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ .Values.nsqadmin.name }}
+        app.kubernetes.io/name: {{ include "nsq.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.nsqadmin.podAnnotations }}
+      annotations:
+{{ toYaml .Values.nsqadmin.podAnnotations | trim | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.nsqadmin.priorityClassName }}
+      priorityClassName: "{{ .Values.nsqadmin.priorityClassName }}"
+{{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.nsqadmin.image.repository }}:{{ .Values.nsqadmin.image.tag }}"
+        imagePullPolicy: {{ .Values.nsqadmin.image.pullPolicy }}
+        command:
+        - /nsqadmin
+        args:
+        {{ $lookupdFullName := include "nsq.nsqlookupd.fullname" . -}}
+        {{ range $i, $e := until (atoi (printf "%d" (int64 .Values.nsqlookupd.replicaCount))) -}}
+        - --lookupd-http-address={{ $lookupdFullName }}-{{ $i }}.{{ $lookupdFullName }}:4161
+        {{ end -}}
+        ports:
+        - containerPort: 4171
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+        resources:
+{{ toYaml .Values.nsqadmin.resources | trim | indent 12 }}
+{{- if .Values.nsqadmin.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nsqadmin.nodeSelector | trim | indent 8 }}
+{{- end }}
+{{- if or .Values.nsqadmin.antiAffinity }}
+      affinity:
+  {{- if eq .Values.nsqadmin.antiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nsq.name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.nsqadmin.name }}"
+  {{- else if eq .Values.nsqadmin.antiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nsq.name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.nsqadmin.name }}"
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/incubator/nsq/templates/nsqd-pdb.yaml
+++ b/incubator/nsq/templates/nsqd-pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.nsqd.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "nsq.nsqd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqd.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Values.nsqd.name }}
+      app.kubernetes.io/name: {{ include "nsq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ toYaml .Values.nsqd.podDisruptionBudget | trim | indent 2 }}
+{{- end -}}

--- a/incubator/nsq/templates/nsqd-service.yaml
+++ b/incubator/nsq/templates/nsqd-service.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nsq.nsqd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqd.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.nsqd.service.annotations }}
+  annotations:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.nsqd.service.type }}
+  clusterIP: None
+  ports:
+  - name: nsqd-tcp
+    port: 4150
+    protocol: TCP
+    targetPort: 4150
+  - name: nsqd-http
+    port: 4151
+    protocol: TCP
+    targetPort: 4151
+  selector:
+    app.kubernetes.io/component: {{ .Values.nsqd.name }}
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/incubator/nsq/templates/nsqd-statefulset.yaml
+++ b/incubator/nsq/templates/nsqd-statefulset.yaml
@@ -1,0 +1,123 @@
+{{ $global := .Values.global}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "nsq.nsqd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqd.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.nsqd.replicaCount }}
+  podManagementPolicy: {{ .Values.nsqd.podManagementPolicy }}
+  serviceName: {{ include "nsq.nsqd.fullname" . }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Values.nsqd.name }}
+      app.kubernetes.io/name: {{ include "nsq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ if .Values.nsqd.updateStrategy -}}
+  updateStrategy:
+{{ toYaml .Values.nsqd.updateStrategy | trim | indent 4 -}}
+{{ end }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ .Values.nsqd.name }}
+        app.kubernetes.io/name: {{ include "nsq.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.nsqd.podAnnotations }}
+      annotations:
+{{ toYaml .Values.nsqd.podAnnotations | trim | indent 8 }}
+{{- end }}
+{{- if .Values.nsqd.priorityClassName }}
+      priorityClassName: "{{ .Values.nsqd.priorityClassName }}"
+{{- end }}
+    spec:
+      nodeSelector:
+{{ toYaml .Values.nsqd.nodeSelector | trim | indent 8 -}}
+      {{- if or .Values.nsqd.antiAffinity }}
+      affinity:
+        {{- if eq .Values.nsqd.antiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nsq.name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.nsqd.name }}"
+        {{- else if eq .Values.nsqd.antiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nsq.name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.nsqd.name }}"
+        {{- end }}
+      {{- end }}
+      containers:
+      - name: nsqd
+        image: "{{ .Values.nsqd.image.repository }}:{{ .Values.nsqd.image.tag }}"
+        imagePullPolicy: {{ .Values.nsqd.image.pullPolicy }}
+        command:
+        - /nsqd
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - --broadcast-address=$(POD_IP)
+        - --data-path=/data
+        {{ $lookupdFullName := include "nsq.nsqlookupd.fullname" . -}}
+        {{ range $i, $e := until (atoi (printf "%d" (int64 .Values.nsqlookupd.replicaCount))) -}}
+        - --lookupd-tcp-address={{ $lookupdFullName }}-{{ $i }}.{{ $lookupdFullName }}:4160
+        {{ end }}
+        {{- range .Values.nsqd.extraArgs -}}
+        - {{ . }}
+        {{ end -}}
+        ports:
+        - containerPort: 4150
+          name: tcp
+        - containerPort: 4151
+          name: http
+        volumeMounts:
+        - mountPath: /data
+          name: data
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        resources:
+{{ toYaml .Values.nsqd.resources | trim | indent 10 }}
+{{- if .Values.nsqd.prometheus.enabled }}
+      - name: prom-exporter
+        image: "{{ .Values.nsqd.prometheus.image.repository }}:{{ .Values.nsqd.prometheus.image.tag }}"
+        ports:
+        - containerPort: 9117
+{{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.nsqd.persistence.storageClass }}
+        resources:
+{{ toYaml .Values.nsqd.persistence.resources | trim | indent 10 }}

--- a/incubator/nsq/templates/nsqlookupd-pdb.yaml
+++ b/incubator/nsq/templates/nsqlookupd-pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.nsqlookupd.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "nsq.nsqlookupd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqlookupd.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: nsqlookupd
+      app.kubernetes.io/name: {{ include "nsq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ toYaml .Values.nsqlookupd.podDisruptionBudget | trim | indent 2 }}
+{{- end -}}

--- a/incubator/nsq/templates/nsqlookupd-service.yaml
+++ b/incubator/nsq/templates/nsqlookupd-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nsq.nsqlookupd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqlookupd.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.nsqlookupd.service.annotations }}
+  annotations:
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  ports:
+  - port: 4160
+    name: tcp
+    targetPort: 4160
+  - port: 4161
+    name: http
+    targetPort: 4161
+  selector:
+    app.kubernetes.io/component: {{ .Values.nsqlookupd.name }}
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/incubator/nsq/templates/nsqlookupd-statefulset.yaml
+++ b/incubator/nsq/templates/nsqlookupd-statefulset.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "nsq.nsqlookupd.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nsq.name" . }}
+    helm.sh/chart: {{ include "nsq.chart" . }}
+    app.kubernetes.io/component: {{ .Values.nsqlookupd.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.nsqlookupd.replicaCount }}
+  podManagementPolicy: {{ .Values.nsqlookupd.podManagementPolicy }}
+  serviceName: {{ include "nsq.nsqlookupd.fullname" . }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Values.nsqlookupd.name }}
+      app.kubernetes.io/name: {{ include "nsq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{ if .Values.nsqlookupd.updateStrategy -}}
+  updateStrategy:
+{{ toYaml .Values.nsqlookupd.updateStrategy | trim | indent 4 -}}
+{{ end }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ .Values.nsqlookupd.name }}
+        app.kubernetes.io/name: {{ include "nsq.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.nsqlookupd.podAnnotations }}
+{{- with .Values.nsqlookupd.podAnnotations }}
+      annotations:
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if .Values.nsqlookupd.priorityClassName }}
+      priorityClassName: "{{ .Values.nsqlookupd.priorityClassName }}"
+{{- end }}
+    spec:
+      nodeSelector:
+{{ toYaml .Values.nsqlookupd.nodeSelector | trim | indent 8 }}
+      {{- if .Values.nsqlookupd.antiAffinity }}
+      affinity:
+        {{- if eq .Values.nsqlookupd.antiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nsq.name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.nsqlookupd.name }}"
+        {{- else if eq .Values.nsqlookupd.antiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "nsq.name" . }}"
+                  release: "{{ .Release.Name }}"
+                  component: "{{ .Values.nsqlookupd.name }}"
+        {{- end }}
+      {{- end }}
+      containers:
+      - name: nsqlookupd
+        image: "{{ .Values.nsqlookupd.image.repository }}:{{ .Values.nsqlookupd.image.tag }}"
+        imagePullPolicy: {{ .Values.nsqlookupd.image.pullPolicy }}
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        command:
+        - /nsqlookupd
+        args:
+        - --broadcast-address=$(POD_IP)
+{{- if .Values.nsqlookupd.extraArgs }}
+{{ toYaml .Values.nsqlookupd.extraArgs | trim | indent 8 }}
+{{- end }}
+        ports:
+        - containerPort: 4160
+          name: tcp
+        - containerPort: 4161
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        resources:
+{{ toYaml .Values.nsqlookupd.resources | trim | indent 10 }}

--- a/incubator/nsq/values.yaml
+++ b/incubator/nsq/values.yaml
@@ -1,0 +1,115 @@
+nsqd:
+  name: "nsqd"
+
+  podDisruptionBudget:
+    minAvailable: 1
+
+  service:
+    type: ClusterIP
+    annotations: {}
+
+  replicaCount: 3
+  podManagementPolicy: "Parallel"
+  podAnnotations: {}
+  # updateStrategy: {}
+  # priorityClassName: ""
+  antiAffinity: "soft"
+  nodeSelector: {}
+
+  image:
+    # Source: https://github.com/nsqio/nsq/blob/master/Dockerfile
+    repository: "nsqio/nsq"
+    tag: "v1.1.0"
+    pullPolicy: "Always"
+  extraArgs:
+  - --max-msg-timeout=4h
+  - --max-req-timeout=3h
+
+  prometheus:
+    enabled: false
+    image:
+      # Because of this issue, we use a fork for 1.1.0: https://github.com/lovoo/nsq_exporter/pull/19
+      # Source: https://github.com/emaincourt/nsq_exporter/blob/master/Dockerfile
+      repository: emaincourt/nsq_exporter
+      tag: latest
+
+  persistence:
+    storageClass: "gp2"
+    resources:
+      requests:
+        storage: 10Gi
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+nsqlookupd:
+  name: "nsqlookupd"
+
+  podDisruptionBudget:
+    minAvailable: 2
+
+  service:
+    annotations: {}
+
+  replicaCount: 3
+  podManagementPolicy: "Parallel"
+  podAnnotations: {}
+  # updateStrategy: {}
+  # priorityClassName: ""
+  antiAffinity: "soft"
+  nodeSelector: {}
+
+  image:
+    # Source: https://github.com/nsqio/nsq/blob/master/Dockerfile
+    repository: "nsqio/nsq"
+    tag: "v1.1.0"
+    pullPolicy: "Always"
+  extraArgs: []
+
+  resources:
+    limits:
+      cpu: 50m
+      memory: 32Mi
+
+nsqadmin:
+  enabled: true
+  name: "admin"
+
+  autoscaling:
+    enabled: true
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 2
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 60
+
+  ingress:
+    enabled: false
+    # annotations: {}
+    # path: "/"
+    # tls: []
+
+  podDisruptionBudget:
+    minAvailable: 1
+
+  service:
+    annotations: {}
+
+  replicaCount: 1
+  podAnnotations: {}
+  # priorityClassName: ""
+  # antiAffinity: ""
+  nodeSelector: {}
+
+  image:
+    # Source: https://github.com/nsqio/nsq/blob/master/Dockerfile
+    repository: "nsqio/nsq"
+    tag: "v1.1.0"
+    pullPolicy: "Always"
+
+  resources:
+    limits:
+      cpu: 50m
+      memory: 32Mi


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds the charts for both a whole NSQ cluster, including `nsqd`, `nsqlookupd` and `nsqadmin`. This configuration ensures the persistence and the resilience of the stored data.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
