### PR TITLE
[stable/rabbitmq] Normalize ports under service

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 3.6.3
+version: 4.0.0
 appVersion: 3.7.8
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -58,17 +58,17 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `rabbitmq.username`                  | RabbitMQ application username                    | `user`                                                  |
 | `rabbitmq.password`                  | RabbitMQ application password                    | _random 10 character long alphanumeric string_          |
 | `rabbitmq.erlangCookie`              | Erlang cookie                                    | _random 32 character long alphanumeric string_          |
-| `rabbitmq.amqpPort`                  | Amqp port                                        | `5672`                                                  |
-| `rabbitmq.distPort`                  | Erlang distribution server port                  | `25672`                                                 |
-| `rabbitmq.nodePort`                  | Node port override, if serviceType NodePort      | _random available between 30000-32767_                  |
-| `rabbitmq.managerPort`               | RabbitMQ Manager port                            | `15672`                                                 |
 | `rabbitmq.diskFreeLimit`             | Disk free limit                                  | `"6GiB"`                                                |
 | `rabbitmq.plugins`                   | configuration file for plugins to enable         | `[rabbitmq_management,rabbitmq_peer_discovery_k8s].`    |
 | `rabbitmq.clustering.address_type`   | Switch clustering mode                           | `ip` or `hostname`                                      |
 | `rabbitmq.clustering.k8s_domain`     | Customize internal k8s cluster domain            | `cluster.local`                                         |
 | `rabbitmq.ulimitNofiles`             | Max File Descriptor limit                        | `65536`                                                 |
 | `rabbitmq.configuration`             | rabbitmq.conf content                            | see values.yaml                                         |
-| `serviceType`                        | Kubernetes Service type                          | `ClusterIP`                                             |
+| `service.type`                        | Kubernetes Service type                          | `ClusterIP`                                             |
+| `service.amqpPort`                  | Amqp port                                        | `5672`                                                  |
+| `service.distPort`                  | Erlang distribution server port                  | `25672`                                                 |
+| `service.nodePort`                  | Node port override, if serviceType NodePort      | _random available between 30000-32767_                  |
+| `service.managerPort`               | RabbitMQ Manager port                            | `15672`                                                 |
 | `persistence.enabled`                | Use a PVC to persist data                        | `false`                                                 |
 | `persistence.storageClass`           | Storage class of backing PVC                     | `nil` (uses alpha storage class annotation)             |
 | `persistence.accessMode`             | Use volume as ReadOnly or ReadWrite              | `ReadWriteOnce`                                         |

--- a/stable/rabbitmq/templates/NOTES.txt
+++ b/stable/rabbitmq/templates/NOTES.txt
@@ -7,11 +7,11 @@ Credentials:
     echo "Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)"
     echo "ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)"
 
