### PR TITLE
Fix es settings that ended up in Splunk

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.13.1
+version: 0.13.2
 appVersion: 0.14.4
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -79,18 +79,6 @@ data:
 {{- if .Values.backend.es.time_key }}
         Time_Key {{ .Values.backend.es.time_key }}
 {{- end }}
-{{ else if eq .Values.backend.type "splunk" }}
-    [OUTPUT]
-        Name  splunk
-        Match *
-        Host  {{ .Values.backend.splunk.host }}
-        Port  {{ .Values.backend.splunk.port }}
-        Splunk_Token  {{ .Values.backend.splunk.token }}
-        Splunk_Send_Raw {{ .Values.backend.splunk.send_raw}}
-        TLS   {{ .Values.backend.splunk.tls }}
-        TLS.Verify   {{ .Values.backend.splunk.tls_verify }}
-        Message_Key   {{ .Values.backend.splunk.message_key }}
-
 {{- if .Values.backend.es.logstash_prefix }}
         Logstash_Prefix {{ .Values.backend.es.logstash_prefix }}
 {{ else if .Values.backend.es.index }}
@@ -107,6 +95,17 @@ data:
 {{- if .Values.backend.es.tls_ca }}
         tls.ca_file /secure/es-tls-ca.crt
 {{- end }}
+{{ else if eq .Values.backend.type "splunk" }}
+    [OUTPUT]
+        Name  splunk
+        Match *
+        Host  {{ .Values.backend.splunk.host }}
+        Port  {{ .Values.backend.splunk.port }}
+        Splunk_Token  {{ .Values.backend.splunk.token }}
+        Splunk_Send_Raw {{ .Values.backend.splunk.send_raw}}
+        TLS   {{ .Values.backend.splunk.tls }}
+        TLS.Verify   {{ .Values.backend.splunk.tls_verify }}
+        Message_Key   {{ .Values.backend.splunk.message_key }}
 {{- end }}
 
 {{ else if eq .Values.backend.type "http" }}


### PR DESCRIPTION
It seems that the following addition of splunk https://github.com/helm/charts/pull/7064/files broke the es settings. This moves them to the correct place.


#### What this PR does / why we need it:
Fix the es settings that got moved into splunk


#### Which issue this PR fixes
https://github.com/helm/charts/issues/7675
https://github.com/helm/charts/issues/7632

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [ X] Variables are documented in the README.md
