### PR TITLE
[stable/redis-ha] Portable init script

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.0.2
+version: 3.0.3
 appVersion: 4.0.11
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -37,24 +37,25 @@ data:
 {{- end }}
 
   init.sh: |
-    MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
+    HOSTNAME=$(hostname)
+    MASTER=$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
     REDIS_CONF=/data/conf/redis.conf
     SENTINEL_CONF=/data/conf/sentinel.conf
     
     set -e
-    function sentinel_update(){
+    sentinel_update() {
         echo "Updating sentinel config"
-        sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \n/" $SENTINEL_CONF
+        sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \\n/" $SENTINEL_CONF
     }
 
-    function redis_update(){
+    redis_update() {
         echo "Updating redis config"
         echo "slaveof $1 {{ .Values.redis.port }}" >> $REDIS_CONF
     }
 
-    function setup_defaults(){
+    setup_defaults() {
         echo "Setting up defaults"
-        if [[ "$HOSTNAME" == "{{ template "redis-ha.fullname" . }}-server-0" ]]; then
+        if [ "$HOSTNAME" = "{{ template "redis-ha.fullname" . }}-server-0" ]; then
             echo "Setting this pod as the default master"
             sed -i "s/^.*slaveof.*//" $REDIS_CONF
             sentinel_update "$POD_IP"
@@ -66,27 +67,27 @@ data:
         fi
     }
 
-    function find_master(){
+    find_master() {
         echo "Attempting to find master"
-        if [[ ! `redis-cli -h $MASTER{{ if .Values.auth }} -a $AUTH{{ end }} ping` ]]; then
+        if [ ! "$(redis-cli -h "$MASTER"{{ if .Values.auth }} -a $AUTH{{ end }} ping)" ]; then
            echo "Can't ping master, attempting to force failover"
            if redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel failover {{ .Values.redis.masterGroupName }} | grep -q 'NOGOODSLAVE' ; then 
                setup_defaults
                return 0
            fi
            sleep 10
-           MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
-           if [[ "$MASTER" ]]; then
-               sentinel_update $MASTER
-               redis_update $MASTER
+           MASTER=$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+           if [ "$MASTER" ]; then
+               sentinel_update "$MASTER"
+               redis_update "$MASTER"
            else
               echo "Could not failover, exiting..."
               exit 1
            fi
         else
             echo "Found reachable master, updating config"
-            sentinel_update $MASTER
-            redis_update $MASTER
+            sentinel_update "$MASTER"
+            redis_update "$MASTER"
         fi
     }
 
@@ -96,12 +97,12 @@ data:
     cp /readonly-config/redis.conf $REDIS_CONF
     cp /readonly-config/sentinel.conf $SENTINEL_CONF
 
-    if [[ "$MASTER" ]]; then
+    if [ "$MASTER" ]; then
         find_master
     else
         setup_defaults
     fi
-    if [[ "$AUTH" ]]; then
+    if [ "$AUTH" ]; then
         echo "Setting auth values"
         sed -i "s/replace-default-auth/$AUTH/" $REDIS_CONF $SENTINEL_CONF
     fi

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -37,31 +37,31 @@ data:
 {{- end }}
 
   init.sh: |
-    HOSTNAME=$(hostname)
-    MASTER=$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+    HOSTNAME="$(hostname)"
+    MASTER="$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
     REDIS_CONF=/data/conf/redis.conf
     SENTINEL_CONF=/data/conf/sentinel.conf
     
     set -e
     sentinel_update() {
         echo "Updating sentinel config"
-        sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \\n/" $SENTINEL_CONF
+        sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \\n/" "$SENTINEL_CONF"
     }
 
     redis_update() {
         echo "Updating redis config"
-        echo "slaveof $1 {{ .Values.redis.port }}" >> $REDIS_CONF
+        echo "slaveof $1 {{ .Values.redis.port }}" >> "$REDIS_CONF"
     }
 
     setup_defaults() {
         echo "Setting up defaults"
         if [ "$HOSTNAME" = "{{ template "redis-ha.fullname" . }}-server-0" ]; then
             echo "Setting this pod as the default master"
-            sed -i "s/^.*slaveof.*//" $REDIS_CONF
+            sed -i "s/^.*slaveof.*//" "$REDIS_CONF"
             sentinel_update "$POD_IP"
         else
             echo "Setting default slave config.."
-            echo "slaveof {{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }} {{ .Values.redis.port }}" >> $REDIS_CONF
+            echo "slaveof {{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }} {{ .Values.redis.port }}" >> "$REDIS_CONF"
             sentinel_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
             redis_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
         fi
@@ -69,14 +69,14 @@ data:
 
     find_master() {
         echo "Attempting to find master"
-        if [ ! "$(redis-cli -h "$MASTER"{{ if .Values.auth }} -a $AUTH{{ end }} ping)" ]; then
+        if [ ! "$(redis-cli -h "$MASTER"{{ if .Values.auth }} -a "$AUTH"{{ end }} ping)" ]; then
            echo "Can't ping master, attempting to force failover"
            if redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel failover {{ .Values.redis.masterGroupName }} | grep -q 'NOGOODSLAVE' ; then 
                setup_defaults
                return 0
            fi
            sleep 10
-           MASTER=$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+           MASTER="$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
            if [ "$MASTER" ]; then
                sentinel_update "$MASTER"
                redis_update "$MASTER"
@@ -94,8 +94,8 @@ data:
     mkdir -p /data/conf/
     echo "Initializing config.."
 
-    cp /readonly-config/redis.conf $REDIS_CONF
-    cp /readonly-config/sentinel.conf $SENTINEL_CONF
+    cp /readonly-config/redis.conf "$REDIS_CONF"
+    cp /readonly-config/sentinel.conf "$SENTINEL_CONF"
 
     if [ "$MASTER" ]; then
         find_master
@@ -104,7 +104,7 @@ data:
     fi
     if [ "$AUTH" ]; then
         echo "Setting auth values"
-        sed -i "s/replace-default-auth/$AUTH/" $REDIS_CONF $SENTINEL_CONF
+        sed -i "s/replace-default-auth/$AUTH/" "$REDIS_CONF" "$SENTINEL_CONF"
     fi
 
     echo "Ready..."

--- a/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "redis-ha.fullname" . }}-configmap-test
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: shellcheck
+    image: koalaman/shellcheck:v0.5.0
+    command:
+    - shellcheck
+    - --shell=sh
+    - /readonly-config/init.sh
+    volumeMounts:
+    - name: config
+      mountPath: /readonly-config
+      readOnly: true
+  volumes:
+  - name: config
+    configMap:
+      name: {{ template "redis-ha.fullname" . }}-configmap
+  restartPolicy: Never


### PR DESCRIPTION
#### What this PR does / why we need it:
These changes makes the init script more portable allowing the chart to be more docker image agnostic. Also adds a helm test to run a shellcheck for POSIX sh compatibility/portability.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Was brought up by @007 here:
https://github.com/helm/charts/pull/8948#issuecomment-440017133

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped