### PR TITLE
[stable/traefik]: fix proxy protocol when TLS offload is done on ELB (L4)

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.52.7
+version: 1.52.8
 appVersion: 1.7.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -93,6 +93,14 @@ data:
       {{- end }}
       address = ":8880"
       compress = {{ .Values.gzip.enabled }}
+      {{- if .Values.proxyProtocol.enabled }}
+        [entryPoints.httpn.proxyProtocol]
+        {{ template "traefik.trustedips" . }}
+      {{- end }}
+      {{- if .Values.forwardedHeaders.enabled }}
+        [entryPoints.httpn.forwardedHeaders]
+        {{ template "traefik.forwardedHeadersTrustedIPs" . }}
+      {{- end }}
       {{- end }}
       {{- if .Values.dashboard.enabled }}
       [entryPoints.traefik]


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Fix for proxy protocol when TLS offload is done on ELB (L4).
Without this change traefik always responds with 400 status (bad request) if  TLS is terminated on ELB in TCP mode.


#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
