### PR TITLE
Use a single image for all cases (HDFS, GCS etc)

### DIFF
--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark-history-server
-version: 0.1.2
+version: 0.2.0
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org

--- a/stable/spark-history-server/Chart.yaml
+++ b/stable/spark-history-server/Chart.yaml
@@ -1,10 +1,11 @@
 name: spark-history-server
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.4.0
 description: A Helm chart for Spark History Server
 home: https://spark.apache.org
 sources:
   - https://github.com/apache/spark
+  - https://github.com/lightbend/spark-history-server-docker
 keywords:
 - spark
 - history-server

--- a/stable/spark-history-server/README.md
+++ b/stable/spark-history-server/README.md
@@ -74,14 +74,16 @@ For details about installing the chart to use HDFS or GCS, see configurations op
 
 The following tables lists the configurable parameters of the Spark History Sever chart and their default values.
 
+Note that the default image `lightbend/spark-history-server` is built using this [repo](https://github.com/lightbend/spark-history-server-docker).
+
 | Parameter                            | Description                                                       |Default                           |
 | ------------------------------------ |----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | hdfs.logDirectory                |The HDFS log directory that starts with "hdfs://"|hdfs://hdfs/history/|
 | hdfs.hdfsSiteConfigMap |The name of the ConfigMap for hdfs-site.xml|hdfs-site|
 | hdfs.coreSiteConfigMap |The name of the ConfigMap for core-site.xml|core-site|
 | hdfs.HADOOP_CONF_DIR |The directory containing core-site.xml and hdfs-site.xml in the image|/etc/hadoop|
-| image.repository |The Docker image used to start the history server daemon|gcr.io/spark-operator/spark|
-| image.tag |The tag of the image|v2.4.0|
+| image.repository |The Docker image used to start the history server daemon|lightbend/spark-history-server|
+| image.tag |The tag of the image|2.4.0|
 | service.type |The type of history server service that exposes the UI|LoadBalancer|
 | service.port |The port on which the service UI can be accessed.|18080|
 | pvc.enablePVC |Whether to use PVC storage|true|
@@ -136,7 +138,7 @@ bin/spark-submit \
     --conf spark.eventLog.enabled=true \
     --conf spark.eventLog.dir=file:/mnt \
     --conf spark.executor.instances=2 \
-    --conf spark.kubernetes.container.image=gcr.io/spark-operator/spark:v2.4.0 \
+    --conf spark.kubernetes.container.image=lightbend/spark-history-server:2.4.0 \
     --conf spark.kubernetes.container.image.pullPolicy=Always \
     --conf spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.options.claimName=nfs-pvc \
     --conf spark.kubernetes.driver.volumes.persistentVolumeClaim.checkpointpvc.mount.path=/mnt \
@@ -178,9 +180,9 @@ bin/spark-submit \
     --conf spark.hadoop.google.cloud.auth.service.account.json.keyfile=/etc/secrets/sparkonk8s.json \
     --conf spark.kubernetes.driver.secrets.history-secrets=/etc/secrets \
     --conf spark.kubernetes.executor.secrets.history-secrets=/etc/secrets \
-    --conf spark.kubernetes.container.image=lightbend/spark:2.4.0-gcs \
+    --conf spark.kubernetes.container.image=lightbend/spark-history-server:2.4.0 \
     local:///opt/spark/examples/jars/spark-examples_2.11-2.4.0.jar
 ```
 
-Note that the image for your Spark job (i.e. `spark.kubernetes.container.image`, `spark.kubernetes.driver.container.image` and `spark.kubernetes.executor.container.image`) needs to have the [GCS connector](https://cloud.google.com/dataproc/docs/concepts/connectors/cloud-storage) dependency, otherwise the `gs://` scheme won't be recognized.
+Note that the image for your Spark job (i.e. `spark.kubernetes.container.image`, `spark.kubernetes.driver.container.image` and `spark.kubernetes.executor.container.image`) needs to have the [GCS connector](https://cloud.google.com/dataproc/docs/concepts/connectors/cloud-storage) dependency, which is included in `lightbend/spark-history-server:2.4.0`, otherwise the `gs://` scheme won't be recognized.
 

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -8,7 +8,7 @@ serviceAccount:
   name:
 
 image:
-  repository: lightbend/spark
+  repository: lightbend/spark-history-server
   tag: 2.4.0
   pullPolicy: IfNotPresent
 

--- a/stable/spark-history-server/values.yaml
+++ b/stable/spark-history-server/values.yaml
@@ -8,8 +8,8 @@ serviceAccount:
   name:
 
 image:
-  repository: gcr.io/spark-operator/spark
-  tag: v2.4.0
+  repository: lightbend/spark
+  tag: 2.4.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Use a single image with all dependencies. Updated the doc to point to the Dockerfile of the default image.