### PR TITLE
[stable/kube-state-metrics] Add securityContext

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.9.0
+version: 0.10.0
 appVersion: 1.4.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -21,8 +21,11 @@ $ helm install stable/kube-state-metrics
 | `prometheusScrape`                    | Whether or not enable prom scrape                       | True                                        |
 | `rbac.create`                         | If true, create & use RBAC resources                    | False                                       |
 | `rbac.serviceAccountName`             | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
+| `securityContext.enabled`             | Enable security context                                 | `true`                                      |
+| `securityContext.fsGroup`             | Group ID for the container                              | `65534`                                     |
+| `securityContext.runAsUser`           | User ID for the container                               | `65534`                                     |
 | `nodeSelector`                        | Node labels for pod assignment                          | {}                                          |
-| `tolerations`                         | Tolerations for pod assignment	                      | []                                          |
+| `tolerations`                         | Tolerations for pod assignment	                  | []                                          |
 | `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
 | `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |
 | `collectors.cronjobs`                 | Enable the cronjobs collector.                          | true                                        |

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -20,6 +20,11 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-state-metrics.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         args:

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -16,6 +16,11 @@ rbac:
   # Ignored if rbac.create is true
   serviceAccountName: default
 
+securityContext:
+  enabled: true
+  runAsUser: 65534
+  fsGroup: 65534
+
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 nodeSelector: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently kube-state-metrics runs as root. Switch to nobody instead. Safer and fixes installing this on podSecurityPolicy-enabled clusters.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
