### PR TITLE
[incubator/common] render yaml objects to env variables notation (snake notation)

### DIFF
--- a/incubator/common/Chart.yaml
+++ b/incubator/common/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Common chartbuilding components and helpers
 name: common
-version: 0.0.4
-appVersion: 0.0.4
+version: 0.0.5
+appVersion: 0.0.5
 home: https://helm.sh
 maintainers:
 - name: technosophos

--- a/incubator/common/templates/_envvar.tpl
+++ b/incubator/common/templates/_envvar.tpl
@@ -36,7 +36,8 @@ valueFrom:
 {{- $itemTemplateName := index . 2 -}}
 
 {{- range $name, $value := $root -}}
-{{- $name := printf "%s_%s" $prefix  (regexReplaceAll "([a-z0-9])([A-Z])" $name "${1}_${2}") | upper -}}
+{{- $name := regexReplaceAll "([[:alnum:]])([[:upper:]])" $name "${1}_${2}" | replace "-" "_" -}}
+{{- $name := printf "%s_%s" $prefix $name | upper -}}
 {{- if kindIs "map" $value }}
 {{- include "common.envvar.from_yaml" (list $value $name $itemTemplateName) -}}
 {{- else if kindIs "slice" $value }}

--- a/incubator/common/templates/_envvar.tpl
+++ b/incubator/common/templates/_envvar.tpl
@@ -2,8 +2,8 @@
 {{- $name := index . 0 -}}
 {{- $value := index . 1 -}}
 
-  name: {{ $name }}
-  value: {{ default "" $value | quote }}
+name: {{ $name }}
+value: {{ default "" $value | quote }}
 {{- end -}}
 
 {{- define "common.envvar.configmap" -}}
@@ -11,11 +11,11 @@
 {{- $configMapName := index . 1 -}}
 {{- $configMapKey := index . 2 -}}
 
-  name: {{ $name }}
-  valueFrom:
-    configMapKeyRef:
-      name: {{ $configMapName }}
-      key: {{ $configMapKey }}
+name: {{ $name }}
+valueFrom:
+  configMapKeyRef:
+    name: {{ $configMapName }}
+    key: {{ $configMapKey }}
 {{- end -}}
 
 {{- define "common.envvar.secret" -}}
@@ -23,11 +23,11 @@
 {{- $secretName := index . 1 -}}
 {{- $secretKey := index . 2 -}}
 
-  name: {{ $name }}
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: {{ $secretKey }}
+name: {{ $name }}
+valueFrom:
+  secretKeyRef:
+    name: {{ $secretName }}
+    key: {{ $secretKey }}
 {{- end -}}
 
 {{- define "common.envvar.from_yaml" -}}

--- a/incubator/common/templates/_envvar.tpl
+++ b/incubator/common/templates/_envvar.tpl
@@ -1,15 +1,15 @@
 {{- define "common.envvar.value" -}}
-  {{- $name := index . 0 -}}
-  {{- $value := index . 1 -}}
+{{- $name := index . 0 -}}
+{{- $value := index . 1 -}}
 
   name: {{ $name }}
   value: {{ default "" $value | quote }}
 {{- end -}}
 
 {{- define "common.envvar.configmap" -}}
-  {{- $name := index . 0 -}}
-  {{- $configMapName := index . 1 -}}
-  {{- $configMapKey := index . 2 -}}
+{{- $name := index . 0 -}}
+{{- $configMapName := index . 1 -}}
+{{- $configMapKey := index . 2 -}}
 
   name: {{ $name }}
   valueFrom:
@@ -19,13 +19,30 @@
 {{- end -}}
 
 {{- define "common.envvar.secret" -}}
-  {{- $name := index . 0 -}}
-  {{- $secretName := index . 1 -}}
-  {{- $secretKey := index . 2 -}}
+{{- $name := index . 0 -}}
+{{- $secretName := index . 1 -}}
+{{- $secretKey := index . 2 -}}
 
   name: {{ $name }}
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ $secretKey }}
+{{- end -}}
+
+{{- define "common.envvar.from_yaml" -}}
+{{- $root := index . 0 -}}
+{{- $prefix := index . 1 -}}
+{{- $itemTemplateName := index . 2 -}}
+
+{{- range $name, $value := $root -}}
+{{- $name := printf "%s_%s" $prefix  (regexReplaceAll "([a-z0-9])([A-Z])" $name "${1}_${2}") | upper -}}
+{{- if kindIs "map" $value }}
+{{- include "common.envvar.from_yaml" (list $value $name $itemTemplateName) -}}
+{{- else if kindIs "slice" $value }}
+{{ include $itemTemplateName (list $name (join "," $value | quote)) }}
+{{- else }}
+{{ include $itemTemplateName (list $name ($value | quote)) }}
+{{- end }}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

* added template to render yaml objects in env variables notation (snake notation)
* some clean up

#### Example
values.yaml
```yaml
env:
  aaaBbbbCcc: value
  nested:
    property:
      enabled: "false"
  test:
    list:
      - 1
      - 2
```

templates/test.yaml
```yaml
{{ include "common.envvar.from_yaml" (list .Values.env "APPLICATION" "common.envvar.value") }}
```

Result
```yaml
name: APPLICATION_AAA_BBBB_CCC
value: "value"
name: APPLICATION_NESTED_PROPERTY_ENABLED
value: "false"
name: APPLICATION_TEST_LIST
value: "1,2"
```