### PR TITLE
[stable/fluentd-elasticsearch] Adding support for the logstash_prefix option

### DIFF
--- a/stable/fluentd-elasticsearch/Chart.yaml
+++ b/stable/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 1.2.0
+version: 1.3.0
 appVersion: 2.3.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/stable/fluentd-elasticsearch/README.md
+++ b/stable/fluentd-elasticsearch/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `configMaps`                       | Fluentd configmaps                         | `default conf files`                                       |
 | `elasticsearch.host`               | Elstaicsearch Host                         | `elasticsearch-client`                                     |
 | `elasticsearch.port`               | Elasticsearch Port                         | `9200`                                                     |
+| `elasticsearch.logstash_prefix`    | Elasticsearch Logstash prefix              | `logstash`                                                 |
 | `elasticsearch.buffer_chunk_limit` | Elasticsearch buffer chunk limit           | `2M`                                                       |
 | `elasticsearch.buffer_queue_limit` | Elasticsearch buffer queue limit           | `8`                                                        |
 | `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -47,6 +47,8 @@ spec:
           value: {{ .Values.elasticsearch.host | quote }}
         - name: OUTPUT_PORT
           value: {{ .Values.elasticsearch.port | quote }}
+        - name: LOGSTASH_PREFIX
+          value: {{ .Values.elasticsearch.logstash_prefix | quote }}
         - name: OUTPUT_BUFFER_CHUNK_LIMIT
           value: {{ .Values.elasticsearch.buffer_chunk_limit | quote }}
         - name: OUTPUT_BUFFER_QUEUE_LIMIT

--- a/stable/fluentd-elasticsearch/values.yaml
+++ b/stable/fluentd-elasticsearch/values.yaml
@@ -22,6 +22,7 @@ elasticsearch:
   port: 9200
   buffer_chunk_limit: 2M
   buffer_queue_limit: 8
+  logstash_prefix: 'logstash'
 
 rbac:
   create: true
@@ -439,6 +440,7 @@ configMaps:
       host "#{ENV['OUTPUT_HOST']}"
       port "#{ENV['OUTPUT_PORT']}"
       logstash_format true
+      logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
       <buffer>
         @type file
         path /var/log/fluentd-buffers/kubernetes.system.buffer


### PR DESCRIPTION
Signed-off-by: Matt Renfrow <mrenfrow@expedia.com>

#### What this PR does / why we need it:

This PR adds support for setting the `logstash_prefix` option for the Elasticsearch output plugin for fluentd. Without being able to set this option, all logs will be sent to an index pattern of `logstash-YYMMDD`, which is undesirable when using a mixed-use Elasticsearch environment.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md