### PR TITLE
[stable/concourse] Optionally not mount k8s secrets

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.0.0
+version: 3.0.1
 appVersion: 4.2.1
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
 | `secrets.localUsers` | Create concourse local users. Default username and password are test:test *See [values.yaml](values.yaml)* |
 | `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
+| `secrets.mount` | Mount the secret resource | `true` |
 | `secrets.hostKey` | Concourse Host Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.hostKeyPub` | Concourse Host Public Key | *See [values.yaml](values.yaml)* |
 | `secrets.sessionSigningKey` | Concourse Session Signing Private Key | *See [values.yaml](values.yaml)* |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -930,6 +930,7 @@ spec:
 {{- end }}
       volumes:
         - name: concourse-keys
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -940,8 +941,12 @@ spec:
                 path: session_signing_key
               - key: worker-key-pub
                 path: worker_key.pub
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- if .Values.concourse.web.vault.enabled }}
         - name: vault-keys
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -956,9 +961,13 @@ spec:
               - key: vault-client-key
                 path: client.key
             {{- end }}
+          {{ else }}
+          emptyDir: {}
+          {{- end }}
         {{- end }}
         {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
         - name: postgresql-keys
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -969,17 +978,25 @@ spec:
                 path: client.cert
               - key: postgresql-client-key
                 path: client.key
+          {{ else }}
+          emptyDir: {}
+          {{- end }}
         {{- end }}
         {{- if .Values.concourse.web.syslog.enabled }}
         - name: syslog-keys
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
             items:
               - key: syslog-ca-cert
                 path: ca.cert
+          {{ else }}
+          emptyDir: {}
+          {{- end }}
         {{- end }}
         - name: auth-keys
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -1004,3 +1021,6 @@ spec:
               - key: oidc-ca-cert
                 path: oidc_ca.cert
               {{- end }}
+          {{ else }}
+          emptyDir: {}
+          {{- end }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -930,7 +930,7 @@ spec:
 {{- end }}
       volumes:
         - name: concourse-keys
-          {{- if .Values.secrets.mount }}
+          {{- if .Values.secrets.mount | default true }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -946,7 +946,7 @@ spec:
           {{- end }}
         {{- if .Values.concourse.web.vault.enabled }}
         - name: vault-keys
-          {{- if .Values.secrets.mount }}
+          {{- if .Values.secrets.mount | default true }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -967,7 +967,7 @@ spec:
         {{- end }}
         {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
         - name: postgresql-keys
-          {{- if .Values.secrets.mount }}
+          {{- if .Values.secrets.mount | default true }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -984,7 +984,7 @@ spec:
         {{- end }}
         {{- if .Values.concourse.web.syslog.enabled }}
         - name: syslog-keys
-          {{- if .Values.secrets.mount }}
+          {{- if .Values.secrets.mount | default true }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -996,7 +996,7 @@ spec:
           {{- end }}
         {{- end }}
         - name: auth-keys
-          {{- if .Values.secrets.mount }}
+          {{- if .Values.secrets.mount | default true }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -159,13 +159,11 @@ spec:
               value: {{ template "concourse.postgresql.fullname" . }}
             - name: CONCOURSE_POSTGRES_USER
               value: {{ .Values.postgresql.postgresUser | quote }}
-            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.postgresql.fullname" . }}
                   key: postgres-password
-            {{- end }}
             - name: CONCOURSE_POSTGRES_DATABASE
               value: {{ .Values.postgresql.postgresDatabase | quote }}
             {{- else }}

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -930,7 +930,7 @@ spec:
 {{- end }}
       volumes:
         - name: concourse-keys
-          {{- if .Values.secrets.mount | default true }}
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -946,7 +946,7 @@ spec:
           {{- end }}
         {{- if .Values.concourse.web.vault.enabled }}
         - name: vault-keys
-          {{- if .Values.secrets.mount | default true }}
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -967,7 +967,7 @@ spec:
         {{- end }}
         {{- if not (eq (default "disable" .Values.concourse.web.postgres.sslmode) "disable") }}
         - name: postgresql-keys
-          {{- if .Values.secrets.mount | default true }}
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -984,7 +984,7 @@ spec:
         {{- end }}
         {{- if .Values.concourse.web.syslog.enabled }}
         - name: syslog-keys
-          {{- if .Values.secrets.mount | default true }}
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -996,7 +996,7 @@ spec:
           {{- end }}
         {{- end }}
         - name: auth-keys
-          {{- if .Values.secrets.mount | default true }}
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: CONCOURSE_BIND_IP
               value: {{ .Values.concourse.web.bindIp | quote }}
             {{- end }}
-            {{- if .Values.concourse.web.localAuth.enabled }}
+            {{- if and .Values.secrets.mount .Values.concourse.web.localAuth.enabled }}
             - name: CONCOURSE_ADD_LOCAL_USER
               valueFrom:
                 secretKeyRef:
@@ -81,7 +81,7 @@ spec:
             - name: CONCOURSE_PEER_URL
               value: "http://$(POD_IP):$(CONCOURSE_BIND_PORT)"
             {{- end }}
-            {{- if .Values.concourse.web.encryption.enabled }}
+            {{- if and .Values.secrets.mount .Values.concourse.web.encryption.enabled }}
             - name: CONCOURSE_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
@@ -159,11 +159,13 @@ spec:
               value: {{ template "concourse.postgresql.fullname" . }}
             - name: CONCOURSE_POSTGRES_USER
               value: {{ .Values.postgresql.postgresUser | quote }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.postgresql.fullname" . }}
                   key: postgres-password
+            {{- end }}
             - name: CONCOURSE_POSTGRES_DATABASE
               value: {{ .Values.postgresql.postgresDatabase | quote }}
             {{- else }}
@@ -179,6 +181,7 @@ spec:
             - name: CONCOURSE_POSTGRES_SOCKET
               value: {{ .Values.concourse.web.postgres.socket | quote }}
             {{- end }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -189,6 +192,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: postgresql-password
+            {{- end }}
             {{- if .Values.concourse.web.postgres.sslmode }}
             - name: CONCOURSE_POSTGRES_SSLMODE
               value: {{ .Values.concourse.web.postgres.sslmode | quote }}
@@ -232,6 +236,7 @@ spec:
             {{- end }}
 
             {{- if .Values.concourse.web.awsSecretsManager.enabled }}
+            {{- if .Values.secretes.mount }}
             - name: CONCOURSE_AWS_SECRETSMANAGER_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -249,6 +254,7 @@ spec:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: aws-secretsmanager-session-token
             {{- end }}
+            {{- end }}
             {{- if .Values.concourse.web.awsSecretsManager.region }}
             - name: AWS_REGION
               value: {{ .Values.concourse.web.awsSecretsManager.region | quote }}
@@ -265,6 +271,7 @@ spec:
 
 
             {{- if .Values.concourse.web.awsSsm.enabled }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_AWS_SSM_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
@@ -281,6 +288,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: aws-ssm-session-token
+            {{- end }}
             {{- end }}
             {{- if .Values.concourse.web.awsSsm.region }}
             - name: AWS_REGION
@@ -307,7 +315,7 @@ spec:
             - name: CONCOURSE_VAULT_CA_CERT
               value: "/concourse-vault/ca.cert"
             {{- end }}
-            {{- if eq (default "" .Values.concourse.web.vault.authBackend) "token" }}
+            {{- if and .Values.secrets.mount eq (default "" .Values.concourse.web.vault.authBackend) "token" }}
             - name: CONCOURSE_VAULT_CLIENT_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -320,7 +328,7 @@ spec:
             - name: CONCOURSE_VAULT_CLIENT_KEY
               value: "/concourse-vault/client.key"
             {{- end }}
-            {{- if eq (default "" .Values.concourse.web.vault.authBackend) "approle" }}
+            {{- if and .Values.secrets.mount eq (default "" .Values.concourse.web.vault.authBackend) "approle" }}
             - name: CONCOURSE_VAULT_AUTH_PARAM
               valueFrom:
                 secretKeyRef:
@@ -414,11 +422,13 @@ spec:
               value: {{ .Values.concourse.web.influxdb.database | quote }}
             - name: CONCOURSE_INFLUXDB_USERNAME
               value: {{ .Values.concourse.web.influxdb.username | quote }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_INFLUXDB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: influxdb-password
+            {{- end }}
             - name: CONCOURSE_INFLUXDB_INSECURE_SKIP_VERIFY
               value: {{ .Values.concourse.web.influxdb.insecureSkipVerify | quote}}
             {{- end }}
@@ -595,6 +605,7 @@ spec:
             {{- end }}
 
             {{- if .Values.concourse.web.auth.cf.enabled }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_CF_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -605,6 +616,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: cf-client-secret
+            {{- end }}
             {{- if .Values.concourse.web.auth.cf.apiUrl }}
             - name: CONCOURSE_CF_API_URL
               value: {{ .Values.concourse.web.auth.cf.apiUrl | quote }}
@@ -620,6 +632,7 @@ spec:
             {{- end }}
 
             {{- if .Values.concourse.web.auth.github.enabled }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_GITHUB_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -630,6 +643,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: github-client-secret
+            {{- end }}
             {{- if .Values.concourse.web.auth.github.host }}
             - name: CONCOURSE_GITHUB_HOST
               value: {{ .Values.concourse.web.auth.github.host | quote }}
@@ -641,6 +655,7 @@ spec:
             {{- end }}
 
             {{- if .Values.concourse.web.auth.gitlab.enabled }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_GITLAB_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -651,6 +666,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: gitlab-client-secret
+            {{- end }}
             {{- if .Values.concourse.web.auth.gitlab.host }}
             - name: CONCOURSE_GITLAB_HOST
               value: {{ .Values.concourse.web.auth.gitlab.host | quote }}
@@ -749,6 +765,7 @@ spec:
             - name: CONCOURSE_OAUTH_DISPLAY_NAME
               value: {{ .Values.concourse.web.auth.oauth.displayName | quote }}
             {{- end }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -759,6 +776,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: oauth-client-secret
+            {{- end }}
             {{- if .Values.concourse.web.auth.oauth.authUrl }}
             - name: CONCOURSE_OAUTH_AUTH_URL
               value: {{ .Values.concourse.web.auth.oauth.authUrl | quote }}
@@ -798,6 +816,7 @@ spec:
             - name: CONCOURSE_OIDC_ISSUER
               value: {{ .Values.concourse.web.auth.oidc.issuer | quote }}
             {{- end }}
+            {{- if .Values.secrets.mount }}
             - name: CONCOURSE_OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -808,6 +827,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "concourse.concourse.fullname" . }}
                   key: oidc-client-secret
+            {{- end }}
             {{- if .Values.concourse.web.auth.oidc.scope }}
             - name: CONCOURSE_OIDC_SCOPE
               value: {{ .Values.concourse.web.auth.oidc.scope | quote }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -484,7 +484,7 @@ spec:
 {{ toYaml .Values.worker.additionalVolumes | indent 8 }}
 {{- end }}
         - name: concourse-keys
-          {{- if .Values.secrets.mount | default true }}
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -484,6 +484,7 @@ spec:
 {{ toYaml .Values.worker.additionalVolumes | indent 8 }}
 {{- end }}
         - name: concourse-keys
+          {{- if .Values.secrets.mount }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400
@@ -494,6 +495,9 @@ spec:
                 path: worker_key
               - key: worker-key-pub
                 path: worker_key.pub
+          {{ else }}
+          emptyDir: {}
+          {{- end }}
 {{- define "concourse.are-there-additional-volumes.with-the-name.concourse-work-dir" }}
   {{- range .Values.worker.additionalVolumes }}
     {{- if .name | eq "concourse-work-dir" }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -484,7 +484,7 @@ spec:
 {{ toYaml .Values.worker.additionalVolumes | indent 8 }}
 {{- end }}
         - name: concourse-keys
-          {{- if .Values.secrets.mount }}
+          {{- if .Values.secrets.mount | default true }}
           secret:
             secretName: {{ template "concourse.concourse.fullname" . }}
             defaultMode: 0400

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -991,7 +991,7 @@ secrets:
   ## Use kubernetes secrets to store the secrets. Setting this to false will mount an
   ## empty directory to the secrets paths. Only set this to false if you intend to inject
   ## the secrets to the secrets paths outside of kubernetes
-  # mount: true
+  mount: true
 
   ## Concourse Host Keys.
   ## ref: https://concourse-ci.org/install.html#generating-keys

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -988,6 +988,11 @@ secrets:
   ##
   create: true
 
+  ## Use kubernetes secrets to store the secrets. Setting this to false will mount an
+  ## empty directory to the secrets paths. Only set this to false if you intend to inject 
+  ## the secrets to the secrets paths outside of helm
+  mount: true
+  
   ## Concourse Host Keys.
   ## ref: https://concourse-ci.org/install.html#generating-keys
   ##

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -991,7 +991,7 @@ secrets:
   ## Use kubernetes secrets to store the secrets. Setting this to false will mount an
   ## empty directory to the secrets paths. Only set this to false if you intend to inject 
   ## the secrets to the secrets paths outside of helm
-  mount: true
+  # mount: true
   
   ## Concourse Host Keys.
   ## ref: https://concourse-ci.org/install.html#generating-keys

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -990,7 +990,7 @@ secrets:
 
   ## Use kubernetes secrets to store the secrets. Setting this to false will mount an
   ## empty directory to the secrets paths. Only set this to false if you intend to inject
-  ## the secrets to the secrets paths outside of helm
+  ## the secrets to the secrets paths outside of kubernetes
   # mount: true
 
   ## Concourse Host Keys.

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -989,10 +989,10 @@ secrets:
   create: true
 
   ## Use kubernetes secrets to store the secrets. Setting this to false will mount an
-  ## empty directory to the secrets paths. Only set this to false if you intend to inject 
+  ## empty directory to the secrets paths. Only set this to false if you intend to inject
   ## the secrets to the secrets paths outside of helm
   # mount: true
-  
+
   ## Concourse Host Keys.
   ## ref: https://concourse-ci.org/install.html#generating-keys
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR allows you to mount an empty dir to the location secrets are expected to manage them outside of kubernetes secrets.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
