### PR TITLE
Give external-dns service port a name handle

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ description:
   Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.5.7
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/service.yaml
+++ b/stable/external-dns/templates/service.yaml
@@ -30,6 +30,7 @@ spec:
     - port: {{ .Values.service.servicePort }}
       protocol: TCP
       targetPort: 7979
+      name: http
   selector:
     app: {{ template "external-dns.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
#### What this PR does / why we need it:

The externaldns service port needs a name in order for prometheus-operator to be able to scrape from it. Give the port a name.

No-one listed in Chart.yaml to not sure who to @-mention?

Signed-off-by: Joe Hohertz <joe@viafoura.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
