### PR TITLE
[stable/rabbitmq] metrics readiness probe: set timeout to 5s.

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 3.5.3
+version: 3.5.4
 appVersion: 3.7.8
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -184,7 +184,7 @@ spec:
             path: /metrics
             port: metrics
           initialDelaySeconds: 5
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         resources:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}


### PR DESCRIPTION
metrics readiness probe: set timeout to 5s.
1s is sometimes not enough for metrics to answer.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

