### PR TITLE
[stable/rabbitmq] re-sync values-production.yaml with values.yaml

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 3.6.2
+version: 3.6.3
 appVersion: 3.7.8
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -11,17 +11,17 @@ image:
   registry: docker.io
   repository: bitnami/rabbitmq
   tag: 3.7.8
-  ## Specify a imagePullPolicy
-  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  ##
-  pullPolicy: IfNotPresent
 
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
   debug: false
 
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -29,8 +29,7 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-
-## does your cluster have rbac enabled?
+## does your cluster have rbac enabled? assume yes by default
 rbacEnabled: true
 
 ## section of specific values for rabbitmq
@@ -54,6 +53,16 @@ rabbitmq:
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
   ##
   nodePort: 5672
+
+  ## Amqp port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  amqpPort: 5672
+
+  ## Dist port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  distPort: 25672
 
   ## Node name to cluster with. e.g.: `clusternode@hostname`
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
@@ -79,7 +88,7 @@ rabbitmq:
 
   ## Plugins to enable
   plugins: |-
-      [rabbitmq_management,rabbitmq_peer_discovery_k8s].
+      [rabbitmq_management, rabbitmq_peer_discovery_k8s].
 
   ## Clustering settings
   clustering:
@@ -114,6 +123,7 @@ securityContext:
   runAsUser: 1001
 
 persistence:
+  ## this enables PVC templates that will create one per pod
   enabled: true
 
   ## rabbitmq data Persistent Volume Storage Class
@@ -148,6 +158,9 @@ nodeSelector:
 tolerations: []
 affinity: {}
 
+## annotations for rabbitmq pods
+podAnnotations: {}
+
 ## Configure the ingress resource that allows you to access the
 ## Wordpress installation. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
@@ -179,7 +192,7 @@ ingress:
   #  kubernetes.io/ingress.class: nginx
   #  kubernetes.io/tls-acme: true
 
-  #The following settings are to configure the frequency of the lifeness and readiness probes
+## The following settings are to configure the frequency of the lifeness and readiness probes
 livenessProbe:
   enabled: true
   initialDelaySeconds: 120


### PR DESCRIPTION
Signed-off-by: Thomas Riccardi <thomas@deepomatic.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
#4591 added a second values file: `values-production.yaml`.
Since then, `values.yaml` has diverged without re-syncing `values-production.yaml`.
This PR re-syncs this file.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
