### PR TITLE
[stable/prometheus-operator]: Fix cadvisor endpoint for http

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 0.1.11
+version: 0.1.12
 appVersion: "0.25.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
+++ b/stable/prometheus-operator/templates/exporters/kubelet/servicemonitor.yaml
@@ -30,7 +30,8 @@ spec:
   - port: http-metrics
     interval: 30s
     honorLabels: true
-  - port: cadvisor
+  - port: http-metrics
+    path: /metrics/cadvisor
     interval: 30s
     honorLabels: true
   {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

It updates the http endpoint metrics for cadvisor. The change has already been done for https metrics but not for http. cadvisor web ui on port 4194 has been deprecated for a long time. On recent cluster, it has been completely disabled. Now, metrics from cadvisor should be done via the `http-metrics` port.

Without this change, half of kubelet endpoints are down (cadvisor).

#### Checklist
- [X] Chart Version bumped
