### PR TITLE
[stable/prometheus-mysql-exporter] to enable/disable collector flags …

### DIFF
--- a/stable/prometheus-mysql-exporter/Chart.yaml
+++ b/stable/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.2.1
+version: 0.2.2
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/stable/prometheus-mysql-exporter/README.md
+++ b/stable/prometheus-mysql-exporter/README.md
@@ -79,3 +79,22 @@ $ helm install --name my-release -f values.yaml stable/prometheus-mysql-exporter
 
 Documentation for the MySQL Exporter can be found here: (https://github.com/prometheus/mysqld_exporter)
 A mysql params overview can be found here: (https://github.com/go-sql-driver/mysql#dsn-data-source-name)
+
+## Collector Flags
+Specify each collector flag to enable in the value file as `--collector.flag.here`. For example,
+```console
+collectors:
+  --collect.global_status,
+  --collect.global_variables,
+  --collect.info_schema.tables,
+  --collect.slave_status
+```
+To disable,
+```console
+collectors:
+  --no-collect.global_status,
+  --no-collect.global_variables,
+  --no-collect.info_schema.tables,
+  --no-collect.slave_status
+```
+Comma(,) is required.  Available collector flags can be found [here](https://github.com/prometheus/mysqld_exporter#collector-flags).

--- a/stable/prometheus-mysql-exporter/templates/deployment.yaml
+++ b/stable/prometheus-mysql-exporter/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- with .Values.collectors}}
+          command: ["/bin/mysqld_exporter",
+{{ toYaml . | indent 21 }}
+                   ]
+{{- end }}          
           env:
             - name: DATA_SOURCE_NAME
               value: "{{ .Values.mysql.user }}:{{ .Values.mysql.pass }}@{{ if .Values.mysql.protocol }}{{ .Values.mysql.protocol }}{{ end }}({{ .Values.mysql.host }}:{{ .Values.mysql.port }})/{{ if .Values.mysql.db }}{{ .Values.mysql.db }}{{ end }}{{ if .Values.mysql.param }}?{{ .Values.mysql.param }}{{ end }}"

--- a/stable/prometheus-mysql-exporter/values.yaml
+++ b/stable/prometheus-mysql-exporter/values.yaml
@@ -70,3 +70,10 @@ cloudsqlproxy:
       "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/user%40project.iam.gserviceaccount.com"
     }'
+
+# mysql exporter collectors https://github.com/prometheus/mysqld_exporter#collector-flags
+collectors:
+  --collect.global_status,
+  --collect.global_variables,
+  --collect.info_schema.tables,
+  --collect.slave_status


### PR DESCRIPTION
What this PR does / why we need it:

to enable/disable mysql-exporter collector flags from the value file.

Signed-off-by: Kilhyun Jun <Kilhyun@gmail.com>

@Juanchimienti 

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