-RabbitMQ can be accessed within the cluster on port {{ .Values.rabbitmq.nodePort }} at {{ template "rabbitmq.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+RabbitMQ can be accessed within the cluster on port {{ .Values.service.nodePort }} at {{ template "rabbitmq.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To access for outside the cluster, perform the following steps:
 
-{{- if contains "NodePort" .Values.serviceType }}
+{{- if contains "NodePort" .Values.service.type }}
 
 Obtain the NodePort IP and ports:
 
@@ -27,7 +27,7 @@ To Access the RabbitMQ Management interface:
 
     echo "URL : http://$NODE_IP:$NODE_PORT_STATS/"
 
-{{- else if contains "LoadBalancer" .Values.serviceType }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
 
 Obtain the LoadBalancer IP:
 
@@ -38,22 +38,22 @@ NOTE: It may take a few minutes for the LoadBalancer IP to be available.
 
 To Access the RabbitMQ AMQP port:
 
-    echo "URL : amqp://$SERVICE_IP:{{ .Values.rabbitmq.amqpPort }}/"
+    echo "URL : amqp://$SERVICE_IP:{{ .Values.service.port }}/"
 
 To Access the RabbitMQ Management interface:
 
-    echo "URL : http://$SERVICE_IP:{{ .Values.rabbitmq.managerPort }}/"
+    echo "URL : http://$SERVICE_IP:{{ .Values.service.managerPort }}/"
 
-{{- else if contains "ClusterIP"  .Values.serviceType }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
 
 To Access the RabbitMQ AMQP port:
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "rabbitmq.fullname" . }} {{ .Values.rabbitmq.amqpPort }}:{{ .Values.rabbitmq.amqpPort }}
-    echo "URL : amqp://127.0.0.1:{{ .Values.rabbitmq.amqpPort }}/"
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "rabbitmq.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+    echo "URL : amqp://127.0.0.1:{{ .Values.service.port }}/"
 
 To Access the RabbitMQ Management interface:
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "rabbitmq.fullname" . }} {{ .Values.rabbitmq.managerPort }}:{{ .Values.rabbitmq.managerPort }}
-    echo "URL : http://127.0.0.1:{{ .Values.rabbitmq.managerPort }}/"
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "rabbitmq.fullname" . }} {{ .Values.service.managerPort }}:{{ .Values.service.managerPort }}
+    echo "URL : http://127.0.0.1:{{ .Values.service.managerPort }}/"
 
 {{- end }}

--- a/stable/rabbitmq/templates/ingress.yaml
+++ b/stable/rabbitmq/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
         - path: {{ default "/" .path }}
           backend:
             serviceName: {{ template "rabbitmq.fullname" . }}
-            servicePort: {{ .Values.rabbitmq.managerPort }}
+            servicePort: {{ .Values.service.managerPort }}
 {{- if .Values.ingress.tls }}
   tls:
   - hosts:

--- a/stable/rabbitmq/templates/statefulset.yaml
+++ b/stable/rabbitmq/templates/statefulset.yaml
@@ -88,15 +88,15 @@ spec:
         - name: epmd
           containerPort: 4369
         - name: amqp
-          containerPort: {{ .Values.rabbitmq.amqpPort }}
+          containerPort: {{ .Values.service.port }}
         - name: dist
-          containerPort: {{ .Values.rabbitmq.distPort }}
+          containerPort: {{ .Values.service.distPort }}
         - name: stats
