### PR TITLE
haproxy-ingress updates and new features

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 name: haproxy-ingress
-version: 0.0.2
-appVersion: 0.5.3
+version: 0.0.3
+appVersion: 0.6.0
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.
 icon: http://www.haproxy.org/img/HAProxyCommunityEdition_60px.png

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -53,12 +53,13 @@ Parameter | Description | Default
 `controller.defaultSslCertificate.secret.name` | name of the secret for default certificate of controller | `""`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#configmap) | `{}`
 `controller.healthzPort` | The port number for liveness and readiness checks | `10253`
-`controller.hostPorts.http` | If `controller.useHostPort` is `true` sets the hostPort | `"80"`
-`controller.hostPorts.https` | If `controller.useHostPort` is `true` sets the hostPort | `"443"`
+`controller.hostPorts.enable` | Enable host-ports for selected ports | `false`
+`controller.hostPorts.http` | If `controller.hostPorts.enable` is `true` and this is non-empty sets the hostPort for http | `"80"`
+`controller.hostPorts.https` | If `controller.hostPorts.enable` is `true` and this is non-empty sets the hostPort for https | `"443"`
+`controller.hostPorts.tcp` | If `controller.hostPorts.enable` is `true` use hostport for these ports from `tcp` | `[]`
 `controller.ingressClass` | name of the ingress class to route through this controller | `haproxy`
 `controller.resources` | controller pod resource requests & limits | `{}`
 `controller.statsPort` | The port number for haproxy statistics | `1936`
-`controller.useHostPort` | enable `hostPort` for http, https and any other tcp ports | `false`
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`
 `controller.service.clusterIP` | internal controller cluster service IP | `""`

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -51,14 +51,23 @@ Parameter | Description | Default
 `controller.image.pullPolicy` | controller container image pullPolicy | `IfNotPresent`
 `controller.defaultSslCertificate.secret.namespace` | namespace of default certificate for controller | `{{ .Release.Namespace }}`
 `controller.defaultSslCertificate.secret.name` | name of the secret for default certificate of controller | `""`
-`controller.config` | haproxy ConfigMap entries | none
+`controller.config` | additional haproxy-ingress [ConfigMap entries](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#configmap) | `{}`
+`controller.healthzPort` | The port number for liveness and readiness checks | `10253`
+`controller.hostPorts.http` | If `controller.useHostPort` is `true` sets the hostPort | `"80"`
+`controller.hostPorts.https` | If `controller.useHostPort` is `true` sets the hostPort | `"443"`
+`controller.ingressClass` | name of the ingress class to route through this controller | `haproxy`
+`controller.resources` | controller pod resource requests & limits | `{}`
+`controller.statsPort` | The port number for haproxy statistics | `1936`
+`controller.useHostPort` | enable `hostPort` for http, https and any other tcp ports | `false`
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`
 `controller.service.clusterIP` | internal controller cluster service IP | `""`
