### PR TITLE
[stable/cockroachdb] Increase the default disk size to 100GB

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.0.5
+version: 2.0.6
 appVersion: 2.1.1
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -29,10 +29,10 @@ helm install --name my-release stable/cockroachdb
 ```
 
 Note that for a production cluster, you are very likely to want to modify the
-`Storage` and `StorageClass` parameters. This chart defaults to just 1 GiB of
-disk space per pod in order for it to work in small environments like Minikube,
+`Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of
+disk space per pod, but you very well may want more or less for your use case,
 and the default persistent volume `StorageClass` in your environment may not be
-what you want for a database (e.g. on GCE the default is not SSD).
+what you want for a database (e.g. on GCE and Azure the default is not SSD).
 
 If you are running in secure mode (with configuration parameter `Secure.Enabled`
 set to `true`), then you will have to manually approve the cluster's security
@@ -82,7 +82,7 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | `ExternalHttpPort`             | CockroachDB HTTP port on service                 | `8080`                                    |
 | `HttpName`                     | Name given to the http service port              | `http`                                    |
 | `Resources`                    | Resource requests and limits                     | `{}`                                      |
-| `Storage`                      | Persistent volume size                           | `1Gi`                                     |
+| `Storage`                      | Persistent volume size                           | `100Gi`                                   |
 | `StorageClass`                 | Persistent volume class                          | `null`                                    |
 | `CacheSize`                    | Size of CockroachDB's in-memory cache            | `25%`                                     |
 | `MaxSQLMemory`                 | Max memory to use processing SQL queries         | `25%`                                     |

--- a/stable/cockroachdb/templates/NOTES.txt
+++ b/stable/cockroachdb/templates/NOTES.txt
@@ -48,11 +48,3 @@ Then you can access the admin UI at https://localhost:{{ .Values.InternalHttpPor
 
 For more information on using CockroachDB, please see the project's docs at
 https://www.cockroachlabs.com/docs/
-
-{{- if eq .Values.Storage "1Gi" }}
-
-WARNING: Only 1 GiB of disk space is being requested for each pod. This will
-not be enough for a production custer. Re-install with a customized "Storage"
-parameter if you woud like more disk space.
-
-{{- end }}

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -29,7 +29,7 @@ Resources: {}
   # requests:
   #   cpu: "100m"
   #   memory: "512Mi"
-Storage: "1Gi"
+Storage: "100Gi"
 ## Persistent Volume Storage Class for database data
 ## If defined, storageClassName: <StorageClass>
 ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
In the past I had problems with Minikube not accepting large disk sizes,
but it no longer seems to be a problem on more recent versions, so let's
default to something a little more reasonable here.

Signed-off-by: Alex Robinson <alexdwanerobinson@gmail.com>

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
