### PR TITLE
[stable/stolon] Add support for mounting custom volumes to the keeper container.

### DIFF
--- a/stable/stolon/Chart.yaml
+++ b/stable/stolon/Chart.yaml
@@ -1,5 +1,5 @@
 name: stolon
-version: 0.4.3
+version: 0.4.4
 appVersion: 0.12.0
 description: Stolon - PostgreSQL cloud native High Availability.
 home: https://github.com/sorintlab/stolon

--- a/stable/stolon/README.md
+++ b/stable/stolon/README.md
@@ -55,6 +55,8 @@ Kubernetes is the default store backend. `consul`, `etcdv2` or `etcdv3` can also
 | `keeper.nodeSelector`                   | Node labels for keeper pod assignment          | `{}`                                                         |
 | `keeper.affinity`                       | Affinity settings for keeper pod assignment    | `{}`                                                         |
 | `keeper.tolerations`                    | Toleration labels for keeper pod assignment    | `[]`                                                         |
+| `keeper.volumes`                        | Additional volumes                             | `[]`                                                         |
+| `keeper.volumeMounts`                   | Mount paths for `keeper.volumes`               | `[]`                                                         |
 | `proxy.replicaCount`                    | Number of proxy nodes                          | `2`                                                          |
 | `proxy.resources`                       | Proxy resource requests/limit                  | `{}`                                                         |
 | `proxy.priorityClassName`               | Proxy priorityClassName                        | `nil`                                                        |

--- a/stable/stolon/templates/keeper-statefulset.yaml
+++ b/stable/stolon/templates/keeper-statefulset.yaml
@@ -88,6 +88,10 @@ spec:
             mountPath: /stolon-data
           - name: stolon-secrets
             mountPath: /etc/secrets/stolon
+{{- range $key, $value := .Values.keeper.volumeMounts }}
+          - name: {{ $key }}
+{{ toYaml $value | indent 12 }}
+{{- end }}
 {{- with .Values.keeper.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -104,6 +108,10 @@ spec:
         - name: stolon-secrets
           secret:
             secretName: {{ template "stolon.fullname" . }}
+{{- range $key, $value := .Values.keeper.volumes }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+{{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/stolon/values.yaml
+++ b/stable/stolon/values.yaml
@@ -75,6 +75,8 @@ keeper:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  volumes: []
+  volumeMounts: []
 
 proxy:
   replicaCount: 2


### PR DESCRIPTION
Useful for situations like adding custom script files to `docker-entrypoint-initdb.d` directory.

Signed-off-by: Alexander Awitin Jr <<alexanderawitin@gmail.com>>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR adds the ability to add custom volumes to the keeper. Useful for situation where you might want to add custom scripts to `docker-entrypoint-initdb.d` directory.

#### Special notes for your reviewer:
@rtluckie
@lwolf

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
