### PR TITLE
[stable/postgresql] Add ability to give postgresql, pg_hba configuration or initdb scripts from parameters.

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 2.5.1
+version: 2.6.0
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -66,6 +66,8 @@ The following tables lists the configurable parameters of the PostgreSQL chart a
 | `postgresqlUsername`                          | PostgreSQL admin user                              | `postgres`                                                |
 | `postgresqlPassword`                          | PostgreSQL admin password                          | _random 10 character alphanumeric string_                 |
 | `postgresqlDatabase`                          | PostgreSQL database                                | `nil`                                                     |
+| `postgresqlConfiguration`                     | Runtime Config Parameters                          | `nil`                                                     |
+| `pgHbaConfiguration`                          | Content of pg\_hba.conf                            | `nil (do not create pg_hba.conf)`                         |
 | `service.type`                                | Kubernetes Service type                            | `ClusterIP`                                               |
 | `service.port`                                | PostgreSQL port                                    | `5432`                                                    |
 | `service.nodePort`                            | Kubernetes Service nodePort                        | `nil`                                                     |
@@ -128,11 +130,13 @@ $ helm install --name my-release -f values.yaml stable/postgresql
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-### postgresql.conf file as configMap
+### postgresql.conf / pg_hba.conf files as configMap
 
-Instead of using specific variables for the PostgreSQL configuration, this helm chart also supports to customize the whole configuration file.
+This helm chart also supports to customize the whole configuration file.
 
 Add your custom file to "files/postgresql.conf" in your working directory. This file will be mounted as configMap to the containers and it will be used for configuring the PostgreSQL server.
+
+Alternatively, you can specify PostgreSQL configuration parameters using the `postgresqlConfiguration` parameter as a dict, using camelCase, e.g. {"sharedBuffers": "500MB"}.
 
 ## Initialize a fresh instance
 

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -68,6 +68,7 @@ The following tables lists the configurable parameters of the PostgreSQL chart a
 | `postgresqlDatabase`                          | PostgreSQL database                                | `nil`                                                     |
 | `postgresqlConfiguration`                     | Runtime Config Parameters                          | `nil`                                                     |
 | `pgHbaConfiguration`                          | Content of pg\_hba.conf                            | `nil (do not create pg_hba.conf)`                         |
+| `initdbScripts`                               | List of initdb scripts                             | `nil`                                                     |
 | `service.type`                                | Kubernetes Service type                            | `ClusterIP`                                               |
 | `service.port`                                | PostgreSQL port                                    | `5432`                                                    |
 | `service.nodePort`                            | Kubernetes Service nodePort                        | `nil`                                                     |
