### PR TITLE
Upgrade fluentd-kubernetes-sumologic

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,6 +1,6 @@
 name: sumologic-fluentd
-version: 0.6.0
-appVersion: 1.16
+version: 0.7.0
+appVersion: 2.0.0
 description: Sumologic Log Collector
 keywords:
   - monitoring

--- a/stable/sumologic-fluentd/templates/_helpers.tpl
+++ b/stable/sumologic-fluentd/templates/_helpers.tpl
@@ -16,13 +16,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-A uniquely named secret, which includes the install time
-*/}}
-{{- define "sumologic-fluentd.fullname-secrets" -}}
-{{- printf "%s-secrets-%d" (include "sumologic-fluentd.fullname" .) .Release.Time.Seconds -}}
-{{- end -}}
-
-{{/*
 Create a default fully qualified fluentd user conf name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
             - name: COLLECTOR_URL
               valueFrom:
                 secretKeyRef:
-                  name: "{{ template "sumologic-fluentd.fullname-secrets" . }}"
+                  name: "{{ template "sumologic-fluentd.fullname" . }}"
                   key: collector-url
             - name: FLUENTD_SOURCE
               value: {{ quote .Values.sumologic.fluentdSource }}

--- a/stable/sumologic-fluentd/templates/secrets.yaml
+++ b/stable/sumologic-fluentd/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ template "sumologic-fluentd.fullname-secrets" . }}"
+  name: {{ template "sumologic-fluentd.fullname" . }}
   labels:
     app: {{ template "sumologic-fluentd.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -1,7 +1,7 @@
 # Default values for sumologic-fluentd.
 image:
   name: sumologic/fluentd-kubernetes-sumologic
-  tag: v1.16
+  tag: v2.0.0
   pullPolicy: IfNotPresent
 
 ## Annotations to add to the DaemonSet's Pods


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrade fluentd-kubernetes-sumologic to v2.0.0 and prevent secrets from being recreated on every sync

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
While it appears to be a major upgrade, the release has no config changes. See https://github.com/SumoLogic/fluentd-kubernetes-sumologic#upgrading-to-v200

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
