### PR TITLE
add prometheus servicemonitor support to pushgateway

### DIFF
--- a/stable/prometheus-pushgateway/Chart.yaml
+++ b/stable/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.6.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 0.1.6
+version: 0.2.0
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/stable/prometheus-pushgateway/README.md
+++ b/stable/prometheus-pushgateway/README.md
@@ -10,7 +10,9 @@ $ helm install stable/prometheus-pushgateway
 
 ## Introduction
 
-This chart bootstraps a prometheus [pusgateway](http://github.com/prometheus/pushgateway) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a prometheus [pushgateway](http://github.com/prometheus/pushgateway) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+An optional prometheus `ServiceMonitor` can be enabled, should you wish to use this gateway with a [Prometheus Operator](https://github.com/coreos/prometheus-operator).
 
 ## Installing the Chart
 
@@ -36,30 +38,34 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the pushgateway chart and their default values.
 
-|        Parameter        |                                                          Description                                                          |      Default       |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `affinity`              | Affinity settings for pod assignment                                                                                          | `{}`               |
-| `extraArgs`             | Optional flags for pushgateway                                                                                                | `[]`               |
-| `image.repository`      | Image repository                                                                                                              | `prom/pushgateway` |
-| `image.tag`             | Image tag                                                                                                                     | `v0.6.0`           |
-| `image.pullPolicy`      | Image pull policy                                                                                                             | `IfNotPresent`     |
-| `ingress.enabled`       | Enables Ingress for pushgateway                                                                                               | `false`            |
-| `ingress.annotations`   | Ingress annotations                                                                                                           | `{}`               |
-| `ingress.hosts`         | Ingress accepted hostnames                                                                                                    | `nil`              |
-| `ingress.tls`           | Ingress TLS configuration                                                                                                     | `[]`               |
-| `resources`             | CPU/Memory resource requests/limits                                                                                           | `{}`               |
-| `replicaCount`          | Number of replicas                                                                                                            | `1`                |
-| `service.type`          | Service type                                                                                                                  | `ClusterIP`        |
-| `service.port`          | The service port                                                                                                              | `9091`             |
-| `service.targetPort`    | The target port of the container                                                                                              | `9091`             |
-| `serviceLabels`         | Labels for service                                                                                                            | `{}`               |
-| `serviceAccount.create` | Specifies whether a service account should be created.                                                                        | `true`             |
-| `serviceAccount.name`   | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                    |
-| `tolerations`           | List of node taints to tolerate                                                                                               | `{}`               |
-| `nodeSelector`          | Node labels for pod assignment                                                                                                | `{}`               |
-| `podAnnotations`        | Annotations for pod                                                                                                           | `{}`               |
-| `podLabels`             | Labels for pod                                                                                                                | `{}`               |
-| `serviceAccountLabels`  | Labels for service account                                                                                                    | `{}`               |
+|        Parameter            |                                                          Description                                                          |      Default                      |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `affinity`                  | Affinity settings for pod assignment                                                                                          | `{}`                              |
+| `extraArgs`                 | Optional flags for pushgateway                                                                                                | `[]`                              |
+| `image.repository`          | Image repository                                                                                                              | `prom/pushgateway`                |
+| `image.tag`                 | Image tag                                                                                                                     | `v0.6.0`                          |
+| `image.pullPolicy`          | Image pull policy                                                                                                             | `IfNotPresent`                    |
+| `ingress.enabled`           | Enables Ingress for pushgateway                                                                                               | `false`                           |
+| `ingress.annotations`       | Ingress annotations                                                                                                           | `{}`                              |
+| `ingress.hosts`             | Ingress accepted hostnames                                                                                                    | `nil`                             |
+| `ingress.tls`               | Ingress TLS configuration                                                                                                     | `[]`                              |
+| `resources`                 | CPU/Memory resource requests/limits                                                                                           | `{}`                              |
+| `replicaCount`              | Number of replicas                                                                                                            | `1`                               |
+| `service.type`              | Service type                                                                                                                  | `ClusterIP`                       |
+| `service.port`              | The service port                                                                                                              | `9091`                            |
+| `service.targetPort`        | The target port of the container                                                                                              | `9091`                            |
+| `serviceLabels`             | Labels for service                                                                                                            | `{}`                              |
+| `serviceAccount.create`     | Specifies whether a service account should be created.                                                                        | `true`                            |
+| `serviceAccount.name`       | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                   |
+| `tolerations`               | List of node taints to tolerate                                                                                               | `{}`                              |
+| `nodeSelector`              | Node labels for pod assignment                                                                                                | `{}`                              |
+| `podAnnotations`            | Annotations for pod                                                                                                           | `{}`                              |
+| `podLabels`                 | Labels for pod                                                                                                                | `{}`                              |
+| `serviceAccountLabels`      | Labels for service account                                                                                                    | `{}`                              |
+| `serviceMonitor.enabled`    | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                        | `false`                           |
+| `serviceMonitor.namespace`  | Namespace which Prometheus is running in                                                                                      | `monitoring`                      |
+| `serviceMonitor.interval`   | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                        |  `nil`                            |
+| `serviceMonitor.selector`   | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install                    | `{ prometheus: kube-prometheus }` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-pushgateway/templates/servicemonitor.yaml
+++ b/stable/prometheus-pushgateway/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-pushgateway.name" .  }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- range $key, $value := .Values.serviceMonitor.selector }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: http
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-pushgateway.name" . }}
+{{- end -}}

--- a/stable/prometheus-pushgateway/values.yaml
+++ b/stable/prometheus-pushgateway/values.yaml
@@ -88,3 +88,15 @@ replicaCount: 1
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+
+# Enable this if you're using https://github.com/coreos/prometheus-operator
+serviceMonitor:
+  enabled: false
+  namespace: monitoring
+  # fallback to the prometheus default unless specified
+  # interval: 10s
+  ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
+  ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
+  ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
+  selector:
+    prometheus: kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds optional (Disabled by default) https://github.com/coreos/prometheus-operator support to the gateway.

The markdown table with the variables needed some columns widened, hence the excessive diff. (turn off github whitespace in the diff for the main changes)

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md

