### PR TITLE
Add k8s-spot-termination-handler chart

### DIFF
--- a/incubator/k8s-spot-termination-handler/.helmignore
+++ b/incubator/k8s-spot-termination-handler/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/k8s-spot-termination-handler/Chart.yaml
+++ b/incubator/k8s-spot-termination-handler/Chart.yaml
@@ -1,0 +1,16 @@
+name: k8s-spot-termination-handler
+version: 0.1.0
+appVersion: 0.1.0
+description: Kubernetes AWS EC2 Spot Termination Handler
+keywords:
+  - aws
+  - spot
+  - spot-instances
+  - termination
+  - termination-handler
+home: https://github.com/pusher/k8s-spot-termination-handler
+sources:
+  - https://github.com/pusher/k8s-spot-termination-handler
+maintainers:
+- name: EmiiKhaos
+  email: e.karisch@pixelart.at

--- a/incubator/k8s-spot-termination-handler/OWNERS
+++ b/incubator/k8s-spot-termination-handler/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- EmiiKhaos
+reviewers:
+- EmiiKhaos

--- a/incubator/k8s-spot-termination-handler/README.md
+++ b/incubator/k8s-spot-termination-handler/README.md
@@ -1,0 +1,57 @@
+# k8s-spot-termination-handler
+
+The [K8s Spot Termination handler](https://github.com/pusher/k8s-spot-termination-handler) watches the AWS metadata service when running on Spot Instances.
+
+When a Spot Instance is due to be terminated, precisely 2 minutes before it's termination a "termination notice" is issued. The K8s Spot Termination Handler watches for this and then gracefully drains the node it is running on before the node is taken away by AWS.
+
+## TL;DR:
+
+```console
+$ helm install incubator/k8s-spot-termination-handler
+```
+
+## Introduction
+
+This chart bootstraps a K8s Spot Termination handler](https://github.com/pusher/k8s-spot-termination-handler) daemon set on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` and into the namespace `kube-system` (recommended):
+
+```console
+$ helm install incubator/k8s-spot-termination-handler --namespace kube-system --name my-release
+```
+
+The command deploys k8s-spot-termination-handler on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` daemon set:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Access control
+
+It is critical for the Kubernetes cluster to correctly setup access control of Kubernetes Dashboard. See this [guide](https://github.com/kubernetes/dashboard/wiki/Access-control) for best practises.
+
+It is highly recommended to use RBAC with minimal privileges needed for Spot Termination handler to run.
+
+## Configuration
+
+The following table lists the configurable parameters of the kubernetes-dashboard chart and their default values.
+
+| Parameter               | Description                                                                                                                 | Default                                       |
+|-------------------------|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+| `image.repository`      | Repository for container image                                                                                              | `quay.io/pusher/k8s-spot-termination-handler` |
+| `image.tag`             | Image tag                                                                                                                   | `v0.1.0`                                      |
+| `image.pullPolicy`      | Image pull policy                                                                                                           | `IfNotPresent`                                |
+| `nodeSelector`          | node labels for pod assignment                                                                                              | `{}`                                          |
+| `tolerations`           | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`                                          |
+| `resources`             | Pod resource requests & limits                                                                                              | `{}`                                          |
+| `rbac.create`           | Create & use RBAC resources                                                                                                 | `true`                                        |
+| `serviceAccount.create` | Whether a new service account name that the agent will use should be created.                                               | `true`                                        |
+| `serviceAccount.name`   | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template. |                                               |

--- a/incubator/k8s-spot-termination-handler/templates/NOTES.txt
+++ b/incubator/k8s-spot-termination-handler/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that k8s-spot-termination-handler has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "k8s-spot-termination-handler.name" . }},release={{ .Release.Name }}"

--- a/incubator/k8s-spot-termination-handler/templates/_helpers.tpl
+++ b/incubator/k8s-spot-termination-handler/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-spot-termination-handler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-spot-termination-handler.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-spot-termination-handler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "k8s-spot-termination-handler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "k8s-spot-termination-handler.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/k8s-spot-termination-handler/templates/clusterrole.yaml
+++ b/incubator/k8s-spot-termination-handler/templates/clusterrole.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "k8s-spot-termination-handler.fullname" . }}
+  labels:
+    app: {{ template "k8s-spot-termination-handler.name" . }}
+    chart: {{ template "k8s-spot-termination-handler.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  # For draining nodes
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+  - apiGroups:
+      - extensions
+    resources:
+      - replicasets
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+{{- end }}

--- a/incubator/k8s-spot-termination-handler/templates/clusterrolebinding.yaml
+++ b/incubator/k8s-spot-termination-handler/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "k8s-spot-termination-handler.fullname" . }}
+  labels:
+    app: {{ template "k8s-spot-termination-handler.name" . }}
+    chart: {{ template "k8s-spot-termination-handler.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-spot-termination-handler.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-spot-termination-handler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/incubator/k8s-spot-termination-handler/templates/daemonset.yaml
+++ b/incubator/k8s-spot-termination-handler/templates/daemonset.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ include "k8s-spot-termination-handler.fullname" . }}
+  labels:
+    app: {{ include "k8s-spot-termination-handler.name" . }}
+    chart: {{ include "k8s-spot-termination-handler.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: {{ include "k8s-spot-termination-handler.fullname" . }}
+      labels:
+        app: {{ include "k8s-spot-termination-handler.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "k8s-spot-termination-handler.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      {{- with .Values.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/incubator/k8s-spot-termination-handler/templates/serviceaccount.yaml
+++ b/incubator/k8s-spot-termination-handler/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "k8s-spot-termination-handler.serviceAccountName" . }}
+  labels:
+    app: {{ template "k8s-spot-termination-handler.name" . }}
+    chart: {{ template "k8s-spot-termination-handler.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/incubator/k8s-spot-termination-handler/values.yaml
+++ b/incubator/k8s-spot-termination-handler/values.yaml
@@ -1,0 +1,41 @@
+image:
+  repository: quay.io/pusher/k8s-spot-termination-handler
+  tag: v0.1.0
+  pullPolicy: IfNotPresent
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+  # node-role.kubernetes.io/spot-worker: "true"
+
+## List of node taints to tolerate (requires Kubernetes >= 1.6)
+##
+tolerations: []
+
+## Configure resources
+##
+resources: {}
+  # To specify resources, uncomment the following lines, adjust them as necessary,
+  # and remove the curly braces after 'resources:'.
+  # requests:
+  #   cpu: 5m
+  #   memory: 20Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 100Mi
+
+## Enable RBAC
+##
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+## Create or use ServiceAccount
+##
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a chart for the [K8s Spot Termination handler](https://github.com/pusher/k8s-spot-termination-handler) which watches the AWS metadata service when running on Spot Instances.

#### Which issue this PR fixes

  - fixes pusher/k8s-spot-termination-handler#6

#### Special notes for your reviewer:

Could this go already straight to stable?

I hope the `OWNERS` file is ok/correct/allowed?

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Variables are documented in the README.md
