### PR TITLE
[stable/jenkins] when mounting the SecretsFilesSecret, also mount the secrets to /run/secrets

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.21.0
+version: 0.21.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -221,6 +221,7 @@ data:
 {{- end }}
 {{- if .Values.Master.SecretsFilesSecret }}
     cp -n /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets;
+    cp -n /var/jenkins_secrets/* /run/secrets;
 {{- end }}
 {{- if .Values.Master.Jobs }}
     for job in $(ls /var/jenkins_jobs); do

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: {{ if .Values.rbac.install }}{{ template "jenkins.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
 {{- if .Values.Master.HostNetworking }}
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet 
+      dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
       initContainers:
         - name: "copy-default-config"
@@ -87,6 +87,9 @@ spec:
               mountPath: /var/jenkins_secrets
               name: jenkins-secrets
               readOnly: true
+            -
+              mountPath: /run/secrets/
+              name: jenkins-casc-secrets
             {{- end }}
             {{- if .Values.Master.Jobs }}
             -
@@ -190,6 +193,10 @@ spec:
               mountPath: /var/jenkins_secrets
               name: jenkins-secrets
               readOnly: true
+            -
+              mountPath: /run/secrets/
+              name: jenkins-casc-secrets
+              readOnly: false
             {{- end }}
             {{- if .Values.Master.Jobs }}
             -
@@ -223,6 +230,8 @@ spec:
       - name: jenkins-secrets
         secret:
           secretName: {{ .Values.Master.SecretsFilesSecret }}
+      - name: jenkins-casc-secrets
+        emptyDir: {}
       {{- end }}
       {{- if .Values.Master.Jobs }}
       - name: jenkins-jobs


### PR DESCRIPTION
#### What this PR does / why we need it:

this is required for Jenkins CasC plugin to work. (as described in this PR https://github.com/jenkinsci/configuration-as-code-plugin/pull/631)

_I thought about adding a specific value to enable mounting to `/run/secrets`, but if it's already mounting the secrets to one place when using the `SecretsFilesSecret` value, it makes sense to just enable CasC by default using the same value_

Signed-off-by: Jeff Knurek <j.knurek@travelaudience.com>

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
