### PR TITLE
[stable/elasticsearch-exporter] Fix typo - Add Readiness probe to exporter deployment.yaml

### DIFF
--- a/stable/elasticsearch-exporter/Chart.yaml
+++ b/stable/elasticsearch-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Elasticsearch stats exporter for Prometheus
 name: elasticsearch-exporter
-version: 0.4.0
+version: 0.4.1
 appVersion: 1.0.2
 home: https://github.com/justwatchcom/elasticsearch_exporter
 sources:

--- a/stable/elasticsearch-exporter/templates/deployment.yaml
+++ b/stable/elasticsearch-exporter/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
               port: http
             initialDelaySeconds: 30
             timeoutSeconds: 10
-          livenessProbe:
+          readinessProbe:
             httpGet:
               path: /health
               port: http


### PR DESCRIPTION
#### What this PR does / why we need it:
The `deployment.yaml` file in stable `elasticsearch-exporter` chart has two liveness probes configured, one with `initialDelaySeconds: 30` and another with `initialDelaySeconds:10`. I have modified one of the probes to readiness probe assuming that it was a miss.

#### Special notes for your reviewer:
@svenmueller Kindly have a look at this simple fix.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
