### PR TITLE
Add additional values input to kubernetes-dashboard to allow HTTP listener

### DIFF
--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -31,7 +31,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+{{- if .Values.autoGenerateCertificates }}
           - --auto-generate-certificates
+{{- end }}          
 {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 10 }}
 {{- end }}

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -36,8 +36,8 @@ spec:
 {{ toYaml .Values.extraArgs | indent 10 }}
 {{- end }}
         ports:
-        - name: https
-          containerPort: 8443
+        - name: {{ .Values.deployment.portName }}
+          containerPort: {{ .Values.deployment.containerPort }}
           protocol: TCP
         volumeMounts:
         - name: kubernetes-dashboard-certs
@@ -47,9 +47,9 @@ spec:
           name: tmp-volume
         livenessProbe:
           httpGet:
-            scheme: HTTPS
+            scheme: {{ .Values.livenessProbe.scheme }}
             path: /
-            port: 8443
+            port: {{ .Values.deployment.containerPort }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         resources:

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -19,7 +19,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - port: {{ .Values.service.externalPort }}
-    targetPort: 8443
+    targetPort: {{ .Values.deployment.containerPort }}
 {{- if hasKey .Values.service "nodePort" }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -22,6 +22,7 @@ labels: {}
 #   - --enable-insecure-login
 #   - --system-banner="Welcome to Kubernetes"
 deployment:
+  autoGenerateCertificates: true
   portName: https
   containerPort: 8443
 

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -21,6 +21,9 @@ labels: {}
 # extraArgs:
 #   - --enable-insecure-login
 #   - --system-banner="Welcome to Kubernetes"
+deployment:
+  portName: https
+  containerPort: 8443
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -107,6 +110,7 @@ serviceAccount:
   name:
 
 livenessProbe:
+  scheme: HTTPS
   # Number of seconds to wait before sending first probe
   initialDelaySeconds: 30
   # Number of seconds to wait for probe response


### PR DESCRIPTION
Fix for https://github.com/helm/charts/issues/7516

The following config would allow a willing user to expose HTTP service for ingress rather than HTTPS

cc @desaintmartin  @kfox1111 

```yaml
        extraArgs:
          - --insecure-bind-address=0.0.0.0
          - --insecure-port=9090
          - --enable-insecure-login
        deployment:
          autoGenerateCertificates: false
          portName: http
          containerPort: 9090
        livenessProbe:
          scheme: HTTP
        service:
          externalPort: 80
```