### PR TITLE
[stable/rabbitmq-ha] Remove readOnly flag from the config volume

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.8
-version: 1.14.2
+version: 1.14.3
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -155,7 +155,6 @@ spec:
               mountPath: /var/lib/rabbitmq
             - name: config
               mountPath: /etc/rabbitmq
-              readOnly: true
             {{- if not .Values.existingSecret }}
             - name: definitions
               mountPath: /etc/definitions


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove a useless constraint on the config files volume

#### Which issue this PR fixes
  - fixes #9220

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
