### PR TITLE
Fix broken ingress template for redmine chart

### DIFF
--- a/stable/redmine/Chart.yaml
+++ b/stable/redmine/Chart.yaml
@@ -1,5 +1,5 @@
 name: redmine
-version: 6.0.1
+version: 6.0.2
 appVersion: 3.4.6
 description: A flexible project management web application.
 keywords:

--- a/stable/redmine/templates/NOTES.txt
+++ b/stable/redmine/templates/NOTES.txt
@@ -17,7 +17,9 @@
 
 {{- else if .Values.ingress.enabled }}
 
-  echo "Redmine URL: http://{{ .Values.ingress.hostname }}/"
+  {{- range .Values.ingress.hosts }}
+    echo "Redmine URL: http://{{ .name }}/"
+  {{- end }}
 
 {{- else if contains "ClusterIP" .Values.serviceType }}
 

--- a/stable/redmine/templates/ingress.yaml
+++ b/stable/redmine/templates/ingress.yaml
@@ -27,10 +27,9 @@ spec:
           servicePort: 80
 {{- if .tls }}
   tls:
-  - hosts:
-    - {{ .name }}
-      secretName: {{ .tlsSecret }}
-{{ toYaml .Values.ingress.tls | indent 4 }}
+    - secretName: {{ .tlsSecret }}
+      hosts:
+        - {{ .name }}
 {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
Fix broken template when `tls: true` is set. This is the error you currently get:

`Error: render error in "redmine/templates/ingress.yaml": template: redmine/templates/ingress.yaml:33:17: executing "redmine/templates/ingress.yaml" at <.Values.ingress.tls>: can't evaluate field ingress in type interface {}`

Also NOTES.txt was not printing the URL, it was making reference to an older variable.

