### PR TITLE
fluentd-elasticsearch typo fix

### DIFF
--- a/stable/fluentd-elasticsearch/README.md
+++ b/stable/fluentd-elasticsearch/README.md
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | ---------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
 | `annotations`                      | Optional daemonset annotations             | `NULL`                                                     |
 | `configMaps`                       | Fluentd configmaps                         | `default conf files`                                       |
-| `elasticsearch.host`               | Elstaicsearch Host                         | `elasticsearch-client`                                     |
+| `elasticsearch.host`               | Elasticsearch Host                         | `elasticsearch-client`                                     |
 | `elasticsearch.port`               | Elasticsearch Port                         | `9200`                                                     |
 | `elasticsearch.buffer_chunk_limit` | Elasticsearch buffer chunk limit           | `2M`                                                       |
 | `elasticsearch.buffer_queue_limit` | Elasticsearch buffer queue limit           | `8`                                                        |


### PR DESCRIPTION
#### What this PR does / why we need it:
Minor typo fix for the `fluentd-elasticsearch` chart.