### PR TITLE
[stable/elasticsearch] add optional additional anti affinities

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.14.1
+version: 1.14.2
 appVersion: 6.5.0
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/README.md
+++ b/stable/elasticsearch/README.md
@@ -87,6 +87,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `client.loadBalancerIP`              | Client loadBalancerIP                                               | `{}`                                                |
 | `client.loadBalancerSourceRanges`    | Client loadBalancerSourceRanges                                     | `{}`                                                |
 | `client.antiAffinity`                | Client anti-affinity policy                                         | `soft`                                              |
+| `client.additionalAntiAffinities`    | Client additional anti-affinity policies                            | `{}`                                                |
 | `client.nodeAffinity`                | Client node affinity policy                                         | `{}`                                                |
 | `master.exposeHttp`                  | Expose http port 9200 on master Pods for monitoring, etc            | `false`                                             |
 | `master.name`                        | Master component name                                               | `master`                                            |
@@ -104,6 +105,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `master.persistence.storageClass`    | Master persistent volume Class                                      | `nil`                                               |
 | `master.persistence.accessMode`      | Master persistent Access Mode                                       | `ReadWriteOnce`                                     |
 | `master.antiAffinity`                | Master anti-affinity policy                                         | `soft`                                              |
+| `master.additionalAntiAffinities`    | Master additional anti-affinity policies                            | `{}`                                                |
 | `master.nodeAffinity`                | Master node affinity policy                                         | `{}`                                                |
 | `data.exposeHttp`                    | Expose http port 9200 on data Pods for monitoring, etc              | `false`                                             |
 | `data.replicas`                      | Data node replicas (statefulset)                                    | `2`                                                 |
@@ -121,6 +123,7 @@ The following table lists the configurable parameters of the elasticsearch chart
 | `data.tolerations`                   | Data tolerations                                                    | `[]`                                                |
 | `data.terminationGracePeriodSeconds` | Data termination grace period (seconds)                             | `3600`                                              |
 | `data.antiAffinity`                  | Data anti-affinity policy                                           | `soft`                                              |
+| `data.additionalAntiAffinities`      | Data additional anti-affinity policies                              | `{}`                                                |
 | `data.nodeAffinity`                  | Data node affinity policy                                           | `{}`                                                |
 | `extraInitContainers`                | Additional init container passed through the tpl 	                 | ``                                                  |
 | `podSecurityPolicy.annotations`      | Specify pod annotations in the pod security policy                  | `{}`                                                |

--- a/stable/elasticsearch/templates/client-deployment.yaml
+++ b/stable/elasticsearch/templates/client-deployment.yaml
@@ -30,18 +30,31 @@ spec:
       {{- if or .Values.client.antiAffinity .Values.client.nodeAffinity }}
       affinity:
       {{- end }}
-      {{- if eq .Values.client.antiAffinity "hard" }}
+      {{- if .Values.client.antiAffinity }}
         podAntiAffinity:
+      {{- $root := . -}}
+      {{- if or (eq .Values.client.antiAffinity "hard") (.Values.client.additionalAntiAffinities.hard) }}
           requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  app: "{{ template "elasticsearch.name" . }}"
-                  release: "{{ .Release.Name }}"
-                  component: "{{ .Values.client.name }}"
-      {{- else if eq .Values.client.antiAffinity "soft" }}
-        podAntiAffinity:
+          {{- if eq .Values.client.antiAffinity "hard" }}
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                app: "{{ template "elasticsearch.name" . }}"
+                release: "{{ .Release.Name }}"
+                component: "{{ .Values.client.name }}"
+          {{- end }}
+          {{- range $antiAffinity := .Values.client.additionalAntiAffinities.hard }}
+          - topologyKey: {{ $antiAffinity.topologyKey }}
+            labelSelector:
+              matchLabels:
+                app: "{{ template "elasticsearch.name" $root }}"
+                release: "{{ $root.Release.Name }}"
+                component: "{{ $root.Values.client.name }}"
+          {{- end }}
+      {{- end }}
+      {{- if or (eq .Values.client.antiAffinity "soft") (.Values.client.additionalAntiAffinities.soft) }}
           preferredDuringSchedulingIgnoredDuringExecution:
