### PR TITLE
[stable/consul] Fix ignoring gossip-key passed via values

### DIFF
--- a/stable/consul/Chart.yaml
+++ b/stable/consul/Chart.yaml
@@ -1,6 +1,6 @@
 name: consul
 home: https://github.com/hashicorp/consul
-version: 3.4.0
+version: 3.4.1
 appVersion: 1.0.0
 description: Highly available and distributed service discovery and key-value store
   designed with support for the modern data center to make distributed systems and

--- a/stable/consul/templates/gossip-secret.yaml
+++ b/stable/consul/templates/gossip-secret.yaml
@@ -10,5 +10,9 @@ metadata:
     component: "{{ .Release.Name }}-{{ .Values.Component }}"
 type: Opaque
 data:
+  {{ if .Values.GossipKey }}
+  gossip-key: {{ .Values.GossipKey | b64enc }}
+  {{ else }}
   gossip-key: {{ randAlphaNum 24 | b64enc }}
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
User specified **GossipKey** is ignored this is breaking the existing helm releases as it changes/ignores the **GossipKey** on chart upgrade

#### Which issue this PR fixes
  - fixes #7881 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped

@lachie83 