### PR TITLE
[stable/prometheus-operator] Lock kube-state-metrics to newest version

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 0.1.13
+version: 0.1.14
 appVersion: "0.25.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.9.0
+  version: 0.11.0
 - name: prometheus-node-exporter
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.5.0
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.17.2
-digest: sha256:a35a2b9bbbab49dec4e77cdc3ef4f101da39a1fbd45247025bce35ca73521b7d
-generated: 2018-10-22T21:32:21.6437929+01:00
+digest: sha256:df4960ff63b59ef5a8abc2b972af9add61a4606980befe26cf491f08d3da2261
+generated: 2018-11-05T20:26:11.88562838Z

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 
   - name: kube-state-metrics
-    version: 0.9.0
+    version: 0.11.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: kubeStateMetrics.enabled
 


### PR DESCRIPTION
Signed-off-by: Bart Verwilst <bart@verwilst.be>

#### What this PR does / why we need it:

New version of kube-state-metrics needed for enabled rbac support. Otherwise PSP-enabled clusters won't install this chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
