### PR TITLE
[stable/mysql] Support host port

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.10.2
+version: 0.10.3
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
         ports:
         - name: mysql
           containerPort: 3306
+          {{- if .Values.hostPort }}
+          hostPort: {{ .Values.hostPort }}
+          {{- end }}
         livenessProbe:
           exec:
             command:

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -4,6 +4,11 @@
 image: "mysql"
 imageTag: "5.7.14"
 
+
+## Specify the port on node if necessary
+## Ref: https://kubernetes.io/docs/concepts/configuration/overview/
+# hostPort: 3306
+
 ## Specify password for root user
 ##
 ## Default: random 10 character string


### PR DESCRIPTION
Add a optional configuration `hostPort`, making it possible to access mysql through port number on host.