### PR TITLE
WIP [stable/prometheus-operator] Add variable to optionally set priorityClassName

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 0.1.25
+version: 0.1.26
 appVersion: "0.25.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -73,6 +73,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `prometheusOperator.createCustomResource` | Create CRDs. Required if deploying anything besides the operator itself as part of the release. The operator will create / update these on startup. If your Helm version < 2.10 you will have to either create the CRDs first or deploy the operator first, then the rest of the resources | `true` |
 | `prometheusOperator.cleanupCustomResource` | Attempt to delete CRDs when the release is removed. This option may be useful while testing but is not recommended, as deleting the CRD definition will delete resources and prevent the operator from being able to clean up resources that it manages | `false` |
 | `prometheusOperator.podLabels` | Labels to add to the operator pod | `{}` |
+| `prometheusOperator.priorityClassName` | Name of Priority Class to assign pods | `nil` |
 | `prometheusOperator.kubeletService.enabled` | If true, the operator will create and maintain a service for scraping kubelets | `true` |
 | `prometheusOperator.kubeletService.namespace` | Namespace to deploy kubelet service | `kube-system` |
 | `prometheusOperator.serviceMonitor.selfMonitor` | Enable monitoring of prometheus operator | `true` |

--- a/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
+++ b/stable/prometheus-operator/templates/prometheus-operator/deployment.yaml
@@ -21,6 +21,9 @@ spec:
 {{ toYaml .Values.prometheusOperator.podLabels | indent 8 }}
 {{- end }}
     spec:
+    {{- if .Values.prometheusOperator.priorityClassName }}
+      priorityClassName: {{ .Values.prometheusOperator.priorityClassName }}
+    {{- end }}
       containers:
         - name: {{ template "prometheus-operator.name" . }}
           image: "{{ .Values.prometheusOperator.image.repository }}:{{ .Values.prometheusOperator.image.tag }}"

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -478,6 +478,9 @@ prometheusOperator:
   ##
   podLabels: {}
 
+  ## Assign a PriorityClassName to pods if set
+  # priorityClassName: ""
+
   ## If true, the operator will create and maintain a service for scraping kubelets
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/helm/prometheus-operator/README.md
   ##


### PR DESCRIPTION
Signed-off-by: Chris O'Brien <chrisob91@gmail.com>

#### What this PR does / why we need it:
Allow `priorityClassName` to be set for the prometheus-operator deployment's `podSpec`.

Additionally, update dependency charts containing the same change of adding `priorityClassName` options.  See #9478 #9427 #9483.

#### Which issue this PR fixes
  - fixes #9476 

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Wait until #9478 and #9427 are merged, then update Helm dependencies
