### PR TITLE
[stable/prometheus-node-exporter] Add variable to optionally set priorityClassName

### DIFF
--- a/stable/prometheus-node-exporter/Chart.yaml
+++ b/stable/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.16.0"
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 0.5.1
+version: 0.6.0
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/stable/prometheus-node-exporter/README.md
+++ b/stable/prometheus-node-exporter/README.md
@@ -50,11 +50,12 @@ The following table lists the configurable parameters of the Node Exporter chart
 | `service.type`                    | Service type                                                                                                                  | `ClusterIP`                             |     |
 | `service.port`                    | The service port                                                                                                              | `9100`                                  |     |
 | `service.targetPort`              | The target port of the container                                                                                              | `9100`                                  |     |
-| `service.annotations`             | Kubernetes service annotations | `{prometheus.io/scrape: "true"}` |
+| `service.annotations`             | Kubernetes service annotations                                                                                                | `{prometheus.io/scrape: "true"}`        |     |
 | `serviceAccount.create`           | Specifies whether a service account should be created.                                                                        | `true`                                  |     |
 | `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                         |     |
 | `serviceAccount.imagePullSecrets` | Specify image pull secrets                                                                                                    | `[]`                                    |     |
 | `tolerations`                     | List of node taints to tolerate                                                                                               | `- effect: NoSchedule operator: Exists` |     |
+| `priorityClassName`               | Name of Priority Class to assign pods                                                                                         | `nil`                                   |     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/prometheus-node-exporter/templates/daemonset.yaml
+++ b/stable/prometheus-node-exporter/templates/daemonset.yaml
@@ -22,6 +22,9 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
       containers:
         - name: node-exporter
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/prometheus-node-exporter/values.yaml
+++ b/stable/prometheus-node-exporter/values.yaml
@@ -49,6 +49,9 @@ tolerations:
   - effect: NoSchedule
     operator: Exists
 
+## Assign a PriorityClassName to pods if set
+# priorityClassName: ""
+
 ## Additional container arguments
 ##
 extraArgs: {}


### PR DESCRIPTION
Signed-off-by: Chris O'Brien <chrisob91@gmail.com>

@gianrubio 

#### What this PR does / why we need it:
Allow `priorityClassName` to be set for prometheus-node-exporter `podSpec`.

#### Which issue this PR fixes
  - fixes #9426

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
