### PR TITLE
Adopting Helm chart best practices

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,6 +1,6 @@
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.1.2
+version: 0.1.3
 appVersion: v1alpha1-0.4-2.3.x
 kubeVersion: ">=1.8.0-0"
 keywords:

--- a/incubator/sparkoperator/README.md
+++ b/incubator/sparkoperator/README.md
@@ -12,10 +12,10 @@ The chart can be installed by running:
 
 ```bash
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-$ helm install incubator/sparkoperator
+$ helm install incubator/sparkoperator --namespace spark-operator
 ```
 
-By default, the chart creates a namespace called "spark-operator" and installs the operator there. Alternatively, you can choose to install the operator in an existing namespace or in a new namespace with your custom name.
+Note that you need to use the `--namespace` flag during `helm install` to specify in which namespace you want to install the operator. The namespace can be existing or not. When it's not available, Helm would take care of creating the namespace. Note that this namespace has no relation to the namespace where you would like to deploy Spark jobs (i.e. the setting `sparkJobNamespace` shown in the table below). They can be the same namespace or different ones. 
 
 #### Configuration
 
@@ -25,9 +25,7 @@ The following table lists the configurable parameters of the Spark operator char
 | ------------------------- | ----------------------------------------------------- | -------------------------------------- |
 | `operatorImageName`       | The name of the operator image                        | `gcr.io/spark-operator/spark-operator` |
 | `operatorVersion`         | The version of the operator to install                | `v2.3.1-v1alpha1-latest`               |
-| `operatorNamespace`       | K8s namespace where operator is installed             | `spark-operator`                       |
-| `sparkJobNamespace`       | K8s namespace where Spark jobs are to be deployed     | `default`                              |
-| `createOperatorNamespace` | Whether to create the operator namespace              | true                                   |
+| `sparkJobNamespace`       | K8s namespace where Spark jobs are to be deployed.    | `default`                              |
 | `createSparkJobNamespace` | Whether to create the Spark job namespace             | false                                  |
 | `enableWebhook`           | Whether to enable mutating admission webhook          | true                                   |
 | `enableMetrics`           | Whether to expose metrics to be scraped by Premetheus | true                                   |

--- a/incubator/sparkoperator/templates/_helpers.tpl
+++ b/incubator/sparkoperator/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sparkoperator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+ {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sparkoperator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+ {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sparkoperator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+ {{/*
+Create the name of the service account to use
+*/}}
+{{- define "sparkoperator.serviceAccountName" -}}
+{{- if .Values.serviceAccounts.sparkoperator.create -}}
+    {{ default (include "sparkoperator.fullname" .) .Values.serviceAccounts.sparkoperator.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.sparkoperator.name }}
+{{- end -}}
+{{- end -}}
+{{- define "spark.serviceAccountName" -}}
+{{- if .Values.serviceAccounts.spark.create -}}
+    {{ $sparkServiceaccount := printf "%s-%s" .Release.Name "spark" }}
+    {{ default $sparkServiceaccount .Values.serviceAccounts.spark.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.spark.name }}
+{{- end -}}
+{{- end -}}

--- a/incubator/sparkoperator/templates/spark-namespace.yaml
+++ b/incubator/sparkoperator/templates/spark-namespace.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.createSparkJobNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.sparkJobNamespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ end }}

--- a/incubator/sparkoperator/templates/spark-operator-deployment.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-deployment.yaml
@@ -4,60 +4,20 @@
 # In the post-install hook, the token corresponding to the operator service account
 # is used to authenticate with the Kubernetes API server to install the secret bundle.
 
