### PR TITLE
[stable/prometheus-operator] update doc for prometheus.prometheusSpec…

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 0.1.30
+version: 0.1.31
 appVersion: "0.25.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -725,7 +725,8 @@ prometheus:
     #     role: example-rules
 
     ## serviceMonitorSelector will limit which servicemonitors are used to create scrape
-    ## configs in Prometheus. By default all are loaded
+    ## configs in Prometheus. By default it picks serviceMonitor having a label "release"
+    ## with a value equal to the release name of your prometheus operator chart.
     ##
     serviceMonitorSelector: {}
 


### PR DESCRIPTION
….serviceMonitorSelector value

#### What this PR does / why we need it:

It fixes a documentation issue about how the `prometheus.prometheusSpec.serviceMonitorSelector` value behaves in the chart stable/prometheus-operator

#### Which issue this PR fixes

  - fixes #9140 

#### Special notes for your reviewer:

#### Checklist

- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
