### PR TITLE
[stable/hlf-peer, stable/hlf-ord] Fix TLS mount clash and YAML indentation on TLS secrets

### DIFF
--- a/stable/hlf-ord/README.md
+++ b/stable/hlf-ord/README.md
@@ -102,7 +102,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `secrets.ord.caCert`               | CA Cert: as 'cacert.pem'                         | ``                                                         |
 | `secrets.ord.intCaCert`            | Int. CA Cert: as 'intermediatecacert.pem'        | ``                                                         |
 | `secrets.ord.tls`                  | TLS secret: as 'tls.crt' and 'tls.key'           | ``                                                         |
-| `secrets.ord.tlsRootCert`          | TLS root CA certificate: as 'cert.pem'           | ``                                                         |
+| `secrets.ord.tlsRootCert`          | TLS root CA certificate: as 'ca.crt'             | ``                                                         |
 | `secrets.genesis`                  | Secret containing Genesis Block for orderer      | ``                                                         |
 | `secrets.adminCert`                | Secret containing Orderer Org admin certificate  | ``                                                         |
 | `resources`                        | CPU/Memory resource requests/limits              | `{}`                                                       |

--- a/stable/hlf-ord/templates/configmap--ord.yaml
+++ b/stable/hlf-ord/templates/configmap--ord.yaml
@@ -24,10 +24,10 @@ data:
   ORDERER_GENERAL_GENESISFILE: /hl_config/genesis/genesis.block
   ORDERER_GENERAL_GENESISPROFILE: initial
   ORDERER_GENERAL_TLS_ENABLED: {{ .Values.ord.tls.server.enabled | quote }}
-  ORDERER_GENERAL_TLS_CERTIFICATE: "/var/hyperledger/msp_tls/tls.crt"
-  ORDERER_GENERAL_TLS_PRIVATEKEY: "/var/hyperledger/msp_tls/tls.key"
-  ORDERER_GENERAL_TLS_ROOTCAS: "/var/hyperledger/msp_tls/cert.pem"
+  ORDERER_GENERAL_TLS_CERTIFICATE: "/var/hyperledger/tls/tls.crt"
+  ORDERER_GENERAL_TLS_PRIVATEKEY: "/var/hyperledger/tls/tls.key"
+  ORDERER_GENERAL_TLS_ROOTCAS: "/var/hyperledger/tls_ca/ca.crt"
   ORDERER_GENERAL_TLS_CLIENTAUTHREQUIRED: {{ .Values.ord.tls.client.enabled | quote }}
-  ORDERER_GENERAL_TLS_CLIENTROOTCAS: "/var/hyperledger/msp_tls/cert.pem"
+  ORDERER_GENERAL_TLS_CLIENTROOTCAS: "/var/hyperledger/tls_ca/ca.crt"
   GODEBUG: "netdns=go"
   ADMIN_MSP_PATH: /var/hyperledger/admin_msp

--- a/stable/hlf-ord/templates/deployment.yaml
+++ b/stable/hlf-ord/templates/deployment.yaml
@@ -142,11 +142,11 @@ spec:
               name: intcacert
             {{- end }}
             {{- if .Values.secrets.ord.tls }}
-            - mountPath: /var/hyperledger/msp_tls
+            - mountPath: /var/hyperledger/tls
               name: tls
             {{- end }}
             {{- if .Values.secrets.ord.tlsRootCert }}
-            - mountPath: /var/hyperledger/msp_tls
+            - mountPath: /var/hyperledger/tls_ca
               name: tls-rootcert
             {{- end }}
             {{- if .Values.secrets.genesis }}

--- a/stable/hlf-ord/templates/deployment.yaml
+++ b/stable/hlf-ord/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         {{- if .Values.secrets.ord.tlsRootCert }}
         - name: tls-rootcert
           secret:
-          secretName: {{ .Values.secrets.ord.tlsRootCert }}
+            secretName: {{ .Values.secrets.ord.tlsRootCert }}
         {{- end }}
         {{- if .Values.secrets.genesis }}
         - name: genesis

