### PR TITLE
allow specification of update strategy on slaves

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.2.8
+version: 4.2.9
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-slave-deployment.yaml
+++ b/stable/redis/templates/redis-slave-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
 {{- if .Values.slave.updateStrategy }}
   strategy:
-{{ toYaml (.Values.slave.updateStrategy | indent 4 }}
+{{ toYaml .Values.slave.updateStrategy | indent 4 }}
 {{- end }}
 {{- if .Values.cluster.slaveCount }}
   replicas: {{ .Values.cluster.slaveCount }}

--- a/stable/redis/templates/redis-slave-deployment.yaml
+++ b/stable/redis/templates/redis-slave-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+{{- if .Values.slave.updateStrategy }}
+  strategy:
+{{ toYaml (.Values.slave.updateStrategy | indent 4 }}
+{{- end }}
 {{- if .Values.cluster.slaveCount }}
   replicas: {{ .Values.cluster.slaveCount }}
 {{- end }}

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -245,7 +245,6 @@ slave:
   # extraFlags: []
   ## Comma-separated list of Redis commands to disable
   # disableCommands: ""
-  
   ## deployment update stategy
   # updateStrategy:
   #   rollingUpdate:

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -245,6 +245,11 @@ slave:
   # extraFlags: []
   ## Comma-separated list of Redis commands to disable
   # disableCommands: ""
+  
+  ## deployment update stategy
+  # updateStrategy:
+  #   rollingUpdate:
+  #     maxUnavailable: 0
 
   ## Redis Slave pod/node affinity/anti-affinity
   ##


### PR DESCRIPTION
allow specification of update strategy on slaves, you should be able to specify stuff like maxUnavailable on slave updates. Otherwise, all your slaves may restart while the master is terminating/initializing. If this happens your slaves will be down just as long as the master