### PR TITLE
[datadog] Bump kube-state-metrics version

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.10.3
+version: 1.11.0
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.11.0
-digest: sha256:6421dac557426682201dd3267e27cbdac36a276310b175764fe6a985a4712c25
-generated: 2018-11-21T18:45:13.407083772+01:00
+digest: sha256:78b2838433c7b6ca3fc7d62ca3a017c2c1116c080df2b245a29f3f6ecc37d544
+generated: 2018-11-21T19:00:49.191534591+01:00

--- a/stable/datadog/requirements.lock
+++ b/stable/datadog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.9.0
-digest: sha256:3375a4cf1bc5c4c4dea05d3a9592360b5ffac63ab8fec76c77d45df23194098e
-generated: 2018-09-11T23:58:12.463953326+02:00
+  version: 0.11.0
+digest: sha256:6421dac557426682201dd3267e27cbdac36a276310b175764fe6a985a4712c25
+generated: 2018-11-21T18:45:13.407083772+01:00

--- a/stable/datadog/requirements.yaml
+++ b/stable/datadog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: kube-state-metrics
-    version: ~0.9.0
+    version: ~0.11.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: kubeStateMetrics.enabled


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Bump kube-state-metrics version in Datadog chart.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