--- a/stable/hlf-peer/README.md
+++ b/stable/hlf-peer/README.md
@@ -94,7 +94,7 @@ The following table lists the configurable parameters of the Hyperledger Fabric 
 | `secrets.peer.caCert`              | CA Cert: as 'cacert.pem'                             | ``                                                         |
 | `secrets.peer.intCaCert`           | Int. CA Cert: as 'intermediatecacert.pem'            | ``                                                         |
 | `secrets.peer.tls`                 | TLS secret: as 'tls.crt' and 'tls.key'               | ``                                                         |
-| `secrets.peer.tlsRootCert`         | TLS root CA certificate: as 'cert.pem'               | ``                                                         |
+| `secrets.peer.tlsRootCert`         | TLS root CA certificate: as 'ca.crt'                 | ``                                                         |
 | `secrets.channel`                  | Secret containing Channel tx for peer to create/join | ``                                                         |
 | `secrets.adminCert`                | Secret containing Peer Org admin certificate         | ``                                                         |
 | `secrets.adminCert`                | Secret containing Peer Org admin private key         | ``                                                         |

--- a/stable/hlf-peer/templates/configmap--peer.yaml
+++ b/stable/hlf-peer/templates/configmap--peer.yaml
@@ -28,9 +28,9 @@ data:
   CORE_PEER_TLS_ENABLED: {{ .Values.peer.tls.server.enabled | quote }}
   CORE_PEER_TLS_CERT_FILE: "/var/hyperledger/tls/tls.crt"
   CORE_PEER_TLS_KEY_FILE: "/var/hyperledger/tls/tls.key"
-  CORE_PEER_TLS_ROOTCERT_FILE: "/var/hyperledger/msp_tls/cert.pem"
+  CORE_PEER_TLS_ROOTCERT_FILE: "/var/hyperledger/tls_ca/ca.crt"
   CORE_PEER_TLS_CLIENTAUTHREQUIRED: {{ .Values.peer.tls.client.enabled | quote }}
-  CORE_PEER_TLS_CLIENTROOTCAS_FILES: "/var/hyperledger/msp_tls/cert.pem"
+  CORE_PEER_TLS_CLIENTROOTCAS_FILES: "/var/hyperledger/tls_ca/ca.crt"
   CORE_PEER_TLS_CLIENTCERT_FILE: "/var/hyperledger/tls/tls.crt"
   CORE_PEER_TLS_CLIENTKEY_FILE: "/var/hyperledger/tls/tls.key"
   CORE_LEDGER_STATE_STATEDATABASE: {{ .Values.peer.databaseType | quote }}

--- a/stable/hlf-peer/templates/deployment.yaml
+++ b/stable/hlf-peer/templates/deployment.yaml
@@ -159,11 +159,11 @@ spec:
               name: intcacert
             {{- end }}
             {{- if .Values.secrets.peer.tls }}
-            - mountPath: /var/hyperledger/msp_tls
+            - mountPath: /var/hyperledger/tls
               name: tls
             {{- end }}
             {{- if .Values.secrets.peer.tlsRootCert }}
-            - mountPath: /var/hyperledger/msp_tls
+            - mountPath: /var/hyperledger/tls_ca
               name: tls-rootcert
             {{- end }}
             {{- if .Values.secrets.channel }}

--- a/stable/hlf-peer/templates/deployment.yaml
+++ b/stable/hlf-peer/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         {{- if .Values.secrets.peer.tlsRootCert }}
         - name: tls-rootcert
           secret:
-          secretName: {{ .Values.secrets.peer.tlsRootCert }}
+            secretName: {{ .Values.secrets.peer.tlsRootCert }}
         {{- end }}
         {{- if .Values.secrets.channel }}
         - name: channel


### PR DESCRIPTION
#### What this PR does / why we need it:
- Fixes incorrect indentation on peer and orderer TLS root CA secrets.
- Fixes a volume mount clash where TLS cert/key and root CA attempt to mount to the same target resulting in the following error:

```
Error: release peer0 failed: Deployment.apps "peer0-hlf-peer" is invalid: spec.template.spec.containers[0].volumeMounts[7].mountPath: Invalid value: "/var/hyperledger/msp_tls": must be unique
```