### PR TITLE
[incubator/cassandra] change backup image, add parallel to values

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.9.1
+version: 0.9.2
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -125,11 +125,12 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `backup.enabled`                     | Enable backup on chart installation             | `false`                                                    |
 | `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
 | `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |
-| `backup.image.repo`                  | Backup image repository                         | `maorfr/cain`                                              |
+| `backup.image.repo`                  | Backup image repository                         | `nuvo/cain`                                                |
 | `backup.image.tag`                   | Backup image tag                                | `0.1.0`                                                    |
 | `backup.env`                         | Backup environment variables                    | AWS_REGION: `us-east-1`                                    |
 | `backup.resources`                   | Backup CPU/Memory resource requests/limits      | Memory: `1Gi`, CPU: `1`                                    |
 | `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |
+| `backup.parallel`                    | Copy n files in parallel                        | `1`                                                        |
 | `exporter.enabled`                   | Enable Cassandra exporter                       | `false`                                                    |
 | `exporter.image.repo`                | Exporter image repository                       | `criteord/cassandra_exporter`                              |
 | `exporter.image.tag`                 | Exporter image tag                              | `2.0.2`                                                    |

--- a/incubator/cassandra/templates/backup/cronjob.yaml
+++ b/incubator/cassandra/templates/backup/cronjob.yaml
@@ -41,7 +41,7 @@ spec:
             - --dst
             - {{ $backup.destination }}
             - --parallel
-            - "0"
+            - "{{ $backup.parallel }}"
           {{- with $backup.env }}
             env:
 {{ toYaml . | indent 12 }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -176,7 +176,7 @@ backup:
   # Additional support can added.
   # Ref: https://github.com/nuvo/skbn
   destination: s3://bucket/cassandra
-  
+
   # Copy n files in parallel
   # 0 for full parallelism
   parallel: 1

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -154,7 +154,7 @@ backup:
     iam.amazonaws.com/role: cain
 
   image:
-    repos: maorfr/cain
+    repos: nuvo/cain
     tag: 0.1.0
 
   # Add additional environment variables
@@ -174,8 +174,12 @@ backup:
   # Destination to store the backup artifacts
   # Currently only s3 is supported
   # Additional support can added.
-  # Ref: https://github.com/maorfr/skbn
+  # Ref: https://github.com/nuvo/skbn
   destination: s3://bucket/cassandra
+  
+  # Copy n files in parallel
+  # 0 for full parallelism
+  parallel: 1
 
 ## Cassandra exported configuration
 ## ref: https://github.com/criteo/cassandra_exporter


### PR DESCRIPTION
#### What this PR does / why we need it:
Change the image to the official image by our company
Allow control over level of parallelism in backup process