### PR TITLE
[stable/prometheus-operator] Upgrading prometheus version to v2.5.0

### DIFF
--- a/stable/prometheus-operator/CONTRIBUTING.md
+++ b/stable/prometheus-operator/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing Guidelines
+
+## How to contribute to this chart
+
+1. Fork this repository, develop and test your Chart.
+1. Bump the chart version for every change.
+1. Ensure PR title has the prefix `[stable/prometheus-operator]`
+1. Check for changes of RBAC rules.
+1. Check for changes in CRD specs.
+1. PR must pass the linter (`helm lint`)

--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 0.1.21
+version: 0.1.24
 appVersion: "0.25.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/ci/test-values.yaml
+++ b/stable/prometheus-operator/ci/test-values.yaml
@@ -157,7 +157,7 @@ alertmanager:
     ##
     image:
       repository: quay.io/prometheus/alertmanager
-      tag: v0.15.2
+      tag: v0.15.3
 
     ## Secrets is a list of Secrets in the same namespace as the Alertmanager object, which shall be mounted into the
     ## Alertmanager Pods. The Secrets are mounted into /etc/alertmanager/secrets/.
@@ -651,10 +651,10 @@ prometheus:
     ##
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v2.4.3
+      tag: v2.5.0
 
     #  repository: quay.io/coreos/prometheus
-    #  tag: v2.4.3
+    #  tag: v2.5.0
 
     ## Tolerations for use with node taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -156,7 +156,7 @@ alertmanager:
     ##
     image:
       repository: quay.io/prometheus/alertmanager
-      tag: v0.15.2
+      tag: v0.15.3
 
     ## Secrets is a list of Secrets in the same namespace as the Alertmanager object, which shall be mounted into the
     ## Alertmanager Pods. The Secrets are mounted into /etc/alertmanager/secrets/.
@@ -641,10 +641,10 @@ prometheus:
     ##
     image:
       repository: quay.io/prometheus/prometheus
-      tag: v2.4.3
+      tag: v2.5.0
 
     #  repository: quay.io/coreos/prometheus
-    #  tag: v2.4.3
+    #  tag: v2.5.0
 
     ## Tolerations for use with node taints
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION

#### What this PR does / why we need it:
This PR upgrades prometheus to its latest release 2.5.0
The PR has been tested locally. There have not been any RBAC changes
between 2.4.3 and 2.5.0


#### Special notes for your reviewer:
@gianrubio 
The PR has been tested locally. There have not been any RBAC changes
between 2.4.3 and 2.5.0

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
