### PR TITLE
[stable/concourse] Decouple postgres keys/certs from sslmode variable

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 2.0.4
+version: 2.0.5
 appVersion: 4.2.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -899,7 +899,7 @@ spec:
               mountPath: /concourse-vault
               readOnly: true
             {{- end }}
-            {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
+            {{- if or (or .Values.secrets.postgresCaCert .Values.secrets.postgresClientCert) .Values.secrets.postgresClientKey }}
             - name: postgresql-keys
               mountPath: /concourse-postgresql
               readOnly: true
@@ -945,18 +945,24 @@ spec:
                 path: client.key
             {{- end }}
         {{- end }}
-        {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
+        {{- if or (or .Values.secrets.postgresCaCert .Values.secrets.postgresClientCert) .Values.secrets.postgresClientKey }}
         - name: postgresql-keys
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
             items:
+            {{- if .Values.secrets.postgresCaCert }}
               - key: postgresql-ca-cert
                 path: ca.cert
+            {{- end }}
+            {{- if .Values.secrets.postgresClientCert }}
               - key: postgresql-client-cert
                 path: client.cert
+            {{- end }}
+            {{- if .Values.secrets.postgresClientKey }}
               - key: postgresql-client-key
                 path: client.key
+            {{- end }}
         {{- end }}
         {{- if .Values.concourse.web.syslog.enabled }}
         - name: syslog-keys


### PR DESCRIPTION
#### What this PR does / why we need it:

In addition to PR #8651 this PR finally decouples postgres sslmode variable from cert/key variables and secrets. As mentioned in: https://github.com/helm/charts/pull/8651#issuecomment-434832046, also #8237 and #8142.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
