### PR TITLE
Add Static IP for for Kafka Brokers external service (LoadBalancerIP)

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.12.0
+version: 0.12.1
 appVersion: 5.0.0
 keywords:
 - kafka

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -8,6 +8,7 @@
     {{- $externalListenerPort := add $root.Values.external.firstListenerPort $i }}
     {{- $responsiblePod := printf "%s-%d" (printf "%s" $fullName) $i }}
     {{- $distinctPrefix := printf "%s-%d" $dnsPrefix $i }}
+    {{- $loadBalancerIP := index $root.Values.external.loadBalancerIP $i }}
 ---
 apiVersion: v1
 kind: Service
@@ -40,6 +41,9 @@ metadata:
     pod: {{ $responsiblePod | quote }}
 spec:
   type: {{ $root.Values.external.type }}
+  {{- if eq $root.Values.external.type "LoadBalancer" }}
+  loadBalancerIP: {{ $loadBalancerIP }}
+  {{- end }}
   ports:
     - name: external-broker
       {{- if and (eq $root.Values.external.type "LoadBalancer") (not $root.Values.external.distinct) }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -151,6 +151,7 @@ external:
     image: "lwolf/kubectl_deployer"
     imageTag: "0.4"
     imagePullPolicy: "IfNotPresent"
+
   # Static IP's and used in conjunction with type "LoadBalancer" on GCP/AWS.
   # This will ensure if the helm chart is deployed again, it will use the same Static IP
   loadBalancerIP: []

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -151,6 +151,9 @@ external:
     image: "lwolf/kubectl_deployer"
     imageTag: "0.4"
     imagePullPolicy: "IfNotPresent"
+  # Static IP's and used in conjunction with type "LoadBalancer" on GCP/AWS.
+  # This will ensure if the helm chart is deployed again, it will use the same Static IP
+  loadBalancerIP: []
 
 # Annotation to be added to Kafka pods
 podAnnotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This adds support for static IP's for Kafka External if type is "LoadBalancer". This can be used in GCP/AWS to make sure there are no new IP's created everytime we delete/install helm chart.

#### Special notes for your reviewer:
@benjigoldberg We are not making much changes here. Just adding support for static IP's in kafka external service.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
