### PR TITLE
[stable/lamp] Update phpmyadmin/phpmyadmin command

### DIFF
--- a/stable/lamp/Chart.yaml
+++ b/stable/lamp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Modular and transparent LAMP stack chart supporting PHP-FPM, Release Cloning, LoadBalancer, Ingress, SSL and lots more!
 name: lamp
-version: 0.1.5
+version: 0.1.6
 appVersion: 5.7
 home: https://github.com/lead4good/helm-lamp-stack
 maintainers:

--- a/stable/lamp/templates/deployment.yaml
+++ b/stable/lamp/templates/deployment.yaml
@@ -673,7 +673,7 @@ spec:
       {{ if .Values.phpmyadmin.enabled }}
       - image: phpmyadmin/phpmyadmin
         name: phpmyadmin
-        command: [sh, -c, sed -i 's/listen\ 80/listen 8080/g' /etc/nginx.conf && /run.sh phpmyadmin]
+        command: [sh, -c, sed -i 's/listen\ 80/listen 8080/g' /etc/nginx.conf && /run.sh supervisord -n]
         env:
         - name: PMA_HOST
           value: 127.0.0.1


### PR DESCRIPTION
#### What this PR does / why we need it:
When `phpmyadmin.enabled: true`, the current phpmyadmin/phpmyadmin:4.8.3 container fails to start with the following error:
```
run.sh: exec: line 20: phpmyadmin: not found
```
In phpmyadmin/phpmyadmin:4.8.2, the ENTRYPOINT script (/run.sh) was updated such that it expects arguments "supervisord -n" instead of "phpmyadmin": 

https://github.com/phpmyadmin/docker/commit/98aa7b80c8a60d5ef4a81b167a49db36778240e3

This PR updates the chart to be compatible with phpmyadmin/phpmyadmin >= 4.8.2
#### Special notes for your reviewer:
It might be desirable if this chart were updated such that the phpmyadmin/phpmyadmin image tag could be specified, or allow the use use of nazarpc/phpmyadmin instead.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ X] Chart Version bumped