### PR TITLE
Expose rpc service  for remote backups and restores

### DIFF
--- a/stable/influxdb/Chart.yaml
+++ b/stable/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 0.11.0
+version: 0.12.0
 appVersion: 1.6
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/stable/influxdb/templates/service.yaml
+++ b/stable/influxdb/templates/service.yaml
@@ -58,5 +58,10 @@ spec:
     port: {{ .Values.config.opentsdb.bind_address }}
     targetPort: {{ .Values.config.opentsdb.bind_address }}
   {{- end }}
+  {{- if .Values.exposeRpcService }}
+  - name: rpc
+    port: {{ .Values.config.bind_address }}
+    targetPort: {{ .Values.config.bind_address }}
+  {{- end }}
   selector:
     app: {{ template "influxdb.fullname" . }}

--- a/stable/influxdb/values.yaml
+++ b/stable/influxdb/values.yaml
@@ -231,3 +231,5 @@ config:
     log_enabled: true
     enabled: true
     run_interval: 1s
+
+exposeRpcService: true


### PR DESCRIPTION


#### What this PR does / why we need it:

Expose bind address port (8088 by default) in order for backup and restores to be done by other influx db pods (e.g. cronjob)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #7145

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md *


*Most variables are not documented in readme
