### PR TITLE
stable/unifi/templates/deployment.yaml: fix probes

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.9.29
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.2.0
+version: 0.2.1
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/templates/deployment.yaml
+++ b/stable/unifi/templates/deployment.yaml
@@ -41,13 +41,13 @@ spec:
               path: /status
               port: https-gui
               scheme: HTTPS
-              initialDelaySeconds: 30
+            initialDelaySeconds: 30
           readinessProbe:
             httpGet:
               path: /status
               port: https-gui
               scheme: HTTPS
-              initialDelaySeconds: 15
+            initialDelaySeconds: 15
           env:
             - name: TZ
               value: "{{ .Values.timezone }}"


### PR DESCRIPTION
The `livenessProbe` and `readinessProbe` are incorrectly defined.
The `initialDelaySeconds` field should not be nested withing the `httpGet`
field.

cc @billimek 