### PR TITLE
[stable/metrics-server] Typo in README.md

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.0.3
+version: 2.0.4
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -1,4 +1,4 @@
-# metric-server
+# metrics-server
 
 Metrics Server is a cluster-wide aggregator of resource usage data.
 


### PR DESCRIPTION
#### What this PR does / why we need it:
There is a typo which proved to be misleading, when trying to install with `stable/metric-server` as stated in the first headline of the readme, it obviously didn't work as it needs to be `stable/metricS-server`.
It is just a typo.


#### Special notes for your reviewer:
Nothing more than a typo, didn't follow the full testing pipe process obviously.

#### Checklist

