### PR TITLE
[stable/redis] Fix hardcoded serviceName

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.2.9
+version: 4.2.10
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/redis-master-statefulset.yaml
+++ b/stable/redis/templates/redis-master-statefulset.yaml
@@ -13,7 +13,7 @@ spec:
       release: "{{ .Release.Name }}"
       role: master
       app: {{ template "redis.name" . }}
-  serviceName: "redis-master"
+  serviceName: {{ template "redis.fullname" . }}-master
   template:
     metadata:
       labels:


### PR DESCRIPTION
#### What this PR does / why we need it:

The master Service name is derived from the `"redis.fullname"` template, which depends on `{full,}nameOverride`. Prior to this change, if the template evaluates to anything other than `redis-master`, e.g. if `fullnameOverride` is set to anything but `redis`, the StatefulSet will be misconfigured.

This change replaces the hardcoded `redis-master` with the appropriate, override-respecting value, which is the same as `metadata.name` in the master service template.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped