### PR TITLE
[incubator/cassandra] update backup image - enable ABS support

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.9.1
+version: 0.9.2
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -125,8 +125,8 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `backup.enabled`                     | Enable backup on chart installation             | `false`                                                    |
 | `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
 | `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |
-| `backup.image.repo`                  | Backup image repository                         | `maorfr/cain`                                              |
-| `backup.image.tag`                   | Backup image tag                                | `0.1.0`                                                    |
+| `backup.image.repo`                  | Backup image repository                         | `nuvo/cain`                                                |
+| `backup.image.tag`                   | Backup image tag                                | `0.2.0`                                                    |
 | `backup.env`                         | Backup environment variables                    | AWS_REGION: `us-east-1`                                    |
 | `backup.resources`                   | Backup CPU/Memory resource requests/limits      | Memory: `1Gi`, CPU: `1`                                    |
 | `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |

--- a/incubator/cassandra/templates/backup/cronjob.yaml
+++ b/incubator/cassandra/templates/backup/cronjob.yaml
@@ -40,8 +40,6 @@ spec:
             - {{ $schedule.keyspace }}
             - --dst
             - {{ $backup.destination }}
-            - --parallel
-            - "0"
           {{- with $backup.env }}
             env:
 {{ toYaml . | indent 12 }}

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -136,7 +136,7 @@ serviceAccount:
   # name:
 
 ## Backup cronjob configuration
-## Ref: https://github.com/maorfr/cain
+## Ref: https://github.com/nuvo/cain
 backup:
   enabled: false
 
@@ -149,13 +149,13 @@ backup:
     cron: "30 7 * * *"
 
   annotations:
-    # Example for authorization using kube2iam
+    # Example for authorization to AWS S3 using kube2iam
     # Can also be done using environment variables
     iam.amazonaws.com/role: cain
 
   image:
-    repos: maorfr/cain
-    tag: 0.1.0
+    repos: nuvo/cain
+    tag: 0.2.0
 
   # Add additional environment variables
   env:
@@ -172,9 +172,9 @@ backup:
       cpu: 1
 
   # Destination to store the backup artifacts
-  # Currently only s3 is supported
-  # Additional support can added.
-  # Ref: https://github.com/maorfr/skbn
+  # Supported cloud storage services: AWS S3, Azure Blob Storage
+  # Additional support can added. Visit this repository for details
+  # Ref: https://github.com/nuvo/skbn
   destination: s3://bucket/cassandra
 
 ## Cassandra exported configuration


### PR DESCRIPTION
#### What this PR does / why we need it:

Change backup image to our company's official image.
Update version to enable support for Azure Blob Storage.
Remove parallelism level of "full" to use default of 1 - reduces resources consumption.

Thanks!