### PR TITLE
[stable/postgresql] Fix NOTES.txt render error when service type is LB

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 2.2.0
+version: 2.2.1
 appVersion: 10.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -47,7 +47,8 @@ To connect to your database from outside the cluster execute the following comma
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "postgresql.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }} --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    mongo --host $SERVICE_IP --port {{ .Values.service.nodePort }} {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
     {{ if .Values.postgresqlPassword }}PGPASSWORD={{ .Values.postgresqlPassword}} "{{- end }}psql --host $SERVICE_IP --port {{ .Values.service.port }} -U {{ .Values.postgresqlUsername }}
 
 {{- else if contains "ClusterIP" .Values.service.type }}

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -48,7 +48,6 @@ To connect to your database from outside the cluster execute the following comma
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "postgresql.fullname" . }}'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-    mongo --host $SERVICE_IP --port {{ .Values.service.nodePort }} {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
     {{ if .Values.postgresqlPassword }}PGPASSWORD={{ .Values.postgresqlPassword}} "{{- end }}psql --host $SERVICE_IP --port {{ .Values.service.port }} -U {{ .Values.postgresqlUsername }}
 
 {{- else if contains "ClusterIP" .Values.service.type }}


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fix the following error when the service type is LoadBalancer:

```
Error: render error in "postgresql/templates/NOTES.txt": template: postgresql/templates/NOTES.txt:50:151: executing "postgresql/templates/NOTES.txt" at <.status.loadBalancer...>: can't evaluate field loadBalancer in type interface {}
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
