### PR TITLE
[stable/keycloak] configuration standalone.xml must be set

### DIFF
--- a/stable/keycloak/templates/configmap.yaml
+++ b/stable/keycloak/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
 {{ . | indent 4 }}
   {{- end }}
 
-    exec /opt/jboss/tools/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ end }}
+    exec /opt/jboss/tools/docker-entrypoint.sh -b 0.0.0.0 {{ .Values.keycloak.extraArgs }}{{- if $highAvailability }} -c standalone-ha.xml{{ else }} -c standalone.xml{{ end }}
     exit "$?"
 
   keycloak.cli: |


### PR DESCRIPTION
New docker jboss/keycloak uses standalone-ha.xml as default config, while this chart assumes standalone.xml as default (see #8751).
