### PR TITLE
add metrics servicemonitor to stable/redis 

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.2.10
+version: 4.2.11
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.3.10
+version: 4.3.0
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.2.11
+version: 4.3.10
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -109,6 +109,10 @@ The following table lists the configurable parameters of the Redis chart and the
 | `metrics.service.annotations`              | Annotations for the services to monitor  (redis master and redis slave service)                                | {}                                                   |
 | `metrics.service.loadBalancerIP`           | loadBalancerIP if redis metrics service type is `LoadBalancer`                                                 | `nil`                                                |
 | `metrics.resources`                        | Exporter resource requests/limit                                                                               | Memory: `256Mi`, CPU: `100m`                         |
+| `metrics.serviceMonitor.enabled`           | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)         | `false`
+| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                                       | `monitoring`
+| `metrics.serviceMonitor.interval`          | Interval that Prometheus scrapes Cluster Autoscaler metrics                                                    | `10s`
+| `metrics.serviceMonitor.selector`          | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install     | `{ prometheus: kube-prometheus }`
 | `persistence.existingClaim`                | Provide an existing PersistentVolumeClaim                                                                      | `nil`                                                |
 | `master.persistence.enabled`               | Use a PVC to persist data (master node)                                                                        | `true`                                               |
 | `master.persistence.path`                  | Path to mount the volume at, to use other images                                                               | `/bitnami`                                           |

--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -109,10 +109,10 @@ The following table lists the configurable parameters of the Redis chart and the
 | `metrics.service.annotations`              | Annotations for the services to monitor  (redis master and redis slave service)                                | {}                                                   |
 | `metrics.service.loadBalancerIP`           | loadBalancerIP if redis metrics service type is `LoadBalancer`                                                 | `nil`                                                |
 | `metrics.resources`                        | Exporter resource requests/limit                                                                               | Memory: `256Mi`, CPU: `100m`                         |
-| `metrics.serviceMonitor.enabled`           | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)         | `false`
-| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                                       | `monitoring`
-| `metrics.serviceMonitor.interval`          | Interval that Prometheus scrapes Cluster Autoscaler metrics                                                    | `10s`
-| `metrics.serviceMonitor.selector`          | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install     | `{ prometheus: kube-prometheus }`
+| `metrics.serviceMonitor.enabled`           | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)         | `false`                                              |
+| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                                       | `monitoring`                                         |
+| `metrics.serviceMonitor.interval`          | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                         |  `nil`                                               |
+| `metrics.serviceMonitor.selector`          | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install     | `{ prometheus: kube-prometheus }`                    |
 | `persistence.existingClaim`                | Provide an existing PersistentVolumeClaim                                                                      | `nil`                                                |
 | `master.persistence.enabled`               | Use a PVC to persist data (master node)                                                                        | `true`                                               |
 | `master.persistence.path`                  | Path to mount the volume at, to use other images                                                               | `/bitnami`                                           |

--- a/stable/redis/templates/metrics-prometheus.yaml
+++ b/stable/redis/templates/metrics-prometheus.yaml
@@ -2,11 +2,15 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "redis.fullname" . }}
+  name: {{ template "redis.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels:
+    app: {{ template "redis.name" . }}
+    chart: {{ template "redis.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/stable/redis/templates/metrics-prometheus.yaml
+++ b/stable/redis/templates/metrics-prometheus.yaml
@@ -1,0 +1,22 @@
+{{- if and (.Values.metrics.enabled) (.Values.metrics.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "redis.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.metrics.serviceMonitor.interval }}
+    port: metrics
+  selector:
+    matchLabels:
+      app: {{ template "redis.name" . }}
+  namespaceSelector:
+      any: true
+{{- end -}}

--- a/stable/redis/templates/metrics-prometheus.yaml
+++ b/stable/redis/templates/metrics-prometheus.yaml
@@ -16,8 +16,10 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - interval: {{ .Values.metrics.serviceMonitor.interval }}
-    port: metrics
+  - port: metrics
+    {{- if .Values.metrics.serviceMonitor.interval }}
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
+    {{- end }}
   selector:
     matchLabels:
       app: {{ template "redis.name" . }}

--- a/stable/redis/values-production.yaml
+++ b/stable/redis/values-production.yaml
@@ -341,7 +341,8 @@ metrics:
   serviceMonitor:
     enabled: false
     namespace: monitoring
-    interval: 10s
+    # fallback to the prometheus default unless specified
+    # interval: 10s
     ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
     ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
     ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)

--- a/stable/redis/values-production.yaml
+++ b/stable/redis/values-production.yaml
@@ -337,6 +337,17 @@ metrics:
   # podAnnotations: {}
   # podLabels: {}
 
+  # Enable this if you're using https://github.com/coreos/prometheus-operator
+  serviceMonitor:
+    enabled: false
+    namespace: monitoring
+    interval: 10s
+    ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
+    ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
+    ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
+    selector:
+      prometheus: kube-prometheus
+
 ##
 ## Init containers parameters:
 ## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -341,6 +341,17 @@ metrics:
   # podAnnotations: {}
   # podLabels: {}
 
+  # Enable this if you're using https://github.com/coreos/prometheus-operator
+  serviceMonitor:
+    enabled: false
+    namespace: monitoring
+    interval: 10s
+    ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
+    ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
+    ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
+    selector:
+      prometheus: kube-prometheus
+
 ##
 ## Init containers parameters:
 ## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -345,7 +345,8 @@ metrics:
   serviceMonitor:
     enabled: false
     namespace: monitoring
-    interval: 10s
+    # fallback to the prometheus default unless specified
+    # interval: 10s
     ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
     ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
     ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)


### PR DESCRIPTION
#### What this PR does / why we need it:

Add support for prometheus operator ServiceMonitor.    

Since this only makes sense if you have metrics enabled, the configuration has been nested under the `metrics.` configuration prefix as `metrics.serviceMonitor`. 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
