### PR TITLE
Deprecate gcloud-sqlproxy chart

### DIFF
--- a/stable/gcloud-sqlproxy/Chart.yaml
+++ b/stable/gcloud-sqlproxy/Chart.yaml
@@ -1,7 +1,7 @@
 name: gcloud-sqlproxy
-version: 0.6.0
+version: 0.6.1
 appVersion: 1.11
-description: Google Cloud SQL Proxy
+description: DEPRECATED Google Cloud SQL Proxy
 keywords:
 - google
 - cloud
@@ -12,7 +12,6 @@ keywords:
 home: https://cloud.google.com/sql/docs/postgres/sql-proxy
 sources:
 - https://github.com/rimusz/charts
-maintainers:
-- name: rimusz
-  email: rmocius@gmail.com
-engine: gotpl
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/buildkiterimusz/charts
+deprecated: true

--- a/stable/gcloud-sqlproxy/README.md
+++ b/stable/gcloud-sqlproxy/README.md
@@ -1,4 +1,9 @@
-# GCP SQL Proxy
+# GCP SQL Proxy - DEPRECATED
+
+**This chart is deprecated! You can find the new chart in:**
+- **Source:** https://github.com/rimusz/charts
+- **Charts repository:** https://charts.rimusz.net
+
 
 [sql-proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy) The Cloud SQL Proxy provides secure access to your Cloud SQL Postgres/MySQL instances without having to whitelist IP addresses or configure SSL.
 
@@ -9,7 +14,7 @@ Accessing your Cloud SQL instance using the Cloud SQL Proxy offers these advanta
 
 ## Introduction
 
-This chart creates a Google Cloud Endpoints deployment and service on a Kubernetes cluster using the Helm package manager.
+This chart creates a Google Cloud SQL Proxy deployment and service on a Kubernetes cluster using the Helm package manager.
 You need to enable Cloud SQL Administration API and create a service account for the proxy as per these [instructions](https://cloud.google.com/sql/docs/postgres/connect-container-engine).
 
 ## Prerequisites

--- a/stable/gcloud-sqlproxy/templates/NOTES.txt
+++ b/stable/gcloud-sqlproxy/templates/NOTES.txt
@@ -1,3 +1,5 @@
+#### THIS CHART IS DEPRECATED! ####
+
 ** Please be patient while the chart is being deployed **
 
 {{ if not (or .Values.serviceAccountKey .Values.existingSecret) -}}


### PR DESCRIPTION
Signed-off-by: rimas <rmocius@gmail.com>

Deprecating gcloud-sqlproxy chart in preparation for the new Helm Distributed repo (hub).
gcloud-sqlproxy  chart is already hosted at https://github.com/rimusz/charts/tree/master/stable/gcloud-sqlproxy