+          {{- if eq .Values.client.antiAffinity "soft" }}
           - weight: 1
             podAffinityTerm:
               topologyKey: kubernetes.io/hostname
@@ -50,6 +63,18 @@ spec:
                   app: "{{ template "elasticsearch.name" . }}"
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.client.name }}"
+          {{- end }}
+          {{- range $antiAffinity := .Values.client.additionalAntiAffinities.soft }}
+          - weight: {{ $antiAffinity.weight }}
+            podAffinityTerm:
+              topologyKey: {{ $antiAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "elasticsearch.name" $root }}"
+                  release: "{{ $root.Release.Name }}"
+                  component: "{{ $root.Values.client.name }}"
+          {{- end }}
+      {{- end }}
       {{- end }}
       {{- with .Values.client.nodeAffinity }}
         nodeAffinity:

--- a/stable/elasticsearch/templates/data-statefulset.yaml
+++ b/stable/elasticsearch/templates/data-statefulset.yaml
@@ -31,18 +31,31 @@ spec:
       {{- if or .Values.data.antiAffinity .Values.data.nodeAffinity }}
       affinity:
       {{- end }}
-      {{- if eq .Values.data.antiAffinity "hard" }}
+      {{- if .Values.data.antiAffinity }}
+      {{- $root := . -}}
         podAntiAffinity:
+      {{- if or (eq .Values.data.antiAffinity "hard") (.Values.data.additionalAntiAffinities.hard) }}
           requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  app: "{{ template "elasticsearch.name" . }}"
-                  release: "{{ .Release.Name }}"
-                  component: "{{ .Values.data.name }}"
-      {{- else if eq .Values.data.antiAffinity "soft" }}
-        podAntiAffinity:
+          {{- if eq .Values.data.antiAffinity "hard" }}
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                app: "{{ template "elasticsearch.name" . }}"
+                release: "{{ .Release.Name }}"
+                component: "{{ .Values.data.name }}"
+          {{- end }}
+          {{- range $antiAffinity := .Values.data.additionalAntiAffinities.hard }}
+          - topologyKey: {{ $antiAffinity.topologyKey }}
+            labelSelector:
+              matchLabels:
+                app: "{{ template "elasticsearch.name" $root }}"
+                release: "{{ $root.Release.Name }}"
+                component: "{{ $root.Values.data.name }}"
+          {{- end }}
+      {{- end }}
+      {{- if or (eq .Values.data.antiAffinity "soft") (.Values.data.additionalAntiAffinities.soft) }}
           preferredDuringSchedulingIgnoredDuringExecution:
+          {{- if eq .Values.data.antiAffinity "soft" }}
           - weight: 1
             podAffinityTerm:
               topologyKey: kubernetes.io/hostname
@@ -51,6 +64,18 @@ spec:
                   app: "{{ template "elasticsearch.name" . }}"
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.data.name }}"
+          {{- end }}
+          {{- range $antiAffinity := .Values.data.additionalAntiAffinities.soft }}
+          - weight: {{ $antiAffinity.weight }}
+            podAffinityTerm:
+              topologyKey: {{ $antiAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "elasticsearch.name" $root }}"
+                  release: "{{ $root.Release.Name }}"
+                  component: "{{ $root.Values.data.name }}"
+          {{- end }}
+      {{- end }}
       {{- end }}
       {{- with .Values.data.nodeAffinity }}
         nodeAffinity:

--- a/stable/elasticsearch/templates/master-statefulset.yaml
+++ b/stable/elasticsearch/templates/master-statefulset.yaml
@@ -31,18 +31,31 @@ spec:
       {{- if or .Values.master.antiAffinity .Values.master.nodeAffinity }}
       affinity:
       {{- end }}
