### PR TITLE
set AWS_DEFAULT_REGION for aws-sd provider

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ description:
   Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.5.7
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/secrets/service-account/credentials.json
         {{- end }}
-        {{- if eq .Values.provider "aws" }}
+        {{- if or (eq .Values.provider "aws") (eq .Values.provider "aws-sd") }}
         {{- if .Values.aws.region }}
           - name: AWS_DEFAULT_REGION
             value: {{ .Values.aws.region }}


### PR DESCRIPTION
Signed-off-by: Pete Erickson <petee@mindtouch.com>

#### What this PR does / why we need it:
This sets the `AWS_DEFAULT_REGION` environment variable if provider is `aws` or `aws-sd`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
