### PR TITLE
Remove the secure-backend annotation from Odoo ingress

### DIFF
--- a/stable/odoo/Chart.yaml
+++ b/stable/odoo/Chart.yaml
@@ -1,5 +1,5 @@
 name: odoo
-version: 5.0.0
+version: 5.0.1
 appVersion: 11.0.20181115
 description: A suite of web based open source business apps.
 home: https://www.odoo.com/

--- a/stable/odoo/templates/ingress.yaml
+++ b/stable/odoo/templates/ingress.yaml
@@ -10,9 +10,6 @@ metadata:
     release: {{ $.Release.Name | quote }}
     heritage: {{ $.Release.Service | quote }}
   annotations:
-    {{- if .tls }}
-    ingress.kubernetes.io/secure-backends: "true"
-    {{- end }}
     {{- if .certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
The `ingress.kubernetes.io/secure-backends` annotation doesn't relate to presenting TLS from the Ingress route; only for connecting to the Odoo backend pod. Since there's no TLS configuration on the Odoo pod, this _always_ causes a HTTP 502 when enabling TLS.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
