### PR TITLE
[stable/kong] update services to route traffic only to app

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.6.3
+version: 0.6.4
 appVersion: 0.14.1

--- a/stable/kong/templates/service-kong-admin.yaml
+++ b/stable/kong/templates/service-kong-admin.yaml
@@ -35,3 +35,4 @@ spec:
   selector:
     app: {{ template "kong.name" . }}
     release: {{ .Release.Name }}
+    component: app

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -35,3 +35,4 @@ spec:
   selector:
     app: {{ template "kong.name" . }}
     release: {{ .Release.Name }}
+    component: app


### PR DESCRIPTION
Since the labels are shared between Ingress controller and Kong
Deployment, this can result in traffic being incorrectly sent to
Ingress Controller pods as well.

Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Avoid sending traffic to Ingress controller pods due to incorrect selectors on the service.