### PR TITLE
fix typo in schema-registry values

### DIFF
--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -83,7 +83,7 @@ sasl:
     #   zookeeperClientPassword:
     #     secretKeyRef:
     #       name: "zookeeper-secret"
-    #       key: "zokeeper-client-password"
+    #       key: "zookeeper-client-password"
 
 ## Kafka Settings
 kafka:


### PR DESCRIPTION
Signed-off-by: Brad Jewell <brad811@gmail.com>

#### What this PR does / why we need it:
Fixes a minor typo in the schema-registry values.yaml file.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed