### PR TITLE
Deprecate Buildkite chart

### DIFF
--- a/stable/buildkite/Chart.yaml
+++ b/stable/buildkite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-description: Agent for Buildkite
+description: DEPRECATED Agent for Buildkite
 name: buildkite
-version: 0.2.3
+version: 0.2.4
 appVersion: 3.0
 icon: https://github.com/buildkite/media/blob/master/marks/Buildkite%20-%20Mark%20-%20colour.png
 keywords:
@@ -12,6 +12,6 @@ keywords:
 home: https://buildkite.com
 sources:
 - https://github.com/buildkite/agent
-maintainers:
-- name: rimusz
-  email: rmocius@gmail.com
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/buildkite/charts
+deprecated: true

--- a/stable/buildkite/README.md
+++ b/stable/buildkite/README.md
@@ -1,7 +1,12 @@
-# Running Buildkite agent
+# Running Buildkite agent - DEPRECATED
 
-The [buildkite agent](https://buildkite.com/docs/agent) is a small, reliable and cross-platform build runner that makes it easy to run automated builds on your own infrastructure. Its main responsibilities are polling buildkite.com for work, running build jobs, reporting back the status code and output log of the job, and uploading the job's artefacts.
-It is simple, lightweight hosted [Buildkite](https://buildkite.com) CI/CD system which only requires to host agents in your Kubernetes cluster.
+**This chart is deprecated! You can find the new chart in:**
+- **Sources:** https://github.com/buildkite/charts
+- **Charts repository:** https://buildkite.github.io/charts/
+
+```bash
+helm repo add buildkite https://buildkite.github.io/charts/
+```
 
 ## Introduction
 

--- a/stable/buildkite/templates/NOTES.txt
+++ b/stable/buildkite/templates/NOTES.txt
@@ -1,3 +1,5 @@
+#### THIS CHART IS DEPRECATED! ####
+
 {{- if .Values.agent.token }}
 
 The {{ template "buildkite.fullname" . }} is getting provisioned in your cluster. After a few minutes, you can run the following to verify.


### PR DESCRIPTION
Signed-off-by: Rimas <rmocius@gmail.com>

Deprecating Buildkite chart in preparation for the new Distributed repo.
Buildkite chart is already hosted at https://github.com/buildkite/charts/tree/master/stable/agent