### PR TITLE
[stable/kube-slack] Upgrade image to latest version

### DIFF
--- a/stable/kube-slack/Chart.yaml
+++ b/stable/kube-slack/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-slack
-version: 0.3.0
-appVersion: v3.5.0
+version: 0.4.0
+appVersion: v3.6.0
 apiVersion: v1
 description: Chart for kube-slack, a monitoring service for Kubernetes
 keywords:

--- a/stable/kube-slack/values.yaml
+++ b/stable/kube-slack/values.yaml
@@ -6,7 +6,7 @@ notReadyMinTime: 60000  # in ms
 ## Configuration for the deployment:
 image:
   repository: willwill/kube-slack
-  tag: v3.5.0
+  tag: v3.6.0
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Latest version of kube-slack is v3.6.0 (https://github.com/wongnai/kube-slack/releases). This PR upgrades kube-slack image to latest version.