-{{ if .Values.createOperatorNamespace }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.operatorNamespace }}
-{{ end }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: sparkoperator
-  namespace: {{ .Values.operatorNamespace }}
----
-{{ if .Values.enableWebhook }}
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: sparkoperator-init
-  namespace: {{ .Values.operatorNamespace }}
-  annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded
-  labels:
-    app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: {{ .Values.operatorVersion }}
-spec:
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: sparkoperator
-        app.kubernetes.io/version: {{ .Values.operatorVersion }}
-    spec:
-      serviceAccountName: sparkoperator
-      restartPolicy: OnFailure
-      containers:
-      - name: main
-        image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
-        imagePullPolicy: IfNotPresent
-        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Values.operatorNamespace }}", "-p"]
-{{ end }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sparkoperator
-  namespace: {{ .Values.operatorNamespace }}
+  name: {{ template "sparkoperator.fullname" . }}
   labels:
-    app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: {{ .Values.operatorVersion }}
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: sparkoperator
+      app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
       app.kubernetes.io/version: {{ .Values.operatorVersion }}
   strategy:
     type: Recreate
@@ -70,12 +30,12 @@ spec:
         prometheus.io/path: "/metrics"
       {{- end }}
       labels:
-        app.kubernetes.io/name: sparkoperator
+        app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
         app.kubernetes.io/version: {{ .Values.operatorVersion }}
       initializers:
         pending: []
     spec:
-      serviceAccountName: sparkoperator
+      serviceAccountName: {{ include "sparkoperator.serviceAccountName" . }}
       {{- if .Values.enableWebhook }}
       volumes:
         - name: webhook-certs
@@ -101,7 +61,7 @@ spec:
         - -enable-metrics=true
         - -metrics-labels=app_type
         - -enable-webhook=true
-        - -webhook-svc-namespace={{ .Values.operatorNamespace }}
+        - -webhook-svc-namespace={{ .Release.Namespace }}
         - -logtostderr
         {{- else if (.Values.enableMetrics) }}
         args:
@@ -111,25 +71,9 @@ spec:
         {{- else if (.Values.enableWebhook) }}
         args:
         - -enable-webhook=true
-        - -webhook-svc-namespace={{ .Values.operatorNamespace }}
+        - -webhook-svc-namespace={{ .Release.Namespace }}
         - -logtostderr
         {{- else }}
         args:
         - -logtostderr
         {{- end }}
----
-{{ if .Values.enableWebhook }}
-kind: Service
-apiVersion: v1
-metadata:
-  name: spark-webhook
-  namespace: {{ .Values.operatorNamespace }}
-spec:
-  ports:
-    - port: 443
-      targetPort: 8080
-      name: webhook
-  selector:
-    app.kubernetes.io/name: sparkoperator
-    app.kubernetes.io/version: {{ .Values.operatorVersion }}
-{{ end }}

--- a/incubator/sparkoperator/templates/spark-operator-deployment.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-deployment.yaml
@@ -7,7 +7,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "sparkoperator.fullname" . }}
+  name: {{ include "sparkoperator.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}

--- a/incubator/sparkoperator/templates/spark-operator-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-rbac.yaml
@@ -1,7 +1,13 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: sparkoperator
+  name: {{ template "sparkoperator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -28,12 +34,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sparkoperator
+  name: {{ template "sparkoperator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 subjects:
   - kind: ServiceAccount
-    name: sparkoperator
-    namespace: {{ .Values.operatorNamespace }}
+    name: {{ include "sparkoperator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: sparkoperator
+  name: {{ template "sparkoperator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/incubator/sparkoperator/templates/spark-operator-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "sparkoperator.fullname" . }}
+  name: sparkoperator-cr
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}
@@ -34,7 +34,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "sparkoperator.fullname" . }}
+  name: sparkoperator-crb
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
@@ -47,6 +47,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "sparkoperator.fullname" . }}
+  name: sparkoperator-cr
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/incubator/sparkoperator/templates/spark-operator-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "sparkoperator.fullname" . }}
+  name: {{ include "sparkoperator.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}
@@ -34,7 +34,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "sparkoperator.fullname" . }}
+  name: {{ include "sparkoperator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
@@ -47,6 +47,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "sparkoperator.fullname" . }}
+  name: {{ include "sparkoperator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/incubator/sparkoperator/templates/spark-operator-serviceaccount.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccounts.sparkoperator.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sparkoperator.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/incubator/sparkoperator/templates/spark-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Values.sparkJobNamespace }}
-  name: {{ template "sparkoperator.fullname" . }}
+  name: {{ include "sparkoperator.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}
@@ -26,7 +26,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "sparkoperator.fullname" . }}
+  name: {{ include "sparkoperator.fullname" . }}
   namespace: {{ .Values.sparkJobNamespace }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
@@ -39,6 +39,6 @@ subjects:
   namespace: {{ .Values.sparkJobNamespace }}
 roleRef:
   kind: Role
-  name: {{ template "sparkoperator.fullname" . }}
+  name: {{ include "sparkoperator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/incubator/sparkoperator/templates/spark-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Values.sparkJobNamespace }}
-  name: {{ include "sparkoperator.fullname" . }}
+  name: spark-role
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}
@@ -26,7 +26,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "sparkoperator.fullname" . }}
+  name: spark-role-binding
   namespace: {{ .Values.sparkJobNamespace }}
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
@@ -39,6 +39,6 @@ subjects:
   namespace: {{ .Values.sparkJobNamespace }}
 roleRef:
   kind: Role
-  name: {{ include "sparkoperator.fullname" . }}
+  name: spark-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/incubator/sparkoperator/templates/spark-rbac.yaml
+++ b/incubator/sparkoperator/templates/spark-rbac.yaml
@@ -1,21 +1,14 @@
-{{ if .Values.createSparkJobNamespace }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.sparkJobNamespace }}
-{{ end }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: spark
-  namespace: {{ .Values.sparkJobNamespace }}
----
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Values.sparkJobNamespace }}
-  name: spark-role
+  name: {{ template "sparkoperator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
 - apiGroups:
   - "" # "" indicates the core API group
@@ -33,13 +26,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: spark-role-binding
+  name: {{ template "sparkoperator.fullname" . }}
   namespace: {{ .Values.sparkJobNamespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 subjects:
 - kind: ServiceAccount
-  name: spark
+  name: {{ include "spark.serviceAccountName" . }}
   namespace: {{ .Values.sparkJobNamespace }}
 roleRef:
   kind: Role
-  name: spark-role
+  name: {{ template "sparkoperator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/incubator/sparkoperator/templates/spark-serviceaccount.yaml
+++ b/incubator/sparkoperator/templates/spark-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccounts.spark.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spark.serviceAccountName" . }}
+  namespace: {{ .Values.sparkJobNamespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
@@ -2,9 +2,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "sparkoperator.fullname" . }}-init
+  name: {{ include "sparkoperator.fullname" . }}-cleanup
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
@@ -18,7 +18,15 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: main
-        image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
+        image: lightbend/curl:7.47.0
         imagePullPolicy: IfNotPresent
-        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-p"]
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "curl -ik \
+          -X DELETE \
+          -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" \
+          -H \"Accept: application/json\" \
+          -H \"Content-Type: application/json\" \
+          https://kubernetes.default.svc/api/v1/namespaces/{{ .Release.Namespace }}/secrets/spark-webhook-certs"
 {{ end }}

--- a/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: main
-        image: lightbend/curl:7.47.0
+        image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
         imagePullPolicy: IfNotPresent
         command:
         - "/bin/sh"

--- a/incubator/sparkoperator/templates/webhook-init-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-init-job.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.enableWebhook }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "sparkoperator.fullname" . }}-init
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "sparkoperator.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+      - name: main
+        image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-p"]
+{{ end }}

--- a/incubator/sparkoperator/templates/webhook-init-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-init-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "sparkoperator.fullname" . }}-init
+  name: {{ include "sparkoperator.fullname" . }}-init
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/incubator/sparkoperator/templates/webhook-service.yaml
+++ b/incubator/sparkoperator/templates/webhook-service.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.enableWebhook }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "sparkoperator.fullname" . }}-webhook
+  labels:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    helm.sh/chart: {{ include "sparkoperator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 8080
+    name: webhook
+  selector:
+    app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
+    app.kubernetes.io/version: {{ .Values.operatorVersion }}
+{{ end }}

--- a/incubator/sparkoperator/templates/webhook-service.yaml
+++ b/incubator/sparkoperator/templates/webhook-service.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ template "sparkoperator.fullname" . }}-webhook
+  name: {{ include "sparkoperator.fullname" . }}-webhook
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}