-          containerPort: {{ .Values.rabbitmq.managerPort }}
+          containerPort: {{ .Values.service.managerPort }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           exec:
-            command: ["sh", "-c", "test \"$(curl -sS -f --user {{ .Values.rabbitmq.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.rabbitmq.managerPort }}/api/healthchecks/node)\" = '{\"status\":\"ok\"}'"]
+            command: ["sh", "-c", "test \"$(curl -sS -f --user {{ .Values.rabbitmq.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.service.managerPort }}/api/healthchecks/node)\" = '{\"status\":\"ok\"}'"]
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -106,7 +106,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           exec:
-            command: ["sh", "-c", "test \"$(curl -sS -f --user {{ .Values.rabbitmq.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.rabbitmq.managerPort }}/api/healthchecks/node)\" = '{\"status\":\"ok\"}'"]
+            command: ["sh", "-c", "test \"$(curl -sS -f --user {{ .Values.rabbitmq.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.service.managerPort }}/api/healthchecks/node)\" = '{\"status\":\"ok\"}'"]
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -170,7 +170,7 @@ spec:
               name: {{ template "rabbitmq.fullname" . }}
               key: rabbitmq-password
         - name: RABBIT_URL
-          value: "http://localhost:{{ .Values.rabbitmq.managerPort }}"
+          value: "http://localhost:{{ .Values.service.managerPort }}"
         - name: RABBIT_USER
           value: {{ .Values.rabbitmq.username }}
         ports:

--- a/stable/rabbitmq/templates/svc-headless.yaml
+++ b/stable/rabbitmq/templates/svc-headless.yaml
@@ -14,13 +14,13 @@ spec:
     port: 4369
     targetPort: epmd
   - name: amqp
-    port: {{ .Values.rabbitmq.amqpPort }}
+    port: {{ .Values.service.port }}
     targetPort: amqp
   - name: dist
-    port: {{ .Values.rabbitmq.distPort }}
+    port: {{ .Values.service.distPort }}
     targetPort: dist
   - name: stats
-    port: {{ .Values.rabbitmq.managerPort }}
+    port: {{ .Values.service.managerPort }}
     targetPort: stats
   selector:
     app: {{ template "rabbitmq.name" . }}

--- a/stable/rabbitmq/templates/svc.yaml
+++ b/stable/rabbitmq/templates/svc.yaml
@@ -12,22 +12,22 @@ metadata:
 {{ toYaml .Values.metrics.annotations | indent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.serviceType }}
+  type: {{ .Values.service.type }}
   ports:
   - name: epmd
     port: 4369
     targetPort: epmd
   - name: amqp
-    port: {{ .Values.rabbitmq.amqpPort }}
+    port: {{ .Values.service.port }}
     targetPort: amqp
-    {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.rabbitmq.nodePort))) }}
-    nodePort: {{ .Values.rabbitmq.nodePort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
     {{- end }}
   - name: dist
-    port: {{ .Values.rabbitmq.distPort }}
+    port: {{ .Values.service.distPort }}
     targetPort: dist
   - name: stats
-    port: {{ .Values.rabbitmq.managerPort }}
+    port: {{ .Values.service.managerPort }}
     targetPort: stats
 {{- if .Values.metrics.enabled }}
   - name: metrics

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -49,30 +49,10 @@ rabbitmq:
   ##
   # erlangCookie:
 
-  ## Node port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-  ##
-  nodePort: 5672
-
-  ## Amqp port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-  ##
-  amqpPort: 5672
-
-  ## Dist port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-  ##
-  distPort: 25672
-
   ## Node name to cluster with. e.g.: `clusternode@hostname`
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
   ##
   # rabbitmqClusterNodeName:
-
-  ## RabbitMQ Manager port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-  ##
-  managerPort: 15672
 
   ## RabbitMQ Disk free limit
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
@@ -109,7 +89,26 @@ rabbitmq:
       loopback_users.guest = false
 
 ## Kubernetes service type
-serviceType: ClusterIP
+service:
+  type: ClusterIP
+  ## Node port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  nodePort: 5672
+
+  ## Amqp port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  amqpPort: 5672
+  ## Dist port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  distPort: 25672
+
+  ## RabbitMQ Manager port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  managerPort: 15672
 
 # Additional pod labels to apply
 podLabels: {}

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -49,30 +49,10 @@ rabbitmq:
   ##
   # erlangCookie:
 
-  ## Node port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-  ##
-  # nodePort: 30672
-
-  ## Amqp port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-  ##
-  amqpPort: 5672
-
-  ## Dist port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-  ##
-  distPort: 25672
-
   ## Node name to cluster with. e.g.: `clusternode@hostname`
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
   ##
   # rabbitmqClusterNodeName:
-
-  ## RabbitMQ Manager port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-  ##
-  managerPort: 15672
 
   ## RabbitMQ Disk free limit
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
@@ -109,7 +89,27 @@ rabbitmq:
       loopback_users.guest = false
 
 ## Kubernetes service type
-serviceType: ClusterIP
+service:
+  type: ClusterIP
+  ## Node port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # nodePort: 30672
+
+  ## Amqp port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  port: 5672
+
+  ## Dist port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  distPort: 25672
+
+  ## RabbitMQ Manager port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  managerPort: 15672
 
 # Additional pod labels to apply
 podLabels: {}


### PR DESCRIPTION
Signed-off-by: Javier J. Salmeron Garcia <jsalmeron@bitnami.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This chart normalizes bitnami charts by setting ports under service. 
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