+`controller.service.enableHttp` | if port 80 should be opened for service | `true`
+`controller.service.enableHttps` | if port 443 should be opened for service | `true`
+`controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
 `controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
 `controller.service.nodePorts.http` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
 `controller.service.nodePorts.https` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`
-
-
+`tcp` | TCP [service ConfigMap](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#tcp-services-configmap): `<port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]` | `{}`

--- a/incubator/haproxy-ingress/templates/controller-configmap.yaml
+++ b/incubator/haproxy-ingress/templates/controller-configmap.yaml
@@ -4,4 +4,8 @@ metadata:
   name: {{ template "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
+  healthz-port: {{ .Values.controller.healthzPort | quote }}
+  stats-port: {{ .Values.controller.statsPort | quote }}
+{{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}
+{{- end }}

--- a/incubator/haproxy-ingress/templates/controller-configmap.yaml
+++ b/incubator/haproxy-ingress/templates/controller-configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: {{ template "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
-{{ toYaml .Values.controller.headers | indent 2 }}
+{{ toYaml .Values.controller.config | indent 2 }}

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -33,6 +33,9 @@ spec:
             - --configmap={{ .Release.Namespace }}/{{ template "haproxy-ingress.fullname" . }}
             - --ingress-class={{ .Values.controller.ingressClass }}
             - --sort-backends
+          {{- if .Values.tcp }}
+            - --tcp-services-configmap={{ .Release.Namespace }}/{{ template "haproxy-ingress.fullname" . }}-tcp
+          {{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -40,6 +43,11 @@ spec:
               containerPort: 443
             - name: stat
               containerPort: 1936
+          {{- range $key, $value := .Values.tcp }}
+            - name: "{{ $key }}-tcp"
+              containerPort: {{ $key }}
+              protocol: TCP
+          {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -41,13 +41,25 @@ spec:
               containerPort: 80
             - name: https
               containerPort: 443
-            - name: stat
-              containerPort: 1936
+            - name: stats
+              containerPort: {{ .Values.controller.statsPort }}
+            - name: healthz
+              containerPort: {{ .Values.controller.healthzPort }}
           {{- range $key, $value := .Values.tcp }}
             - name: "{{ $key }}-tcp"
               containerPort: {{ $key }}
               protocol: TCP
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.controller.healthzPort }}
+              scheme: HTTP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.controller.healthzPort }}
+              scheme: HTTP
           env:
             - name: POD_NAME
               valueFrom:

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -39,8 +39,14 @@ spec:
           ports:
             - name: http
               containerPort: 80
+            {{- if .Values.controller.useHostPort }}
+              hostPort: {{ .Values.controller.hostPorts.http }}
+            {{- end }}
             - name: https
               containerPort: 443
+            {{- if .Values.controller.useHostPort }}
+              hostPort: {{ .Values.controller.hostPorts.https }}
+            {{- end }}
             - name: stats
               containerPort: {{ .Values.controller.statsPort }}
             - name: healthz
@@ -49,6 +55,9 @@ spec:
             - name: "{{ $key }}-tcp"
               containerPort: {{ $key }}
               protocol: TCP
+            {{- if $.Values.controller.useHostPort }}
+              hostPort: {{ $key }}
+            {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -69,3 +69,5 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          resources:
+{{ toYaml .Values.controller.resources | indent 12 }}

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -39,12 +39,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
-            {{- if .Values.controller.useHostPort }}
+            {{- if (and .Values.controller.hostPorts.enable (not (empty .Values.controller.hostPorts.http))) }}
               hostPort: {{ .Values.controller.hostPorts.http }}
             {{- end }}
             - name: https
               containerPort: 443
-            {{- if .Values.controller.useHostPort }}
+            {{- if (and .Values.controller.hostPorts.enable (not (empty .Values.controller.hostPorts.https))) }}
               hostPort: {{ .Values.controller.hostPorts.https }}
             {{- end }}
             - name: stats
@@ -55,8 +55,12 @@ spec:
             - name: "{{ $key }}-tcp"
               containerPort: {{ $key }}
               protocol: TCP
-            {{- if $.Values.controller.useHostPort }}
+            {{- if $.Values.controller.hostPorts.enable }}
+              {{- range $p := $.Values.controller.hostPorts.tcp }}
+                {{- if eq $key $p }}
               hostPort: {{ $key }}
+                {{- end }}
+              {{- end }}
             {{- end }}
           {{- end }}
           livenessProbe:

--- a/incubator/haproxy-ingress/templates/controller-daemonset.yaml
+++ b/incubator/haproxy-ingress/templates/controller-daemonset.yaml
@@ -31,6 +31,7 @@ spec:
             - --default-ssl-certificate={{ .Values.controller.defaultSslCertificate.secret.namespace | default .Release.Namespace }}/{{ .Values.controller.defaultSslCertificate.secret.name }}
           {{- end}}
             - --configmap={{ .Release.Namespace }}/{{ template "haproxy-ingress.fullname" . }}
+            - --ingress-class={{ .Values.controller.ingressClass }}
             - --sort-backends
           ports:
             - name: http

--- a/incubator/haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-service.yaml
@@ -23,6 +23,7 @@ spec:
   loadBalancerIP: "{{ .Values.controller.service.loadBalancerIP }}"
 {{- end }}
   ports:
+    {{- if .Values.controller.service.enableHttp }}
     - name: http
       port: 80
       protocol: TCP
@@ -30,6 +31,8 @@ spec:
       {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
       {{- end }}
+    {{- end }}
+    {{- if .Values.controller.service.enableHttps }}
     - name: https
       port: 443
       protocol: TCP
@@ -37,6 +40,7 @@ spec:
       {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
       {{- end }}
+    {{- end }}
   selector:
     app: {{ template "haproxy-ingress.name" . }}
     release: {{ .Release.Name }}

--- a/incubator/haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-service.yaml
@@ -41,6 +41,12 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.https }}
       {{- end }}
     {{- end }}
+  {{- range $key, $value := .Values.tcp }}
+    - name: "{{ $key }}-tcp"
+      port: {{ $key }}
+      protocol: TCP
+      targetPort: "{{ $key }}-tcp"
+  {{- end }}
   selector:
     app: {{ template "haproxy-ingress.name" . }}
     release: {{ .Release.Name }}

--- a/incubator/haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-service.yaml
@@ -16,7 +16,12 @@ metadata:
   name: {{ template "haproxy-ingress.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+{{- if .Values.controller.service.clusterIP }}
   clusterIP: "{{ .Values.controller.service.clusterIP }}"
+{{- end }}
+{{- if .Values.controller.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.service.loadBalancerIP }}"
+{{- end }}
   ports:
     - name: http
       port: 80

--- a/incubator/haproxy-ingress/templates/tcp-configmap.yaml
+++ b/incubator/haproxy-ingress/templates/tcp-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.tcp }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxy-ingress.fullname" . }}-tcp
+data:
+{{ toYaml .Values.tcp | indent 2 }}
+{{- end }}

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -44,6 +44,9 @@ controller:
   # Name of the ingress class to route through this controller
   ingressClass: haproxy
 
+  healthzPort: 10253
+  statsPort: 1936
+
   service:
     annotations: {}
     labels: {}

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -28,7 +28,7 @@ controller:
   name: controller
   image:
     repository: quay.io/jcmoraisjr/haproxy-ingress
-    tag: "v0.5-beta.3"
+    tag: "v0.6"
     pullPolicy: IfNotPresent
 
   defaultSslCertificate:

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -41,11 +41,13 @@ controller:
   # ConfigMap to configure haproxy ingress
   config: {}
 
-  # Use host ports http, http3, and any specified in tcp
-  useHostPort: false
+  # Use host ports?
   hostPorts:
+    enable: false
     http: 80
     https: 443
+    # List of ports from tcp map
+    tcp: []
 
 
   # Name of the ingress class to route through this controller

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -41,6 +41,13 @@ controller:
   # ConfigMap to configure haproxy ingress
   config: {}
 
+  # Use host ports http, http3, and any specified in tcp
+  useHostPort: false
+  hostPorts:
+    http: 80
+    https: 443
+
+
   # Name of the ingress class to route through this controller
   ingressClass: haproxy
 

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -41,6 +41,9 @@ controller:
   # ConfigMap to configure haproxy ingress
   config: {}
 
+  # Name of the ingress class to route through this controller
+  ingressClass: haproxy
+
   service:
     annotations: {}
     labels: {}

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -56,6 +56,9 @@ controller:
     type: LoadBalancer
     loadBalancerIP: ""
 
+    enableHttp: true
+    enableHttps: true
+
     # type: NodePort
     # nodePorts:
     #   http: 32080

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -66,3 +66,9 @@ controller:
     nodePorts:
       http: ""
       https: ""
+
+# TCP service key:value pairs
+# <port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]
+# https://github.com/jcmoraisjr/haproxy-ingress/tree/v0.6#tcp-services-configmap
+tcp: {}
+#  8080: "default/example-tcp-svc:9000"

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -70,6 +70,8 @@ controller:
       http: ""
       https: ""
 
+  resources: {}
+
 # TCP service key:value pairs
 # <port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]
 # https://github.com/jcmoraisjr/haproxy-ingress/tree/v0.6#tcp-services-configmap

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -54,6 +54,7 @@ controller:
       https: 443
 
     type: LoadBalancer
+    loadBalancerIP: ""
 
     # type: NodePort
     # nodePorts:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updated:
- haproxy-ingress image version

Fixed:
- `controller.config` ConfigMap, previously it was referenced as `controller.headers` and therefore ignored

New:
- `tcp`: A port-service map for TCP (non-HTTP) forwarding
- `controller.ingressClass`: Optional custom ingress class
- `controller.healthzPort`, `controller.statsPort`: These were already enabled in haproxy-ingress, these parameters allow the ports to be configured
- Added readiness and liveness checks 
- `controller.useHostPort`: haproxy-ingress can bind to hostports, e.g. for bare-metal clusters (based on nginx-ingress). Can be configured with `controller.hostPorts.http`, `controller.hostPorts.https`
- `controller.resources`: Controller pod limits
- `controller.service.enableHttp`, `controller.service.enableHttps`: control which service ports are enabled (based on nginx-ingress)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
@xianlubird
