### PR TITLE
[stable/nginx-ingress] Loops through the yaml instead to generate the configMap rather than …

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 0.30.0
+version: 0.30.1
 appVersion: 0.20.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-configmap.yaml
+++ b/stable/nginx-ingress/templates/controller-configmap.yaml
@@ -13,6 +13,6 @@ data:
 {{- if .Values.controller.headers }}
   proxy-set-headers: {{ .Release.Namespace }}/{{ template "nginx-ingress.fullname" . }}-custom-headers
 {{- end }}
-{{- if .Values.controller.config }}
-{{ toYaml .Values.controller.config | indent 2 }}
+{{- range $key, $value := .Values.controller.config }}
+  {{ $key }}: {{ $value | quote }}
 {{- end }}

--- a/stable/nginx-ingress/templates/headers-configmap.yaml
+++ b/stable/nginx-ingress/templates/headers-configmap.yaml
@@ -10,5 +10,7 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-custom-headers
 data:
-{{ toYaml .Values.controller.headers | indent 2 }}
+{{- range $key, $value := .Values.controller.headers }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}

--- a/stable/nginx-ingress/templates/tcp-configmap.yaml
+++ b/stable/nginx-ingress/templates/tcp-configmap.yaml
@@ -10,5 +10,7 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-tcp
 data:
-{{ toYaml .Values.tcp | indent 2 }}
+{{- range $key, $value := .Values.tcp }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}

--- a/stable/nginx-ingress/templates/udp-configmap.yaml
+++ b/stable/nginx-ingress/templates/udp-configmap.yaml
@@ -10,5 +10,7 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.fullname" . }}-udp
 data:
-{{ toYaml .Values.udp | indent 2 }}
+{{- range $key, $value := .Values.udp }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
ConfigMaps only accept key value pairs as strings or null. Objects, integers, booleans etc might be set accidentially in the values.yaml file and not quoted. This will ensure those values are wrapped in quotes and passed to k8s as string values. 

Unquoted values below will be accepted by the helm linter as valid YAML and not picked up by a dry-run of kubectl apply -f <configmap.yaml> --dry-run

E.g. 
```
data:
  test: false
  this: 0.01 
```

The template change in this PR will ensure the values provided will be wrapped in double quotes and accepted by k8s:

```
data:
  test: "false"
  this: "0.01" 
```


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped

@jackzampolin @mgoodness @chancez