### PR TITLE
Adding missing enivornment variables to kong ingress controller

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.14.1

--- a/stable/kong/templates/controller-deployment.yaml
+++ b/stable/kong/templates/controller-deployment.yaml
@@ -44,6 +44,10 @@ spec:
           value: "/dev/stderr"
         - name: KONG_ADMIN_ERROR_LOG
           value: "/dev/stderr"
+        {{- range $key, $val := .Values.env }}
+        - name: KONG_{{ $key | upper}}
+          value: {{ $val | quote }}
+        {{- end}}
         {{- if .Values.postgresql.enabled }}
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
@@ -71,6 +75,10 @@ spec:
           value: "/dev/stdout"
         - name: KONG_ADMIN_ERROR_LOG
           value: "/dev/stderr"
+        {{- range $key, $val := .Values.env }}
+        - name: KONG_{{ $key | upper}}
+          value: {{ $val | quote }}
+        {{- end}}
         {{- if .Values.admin.useTLS }}
         - name: KONG_ADMIN_LISTEN
           value: "0.0.0.0:{{ .Values.admin.containerPort }} ssl"


### PR DESCRIPTION
Signed-off-by: Yousaf Syed <mmesunny@gmail.com>

#### What this PR does / why we need it:
This PR is a fix for the bug in the kong ingress controlled when used with Cassandra does not use the environment variable which causes the controller to look at the default database.

#### Which issue this PR fixes
  - fixes the Cassandra database with ingress controller

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
