### PR TITLE
[stable/nfs-server-provisioner] Moved mountOptions to top level

### DIFF
--- a/stable/nfs-server-provisioner/Chart.yaml
+++ b/stable/nfs-server-provisioner/Chart.yaml
@@ -2,10 +2,12 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.2.2
+version: 0.2.3
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie
+- name: joaocc
+  email: joaocc-dev@live.com
 home: https://github.com/kubernetes/charts/tree/master/stable/nfs-server-provisioner
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs

--- a/stable/nfs-server-provisioner/Chart.yaml
+++ b/stable/nfs-server-provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.8
 description: nfs-server-provisioner is an out-of-tree dynamic provisioner for Kubernetes. You can use it to quickly & easily deploy shared storage that works almost anywhere.
 name: nfs-server-provisioner
-version: 0.2.1
+version: 0.2.2
 maintainers:
 - name: kiall
   email: kiall@macinnes.ie

--- a/stable/nfs-server-provisioner/README.md
+++ b/stable/nfs-server-provisioner/README.md
@@ -74,7 +74,7 @@ their default values.
 | `storageClass.defaultClass`    | Whether to set the created StorageClass as the clusters default StorageClass                                    | `false`                                                  |
 | `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
 | `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `{}`                                                     |
-| `storageClass.mountOptions`    | Mount options for StorageClass                                                                                  | `- vers=4.1`                                             |
+| `storageClass.mountOptions`    | Mount options for StorageClass                                                                                  | `[ "vers=4.1", "noatime" ]`                              |
 | `storageClass.reclaimPolicy`   | ReclaimPolicy field of the class, which can be either Delete or Retain                                          | `Delete`                                                    |
 | `resources`                    | Resource limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |

--- a/stable/nfs-server-provisioner/README.md
+++ b/stable/nfs-server-provisioner/README.md
@@ -73,7 +73,8 @@ their default values.
 | `storageClass.provisionerName` | The provisioner name for the storageclass                                                                       | `cluster.local/{release-name}-{chart-name}`              |
 | `storageClass.defaultClass`    | Whether to set the created StorageClass as the clusters default StorageClass                                    | `false`                                                  |
 | `storageClass.name`            | The name to assign the created StorageClass                                                                     | `nfs`                                                    |
-| `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `mountOptions: vers=4.1`                                 |
+| `storageClass.parameters`      | Parameters for StorageClass                                                                                     | `{}`                                                     |
+| `storageClass.mountOptions`    | Mount options for StorageClass                                                                                  | `- vers=4.1`                                             |
 | `storageClass.reclaimPolicy`   | ReclaimPolicy field of the class, which can be either Delete or Retain                                          | `Delete`                                                    |
 | `resources`                    | Resource limits for nfs-server-provisioner pod                                                                          | `{}`                                                     |
 | `nodeSelector`                 | Map of node labels for pod assignment                                                                           | `{}`                                                     |

--- a/stable/nfs-server-provisioner/templates/storageclass.yaml
+++ b/stable/nfs-server-provisioner/templates/storageclass.yaml
@@ -19,3 +19,7 @@ reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
+{{- with .Values.storageClass.mountOptions }}
+mountOptions:
+{{ toYaml . | indent 2 }}
+{{- end }}

--- a/stable/nfs-server-provisioner/templates/storageclass.yaml
+++ b/stable/nfs-server-provisioner/templates/storageclass.yaml
@@ -19,7 +19,7 @@ reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
-{{- with .Values.mountOptions }}
+{{- with .Values.storageClass.mountOptions }}
 mountOptions:
 {{ toYaml . | indent 2 }}
 {{- end }}

--- a/stable/nfs-server-provisioner/templates/storageclass.yaml
+++ b/stable/nfs-server-provisioner/templates/storageclass.yaml
@@ -19,7 +19,7 @@ reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 parameters:
 {{ toYaml . | indent 2 }}
 {{- end }}
-{{- with .Values.storageClass.mountOptions }}
+{{- with .Values.mountOptions }}
 mountOptions:
 {{ toYaml . | indent 2 }}
 {{- end }}

--- a/stable/nfs-server-provisioner/values.yaml
+++ b/stable/nfs-server-provisioner/values.yaml
@@ -55,7 +55,10 @@ storageClass:
 
   ## StorageClass parameters
   parameters:
-    mountOptions: vers=4.1
+    {}
+
+  mountOptions:
+    - vers=4.1
 
   ## ReclaimPolicy field of the class, which can be either Delete or Retain
   reclaimPolicy: Delete

--- a/stable/nfs-server-provisioner/values.yaml
+++ b/stable/nfs-server-provisioner/values.yaml
@@ -54,11 +54,11 @@ storageClass:
   name: nfs
 
   ## StorageClass parameters
-  parameters:
-    {}
+  parameters: {}
 
   mountOptions:
     - vers=4.1
+    - noatime
 
   ## ReclaimPolicy field of the class, which can be either Delete or Retain
   reclaimPolicy: Delete


### PR DESCRIPTION
#### What this PR does / why we need it:
mountOptions in StorageClass were defined as parameters.mountOptions.
This has been deprecated as per https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/docs/usage.md

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
