### PR TITLE
[incubator/gogs] add install lock opportunity

### DIFF
--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -5,7 +5,7 @@ version: 0.7.2
 appVersion: 0.11.66
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico
-maintainers: 
+maintainers:
   - name: obeyler
 keywords:
 - git

--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: 'Gogs: Go Git Service'
 name: gogs
-version: 0.7.1
+version: 0.7.2
 appVersion: 0.11.66
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico

--- a/incubator/gogs/Chart.yaml
+++ b/incubator/gogs/Chart.yaml
@@ -5,5 +5,7 @@ version: 0.7.2
 appVersion: 0.11.66
 home: https://gogs.io/
 icon: https://gogs.io/img/favicon.ico
+maintainers: 
+  - name: obeyler
 keywords:
 - git

--- a/incubator/gogs/OWNERS
+++ b/incubator/gogs/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- obeyler
+reviewers:
+- obeyler

--- a/incubator/gogs/templates/configmap.yaml
+++ b/incubator/gogs/templates/configmap.yaml
@@ -47,7 +47,7 @@ data:
     PASSWD = {{ template "gogs.database.password" . }}
 
     [security]
-    INSTALL_LOCK = true
+    INSTALL_LOCK = {{ .Values.service.gogs.installLock }}
     SECRET_KEY = {{ default "" .Values.service.gogs.securitySecretKey | b64enc | quote }}
 
     [ui]

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -55,6 +55,10 @@ service:
     ## disabled, users can only perform Git operations via SSH.
     ##
     disableHttpGit: false
+    
+    ## Lock the path /install to configure gogs
+    ##
+    installLock : true
 
     ## Indicates whether or not to enable repository file upload feature.
     ##

--- a/incubator/gogs/values.yaml
+++ b/incubator/gogs/values.yaml
@@ -55,10 +55,10 @@ service:
     ## disabled, users can only perform Git operations via SSH.
     ##
     disableHttpGit: false
-    
+
     ## Lock the path /install to configure gogs
     ##
-    installLock : true
+    installLock: true
 
     ## Indicates whether or not to enable repository file upload feature.
     ##


### PR DESCRIPTION
/assign @responsible 
/assign @cheyang

#### What this PR does / why we need it:
This PR propose to allow launch gogs with INSTALL_LOCK=false
The aim of this is to be able install a gogs automatically with self register option disactivated and be able to create an admin user.

If you want that you just have to install helm with install_lock= false, create an user with a curl on /install path, change the configmap to have install_lock = true and recreate the gogs pod to reload the config map


#### Which issue this PR fixes

fixes :  #6942 , #9278

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
