### PR TITLE
Ark correct apitimeout

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.9.1
 description: A Helm chart for ark
 name: ark
-version: 1.2.2
+version: 1.2.3
 home: https://heptio.com/products/#heptio-ark
 sources:
 - https://github.com/heptio/ark

--- a/stable/ark/templates/configmap.yaml
+++ b/stable/ark/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
       {{- with .region }}
         region: {{ . }}
       {{- end }}
-      {{- with .apitimeout }}
+      {{- with .apiTimeout }}
         apiTimeout: {{ . }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Ark chart doesn't work with Azure, since the apiTimeout was not set correctly.

#### Which issue this PR fixes
no related issue exists yet


#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
