### PR TITLE
[stable/k8s-spot-rescheduler] Support pod affinity

### DIFF
--- a/stable/k8s-spot-rescheduler/Chart.yaml
+++ b/stable/k8s-spot-rescheduler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.2.0"
 description: A k8s-spot-rescheduler Helm chart for Kubernetes
 name: k8s-spot-rescheduler
-version: 0.3.0
+version: 0.3.1
 keywords:
   - spot
   - rescheduler

--- a/stable/k8s-spot-rescheduler/templates/deployment.yaml
+++ b/stable/k8s-spot-rescheduler/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
             containerPort: 9235
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       tolerations:

--- a/stable/k8s-spot-rescheduler/values.yaml
+++ b/stable/k8s-spot-rescheduler/values.yaml
@@ -34,6 +34,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
 tolerations: []
 
 # Node labels for pod assignment


### PR DESCRIPTION
#### What this PR does / why we need it:

When using spot instances the spot rescheduler should be hosted only on ondemand instances (node selector or affinity) and I want it to spread over two failure zones when using two replicas (pod anti affinity).

cc @komljen 

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
