### PR TITLE
Revert "[stable/postgresql] Release 2.2.3 (#8856)"

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 name: postgresql
-version: 2.2.3
-appVersion: 11.0.0
+version: 2.2.4
+appVersion: 10.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:
 - postgresql

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.0.0
+  tag: 10.5.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -10,7 +10,7 @@
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.0.0
+  tag: 10.5.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
This reverts commit b772e0abc0e516e8f0b6c6de1bcfc7e2a0d384b4.

Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

This PR revert another PR https://github.com/helm/charts/pull/8856 that updated PostgreSQL from `10.X` to `11.X`. Because it is a major version, we prefer to test it properly before use it in the stable chart, after test it we'll create the proper PR including notable changes, update notes, etc

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
