### PR TITLE
[stable/nats] Improve Prometheus Metrics

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,5 +1,5 @@
 name: nats
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.3.0
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,5 +1,5 @@
 name: nats
-version: 1.2.1
+version: 1.3.0
 appVersion: 1.3.0
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -45,87 +45,88 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the NATS chart and their default values.
 
-| Parameter                            | Description                                                                                  | Default                           |
-|--------------------------------------|----------------------------------------------------------------------------------------------|-----------------------------------|
-| `global.imageRegistry`               | Global Docker image registry                                                                 | `nil`                             |
-| `image.registry`                     | NATS image registry                                                                          | `docker.io`                       |
-| `image.repository`                   | NATS Image name                                                                              | `bitnami/nats`                    |
-| `image.tag`                          | NATS Image tag                                                                               | `{VERSION}`                       |
-| `image.pullPolicy`                   | Image pull policy                                                                            | `Always`                          |
-| `image.pullSecrets`                  | Specify image pull secrets                                                                   | `nil`                             |
-| `auth.enabled`                       | Switch to enable/disable client authentication                                               | `true`                            |
-| `auth.user`                          | Client authentication user                                                                   | `nats_cluster`                    |
-| `auth.password`                      | Client authentication password                                                               | `random alhpanumeric string (10)` |
-| `auth.token`                         | Client authentication token                                                                  | `nil`                             |
-| `clusterAuth.enabled`                | Switch to enable/disable cluster authentication                                              | `true`                            |
-| `clusterAuth.user`                   | Cluster authentication user                                                                  | `nats_cluster`                    |
-| `clusterAuth.password`               | Cluster authentication password                                                              | `random alhpanumeric string (10)` |
-| `clusterAuth.token`                  | Cluster authentication token                                                                 | `nil`                             |
-| `debug.enabled`                      | Switch to enable/disable debug on logging                                                    | `false`                           |
-| `debug.trace`                        | Switch to enable/disable trace debug level on logging                                        | `false`                           |
-| `debug.logtime`                      | Switch to enable/disable logtime on logging                                                  | `false`                           |
-| `maxConnections`                     | Max. number of client connections                                                            | `nil`                             |
-| `maxControlLine`                     | Max. protocol control line                                                                   | `nil`                             |
-| `maxPayload`                         | Max. payload                                                                                 | `nil`                             |
-| `writeDeadline`                      | Duration the server can block on a socket write to a client                                  | `nil`                             |
-| `replicaCount`                       | Number of NATS nodes                                                                         | `1`                               |
-| `securityContext.enabled`            | Enable security context                                                                      | `true`                            |
-| `securityContext.fsGroup`            | Group ID for the container                                                                   | `1001`                            |
-| `securityContext.runAsUser`          | User ID for the container                                                                    | `1001`                            |
-| `statefulset.updateStrategy`         | Statefulsets Update strategy                                                                | `OnDelete`                        |
-| `rollingUpdatePartition`             | Partition for Rolling Update strategy                                                        | `nil`                             |
-| `podLabels`                          | Additional labels to be added to pods                                                        | {}                                |
-| `podAnnotations`                     | Annotations to be added to pods                                                              | {}                                |
-| `nodeSelector`                       | Node labels for pod assignment                                                               | `nil`                             |
-| `schedulerName`                      | Name of an alternate                                                                         | `nil`                             |
-| `antiAffinity`                       | Anti-affinity for pod assignment                                                             | `soft`                            |
-| `tolerations`                        | Toleration labels for pod assignment                                                         | `nil`                             |
-| `resources`                          | CPU/Memory resource requests/limits                                                          | {}                                |
-| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                     | `30`                              |
-| `livenessProbe.periodSeconds`        | How often to perform the probe                                                               | `10`                              |
-| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                     | `5`                               |
-| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                               |
-| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                               |
-| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                    | `5`                               |
-| `readinessProbe.periodSeconds`       | How often to perform the probe                                                               | `10`                              |
-| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | `5`                               |
-| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                               |
-| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                               |
-| `clientService.type`                 | Kubernetes Service type (NATS client)                                                        | `ClusterIP`                       |
-| `clientService.port`                 | NATS client port                                                                             | `4222`                            |
-| `clientService.nodePort`             | Port to bind to for NodePort service type (NATS client)                                      | `nil`                             |
-| `clientService.annotations`          | Annotations for NATS client service                                                          | {}                                |
-| `clientService.loadBalancerIP`       | loadBalancerIP if NATS client service type is `LoadBalancer`                                 | `nil`                             |
-| `clusterService.type`                | Kubernetes Service type (NATS cluster)                                                       | `ClusterIP`                       |
-| `clusterService.port`                | NATS cluster port                                                                            | `6222`                            |
-| `clusterService.nodePort`            | Port to bind to for NodePort service type (NATS cluster)                                     | `nil`                             |
-| `clusterService.annotations`         | Annotations for NATS cluster service                                                         | {}                                |
-| `clusterService.loadBalancerIP`      | loadBalancerIP if NATS cluster service type is `LoadBalancer`                                | `nil`                             |
-| `monitoringService.type`             | Kubernetes Service type (NATS monitoring)                                                    | `ClusterIP`                       |
-| `monitoringService.port`             | NATS monitoring port                                                                         | `8222`                            |
-| `monitoringService.nodePort`         | Port to bind to for NodePort service type (NATS monitoring)                                  | `nil`                             |
-| `monitoringService.annotations`      | Annotations for NATS monitoring service                                                      | {}                                |
-| `monitoringService.loadBalancerIP`   | loadBalancerIP if NATS monitoring service type is `LoadBalancer`                             | `nil`                             |
-| `ingress.enabled`                    | Enable ingress controller resource                                                           | `false`                           |
-| `ingress.hosts[0].name`              | Hostname for NATS monitoring                                                                 | `nats.local`                      |
-| `ingress.hosts[0].path`              | Path within the url structure                                                                | `/`                               |
-| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                               | `false`                           |
-| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                    | `nats.local-tls-secret`           |
-| `ingress.hosts[0].annotations`       | Annotations for this host's ingress record                                                   | `[]`                              |
-| `ingress.secrets[0].name`            | TLS Secret Name                                                                              | `nil`                             |
-| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                                       | `nil`                             |
-| `ingress.secrets[0].key`             | TLS Secret Key                                                                               | `nil`                             |
-| `networkPolicy.enabled`              | Enable NetworkPolicy                                                                         | `false`                           |
-| `networkPolicy.allowExternal`        | Allow external connections                                                                   | `true`                            |
-| `sidecars`                           | Attach additional containers to the pod.                                                     | `nil`                             |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | MongoDB exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | MongoDB exporter image name                                                                                      | `appcelerator/prometheus-nats-exporter`                           |
-| `metrics.image.tag`                        | MongoDB exporter image tag                                                                                       | `0.17.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `nil`                                                |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | {}                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | Memory: `256Mi`, CPU: `100m`                         |
+| Parameter                            | Description                                                                                  | Default                                                       |
+| ------------------------------------ | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `global.imageRegistry`               | Global Docker image registry                                                                 | `nil`                                                         |
+| `image.registry`                     | NATS image registry                                                                          | `docker.io`                                                   |
+| `image.repository`                   | NATS Image name                                                                              | `bitnami/nats`                                                |
+| `image.tag`                          | NATS Image tag                                                                               | `{VERSION}`                                                   |
+| `image.pullPolicy`                   | Image pull policy                                                                            | `Always`                                                      |
+| `image.pullSecrets`                  | Specify image pull secrets                                                                   | `nil`                                                         |
+| `auth.enabled`                       | Switch to enable/disable client authentication                                               | `true`                                                        |
+| `auth.user`                          | Client authentication user                                                                   | `nats_cluster`                                                |
+| `auth.password`                      | Client authentication password                                                               | `random alhpanumeric string (10)`                             |
+| `auth.token`                         | Client authentication token                                                                  | `nil`                                                         |
+| `clusterAuth.enabled`                | Switch to enable/disable cluster authentication                                              | `true`                                                        |
+| `clusterAuth.user`                   | Cluster authentication user                                                                  | `nats_cluster`                                                |
+| `clusterAuth.password`               | Cluster authentication password                                                              | `random alhpanumeric string (10)`                             |
+| `clusterAuth.token`                  | Cluster authentication token                                                                 | `nil`                                                         |
+| `debug.enabled`                      | Switch to enable/disable debug on logging                                                    | `false`                                                       |
+| `debug.trace`                        | Switch to enable/disable trace debug level on logging                                        | `false`                                                       |
+| `debug.logtime`                      | Switch to enable/disable logtime on logging                                                  | `false`                                                       |
+| `maxConnections`                     | Max. number of client connections                                                            | `nil`                                                         |
+| `maxControlLine`                     | Max. protocol control line                                                                   | `nil`                                                         |
+| `maxPayload`                         | Max. payload                                                                                 | `nil`                                                         |
+| `writeDeadline`                      | Duration the server can block on a socket write to a client                                  | `nil`                                                         |
+| `replicaCount`                       | Number of NATS nodes                                                                         | `1`                                                           |
+| `securityContext.enabled`            | Enable security context                                                                      | `true`                                                        |
+| `securityContext.fsGroup`            | Group ID for the container                                                                   | `1001`                                                        |
+| `securityContext.runAsUser`          | User ID for the container                                                                    | `1001`                                                        |
+| `statefulset.updateStrategy`         | Statefulsets Update strategy                                                                 | `OnDelete`                                                    |
+| `rollingUpdatePartition`             | Partition for Rolling Update strategy                                                        | `nil`                                                         |
+| `podLabels`                          | Additional labels to be added to pods                                                        | {}                                                            |
+| `podAnnotations`                     | Annotations to be added to pods                                                              | {}                                                            |
+| `nodeSelector`                       | Node labels for pod assignment                                                               | `nil`                                                         |
+| `schedulerName`                      | Name of an alternate                                                                         | `nil`                                                         |
+| `antiAffinity`                       | Anti-affinity for pod assignment                                                             | `soft`                                                        |
+| `tolerations`                        | Toleration labels for pod assignment                                                         | `nil`                                                         |
+| `resources`                          | CPU/Memory resource requests/limits                                                          | {}                                                            |
+| `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                     | `30`                                                          |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                                                               | `10`                                                          |
+| `livenessProbe.timeoutSeconds`       | When the probe times out                                                                     | `5`                                                           |
+| `livenessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                                           |
+| `livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                                           |
+| `readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                    | `5`                                                           |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                                                               | `10`                                                          |
+| `readinessProbe.timeoutSeconds`      | When the probe times out                                                                     | `5`                                                           |
+| `readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                                           |
+| `readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                                           |
+| `clientService.type`                 | Kubernetes Service type (NATS client)                                                        | `ClusterIP`                                                   |
+| `clientService.port`                 | NATS client port                                                                             | `4222`                                                        |
+| `clientService.nodePort`             | Port to bind to for NodePort service type (NATS client)                                      | `nil`                                                         |
+| `clientService.annotations`          | Annotations for NATS client service                                                          | {}                                                            |
+| `clientService.loadBalancerIP`       | loadBalancerIP if NATS client service type is `LoadBalancer`                                 | `nil`                                                         |
+| `clusterService.type`                | Kubernetes Service type (NATS cluster)                                                       | `ClusterIP`                                                   |
+| `clusterService.port`                | NATS cluster port                                                                            | `6222`                                                        |
+| `clusterService.nodePort`            | Port to bind to for NodePort service type (NATS cluster)                                     | `nil`                                                         |
+| `clusterService.annotations`         | Annotations for NATS cluster service                                                         | {}                                                            |
+| `clusterService.loadBalancerIP`      | loadBalancerIP if NATS cluster service type is `LoadBalancer`                                | `nil`                                                         |
+| `monitoringService.type`             | Kubernetes Service type (NATS monitoring)                                                    | `ClusterIP`                                                   |
+| `monitoringService.port`             | NATS monitoring port                                                                         | `8222`                                                        |
+| `monitoringService.nodePort`         | Port to bind to for NodePort service type (NATS monitoring)                                  | `nil`                                                         |
+| `monitoringService.annotations`      | Annotations for NATS monitoring service                                                      | {}                                                            |
+| `monitoringService.loadBalancerIP`   | loadBalancerIP if NATS monitoring service type is `LoadBalancer`                             | `nil`                                                         |
+| `ingress.enabled`                    | Enable ingress controller resource                                                           | `false`                                                       |
+| `ingress.hosts[0].name`              | Hostname for NATS monitoring                                                                 | `nats.local`                                                  |
+| `ingress.hosts[0].path`              | Path within the url structure                                                                | `/`                                                           |
+| `ingress.hosts[0].tls`               | Utilize TLS backend in ingress                                                               | `false`                                                       |
+| `ingress.hosts[0].tlsSecret`         | TLS Secret (certificates)                                                                    | `nats.local-tls-secret`                                       |
+| `ingress.hosts[0].annotations`       | Annotations for this host's ingress record                                                   | `[]`                                                          |
+| `ingress.secrets[0].name`            | TLS Secret Name                                                                              | `nil`                                                         |
+| `ingress.secrets[0].certificate`     | TLS Secret Certificate                                                                       | `nil`                                                         |
+| `ingress.secrets[0].key`             | TLS Secret Key                                                                               | `nil`                                                         |
+| `networkPolicy.enabled`              | Enable NetworkPolicy                                                                         | `false`                                                       |
+| `networkPolicy.allowExternal`        | Allow external connections                                                                   | `true`                                                        |
+| `metrics.enabled`                    | Enable Prometheus metrics via exporter side-car                                              | `false`                                                       |
+| `metrics.image.registry`             | Prometheus metrics exporter image registry                                                   | `docker.io`                                                   |
+| `metrics.image.repository`           | Prometheus metrics exporter image name                                                       | `synadia/prometheus-nats-exporter`                            |
+| `metrics.image.tag`                  | Prometheus metrics exporter image tag                                                        | `0.1.0`                                                       |
+| `metrics.image.pullPolicy`           | Prometheus metrics image pull policy                                                         | `IfNotPresent`                                                |
+| `metrics.image.pullSecrets`          | Prometheus metrics image pull secrets                                                        | `nil`                                                         |
+| `metrics.port`                       | Prometheus metrics exporter annotations                                                      | `7777`                                                        |
+| `metrics.annotations`                | Prometheus metrics exporter annotations                                                      | `prometheus.io/scrape: "true"`,  `prometheus.io/port: "7777"` |
+| `metrics.resources`                  | Prometheus metrics exporter resource requests/limit                                          | {}                                                            |
+| `sidecars`                           | Attach additional containers to the pod                                                      | `nil`                                                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `securityContext.fsGroup`            | Group ID for the container                                                                   | `1001`                                                        |
 | `securityContext.runAsUser`          | User ID for the container                                                                    | `1001`                                                        |
 | `statefulset.updateStrategy`         | Statefulsets Update strategy                                                                 | `OnDelete`                                                    |
-| `rollingUpdatePartition`             | Partition for Rolling Update strategy                                                        | `nil`                                                         |
+| `statefulset.rollingUpdatePartition` | Partition for Rolling Update strategy                                                        | `nil`                                                         |
 | `podLabels`                          | Additional labels to be added to pods                                                        | {}                                                            |
 | `podAnnotations`                     | Annotations to be added to pods                                                              | {}                                                            |
 | `nodeSelector`                       | Node labels for pod assignment                                                               | `nil`                                                         |

--- a/stable/nats/README.md
+++ b/stable/nats/README.md
@@ -123,8 +123,8 @@ The following table lists the configurable parameters of the NATS chart and thei
 | `metrics.image.tag`                  | Prometheus metrics exporter image tag                                                        | `0.1.0`                                                       |
 | `metrics.image.pullPolicy`           | Prometheus metrics image pull policy                                                         | `IfNotPresent`                                                |
 | `metrics.image.pullSecrets`          | Prometheus metrics image pull secrets                                                        | `nil`                                                         |
-| `metrics.port`                       | Prometheus metrics exporter annotations                                                      | `7777`                                                        |
-| `metrics.annotations`                | Prometheus metrics exporter annotations                                                      | `prometheus.io/scrape: "true"`,  `prometheus.io/port: "7777"` |
+| `metrics.port`                       | Prometheus metrics exporter port                                                             | `7777`                                                        |
+| `metrics.podAnnotations`             | Prometheus metrics exporter annotations                                                      | `prometheus.io/scrape: "true"`,  `prometheus.io/port: "7777"` |
 | `metrics.resources`                  | Prometheus metrics exporter resource requests/limit                                          | {}                                                            |
 | `sidecars`                           | Attach additional containers to the pod                                                      | `nil`                                                         |
 

--- a/stable/nats/templates/NOTES.txt
+++ b/stable/nats/templates/NOTES.txt
@@ -74,5 +74,15 @@ To access the Monitoring svc from outside the cluster, follow the steps below:
     kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "nats.fullname" . }}-monitoring {{ .Values.monitoringService.port }}:{{ .Values.monitoringService.port }}
 {{- end }}
 
-2. Access the NATS monitoring opening the URL obtained on a browser.
+2. Access NATS monitoring by opening the URL obtained in a browser.
+{{- end }}
+
+{{- if .Values.metrics.enabled }}
+
+3. Get the NATS Prometheus Metrics URL by running:
+
+    echo "Prometheus Metrics URL: http://127.0.0.1:{{ .Values.metrics.port }}"
+    kubectl port-forward --namespace {{ .Release.Namespace }} {{ template "nats.fullname" . }}-0 {{ .Values.metrics.port }}:{{ .Values.metrics.port }}
+
+4. Access NATS Prometheus metrics by opening the URL obtained in a browser.
 {{- end }}

--- a/stable/nats/templates/statefulset.yaml
+++ b/stable/nats/templates/statefulset.yaml
@@ -34,8 +34,8 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
-{{- if .Values.metrics.podAnnotations }}
-{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
+{{- if .Values.metrics.annotations }}
+{{ toYaml .Values.metrics.annotations | indent 8 }}
 {{- end }}
 {{- end }}
     spec:
@@ -131,10 +131,12 @@ spec:
       - name: metrics
         image: {{ template "metrics.image" . }}
         imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
-        command: [ '/prometheus-nats-exporter', '-varz', 'http://localhost:{{ .Values.monitoringService.port }}' ]
+        args:
+{{ toYaml .Values.metrics.args | indent 10 -}}
+          - "http://localhost:{{ .Values.monitoringService.port }}"
         ports:
         - name: metrics
-          containerPort: 7777
+          containerPort: {{ .Values.metrics.port }}
         livenessProbe:
           httpGet:
             path: /metrics

--- a/stable/nats/templates/statefulset.yaml
+++ b/stable/nats/templates/statefulset.yaml
@@ -34,8 +34,8 @@ spec:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
-{{- if .Values.metrics.annotations }}
-{{ toYaml .Values.metrics.annotations | indent 8 }}
+{{- if .Values.metrics.podAnnotations }}
+{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
 {{- end }}
 {{- end }}
     spec:

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -246,6 +246,39 @@ ingress:
   #   key:
   #   certificate:
 
+## Metrics / Prometheus NATS Exporter
+##
+## ref: https://github.com/nats-io/prometheus-nats-exporter
+metrics:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: synadia/prometheus-nats-exporter
+    tag: 0.1.0
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  # resources: {}
+  ## Metrics exporter port
+  port: 7777
+  ## Metrics exporter annotations
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "7777"
+  ## Metrics exporter flags
+  args:
+    - -connz
+    - -routez
+    - -subz
+    - -varz
+
 sidecars:
 ## Add sidecars to the pod.
 ## e.g.
@@ -255,27 +288,3 @@ sidecars:
   # ports:
   # - name: portname
   #   containerPort: 1234
-
-## Prometheus Exporter / Metrics
-##
-metrics:
-  enabled: true
-  image:
-    registry: docker.io
-    repository: appcelerator/prometheus-nats-exporter
-    tag: 0.17.0
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistrKeySecretName
-   ## Metrics exporter resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ##
-  # resources: {}
-   ## Metrics exporter pod Annotation
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "7777"

--- a/stable/nats/values-production.yaml
+++ b/stable/nats/values-production.yaml
@@ -269,7 +269,7 @@ metrics:
   ## Metrics exporter port
   port: 7777
   ## Metrics exporter annotations
-  annotations:
+  podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "7777"
   ## Metrics exporter flags

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -250,6 +250,39 @@ ingress:
   #   key:
   #   certificate:
 
+## Metrics / Prometheus NATS Exporter
+##
+## ref: https://github.com/nats-io/prometheus-nats-exporter
+metrics:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: synadia/prometheus-nats-exporter
+    tag: 0.1.0
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  # resources: {}
+  ## Metrics exporter port
+  port: 7777
+  ## Metrics exporter annotations
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "7777"
+  ## Metrics exporter flags
+  args:
+    - -connz
+    - -routez
+    - -subz
+    - -varz
+
 sidecars:
 ## Add sidecars to the pod.
 ## e.g.
@@ -259,27 +292,3 @@ sidecars:
   # ports:
   # - name: portname
   #   containerPort: 1234
-
-## Prometheus Exporter / Metrics
-##
-metrics:
-  enabled: false
-  image:
-    registry: docker.io
-    repository: appcelerator/prometheus-nats-exporter
-    tag: 0.17.0
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistrKeySecretName
-   ## Metrics exporter resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  ##
-  # resources: {}
-   ## Metrics exporter pod Annotation
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "7777"

--- a/stable/nats/values.yaml
+++ b/stable/nats/values.yaml
@@ -273,7 +273,7 @@ metrics:
   ## Metrics exporter port
   port: 7777
   ## Metrics exporter annotations
-  annotations:
+  podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "7777"
   ## Metrics exporter flags


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
Signed-off-by: Tong Jia <ttjiaa@gmail.com>

#### This PR:
- improves Prometheus metrics sidecar:
  - updates `prometheus-nats-exporter` image to image hosted by `Synadia`
  - templates metrics `port`
  - templates `args` and replaces `command`
  - add additional `flags` under `args` to expose more metrics groups by default:
    - `-connz`: Get connection metrics
    - `-routez`: Get route metrics
    - `-subz`: Get subscription metrics
    - `-varz`: Get connection metrics
  - updates `NOTES.txt` to include instructions on accessing `/metrics`
  - updates `README.md`
- fixes typo in `README.md` for `statefulset.rollingUpdatePartition`
      

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
