### PR TITLE
[stable/hlf-ord] Minor fix to remove duplicate ports definition

### DIFF
--- a/stable/hlf-ord/Chart.yaml
+++ b/stable/hlf-ord/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Hyperledger Fabric Orderer chart (these charts are created by AID:Tech and are currently not directly associated with the Hyperledger project)
 name: hlf-ord
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.2.0
 keywords:
   - blockchain

--- a/stable/hlf-ord/templates/deployment.yaml
+++ b/stable/hlf-ord/templates/deployment.yaml
@@ -118,10 +118,6 @@ spec:
             {{- end }}
             - configMapRef:
                 name: {{ include "hlf-ord.fullname" . }}--ord
-          ports:
-            - name: ord-port
-              containerPort: 7050
-              protocol: TCP
           volumeMounts:
             - mountPath: /var/hyperledger
               name: data


### PR DESCRIPTION
#### What this PR does / why we need it:

The current ` deployment.yaml` defines twice the `ports`.

It seems it's not a problem when the chart is installed using helm but when the chart is created using [Pulumi](https://pulumi.io/), the execution fails with this error:

```
Diagnostics:
  pulumi:pulumi:Stack (network-local):
    error: YAMLException: duplicated mapping key at line 155, column -97:
                  ports:
                  ^
    error: an unhandled error occurred: Program exited with non-zero exit code: 1
```

#### Which issue this PR fixes

This PR just remove the duplicated `ports` definition
 
#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
