### PR TITLE
adding configmap to activate the external metrics provider

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.9.0
+version: 1.9.1
 appVersion: 6.5.2
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/agent-clusterrole.yaml
+++ b/stable/datadog/templates/agent-clusterrole.yaml
@@ -48,6 +48,7 @@ rules:
   - datadog-leader-election  # Leader election token
 {{- if .Values.clusterAgent.metricsProvider.enabled }}
   - datadog-custom-metrics
+  - extension-apiserver-authentication
 {{- end }}
   verbs:
   - get


### PR DESCRIPTION
#### What this PR does / why we need it:

Add get/update access to the configmap `extension-apiserver-authentication` for the Cluster Agent agent to properly start the external metrics server.

#### Which issue this PR fixes
  - it's not been reported as an issue yet as far as I know

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [] Variables are documented in the README.md

Signed-off-by: charlyF <charly@datadoghq.com>