### PR TITLE
Deprecate and promote spring-cloud-data-flow to stable

### DIFF
--- a/incubator/spring-cloud-data-flow/Chart.yaml
+++ b/incubator/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-description: Toolkit for building data processing pipelines.
+description: DEPRECATED Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 0.2.6
+version: 0.2.7
 appVersion: 1.6.2.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:
@@ -10,8 +10,5 @@ sources:
 - https://github.com/spring-cloud/spring-cloud-skipper
 - https://github.com/spring-cloud/spring-cloud-dataflow-metrics-collector
 icon: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/master/spring-cloud-dataflow-docs/src/main/docbook/images/logo.png
-maintainers:
-- name: trisberg
-  email: trisberg@pivotal.io
-- name: chrisjs
-  email: cschaefer@pivotal.io
+# The chart has been moved to stable.
+deprecated: true

--- a/incubator/spring-cloud-data-flow/README.md
+++ b/incubator/spring-cloud-data-flow/README.md
@@ -1,5 +1,9 @@
 # Spring Cloud Data Flow Chart
 
+****
+**NOTE: This chart has been DEPRECATED. Please use stable/spring-cloud-data-flow.**
+****
+
 [Spring Cloud Data Flow](http://cloud.spring.io/spring-cloud-dataflow/) is a toolkit for building data integration and real-time data processing pipelines.
 
 Pipelines consist of [Spring Boot](http://projects.spring.io/spring-boot/) apps, built using the [Spring Cloud Stream](http://cloud.spring.io/spring-cloud-stream/) or [Spring Cloud Task](http://cloud.spring.io/spring-cloud-task/) microservice frameworks. This makes Spring Cloud Data Flow suitable for a range of data processing use cases, from import/export to event streaming and predictive analytics.

--- a/incubator/spring-cloud-data-flow/templates/NOTES.txt
+++ b/incubator/spring-cloud-data-flow/templates/NOTES.txt
@@ -1,3 +1,7 @@
+***********************************************************************************
+* NOTE: This chart has been DEPRECATED. Please use stable/spring-cloud-data-flow. *
+***********************************************************************************
+
 1. Get the application URL by running these commands:
 {{- if contains "NodePort" .Values.server.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "scdf.fullname" . }}-server)

--- a/stable/spring-cloud-data-flow/.helmignore
+++ b/stable/spring-cloud-data-flow/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/spring-cloud-data-flow/Chart.yaml
+++ b/stable/spring-cloud-data-flow/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+description: Toolkit for building data processing pipelines.
+name: spring-cloud-data-flow
+version: 0.3.0
+appVersion: 1.7.0.RELEASE
+home: http://cloud.spring.io/spring-cloud-dataflow/
+sources:
+- https://github.com/spring-cloud/spring-cloud-dataflow
+- https://github.com/spring-cloud/spring-cloud-dataflow-server-kubernetes
+- https://github.com/spring-cloud/spring-cloud-skipper
+- https://github.com/spring-cloud/spring-cloud-dataflow-metrics-collector
+icon: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/master/spring-cloud-dataflow-docs/src/main/docbook/images/logo.png
+maintainers:
+- name: trisberg
+  email: trisberg@pivotal.io
+- name: chrisjs
+  email: cschaefer@pivotal.io

--- a/stable/spring-cloud-data-flow/Chart.yaml
+++ b/stable/spring-cloud-data-flow/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Toolkit for building data processing pipelines.
 name: spring-cloud-data-flow
-version: 0.3.0
+version: 1.0.0
 appVersion: 1.7.0.RELEASE
 home: http://cloud.spring.io/spring-cloud-dataflow/
 sources:

--- a/stable/spring-cloud-data-flow/README.md
+++ b/stable/spring-cloud-data-flow/README.md
@@ -1,0 +1,108 @@
+# Spring Cloud Data Flow Chart
+
+[Spring Cloud Data Flow](http://cloud.spring.io/spring-cloud-dataflow/) is a toolkit for building data integration and real-time data processing pipelines.
+
+Pipelines consist of [Spring Boot](http://projects.spring.io/spring-boot/) apps, built using the [Spring Cloud Stream](http://cloud.spring.io/spring-cloud-stream/) or [Spring Cloud Task](http://cloud.spring.io/spring-cloud-task/) microservice frameworks. This makes Spring Cloud Data Flow suitable for a range of data processing use cases, from import/export to event streaming and predictive analytics.
+
+## Chart Details
+This chart will provision a fully functional and fully featured Spring Cloud Data Flow installation
+that can deploy and manage data processing pipelines in the cluster that it is deployed to.
+
+MySQL and Redis are used as the stores for Spring Cloud Data Flow state and RabbitMQ is used for the pipelines' messaging layer.
+
+For more information on Spring Cloud Data Flow and its capabilities, see it's [documentation](http://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/).
+
+## Prerequisites
+
+Assumes that serviceAccount credentials are available so the deployed Data Flow server can access the API server (Works on GKE and Minikube by default). See [Configure Service Accounts for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/spring-cloud-data-flow
+```
+
+If you are using a cluster that does not have a load balancer (like Minikube) then you can install using a NodePort:
+
+```bash
+$ helm install --name my-release --set server.service.type=NodePort stable/spring-cloud-data-flow
+```
+
+Note that this chart pulls in many different Docker images so can take a while to fully install.
+
+## Configuration
+
+The following tables list the configurable parameters and their default values.
+
+### RBAC Configuration
+
+| Parameter     | Description                 | Default                   |
+| ------------- | --------------------------- | ------------------------- |
+| rbac.create   | Create RBAC configurations  | true
+
+### ServiceAccount Configuration
+
+| Parameter             | Description            | Default                     |
+| --------------------- | ---------------------- | --------------------------- |
+| serviceAccount.create | Create ServiceAccount  | true
+| serviceAccount.name   | ServiceAccount name    | (generated if not specified)
+
+### Data Flow User Accounts
+
+| Parameter               | Description                            | Default                   |
+| ----------------------- | -------------------------------------- | ------------------------- |
+| dataflowUsername        | The username for the primary user      | user
+| dataflowPassword        | The password for the primary user      | password
+| dataflowRoles           | The roles assigned to the primary user | ROLE_VIEW, ROLE_CREATE
+| dataflowAdminUsername   | The username for the admin user        | admin
+| dataflowAdminPassword   | The password for the admin user        | admin
+| dataflowAdminRoles      | The roles assigned to the admin user   | ROLE_MANAGE, ROLE_VIEW
+
+### Data Flow Server Configuration
+
+| Parameter                         | Description                                        | Default          |
+| --------------------------------- | -------------------------------------------------- | ---------------- |
+| server.version                    | The version/tag of the Data Flow server            | 1.7.0.RELEASE
+| server.imagePullPolicy            | The imagePullPolicy of the Data Flow server        | IfNotPresent
+| server.service.type               | The service type for the Data Flow server          | LoadBalancer
+| server.service.externalPort       | The external port for the Data Flow server         | 80
+
+### Skipper Server Configuration
+
+| Parameter                          | Description                                       | Default          |
+| ---------------------------------- | ------------------------------------------------- | ---------------- |
+| skipper.version                    | The version/tag of the Skipper server             | 1.1.0.RELEASE
+| skipper.imagePullPolicy            | The imagePullPolicy of the Skipper server         | IfNotPresent
+| skipper.platformName               | The name of the configured platform account       | minikube
+| skipper.service.type               | The service type for the Skipper server           | ClusterIP
+
+### Metrics Server Configuration
+
+| Parameter                          | Description                                       | Default          |
+| ---------------------------------- | ------------------------------------------------- | ---------------- |
+| metrics.version                    | The version/tag of the Metrics server             | 2.0.0.RELEASE
+| metrics.imagePullPolicy            | The imagePullPolicy of the Metrics server         | IfNotPresent
+| metrics.service.type               | The service type for the Metrics server           | ClusterIP
+
+### Spring Cloud Deployer Configuration
+
+| Parameter                                   | Description                            | Default                   |
+| ------------------------------------------- | -------------------------------------- | ------------------------- |
+| deployer.resourceLimits.cpu                 | Deployer resource limit for cpu        | 500m
+| deployer.resourceLimits.memory              | Deployer resource limit for memory     | 1024Mi
+| deployer.readinessProbe.initialDelaySeconds | Deployer readiness probe initial delay | 120
+| deployer.livenessProbe.initialDelaySeconds  | Deployer liveness probe initial delay  | 90
+
+### RabbitMQ Configuration
+
+| Parameter                  | Description           | Default                   |
+| -------------------------- | --------------------- | ------------------------- |
+| rabbitmq.rabbitmqUsername  | RabbitMQ user name    | user
+
+### MySQL Configuration
+
+| Parameter                  | Description           | Default                   |
+| -------------------------- | --------------------- | ------------------------- |
+| mysql.mysqlDatabase        | MySQL database name   | dataflow

--- a/stable/spring-cloud-data-flow/requirements.lock
+++ b/stable/spring-cloud-data-flow/requirements.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: mysql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.3.4
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 1.1.11
+- name: rabbitmq
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 0.6.16
+digest: sha256:b16ffdc5da316b3a7e677d3a83670341b13670d7e59f8ce74d023a01df05f135
+generated: 2018-01-31T09:21:26.470351-05:00

--- a/stable/spring-cloud-data-flow/requirements.yaml
+++ b/stable/spring-cloud-data-flow/requirements.yaml
@@ -1,0 +1,10 @@
+dependencies:
+- name:  mysql
+  version: 0.3.4
+  repository: https://kubernetes-charts.storage.googleapis.com/
+- name:  redis
+  version: 1.1.11
+  repository: https://kubernetes-charts.storage.googleapis.com/
+- name:  rabbitmq
+  version: 0.6.16
+  repository: https://kubernetes-charts.storage.googleapis.com/

--- a/stable/spring-cloud-data-flow/templates/NOTES.txt
+++ b/stable/spring-cloud-data-flow/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.server.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "scdf.fullname" . }}-server)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.server.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of the server by running 'kubectl get svc -w {{ template "scdf.fullname" . }}-server'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "scdf.fullname" . }}-server -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.server.service.externalPort }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "scdf.fullname" . }}-server" -> -l "app={{ template "scdf.name" . }},release={{ .Release.Name }},component=server"
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.server.service.externalPort }}
+{{- end }}

--- a/stable/spring-cloud-data-flow/templates/_helpers.tpl
+++ b/stable/spring-cloud-data-flow/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "scdf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default short app name to use for resource naming.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "scdf.fullname" -}}
+{{- $name := default "data-flow" .Values.appNameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create an uppercase app name to use for environment variables.
+*/}}
+{{- define "scdf.envname" -}}
+{{- $name := default "data-flow" .Values.appNameOverride -}}
+{{- printf "%s_%s" .Release.Name $name | upper | replace "-" "_" | trimSuffix "_" -}}
+{{- end -}}
+
+{{/*
+Create an uppercase release prefix to use for environment variables.
+*/}}
+{{- define "scdf.envrelease" -}}
+{{- printf "%s" .Release.Name | upper | replace "-" "_" | trimSuffix "_" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "scdf.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "scdf.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/spring-cloud-data-flow/templates/metrics-deployment-rabbit.yaml
+++ b/stable/spring-cloud-data-flow/templates/metrics-deployment-rabbit.yaml
@@ -1,0 +1,61 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "scdf.fullname" . }}-metrics
+  labels:
+    app: {{ template "scdf.name" . }}
+    component: metrics
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "scdf.name" . }}
+        component: metrics
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: {{ template "scdf.fullname" . }}-metrics
+        image: {{ .Values.metrics.image }}:{{ .Values.metrics.version }}
+        imagePullPolicy: {{ .Values.metrics.imagePullPolicy }}
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /actuator/health
+            port: http
+          initialDelaySeconds: 90
+          periodSeconds: 15
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: http
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 5
+        env:
+        - name: SERVER_PORT
+          value: '8080'
+        - name: SPRING_CLOUD_CONFIG_ENABLED
+          value: 'false'
+        - name: SPRING_AUTOCONFIGURE_EXCLUDE
+          value: 'org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration'
+        - name: SPRING_RABBITMQ_HOST
+          value: '${{ printf "{" }}{{ template "scdf.envrelease" . }}_RABBITMQ_SERVICE_HOST}'
+        - name: SPRING_RABBITMQ_PORT
+          value: '${{ printf "{" }}{{ template "scdf.envrelease" . }}_RABBITMQ_SERVICE_PORT_AMQP}'
+        - name: SPRING_RABBITMQ_USERNAME
+          value: '{{ .Values.rabbitmq.rabbitmqUsername }}'
+        - name: SPRING_RABBITMQ_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "rabbitmq" | trunc 63 | trimSuffix "-" }}
+              key: rabbitmq-password
+      serviceAccountName: {{ template "scdf.serviceAccountName" . }}

--- a/stable/spring-cloud-data-flow/templates/metrics-deployment-rabbit.yaml
+++ b/stable/spring-cloud-data-flow/templates/metrics-deployment-rabbit.yaml
@@ -13,6 +13,7 @@ spec:
     matchLabels:
       app: {{ template "scdf.name" . }}
       component: metrics
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:

--- a/stable/spring-cloud-data-flow/templates/metrics-deployment-rabbit.yaml
+++ b/stable/spring-cloud-data-flow/templates/metrics-deployment-rabbit.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "scdf.fullname" . }}-metrics
@@ -9,6 +9,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "scdf.name" . }}
+      component: metrics
   replicas: 1
   template:
     metadata:

--- a/stable/spring-cloud-data-flow/templates/metrics-service.yaml
+++ b/stable/spring-cloud-data-flow/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "scdf.fullname" . }}-metrics
+  labels:
+    app: {{ template "scdf.name" . }}
+    component: metrics
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.metrics.service.type }}
+  ports:
+    - port: 80
+      targetPort: http
+      name: http
+  selector:
+    app: {{ template "scdf.name" . }}
+    component: metrics
+    release: {{ .Release.Name }}

--- a/stable/spring-cloud-data-flow/templates/secrets.yaml
+++ b/stable/spring-cloud-data-flow/templates/secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "scdf.fullname" . }}
+  labels:
+    app: {{ template "scdf.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{- if .Values.dataflowAdminPassword }}
+  data-flow-admin-password: {{ .Values.dataflowAdminPassword | b64enc | quote }}
+  {{- else }}
+  data-flow-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.dataflowPassword }}
+  data-flow-password: {{ .Values.dataflowPassword | b64enc | quote }}
+  {{- else }}
+  data-flow-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{- end }}

--- a/stable/spring-cloud-data-flow/templates/server-config-rabbit.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-config-rabbit.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "scdf.fullname" . }}-server
+  labels:
+    app: {{ template "scdf.name" . }}
+    component: server
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  application.yaml: |-
+    security:
+      basic:
+        enabled: true
+        realm: Spring Cloud Data Flow
+    spring:
+      cloud:
+        dataflow:
+          security:
+            authentication:
+              file:
+                enabled: true
+                users:
+                  {{ .Values.dataflowAdminUsername }}: ${data-flow-admin-password}, {{ .Values.dataflowAdminRoles }}
+                  {{ .Values.dataflowUsername }}: ${data-flow-password}, {{ .Values.dataflowRoles }}
+        deployer:
+          kubernetes:
+            environmentVariables: 'SPRING_RABBITMQ_HOST=${{ printf "{" }}{{ template "scdf.envrelease" . }}_RABBITMQ_SERVICE_HOST},SPRING_RABBITMQ_PORT=${{ printf "{" }}{{ template "scdf.envrelease" . }}_RABBITMQ_SERVICE_PORT_AMQP},SPRING_RABBITMQ_USERNAME={{ .Values.rabbitmq.rabbitmqUsername }},SPRING_RABBITMQ_PASSWORD=${rabbitmq-password},SPRING_REDIS_HOST=${{ printf "{" }}{{ template "scdf.envrelease" . }}_REDIS_SERVICE_HOST},SPRING_REDIS_PORT=${{ printf "{" }}{{ template "scdf.envrelease" . }}_REDIS_SERVICE_PORT},SPRING_REDIS_PASSWORD=${redis-password}'
+      datasource:
+        url: 'jdbc:mysql://${{ printf "{" }}{{ template "scdf.envrelease" . }}_MYSQL_SERVICE_HOST}:3306/dataflow'
+        driverClassName: org.mariadb.jdbc.Driver
+        username: root
+        password: ${mysql-root-password}
+        testOnBorrow: true
+        validationQuery: "SELECT 1"
+      redis:
+        host: ${{ printf "{" }}{{ template "scdf.envrelease" . }}_REDIS_SERVICE_HOST}
+        port: ${{ printf "{" }}{{ template "scdf.envrelease" . }}_REDIS_SERVICE_PORT}
+        password: ${redis-password}

--- a/stable/spring-cloud-data-flow/templates/server-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-deployment.yaml
@@ -1,0 +1,137 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "scdf.fullname" . }}-server
+  labels:
+    app: {{ template "scdf.name" . }}
+    component: server
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "scdf.name" . }}
+        component: server
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: {{ template "scdf.fullname" . }}-server
+        image: {{ .Values.server.image }}:{{ .Values.server.version }}
+        imagePullPolicy: {{ .Values.server.imagePullPolicy }}
+        volumeMounts: [
+          {
+            name: data-flow,
+            mountPath: /etc/secrets/data-flow,
+            readOnly: true
+          },
+          {
+            name: rabbitmq,
+            mountPath: /etc/secrets/rabbitmq,
+            readOnly: true
+          },
+          {
+            name: mysql,
+            mountPath: /etc/secrets/mysql,
+            readOnly: true
+          },
+          {
+            name: redis,
+            mountPath: /etc/secrets/redis,
+            readOnly: true
+          }
+        ]
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+{{ toYaml .Values.server.resources | indent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /management/health
+            port: http
+            httpHeaders:
+            - name: Authorization
+              value: 'Basic {{ printf "%s:%s" .Values.dataflowAdminUsername .Values.dataflowAdminPassword | b64enc }}'
+          initialDelaySeconds: 120
+          periodSeconds: 15
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /management/health
+            port: http
+            httpHeaders:
+            - name: Authorization
+              value: 'Basic {{ printf "%s:%s" .Values.dataflowAdminUsername .Values.dataflowAdminPassword | b64enc }}'
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 5
+        env:
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.namespace"
+        - name: SERVER_PORT
+          value: '8080'
+        - name: SPRING_CLOUD_CONFIG_ENABLED
+          value: 'false'
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_ANALYTICS_ENABLED
+          value: 'true'
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_SCHEDULES_ENABLED
+          value: 'true'
+        - name: SPRING_CLOUD_DEPLOYER_KUBERNETES_CREATE_DEPLOYMENT
+          value: 'true'
+        - name: SPRING_CLOUD_DEPLOYER_KUBERNETES_CPU
+          value: '{{ .Values.deployer.resourceLimits.cpu }}'
+        - name: SPRING_CLOUD_DEPLOYER_KUBERNETES_MEMORY
+          value: '{{ .Values.deployer.resourceLimits.memory }}'
+        - name: SPRING_CLOUD_DEPLOYER_KUBERNETES_READINESS_PROBE_DELAY
+          value: '{{ .Values.deployer.readinessProbe.initialDelaySeconds }}'
+        - name: SPRING_CLOUD_DEPLOYER_KUBERNETES_LIVENESS_PROBE_DELAY
+          value: '{{ .Values.deployer.livenessProbe.initialDelaySeconds }}'
+        - name: SPRING_CLOUD_KUBERNETES_CONFIG_NAME
+          value: {{ template "scdf.fullname" . }}-server
+        - name: SPRING_CLOUD_KUBERNETES_SECRETS_ENABLE_API
+          value: 'true'
+        - name: SPRING_CLOUD_KUBERNETES_SECRETS_PATHS
+          value: /etc/secrets
+        - name: SPRING_CLOUD_DATAFLOW_FEATURES_SKIPPER_ENABLED
+          value: 'true'
+        - name: SPRING_CLOUD_SKIPPER_CLIENT_SERVER_URI
+          value: 'http://${{ printf "{" }}{{ template "scdf.envname" . }}_SKIPPER_SERVICE_HOST}/api'
+        - name: SPRING_CLOUD_DATAFLOW_METRICS_COLLECTOR_URI
+          value: 'http://${{ printf "{" }}{{ template "scdf.envname" . }}_METRICS_SERVICE_HOST}'
+        - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
+          value: 'http://${{ printf "{" }}{{ template "scdf.envname" . }}_SERVER_SERVICE_HOST}:${{ printf "{" }}{{ template "scdf.envname" . }}_SERVER_SERVICE_PORT}'
+          # Maven repo for metadata artifact resolution plus metrics destination for all stream apps
+        - name: SPRING_APPLICATION_JSON
+          value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } }, \"spring.cloud.dataflow.application-properties.stream.spring.cloud.stream.bindings.applicationMetrics.destination\": \"metrics\" }"
+      volumes: [
+        {
+          name: data-flow,
+          secret: {
+            secretName: {{ template "scdf.fullname" . }}
+          }
+        },
+        {
+          name: rabbitmq,
+          secret: {
+            secretName: {{ printf "%s-%s" .Release.Name "rabbitmq" | trunc 63 | trimSuffix "-" }}
+          }
+        },
+        {
+          name: mysql,
+          secret: {
+            secretName: {{ printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" }}
+          }
+        },
+        {
+          name: redis,
+          secret: {
+            secretName: {{ printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" }}
+          }
+        }
+      ]
+      serviceAccountName: {{ template "scdf.serviceAccountName" . }}

--- a/stable/spring-cloud-data-flow/templates/server-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     matchLabels:
       app: {{ template "scdf.name" . }}
       component: server
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:

--- a/stable/spring-cloud-data-flow/templates/server-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "scdf.fullname" . }}-server
@@ -9,6 +9,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "scdf.name" . }}
+      component: server
   replicas: 1
   template:
     metadata:
@@ -21,28 +25,19 @@ spec:
       - name: {{ template "scdf.fullname" . }}-server
         image: {{ .Values.server.image }}:{{ .Values.server.version }}
         imagePullPolicy: {{ .Values.server.imagePullPolicy }}
-        volumeMounts: [
-          {
-            name: data-flow,
-            mountPath: /etc/secrets/data-flow,
+        volumeMounts:
+          - name: data-flow
+            mountPath: /etc/secrets/data-flow
             readOnly: true
-          },
-          {
-            name: rabbitmq,
-            mountPath: /etc/secrets/rabbitmq,
+          - name: rabbitmq
+            mountPath: /etc/secrets/rabbitmq
             readOnly: true
-          },
-          {
-            name: mysql,
-            mountPath: /etc/secrets/mysql,
+          - name: mysql
+            mountPath: /etc/secrets/mysql
             readOnly: true
-          },
-          {
-            name: redis,
-            mountPath: /etc/secrets/redis,
+          - name: redis
+            mountPath: /etc/secrets/redis
             readOnly: true
-          }
-        ]
         ports:
         - containerPort: 8080
           name: http
@@ -108,30 +103,17 @@ spec:
           # Maven repo for metadata artifact resolution plus metrics destination for all stream apps
         - name: SPRING_APPLICATION_JSON
           value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } }, \"spring.cloud.dataflow.application-properties.stream.spring.cloud.stream.bindings.applicationMetrics.destination\": \"metrics\" }"
-      volumes: [
-        {
-          name: data-flow,
-          secret: {
+      volumes:
+        - name: data-flow
+          secret:
             secretName: {{ template "scdf.fullname" . }}
-          }
-        },
-        {
-          name: rabbitmq,
-          secret: {
+        - name: rabbitmq
+          secret:
             secretName: {{ printf "%s-%s" .Release.Name "rabbitmq" | trunc 63 | trimSuffix "-" }}
-          }
-        },
-        {
-          name: mysql,
-          secret: {
+        - name: mysql
+          secret:
             secretName: {{ printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" }}
-          }
-        },
-        {
-          name: redis,
-          secret: {
+        - name: redis
+          secret:
             secretName: {{ printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" }}
-          }
-        }
-      ]
       serviceAccountName: {{ template "scdf.serviceAccountName" . }}

--- a/stable/spring-cloud-data-flow/templates/server-rbac.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-rbac.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.rbac.create -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+metadata:
+  name: {{ template "scdf.fullname" . }}
+  labels:
+    app: {{ template "scdf.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  - apiGroups: [""]
+    resources: ["services", "pods", "replicationcontrollers", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments", "replicasets", "jobs"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+metadata:
+  name: {{ template "scdf.fullname" . }}
+  labels:
+    app: {{ template "scdf.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  kind: Role
+  name: {{ template "scdf.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "scdf.serviceAccountName" . }}
+{{- end -}}

--- a/stable/spring-cloud-data-flow/templates/server-rbac.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "scdf.fullname" . }}
   labels:
@@ -26,7 +26,7 @@ rules:
     verbs: ["create", "delete", "get", "list", "watch"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "scdf.fullname" . }}
   labels:

--- a/stable/spring-cloud-data-flow/templates/server-service.yaml
+++ b/stable/spring-cloud-data-flow/templates/server-service.yaml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "scdf.fullname" . }}-server
+  labels:
+    app: {{ template "scdf.name" . }}
+    component: server
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  # If you are running k8s on a local dev box, you can use type NodePort instead
+  type: {{ .Values.server.service.type }}
+  ports:
+    - port: {{ .Values.server.service.externalPort }}
+      targetPort: http
+      name: http
+  selector:
+    app: {{ template "scdf.name" . }}
+    component: server
+    release: {{ .Release.Name }}

--- a/stable/spring-cloud-data-flow/templates/service-account.yaml
+++ b/stable/spring-cloud-data-flow/templates/service-account.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "scdf.serviceAccountName" . }}
+  labels:
+    app: {{ template "scdf.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end -}}

--- a/stable/spring-cloud-data-flow/templates/skipper-config.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "scdf.fullname" . }}-skipper
+  labels:
+    app: {{ template "scdf.name" . }}
+    component: skipper
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  spring.application.json: '{"spring.cloud.skipper.server.enableLocalPlatform" : false, "spring.cloud.skipper.server.platform.kubernetes.accounts.{{ .Values.skipper.platformName }}.environmentVariables" : "SPRING_RABBITMQ_HOST=${{ printf "{" }}{{ template "scdf.envrelease" . }}_RABBITMQ_SERVICE_HOST},SPRING_RABBITMQ_PORT=${{ printf "{" }}{{ template "scdf.envrelease" . }}_RABBITMQ_SERVICE_PORT_AMQP},SPRING_RABBITMQ_USERNAME={{ .Values.rabbitmq.rabbitmqUsername }},SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}","spring.cloud.skipper.server.platform.kubernetes.accounts.{{ .Values.skipper.platformName }}.memory" : "{{ .Values.deployer.resourceLimits.memory }}","spring.cloud.skipper.server.platform.kubernetes.accounts.{{ .Values.skipper.platformName }}.cpu" : "{{ .Values.deployer.resourceLimits.cpu }}","spring.cloud.skipper.server.platform.kubernetes.accounts.{{ .Values.skipper.platformName }}.createDeployment" : true}'

--- a/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "scdf.fullname" . }}-skipper
+  labels:
+    app: {{ template "scdf.name" . }}
+    component: skipper
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "scdf.name" . }}
+        component: skipper
+        release: "{{ .Release.Name }}"
+    spec:
+      containers:
+      - name: {{ template "scdf.fullname" . }}-skipper
+        image: {{ .Values.skipper.image }}:{{ .Values.skipper.version }}
+        imagePullPolicy: {{ .Values.skipper.imagePullPolicy }}
+        ports:
+        - containerPort: 7577
+          name: http
+        resources:
+{{ toYaml .Values.skipper.resources | indent 10 }}
+        livenessProbe:
+          httpGet:
+            path: /api/about
+            port: http
+          initialDelaySeconds: 90
+          periodSeconds: 15
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /api/about
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          timeoutSeconds: 5
+        env:
+        - name: SPRING_DATASOURCE_URL
+          value: 'jdbc:mysql://${{ printf "{" }}{{ template "scdf.envrelease" . }}_MYSQL_SERVICE_HOST}:3306/skipper'
+        - name: SPRING_DATASOURCE_USERNAME
+          value: root
+        - name: SPRING_DATASOURCE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" }}
+              key: mysql-root-password
+        - name: SPRING_DATASOURCE_DRIVER_CLASS_NAME
+          value: org.mariadb.jdbc.Driver
+        - name: RABBITMQ_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "rabbitmq" | trunc 63 | trimSuffix "-" }}
+              key: rabbitmq-password
+        - name: SPRING_APPLICATION_JSON
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "scdf.fullname" . }}-skipper
+              key: spring.application.json
+          value: 
+      initContainers:
+      - name: init-mysql-wait
+        image: busybox
+        command: ['sh', '-c', 'until nc -w3 -z {{ printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" }} 3306; do echo waiting for mysql; sleep 3; done;']
+      - name: init-mysql-database
+        image: mysql:5.7.14
+        env:
+        - name: MYSQL_PWD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" }}
+              key: mysql-root-password
+        command: ['sh', '-c', 'mysql -h {{ printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" }} -u root -e "CREATE DATABASE IF NOT EXISTS skipper;"']
+      serviceAccountName: {{ template "scdf.serviceAccountName" . }}

--- a/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "scdf.fullname" . }}-skipper
@@ -9,6 +9,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "scdf.name" . }}
+      component: skipper
   replicas: 1
   template:
     metadata:

--- a/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     matchLabels:
       app: {{ template "scdf.name" . }}
       component: skipper
+      release: "{{ .Release.Name }}"
   replicas: 1
   template:
     metadata:

--- a/stable/spring-cloud-data-flow/templates/skipper-service.yaml
+++ b/stable/spring-cloud-data-flow/templates/skipper-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "scdf.fullname" . }}-skipper
+  labels:
+    app: {{ template "scdf.name" . }}
+    component: skipper
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.skipper.service.type }}
+  ports:
+    - port: 80
+      targetPort: http
+      name: http
+  selector:
+    app: {{ template "scdf.name" . }}
+    component: skipper
+    release: {{ .Release.Name }}

--- a/stable/spring-cloud-data-flow/values.yaml
+++ b/stable/spring-cloud-data-flow/values.yaml
@@ -1,0 +1,80 @@
+# Default values for spring-cloud-data-flow.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+dataflowUsername: user
+dataflowPassword: password
+dataflowRoles: ROLE_VIEW, ROLE_CREATE
+dataflowAdminUsername: admin
+dataflowAdminPassword: admin
+dataflowAdminRoles: ROLE_MANAGE, ROLE_VIEW
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  apiVersion: v1beta1
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the serviceAccountName template
+  name:
+
+server:
+  image: springcloud/spring-cloud-dataflow-server-kubernetes
+  version: 1.7.0.RELEASE
+  imagePullPolicy: IfNotPresent
+  service:
+    type: LoadBalancer
+    externalPort: 80
+  resources: {}
+  #  limits:
+  #    cpu: 1.0
+  #    memory: 2048Mi
+  #  requests:
+  #    cpu: 0.5
+  #    memory: 640Mi
+
+skipper:
+  image: springcloud/spring-cloud-skipper-server
+  version: 1.1.0.RELEASE
+  imagePullPolicy: IfNotPresent
+  platformName: minikube
+  service:
+    type: ClusterIP
+  resources: {}
+  #  limits:
+  #    cpu: 1.0
+  #    memory: 1024Mi
+  #  requests:
+  #    cpu: 0.5
+  #    memory: 640Mi
+
+metrics:
+  image: springcloud/metrics-collector-rabbit
+  version: 2.0.0.RELEASE
+  imagePullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+  resources: {}
+  #  limits:
+  #    cpu: 1.0
+  #    memory: 1024Mi
+  #  requests:
+  #    cpu: 0.5
+  #    memory: 640Mi
+
+deployer:
+  resourceLimits:
+    cpu: 500m
+    memory: 1024Mi
+  readinessProbe:
+    initialDelaySeconds: 120
+  livenessProbe:
+    initialDelaySeconds: 90
+
+rabbitmq:
+  rabbitmqUsername: user
+
+mysql:
+  mysqlDatabase: dataflow

--- a/stable/spring-cloud-data-flow/values.yaml
+++ b/stable/spring-cloud-data-flow/values.yaml
@@ -11,7 +11,6 @@ dataflowAdminRoles: ROLE_MANAGE, ROLE_VIEW
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
-  apiVersion: v1beta1
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
#### What this PR does / why we need it:

Deprecates incubator/spring-cloud-data-flow and promotes to stable
Updates to new SCDF version 1.7.0 and deps in stable chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md