### PR TITLE
Adding OWNERS and .helmignore files

### DIFF
--- a/stable/newrelic-infrastructure/.helmignore
+++ b/stable/newrelic-infrastructure/.helmignore
@@ -1,0 +1,3 @@
+.git
+# OWNERS file for Kubernetes
+OWNERS

--- a/stable/newrelic-infrastructure/Chart.yaml
+++ b/stable/newrelic-infrastructure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy the New Relic Infrastructure Agent as a DaemonSet
 name: newrelic-infrastructure
-version: 0.7.0
+version: 0.7.1
 appVersion: 1.3.1
 home: https://hub.docker.com/r/newrelic/infrastructure/
 source:

--- a/stable/newrelic-infrastructure/OWNERS
+++ b/stable/newrelic-infrastructure/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- rk295
+reviewers:
+- rk295


### PR DESCRIPTION
#### What this PR does / why we need it:

The `newrelic-infrastructure` chart lacked an OWNERS file, this was highlighted in #9283 

#### Which issue this PR fixes

* Adds `OWNERS` and `.helmignore` files to the chart

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
