### PR TITLE
[sumologic-fluentd]Control stream and time via values

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.9.0
+version: 0.10.0
 appVersion: 2.1.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -91,6 +91,8 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 | `sumologic.auditLogPath` | Define the path to the [Kubernetes Audit Log](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) | `/mnt/log/kube-apiserver-audit.log` |
 | `sumologic.timeKey` | The field name for json formatted sources that should be used as the time. See [time_key](https://docs.fluentd.org/v0.12/articles/formatter_json#time_key-(string,-optional,-defaults-to-%E2%80%9Ctime%E2%80%9D)). | `time`
 | `sumologic.addTimeStamp` | Option to control adding timestamp to logs. | `true`
+| `sumologic.addTime` | Option to control adding time to logs. | `true`
+| `sumologic.addStream` | Option to control adding stream to logs. | `true`
 | `sumologic.containerLogsPath` | Specify the path in_tail should watch for container logs. | `/mnt/log/containers/*.log`
 | `sumologic.proxyUri` | Add the uri of the proxy environment if present. | `Nil`
 | `sumologic.enableStatWatcher` | Option to control the enabling of [stat_watcher](https://docs.fluentd.org/v1.0/articles/in_tail#enable_stat_watcher). | `true`

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -158,6 +158,14 @@ spec:
             - name: ADD_TIMESTAMP
               value: {{ quote .Values.sumologic.addTimeStamp }}
             {{- end }}
+            {{- if quote .Values.sumologic.addTime }}
+            - name: ADD_TIME
+              value: {{ quote .Values.sumologic.addTime }}
+            {{- end }}
+            {{- if quote .Values.sumologic.addStream }}
+            - name: ADD_STREAM
+              value: {{ quote .Values.sumologic.addStream }}
+            {{- end }}
             {{- if quote .Values.sumologic.verifySsl }}
             - name: VERIFY_SSL
               value: {{ quote .Values.sumologic.verifySsl }}

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -135,6 +135,12 @@ sumologic:
   ## Option to control adding timestamp to logs. (Default true)
   addTimeStamp: true
 
+  ## Option to control adding time to logs. (Default true)
+  addTime: true
+
+  ## Option to control adding stream to logs. (Default true)
+  addStream: true
+
   ## Fluentd command line options
   ## ref: http://docs.fluentd.org/v0.12/articles/command-line-option
   fluentdOpt: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds `sumologic.addTime` and `sumologic.addStream` values, to give more control over adding/removing those values from log metadata (PR in docker image repo: https://github.com/SumoLogic/fluentd-kubernetes-sumologic/pull/96 ). 


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@frankreno @darend @flah00 