### PR TITLE
Allow custom GCP creds to be mounted

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 0.0.4
+version: 0.0.5
 appVersion: 0.5.1
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -72,7 +72,8 @@ Parameter                           | Description                          | Def
 `stackdriver.metrics.offset`        | Offset (into the past) to request    | `0s`
 `web.listenAddress`                 | Port to listen on                    | `9255`
 `web.path`                          | Path under which to expose metrics   | `/metrics`
-`annoations`                        | Deployment annotations               | `{}`
+`annotations`                       | Deployment annotations               | `{}`
+`gcp.credentials`                   | GCP credentials (mounted secret)     | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example,

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -47,6 +47,16 @@ spec:
               value: {{ .Values.web.listenAddress | quote }}
             - name: STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH
               value: {{ .Values.web.path | quote }}
+{{- if .Values.gcp.credentials }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: {{ .Values.gcp.credentials.mountPath }}/key.json
+{{- end }}
+{{- if .Values.gcp.credentials }}
+          volumeMounts:
+            - name: {{ .Values.gcp.credentials.volumeName }}
+              mountPath: {{ .Values.gcp.credentials.mountPath }}
+              readOnly: true
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:
@@ -64,3 +74,10 @@ spec:
               port: http
             initialDelaySeconds: 10
             timeoutSeconds: 10
+{{- if .Values.gcp.credentials }}
+      volumes:
+        - name: {{ .Values.gcp.credentials.volumeName }}
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gcp.credentials.secretName }}
+{{- end }}

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -40,3 +40,9 @@ web:
   path: /metrics
 
 annotations: {}
+
+gcp:
+  credentials: {}
+    # volumeName: gcp-creds
+    # mountName: /var/secrets/google
+    # secretName: monitoring-service


### PR DESCRIPTION
#### What this PR does / why we need it:
This patch allows an existing GCP service account key on a k8s secret to be mounted as used instead of the default one.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
