### PR TITLE
[stable/sumologic-fluentd] Support defining PriorityClass

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.8.2
+version: 0.9.0
 appVersion: 2.1.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 | `resources.limits.memory` | Memory resource limits | 256Mi |
 | `rbac.create` | Is Role Based Authentication enabled in the cluster | `false` |
 | `rbac.serviceAccountName` | RBAC service account name | {{ fullname }} |
+| `daemonset.priorityClassName` | Priority Class to use for the daemonset | `Nil` |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/sumologic-fluentd/ci/no-url-values.yaml
+++ b/stable/sumologic-fluentd/ci/no-url-values.yaml
@@ -1,3 +1,5 @@
 sumologic:
   collectorUrl: https://endpoint1.collection.us2.sumologic.com/receiver/v1/http/1234
   excludePath: "[\"/mnt/log/*.log\", \"/var/log/*.log\", \"/mnt/log/*/*.log\"]"
+
+daemonset: {}

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -21,6 +21,9 @@ spec:
         app: {{ template "sumologic-fluentd.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.daemonset.priorityClassName }}
+      priorityClassName: {{ .Values.daemonset.priorityClassName }}
+      {{- end }}
       containers:
         - name: {{ template "sumologic-fluentd.fullname" . }}
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -182,3 +182,7 @@ rbac:
 
   ## Ignored if rbac.create is true
   serviceAccountName: default
+
+daemonset:
+  # Priority Class to use for deployed daemonsets
+  # priorityClassName: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
Enables users to specify a [priorityClassName](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass) for DaemonSet pods. 

#### Special notes for your reviewer:
Since Kubernetes 1.11, the Kubernetes scheduler defaults to using a Pod's Priority Class to determine preemption and scheduling priority relative to other Pods running in the cluster. This change allows the operator to specify a priority for sumologic-fluentd-deployed Pods.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

/cc @flah00 @frankreno @darend 