### PR TITLE
[stable/kured]: update to new release

### DIFF
--- a/stable/kured/Chart.yaml
+++ b/stable/kured/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "master-c42fff3"
+appVersion: "1.1.0"
 description: A Helm chart for kured
 name: kured
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: plumdog

--- a/stable/kured/README.md
+++ b/stable/kured/README.md
@@ -12,7 +12,7 @@ See https://github.com/weaveworks/kured
 | `serviceAccount.create` | Create service account roles                                                | `true`                     |
 | `serviceAccount.name`   | Service account name to create (or use if `serviceAccount.create` is false) | (chart fullname)           |
 | `updateStrategy`        | Daemonset update strategy                                                   | `OnDelete`                 |
-| `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)       | `[]`                       |
+| `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)       | `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]`|
 
 See https://github.com/weaveworks/kured#configuration for values for `extraArgs`. Note that
 ```yaml

--- a/stable/kured/templates/clusterrole.yaml
+++ b/stable/kured/templates/clusterrole.yaml
@@ -13,25 +13,16 @@ rules:
 # Allow kubectl to drain/uncordon
 #
 # NB: These permissions are tightly coupled to the bundled version of kubectl; the ones below
-# match https://github.com/kubernetes/kubernetes/blob/v1.9.6/pkg/kubectl/cmd/drain.go
+# match https://github.com/kubernetes/kubernetes/blob/v1.12.1/pkg/kubectl/cmd/drain.go
 #
 - apiGroups: [""]
   resources: ["nodes"]
   verbs:     ["get", "patch"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs:     ["list"]
-- apiGroups: [""]
-  resources: ["replicationcontrollers"]
-  verbs:     ["get"]
-- apiGroups: ["apps"]
-  resources: ["statefulsets"]
-  verbs:     ["get"]
+  verbs:     ["list","delete","get"]
 - apiGroups: ["extensions"]
-  resources: ["daemonsets", "replicasets"]
-  verbs:     ["get"]
-- apiGroups: ["batch"]
-  resources: ["jobs"]
+  resources: ["daemonsets"]
   verbs:     ["get"]
 - apiGroups: [""]
   resources: ["pods/eviction"]

--- a/stable/kured/templates/daemonset.yaml
+++ b/stable/kured/templates/daemonset.yaml
@@ -23,10 +23,14 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "kured.serviceAccountName" . }}
+      hostPID: true
+      restartPolicy: Always
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: true # Give permission to nsenter /proc/1/ns/mnt
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           command:
@@ -48,18 +52,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          volumeMounts:
-            # Needed for two purposes:
-            # * Testing for the existence of /var/run/reboot-required
-            # * Accessing /var/run/dbus/system_bus_socket to effect reboot
-            - name: hostrun
-              mountPath: /var/run
       restartPolicy: Always
       {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      volumes:
-        - name: hostrun
-          hostPath:
-            path: /var/run

--- a/stable/kured/values.yaml
+++ b/stable/kured/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/weaveworks/kured
   # Appears to be without numbered numbered tags, so using this instead
-  tag: master-c42fff3
+  tag: 1.1.0
   pullPolicy: IfNotPresent
 
 extraArgs: {}
@@ -15,4 +15,6 @@ serviceAccount:
 
 updateStrategy: OnDelete
 
-tolerations: []
+tolerations:
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule


### PR DESCRIPTION
#### What this PR does / why we need it:

- Updates the kured chart (to use a recent released image)
- Updated clusterrole and daemonset according to weaveworks/kured

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
