### PR TITLE
[stable/concourse] Fix AWS SSM Syntax Error

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,9 @@
 name: concourse
+<<<<<<< HEAD
 version: 3.1.0
+=======
+version: 3.0.3
+>>>>>>> bump version, remove newline
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,9 +1,5 @@
 name: concourse
-<<<<<<< HEAD
-version: 3.1.0
-=======
 version: 3.0.3
->>>>>>> bump version, remove newline
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.0.3
+version: 3.1.1
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -286,13 +286,13 @@ spec:
             - name: AWS_REGION
               value: {{ .Values.concourse.web.awsSsm.region | quote }}
             {{- end }}
-            {{- if .Values.credentialManager.awsSsm.pipelineSecretTemplate }}
+            {{- if .Values.concourse.web.awsSsm.pipelineSecretTemplate }}
             - name: CONCOURSE_AWS_SSM_PIPELINE_SECRET_TEMPLATE
-              value: {{ .Values.credentialManager.awsSsm.pipelineSecretTemplate | quote }}
+              value: {{ .Values.concourse.web.awsSsm.pipelineSecretTemplate | quote }}
             {{- end }}
-            {{- if .Values.credentialManager.awsSsm.teamSecretTemplate }}
+            {{- if .Values.concourse.web.awsSsm.teamSecretTemplate }}
             - name: CONCOURSE_AWS_SSM_TEAM_SECRET_TEMPLATE
-              value: {{ .Values.credentialManager.awsSsm.teamSecretTemplate | quote }}
+              value: {{ .Values.concourse.web.awsSsm.teamSecretTemplate | quote }}
             {{- end }}
             {{- end }}
 

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -263,7 +263,6 @@ spec:
             {{- end }}
             {{- end }}
 
-
             {{- if .Values.concourse.web.awsSsm.enabled }}
             - name: CONCOURSE_AWS_SSM_ACCESS_KEY
               valueFrom:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes a syntax issue in the [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/APIReference/Welcome.html) configuration in the Concourse Helm Chart. Without this fix it is not possible to use Concourse v4.x and AWS SSM together.

Concourse can use the [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) to store configuration parameter and secrets.

#### Which issue this PR fixes

  - fixes #9199

#### Special notes for your reviewer:

- this is my first pull request in the Helm Chart repository.
- this pull request tries to finish what that pull request started: https://github.com/helm/charts/pull/8423

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
