### PR TITLE
Update MetalLB README.md and values.yaml

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.8.0
+version: 0.8.1
 
 name: metallb
 appVersion: 0.7.3

--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -87,16 +87,6 @@ By default, this chart does not install a configuration for MetalLB, and simply
 warns you that you must follow [the configuration instructions on MetalLB's
 website][metallb-config] to create an appropriate ConfigMap.
 
-For simple setups that only use MetalLB's [ARP mode][metallb-arpndp-concepts],
-you can specify a single IP range using the `arpAddresses` parameter to have the
-chart install a working configuration for you:
-
-```console
-$ helm install --name metallb \
-  --set arpAddresses=192.168.16.240/30 \
-  stable/metallb
-```
-
 If you have a more complex configuration and want Helm to manage it for you, you
 can provide it in the `config` parameter. The configuration format is
 [documented on MetalLB's website][metallb-config].

--- a/stable/metallb/values.yaml
+++ b/stable/metallb/values.yaml
@@ -18,6 +18,23 @@ existingConfigMap: metallb-config
 # Refer to https://metallb.universe.tf/configuration/ for
 # available options.
 configInline:
+    # Example ARP Configuration
+    # address-pools:
+    # - name: default
+    #  protocol: layer2
+    #  addresses:
+    #  - 192.168.1.240-192.168.1.250
+    #
+    # Example BGP Configuration
+    # peers:
+    # - peer-address: 10.0.0.1
+    #   peer-asn: 64501
+    #   my-asn: 64500
+    # address-pools:
+    # - name: default
+    #   protocol: bgp
+    #   addresses:
+    #   - 192.168.10.0/24
 
 rbac:
   # create specifies whether to install and use RBAC rules.


### PR DESCRIPTION
Updates the MetalLB README as well as values to include an example for
Arp / BGP configuration as well as removing the ArpAddresses parameter
example that is no longer supported / used.