### PR TITLE
[dns-autoscaler] new chart, autoscaling of the kubernetes dns components

### DIFF
--- a/incubator/dns-autoscaler/.helmignore
+++ b/incubator/dns-autoscaler/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+OWNERS

--- a/incubator/dns-autoscaler/Chart.yaml
+++ b/incubator/dns-autoscaler/Chart.yaml
@@ -1,0 +1,15 @@
+name: dns-autoscaler
+version: 0.0.1
+appVersion: 0.0.1
+description: Scales the number of DNS replicas according to the number of schedulable nodes and cores of the cluster.
+keywords:
+- autoscaler
+- dns
+- kubedns
+- coredns
+home: https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/
+sources:
+- https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
+maintainers:
+- name: Smana
+  email: smainklh@gmail.com

--- a/incubator/dns-autoscaler/OWNERS
+++ b/incubator/dns-autoscaler/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- smana
+reviewers:
+- smana

--- a/incubator/dns-autoscaler/OWNERS
+++ b/incubator/dns-autoscaler/OWNERS
@@ -1,4 +1,6 @@
 approvers:
 - smana
+- seanknox
 reviewers:
 - smana
+- seanknox

--- a/incubator/dns-autoscaler/README.md
+++ b/incubator/dns-autoscaler/README.md
@@ -1,0 +1,62 @@
+# DNS autoscaler
+
+## Introduction
+
+The DNS autoscaler watches over the number of schedulable nodes and cores of the cluster and resizes the number of replicas for the required resource.
+
+
+## Prerequisites
+
+### Getting the name of the target to be scaled
+
+In Kubernetes versions earlier than 1.12, the DNS Deployment was called “kube-dns”.
+
+```shell
+$ kubectl get deployment --namespace=kube-system
+NAME                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+coredns-coredns      2         2         2            2           3h
+...
+```
+
+## Configuration
+
+
+| Parameter                   | Description                                 | Default                                            |
+| --------------------------- | ------------------------------------------- | -------------------------------------------------- |
+| `config.scaleTarget`        | Name of the deployment to be scaled         | `coredns-coredns`                                  |
+| `config.min`                | Minimum number of replicas                  | `1`                                                |
+| `config.nodesPerReplica`    | Number of nodes per replica                 | `16`                                               |
+| `config.coresPerReplica`    | Nuber of cpu cores per replica              | `256`                                              |
+| `image.pullPolicy`          | Container pull policy                       | `IfNotPresent`                                     |
+| `image.repository`          | Container image to use                      | `k8s.gcr.io/cluster-proportional-autoscaler-amd64` |
+| `image.tag`                 | Container image tag to deploy               | `1.1.1`                                            |
+| `replicaCount`              | k8s replicas                                | `1`                                                |
+| `resources.limits.cpu`      | Container maximum CPU                       | `80m`                                              |
+| `resources.limits.memory`   | Container maximum memory                    | `64Mi`                                             |
+| `resources.requests.cpu`    | Container requested CPU                     | `40m`                                              |
+| `resources.requests.memory` | Container requested memory                  | `32Mi`                                             |
+| `serviceAccount.create`     | If true, create the service account         | `false`                                            |
+| `serviceAccount.name`       | Name of the serviceAccount to create or use | `{{ dnsAutoscaler.fullname }}`                     |
+| `nodeSelector`              | Map of node labels for pod assignment       | `{}`                                               |
+| `tolerations`               | List of node taints to tolerate             | `[]`                                               |
+| `affinity`                  | Map of node/pod affinities                  | `{}`                                               |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to
+`helm install`.
+
+## Installation
+
+```shell
+helm install --name my-dns-autoscaler -f custom.yaml incubator/dns-autoscaler
+```
+
+## Uninstall
+
+```shell
+helm delete my-dns-autoscaler
+```
+
+To delete the deployment and its history:
+```shell
+helm delete --purge my-dns-autoscaler
+```

--- a/incubator/dns-autoscaler/templates/_helpers.tpl
+++ b/incubator/dns-autoscaler/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dnsAutoscaler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "dnsAutoscaler.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/dns-autoscaler/templates/configmap.yaml
+++ b/incubator/dns-autoscaler/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dnsAutoscaler.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "dnsAutoscaler.name" . }}
+data:
+  linear: '{"coresPerReplica": {{ .Values.config.coresPerReplica }},"min": {{ .Values.config.min }},"nodesPerReplica": {{ .Values.config.nodesPerReplica }} }'

--- a/incubator/dns-autoscaler/templates/deployment.yaml
+++ b/incubator/dns-autoscaler/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-autoscaler
+  namespace: kube-system
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "dnsAutoscaler.name" . }}
+spec:
+  selector:
+    matchLabels:
+        app: {{ template "dnsAutoscaler.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "dnsAutoscaler.name" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      {{- if or .Values.rbac.create .Values.rbac.serviceAccountName }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "dnsAutoscaler.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      {{- end }}
+      containers:
+      - name: autoscaler
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        command:
+          - /cluster-proportional-autoscaler
+          - --configmap={{ template "dnsAutoscaler.fullname" . }}
+          - --target=deployment/{{ .Values.config.scaleTarget }}
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":1}}
+          - --namespace=kube-system
+          - --logtostderr=true
+          - --v=2

--- a/incubator/dns-autoscaler/templates/rbac.yaml
+++ b/incubator/dns-autoscaler/templates/rbac.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.rbac.create }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "dnsAutoscaler.name" . }}
+  name: {{ template "dnsAutoscaler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:{{ template "dnsAutoscaler.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "dnsAutoscaler.name" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "dnsAutoscaler.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "dnsAutoscaler.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dnsAutoscaler.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: system:{{ template "dnsAutoscaler.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/incubator/dns-autoscaler/values.yaml
+++ b/incubator/dns-autoscaler/values.yaml
@@ -1,0 +1,56 @@
+# Default values for dns-autoscaler.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+  tag: "1.1.1"
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: "40m"
+    memory: "32Mi"
+  limits:
+    cpu: "80m"
+    memory: "64Mi"
+
+rbac:
+  # If true, create & use RBAC resources
+  create: false
+  # Ignored if rbac.create is true
+  serviceAccountName: default
+
+config:
+  scaleTarget: "coredns-coredns"
+  min: 1
+  nodesPerReplica: 16
+  coresPerReplica: 256 
+
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+# for example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+# for example:
+#   tolerations:
+#   - key: foo.bar.com/role
+#     operator: Equal
+#     value: master
+#     effect: NoSchedule
+tolerations: []

--- a/incubator/dns-autoscaler/values.yaml
+++ b/incubator/dns-autoscaler/values.yaml
@@ -27,7 +27,7 @@ config:
   scaleTarget: "coredns-coredns"
   min: 1
   nodesPerReplica: 16
-  coresPerReplica: 256 
+  coresPerReplica: 256
 
 # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
 # for example:


### PR DESCRIPTION
#### What this PR does / why we need it:

Autoscaling for `coredns` or `kube-dns`.
sources:
https://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/#tuning-autoscaling-parameters
https://github.com/kubernetes-incubator/cluster-proportional-autoscaler

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md