### PR TITLE
[stable/cockroachdb] Increase the default disk size to 100GB

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.0.5
+version: 2.0.6
 appVersion: 2.1.1
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/README.md
+++ b/stable/cockroachdb/README.md
@@ -29,10 +29,10 @@ helm install --name my-release stable/cockroachdb
 ```
 
 Note that for a production cluster, you are very likely to want to modify the
-`Storage` and `StorageClass` parameters. This chart defaults to just 1 GiB of
-disk space per pod in order for it to work in small environments like Minikube,
+`Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of
+disk space per pod, but you may want more or less depending on your use case,
 and the default persistent volume `StorageClass` in your environment may not be
-what you want for a database (e.g. on GCE the default is not SSD).
+what you want for a database (e.g. on GCE and Azure the default is not SSD).
 
 If you are running in secure mode (with configuration parameter `Secure.Enabled`
 set to `true`), then you will have to manually approve the cluster's security
@@ -49,7 +49,7 @@ Due to having no explicit selector set for the StatefulSet before version 2.0.0 
 this chart, upgrading from any version that uses a version of kubernetes that locks
 the selector labels to any other version is impossible without deleting the StatefulSet.
 Luckily there is a way to do it without actually deleting all the resources managed
-by the StatefulSet. Use the workaround below to upgrade from charts versions previous 
+by the StatefulSet. Use the workaround below to upgrade from charts versions previous
 to 2.0.0. The following example assumes that the release name is crdb:
 
 ```console
@@ -82,7 +82,7 @@ The following table lists the configurable parameters of the CockroachDB chart a
 | `ExternalHttpPort`             | CockroachDB HTTP port on service                 | `8080`                                    |
 | `HttpName`                     | Name given to the http service port              | `http`                                    |
 | `Resources`                    | Resource requests and limits                     | `{}`                                      |
-| `Storage`                      | Persistent volume size                           | `1Gi`                                     |
+| `Storage`                      | Persistent volume size                           | `100Gi`                                     |
 | `StorageClass`                 | Persistent volume class                          | `null`                                    |
 | `CacheSize`                    | Size of CockroachDB's in-memory cache            | `25%`                                     |
 | `MaxSQLMemory`                 | Max memory to use processing SQL queries         | `25%`                                     |

--- a/stable/cockroachdb/templates/NOTES.txt
+++ b/stable/cockroachdb/templates/NOTES.txt
@@ -23,7 +23,7 @@ your cluster fail.
 
 Note that because the cluster is running in secure mode, any client application
 that you attempt to connect will either need to have a valid client certificate
-or a valid username and password. 
+or a valid username and password.
 {{- end }}
 
 {{- if and (.Values.NetworkPolicy.Enabled) (not .Values.NetworkPolicy.AllowExternal) }}
@@ -48,11 +48,3 @@ Then you can access the admin UI at https://localhost:{{ .Values.InternalHttpPor
 
 For more information on using CockroachDB, please see the project's docs at
 https://www.cockroachlabs.com/docs/
-
-{{- if eq .Values.Storage "1Gi" }}
-
-WARNING: Only 1 GiB of disk space is being requested for each pod. This will
-not be enough for a production custer. Re-install with a customized "Storage"
-parameter if you woud like more disk space.
-
-{{- end }}

--- a/stable/cockroachdb/values.yaml
+++ b/stable/cockroachdb/values.yaml
@@ -29,7 +29,7 @@ Resources: {}
   # requests:
   #   cpu: "100m"
   #   memory: "512Mi"
-Storage: "1Gi"
+Storage: "100Gi"
 ## Persistent Volume Storage Class for database data
 ## If defined, storageClassName: <StorageClass>
 ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
In the past there had problems with Minikube not accepting large disk sizes,
but it no longer seems to be a problem on more recent versions, so let's
default to something a little more reasonable here.

Signed-off-by: Bram Gruneir <bram@cockroachlabs.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
