### PR TITLE
[stable/concourse] Specify secrets mount path

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.5.1
+version: 3.6.0
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -79,6 +79,11 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
 | `web.annotations`| Concourse Web deployment annotations | `nil` |
+| `web.keysSecretsPath` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
+| `web.postgresqlSecrtsPath` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
+| `web.vaultSecretsPath` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
+| `web.syslogSecretsPath` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
+| `web.authSecretsPath` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
 | `web.tolerations` | Tolerations for the web nodes | `[]` |
 | `web.nodeSelector` | Node selector for web nodes | `{}` |
 | `web.service.type` | Concourse Web service type | `ClusterIP` |
@@ -98,6 +103,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `worker.resources` | Concourse Worker resource requests and limits | `{requests: {cpu: "100m", memory: "512Mi"}}` |
 | `worker.env` | Configure additional environment variables for the worker container(s) | `[]` |
 | `worker.annotations` | Annotations to be added to the worker pods | `{}` |
+| `worker.keysSecretsPath` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
 | `worker.additionalVolumeMounts` | VolumeMounts to be added to the worker pods | `nil` |
 | `worker.additionalVolumes` | Volumes to be added to the worker pods | `nil` |
 | `worker.additionalAffinities` | Additional affinities to apply to worker pods. E.g: node affinity | `{}` |
@@ -123,12 +129,6 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
 | `secrets.localUsers` | Create concourse local users. Default username and password are test:test *See [values.yaml](values.yaml)* |
 | `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
-| `secrets.mountPathWorkerKeys` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
-| `secrets.mountPathWebKeys` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
-| `secrets.mountPathWebPostgresql` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
-| `secrets.mountPathWebVault` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
-| `secrets.mountPathWebSyslog` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
-| `secrets.mountPathWebAuth` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
 | `secrets.hostKey` | Concourse Host Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.hostKeyPub` | Concourse Host Public Key | *See [values.yaml](values.yaml)* |
 | `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -123,12 +123,12 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
 | `secrets.localUsers` | Create concourse local users. Default username and password are test:test *See [values.yaml](values.yaml)* |
 | `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
