### PR TITLE
[stable/grafana] Update sidecar to allow searches in a single namespace

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.17.6
+version: 1.18.0
 appVersion: 5.3.4
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -29,54 +29,56 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-| Parameter                       | Description                                   | Default                                                 |
-|---------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `replicas`                      | Number of nodes                               | `1`                                                     |
-| `deploymentStrategy`            | Deployment strategy                           | `RollingUpdate`                                         |
-| `livenessProbe`                 | Liveness Probe settings                       | `{ "httpGet": { "path": "/api/health", "port": 3000 } "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10 }` |
-| `readinessProbe`                | Rediness Probe settings                       | `{ "httpGet": { "path": "/api/health", "port": 3000 } }`|
-| `securityContext`               | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
-| `image.repository`              | Image repository                              | `grafana/grafana`                                       |
-| `image.tag`                     | Image tag. (`Must be >= 5.0.0`)               | `5.3.4`                                                 |
-| `image.pullPolicy`              | Image pull policy                             | `IfNotPresent`                                          |
-| `service.type`                  | Kubernetes service type                       | `ClusterIP`                                             |
-| `service.port`                  | Kubernetes port where service is exposed      | `80`                                                    |
-| `service.annotations`           | Service annotations                           | `{}`                                                    |
-| `service.labels`                | Custom labels                                 | `{}`                                                    |
-| `ingress.enabled`               | Enables Ingress                               | `false`                                                 |
-| `ingress.annotations`           | Ingress annotations                           | `{}`                                                    |
-| `ingress.labels`                | Custom labels                                 | `{}`                                                    |
-| `ingress.hosts`                 | Ingress accepted hostnames                    | `[]`                                                    |
-| `ingress.tls`                   | Ingress TLS configuration                     | `[]`                                                    |
-| `resources`                     | CPU/Memory resource requests/limits           | `{}`                                                    |
-| `nodeSelector`                  | Node labels for pod assignment                | `{}`                                                    |
-| `tolerations`                   | Toleration labels for pod assignment          | `[]`                                                    |
-| `affinity`                      | Affinity settings for pod assignment          | `{}`                                                    |
-| `persistence.enabled`           | Use persistent volume to store data           | `false`                                                 |
-| `persistence.size`              | Size of persistent volume claim               | `10Gi`                                                  |
-| `persistence.existingClaim`     | Use an existing PVC to persist data           | `nil`                                                   |
-| `persistence.storageClassName`  | Type of persistent volume claim               | `nil`                                                   |
-| `persistence.accessModes`       | Persistence access modes                      | `[]`                                                    |
-| `persistence.subPath`           | Mount a sub dir of the persistent volume      | `""`                                                    |
-| `schedulerName`                 | Alternate scheduler name                      | `nil`                                                   |
-| `env`                           | Extra environment variables passed to pods    | `{}`                                                    |
-| `envFromSecret`                 | Name of a Kubenretes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |
-| `extraSecretMounts`             | Additional grafana server secret mounts       | `[]`                                                    |
-| `plugins`                       | Plugins to be loaded along with Grafana       | `[]`                                                    |
-| `datasources`                   | Configure grafana datasources                 | `{}`                                                    |
-| `dashboardProviders`            | Configure grafana dashboard providers         | `{}`                                                    |
-| `dashboards`                    | Dashboards to import                          | `{}`                                                    |
-| `dashboardsConfigMaps`          | ConfigMaps reference that contains dashboards | `{}`                                                    |
-| `grafana.ini`                   | Grafana's primary configuration               | `{}`                                                    |
-| `ldap.existingSecret`           | The name of an existing secret containing the `ldap.toml` file, this must have the key `ldap-toml`. | `""` |
-| `ldap.config  `                 | Grafana's LDAP configuration                  | `""`                                                    |
-| `annotations`                   | Deployment annotations                        | `{}`                                                    |
-| `podAnnotations`                | Pod annotations                               | `{}`                                                    |
-| `sidecar.dashboards.enabled`    | Enabled the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
-| `sidecar.dashboards.label`      | Label that config maps with dashboards should have to be added | `false`                                |
-| `sidecar.datasources.enabled`   | Enabled the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |
-| `sidecar.datasources.label`     | Label that config maps with datasources should have to be added | `false`                               |
-| `smtp.existingSecret`           | The name of an existing secret containing the SMTP credentials, this must have the keys `user` and `password`. | `""` |
+| Parameter                                 | Description                                   | Default                                                 |
+|-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
+| `replicas`                                | Number of nodes                               | `1`                                                     |
+| `deploymentStrategy`                      | Deployment strategy                           | `RollingUpdate`                                         |
+| `livenessProbe`                           | Liveness Probe settings                       | `{ "httpGet": { "path": "/api/health", "port": 3000 } "initialDelaySeconds": 60, "timeoutSeconds": 30, "failureThreshold": 10 }` |
+| `readinessProbe`                          | Rediness Probe settings                       | `{ "httpGet": { "path": "/api/health", "port": 3000 } }`|
+| `securityContext`                         | Deployment securityContext                    | `{"runAsUser": 472, "fsGroup": 472}`                    |
+| `image.repository`                        | Image repository                              | `grafana/grafana`                                       |
+| `image.tag`                               | Image tag. (`Must be >= 5.0.0`)               | `5.3.4`                                                 |
+| `image.pullPolicy`                        | Image pull policy                             | `IfNotPresent`                                          |
+| `service.type`                            | Kubernetes service type                       | `ClusterIP`                                             |
+| `service.port`                            | Kubernetes port where service is exposed      | `80`                                                    |
+| `service.annotations`                     | Service annotations                           | `{}`                                                    |
+| `service.labels`                          | Custom labels                                 | `{}`                                                    |
+| `ingress.enabled`                         | Enables Ingress                               | `false`                                                 |
+| `ingress.annotations`                     | Ingress annotations                           | `{}`                                                    |
+| `ingress.labels`                          | Custom labels                                 | `{}`                                                    |
+| `ingress.hosts`                           | Ingress accepted hostnames                    | `[]`                                                    |
+| `ingress.tls`                             | Ingress TLS configuration                     | `[]`                                                    |
+| `resources`                               | CPU/Memory resource requests/limits           | `{}`                                                    |
+| `nodeSelector`                            | Node labels for pod assignment                | `{}`                                                    |
+| `tolerations`                             | Toleration labels for pod assignment          | `[]`                                                    |
+| `affinity`                                | Affinity settings for pod assignment          | `{}`                                                    |
+| `persistence.enabled`                     | Use persistent volume to store data           | `false`                                                 |
+| `persistence.size`                        | Size of persistent volume claim               | `10Gi`                                                  |
+| `persistence.existingClaim`               | Use an existing PVC to persist data           | `nil`                                                   |
+| `persistence.storageClassName`            | Type of persistent volume claim               | `nil`                                                   |
+| `persistence.accessModes`                 | Persistence access modes                      | `[]`                                                    |
+| `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `""`                                                    |
+| `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
+| `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
+| `envFromSecret`                           | Name of a Kubenretes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |
+| `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
+| `plugins`                                 | Plugins to be loaded along with Grafana       | `[]`                                                    |
+| `datasources`                             | Configure grafana datasources                 | `{}`                                                    |
+| `dashboardProviders`                      | Configure grafana dashboard providers         | `{}`                                                    |
+| `dashboards`                              | Dashboards to import                          | `{}`                                                    |
+| `dashboardsConfigMaps`                    | ConfigMaps reference that contains dashboards | `{}`                                                    |
+| `grafana.ini`                             | Grafana's primary configuration               | `{}`                                                    |
+| `ldap.existingSecret`                     | The name of an existing secret containing the `ldap.toml` file, this must have the key `ldap-toml`. | `""` |
+| `ldap.config  `                           | Grafana's LDAP configuration                  | `""`                                                    |
+| `annotations`                             | Deployment annotations                        | `{}`                                                    |
+| `podAnnotations`                          | Pod annotations                               | `{}`                                                    |
+| `sidecar.dashboards.enabled`              | Enabled the cluster wide search for dashboards and adds/updates/deletes them in grafana | `false`       |
+| `sidecar.dashboards.label`                | Label that config maps with dashboards should have to be added | `false`                                |
+| `sidecar.dashboards.searchNamespace`      | If specified, the sidecar will search for dashboard config-maps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces | `nil`                                |
+| `sidecar.datasources.enabled`             | Enabled the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |
+| `sidecar.datasources.label`               | Label that config maps with datasources should have to be added | `false`                               |
+| `sidecar.datasources.searchNamespace`     | If specified, the sidecar will search for datasources config-maps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces | `nil`                               |
+| `smtp.existingSecret`                     | The name of an existing secret containing the SMTP credentials, this must have the keys `user` and `password`. | `""` |
 
 ## Sidecar for dashboards
 

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     type: {{ .Values.deploymentStrategy }}
   {{- if ne .Values.deploymentStrategy "RollingUpdate" }}
     rollingUpdate: null
