### PR TITLE
[stable/keycloak] use tcp instead of udp for jgroups

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.0.2
+version: 4.0.3
 appVersion: 4.5.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -49,10 +49,7 @@ keycloak:
   password: ""
 
   ## Allows the specification of additional environment variables for Keycloak
-  ## Set PROXY_ADDRESS_FORWARDING if using ingress
   extraEnv: |
-    # - name:  PROXY_ADDRESS_FORWARDING
-    #   value: "true"
     # - name: KEYCLOAK_LOGLEVEL
     #   value: DEBUG
     # - name: WILDFLY_LOGLEVEL

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -49,7 +49,10 @@ keycloak:
   password: ""
 
   ## Allows the specification of additional environment variables for Keycloak
+  ## Set PROXY_ADDRESS_FORWARDING if using ingress
   extraEnv: |
+    # - name:  PROXY_ADDRESS_FORWARDING
+    #   value: "true"
     # - name: KEYCLOAK_LOGLEVEL
     #   value: DEBUG
     # - name: WILDFLY_LOGLEVEL
@@ -132,6 +135,8 @@ keycloak:
       /subsystem=infinispan/cache-container=keycloak/distributed-cache=authenticationSessions:write-attribute(name=owners, value=${env.CACHE_OWNERS:2})
       /subsystem=infinispan/cache-container=keycloak/distributed-cache=offlineSessions:write-attribute(name=owners, value=${env.CACHE_OWNERS:2})
       /subsystem=infinispan/cache-container=keycloak/distributed-cache=loginFailures:write-attribute(name=owners, value=${env.CACHE_OWNERS:2})
+
+      /subsystem=jgroups/channel=ee:write-attribute(name=stack, value=tcp)
 
     # Custom CLI script
     custom: ""


### PR DESCRIPTION
Signed-off-by: Michael Dop <michael.p.dop@gmail.com>

#### What this PR does / why we need it: 
The default jgroups protocol is udp so need to change back to tcp.  When using udp the the nodes cannot communicate to each other and start timing out causing ha keycloak to fail when using DNS_PING.

#### Which issue this PR fixes
- fixes #8355

#### Special notes for your reviewer: 
