### PR TITLE
nfs-server-provisioner: remove irrelevant reference to kibana in README

### DIFF
--- a/stable/nfs-server-provisioner/README.md
+++ b/stable/nfs-server-provisioner/README.md
@@ -49,7 +49,7 @@ deletes the release.
 
 ## Configuration
 
-The following table lists the configurable parameters of the kibana chart and
+The following table lists the configurable parameters of the chart and
 their default values.
 
 | Parameter                      | Description                                                                                                     | Default                                                  |


### PR DESCRIPTION
Minor fix in stable/nfs-server-provisioner README