### PR TITLE
Adds tolerations to cassandra statefulset spec

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.9.2
+version: 0.9.3
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -135,6 +135,9 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `exporter.image.tag`                 | Exporter image tag                              | `2.0.2`                                                    |
 | `exporter.port`                      | Exporter port                                   | `5556`                                                     |
 | `exporter.jvmOpts`                   | Exporter additional JVM options                 |                                                            |
+| `affinity`                           | Kubernetes node affinity                        | `{}`                                                       |
+| `tolerations`                        | Kubernetes node tolerations                     | `[]`                                                       |
+
 
 ## Scale cassandra
 When you want to change the cluster size of your cassandra, you can use the helm upgrade command.

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
 {{- end }}
 {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations indent 8 }}
+{{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}
       containers:
 {{- if .Values.exporter.enabled }}

--- a/incubator/cassandra/templates/statefulset.yaml
+++ b/incubator/cassandra/templates/statefulset.yaml
@@ -42,6 +42,10 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
 {{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations indent 8 }}
+{{- end }}
       containers:
 {{- if .Values.exporter.enabled }}
       - name: cassandra-exporter

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -124,6 +124,10 @@ securityContext:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+## Node tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true


### PR DESCRIPTION
Signed-off-by: Tom Gummery <tgummery@unit2games.com>

@KongZ @maver1ck

#### What this PR does / why we need it:
Adds `tolerations` section to the pod spec so that Cassandra pods can be scheduled to tainted nodes.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
