### PR TITLE
refs: #8747 - added image value and fixed deployment template

### DIFF
--- a/stable/percona/Chart.yaml
+++ b/stable/percona/Chart.yaml
@@ -1,5 +1,5 @@
 name: percona
-version: 0.3.3
+version: 0.3.4
 appVersion: 5.7.17
 description: free, fully compatible, enhanced, open source drop-in replacement for
   MySQL

--- a/stable/percona/README.md
+++ b/stable/percona/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Percona chart and t
 
 | Parameter                  | Description                        | Default                                                    |
 | -----------------------    | ---------------------------------- | ---------------------------------------------------------- |
+| `image`                    | `percona` image.                   | Percona official image on Docker Hub                       |
 | `imageTag`                 | `percona` image tag.                 | Most recent release                                        |
 | `imagePullPolicy`          | Image pull policy                  | `IfNotPresent`                                             |
 | `perconaRootPassword`        | Password for the `root` user.      | `nil`                                                      |

--- a/stable/percona/templates/deployment.yaml
+++ b/stable/percona/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           mountPath: /var/lib/mysql
       containers:
       - name: {{ template "percona.fullname" . }}
-        image: "mysql:{{ .Values.imageTag }}"
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/stable/percona/values.yaml
+++ b/stable/percona/values.yaml
@@ -1,3 +1,8 @@
+## percona image
+## ref: https://hub.docker.com/_/percona/
+##
+image: "percona"
+
 ## percona image version
 ## ref: https://hub.docker.com/r/library/percona/tags/
 ##


### PR DESCRIPTION
Signed-off-by: Daniele Piaggesi <daniele.piaggesi@bonsaimeme.com>

#### What this PR does / why we need it:
Added an "image" variable in values.yml and used in deployment template. Set by default for using "percona" official docker image. But it is overridable.

This simple fix seems to resolve. I tried on my Kubernetes Cluster and it works.
Hope this helps and could be integrated soon in order to use this chart that, at the moment, is not usable at all.

#### Which issue this PR fixes
  - fixes #8747 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
