### PR TITLE
[stable/kibana] Add PVC support and security context for Kibana

### DIFF
--- a/stable/kibana/Chart.yaml
+++ b/stable/kibana/Chart.yaml
@@ -1,5 +1,5 @@
 name: kibana
-version: 0.17.1
+version: 0.18.0
 appVersion: 6.4.3
 description: Kibana is an open source data visualization plugin for Elasticsearch
 icon: https://raw.githubusercontent.com/elastic/kibana/master/src/ui/public/icons/kibana-color.svg

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -22,6 +22,8 @@ $ helm install stable/kibana --name my-release
 
 The command deploys kibana on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
+NOTE : We notice that lower resource constraints given to the chart + plugins are likely not going to work well.
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `my-release` deployment:

--- a/stable/kibana/README.md
+++ b/stable/kibana/README.md
@@ -80,6 +80,16 @@ The following table lists the configurable parameters of the kibana chart and th
 | `plugins.enabled`                             | Enable installation of plugins.            | `false`                                |
 | `plugins.reset`                               | Optional : Remove all installed plugins before installing all new ones | `false`                                   |
 | `plugins.values`                              | List of plugins to install. Format <pluginName,version,URL> with URLs pointing to zip files of Kibana plugins to install                                 | None:                                   |
+| `persistentVolumeClaim.enabled`               | Enable PVC for plugins                     | `false`                                 |
+| `persistentVolumeClaim.existingClaim`         | Use your own PVC for plugins               | `false`                                 |
+| `persistentVolumeClaim.annotations`           | Add your annotations for the PVC           | `{}`                                    |
+| `persistentVolumeClaim.accessModes`           | Acces mode to the PVC                      | `ReadWriteOnce`                         |
+| `persistentVolumeClaim.size`                  | Size of the PVC                            | `5Gi`                                   |
+| `persistentVolumeClaim.storageClass`          | Storage class of the PVC                   | None:                                   |
+| `securityContext.enabled`                     | Enable security context (should be true for PVC)                    | `false`                                  |
+| `securityContext.allowPrivilegeEscalation`    | Allow privilege escalation                 | `false`                                 |
+| `securityContext.runAsUser`                   | User id to run in pods                     | `1000`                                  |
+| `securityContext.fsGroup`                     | fsGroup id to run in pods                  | `2000`                                  |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/kibana/ci/plugin-install.yaml
+++ b/stable/kibana/ci/plugin-install.yaml
@@ -5,5 +5,5 @@ plugins:
   reset: false
   # Use <plugin_name,version,url> to add/upgrade plugin
   values:
-    - logtrail,0.1.30,https://github.com/sivasamyk/logtrail/releases/download/v0.1.30/logtrail-6.4.2-0.1.30.zip
+    - logtrail,0.1.30,https://github.com/sivasamyk/logtrail/releases/download/v0.1.30/logtrail-6.4.3-0.1.30.zip
     # - other_plugin

--- a/stable/kibana/ci/pvc.yaml
+++ b/stable/kibana/ci/pvc.yaml
@@ -1,0 +1,11 @@
+---
+persistentVolumeClaim:
+  # set to true to use pvc
+  enabled: true
+  # set to true to use you own pvc
+  existingClaim: false
+  annotations: {}
+
+  accessModes:
+    - ReadWriteOnce
+  size: "5Gi"

--- a/stable/kibana/ci/security-context.yaml
+++ b/stable/kibana/ci/security-context.yaml
@@ -1,0 +1,6 @@
+---
+securityContext:
+  enabled: true
+  allowPrivilegeEscalation: false
+  runAsUser: 1000
+  fsGroup: 2000

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -68,6 +68,7 @@ spec:
           - "-c"
           - |
             set -e
