### PR TITLE
[incubator/couchdb] Enable fixed node port in service when type is NodePort

### DIFF
--- a/incubator/couchdb/Chart.yaml
+++ b/incubator/couchdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: couchdb
-version: 1.0.0
+version: 1.0.1
 appVersion: 2.2.0
 description: A database featuring seamless multi-master sync, that scales from
   big data to mobile, with an intuitive HTTP/JSON API and designed for

--- a/incubator/couchdb/README.md
+++ b/incubator/couchdb/README.md
@@ -125,3 +125,4 @@ A variety of other parameters are also configurable. See the comments in the
 | `service.enabled`               | true                                   |
 | `service.type`                  | ClusterIP                              |
 | `service.externalPort`          | 5984                                   |
+| `service.nodePort`              | 5984                                   |

--- a/incubator/couchdb/templates/service.yaml
+++ b/incubator/couchdb/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
     - port: {{ .Values.service.externalPort }}
       protocol: TCP
       targetPort: 5984
+      {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   type: {{ .Values.service.type }}
   selector:
     app: {{ template "couchdb.name" . }}

--- a/incubator/couchdb/values.yaml
+++ b/incubator/couchdb/values.yaml
@@ -75,6 +75,7 @@ service:
   enabled: true
   type: ClusterIP
   externalPort: 5984
+  # nodePort: 5984
 
 ## An Ingress resource can provide name-based virtual hosting and TLS
 ## termination among other things for CouchDB deployments which are accessed


### PR DESCRIPTION
Signed-off-by: Rémy Saintobert <remy.qotto@gmail.com>


#### What this PR does / why we need it:
Enable fixed node port in service when type is NodePort

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X ] Chart Version bumped
- [ X] Variables are documented in the README.md
