### PR TITLE
Fix cri option typo and document socket path

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.10.0
+version: 1.10.1
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.confd`             | Additional check configurations (static and Autodiscovery) | `nil`             |
 | `datadog.criSocketPath`     | Path to the container runtime socket (if different from Docker) | `nil`        |
 | `datadog.tags`              | Set host tags                      | `nil`                                     |
-| `datadog.useCriSocketPathVolume` | Enable mounting the container runtime socket in Agent containers | `True` |
+| `datadog.useCriSocketVolume` | Enable mounting the container runtime socket in Agent containers | `True` |
 | `datadog.volumes`           | Additional volumes for the daemonset or deployment | `nil`                     |
 | `datadog.volumeMounts`      | Additional volumeMounts for the daemonset or deployment | `nil`                |
 | `datadog.podAnnotationsAsTags` | Kubernetes Annotations to Datadog Tags mapping | `nil`                      |
@@ -207,3 +207,12 @@ podLabelsAsTags:
   app: kube_app
   release: helm_release
 ```
+
+### CRI integration
+
+As of the version 6.6.0, the Datadog Agent supports collecting metrics from any container runtime interface used in your cluster.
+Configure the location path of the socket with `datadog.criSocketPath` and make sure you allow the socket to be mounted into the pod running the agent by setting `datadog.useCriSocketVolume` to `True`.
+Standard paths are:
+- Docker socket: `/var/run/docker.sock`
+- Containerd socket: `/var/run/containerd/containerd.sock`
+- Cri-o socket: `/var/run/crio/crio.sock`


### PR DESCRIPTION
#### What this PR does / why we need it:

The documented option to mount the CRI socket had a typo.
Also adding a note on standard paths as it is usually not transparent, especially when using managed Kubernetes services.

#### Which issue this PR fixes

NONE 

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
