### PR TITLE
[stable/prometheus] Defaulting the PVC's reclaim policy to Retain

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 7.4.3
+version: 7.4.4
 appVersion: 2.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -246,6 +246,7 @@ Parameter | Description | Default
 `server.persistentVolume.annotations` | Prometheus server data Persistent Volume annotations | `{}`
 `server.persistentVolume.existingClaim` | Prometheus server data Persistent Volume existing claim name | `""`
 `server.persistentVolume.mountPath` | Prometheus server data Persistent Volume mount root path | `/data`
+`server.persistentVolume.reclaimPolicy` | Prometheus server data Persistent Volume reclaim policy | `Retain`
 `server.persistentVolume.size` | Prometheus server data Persistent Volume size | `8Gi`
 `server.persistentVolume.storageClass` | Prometheus server data Persistent Volume Storage Class |  `unset`
 `server.persistentVolume.subPath` | Subdirectory of Prometheus server data Persistent Volume to mount | `""`

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -24,6 +24,7 @@ spec:
   storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
 {{- end }}
 {{- end }}
+  persistentVolumeReclaimPolicy: {{ .Values.server.persistentVolume.reclaimPolicy | quote }}
   resources:
     requests:
       storage: "{{ .Values.server.persistentVolume.size }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -651,6 +651,12 @@ server:
     ##
     subPath: ""
 
+    ## reclaimPolicy for the persistent volume.
+    ## See https://kubernetes.io/docs/tasks/administer-cluster/change-pv-reclaim-policy/
+    ## Can be Retain, Recycle, or Delete
+    ##
+    reclaimPolicy: Retain
+
   ## Annotations to be added to Prometheus server pods
   ##
   podAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

- Sets the Prometheus PVC's `persistentVolumeReclaimPolicy` to `Retain` by default
- Allows overriding the value with `server.persistentVolume.reclaimPolicy`

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Dave Henderson <dhenderson@gmail.com>