### PR TITLE
[stable/kiam] Optional service for exposing prometheus metrics

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kiam
-version: 2.0.0-rc3
+version: 2.0.0-rc4
 appVersion: 3.0-rc1
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/README.md
+++ b/stable/kiam/README.md
@@ -87,6 +87,7 @@ Parameter | Description | Default
 `agent.prometheus.port` | Agent Prometheus metrics port | `9620`
 `agent.prometheus.scrape` | Whether or not Prometheus metrics for the agent should be scraped | `true`
 `agent.prometheus.syncInterval` | Agent Prometheus synchronization interval | `5s`
+`agent.prometheus.service.enabled` | Expose Agent prometheus metrics as a service | `false`
 `agent.podAnnotations` | Annotations to be added to agent pods | `{}`
 `agent.podLabels` | Labels to be added to agent pods | `{}`
 `agent.resources` | Agent container resources | `{}`
@@ -112,6 +113,7 @@ Parameter | Description | Default
 `server.prometheus.port` | Server Prometheus metrics port | `9620`
 `server.prometheus.scrape` | Whether or not Prometheus metrics for the server should be scraped | `true`
 `server.prometheus.syncInterval` | Server Prometheus synchronization interval | `5s`
+`server.prometheus.service.enabled` | Expose Server prometheus metrics as a service | `false`
 `server.podAnnotations` | Annotations to be added to server pods | `{}`
 `server.podLabels` | Labels to be added to server pods | `{}`
 `server.probes.serverAddress` | Address that readyness and liveness probes will hit | `localhost`

--- a/stable/kiam/templates/agent-metric-service.yaml
+++ b/stable/kiam/templates/agent-metric-service.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.agent.prometheus.scrape .Values.agent.prometheus.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.agent.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kiam.fullname" . }}-agent-metrics
+spec:
+  selector:
+    app: {{ template "kiam.name" . }}
+    component: "{{ .Values.agent.name }}"
+    release: {{ .Release.Name }}
+  ports:
+    - name: metrics
+      port: {{ .Values.agent.prometheus.port }}
+      targetPort: {{ .Values.agent.prometheus.port }}
+      protocol: TCP
+{{- end }}

--- a/stable/kiam/templates/metric-services.yaml
+++ b/stable/kiam/templates/metric-services.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.agent.prometheus.scrape .Values.agent.prometheus.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.agent.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kiam.fullname" . }}-agent-metrics
+spec:
+  selector:
+    app: {{ template "kiam.name" . }}
+    component: "{{ .Values.agent.name }}"
+    release: {{ .Release.Name }}
+  ports:
+    - name: metrics
+      port: {{ .Values.agent.prometheus.port }}
+      targetPort: {{ .Values.agent.prometheus.port }}
+      protocol: TCP
+{{- end }}
+{{- if and .Values.server.prometheus.scrape .Values.server.prometheus.service.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "kiam.name" . }}
+    chart: {{ template "kiam.chart" . }}
+    component: "{{ .Values.server.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kiam.fullname" . }}-server-metrics
+spec:
+  selector:
+    app: {{ template "kiam.name" . }}
+    component: "{{ .Values.server.name }}"
+    release: {{ .Release.Name }}
+  ports:
+    - name: metrics
+      port: {{ .Values.server.prometheus.port }}
+      targetPort: {{ .Values.server.prometheus.port }}
+      protocol: TCP
+{{- end }}

--- a/stable/kiam/templates/server-metric-service.yaml
+++ b/stable/kiam/templates/server-metric-service.yaml
@@ -1,27 +1,4 @@
-{{- if and .Values.agent.prometheus.scrape .Values.agent.prometheus.service.enabled -}}
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: {{ template "kiam.name" . }}
-    chart: {{ template "kiam.chart" . }}
-    component: "{{ .Values.agent.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ template "kiam.fullname" . }}-agent-metrics
-spec:
-  selector:
-    app: {{ template "kiam.name" . }}
-    component: "{{ .Values.agent.name }}"
-    release: {{ .Release.Name }}
-  ports:
-    - name: metrics
-      port: {{ .Values.agent.prometheus.port }}
-      targetPort: {{ .Values.agent.prometheus.port }}
-      protocol: TCP
-{{- end }}
 {{- if and .Values.server.prometheus.scrape .Values.server.prometheus.service.enabled -}}
----
 apiVersion: v1
 kind: Service
 metadata:

--- a/stable/kiam/values.yaml
+++ b/stable/kiam/values.yaml
@@ -31,6 +31,8 @@ agent:
     scrape: true
     port: 9620
     syncInterval: 5s
+    service:
+      enabled: false
   ## Annotations to be added to pods
   ##
   podAnnotations: {}
@@ -112,6 +114,8 @@ server:
     scrape: true
     port: 9620
     syncInterval: 5s
+    service:
+      enabled: false
   ## Annotations to be added to pods
   ##
   podAnnotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
In order to scrape metrics when using prometheus-operator you have to define a ServiceMonitor that selects a service. I was originally creating these outside of the helm chart but that was slightly annoying, and I figured it might be useful if the chart could take care of creating the services.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
