### PR TITLE
[stable/kibana] Add kibana plugin installed control (#8581)

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.16.4
+version: 0.17.0
 appVersion: 6.4.2
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -77,7 +77,9 @@ The following table lists the configurable parameters of the kibana chart and th
 | `dashboardImport.xpackauth.username`          | Optional Xpack username                    | `myuser`                               |
 | `dashboardImport.xpackauth.password`          | Optional Xpack password                    | `mypass`                               |
 | `dashboardImport.dashboards`                  | Dashboards                                 | `{}`                                   |
-| `plugins`                                     | List of URLs pointing to zip files of Kibana plugins to install                                 | None:                                   |
+| `plugins.enabled`                             | Enable installation of plugins.            | `false`                                |
+| `plugins.reset`                               | Optional : Remove all installed plugins before installing all new ones | `false`                                   |
+| `plugins.values`                              | List of plugins to install. Format <pluginName,version,URL> with URLs pointing to zip files of Kibana plugins to install                                 | None:                                   |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -93,7 +93,7 @@ $ helm install stable/kibana --name my-release \
   --set=image.tag=v0.0.2,resources.limits.cpu=200m
 ```
 
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example :
 
 ```console
 $ helm install stable/kibana --name my-release -f values.yaml

--- a/stable/kibana/ci/plugin-install.yaml
+++ b/stable/kibana/ci/plugin-install.yaml
@@ -1,0 +1,9 @@
+---
+# enable the plugin init container with plugins retrieved from an URL
+plugins:
+  enabled: true
+  reset: false
+  # Use <plugin_name,version,url> to add/upgrade plugin
+  values:
+    - logtrail,0.1.30,https://github.com/sivasamyk/logtrail/releases/download/v0.1.30/logtrail-6.4.2-0.1.30.zip
+    # - other_plugin

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
-{{- if or (.Values.dashboardImport.dashboards) (.Values.plugins) }}
+{{- if or (.Values.dashboardImport.dashboards) (.Values.plugins.enabled) }}
       initContainers:
 {{- if .Values.dashboardImport.dashboards }}
       - name: {{ .Chart.Name }}-dashboardimport
@@ -59,7 +59,7 @@ spec:
           subPath: {{ $configFile }}
         {{- end }}
 {{- end }}
-{{- if .Values.plugins}}
+{{- if .Values.plugins.enabled}}
       - name: {{ .Chart.Name }}-plugins-install
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -69,13 +69,32 @@ spec:
           - |
             set -e
             plugins=(
-            {{- range .Values.plugins }}
+            {{- range .Values.plugins.values }}
             {{ . }}
             {{- end }}
             )
+            if {{ .Values.plugins.reset }}
+            then
+              for p in $(./bin/kibana-plugin list | cut -d "@" -f1)
+              do
+                ./bin/kibana-plugin remove ${p}
+              done
+            fi
             for i in "${plugins[@]}"
             do
-               ./bin/kibana-plugin install $i
+              IFS=',' read -ra PLUGIN <<< "$i"
+              pluginInstalledCheck=$(./bin/kibana-plugin list | grep "${PLUGIN[0]}" | cut -d '@' -f1 || true)
+              pluginVersionCheck=$(./bin/kibana-plugin list | grep "${PLUGIN[0]}" | cut -d '@' -f2 || true)
+              if [ "${pluginInstalledCheck}" = "${PLUGIN[0]}" ]
+              then
+                if [ "${pluginVersionCheck}" != "${PLUGIN[1]}" ]
+                then
+                  ./bin/kibana-plugin remove "${PLUGIN[0]}"
+                  ./bin/kibana-plugin install "${PLUGIN[2]}"
+                fi
+              else
+                ./bin/kibana-plugin install "${PLUGIN[2]}"
+              fi
             done
         env:
         {{- range $key, $value := .Values.env }}
@@ -141,7 +160,7 @@ spec:
           mountPath: "/usr/share/kibana/config/{{ $configFile }}"
           subPath: {{ $configFile }}
         {{- end }}
-{{- if .Values.plugins}}
+{{- if .Values.plugins.enabled}}
         - name: plugins
           mountPath: /usr/share/kibana/plugins
 {{- end }}
@@ -166,7 +185,7 @@ spec:
         - name: {{ template "kibana.name" . }}
           configMap:
             name: {{ template "kibana.fullname" . }}
-{{- if .Values.plugins}}
+{{- if .Values.plugins.enabled}}
         - name: plugins
           emptyDir: {}
 {{- end }}

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -137,7 +137,14 @@ dashboardImport:
   dashboards: {}
     # k8s: https://raw.githubusercontent.com/monotek/kibana-dashboards/master/k8s-fluentd-elasticsearch.json
 
-# List of pluginns to install using initContainer
+# List of plugins to install using initContainer
 plugins:
-  # - https://github.com/sivasamyk/logtrail/releases/download/v0.1.29/logtrail-6.4.0-0.1.29.zip
-  # - other_plugin
+  # set to true to enable plugins installation
+  enabled: false
+  # set to true to remove all kibana plugins before installation
+  reset: false
+  # Use <plugin_name,version,url> to add/upgrade plugin
+  values:
+    # - elastalert-kibana-plugin,1.0.1,https://github.com/bitsensor/elastalert-kibana-plugin/releases/download/1.0.1/elastalert-kibana-plugin-1.0.1-6.4.2.zip
+    # - logtrail,0.1.30,https://github.com/sivasamyk/logtrail/releases/download/v0.1.30/logtrail-6.4.2-0.1.30.zip
+    # - other_plugin


### PR DESCRIPTION
#### What this PR does / why we need it:
Checks if a plugin is already installed to avoid reinstallation and make Kibana image fail. Allows to upgrade/downgrade plugin (with control version).

#### Which issue this PR fixes
- fixes #8581

#### Special notes for your reviewer:
Tested in Kibana version 6.4.1 and 6.4.2 with elastalert plugin and logtrail plugin.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
