### PR TITLE
Update stable/grafana README to reflect actual default value

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.17.6
+version: 1.17.7
 appVersion: 5.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -53,7 +53,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tolerations`                   | Toleration labels for pod assignment          | `[]`                                                    |
 | `affinity`                      | Affinity settings for pod assignment          | `{}`                                                    |
 | `persistence.enabled`           | Use persistent volume to store data           | `false`                                                 |
-| `persistence.size`              | Size of persistent volume claim               | `10Gi`                                                  |
+| `persistence.size`              | Size of persistent volume claim               | `nil`                                                  |
 | `persistence.existingClaim`     | Use an existing PVC to persist data           | `nil`                                                   |
 | `persistence.storageClassName`  | Type of persistent volume claim               | `nil`                                                   |
 | `persistence.accessModes`       | Persistence access modes                      | `[]`                                                    |


### PR DESCRIPTION
#### What this PR does / why we need it:

The README suggests that `persistence.size` has a default of `10Gi`, but there is no default in the `values.yaml`. Well, there is, but [it's commented out](https://github.com/helm/charts/blob/master/stable/grafana/values.yaml#L107). This hung me up for a minute when I was enabling persistence in our installation.

#### Which issue this PR fixes

#### Special notes for your reviewer:

Thanks so much for this chart, it's great!

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