--- a/incubator/sparkoperator/values.yaml
+++ b/incubator/sparkoperator/values.yaml
@@ -1,9 +1,18 @@
 operatorImageName: gcr.io/spark-operator/spark-operator
 operatorVersion: v2.3.1-v1alpha1-latest
-operatorNamespace: spark-operator
 sparkJobNamespace: default
 
-createOperatorNamespace: true
+rbac:
+  create: true
+
+serviceAccounts:
+  spark:
+    create: true
+    name:
+  sparkoperator:
+    create: true
+    name:
+
 createSparkJobNamespace: false
 
 enableWebhook: true


### PR DESCRIPTION
Made the following changes to conform to Helm chart best practices.

- Use helm `--namespace` flag to manage namespace instead of manually managing it. Now the user specifies the namespace in which he wants to install the chart with `helm install incubator/sparkoperator --namespace myns`. `myns` can be an existing namespace or it can be a new one, in which case `helm` CLI takes care of creating it.

- Included a `_helpers.tpl` file borrowed from the result of `helm create` that provides standard template variables.

- All resource names now use the fullname template (e.g. {{ include "sparkoperator.fullname" . }}). These names make sure no conflicts would occur between multiple Helm releases.

- Use standard labels generated from `helm create` that uniquely identify the Helm release corresponding to a resource.

- Changed RBAC configurations to conform to [RBAC best practices](https://github.com/helm/helm/blob/master/docs/chart_best_practices/rbac.md). 

- Each file should only contain a single resource (except for `rbac.yaml`, which contains two resources related to RBAC).

Feature changes:
Now include a pre-delete hook job that deletes the webhook secret. 