### PR TITLE
[stable/gocd] Volume mount config map even if persistence is disabled.

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.5.5
+
+* [22f3354](https://github.com/helm/charts/commit/22f3354):
+  - Volume mount the config map to preconfigure the server even if persistence is disabled. ([#8579](https://github.com/helm/charts/issues/8579))
+
 ### 1.5.4
 
 * [4018a215](https://github.com/kubernetes/charts/commit/4018a215):

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.5.4
+version: 1.5.5
 appVersion: 18.10.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/templates/configmap.yaml
+++ b/stable/gocd/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.shouldPreconfigure }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -134,3 +135,5 @@ data:
                   }' >> /godata/logs/preconfigure.log )
 
     echo "Done preconfiguring the GoCD server" > /godata/logs/preconfigure_complete.log
+
+{{- end }}

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -26,16 +26,18 @@ spec:
         component: server
     spec:
       serviceAccountName: {{ template "gocd.serviceAccountName" . }}
-      {{- if or .Values.server.persistence.enabled .Values.server.security.ssh.enabled }}
+      {{- if or .Values.server.shouldPreconfigure (or .Values.server.persistence.enabled .Values.server.security.ssh.enabled) }}
       volumes:
+      {{- end }}
+      {{- if .Values.server.shouldPreconfigure }}
+        - name: config-vol
+          configMap:
+            name: {{ template "gocd.fullname" . }}
       {{- end }}
       {{- if .Values.server.persistence.enabled }}
         - name: goserver-vol
           persistentVolumeClaim:
             claimName: {{ .Values.server.persistence.existingClaim | default (printf "%s-%s" (include "gocd.fullname" .) "server") }}
-        - name: config-vol
-          configMap:
-            name: {{ template "gocd.fullname" . }}
         {{- if ne (len .Values.server.persistence.extraVolumes) 0 }}
 {{ toYaml .Values.server.persistence.extraVolumes | indent 8 }}
         {{- end }}
@@ -78,8 +80,13 @@ spec:
             initialDelaySeconds: {{ .Values.server.healthCheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.healthCheck.periodSeconds }}
             failureThreshold: {{ .Values.server.healthCheck.failureThreshold }}
-          {{- if or .Values.server.persistence.enabled .Values.server.security.ssh.enabled }}
+          {{- if or .Values.server.shouldPreconfigure (or .Values.server.persistence.enabled .Values.server.security.ssh.enabled) }}
           volumeMounts:
+          {{- end }}
+          {{- if .Values.server.shouldPreconfigure }}
+            - name: config-vol
+              mountPath: /preconfigure_server.sh
+              subPath: preconfigure_server.sh
           {{- end }}
           {{- if .Values.server.persistence.enabled }}
             - name: goserver-vol
@@ -91,9 +98,6 @@ spec:
             - name: {{ .Values.server.persistence.name.dockerEntryPoint }}
               mountPath: /docker-entrypoint.d
               subPath: {{ .Values.server.persistence.subpath.dockerEntryPoint }}
-            - name: config-vol
-              mountPath: /preconfigure_server.sh
-              subPath: preconfigure_server.sh
             {{- if ne (len .Values.server.persistence.extraVolumeMounts) 0 }}
 {{ toYaml .Values.server.persistence.extraVolumeMounts | indent 12 }}
             {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
-  If ` .Values.server.shouldPreconfigure` is true, then, a configMap must be mounted onto the gocd server container
-  If ` .Values.server.shouldPreconfigure` is false, then, do not create a config map, volume or a mount. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #8579 
 - incorporates changes made in https://github.com/helm/charts/pull/8430
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
