### PR TITLE
Fix edge case where secret names will contain dots (for DNS-named secrets)

### DIFF
--- a/incubator/vault/Chart.yaml
+++ b/incubator/vault/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Vault, a tool for managing secrets
 name: vault
-version: 0.14.2
+version: 0.14.3
 appVersion: 0.11.2
 home: https://www.vaultproject.io/
 icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg

--- a/incubator/vault/templates/deployment.yaml
+++ b/incubator/vault/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
         - name: vault-root
           mountPath: /root/
         {{- range .Values.vault.customSecrets }}
-        - name: {{ .secretName }}
+        - name: {{ .secretName | replace "." "-"}}
           mountPath: {{ .mountPath }}
         {{- end }}
 {{- if .Values.vault.extraContainers }}
@@ -126,7 +126,7 @@ spec:
         - name: vault-root
           emptyDir: {}
         {{- range .Values.vault.customSecrets }}
-        - name: {{ .secretName }}
+        - name: {{ .secretName | replace "." "-"}}
           secret:
             secretName: {{ .secretName }}
         {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

@jpds

#### What this PR does / why we need it:

Our SSL certificate kubernetes secrets are named after their DNS names.  This PR will just change any dots that appear in secret names into dashes, which will allow these secrets to be mounted in the containers.  It's probably an edge case, but it doesn't seem harmful to include.

#### Which issue this PR fixes
No raised issue.  I can raise an issue if that helps.

#### Special notes for your reviewer:

It fixes a minor issue, again, for my names regarding DNS-named secrets.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
