### PR TITLE
[stable/elasticsearch] disable all xpack features in es5 when cluster.xpackEnable: false

### DIFF
--- a/stable/elasticsearch/Chart.yaml
+++ b/stable/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 1.17.0
+version: 1.17.1
 appVersion: 6.5.4
 description: Flexible and powerful open source, distributed real-time search and analytics
   engine.

--- a/stable/elasticsearch/templates/configmap.yaml
+++ b/stable/elasticsearch/templates/configmap.yaml
@@ -41,12 +41,16 @@ data:
 
 {{- if .Values.cluster.xpackEnable }}
     # see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+  {{- if .Values.appVersion gt 5.4 or .Values.appVersion eq 5.4 }}
     xpack.ml.enabled: ${XPACK_ML_ENABLED:false}
+  {{- end }}
     xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
     xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
     xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
 {{- else }}
+  {{- if .Values.appVersion gt 5.4 or .Values.appVersion eq 5.4 }}
     xpack.ml.enabled: false
+  {{- end }}
     xpack.monitoring.enabled: false
     xpack.security.enabled: false
     xpack.watcher.enabled: false

--- a/stable/elasticsearch/templates/configmap.yaml
+++ b/stable/elasticsearch/templates/configmap.yaml
@@ -45,6 +45,11 @@ data:
     xpack.monitoring.enabled: ${XPACK_MONITORING_ENABLED:false}
     xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
     xpack.watcher.enabled: ${XPACK_WATCHER_ENABLED:false}
+{{- else }}
+    xpack.ml.enabled: false
+    xpack.monitoring.enabled: false
+    xpack.security.enabled: false
+    xpack.watcher.enabled: false
 {{- end }}
 {{- else if hasPrefix "6." .Values.appVersion }}
     # see https://github.com/kubernetes/kubernetes/issues/3595


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes issue where xpack features default to enabled for es5 when cluster.xpackEnable: false.

#### Which issue this PR fixes
  - fixes #9343 
  - fixes #8996 

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@simonswine @icereval @rendhalver @desaintmartin 