### PR TITLE
add shared memory for firefox to avoid crash

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.12.0
+version: 0.12.1
 appVersion: 3.14.0
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
-      annotations: 
+      annotations:
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -75,8 +75,16 @@ spec:
             - name: TZ
               value: {{ .Values.firefox.timeZone | quote }}
             {{- end }}
+          volumeMounts:
+{{ if .Values.chrome.volumeMounts -}}
+{{ toYaml .Values.firefox.volumeMounts | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.firefox.resources | indent 12 }}
+      volumes:
+{{ if .Values.firefox.volumes -}}
+{{ toYaml .Values.firefox.volumes | indent 8 }}
+{{- end }}
       nodeSelector:
 {{- if .Values.firefox.nodeSelector }}
 {{ toYaml .Values.firefox.nodeSelector | indent 8  }}

--- a/stable/selenium/templates/firefoxDebug-deployment.yaml
+++ b/stable/selenium/templates/firefoxDebug-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
-      annotations: 
+      annotations:
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -26,7 +26,7 @@ spec:
               name: jmx
               protocol: TCP
             {{- end }}
-            - containerPort: 5900 
+            - containerPort: 5900
               name: vnc
           env:
             - name: HUB_PORT_4444_TCP_ADDR
@@ -77,8 +77,16 @@ spec:
             - name: TZ
               value: {{ .Values.firefoxDebug.timeZone | quote }}
             {{- end }}
+          volumeMounts:
+{{ if .Values.chrome.volumeMounts -}}
+{{ toYaml .Values.firefox.volumeMounts | indent 12 }}
+{{- end }}
           resources:
-{{ toYaml .Values.firefoxDebug.resources | indent 12 }}
+{{ toYaml .Values.firefox.resources | indent 12 }}
+      volumes:
+{{ if .Values.firefox.volumes -}}
+{{ toYaml .Values.firefox.volumes | indent 8 }}
+{{- end }}
       nodeSelector:
 {{- if .Values.firefoxDebug.nodeSelector }}
 {{ toYaml .Values.firefoxDebug.nodeSelector | indent 8  }}

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -298,6 +298,21 @@ firefox:
   ## ref: http://openjdk.java.net/groups/jmx/
   # jmxPort: 4000
 
+  ## User defined volumes
+  ## ref: https://kubernetes.io/docs/user-guide/volumes/
+  volumes:
+    ## https://github.com/kubernetes/kubernetes/pull/34928#issuecomment-277952723
+    ## https://bugzilla.mozilla.org/show_bug.cgi?id=1338771#c10
+    ## https://github.com/jlesage/docker-firefox#usage
+    ## http://stackoverflow.com/questions/39852716/chrome-driver-throwing-org-openqa-selenium-remote-sessionnotfoundexception-whe
+    ## Firefox wants more than 64mb of shared memory. Docker/k8s default to 64mb.
+    - name: dshm
+      emptyDir:
+        medium: Memory
+  volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources:
@@ -359,6 +374,21 @@ firefoxDebug:
   ##   -Dcom.sun.management.jmxremote.ssl=false
   ## ref: http://openjdk.java.net/groups/jmx/
   # jmxPort: 4000
+
+  ## User defined volumes
+  ## ref: https://kubernetes.io/docs/user-guide/volumes/
+  volumes:
+    ## https://github.com/kubernetes/kubernetes/pull/34928#issuecomment-277952723
+    ## https://bugzilla.mozilla.org/show_bug.cgi?id=1338771#c10
+    ## https://github.com/jlesage/docker-firefox#usage
+    ## http://stackoverflow.com/questions/39852716/chrome-driver-throwing-org-openqa-selenium-remote-sessionnotfoundexception-whe
+    ## Firefox wants more than 64mb of shared memory. Docker/k8s default to 64mb.
+    - name: dshm
+      emptyDir:
+        medium: Memory
+  volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
 
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
#### What this PR does / why we need it:
When running Selenium Grid using Kubernetes and Helm charts, chrome ("3.14.0") pod worked fine. But when running test on Firefox "3.14.0", the browser was crashing.
Based on the following guidelines
[https://bugzilla.mozilla.org/show_bug.cgi?id=1338771#c10](https://bugzilla.mozilla.org/show_bug.cgi?id=1338771#c10)
[https://github.com/jlesage/docker-firefox#usage](https://github.com/jlesage/docker-firefox#usage)
I have added the shared memory fix for Firefox as well and it worked fine.