@@ -141,6 +142,8 @@ Alternatively, you can specify PostgreSQL configuration parameters using the `po
 ## Initialize a fresh instance
 
 The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+
+Alternatively, you can specify custom scripts using the `initdbScripts` parameter as dict.
 
 The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
 

--- a/stable/postgresql/templates/configmap.yaml
+++ b/stable/postgresql/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{ if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") }}
+{{ if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,8 +11,16 @@ metadata:
 data:
 {{- if (.Files.Glob "files/postgresql.conf") }}
 {{ (.Files.Glob "files/postgresql.conf").AsConfig | indent 2 }}
+{{- else if .Values.postgresqlConfiguration }}
+  postgresql.conf: |
+{{- range $key, $value := default dict .Values.postgresqlConfiguration }}
+    {{ $key | snakecase }}={{ $value }}
+{{- end }}
 {{- end }}
 {{- if (.Files.Glob "files/pg_hba.conf") }}
 {{ (.Files.Glob "files/pg_hba.conf").AsConfig | indent 2 }}
+{{- else if .Values.pgHbaConfiguration }}
+  pg_hba.conf: |
+{{ .Values.pgHbaConfiguration | indent 4 }}
 {{- end }}
 {{ end }}

--- a/stable/postgresql/templates/initialization-configmap.yaml
+++ b/stable/postgresql/templates/initialization-configmap.yaml
@@ -9,3 +9,6 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 data:
 {{ (.Files.Glob "files/docker-entrypoint-initdb.d/*").AsConfig | indent 2 }}
+{{- with .Values.initdbScripts }}
+{{ toYaml . | indent 2 }}
+{{- end }}

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -132,18 +132,18 @@ spec:
         - name: data
           mountPath: /bitnami/postgresql
         {{ end }}
-        {{ if  (.Files.Glob "files/postgresql.conf") }}
+        {{ if or (.Files.Glob "files/postgresql.conf") .Values.postgresqlConfiguration }}
         - name: postgresql-config
           mountPath: /opt/bitnami/postgresql/conf/postgresql.conf
           subPath: postgresql.conf
         {{ end }}
-        {{ if (.Files.Glob "files/pg_hba.conf") }}
+        {{ if or (.Files.Glob "files/pg_hba.conf") .Values.pgHbaConfiguration }}
         - name: postgresql-config
           mountPath: /opt/bitnami/postgresql/conf/pg_hba.conf
           subPath: pg_hba.conf
         {{ end }}
       volumes:
-      {{ if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") }}
+      {{ if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration }}
       - name: postgresql-config
         configMap:
           name: {{ template "postgresql.fullname" . }}-configuration

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -140,18 +140,18 @@ spec:
         - name: data
           mountPath: /bitnami/postgresql
         {{ end }}
-        {{ if  (.Files.Glob "files/postgresql.conf") }}
+        {{ if or (.Files.Glob "files/postgresql.conf") .Values.postgresqlConfiguration }}
         - name: postgresql-config
           mountPath: /opt/bitnami/postgresql/conf/postgresql.conf
           subPath: postgresql.conf
         {{ end }}
-        {{ if (.Files.Glob "files/pg_hba.conf") }}
+        {{ if or (.Files.Glob "files/pg_hba.conf") .Values.pgHbaConfiguration }}
         - name: postgresql-config
           mountPath: /opt/bitnami/postgresql/conf/pg_hba.conf
           subPath: pg_hba.conf
         {{ end }}
       volumes:
-      {{ if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") }}
+      {{ if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration }}
       - name: postgresql-config
         configMap:
           name: {{ template "postgresql.fullname" . }}-configuration

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -87,6 +87,15 @@ postgresqlUsername: postgres
 #   host all all localhost trust
 #   host mydatabase mysuser 192.168.0.0/24 md5
 
+## initdb scripts
+## Specify dictionnary of scripts to be run at first boot
+## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
+##
+# initdbScripts:
+#   my_init_script.sh:|
+#      #!/bin/sh
+#      echo "Do something."
+
 ## PostgreSQL service configuration
 service:
   ## PosgresSQL service type

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -70,6 +70,23 @@ postgresqlUsername: postgres
 ##
 # postgresqlDatabase:
 
+## PostgreSQL configuration
+## Specify runtime configuration parameters as a dict, using camelCase, e.g.
+## {"sharedBuffers": "500MB"}
+## Alternatively, you can put your postgresql.conf under the files/ directory
+## ref: https://www.postgresql.org/docs/current/static/runtime-config.html
+##
+# postgresqlConfiguration:
+
+## PostgreSQL client authentication configuration
+## Specify content for pg_hba.conf
+## Default: do not create pg_hba.conf
+## Alternatively, you can put your pg_hba.conf under the files/ directory
+# pgHbaConfiguration: |-
+#   local all all trust
+#   host all all localhost trust
+#   host mydatabase mysuser 192.168.0.0/24 md5
+
 ## PostgreSQL service configuration
 service:
   ## PosgresSQL service type

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -70,6 +70,23 @@ postgresqlUsername: postgres
 ##
 # postgresqlDatabase:
 
+## PostgreSQL configuration
+## Specify runtime configuration parameters as a dict, using camelCase, e.g.
+## {"sharedBuffers": "500MB"}
+## Alternatively, you can put your postgresql.conf under the files/ directory
+## ref: https://www.postgresql.org/docs/current/static/runtime-config.html
+##
+# postgresqlConfiguration:
+
+## PostgreSQL client authentication configuration
+## Specify content for pg_hba.conf
+## Default: do not create pg_hba.conf
+## Alternatively, you can put your pg_hba.conf under the files/ directory
+# pgHbaConfiguration: |-
+#   local all all trust
+#   host all all localhost trust
+#   host mydatabase mysuser 192.168.0.0/24 md5
+
 ## Optional duration in seconds the pod needs to terminate gracefully.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
 ##

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -87,6 +87,15 @@ postgresqlUsername: postgres
 #   host all all localhost trust
 #   host mydatabase mysuser 192.168.0.0/24 md5
 
+## initdb scripts
+## Specify dictionnary of scripts to be run at first boot
+## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
+##
+# initdbScripts:
+#   my_init_script.sh:|
+#      #!/bin/sh
+#      echo "Do something."
+
 ## Optional duration in seconds the pod needs to terminate gracefully.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Current file approach is limited:

- No possible inheritance
- Not usable as subchart

this allows to also use the old parameter from the "deployment-based postgres chart" that got removed.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