-  {{- end }}    
+  {{- end }}
   template:
     metadata:
       labels:
@@ -75,6 +75,10 @@ spec:
               value: "{{ .Values.sidecar.dashboards.label }}"
             - name: FOLDER
               value: "{{ .Values.sidecar.dashboards.folder }}"
+            {{- if .Values.sidecar.dashboards.searchNamespace }}
+            - name: NAMESPACE
+              value: "{{ .Values.sidecar.dashboards.searchNamespace }}"
+            {{- end }}
           resources:
 {{ toYaml .Values.sidecar.resources | indent 12 }}
           volumeMounts:
@@ -90,6 +94,10 @@ spec:
               value: "{{ .Values.sidecar.datasources.label }}"
             - name: FOLDER
               value: "/etc/grafana/provisioning/datasources"
+            {{- if .Values.sidecar.datasources.searchNamespace }}
+            - name: NAMESPACE
+              value: "{{ .Values.sidecar.datasources.searchNamespace }}"
+            {{- end }}
           resources:
 {{ toYaml .Values.sidecar.resources | indent 12 }}
           volumeMounts:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -254,7 +254,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:0.0.3
+  image: kiwigrid/k8s-sidecar:0.0.6
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:
@@ -269,7 +269,15 @@ sidecar:
     label: grafana_dashboard
     # folder in the pod that should hold the collected dashboards
     folder: /tmp/dashboards
+    # If specified, the sidecar will search for dashboard config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
   datasources:
     enabled: false
     # label that the configmaps with datasources are marked with
     label: grafana_datasource
+    # If specified, the sidecar will search for datasource config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null


### PR DESCRIPTION
#### What this PR does / why we need it:
The grafana sidecar is out of date and needs to be updated to support the ability to restrict namespaces in which dashboards and datasources are loaded from.

#### Which issue this PR fixes
- fixes #9136

#### Special notes for your reviewer:
The upgrade to the chart between 1.17 and 1.18 is because this is a more restrictive namespace search. If it's worth making a change to search in ALL namespaces and then follow up with a 1.18 release for the breaking defaults change I can do that one instead.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
