### PR TITLE
[stable/prometheus-node-exporter] Fix typo causing PSP resources not being created

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.16.0"
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 0.5.0
+version: 0.5.1
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/templates/psp-clusterrole.yaml
+++ b/stable/prometheus-node-exporter/templates/psp-clusterrole.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.rbacEnable }}
-{{- if .Values.pspEnable }}
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.pspEnabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/stable/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/stable/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.rbacEnable }}
-{{- if .Values.pspEnable }}
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.pspEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/prometheus-node-exporter/templates/psp.yaml
+++ b/stable/prometheus-node-exporter/templates/psp.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.rbacEnable }}
-{{- if .Values.pspEnable }}
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.pspEnabled }}
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes typo in chart when creating psp resources

#### Which issue this PR fixes
Relates to https://github.com/helm/charts/issues/8877, but does not actually fix it in the chart in question.

#### Special notes for your reviewer:
I don't know if there's a way to regenerate the lockfile correctly for stable/prometheus-operator. If there is, both could be fixed in one PR

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