-| `secrets.mountPath.worker.keys` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
-| `secrets.mountPath.web.keys` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
-| `secrets.mountPath.web.postgresql` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
-| `secrets.mountPath.web.vault` | Specify the mount directory of the web vault secrets | `/concourse-keys` |
-| `secrets.mountPath.web.syslog` | Specify the mount directory of the web syslog secrets | `/concourse-keys` |
-| `secrets.mountPath.web.auth` | Specify the mount directory of the web auth secrets | `/concourse-keys` |
+| `secrets.mountPathWorkerKeys` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
+| `secrets.mountPathWebKeys` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
+| `secrets.mountPathWebPostgresql` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
+| `secrets.mountPathWebVault` | Specify the mount directory of the web vault secrets | `/concourse-vault` |
+| `secrets.mountPathWebSyslog` | Specify the mount directory of the web syslog secrets | `/concourse-syslog` |
+| `secrets.mountPathWebAuth` | Specify the mount directory of the web auth secrets | `/concourse-auth` |
 | `secrets.hostKey` | Concourse Host Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.hostKeyPub` | Concourse Host Public Key | *See [values.yaml](values.yaml)* |
 | `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -123,6 +123,12 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
 | `secrets.localUsers` | Create concourse local users. Default username and password are test:test *See [values.yaml](values.yaml)* |
 | `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
+| `secrets.mountPath.worker.keys` | Specify the mount directory of the worker keys secrets | `/concourse-keys` |
+| `secrets.mountPath.web.keys` | Specify the mount directory of the web keys secrets | `/concourse-keys` |
+| `secrets.mountPath.web.postgresql` | Specify the mount directory of the web postgresql secrets | `/concourse-postgresql` |
+| `secrets.mountPath.web.vault` | Specify the mount directory of the web vault secrets | `/concourse-keys` |
+| `secrets.mountPath.web.syslog` | Specify the mount directory of the web syslog secrets | `/concourse-keys` |
+| `secrets.mountPath.web.auth` | Specify the mount directory of the web auth secrets | `/concourse-keys` |
 | `secrets.hostKey` | Concourse Host Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.hostKeyPub` | Concourse Host Public Key | *See [values.yaml](values.yaml)* |
 | `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -203,15 +203,15 @@ spec:
             {{- end }}
             {{- if .Values.secrets.postgresCaCert }}
             - name: CONCOURSE_POSTGRES_CA_CERT
-              value: {{ printf "%s/ca.cert" .Values.secrets.mountPath.web.postgresql }}
+              value: "{{ .Values.secrets.mountPathWebPostgresql | default "/concourse-postgresql" }}/ca.cert"
             {{- end }}
             {{- if .Values.secrets.postgresClientCert }}
             - name: CONCOURSE_POSTGRES_CLIENT_CERT
-              value: {{ printf "%s/client.cert" .Values.secrets.mountPath.web.postgresql }}
+              value: "{{ .Values.secrets.mountPathWebPostgresql | default "/concourse-postgresql" }}/client.cert"
             {{- end }}
             {{- if .Values.secrets.postgresClientKey }}
             - name: CONCOURSE_POSTGRES_CLIENT_KEY
-              value: {{ printf "%s/client.key" .Values.secrets.mountPath.web.postgresql }}
+              value: "{{ .Values.secrets.mountPathWebPostgresql | default "/concourse-postgresql" }}/client.key"
             {{- end }}
             {{- if .Values.concourse.web.postgres.connectTimeout }}
             - name: CONCOURSE_POSTGRES_CONNECT_TIMEOUT
@@ -312,7 +312,7 @@ spec:
               value: {{ .Values.concourse.web.vault.authBackend | quote }}
             {{- if .Values.concourse.web.vault.useCaCert }}
             - name: CONCOURSE_VAULT_CA_CERT
-              value: {{ printf "%s/ca.cert" .Values.secrets.mountPath.web.vault }}
+              value: "{{ .Values.secrets.mountPathWebVault | default "/concourse-vault" }}/ca.cert"
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "token" }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
@@ -323,9 +323,9 @@ spec:
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "cert" }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
-              value: {{ printf "%s/client.cert" .Values.secrets.mountPath.web.vault }}
+              value: "{{ .Values.secrets.mountPathWebVault | default "/concourse-vault" }}/client.cert"
             - name: CONCOURSE_VAULT_CLIENT_KEY
-              value: {{ printf "%s/client.key" .Values.secrets.mountPath.web.vault }}
+              value: "{{ .Values.secrets.mountPathWebVault | default "/concourse-vault" }}/client.key"
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "approle" }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
@@ -511,7 +511,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.syslog.useCaCert }}
             - name: CONCOURSE_SYSLOG_CA_CERT
-              value: {{ printf "%s/ca.cert" .Values.secrets.mountPath.web.syslog }}
+              value: "{{ .Values.secrets.mountPathWebSyslog | default "/concourse-syslog" }}/ca.cert"
             {{- end }}
             {{- end }}
 
@@ -524,7 +524,7 @@ spec:
               value: {{ .Values.concourse.web.auth.duration | quote }}
             {{- end }}
             - name: CONCOURSE_SESSION_SIGNING_KEY
-              value: {{ printf "%s/session_signing_key" .Values.secrets.mountPath.web.keys }}
+              value: "{{ .Values.secrets.mountPathWebKeys | default "/concourse-keys" }}/session_signing_key"
 
             {{- if .Values.concourse.web.auth.mainTeam.localUser }}
             - name: CONCOURSE_MAIN_TEAM_LOCAL_USER
@@ -618,7 +618,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.cf.useCaCert }}
             - name: CONCOURSE_CF_CA_CERT
-              value: {{ printf "%s/cf_ca.cert" .Values.secrets.mountPath.web.auth }}
+              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/cf_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.cf.skipSslValidation }}
             - name: CONCOURSE_CF_SKIP_SSL_VALIDATION
@@ -643,7 +643,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.github.useCaCert }}
             - name: CONCOURSE_GITHUB_CA_CERT
-              value: {{ printf "%s/github_ca.cert" .Values.secrets.mountPath.web.auth }}
+              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/github_ca.cert"
             {{- end }}
             {{- end }}
 
@@ -675,7 +675,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.ldap.useCaCert }}
             - name: CONCOURSE_LDAP_CA_CERT
-              value: {{ printf "%s/ldap_ca.cert" .Values.secrets.mountPath.web.auth }}
+              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/ldap_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.ldap.displayName }}
             - name: CONCOURSE_LDAP_DISPLAY_NAME
@@ -788,7 +788,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.oauth.useCaCert }}
             - name: CONCOURSE_OAUTH_CA_CERT
-              value: {{ printf "%s/oauth_ca.cert" .Values.secrets.mountPath.web.auth }}
+              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/oauth_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.oauth.skipSslValidation }}
             - name: CONCOURSE_OAUTH_SKIP_SSL_VALIDATION
@@ -829,7 +829,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.useCaCert }}
             - name: CONCOURSE_OIDC_CA_CERT
-              value: {{ printf "%s/oidc_ca.cert" .Values.secrets.mountPath.web.auth }}
+              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/oidc_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.skipSslValidation }}
             - name: CONCOURSE_OIDC_SKIP_SSL_VALIDATION
@@ -856,9 +856,9 @@ spec:
               value: {{ .Values.concourse.web.tsa.peerIp | quote }}
             {{- end }}
             - name: CONCOURSE_TSA_HOST_KEY
-              value: {{ printf "%s/host_key" .Values.secrets.mountPath.web.keys }}
+              value: "{{ .Values.secrets.mountPathWebKeys | default "/concourse-keys" }}/host_key"
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
-              value: {{ printf "%s/worker_key.pub" .Values.secrets.mountPath.web.keys }}
+              value: "{{ .Values.secrets.mountPathWebKeys | default "/concourse-keys" }}/worker_key.pub"
             {{- if .Values.concourse.web.tsa.teamAuthorizedKeys }}
             - name: CONCOURSE_TSA_TEAM_AUTHORIZED_KEYS
               value: {{ .Values.concourse.web.tsa.teamAuthorizedKeys | quote }}
@@ -907,7 +907,7 @@ spec:
 {{ toYaml .Values.web.resources | indent 12 }}
           volumeMounts:
             - name: concourse-keys
-              mountPath: {{ .Values.secrets.mountPath.web.keys | default "/concourse-keys" | quote }}
+              mountPath: {{ .Values.secrets.mountPathWebKeys | default "/concourse-keys" | quote }}
               readOnly: true
             {{- if .Values.concourse.web.tls.enabled }}
             - name: web-tls
@@ -916,21 +916,21 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.vault.enabled }}
             - name: vault-keys
-              mountPath: {{ .Values.secrets.mountPath.web.vault | default "/concourse-vault" | quote }}
+              mountPath: {{ .Values.secrets.mountPathWebVault | default "/concourse-vault" | quote }}
               readOnly: true
             {{- end }}
             {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
             - name: postgresql-keys
-              mountPath: {{ .Values.secrets.mountPath.web.postgresql | default "/concourse-postgresql" | quote }}
+              mountPath: {{ .Values.secrets.mountPathWebPostgresql | default "/concourse-postgresql" | quote }}
               readOnly: true
             {{- end }}
             {{- if .Values.concourse.web.syslog.enabled }}
             - name: syslog-keys
-              mountPath: {{ .Values.secrets.mountPath.web.syslog | default "/concourse-syslog" | quote }}
+              mountPath: {{ .Values.secrets.mountPathWebSyslog | default "/concourse-syslog" | quote }}
               readOnly: true
             {{- end }}
             - name: auth-keys
-              mountPath: {{ .Values.secrets.mountPath.web.auth | default "/concourse-auth" | quote }}
+              mountPath: {{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" | quote }}
               readOnly: true
       affinity:
 {{- if .Values.web.additionalAffinities }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -203,15 +203,15 @@ spec:
             {{- end }}
             {{- if .Values.secrets.postgresCaCert }}
             - name: CONCOURSE_POSTGRES_CA_CERT
-              value: "/concourse-postgresql/ca.cert"
+              value: {{ printf "%s/ca.cert" .Values.secrets.mountPath.web.postgresql }}
             {{- end }}
             {{- if .Values.secrets.postgresClientCert }}
             - name: CONCOURSE_POSTGRES_CLIENT_CERT
-              value: "/concourse-postgresql/client.cert"
+              value: {{ printf "%s/client.cert" .Values.secrets.mountPath.web.postgresql }}
             {{- end }}
             {{- if .Values.secrets.postgresClientKey }}
             - name: CONCOURSE_POSTGRES_CLIENT_KEY
-              value: "/concourse-postgresql/client.key"
+              value: {{ printf "%s/client.key" .Values.secrets.mountPath.web.postgresql }}
             {{- end }}
             {{- if .Values.concourse.web.postgres.connectTimeout }}
             - name: CONCOURSE_POSTGRES_CONNECT_TIMEOUT
@@ -312,7 +312,7 @@ spec:
               value: {{ .Values.concourse.web.vault.authBackend | quote }}
             {{- if .Values.concourse.web.vault.useCaCert }}
             - name: CONCOURSE_VAULT_CA_CERT
-              value: "/concourse-vault/ca.cert"
+              value: {{ printf "%s/ca.cert" .Values.secrets.mountPath.web.vault }}
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "token" }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
@@ -323,9 +323,9 @@ spec:
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "cert" }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
-              value: "/concourse-vault/client.cert"
+              value: {{ printf "%s/client.cert" .Values.secrets.mountPath.web.vault }}
             - name: CONCOURSE_VAULT_CLIENT_KEY
-              value: "/concourse-vault/client.key"
+              value: {{ printf "%s/client.key" .Values.secrets.mountPath.web.vault }}
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "approle" }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
@@ -511,7 +511,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.syslog.useCaCert }}
             - name: CONCOURSE_SYSLOG_CA_CERT
-              value: "/concourse-syslog/ca.cert"
+              value: {{ printf "%s/ca.cert" .Values.secrets.mountPath.web.syslog }}
             {{- end }}
             {{- end }}
 
@@ -524,7 +524,7 @@ spec:
               value: {{ .Values.concourse.web.auth.duration | quote }}
             {{- end }}
             - name: CONCOURSE_SESSION_SIGNING_KEY
-              value: "/concourse-keys/session_signing_key"
+              value: {{ printf "%s/session_signing_key" .Values.secrets.mountPath.web.keys }}
 
             {{- if .Values.concourse.web.auth.mainTeam.localUser }}
             - name: CONCOURSE_MAIN_TEAM_LOCAL_USER
@@ -618,7 +618,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.cf.useCaCert }}
             - name: CONCOURSE_CF_CA_CERT
-              value: "/concourse-auth/cf_ca.cert"
+              value: {{ printf "%s/cf_ca.cert" .Values.secrets.mountPath.web.auth }}
             {{- end }}
             {{- if .Values.concourse.web.auth.cf.skipSslValidation }}
             - name: CONCOURSE_CF_SKIP_SSL_VALIDATION
@@ -643,7 +643,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.github.useCaCert }}
             - name: CONCOURSE_GITHUB_CA_CERT
-              value: "/concourse-auth/github_ca.cert"
+              value: {{ printf "%s/github_ca.cert" .Values.secrets.mountPath.web.auth }}
             {{- end }}
             {{- end }}
 
@@ -675,7 +675,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.ldap.useCaCert }}
             - name: CONCOURSE_LDAP_CA_CERT
-              value: "/concourse-auth/ldap_ca.cert"
+              value: {{ printf "%s/ldap_ca.cert" .Values.secrets.mountPath.web.auth }}
             {{- end }}
             {{- if .Values.concourse.web.auth.ldap.displayName }}
             - name: CONCOURSE_LDAP_DISPLAY_NAME
@@ -788,7 +788,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.oauth.useCaCert }}
             - name: CONCOURSE_OAUTH_CA_CERT
-              value: "/concourse-auth/oauth_ca.cert"
+              value: {{ printf "%s/oauth_ca.cert" .Values.secrets.mountPath.web.auth }}
             {{- end }}
             {{- if .Values.concourse.web.auth.oauth.skipSslValidation }}
             - name: CONCOURSE_OAUTH_SKIP_SSL_VALIDATION
@@ -829,7 +829,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.useCaCert }}
             - name: CONCOURSE_OIDC_CA_CERT
-              value: "/concourse-auth/oidc_ca.cert"
+              value: {{ printf "%s/oidc_ca.cert" .Values.secrets.mountPath.web.auth }}
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.skipSslValidation }}
             - name: CONCOURSE_OIDC_SKIP_SSL_VALIDATION
@@ -856,9 +856,9 @@ spec:
               value: {{ .Values.concourse.web.tsa.peerIp | quote }}
             {{- end }}
             - name: CONCOURSE_TSA_HOST_KEY
-              value: "/concourse-keys/host_key"
+              value: {{ printf "%s/host_key" .Values.secrets.mountPath.web.keys }}
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
-              value: "/concourse-keys/worker_key.pub"
+              value: {{ printf "%s/worker_key.pub" .Values.secrets.mountPath.web.keys }}
             {{- if .Values.concourse.web.tsa.teamAuthorizedKeys }}
             - name: CONCOURSE_TSA_TEAM_AUTHORIZED_KEYS
               value: {{ .Values.concourse.web.tsa.teamAuthorizedKeys | quote }}
@@ -907,7 +907,7 @@ spec:
 {{ toYaml .Values.web.resources | indent 12 }}
           volumeMounts:
             - name: concourse-keys
-              mountPath: /concourse-keys
+              mountPath: {{ .Values.secrets.mountPath.web.keys | default "/concourse-keys" | quote }}
               readOnly: true
             {{- if .Values.concourse.web.tls.enabled }}
             - name: web-tls
@@ -916,21 +916,21 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.vault.enabled }}
             - name: vault-keys
-              mountPath: /concourse-vault
+              mountPath: {{ .Values.secrets.mountPath.web.vault | default "/concourse-vault" | quote }}
               readOnly: true
             {{- end }}
             {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
             - name: postgresql-keys
-              mountPath: /concourse-postgresql
+              mountPath: {{ .Values.secrets.mountPath.web.postgresql | default "/concourse-postgresql" | quote }}
               readOnly: true
             {{- end }}
             {{- if .Values.concourse.web.syslog.enabled }}
             - name: syslog-keys
-              mountPath: /concourse-syslog
+              mountPath: {{ .Values.secrets.mountPath.web.syslog | default "/concourse-syslog" | quote }}
               readOnly: true
             {{- end }}
             - name: auth-keys
-              mountPath: /concourse-auth
+              mountPath: {{ .Values.secrets.mountPath.web.auth | default "/concourse-auth" | quote }}
               readOnly: true
       affinity:
 {{- if .Values.web.additionalAffinities }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -64,9 +64,9 @@ spec:
             - name: CONCOURSE_TLS_BIND_PORT
               value: {{ .Values.concourse.web.tls.bindPort | default "443" | quote }}
             - name: CONCOURSE_TLS_CERT
-              value: "/concourse-web-tls/client.cert"
+              value: "{{ .Values.web.tlsSecretsPath }}/client.cert"
             - name: CONCOURSE_TLS_KEY
-              value: "/concourse-web-tls/client.key"
+              value: "{{ .Values.web.tlsSecretsPath }}/client.key"
             {{- end }}
             {{- if .Values.concourse.web.tls.enabled }}
             - name: CONCOURSE_EXTERNAL_URL
@@ -911,7 +911,7 @@ spec:
               readOnly: true
             {{- if .Values.concourse.web.tls.enabled }}
             - name: web-tls
-              mountPath: /concourse-web-tls
+              mountPath: {{ .Values.web.tlsSecretsPath | quote }}
               readOnly: true
             {{- end }}
             {{- if .Values.concourse.web.vault.enabled }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -203,15 +203,15 @@ spec:
             {{- end }}
             {{- if .Values.secrets.postgresCaCert }}
             - name: CONCOURSE_POSTGRES_CA_CERT
-              value: "{{ .Values.web.postgresqlSecretsPath | default "/concourse-postgresql" }}/ca.cert"
+              value: "{{ .Values.web.postgresqlSecretsPath }}/ca.cert"
             {{- end }}
             {{- if .Values.secrets.postgresClientCert }}
             - name: CONCOURSE_POSTGRES_CLIENT_CERT
-              value: "{{ .Values.web.postgresqlSecretsPath | default "/concourse-postgresql" }}/client.cert"
+              value: "{{ .Values.web.postgresqlSecretsPath }}/client.cert"
             {{- end }}
             {{- if .Values.secrets.postgresClientKey }}
             - name: CONCOURSE_POSTGRES_CLIENT_KEY
-              value: "{{ .Values.web.postgresqlSecretsPath | default "/concourse-postgresql" }}/client.key"
+              value: "{{ .Values.web.postgresqlSecretsPath }}/client.key"
             {{- end }}
             {{- if .Values.concourse.web.postgres.connectTimeout }}
             - name: CONCOURSE_POSTGRES_CONNECT_TIMEOUT
@@ -312,7 +312,7 @@ spec:
               value: {{ .Values.concourse.web.vault.authBackend | quote }}
             {{- if .Values.concourse.web.vault.useCaCert }}
             - name: CONCOURSE_VAULT_CA_CERT
-              value: "{{ .Values.web.vaultSecretsPath | default "/concourse-vault" }}/ca.cert"
+              value: "{{ .Values.web.vaultSecretsPath }}/ca.cert"
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "token" }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
@@ -323,9 +323,9 @@ spec:
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "cert" }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
-              value: "{{ .Values.web.vaultSecretsPath | default "/concourse-vault" }}/client.cert"
+              value: "{{ .Values.web.vaultSecretsPath }}/client.cert"
             - name: CONCOURSE_VAULT_CLIENT_KEY
-              value: "{{ .Values.web.vaultSecretsPath | default "/concourse-vault" }}/client.key"
+              value: "{{ .Values.web.vaultSecretsPath }}/client.key"
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "approle" }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
@@ -511,7 +511,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.syslog.useCaCert }}
             - name: CONCOURSE_SYSLOG_CA_CERT
-              value: "{{ .Values.web.syslogSecretsPath | default "/concourse-syslog" }}/ca.cert"
+              value: "{{ .Values.web.syslogSecretsPath }}/ca.cert"
             {{- end }}
             {{- end }}
 
@@ -524,7 +524,7 @@ spec:
               value: {{ .Values.concourse.web.auth.duration | quote }}
             {{- end }}
             - name: CONCOURSE_SESSION_SIGNING_KEY
-              value: "{{ .Values.web.keySecretsPath | default "/concourse-keys" }}/session_signing_key"
+              value: "{{ .Values.web.keySecretsPath }}/session_signing_key"
 
             {{- if .Values.concourse.web.auth.mainTeam.localUser }}
             - name: CONCOURSE_MAIN_TEAM_LOCAL_USER
@@ -618,7 +618,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.cf.useCaCert }}
             - name: CONCOURSE_CF_CA_CERT
-              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/cf_ca.cert"
+              value: "{{ .Values.web.authSecretsPath }}/cf_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.cf.skipSslValidation }}
             - name: CONCOURSE_CF_SKIP_SSL_VALIDATION
@@ -643,7 +643,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.github.useCaCert }}
             - name: CONCOURSE_GITHUB_CA_CERT
-              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/github_ca.cert"
+              value: "{{ .Values.web.authSecretsPath }}/github_ca.cert"
             {{- end }}
             {{- end }}
 
@@ -675,7 +675,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.ldap.useCaCert }}
             - name: CONCOURSE_LDAP_CA_CERT
-              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/ldap_ca.cert"
+              value: "{{ .Values.web.authSecretsPath }}/ldap_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.ldap.displayName }}
             - name: CONCOURSE_LDAP_DISPLAY_NAME
@@ -788,7 +788,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.oauth.useCaCert }}
             - name: CONCOURSE_OAUTH_CA_CERT
-              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/oauth_ca.cert"
+              value: "{{ .Values.web.authSecretsPath }}/oauth_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.oauth.skipSslValidation }}
             - name: CONCOURSE_OAUTH_SKIP_SSL_VALIDATION
@@ -829,7 +829,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.useCaCert }}
             - name: CONCOURSE_OIDC_CA_CERT
-              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/oidc_ca.cert"
+              value: "{{ .Values.web.authSecretsPath }}/oidc_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.skipSslValidation }}
             - name: CONCOURSE_OIDC_SKIP_SSL_VALIDATION
@@ -856,9 +856,9 @@ spec:
               value: {{ .Values.concourse.web.tsa.peerIp | quote }}
             {{- end }}
             - name: CONCOURSE_TSA_HOST_KEY
-              value: "{{ .Values.web.keySecretsPath | default "/concourse-keys" }}/host_key"
+              value: "{{ .Values.web.keySecretsPath }}/host_key"
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
-              value: "{{ .Values.web.keySecretsPath | default "/concourse-keys" }}/worker_key.pub"
+              value: "{{ .Values.web.keySecretsPath }}/worker_key.pub"
             {{- if .Values.concourse.web.tsa.teamAuthorizedKeys }}
             - name: CONCOURSE_TSA_TEAM_AUTHORIZED_KEYS
               value: {{ .Values.concourse.web.tsa.teamAuthorizedKeys | quote }}
@@ -907,7 +907,7 @@ spec:
 {{ toYaml .Values.web.resources | indent 12 }}
           volumeMounts:
             - name: concourse-keys
-              mountPath: {{ .Values.web.keySecretsPath | default "/concourse-keys" | quote }}
+              mountPath: {{ .Values.web.keySecretsPath | quote }}
               readOnly: true
             {{- if .Values.concourse.web.tls.enabled }}
             - name: web-tls
@@ -916,21 +916,21 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.vault.enabled }}
             - name: vault-keys
-              mountPath: {{ .Values.web.vaultSecretsPath | default "/concourse-vault" | quote }}
+              mountPath: {{ .Values.web.vaultSecretsPath | quote }}
               readOnly: true
             {{- end }}
             {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
             - name: postgresql-keys
-              mountPath: {{ .Values.web.postgresqlSecretsPath | default "/concourse-postgresql" | quote }}
+              mountPath: {{ .Values.web.postgresqlSecretsPath | quote }}
               readOnly: true
             {{- end }}
             {{- if .Values.concourse.web.syslog.enabled }}
             - name: syslog-keys
-              mountPath: {{ .Values.web.syslogSecretsPath | default "/concourse-syslog" | quote }}
+              mountPath: {{ .Values.web.syslogSecretsPath | quote }}
               readOnly: true
             {{- end }}
             - name: auth-keys
-              mountPath: {{ .Values.web.authSecretsPath | default "/concourse-auth" | quote }}
+              mountPath: {{ .Values.web.authSecretsPath | quote }}
               readOnly: true
       affinity:
 {{- if .Values.web.additionalAffinities }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -203,15 +203,15 @@ spec:
             {{- end }}
             {{- if .Values.secrets.postgresCaCert }}
             - name: CONCOURSE_POSTGRES_CA_CERT
-              value: "{{ .Values.secrets.mountPathWebPostgresql | default "/concourse-postgresql" }}/ca.cert"
+              value: "{{ .Values.web.postgresqlSecretsPath | default "/concourse-postgresql" }}/ca.cert"
             {{- end }}
             {{- if .Values.secrets.postgresClientCert }}
             - name: CONCOURSE_POSTGRES_CLIENT_CERT
-              value: "{{ .Values.secrets.mountPathWebPostgresql | default "/concourse-postgresql" }}/client.cert"
+              value: "{{ .Values.web.postgresqlSecretsPath | default "/concourse-postgresql" }}/client.cert"
             {{- end }}
             {{- if .Values.secrets.postgresClientKey }}
             - name: CONCOURSE_POSTGRES_CLIENT_KEY
-              value: "{{ .Values.secrets.mountPathWebPostgresql | default "/concourse-postgresql" }}/client.key"
+              value: "{{ .Values.web.postgresqlSecretsPath | default "/concourse-postgresql" }}/client.key"
             {{- end }}
             {{- if .Values.concourse.web.postgres.connectTimeout }}
             - name: CONCOURSE_POSTGRES_CONNECT_TIMEOUT
@@ -312,7 +312,7 @@ spec:
               value: {{ .Values.concourse.web.vault.authBackend | quote }}
             {{- if .Values.concourse.web.vault.useCaCert }}
             - name: CONCOURSE_VAULT_CA_CERT
-              value: "{{ .Values.secrets.mountPathWebVault | default "/concourse-vault" }}/ca.cert"
+              value: "{{ .Values.web.vaultSecretsPath | default "/concourse-vault" }}/ca.cert"
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "token" }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
@@ -323,9 +323,9 @@ spec:
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "cert" }}
             - name: CONCOURSE_VAULT_CLIENT_CERT
-              value: "{{ .Values.secrets.mountPathWebVault | default "/concourse-vault" }}/client.cert"
+              value: "{{ .Values.web.vaultSecretsPath | default "/concourse-vault" }}/client.cert"
             - name: CONCOURSE_VAULT_CLIENT_KEY
-              value: "{{ .Values.secrets.mountPathWebVault | default "/concourse-vault" }}/client.key"
+              value: "{{ .Values.web.vaultSecretsPath | default "/concourse-vault" }}/client.key"
             {{- end }}
             {{- if eq (default "" .Values.concourse.web.vault.authBackend) "approle" }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
@@ -511,7 +511,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.syslog.useCaCert }}
             - name: CONCOURSE_SYSLOG_CA_CERT
-              value: "{{ .Values.secrets.mountPathWebSyslog | default "/concourse-syslog" }}/ca.cert"
+              value: "{{ .Values.web.syslogSecretsPath | default "/concourse-syslog" }}/ca.cert"
             {{- end }}
             {{- end }}
 
@@ -524,7 +524,7 @@ spec:
               value: {{ .Values.concourse.web.auth.duration | quote }}
             {{- end }}
             - name: CONCOURSE_SESSION_SIGNING_KEY
-              value: "{{ .Values.secrets.mountPathWebKeys | default "/concourse-keys" }}/session_signing_key"
+              value: "{{ .Values.web.keySecretsPath | default "/concourse-keys" }}/session_signing_key"
 
             {{- if .Values.concourse.web.auth.mainTeam.localUser }}
             - name: CONCOURSE_MAIN_TEAM_LOCAL_USER
@@ -618,7 +618,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.cf.useCaCert }}
             - name: CONCOURSE_CF_CA_CERT
-              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/cf_ca.cert"
+              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/cf_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.cf.skipSslValidation }}
             - name: CONCOURSE_CF_SKIP_SSL_VALIDATION
@@ -643,7 +643,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.github.useCaCert }}
             - name: CONCOURSE_GITHUB_CA_CERT
-              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/github_ca.cert"
+              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/github_ca.cert"
             {{- end }}
             {{- end }}
 
@@ -675,7 +675,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.ldap.useCaCert }}
             - name: CONCOURSE_LDAP_CA_CERT
-              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/ldap_ca.cert"
+              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/ldap_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.ldap.displayName }}
             - name: CONCOURSE_LDAP_DISPLAY_NAME
@@ -788,7 +788,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.oauth.useCaCert }}
             - name: CONCOURSE_OAUTH_CA_CERT
-              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/oauth_ca.cert"
+              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/oauth_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.oauth.skipSslValidation }}
             - name: CONCOURSE_OAUTH_SKIP_SSL_VALIDATION
@@ -829,7 +829,7 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.useCaCert }}
             - name: CONCOURSE_OIDC_CA_CERT
-              value: "{{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" }}/oidc_ca.cert"
+              value: "{{ .Values.web.authSecretsPath | default "/concourse-auth" }}/oidc_ca.cert"
             {{- end }}
             {{- if .Values.concourse.web.auth.oidc.skipSslValidation }}
             - name: CONCOURSE_OIDC_SKIP_SSL_VALIDATION
@@ -856,9 +856,9 @@ spec:
               value: {{ .Values.concourse.web.tsa.peerIp | quote }}
             {{- end }}
             - name: CONCOURSE_TSA_HOST_KEY
-              value: "{{ .Values.secrets.mountPathWebKeys | default "/concourse-keys" }}/host_key"
+              value: "{{ .Values.web.keySecretsPath | default "/concourse-keys" }}/host_key"
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
-              value: "{{ .Values.secrets.mountPathWebKeys | default "/concourse-keys" }}/worker_key.pub"
+              value: "{{ .Values.web.keySecretsPath | default "/concourse-keys" }}/worker_key.pub"
             {{- if .Values.concourse.web.tsa.teamAuthorizedKeys }}
             - name: CONCOURSE_TSA_TEAM_AUTHORIZED_KEYS
               value: {{ .Values.concourse.web.tsa.teamAuthorizedKeys | quote }}
@@ -907,7 +907,7 @@ spec:
 {{ toYaml .Values.web.resources | indent 12 }}
           volumeMounts:
             - name: concourse-keys
-              mountPath: {{ .Values.secrets.mountPathWebKeys | default "/concourse-keys" | quote }}
+              mountPath: {{ .Values.web.keySecretsPath | default "/concourse-keys" | quote }}
               readOnly: true
             {{- if .Values.concourse.web.tls.enabled }}
             - name: web-tls
@@ -916,21 +916,21 @@ spec:
             {{- end }}
             {{- if .Values.concourse.web.vault.enabled }}
             - name: vault-keys
-              mountPath: {{ .Values.secrets.mountPathWebVault | default "/concourse-vault" | quote }}
+              mountPath: {{ .Values.web.vaultSecretsPath | default "/concourse-vault" | quote }}
               readOnly: true
             {{- end }}
             {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
             - name: postgresql-keys
-              mountPath: {{ .Values.secrets.mountPathWebPostgresql | default "/concourse-postgresql" | quote }}
+              mountPath: {{ .Values.web.postgresqlSecretsPath | default "/concourse-postgresql" | quote }}
               readOnly: true
             {{- end }}
             {{- if .Values.concourse.web.syslog.enabled }}
             - name: syslog-keys
-              mountPath: {{ .Values.secrets.mountPathWebSyslog | default "/concourse-syslog" | quote }}
+              mountPath: {{ .Values.web.syslogSecretsPath | default "/concourse-syslog" | quote }}
               readOnly: true
             {{- end }}
             - name: auth-keys
-              mountPath: {{ .Values.secrets.mountPathWebAuth | default "/concourse-auth" | quote }}
+              mountPath: {{ .Values.web.authSecretsPath | default "/concourse-auth" | quote }}
               readOnly: true
       affinity:
 {{- if .Values.web.additionalAffinities }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -147,9 +147,9 @@ spec:
             - name: CONCOURSE_TSA_HOST
               value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.web.tsa.bindPort}}"
             - name: CONCOURSE_TSA_PUBLIC_KEY
-              value: "/concourse-keys/host_key.pub"
+              value: {{ printf "%s/host_key.pub" .Values.secrets.mountPath.worker.keys }}
             - name: CONCOURSE_TSA_WORKER_PRIVATE_KEY
-              value: "/concourse-keys/worker_key"
+              value: {{ printf "%s/worker_key" .Values.secrets.mountPath.worker.keys }}
 
             {{- if .Values.concourse.worker.garden.logLevel }}
             - name: CONCOURSE_GARDEN_LOG_LEVEL
@@ -456,7 +456,7 @@ spec:
             privileged: true
           volumeMounts:
             - name: concourse-keys
-              mountPath: /concourse-keys
+              mountPath: {{ .Values.secrets.mountPath.worker.keys | default "/concourse-keys" | quote }}
               readOnly: true
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.workingDirectory | default "/concourse-work-dir" | quote }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -147,9 +147,9 @@ spec:
             - name: CONCOURSE_TSA_HOST
               value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.web.tsa.bindPort}}"
             - name: CONCOURSE_TSA_PUBLIC_KEY
-              value: "{{ .Values.secrets.mountPathWorkerKeys | default "/concourse-keys" }}/host_key.pub"
+              value: "{{ .Values.worker.keySecretsPath | default "/concourse-keys" }}/host_key.pub"
             - name: CONCOURSE_TSA_WORKER_PRIVATE_KEY
-              value: "{{ .Values.secrets.mountPathWorkerKeys | default "/concourse-keys" }}/worker_key"
+              value: "{{ .Values.worker.keySecretsPath | default "/concourse-keys" }}/worker_key"
 
             {{- if .Values.concourse.worker.garden.logLevel }}
             - name: CONCOURSE_GARDEN_LOG_LEVEL
@@ -456,7 +456,7 @@ spec:
             privileged: true
           volumeMounts:
             - name: concourse-keys
-              mountPath: {{ .Values.secrets.mountPathWorkerKeys | default "/concourse-keys" | quote }}
+              mountPath: {{ .Values.worker.keySecretsPath | default "/concourse-keys" | quote }}
               readOnly: true
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.workingDirectory | default "/concourse-work-dir" | quote }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -147,9 +147,9 @@ spec:
             - name: CONCOURSE_TSA_HOST
               value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.web.tsa.bindPort}}"
             - name: CONCOURSE_TSA_PUBLIC_KEY
-              value: {{ printf "%s/host_key.pub" .Values.secrets.mountPath.worker.keys }}
+              value: "{{ .Values.secrets.mountPathWorkerKeys | default "/concourse-keys" }}/host_key.pub"
             - name: CONCOURSE_TSA_WORKER_PRIVATE_KEY
-              value: {{ printf "%s/worker_key" .Values.secrets.mountPath.worker.keys }}
+              value: "{{ .Values.secrets.mountPathWorkerKeys | default "/concourse-keys" }}/worker_key"
 
             {{- if .Values.concourse.worker.garden.logLevel }}
             - name: CONCOURSE_GARDEN_LOG_LEVEL
@@ -456,7 +456,7 @@ spec:
             privileged: true
           volumeMounts:
             - name: concourse-keys
-              mountPath: {{ .Values.secrets.mountPath.worker.keys | default "/concourse-keys" | quote }}
+              mountPath: {{ .Values.secrets.mountPathWorkerKeys | default "/concourse-keys" | quote }}
               readOnly: true
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.workingDirectory | default "/concourse-work-dir" | quote }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -147,9 +147,9 @@ spec:
             - name: CONCOURSE_TSA_HOST
               value: "{{ template "concourse.web.fullname" . }}:{{ .Values.concourse.web.tsa.bindPort}}"
             - name: CONCOURSE_TSA_PUBLIC_KEY
-              value: "{{ .Values.worker.keySecretsPath | default "/concourse-keys" }}/host_key.pub"
+              value: "{{ .Values.worker.keySecretsPath }}/host_key.pub"
             - name: CONCOURSE_TSA_WORKER_PRIVATE_KEY
-              value: "{{ .Values.worker.keySecretsPath | default "/concourse-keys" }}/worker_key"
+              value: "{{ .Values.worker.keySecretsPath }}/worker_key"
 
             {{- if .Values.concourse.worker.garden.logLevel }}
             - name: CONCOURSE_GARDEN_LOG_LEVEL
@@ -456,7 +456,7 @@ spec:
             privileged: true
           volumeMounts:
             - name: concourse-keys
-              mountPath: {{ .Values.worker.keySecretsPath | default "/concourse-keys" | quote }}
+              mountPath: {{ .Values.worker.keySecretsPath | quote }}
               readOnly: true
             - name: concourse-work-dir
               mountPath: {{ .Values.concourse.workingDirectory | default "/concourse-work-dir" | quote }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -695,11 +695,11 @@ web:
   #     value: "debug"
 
   ## For managing where secrets should be mounted for the web agents
-  # keySecretsPath: "/concourse-keys"
-  # authSecretsPath: "/concourse-auth"
-  # vaultSecretsPath: "/concourse-vault"
-  # postgresqlSecretsPath: "/concourse-postgresql"
-  # syslogSecretsPath: "/concourse-syslog"
+  keySecretsPath: "/concourse-keys"
+  authSecretsPath: "/concourse-auth"
+  vaultSecretsPath: "/concourse-vault"
+  postgresqlSecretsPath: "/concourse-postgresql"
+  syslogSecretsPath: "/concourse-syslog"
 
   ## Additional affinities to add to the web pods.
   ##
@@ -842,7 +842,7 @@ worker:
 
 
   ## For managing where secrets should be mounted for worker agents
-  # keySecretsPath: "/concourse-keys"
+  keySecretsPath: "/concourse-keys"
 
   ## Configure additional volumeMounts for the
   ## worker container(s)

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -700,6 +700,7 @@ web:
   vaultSecretsPath: "/concourse-vault"
   postgresqlSecretsPath: "/concourse-postgresql"
   syslogSecretsPath: "/concourse-syslog"
+  tlsSecretsPath: "/concourse-web-tls"
 
   ## Additional affinities to add to the web pods.
   ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1017,18 +1017,15 @@ rbac:
 ##
 secrets:
 
-  # For managing where secrets should be mounted
-  mountPath:
-    # The directory to mount secret volumes to in the worker agent
-    worker:
-      keys: "/concourse-keys"
-    # The directory to mount secret volumes to in the web agent
-    web:
-      keys: "/concourse-keys"
-      auth: "/concourse-auth"
-      vault: "/concourse-vault"
-      postgresql: "/concourse-postgresql"
-      syslog: "/concourse-syslog"
+  ## For managing where secrets should be mounted for worker agents
+  # mountPathWorkerKeys: "concourse-keys"
+
+  ## For managing where secrets should be mounted for the web agents
+  # mountPathWebKeys: "/concourse-keys"
+  # mountPathWebAuth: "/concourse-auth"
+  # mountPathWebVault: "/concourse-vault"
+  # mountPathWebPostgresql: "/concourse-postgresql"
+  # mountPathWebSyslog: "/concourse-syslog"
 
   ## List of username:bcrypted_password combinations for all your local concourse users.
   localUsers: "test:$2a$10$sDB6AsH2HheOWHILrnHVJOCZq/GYtUYE02ypJJTQBmWJNivYNhP3y"

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -693,7 +693,7 @@ web:
   #     value: "debug"
   #   - name: CONCOURSE_TSA_LOG_LEVEL
   #     value: "debug"
-  
+
   ## For managing where secrets should be mounted for the web agents
   # keySecretsPath: "/concourse-keys"
   # authSecretsPath: "/concourse-auth"
@@ -1026,8 +1026,6 @@ rbac:
 ## For managing secrets using Helm
 ##
 secrets:
-
-
 
   ## List of username:bcrypted_password combinations for all your local concourse users.
   localUsers: "test:$2a$10$sDB6AsH2HheOWHILrnHVJOCZq/GYtUYE02ypJJTQBmWJNivYNhP3y"

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -1017,6 +1017,19 @@ rbac:
 ##
 secrets:
 
+  # For managing where secrets should be mounted
+  mountPath:
+    # The directory to mount secret volumes to in the worker agent
+    worker:
+      keys: "/concourse-keys"
+    # The directory to mount secret volumes to in the web agent
+    web:
+      keys: "/concourse-keys"
+      auth: "/concourse-auth"
+      vault: "/concourse-vault"
+      postgresql: "/concourse-postgresql"
+      syslog: "/concourse-syslog"
+
   ## List of username:bcrypted_password combinations for all your local concourse users.
   localUsers: "test:$2a$10$sDB6AsH2HheOWHILrnHVJOCZq/GYtUYE02ypJJTQBmWJNivYNhP3y"
   ## Create the secret resource from the following values. Set this to

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -693,6 +693,13 @@ web:
   #     value: "debug"
   #   - name: CONCOURSE_TSA_LOG_LEVEL
   #     value: "debug"
+  
+  ## For managing where secrets should be mounted for the web agents
+  # keySecretsPath: "/concourse-keys"
+  # authSecretsPath: "/concourse-auth"
+  # vaultSecretsPath: "/concourse-vault"
+  # postgresqlSecretsPath: "/concourse-postgresql"
+  # syslogSecretsPath: "/concourse-syslog"
 
   ## Additional affinities to add to the web pods.
   ##
@@ -833,6 +840,9 @@ worker:
   #   - name: CONCOURSE_GARDEN_ALLOW_HOST_ACCESS
   #     value: "true"
 
+
+  ## For managing where secrets should be mounted for worker agents
+  # keySecretsPath: "/concourse-keys"
 
   ## Configure additional volumeMounts for the
   ## worker container(s)
@@ -1017,15 +1027,7 @@ rbac:
 ##
 secrets:
 
-  ## For managing where secrets should be mounted for worker agents
-  # mountPathWorkerKeys: "concourse-keys"
 
-  ## For managing where secrets should be mounted for the web agents
-  # mountPathWebKeys: "/concourse-keys"
-  # mountPathWebAuth: "/concourse-auth"
-  # mountPathWebVault: "/concourse-vault"
-  # mountPathWebPostgresql: "/concourse-postgresql"
-  # mountPathWebSyslog: "/concourse-syslog"
 
   ## List of username:bcrypted_password combinations for all your local concourse users.
   localUsers: "test:$2a$10$sDB6AsH2HheOWHILrnHVJOCZq/GYtUYE02ypJJTQBmWJNivYNhP3y"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR allows the user to specify where the secrets that manage the system are mounted on the web and worker agent. For our security tools we need to specify where the secrets are found or expected.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
