### PR TITLE
[stable/prometheus] Remove unnecessary reclaim policy

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 7.4.4
+version: 7.4.5
 appVersion: 2.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -246,7 +246,6 @@ Parameter | Description | Default
 `server.persistentVolume.annotations` | Prometheus server data Persistent Volume annotations | `{}`
 `server.persistentVolume.existingClaim` | Prometheus server data Persistent Volume existing claim name | `""`
 `server.persistentVolume.mountPath` | Prometheus server data Persistent Volume mount root path | `/data`
-`server.persistentVolume.reclaimPolicy` | Prometheus server data Persistent Volume reclaim policy | `Retain`
 `server.persistentVolume.size` | Prometheus server data Persistent Volume size | `8Gi`
 `server.persistentVolume.storageClass` | Prometheus server data Persistent Volume Storage Class |  `unset`
 `server.persistentVolume.subPath` | Subdirectory of Prometheus server data Persistent Volume to mount | `""`

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -24,7 +24,6 @@ spec:
   storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
 {{- end }}
 {{- end }}
-  persistentVolumeReclaimPolicy: {{ .Values.server.persistentVolume.reclaimPolicy | quote }}
   resources:
     requests:
       storage: "{{ .Values.server.persistentVolume.size }}"

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -651,12 +651,6 @@ server:
     ##
     subPath: ""
 
-    ## reclaimPolicy for the persistent volume.
-    ## See https://kubernetes.io/docs/tasks/administer-cluster/change-pv-reclaim-policy/
-    ## Can be Retain, Recycle, or Delete
-    ##
-    reclaimPolicy: Retain
-
   ## Annotations to be added to Prometheus server pods
   ##
   podAnnotations: {}


### PR DESCRIPTION
persistentVolumeReclaimPolicy is unnecessary for PVC, so let's
remove it.

Signed-off-by: OTSUKA, Yuanying <yuanying@fraction.jp>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

persistentVolumeReclaimPolicy is unnecessary for PVC, so let's
remove it.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md