### PR TITLE
Add custom serviceaccount functionality  to Sonarqube

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.10.1
+version: 0.11.0
 appVersion: 6.7.3
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | Parameter                                   | Description                               | Default                                    |
 | ------------------------------------------  | ----------------------------------------  | -------------------------------------------|
 | `serviceAccount.create`                     | Creates a Service Account                 | `false`                                    |
-| `serviceAccount.name`                       | The service account name. Uses existing SA if create set to false                 | `false`                                    |
+| `serviceAccount.name`                       | The service account name. Uses existing SA if create set to false                 | `empty`                                    |
 | `image.repository`                          | image repository                          | `sonarqube`                                |
 | `image.tag`                                 | `sonarqube` image tag.                    | 6.5                                        |
 | `image.pullPolicy`                          | Image pull policy                         | `IfNotPresent`                             |

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -39,6 +39,8 @@ The following table lists the configurable parameters of the Sonarqube chart and
 
 | Parameter                                   | Description                               | Default                                    |
 | ------------------------------------------  | ----------------------------------------  | -------------------------------------------|
+| `serviceAccount.create`                     | Creates a Service Account                 | `false`                                    |
+| `serviceAccount.name`                       | The service account name. Uses existing SA if create set to false                 | `false`                                    |
 | `image.repository`                          | image repository                          | `sonarqube`                                |
 | `image.tag`                                 | `sonarqube` image tag.                    | 6.5                                        |
 | `image.pullPolicy`                          | Image pull policy                         | `IfNotPresent`                             |

--- a/stable/sonarqube/templates/_helpers.tpl
+++ b/stable/sonarqube/templates/_helpers.tpl
@@ -47,3 +47,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "sonarqube.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "sonarqube.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
         app: {{ template "sonarqube.name" . }}
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ template "sonarqube.serviceAccountName" . }}
       {{- if .Values.plugins.install }}
       initContainers:
         - name: install-plugins

--- a/stable/sonarqube/templates/serviceaccount.yaml
+++ b/stable/sonarqube/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "sonarqube.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "sonarqube.serviceAccountName" . }}
+{{- end }}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -1,6 +1,13 @@
 # Default values for sonarqube.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# If using an existing service account set create to false, and specify a name.
+# Uses the default SA if no name is specified
+serviceAccount:
+  create: false
+  name:
+
 replicaCount: 1
 image:
   repository: sonarqube


### PR DESCRIPTION
Signed-off-by: Aaron Mell

#### What this PR does / why we need it:
Adds  a custom serviceaccount to the Sonarqube chart

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
