### PR TITLE
Revert "[stable/fluent-bit] Fix indentation of extra params (#8825)"

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluent-bit
-version: 0.16.1
+version: 0.16.2
 appVersion: 0.14.6
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -36,7 +36,7 @@ data:
         DB               /tail-db/tail-containers-state.db
         DB.Sync          Normal
 {{- end }}
-{{ .Values.extraInputs | indent 8 }}
+{{ .Values.extraInputs | indent 4 }}
 
     [FILTER]
         Name                kubernetes
@@ -53,7 +53,7 @@ data:
 {{- if .Values.filter.enableExclude }}
         K8S-Logging.Exclude On
 {{- end }}
-{{ .Values.extraFilters | indent 8 }}
+{{ .Values.extraFilters | indent 4 }}
 
 {{ if eq .Values.backend.type "test" }}
     [OUTPUT]
@@ -130,7 +130,7 @@ data:
 {{- end }}
         Format {{ .Values.backend.http.format }}
 {{- end }}
-{{ .Values.extraOutputs | indent 8 }}
+{{ .Values.extraOutputs | indent 4 }}
 
   parsers.conf: |-
 {{- if .Values.parsers.regex }}


### PR DESCRIPTION
This reverts commit 9ab3cbbc28bf0416cf5400fb9ea4679763807506.

Signed-off-by: Christian Groschupp <christian@groschupp.org>

#### What this PR does / why we need it:
The parameters extraInputs, extraFilters and extraOutputs are used to create additional Input/Filters/Outputs blocks that require a indentation of 4 and not to append options to the previous block.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
