### PR TITLE
Allow for custom service annotations for prometheus and alertmanager

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 0.1.16
+version: 0.1.17
 appVersion: "0.25.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -74,6 +74,9 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `prometheusOperator.kubeletService.enabled` | If true, the operator will create and maintain a service for scraping kubelets | `true` |
 | `prometheusOperator.kubeletService.namespace` | Namespace to deploy kubelet service | `true` |
 | `prometheusOperator.serviceMonitor.selfMonitor` | Enable monitoring of prometheus operator | `true` |
+| `prometheusOperator.service.type` | Prometheus operator service type | `ClusterIP` |
+| `prometheusOperator.service.nodePort` | Port to expose prometheus operator service on each node | `38080` |
+| `prometheusOperator.service.annotations` | Annotations to be added to the prometheus operator service | `{}` |
 | `prometheusOperator.resources` | Resource limits for prometheus operator | `{}` |
 | `prometheusOperator.nodeSelector` | Prometheus operator node selector https://kubernetes.io/docs/user-guide/node-selection/ | `{}` |
 | `prometheusOperator.tolerations` | Tolerations for use with node taints https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ | `[]` |
@@ -96,6 +99,9 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `prometheus.serviceMonitor.selfMonitor` | Create a `serviceMonitor` to automatically monitor the prometheus instance | `true` |
 | `prometheus.serviceAccount.create` | Create a default serviceaccount for prometheus to use | `true` |
 | `prometheus.serviceAccount.name` | Name for prometheus serviceaccount | `""` |
