### PR TITLE
Adding support for externally defined adapter rules

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.2.3
+version: v0.3.0
 appVersion: v0.4.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
 | `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
 | `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
+| `rules.existing`                | The name of an existing configMap with rules. Overrides default and custom.     | ``                                          |                                                                                                        
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -95,7 +95,11 @@ spec:
       volumes:
       - name: config
         configMap:
+          {{- if .Values.rules.existing }}
+          name: {{ .Values.rules.existing }}
+          {{- else }}
           name: {{ template "k8s-prometheus-adapter.fullname" . }}
+          {{- end }}
       - name: tmp
         emptyDir: {}
 {{- if .Values.tls.enable }}

--- a/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.rules.existing -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -81,4 +82,4 @@ data:
 {{- if .Values.rules.custom }}
 {{ toYaml .Values.rules.custom | indent 4 }}
 {{- end -}}
-
+{{- end -}}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -48,6 +48,7 @@ rules:
 #     matches: ""
 #     as: "my_custom_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+  existing:
 
 service:
   annotations: {}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -48,6 +48,8 @@ rules:
 #     matches: ""
 #     as: "my_custom_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+  # Mounts a configMap with pre-generated rules for use. Overrides the 
+  # default and custom entries
   existing:
 
 service:

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -48,7 +48,7 @@ rules:
 #     matches: ""
 #     as: "my_custom_metric"
 #   metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
-  # Mounts a configMap with pre-generated rules for use. Overrides the 
+  # Mounts a configMap with pre-generated rules for use. Overrides the
   # default and custom entries
   existing:
 


### PR DESCRIPTION
This PR adds the ability to utilize externally defined rules for the adapter. One use case is for creating custom rules for HPA's based on dynamic chart content that may not be easily exposed globally.