### PR TITLE
[coredns] deployment selector must match labels

### DIFF
--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- if .Values.isClusterService }}
         k8s-app: {{ .Chart.Name | quote }}
         {{- end }}
-        app: {{ template "coredns.fullname" . }}
+        app: {{ template "coredns.name" . }}
         release: {{ .Release.Name | quote }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
Otherwise the deployment would fail with the following error : 
```
helm install --name coredns --namespace=kube-system stable/coredns --set rbac.create=True
Error: release coredns failed: Deployment.apps "coredns-coredns" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"coredns-coredns", "k8s-app":"coredns", "release":"coredns"}: `s
elector` does not match template `labels`
```