### PR TITLE
[stable/kube-state-metrics] Enable RBAC by default (needed for securitycontexts)

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.10.0
+version: 0.11.0
 appVersion: 1.4.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -18,8 +18,8 @@ $ helm install stable/kube-state-metrics
 | `image.tag`                           | The image tag to pull from                              | `v1.4.0`                          |
 | `image.pullPolicy`                    | Image pull policy                                       | IfNotPresent                                |
 | `service.port`                        | The port of the container                               | 8080                                        |
-| `prometheusScrape`                    | Whether or not enable prom scrape                       | True                                        |
-| `rbac.create`                         | If true, create & use RBAC resources                    | True                                        |
+| `prometheusScrape`                    | Whether or not enable prom scrape                       | true                                        |
+| `rbac.create`                         | If true, create & use RBAC resources                    | true                                        |
 | `rbac.serviceAccountName`             | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
 | `securityContext.enabled`             | Enable security context                                 | `true`                                      |
 | `securityContext.fsGroup`             | Group ID for the container                              | `65534`                                     |

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -19,7 +19,7 @@ $ helm install stable/kube-state-metrics
 | `image.pullPolicy`                    | Image pull policy                                       | IfNotPresent                                |
 | `service.port`                        | The port of the container                               | 8080                                        |
 | `prometheusScrape`                    | Whether or not enable prom scrape                       | True                                        |
-| `rbac.create`                         | If true, create & use RBAC resources                    | False                                       |
+| `rbac.create`                         | If true, create & use RBAC resources                    | True                                        |
 | `rbac.serviceAccountName`             | ServiceAccount to be used (ignored if rbac.create=true) | default                                     |
 | `securityContext.enabled`             | Enable security context                                 | `true`                                      |
 | `securityContext.fsGroup`             | Group ID for the container                              | `65534`                                     |

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -12,7 +12,7 @@ service:
   loadBalancerIP: ""
 rbac:
   # If true, create & use RBAC resources
-  create: false
+  create: true
   # Ignored if rbac.create is true
   serviceAccountName: default
 


### PR DESCRIPTION
Signed-off-by: Bart Verwilst <bart@verwilst.be>

#### What this PR does / why we need it:

The container now runs under a nonroot user, but without rbac.enabled=true it's not allowed to fetch any endpoints from kubernetes.

```
E1105 15:15:23.605228       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:kube-state-metrics:default" cannot list jobs.batch at the cluster scope
E1105 15:15:23.605785       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v2beta1.HorizontalPodAutoscaler: horizontalpodautoscalers.autoscaling is forbidden: User "system:serviceaccount:kube-state-metrics:default" cannot list horizontalpodautoscalers.autoscaling at the cluster scope
E1105 15:15:23.605891       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1beta1.ReplicaSet: replicasets.extensions is forbidden: User "system:serviceaccount:kube-state-metrics:default" cannot list replicasets.extensions at the cluster scope
E1105 15:15:23.691650       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.LimitRange: limitranges is forbidden: User "system:serviceaccount:kube-state-metrics:default" cannot list limitranges at the cluster scope
E1105 15:15:23.891805       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.Node: nodes is forbidden: User "system:serviceaccount:kube-state-metrics:default" cannot list nodes at the cluster scope
E1105 15:15:24.091682       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.PersistentVolumeClaim: persistentvolumeclaims is forbidden: User "system:serviceaccount:kube-state-metrics:default" cannot list persistentvolumeclaims at the cluster scope
E1105 15:15:24.291943       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.PersistentVolume: persistentvolumes is forbidden: User "system:serviceaccount:kube-state-metrics:default" cannot list persistentvolumes at the cluster scope
E1105 15:15:24.541599       1 reflector.go:205] k8s.io/kube-state-metrics/pkg/collectors/collectors.go:91: Failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:kube-state-metrics:default" cannot list endpoints at the cluster scope
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
