### PR TITLE
[stable/mongodb-replicaset] Fix joining replica set after failure

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.6.4
+version: 3.7.0
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `tls.cacert`                        | The CA certificate used for the members                                   | Our self signed CA certificate                      |
 | `tls.cakey`                         | The CA key used for the members                                           | Our key for the self signed CA certificate          |
 | `init.resources`                    | Pod resource requests and limits (for init containers)                    | `{}`                                                |
+| `init.timeout`                      | The amount of time in seconds to wait for bootstrap to finish             | `900`                                               |
 | `metrics.enabled`                   | Enable Prometheus compatible metrics for pods and replicasets             | `false`                                             |
 | `metrics.image.repository`           | Image name for metrics exporter                                           | `ssalaues/mongodb-exporter`                         |
 | `metrics.image.tag`                  | Image tag for metrics exporter                                            | `0.6.1`                                             |

--- a/stable/mongodb-replicaset/templates/mongodb-service-client.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service-client.yaml
@@ -1,0 +1,32 @@
+# A headless service for client applications to use
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  {{- if .Values.serviceAnnotations }}
+{{ toYaml .Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ template "mongodb-replicaset.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+{{- end }}
+  name: {{ template "mongodb-replicaset.fullname" . }}-client
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: mongodb
+      port: {{ .Values.port }}
+{{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+{{- end }}
+  selector:
+    app: {{ template "mongodb-replicaset.name" . }}
+    release: {{ .Release.Name }}
+

--- a/stable/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service.yaml
@@ -1,12 +1,9 @@
-# A headless service to create DNS records
+# A headless service to create DNS records for discovery purposes. Use the -client service to connect applications
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-  {{- if .Values.serviceAnnotations }}
-{{ toYaml .Values.serviceAnnotations | indent 4 }}
-  {{- end }}
   labels:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ template "mongodb-replicaset.chart" . }}
@@ -22,11 +19,7 @@ spec:
   ports:
     - name: mongodb
       port: {{ .Values.port }}
-{{- if .Values.metrics.enabled }}
-    - name: metrics
-      port: {{ .Values.metrics.port }}
-      targetPort: metrics
-{{- end }}
+  publishNotReadyAddresses: true
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
     release: {{ .Release.Name }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -104,6 +104,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: REPLICA_SET
               value: {{ .Values.replicaSetName }}
+            - name: TIMEOUT
+              value: "{{ .Values.init.timeout }}"
           {{- if .Values.auth.enabled }}
             - name: AUTH
               value: "true"

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -59,6 +59,7 @@ securityContext:
 
 init:
   resources: {}
+  timeout: 900
 
 resources: {}
 # limits:


### PR DESCRIPTION
#### What this PR does / why we need it:
- Makes the bootstrap timeout configurable
- Increase the bootstrap timeout to 15 minutes. For replica sets with a lot of data, 5 was too low.
- Fixes the error `replSetReconfig got BadValue: Found two member configurations with same host field` when initial join fails part way through.
- Adds `publishNotReadyAddresses: true` to service since the tolerate-unready-endpoints annotation is deprecated.
- Adds a new service for use by clients that only returns ready endpoints. This resolves clients connecting to pods that are crashing or in the process of joining. Users will need to update their applications to the new service to take advantage of this functionality, but they can continue to use the old service and it won't break anything. Note that I could not add a discovery service and keep the existing service for clients since `serviceName` in StatefulSet is not an editable field.

#### Which issue this PR fixes
  - fixes #9459
  - fixes #9266 

#### Special notes for your reviewer:
I tested a new install and upgrade from the previous chart version

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