-      {{- if eq .Values.master.antiAffinity "hard" }}
+      {{- if .Values.master.antiAffinity }}
         podAntiAffinity:
+      {{- $root := . -}}
+      {{- if or (eq .Values.master.antiAffinity "hard") (.Values.master.additionalAntiAffinities.hard) }}
           requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  app: "{{ template "elasticsearch.name" . }}"
-                  release: "{{ .Release.Name }}"
-                  component: "{{ .Values.master.name }}"
-      {{- else if eq .Values.master.antiAffinity "soft" }}
-        podAntiAffinity:
+          {{- if eq .Values.master.antiAffinity "hard" }}
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                app: "{{ template "elasticsearch.name" . }}"
+                release: "{{ .Release.Name }}"
+                component: "{{ .Values.master.name }}"
+          {{- end }}
+          {{- range $antiAffinity := .Values.master.additionalAntiAffinities.hard }}
+          - topologyKey: {{ $antiAffinity.topologyKey }}
+            labelSelector:
+              matchLabels:
+                app: "{{ template "elasticsearch.name" $root }}"
+                release: "{{ $root.Release.Name }}"
+                component: "{{ $root.Values.master.name }}"
+          {{- end }}
+      {{- end }}
+      {{- if or (eq .Values.master.antiAffinity "soft") (.Values.master.additionalAntiAffinities.soft) }}
           preferredDuringSchedulingIgnoredDuringExecution:
+          {{- if eq .Values.master.antiAffinity "soft" }}
           - weight: 1
             podAffinityTerm:
               topologyKey: kubernetes.io/hostname
@@ -51,6 +64,18 @@ spec:
                   app: "{{ template "elasticsearch.name" . }}"
                   release: "{{ .Release.Name }}"
                   component: "{{ .Values.master.name }}"
+          {{- end }}
+          {{- range $antiAffinity := .Values.master.additionalAntiAffinities.soft }}
+          - weight: {{ $antiAffinity.weight }}
+            podAffinityTerm:
+              topologyKey: {{ $antiAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "elasticsearch.name" $root }}"
+                  release: "{{ $root.Release.Name }}"
+                  component: "{{ $root.Values.master.name }}"
+          {{- end }}
+      {{- end }}
       {{- end }}
       {{- with .Values.master.nodeAffinity }}
         nodeAffinity:

--- a/stable/elasticsearch/values.yaml
+++ b/stable/elasticsearch/values.yaml
@@ -72,6 +72,12 @@ client:
 #    example: client-svc-foo
   heapSize: "512m"
   antiAffinity: "soft"
+  additionalAntiAffinities: {}
+    # soft:
+    # - weight: 10
+    #   topologyKey: failure-domain.beta.kubernetes.io/zone
+    # hard:
+    # - topologyKey: failure-domain.beta.kubernetes.io/zone
   nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
@@ -103,6 +109,12 @@ master:
     size: "4Gi"
     # storageClass: "ssd"
   antiAffinity: "soft"
+  additionalAntiAffinities: {}
+    # soft:
+    # - weight: 10
+    #   topologyKey: failure-domain.beta.kubernetes.io/zone
+    # hard:
+    # - topologyKey: failure-domain.beta.kubernetes.io/zone
   nodeAffinity: {}
   nodeSelector: {}
   tolerations: []
@@ -137,6 +149,12 @@ data:
     # storageClass: "ssd"
   terminationGracePeriodSeconds: 3600
   antiAffinity: "soft"
+  additionalAntiAffinities: {}
+    # soft:
+    # - weight: 10
+    #   topologyKey: failure-domain.beta.kubernetes.io/zone
+    # hard:
+    # - topologyKey: failure-domain.beta.kubernetes.io/zone
   nodeAffinity: {}
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows users to specify additional anti affinity topology keys and weights.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@simonswine @icereval @rendhalver @desaintmartin 