+            rm -rf plugins/lost+found
             plugins=(
             {{- range .Values.plugins.values }}
             {{ . }}
@@ -112,6 +113,10 @@ spec:
         - name: {{ template "kibana.name" $ }}
           mountPath: "/usr/share/kibana/config/{{ $configFile }}"
           subPath: {{ $configFile }}
+        {{- end }}
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
         {{- end }}
 {{- end }}
 {{- end }}
@@ -181,13 +186,23 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       volumes:
         - name: {{ template "kibana.name" . }}
           configMap:
             name: {{ template "kibana.fullname" . }}
 {{- if .Values.plugins.enabled}}
         - name: plugins
+          {{- if .Values.persistentVolumeClaim.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ template "kibana.fullname" . }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
 {{- end }}
 {{- if .Values.dashboardImport.dashboards }}
         - name: {{ template "kibana.fullname" . }}-dashboards

--- a/stable/kibana/templates/deployment.yaml
+++ b/stable/kibana/templates/deployment.yaml
@@ -114,10 +114,10 @@ spec:
           mountPath: "/usr/share/kibana/config/{{ $configFile }}"
           subPath: {{ $configFile }}
         {{- end }}
-        {{- if .Values.securityContext.enabled }}
+{{- if .Values.securityContext.enabled }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-        {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
       containers:
@@ -186,11 +186,11 @@ spec:
     {{- end }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
-      {{- if .Values.securityContext.enabled }}
+{{- if .Values.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
+{{- end }}
       volumes:
         - name: {{ template "kibana.name" . }}
           configMap:

--- a/stable/kibana/templates/volume-claim.yaml
+++ b/stable/kibana/templates/volume-claim.yaml
@@ -3,10 +3,10 @@
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
 metadata:
-  {{- if .Values.persistentVolumeClaim.annotations }}
+{{- if .Values.persistentVolumeClaim.annotations }}
   annotations:
 {{ toYaml .Values.persistentVolumeClaim.annotations | indent 4 }}
-  {{- end }}
+{{- end }}
   labels:
     app: {{ template "kibana.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/kibana/templates/volume-claim.yaml
+++ b/stable/kibana/templates/volume-claim.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.plugins.enabled .Values.persistentVolumeClaim.enabled -}}
+{{- if not .Values.persistentVolumeClaim.existingClaim -}}
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  {{- if .Values.persistentVolumeClaim.annotations }}
+  annotations:
+{{ toYaml .Values.persistentVolumeClaim.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    app: {{ template "kibana.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.persistentVolumeClaim.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kibana.fullname" . }}
+spec:
+  accessModes:
+{{ toYaml .Values.persistentVolumeClaim.accessModes | indent 4 }}
+{{- if .Values.persistentVolumeClaim.storageClass }}
+{{- if (eq "-" .Values.persistentVolumeClaim.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistentVolumeClaim.storageClass }}"
+{{- end }}
+{{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.persistentVolumeClaim.size }}"
+{{- end -}}
+{{- end -}}

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -138,6 +138,7 @@ dashboardImport:
     # k8s: https://raw.githubusercontent.com/monotek/kibana-dashboards/master/k8s-fluentd-elasticsearch.json
 
 # List of plugins to install using initContainer
+# NOTE : We notice that lower resource constraints given to the chart + plugins are likely not going to work well.
 plugins:
   # set to true to enable plugins installation
   enabled: false

--- a/stable/kibana/values.yaml
+++ b/stable/kibana/values.yaml
@@ -148,3 +148,28 @@ plugins:
     # - elastalert-kibana-plugin,1.0.1,https://github.com/bitsensor/elastalert-kibana-plugin/releases/download/1.0.1/elastalert-kibana-plugin-1.0.1-6.4.2.zip
     # - logtrail,0.1.30,https://github.com/sivasamyk/logtrail/releases/download/v0.1.30/logtrail-6.4.2-0.1.30.zip
     # - other_plugin
+
+persistentVolumeClaim:
+  # set to true to use pvc
+  enabled: false
+  # set to true to use you own pvc
+  existingClaim: false
+  annotations: {}
+
+  accessModes:
+    - ReadWriteOnce
+  size: "5Gi"
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
+# default security context
+securityContext:
+  enabled: false
+  allowPrivilegeEscalation: false
+  runAsUser: 1000
+  fsGroup: 2000


### PR DESCRIPTION
What this PR does / why we need it:
Add PVC support for Kibana plugins to persist plugins and avoid plugins installation at startup.
Add security context for PVC.

Special notes for your reviewer:
Tested in Kibana 6.4.2 with elastalert plugin. 3 cases tested : 
- without plugins
- with plugins without PVC
- with plugins and PVC and security context to true with default values
I did not test with custom PVC.

Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

  [x] DCO signed
  [x] Chart Version bumped
  [x] Variables are documented in the README.md