### PR TITLE
[incubator/fluentd-graylog]

### DIFF
--- a/incubator/fluentd-graylog/Chart.yaml
+++ b/incubator/fluentd-graylog/Chart.yaml
@@ -1,0 +1,17 @@
+name: fluentd-graylog
+version: 0.1.0
+appVersion: v0.12.43-debian-graylog
+description: A Fluentd Graylog Helm chart for Kubernetes.
+home: https://www.fluentd.org/
+icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
+keywords:
+- fluentd
+- graylog
+- logging
+sources:
+- https://github.com/kubernetes/charts
+- https://github.com/fluent/fluentd-kubernetes-daemonset
+maintainers:
+- name: madushan1000
+  email: jlmadushan@gmail.com
+engine: gotpl

--- a/incubator/fluentd-graylog/README.md
+++ b/incubator/fluentd-graylog/README.md
@@ -1,0 +1,83 @@
+# Fluentd Graylog
+
+* Installs [Fluentd](https://www.fluentd.org/) [Graylog](https://www.graylog.org/) log forwarder.
+
+## TL;DR;
+
+```console
+$ helm install incubator/fluentd-graylog
+```
+
+## Introduction
+
+This chart bootstraps a [Fluentd](https://www.fluentd.org/) [Graylog](https://www.graylog.org/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- Existing graylog server
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ # use ec2 instance role credential
+$ helm install --name my-release incubator/fluentd-graylog
+$ # or add graylog host and port in the command line
+$ helm install --name my-release incubator/fluentd-graylog --set graylogHost=a<graylog host ip/domain> --set graylogPort=<graylog port>
+```
+
+The command deploys Fluentd Graylog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Fluentd Graylog chart and their default values.
+
+| Parameter                       | Description                                                               | Default                               |
+| ------------------------------- | ------------------------------------------------------------------------- | --------------------------------------|
+| `image.repository`              | Image repository                                                          | `fluent/fluentd-kubernetes-daemonset` |
+| `image.tag`                     | Image tag                                                                 | `v0.12.43-debian-graylog`                 |
+| `image.pullPolicy`              | Image pull policy                                                         | `IfNotPresent`                        |
+| `resources.limits.cpu`          | CPU limit                                                                 | `100m`                                |
+| `resources.limits.memory`       | Memory limit                                                              | `200Mi`                               |
+| `resources.requests.cpu`        | CPU request                                                               | `100m`                                |
+| `resources.requests.memory`     | Memory request                                                            | `200Mi`                               |
+| `hostNetwork`                   | Host network                                                              | `false`                               |
+| `annotations` (removed for now) | Annotations                                                               | `nil`                                 |                                 |
+| `fluentdConfig`                 | Fluentd configuration                                                     | `example configuration`               |                          |
+| `rbac.create`                   | If true, create & use RBAC resources                                      | `false`                               |
+| `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true)              | `default`                             |
+| `tolerations`                   | Add tolerations                                                           | `[]`                                  |
+| `extraVars`                     | Add pod environment variables (must be specified as a single line object) | `[]`                                  |
+
+Starting with fluentd-kubernetes-daemonset v0.12.43-debian-graylog, the container runs as user fluentd. To be able to write pos files to the host system, you'll need to run fluentd as root. Add the following extraVars value to run as root.
+
+```code
+"{ name: FLUENT_UID, value: '0' }"
+```
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+  --set graylogHost=10.0.0.2 \
+  --set graylogPort=2500 \
+    incubator/fluentd-graylog
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml incubator/fluentd-graylog
+```

--- a/incubator/fluentd-graylog/README.md
+++ b/incubator/fluentd-graylog/README.md
@@ -22,10 +22,9 @@ This chart bootstraps a [Fluentd](https://www.fluentd.org/) [Graylog](https://ww
 To install the chart with the release name `my-release`:
 
 ```console
-$ # use ec2 instance role credential
 $ helm install --name my-release incubator/fluentd-graylog
 $ # or add graylog host and port in the command line
-$ helm install --name my-release incubator/fluentd-graylog --set graylogHost=a<graylog host ip/domain> --set graylogPort=<graylog port>
+$ helm install --name my-release incubator/fluentd-graylog --set graylogHost=<graylog host ip/domain> --set graylogPort=<graylog port>
 ```
 
 The command deploys Fluentd Graylog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/incubator/fluentd-graylog/templates/NOTES.txt
+++ b/incubator/fluentd-graylog/templates/NOTES.txt
@@ -1,0 +1,6 @@
+To verify that Fluentd Graylog has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "fluentd-graylog.name" . }},release={{ .Release.Name }}"
+
+THIS APPLICATION CAPTURES ALL CONSOLE OUTPUT AND FORWARDS IT TO GRAYLOG. Anything that might be identifying,
+including things like IP addresses, container images, and object names will NOT be anonymized.

--- a/incubator/fluentd-graylog/templates/_helpers.tpl
+++ b/incubator/fluentd-graylog/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fluentd-graylog.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fluentd-graylog.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fluentd-graylog.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/fluentd-graylog/templates/clusterrole.yaml
+++ b/incubator/fluentd-graylog/templates/clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "fluentd-graylog.fullname" . }}
+  labels:
+    app: {{ template "fluentd-graylog.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "pods"]
+  verbs: ["get", "list", "watch"]
+{{- end }}

--- a/incubator/fluentd-graylog/templates/clusterrolebinding.yaml
+++ b/incubator/fluentd-graylog/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "fluentd-graylog.fullname" . }}
+  labels:
+    app: {{ template "fluentd-graylog.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd-graylog.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "fluentd-graylog.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/incubator/fluentd-graylog/templates/configmap.yaml
+++ b/incubator/fluentd-graylog/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fluentd-graylog.fullname" . }}
+  labels:
+    app: {{ template "fluentd-graylog.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+data:
+  fluent.conf: {{ toYaml .Values.fluentdConfig | indent 2 }}

--- a/incubator/fluentd-graylog/templates/daemonset.yaml
+++ b/incubator/fluentd-graylog/templates/daemonset.yaml
@@ -1,0 +1,70 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fluentd-graylog.fullname" . }}
+  labels:
+    app: {{ template "fluentd-graylog.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fluentd-graylog.name" . }}
+        release: "{{ .Release.Name }}"
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "fluentd-graylog.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      initContainers:
+        - name: copy-fluentd-config
+          image: busybox
+          command: ['sh', '-c', 'cp /config-volume/* /etc/fluentd']
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: config
+              mountPath: /etc/fluentd
+      containers:
+      - name: {{ template "fluentd-graylog.fullname" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        #hostNetwork: {{ default false .Values.hostNetwork }}
+        env:
+        - name: GRAYLOG_HOST
+          value: {{ .Values.graylogHost }}
+        - name: GRAYLOG_PORT
+          value: {{ .Values.graylogPort }}
+{{- range $env := .Values.extraVars }}
+        - {{ $env  }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: config
+          mountPath: /fluentd/etc
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: config
+        emptyDir: {}
+      - name: config-volume
+        configMap:
+          name: {{ template "fluentd-graylog.fullname" . }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}

--- a/incubator/fluentd-graylog/templates/daemonset.yaml
+++ b/incubator/fluentd-graylog/templates/daemonset.yaml
@@ -35,9 +35,9 @@ spec:
         #hostNetwork: {{ default false .Values.hostNetwork }}
         env:
         - name: GRAYLOG_HOST
-          value: {{ .Values.graylogHost }}
+          value: {{ quote .Values.graylogHost }}
         - name: GRAYLOG_PORT
-          value: {{ .Values.graylogPort }}
+          value: {{ quote .Values.graylogPort }}
 {{- range $env := .Values.extraVars }}
         - {{ $env  }}
 {{- end }}

--- a/incubator/fluentd-graylog/templates/serviceaccount.yaml
+++ b/incubator/fluentd-graylog/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "fluentd-graylog.fullname" . }}
+  labels:
+    app: {{ template "fluentd-graylog.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/incubator/fluentd-graylog/values.yaml
+++ b/incubator/fluentd-graylog/values.yaml
@@ -191,4 +191,5 @@ fluentdConfig: |
      max_retry_wait 30
      disable_retry_limit
      num_threads 8
-  </match> 
+  </match>
+  

--- a/incubator/fluentd-graylog/values.yaml
+++ b/incubator/fluentd-graylog/values.yaml
@@ -1,0 +1,193 @@
+image:
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: v0.12.43-debian-graylog
+## Specify an imagePullPolicy (Required)
+## It's recommended to change this to 'Always' if the image tag is 'latest'
+## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+  pullPolicy: IfNotPresent
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  limits:
+    cpu: 100m
+    memory: 200Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+
+# hostNetwork: false
+
+## Add tolerations if specified
+tolerations: []
+#   - key: node-role.kubernetes.io/master
+#     operator: Exists
+#     effect: NoSchedule
+
+podAnnotations: {}
+
+graylogHost: graylogclient.kubernetes.local
+graylogPort: 12201
+
+rbac:
+  ## If true, create and use RBAC resources
+  create: false
+
+  ## Ignored if rbac.create is true
+  serviceAccountName: default
+# Add extra environment variables if specified (must be specified as a single line object and be quoted)
+extraVars: []
+# - "{ name: NODE_NAME, valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }"
+
+fluentdConfig: |
+  <match fluent.**>
+    type null
+  </match>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    path /var/log/containers/*.log
+    pos_file /var/log/fluentd-containers.log.pos
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+    tag kubernetes.*
+    format json
+    read_from_head true
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
+    time_format %Y-%m-%d %H:%M:%S
+    path /var/log/salt/minion
+    pos_file /var/log/fluentd-salt.pos
+    tag salt
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format syslog
+    path /var/log/startupscript.log
+    pos_file /var/log/fluentd-startupscript.log.pos
+    tag startupscript
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+    path /var/log/docker.log
+    pos_file /var/log/fluentd-docker.log.pos
+    tag docker
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format none
+    path /var/log/etcd.log
+    pos_file /var/log/fluentd-etcd.log.pos
+    tag etcd
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format kubernetes
+    multiline_flush_interval 5s
+    path /var/log/kubelet.log
+    pos_file /var/log/fluentd-kubelet.log.pos
+    tag kubelet
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format kubernetes
+    multiline_flush_interval 5s
+    path /var/log/kube-proxy.log
+    pos_file /var/log/fluentd-kube-proxy.log.pos
+    tag kube-proxy
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format kubernetes
+    multiline_flush_interval 5s
+    path /var/log/kube-apiserver.log
+    pos_file /var/log/fluentd-kube-apiserver.log.pos
+    tag kube-apiserver
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format kubernetes
+    multiline_flush_interval 5s
+    path /var/log/kube-controller-manager.log
+    pos_file /var/log/fluentd-kube-controller-manager.log.pos
+    tag kube-controller-manager
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format kubernetes
+    multiline_flush_interval 5s
+    path /var/log/kube-scheduler.log
+    pos_file /var/log/fluentd-kube-scheduler.log.pos
+    tag kube-scheduler
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format kubernetes
+    multiline_flush_interval 5s
+    path /var/log/rescheduler.log
+    pos_file /var/log/fluentd-rescheduler.log.pos
+    tag rescheduler
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format kubernetes
+    multiline_flush_interval 5s
+    path /var/log/glbc.log
+    pos_file /var/log/fluentd-glbc.log.pos
+    tag glbc
+  </source>
+
+  <source>
+    type tail
+    enable_stat_watcher false
+    format kubernetes
+    multiline_flush_interval 5s
+    path /var/log/cluster-autoscaler.log
+    pos_file /var/log/fluentd-cluster-autoscaler.log.pos
+    tag cluster-autoscaler
+  </source>
+
+  <filter kubernetes.**>
+    type kubernetes_metadata
+  </filter>
+
+  <match **>
+     @type gelf
+     @id out_graylog
+     @log_level info
+     include_tag_key true
+     host "#{ENV['GRAYLOG_HOST']}"
+     port "#{ENV['GRAYLOG_PORT']}"
+     buffer_chunk_limit 4096K
+     buffer_queue_limit 512
+     flush_interval 5s
+     max_retry_wait 30
+     disable_retry_limit
+     num_threads 8
+  </match> 

--- a/incubator/fluentd-graylog/values.yaml
+++ b/incubator/fluentd-graylog/values.yaml
@@ -38,7 +38,7 @@ rbac:
   serviceAccountName: default
 # Add extra environment variables if specified (must be specified as a single line object and be quoted)
 extraVars:
- - "{ name: FLUENT_UID, value: \"0\" }"
+  - "{ name: FLUENT_UID, value: \"0\" }"
 # - "{ name: NODE_NAME, valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }"
 
 fluentdConfig: |
@@ -192,4 +192,3 @@ fluentdConfig: |
      disable_retry_limit
      num_threads 8
   </match>
-  

--- a/incubator/fluentd-graylog/values.yaml
+++ b/incubator/fluentd-graylog/values.yaml
@@ -37,7 +37,8 @@ rbac:
   ## Ignored if rbac.create is true
   serviceAccountName: default
 # Add extra environment variables if specified (must be specified as a single line object and be quoted)
-extraVars: []
+extraVars:
+ - "{ name: FLUENT_UID, value: \"0\" }"
 # - "{ name: NODE_NAME, valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }"
 
 fluentdConfig: |


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR adds a new chart to the incubator designed to push kubernetes logs to graylog2 using fluentd and gelf plugin. It's adopts the already existing and maintained docker image from [fluent/fluentd-kubernetes-daemonset](https://github.com/fluent/fluentd-kubernetes-daemonset).

This initial version of the chart is created by doing the minimal changes to the helm templates in [incubator/fluentd-cloudwatch](https://github.com/helm/charts/tree/master/incubator/fluentd-cloudwatch) as it uses the same base docker images.
