### PR TITLE
[stable/k8s-spot-rescheduler] Add pod disruption budget

### DIFF
--- a/stable/k8s-spot-rescheduler/Chart.yaml
+++ b/stable/k8s-spot-rescheduler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.2.0"
 description: A k8s-spot-rescheduler Helm chart for Kubernetes
 name: k8s-spot-rescheduler
-version: 0.3.1
+version: 0.4.0
 keywords:
   - spot
   - rescheduler

--- a/stable/k8s-spot-rescheduler/templates/pdb.yaml
+++ b/stable/k8s-spot-rescheduler/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "k8s-spot-rescheduler.fullname" . }}
+  labels:
+    app: {{ template "k8s-spot-rescheduler.name" . }}
+    chart: {{ template "k8s-spot-rescheduler.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "k8s-spot-rescheduler.name" . }}
+      release: {{ .Release.Name }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/stable/k8s-spot-rescheduler/values.yaml
+++ b/stable/k8s-spot-rescheduler/values.yaml
@@ -3,6 +3,9 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+
 image:
   repository: quay.io/pusher/k8s-spot-rescheduler
   tag: v0.2.0


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows to define a pod disruption budget and creates it if defined. To allow evictions by cluster-autoscaler and admin maintenance when running on worker nodes.

The pdb is not created by default to not create unexpected behavior for current users when updating the chart, cc @komljen 

#### Which issue this PR fixes

  - fixes #8895

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
