### PR TITLE
[mongodb/replicaset] readiness probe now checks if primary or secondary

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.6.4
+version: 3.7.0
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/mongodb-service-discovery.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service-discovery.yaml
@@ -2,8 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.serviceAnnotations }}
   annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  {{- if .Values.serviceAnnotations }}
 {{ toYaml .Values.serviceAnnotations | indent 4 }}
   {{- end }}
   labels:
@@ -14,19 +15,14 @@ metadata:
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
-  name: {{ template "mongodb-replicaset.fullname" . }}
+  name: {{ template "mongodb-replicaset.fullname" . }}-discovery
 spec:
   type: ClusterIP
   clusterIP: None
   ports:
     - name: mongodb
       port: {{ .Values.port }}
-{{- if .Values.metrics.enabled }}
-    - name: metrics
-      port: {{ .Values.metrics.port }}
-      targetPort: metrics
-{{- end }}
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
     release: {{ .Release.Name }}
-  publishNotReadyAddresses: false
+  publishNotReadyAddresses: true

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -94,7 +94,7 @@ spec:
             - /work-dir/peer-finder
           args:
             - -on-start=/init/on-start.sh
-            - "-service={{ template "mongodb-replicaset.fullname" . }}"
+            - "-service={{ template "mongodb-replicaset.fullname" . }}-discovery"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           env:
             - name: POD_NAMESPACE


### PR DESCRIPTION
Signed-off-by: moody <moody.saada@agolo.com>

#### What this PR does / why we need it:
Currently, the mongodb service sends traffic to pods that are not yet ready to process requests due to readinessProbes passing during initContainer stage. Some init containers spin up mongo, and the only check we currently have are `ping` requests; which will pass when mongo runs in standalone mode during init stage. This is especially problematic when upgrades include misconfiguration, the first pod in the rollingUpdate stays stuck in the init stage due to misconfiguration; yet traffic still flows through.

Easiest way to reproduce

```yaml
mongodb-replicaset:
  configmap:
    operationProfiling:
      mode: off
```

This PR changes the readinessProbe to check if pod is either Primary or Secondary before considering it healthy.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
