### PR TITLE
[test] Fix setting Helm timeout

### DIFF
--- a/test/ct.yaml
+++ b/test/ct.yaml
@@ -7,4 +7,4 @@ excluded-charts:
   - common
 chart-repos:
   - incubator=https://kubernetes-charts-incubator.storage.googleapis.com/
-timeout: 10m
+helm-extra-args: --timeout 600


### PR DESCRIPTION
The --timeout flag was replaced with the more general --helm-extra-args.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>
