### PR TITLE
[stable/jaeger-operator] Allowed chart to be a dependency of a chart containing CRDs

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.7.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/templates/crd.yaml
+++ b/stable/jaeger-operator/templates/crd.yaml
@@ -2,6 +2,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: jaegers.io.jaegertracing
+{{- if semverCompare ">=2.10-0" .Capabilities.TillerVersion.SemVer }}
+  annotations:
+    "helm.sh/hook": crd-install
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
     helm.sh/chart: {{ include "jaeger-operator.chart" . }}


### PR DESCRIPTION
Allowed chart to be a dependency of a chart containing CRDs

Signed-off-by: Christopher King <chris@coyfox.net>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This allows the chart to be listed as a dependency while deploying CRDs currently made available by the chart.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
