### PR TITLE
[stable/postgresql] Specify user for the initContainer

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 2.3.0
+version: 2.3.1
 appVersion: 10.5.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -45,67 +45,68 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the PostgreSQL chart and their default values.
 
-|         Parameter                    |                Description                         |                            Default                        |
-|--------------------------------------|----------------------------------------------------|---------------------------------------------------------- |
-| `global.imageRegistry`               | Global Docker Image registry                       | `nil`                                                     |
-| `image.registry`                     | PostgreSQL Image registry                          | `docker.io`                                               |
-| `image.repository`                   | PostgreSQL Image name                              | `bitnami/postgresql`                                      |
-| `image.tag`                          | PostgreSQL Image tag                               | `{VERSION}`                                               |
-| `image.pullPolicy`                   | PostgreSQL Image pull policy                       | `Always`                                                  |
-| `image.pullSecrets`                  | Specify Image pull secrets                         | `nil` (does not add image pull secrets to deployed pods)  |
-| `image.debug`                        | Specify if debug values should be set              | `false`                                                   |
-| `volumePermissions.image.registry`   | Init container volume-permissions image registry   | `docker.io`                                               |
-| `volumePermissions.image.repository` | Init container volume-permissions image name       | `bitnami/minideb`                                         |
-| `volumePermissions.image.tag`        | Init container volume-permissions image tag        | `latest`                                                  |
-| `volumePermissions.image.pullPolicy` | Init container volume-permissions image pull policy| `Always`                                            |
-| `replication.enabled`                | Would you like to enable replication               | `false`                                                   |
-| `replication.user`                   | Replication user                                   | `repl_user`                                               |
-| `replication.password`               | Replication user password                          | `repl_password`                                           |
-| `replication.slaveReplicas`          | Number of slaves replicas                          | `1`                                                       |
-| `postgresqlUsername`                 | PostgreSQL admin user                              | `postgres`                                                |
-| `postgresqlPassword`                 | PostgreSQL admin password                          | _random 10 character alphanumeric string_                 |
-| `postgresqlDatabase`                 | PostgreSQL database                                | `nil`                                                     |
-| `service.type`                       | Kubernetes Service type                            | `ClusterIP`                                               |
-| `service.port`                       | PostgreSQL port                                    | `5432`                                                    |
-| `service.nodePort`                   | Kubernetes Service nodePort                        | `nil`                                                     |
-| `service.annotations`                | Annotations for PostgreSQL service                 | {}                                                        |
-| `service.loadBalancerIP`             | loadBalancerIP if service type is `LoadBalancer`   | `nil`                                                     |
-| `persistence.enabled`                | Enable persistence using PVC                       | `true`                                                    |
-| `persistence.storageClass`           | PVC Storage Class for PostgreSQL volume            | `nil`                                                     |
-| `persistence.accessMode`             | PVC Access Mode for PostgreSQL volume              | `ReadWriteOnce`                                           |
-| `persistence.size`                   | PVC Storage Request for PostgreSQL volume          | `8Gi`                                                     |
-| `persistence.annotations`            | Annotations for the PVC                            | `{}`                                                      |
-| `nodeSelector`                       | Node labels for pod assignment                     | `{}`                                                      |
-| `tolerations`                        | Toleration labels for pod assignment               | `[]`                                                      |
-| `terminationGracePeriodSeconds`      | Seconds the pod needs to terminate gracefully      | `nil`                                                     |
-| `resources`                          | CPU/Memory resource requests/limits                | Memory: `256Mi`, CPU: `250m`                              |
-| `securityContext.enabled`            | Enable security context                            | `true`                                                    |
-| `securityContext.fsGroup`            | Group ID for the container                         | `1001`                                                    |
-| `securityContext.runAsUser`          | User ID for the container                          | `1001`                                                    |
-| `livenessProbe.enabled`              | Would you like a livessProbed to be enabled        |  `true`                                                   |
-| `networkPolicy.enabled`              | Enable NetworkPolicy                               | `false`                                                   |
-| `networkPolicy.allowExternal`        | Don't require client label for connections         | `true`                                                    |
-| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated           |  30                                                       |
-| `livenessProbe.periodSeconds`        | How often to perform the probe                     |  10                                                       |
-| `livenessProbe.timeoutSeconds`       | When the probe times out                           |  5                                                        |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.    |  6             |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed   |  1             |
-| `readinessProbe.enabled`             | would you like a readinessProbe to be enabled      |  `true`                                                   |
-| `readinessProbe.initialDelaySeconds` | Delay before liveness probe is initiated           |  5                                                        |
-| `readinessProbe.periodSeconds`       | How often to perform the probe                     |  10                                                       |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                           |  5                                                        |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.    |  6             |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed   |  1             |
-| `metrics.enabled`                    | Start a prometheus exporter                        | `false`                                                   |
-| `metrics.service.type`               | Kubernetes Service type                            |  `ClusterIP`                                              |
-| `metrics.service.annotatios`         | Additional annotations for metrics exporter pod    |  `{}`                                                     |
-| `metrics.service.loadBalancerIP`     | loadBalancerIP if redis metrics service type is `LoadBalancer` | `nil`                                         |
-| `metrics.image.registry`             | PostgreSQL Image registry                          | `docker.io`                                               |
-| `metrics.image.repository`           | PostgreSQL Image name                              | `wrouesnel/postgres_exporter`                             |
-| `metrics.image.tag`                  | PostgreSQL Image tag                               | `{VERSION}`                                               |
-| `metrics.image.pullPolicy`           | PostgreSQL Image pull policy                       | `IfNotPresent`                                            |
-| `metrics.image.pullSecrets`          | Specify Image pull secrets                         | `nil` (does not add image pull secrets to deployed pods)  |
-| `extraEnv`                           | Any extra environment variables you would like to pass on to the pod | `{}`                                    |
+|         Parameter                             |                Description                         |                            Default                        |
+|-----------------------------------------------|----------------------------------------------------|---------------------------------------------------------- |
+| `global.imageRegistry`                        | Global Docker Image registry                       | `nil`                                                     |
+| `image.registry`                              | PostgreSQL Image registry                          | `docker.io`                                               |
+| `image.repository`                            | PostgreSQL Image name                              | `bitnami/postgresql`                                      |
+| `image.tag`                                   | PostgreSQL Image tag                               | `{VERSION}`                                               |
+| `image.pullPolicy`                            | PostgreSQL Image pull policy                       | `Always`                                                  |
+| `image.pullSecrets`                           | Specify Image pull secrets                         | `nil` (does not add image pull secrets to deployed pods)  |
+| `image.debug`                                 | Specify if debug values should be set              | `false`                                                   |
+| `volumePermissions.image.registry`            | Init container volume-permissions image registry   | `docker.io`                                               |
+| `volumePermissions.image.repository`          | Init container volume-permissions image name       | `bitnami/minideb`                                         |
+| `volumePermissions.image.tag`                 | Init container volume-permissions image tag        | `latest`                                                  |
+| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy| `Always`                                                  |
+| `volumePermissions.securityContext.runAsUser` | User ID for the init container                     | `0`                                                       |
+| `replication.enabled`                         | Would you like to enable replication               | `false`                                                   |
+| `replication.user`                            | Replication user                                   | `repl_user`                                               |
+| `replication.password`                        | Replication user password                          | `repl_password`                                           |
+| `replication.slaveReplicas`                   | Number of slaves replicas                          | `1`                                                       |
+| `postgresqlUsername`                          | PostgreSQL admin user                              | `postgres`                                                |
+| `postgresqlPassword`                          | PostgreSQL admin password                          | _random 10 character alphanumeric string_                 |
+| `postgresqlDatabase`                          | PostgreSQL database                                | `nil`                                                     |
+| `service.type`                                | Kubernetes Service type                            | `ClusterIP`                                               |
+| `service.port`                                | PostgreSQL port                                    | `5432`                                                    |
+| `service.nodePort`                            | Kubernetes Service nodePort                        | `nil`                                                     |
+| `service.annotations`                         | Annotations for PostgreSQL service                 | {}                                                        |
+| `service.loadBalancerIP`                      | loadBalancerIP if service type is `LoadBalancer`   | `nil`                                                     |
+| `persistence.enabled`                         | Enable persistence using PVC                       | `true`                                                    |
+| `persistence.storageClass`                    | PVC Storage Class for PostgreSQL volume            | `nil`                                                     |
+| `persistence.accessMode`                      | PVC Access Mode for PostgreSQL volume              | `ReadWriteOnce`                                           |
+| `persistence.size`                            | PVC Storage Request for PostgreSQL volume          | `8Gi`                                                     |
+| `persistence.annotations`                     | Annotations for the PVC                            | `{}`                                                      |
+| `nodeSelector`                                | Node labels for pod assignment                     | `{}`                                                      |
+| `tolerations`                                 | Toleration labels for pod assignment               | `[]`                                                      |
+| `terminationGracePeriodSeconds`               | Seconds the pod needs to terminate gracefully      | `nil`                                                     |
+| `resources`                                   | CPU/Memory resource requests/limits                | Memory: `256Mi`, CPU: `250m`                              |
+| `securityContext.enabled`                     | Enable security context                            | `true`                                                    |
+| `securityContext.fsGroup`                     | Group ID for the container                         | `1001`                                                    |
+| `securityContext.runAsUser`                   | User ID for the container                          | `1001`                                                    |
+| `livenessProbe.enabled`                       | Would you like a livessProbed to be enabled        |  `true`                                                   |
+| `networkPolicy.enabled`                       | Enable NetworkPolicy                               | `false`                                                   |
+| `networkPolicy.allowExternal`                 | Don't require client label for connections         | `true`                                                    |
+| `livenessProbe.initialDelaySeconds`           | Delay before liveness probe is initiated           |  30                                                       |
+| `livenessProbe.periodSeconds`                 | How often to perform the probe                     |  10                                                       |
+| `livenessProbe.timeoutSeconds`                | When the probe times out                           |  5                                                        |
+| `livenessProbe.failureThreshold`              | Minimum consecutive failures for the probe to be considered failed after having succeeded.    |  6             |
+| `livenessProbe.successThreshold`              | Minimum consecutive successes for the probe to be considered successful after having failed   |  1             |
+| `readinessProbe.enabled`                      | would you like a readinessProbe to be enabled      |  `true`                                                   |
+| `readinessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated           |  5                                                        |
+| `readinessProbe.periodSeconds`                | How often to perform the probe                     |  10                                                       |
+| `readinessProbe.timeoutSeconds`               | When the probe times out                           |  5                                                        |
+| `readinessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.    |  6             |
+| `readinessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed   |  1             |
+| `metrics.enabled`                             | Start a prometheus exporter                        | `false`                                                   |
+| `metrics.service.type`                        | Kubernetes Service type                            |  `ClusterIP`                                              |
+| `metrics.service.annotatios`                  | Additional annotations for metrics exporter pod    |  `{}`                                                     |
+| `metrics.service.loadBalancerIP`              | loadBalancerIP if redis metrics service type is `LoadBalancer` | `nil`                                         |
+| `metrics.image.registry`                      | PostgreSQL Image registry                          | `docker.io`                                               |
+| `metrics.image.repository`                    | PostgreSQL Image name                              | `wrouesnel/postgres_exporter`                             |
+| `metrics.image.tag`                           | PostgreSQL Image tag                               | `{VERSION}`                                               |
+| `metrics.image.pullPolicy`                    | PostgreSQL Image pull policy                       | `IfNotPresent`                                            |
+| `metrics.image.pullSecrets`                   | Specify Image pull secrets                         | `nil` (does not add image pull secrets to deployed pods)  |
+| `extraEnv`                                    | Any extra environment variables you would like to pass on to the pod | `{}`                                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -49,10 +49,12 @@ spec:
       {{- end }}
       {{- if and .Values.persistence.enabled .Values.securityContext.enabled}}
       initContainers:
-      - name: init-chown-data
+      - name: init-chmod-data
         image: {{ template "postgresql.volumePermissions.image" . }}
         imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
         command: ['sh' , '-c' , 'if [ -d /bitnami/postgresql/data ]; then chmod  0700 /bitnami/postgresql/data; fi']
+        securityContext:
+          runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
         volumeMounts:
         - name: data
           mountPath: /bitnami/postgresql

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -51,10 +51,12 @@ spec:
       {{- end }}
       {{- if and .Values.persistence.enabled .Values.securityContext.enabled}}
       initContainers:
-      - name: init-chown-data
+      - name: init-chmod-data
         image: {{ template "postgresql.volumePermissions.image" . }}
         imagePullPolicy: "{{ .Values.volumePermissions.image.pullPolicy }}"
         command: ['sh' , '-c' , 'if [ -d /bitnami/postgresql/data ]; then chmod  0700 /bitnami/postgresql/data; fi']
+        securityContext:
+          runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
         volumeMounts:
         - name: data
           mountPath: /bitnami/postgresql

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -39,6 +39,8 @@ volumePermissions:
     repository: bitnami/minideb
     tag: latest
     pullPolicy: Always
+  securityContext:
+    runAsUser: 0
 
 ## Pod Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -39,6 +39,8 @@ volumePermissions:
     repository: bitnami/minideb
     tag: latest
     pullPolicy: Always
+  securityContext:
+    runAsUser: 0
 
 ## Pod Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This pull request allows specifying the user that will run the init container. It will be executed as user id 0 by default.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