+| `prometheus.service.type` | Prometheus service type | `ClusterIP` |
+| `prometheus.service.nodePort` | Port to expose Prometheus service on each node | `39090` |
+| `prometheus.service.annotations` | Annotations to be added to the prometheus service | `{}` |
 | `prometheus.rbac.roleNamespaces` | Create role bindings in the specified namespaces, to allow Prometheus monitoring a role binding in the release namespace will always be created. | `["kube-system"]` |
 | `prometheus.podDisruptionBudget.enabled` | If true, create a pod disruption budget for prometheus pods. The created resource cannot be modified once created - it must be deleted to perform a change | `true` |
 | `prometheus.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `1` |
@@ -148,6 +154,9 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `alertmanager.enabled` | Deploy alertmanager | `true` |
 | `alertmanager.serviceAccount.create` | Create a `serviceAccount` for alertmanager | `true` |
 | `alertmanager.serviceAccount.name` | Name for Alertmanager service account | `""` |
+| alertmanager.service.type | Alertmanager service type | ClusterIP |
+| alertmanager.service.nodePort | Port to expose alertmanager service on each node | 39093 |
+| alertmanager.service.annotations | Annotations to be added to the alertmanager service | {} |
 | `alertmanager.podDisruptionBudget.enabled` | If true, create a pod disruption budget for Alertmanager pods. The created resource cannot be modified once created - it must be deleted to perform a change | `true` |
 | `alertmanager.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled | `1` |
 | `alertmanager.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable | `""` |

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -449,6 +449,18 @@ prometheusOperator:
     create: true
     name: ""
 
+  ## Configuration for Prometheus operator service
+  ##
+  service:
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
+    nodePort: 38080
+
+    ## Service type
+    ##
+    type: ClusterIP
+
   ## Deploy CRDs used by Prometheus Operator.
   ##
   createCustomResource: true
@@ -548,6 +560,18 @@ prometheus:
   serviceAccount:
     create: true
     name: ""
+
+  ## Configuration for Prometheus service
+  ##
+  service:
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
+    nodePort: 39090
+
+    ## Service type
+    ##
+    type: ClusterIP
 
   rbac:
     ## Create role bindings in the specified namespaces, to allow Prometheus monitoring

--- a/stable/prometheus-operator/templates/alertmanager/service.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/service.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app: {{ template "prometheus-operator.name" . }}-alertmanager
 {{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.alertmanager.service.annotations }}
+  annotations:
+{{ toYaml .Values.alertmanager.service.annotations | indent 4 }}
+{{- end }}
 spec:
   ports:
     - name: web

--- a/stable/prometheus-operator/templates/prometheus-operator/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/service.yaml
@@ -6,14 +6,21 @@ metadata:
   labels:
     app: {{ template "prometheus-operator.name" . }}-operator
 {{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.prometheusOperator.service.annotations }}
+  annotations:
+{{ toYaml .Values.prometheusOperator.service.annotations | indent 4 }}
+{{- end }}
 spec:
   clusterIP: None
   ports:
   - name: http
+    {{- if eq .Values.prometheusOperator.service.type "NodePort" }}
+    nodePort: {{ .Values.prometheusOperator.service.nodePort }}
+    {{- end }}
     port: 8080
     targetPort: http
   selector:
     app: {{ template "prometheus-operator.name" . }}-operator
     release: {{ .Release.Name | quote }}
-
+  type: "{{ .Values.prometheusOperator.service.type }}"
 {{- end }}

--- a/stable/prometheus-operator/templates/prometheus/service.yaml
+++ b/stable/prometheus-operator/templates/prometheus/service.yaml
@@ -6,12 +6,20 @@ metadata:
   labels:
     app: {{ template "prometheus-operator.name" . }}-prometheus
 {{ include "prometheus-operator.labels" . | indent 4 }}
+{{- if .Values.prometheus.service.annotations }}
+  annotations:
+{{ toYaml .Values.prometheus.service.annotations | indent 4 }}
+{{- end }}
 spec:
   ports:
   - name: web
+    {{- if eq .Values.prometheus.service.type "NodePort" }}
+    nodePort: {{ .Values.prometheus.service.nodePort }}
+    {{- end }}
     port: 9090
     targetPort: web
   selector:
     app: prometheus
     prometheus: {{ template "prometheus-operator.fullname" . }}-prometheus
+  type: "{{ .Values.prometheus.service.type }}"
 {{- end }}

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -49,6 +49,10 @@ alertmanager:
     create: true
     name: ""
 
+  service:
+    type: ClusterIP
+    nodePort: 30903
+
   ## Configure pod disruption budgets for Alertmanager
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
   ## This configuration is immutable once created and will require the PDB to be deleted to be changed
@@ -449,6 +453,10 @@ prometheusOperator:
     create: true
     name: ""
 
+  service:
+    type: ClusterIP
+    nodePort: 38080
+
   ## Deploy CRDs used by Prometheus Operator.
   ##
   createCustomResource: true
@@ -548,6 +556,10 @@ prometheus:
   serviceAccount:
     create: true
     name: ""
+
+  service:
+    type: ClusterIP
+    nodePort: 39090
 
   rbac:
     ## Create role bindings in the specified namespaces, to allow Prometheus monitoring

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -49,10 +49,6 @@ alertmanager:
     create: true
     name: ""
 
-  service:
-    type: ClusterIP
-    nodePort: 30903
-
   ## Configure pod disruption budgets for Alertmanager
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
   ## This configuration is immutable once created and will require the PDB to be deleted to be changed
@@ -453,9 +449,17 @@ prometheusOperator:
     create: true
     name: ""
 
+  ## Configuration for Prometheus operator service
+  ##
   service:
-    type: ClusterIP
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
     nodePort: 38080
+
+    ## Service type
+    ##
+    type: ClusterIP
 
   ## Deploy CRDs used by Prometheus Operator.
   ##
@@ -557,9 +561,17 @@ prometheus:
     create: true
     name: ""
 
+  ## Configuration for Prometheus service
+  ##
   service:
-    type: ClusterIP
+    ## Port to expose on each node
+    ## Only used if service.type is 'NodePort'
+    ##
     nodePort: 39090
+
+    ## Service type
+    ##
+    type: ClusterIP
 
   rbac:
     ## Create role bindings in the specified namespaces, to allow Prometheus monitoring


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows for custom service annotations for 
1. Prometheus Operator
2. Prometheus
3. Alertmanager

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
