### PR TITLE
[stable/chronograf] use env vars, and env secret and update image to 1.7

### DIFF
--- a/stable/chronograf/Chart.yaml
+++ b/stable/chronograf/Chart.yaml
@@ -1,6 +1,6 @@
 name: chronograf
-version: 0.4.5
-appVersion: 1.3
+version: 0.5.0
+appVersion: 1.7
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation
   rules.

--- a/stable/chronograf/Chart.yaml
+++ b/stable/chronograf/Chart.yaml
@@ -10,6 +10,6 @@ keywords:
 - timeseries
 home: https://www.influxdata.com/time-series-platform/chronograf/
 maintainers:
-- name: Jack Zampolin
+- name: jackzampolin
   email: jack@influxdb.com
 engine: gotpl

--- a/stable/chronograf/Chart.yaml
+++ b/stable/chronograf/Chart.yaml
@@ -1,5 +1,5 @@
 name: chronograf
-version: 0.5.0
+version: 1.0.0
 appVersion: 1.7
 description: Open-source web application written in Go and React.js that provides
   the tools to visualize your monitoring data and easily create alerting and automation

--- a/stable/chronograf/OWNERS
+++ b/stable/chronograf/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- jackzampolin
+reviewers:
+- jackzampolin

--- a/stable/chronograf/README.md
+++ b/stable/chronograf/README.md
@@ -69,3 +69,32 @@ $ helm install --name my-release -f values.yaml stable/chronograf
 The [Chronograf](https://quay.io/influxdb/chronograf) image stores data in the `/var/lib/chronograf` directory in the container.
 
 The chart optionally mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
+
+## OAuth Using Kubernetes Secret
+
+OAuth, among other things, can be configured in Chronograf using environment variables. For more information please see https://docs.influxdata.com/chronograf/latest/administration/managing-security
+
+Taking Google as an example, to use an existing Kubernetes Secret that contains sensitive information (`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`), e.g.:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chronograf-google-env-secrets
+  namespace: tick
+type: Opaque
+data:
+    GOOGLE_CLIENT_ID: <BASE64_ENCODED_GOOGLE_CLIENT_ID>
+    GOOGLE_CLIENT_SECRET: <BASE64_ENCODED_GOOGLE_CLIENT_SECRET>
+```
+
+in conjunction with less sensitive information such as `GOOGLE_DOMAINS` and `PUBLIC_URL`, one can make use of the chart's `envFromSecret` and `env` values, e.g. a values file can have the following:
+
+```
+[...]
+env:
+  GOOGLE_DOMAINS: "yourdomain.com"
+  PUBLIC_URL: "https://chronograf.yourdomain.com"
+envFromSecret: chronograf-google-env-secrets
+[...]
+```

--- a/stable/chronograf/templates/deployment.yaml
+++ b/stable/chronograf/templates/deployment.yaml
@@ -18,8 +18,12 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.oauth.enabled }}
         env:
+{{- range $key, $value := .Values.env }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
+{{- end }}
+{{- if .Values.oauth.enabled }}
         - name: TOKEN_SECRET
           valueFrom:
             secretKeyRef:
@@ -81,6 +85,11 @@ spec:
               name: {{ template "chronograf.fullname" . }}
               key: go_public_url
 {{- end }}
+{{- end }}
+{{- if .Values.envFromSecret }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.envFromSecret }}
 {{- end }}
         ports:
         - containerPort: 8888

--- a/stable/chronograf/values.yaml
+++ b/stable/chronograf/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: "docker.io/chronograf"
-  tag: "1.3-alpine"
+  tag: "1.7-alpine"
   pullPolicy: "Always"
 
 ## Specify a service type

--- a/stable/chronograf/values.yaml
+++ b/stable/chronograf/values.yaml
@@ -80,3 +80,10 @@ oauth:
     client_secret: CHANGE_ME
     # This is a comma separated list of Heroku organizations (OPTIONAL)
     he_orgs: ""
+
+## Extra environment variables that will be passed onto deployment pods
+env: {}
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc
+envFromSecret: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Inspired by grafana's helm chart, where we can use a k8s secret to populate env vars, and also add our own env vars, this change will allow a user to do just that. In my particular case, I prefer to use a k8s secret to populate OAUTH related env vars for example.
Update image from 1.3 to current 1.7 ....

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md


