### PR TITLE
updating stable/telegraf for management of telegraf port config and checks

### DIFF
--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -1,5 +1,5 @@
 name: telegraf
-version: 0.3.3
+version: 0.3.4
 appVersion: 1.5
 deprecated: true
 description: Telegraf is an agent written in Go for collecting, processing, aggregating, and writing metrics.

--- a/stable/telegraf/Chart.yaml
+++ b/stable/telegraf/Chart.yaml
@@ -9,7 +9,4 @@ keywords:
 - timeseries
 - influxdata
 home: https://www.influxdata.com/time-series-platform/telegraf/
-maintainers:
-- name: Jack Zampolin
-  email: jack@influxdb.com
 engine: gotpl

--- a/stable/telegraf/README.md
+++ b/stable/telegraf/README.md
@@ -80,7 +80,7 @@ This chart deploys the following by default:
   * [`prometheus`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/prometheus)
   * [`influxdb`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/influxdb)
   * [`statsd`](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd)
-
+  > * `statsd` by default gets exposed at 8125/TCP, to configure it's port/protocol to custom values, can set required values at `single.service.ports[0].containerPort`, `single.service.ports[0].protocol`  and `single.config.inputs.statsd.protocol`
   
 ### Supported Outputs
 

--- a/stable/telegraf/templates/deployment.yaml
+++ b/stable/telegraf/templates/deployment.yaml
@@ -19,6 +19,11 @@ spec:
       - name: {{ template "fullname" . }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ default "" .Values.image.pullPolicy | quote }}
+        ports:
+        {{- range .Values.single.service.ports }}
+        - containerPort: {{ .containerPort }}
+          protocol: {{ if eq "" .protocol }}"TCP"{{else }}{{ .protocol }}{{ end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.single.resources | indent 10 }}
         volumeMounts:

--- a/stable/telegraf/templates/service.yaml
+++ b/stable/telegraf/templates/service.yaml
@@ -19,6 +19,7 @@ spec:
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
     name: "statsd"
+    protocol: {{ if eq "" $value.protocol }}"TCP"{{else }}{{ $value.protocol | upper }}{{ end }}
     {{- end }}
     {{- if eq $key "tcp-listener" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}

--- a/stable/telegraf/values.yaml
+++ b/stable/telegraf/values.yaml
@@ -148,6 +148,9 @@ single:
   service:
     enabled: true
     type: ClusterIP
+    ports:
+      - containerPort: 8125
+        protocol: TCP
   ## Exposed telegraf configuration
   ## For full list of possible values see `/docs/all-config-values.yaml` and `/docs/all-config-values.toml`
   ## ref: https://docs.influxdata.com/telegraf/v1.1/administration/configuration/
@@ -481,6 +484,7 @@ single:
 ##        max_body_size: 0
 ##        max_line_size: 0
       statsd:
+        protocol: TCP
         service_address: ":8125"
         percentiles:
           - 50


### PR DESCRIPTION
/cc @jackzampolin 

Is this a BUG REPORT or FEATURE REQUEST? (choose one): Feature Request

Our setup required Telegraf statsd listener to listen at UDP. This PR updates Deployment and Service resoruce templates to be able to manage explicit selection of a port/protocol and using default of 8125/TCP via default values.yaml

Have tested and used it on our cluster with success.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed (Signed-off-by: AbhishekKr <abhikumar163@gmail.com>)
- [x] Chart Version bumped to 0.3.4
- [x] Variables are documented in the README.md
