### PR TITLE
[stable/ghost] Use minideb as initContainer to change volumes permissions

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 5.3.6
+version: 5.4.0
 appVersion: 2.4.0
 description: A simple, powerful publishing platform that allows you to share your
   stories with the world

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -47,53 +47,57 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Ghost chart and their default values.
 
-| Parameter                        | Description                                                   | Default                                                  |
-|----------------------------------|---------------------------------------------------------------|----------------------------------------------------------|
-| `global.imageRegistry`           | Global Docker image registry                                  | `nil`                                                    |
-| `image.registry`                 | Ghost image registry                                          | `docker.io`                                              |
-| `image.repository`               | Ghost Image name                                              | `bitnami/ghost`                                          |
-| `image.tag`                      | Ghost Image tag                                               | `{VERSION}`                                              |
-| `image.pullPolicy`               | Image pull policy                                             | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
-| `image.pullSecrets`              | Specify image pull secrets                                    | `nil`                                                    |
-| `ghostHost`                      | Ghost host to create application URLs                         | `nil`                                                    |
-| `ghostPath`                      | Ghost path to create application URLs                         | `nil`                                                    |
-| `ghostPort`                      | Ghost port to create application URLs along with host         | `80`                                                     |
-| `ghostLoadBalancerIP`            | `loadBalancerIP` for the Ghost Service                        | `nil`                                                    |
-| `ghostUsername`                  | User of the application                                       | `user@example.com`                                       |
-| `ghostPassword`                  | Application password                                          | Randomly generated                                       |
-| `ghostEmail`                     | Admin email                                                   | `user@example.com`                                       |
-| `ghostBlogTitle`                 | Ghost Blog name                                               | `User's Blog`                                            |
-| `allowEmptyPassword`             | Allow DB blank passwords                                      | `yes`                                                    |
-| `serviceType`                    | Kubernetes Service type                                       | `LoadBalancer`                                           |
-| `securityContext.enabled`        | Enable security context                                       | `true`                                                   |
-| `securityContext.fsGroup`        | Group ID for the container                                    | `1001`                                                   |
-| `securityContext.runAsUser`      | User ID for the container                                     | `1001`                                                   |
-| `ingress.enabled`                | Enable ingress controller resource                            | `false`                                                  |
-| `ingress.hosts[0].name`          | Hostname to your Ghost installation                           | `ghost.local`                                            |
-| `ingress.hosts[0].path`          | Path within the url structure                                 | `/`                                                      |
-| `ingress.hosts[0].tls`           | Utilize TLS backend in ingress                                | `false`                                                  |
-| `ingress.hosts[0].certManager`   | Add annotations for cert-manager                              | `false`                                                  |
-| `ingress.hosts[0].tlsSecret`     | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
-| `ingress.hosts[0].annotations`   | Annotations for this host's ingress record                    | `[]`                                                     |
-| `ingress.secrets[0].name`        | TLS Secret Name                                               | `nil`                                                    |
-| `ingress.secrets[0].certificate` | TLS Secret Certificate                                        | `nil`                                                    |
-| `ingress.secrets[0].key`         | TLS Secret Key                                                | `nil`                                                    |
-| `externalDatabase.host`          | Host of the external database                                 | `nil`                                                    |
-| `externalDatabase.port`          | Port of the external database                                 | `nil`                                                    |
-| `externalDatabase.user`          | Existing username in the external db                          | `bn_ghost`                                               |
-| `externalDatabase.password`      | Password for the above username                               | `nil`                                                    |
-| `externalDatabase.database`      | Name of the existing database                                 | `bitnami_ghost`                                          |
-| `mariadb.enabled`                | Whether or not to install MariaDB (disable if using external) | `true`                                                   |
-| `mariadb.rootUser.password`      | MariaDB admin password                                        | `nil`                                                    |
-| `mariadb.db.name`                | MariaDB Database name to create                               | `bitnami_ghost`                                          |
-| `mariadb.db.user`                | MariaDB Database user to create                               | `bn_ghost`                                               |
-| `mariadb.db.password`            | MariaDB Password for user                                     | _random 10 character long alphanumeric string_           |
-| `persistence.enabled`            | Enable persistence using PVC                                  | `true`                                                   |
-| `persistence.storageClass`       | PVC Storage Class for Ghost volume                            | `nil` (uses alpha storage annotation)                    |
-| `persistence.accessMode`         | PVC Access Mode for Ghost volume                              | `ReadWriteOnce`                                          |
-| `persistence.size`               | PVC Storage Request for Ghost volume                          | `8Gi`                                                    |
-| `persistence.path`               | Path to mount the volume at, to use other images              | `/bitnami`                                               |
-| `resources`                      | CPU/Memory resource requests/limits                           | Memory: `512Mi`, CPU: `300m`                             |
+| Parameter                           | Description                                                   | Default                                                  |
+|-------------------------------------|---------------------------------------------------------------|----------------------------------------------------------|
+| `global.imageRegistry`              | Global Docker image registry                                  | `nil`                                                    |
+| `image.registry`                    | Ghost image registry                                          | `docker.io`                                              |
+| `image.repository`                  | Ghost Image name                                              | `bitnami/ghost`                                          |
+| `image.tag`                         | Ghost Image tag                                               | `{VERSION}`                                              |
+| `image.pullPolicy`                  | Image pull policy                                             | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
+| `image.pullSecrets`                 | Specify image pull secrets                                    | `nil`                                                    |
+| `volumePermissions.image.registry`  | Init container volume-permissions image registry              | `docker.io`                                              |
+| `volumePermissions.image.repository`| Init container volume-permissions image name                  | `bitnami/minideb`                                        |
+| `volumePermissions.image.tag`       | Init container volume-permissions image tag                   | `latest`                                                 |
+| `volumePermissions.image.pullPolicy`| Init container volume-permissions image pull policy           | `Always`                                                 |
+| `ghostHost`                         | Ghost host to create application URLs                         | `nil`                                                    |
+| `ghostPath`                         | Ghost path to create application URLs                         | `nil`                                                    |
+| `ghostPort`                         | Ghost port to create application URLs along with host         | `80`                                                     |
+| `ghostLoadBalancerIP`               | `loadBalancerIP` for the Ghost Service                        | `nil`                                                    |
+| `ghostUsername`                     | User of the application                                       | `user@example.com`                                       |
+| `ghostPassword`                     | Application password                                          | Randomly generated                                       |
+| `ghostEmail`                        | Admin email                                                   | `user@example.com`                                       |
+| `ghostBlogTitle`                    | Ghost Blog name                                               | `User's Blog`                                            |
+| `allowEmptyPassword`                | Allow DB blank passwords                                      | `yes`                                                    |
+| `serviceType`                       | Kubernetes Service type                                       | `LoadBalancer`                                           |
+| `securityContext.enabled`           | Enable security context                                       | `true`                                                   |
+| `securityContext.fsGroup`           | Group ID for the container                                    | `1001`                                                   |
+| `securityContext.runAsUser`         | User ID for the container                                     | `1001`                                                   |
+| `ingress.enabled`                   | Enable ingress controller resource                            | `false`                                                  |
+| `ingress.hosts[0].name`             | Hostname to your Ghost installation                           | `ghost.local`                                            |
+| `ingress.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
+| `ingress.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
+| `ingress.hosts[0].certManager`      | Add annotations for cert-manager                              | `false`                                                  |
+| `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
+| `ingress.hosts[0].annotations`      | Annotations for this host's ingress record                    | `[]`                                                     |
+| `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
+| `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |
+| `ingress.secrets[0].key`            | TLS Secret Key                                                | `nil`                                                    |
+| `externalDatabase.host`             | Host of the external database                                 | `nil`                                                    |
+| `externalDatabase.port`             | Port of the external database                                 | `nil`                                                    |
+| `externalDatabase.user`             | Existing username in the external db                          | `bn_ghost`                                               |
+| `externalDatabase.password`         | Password for the above username                               | `nil`                                                    |
+| `externalDatabase.database`         | Name of the existing database                                 | `bitnami_ghost`                                          |
+| `mariadb.enabled`                   | Whether or not to install MariaDB (disable if using external) | `true`                                                   |
+| `mariadb.rootUser.password`         | MariaDB admin password                                        | `nil`                                                    |
+| `mariadb.db.name`                   | MariaDB Database name to create                               | `bitnami_ghost`                                          |
+| `mariadb.db.user`                   | MariaDB Database user to create                               | `bn_ghost`                                               |
+| `mariadb.db.password`               | MariaDB Password for user                                     | _random 10 character long alphanumeric string_           |
+| `persistence.enabled`               | Enable persistence using PVC                                  | `true`                                                   |
+| `persistence.storageClass`          | PVC Storage Class for Ghost volume                            | `nil` (uses alpha storage annotation)                    |
+| `persistence.accessMode`            | PVC Access Mode for Ghost volume                              | `ReadWriteOnce`                                          |
+| `persistence.size`                  | PVC Storage Request for Ghost volume                          | `8Gi`                                                    |
+| `persistence.path`                  | Path to mount the volume at, to use other images              | `/bitnami`                                               |
+| `resources`                         | CPU/Memory resource requests/limits                           | Memory: `512Mi`, CPU: `300m`                             |
 
 The above parameters map to the env variables defined in [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost). For more information please refer to the [bitnami/ghost](http://github.com/bitnami/bitnami-docker-ghost) image documentation.
 

--- a/stable/ghost/templates/_helpers.tpl
+++ b/stable/ghost/templates/_helpers.tpl
@@ -86,3 +86,26 @@ Also, we can't use a single if because lazy evaluation is not an option
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the proper image name to change the volume permissions
+*/}}
+{{- define "ghost.volumePermissions.image" -}}
+{{- $registryName := .Values.volumePermissions.image.registry -}}
+{{- $repositoryName := .Values.volumePermissions.image.repository -}}
+{{- $tag := .Values.volumePermissions.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -28,8 +28,8 @@ spec:
       {{- else }}
       initContainers:
       - name: volume-permissions
-        image: "{{ .Values.volumePermissions.image.name }}:{{ .Values.volumePermissions.image.tag }}"
-        imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+        image: {{ template "ghost.volumePermissions.image" . }}
+        imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
         command: ['sh', '-c', 'chmod -R g+rwX {{ .Values.persistence.path }}']
         volumeMounts:
         - mountPath: {{ .Values.persistence.path }}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -23,13 +23,16 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-## Busybox image used to configure volume permissions
+##
+## Init containers parameters:
+## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
 ##
 volumePermissions:
   image:
-    name: busybox
-    tag: 1.28.3
-#    pullPolicy:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: latest
+    pullPolicy: Always
 
 ## Ghost host and path to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-ghost#configuration


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
In order to maintain the image up-to-date, with CVEs tracking and integrated on a tested pipeline I suggest replacing busybox image with minideb. minideb is already pulled to the cluster

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
