### PR TITLE
Deprecating keel chart

### DIFF
--- a/stable/keel/Chart.yaml
+++ b/stable/keel/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: keel
-description: Open source, tool for automating Kubernetes deployment updates. Keel
+description: DEPRECATED Open source, tool for automating Kubernetes deployment updates. Keel
   is stateless, robust and lightweight.
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.9.5
 keywords:
 - kubernetes deployment
@@ -11,13 +11,6 @@ keywords:
 home: https://keel.sh
 sources:
 - https://github.com/keel-hq/keel
-maintainers:
-- name: rimusz
-  email: rmocius@gmail.com
-- name: rusenask
-  email: karolis.rusenas@gmail.com
-- name: archifleks
-  email: lefevre.kevin@gmail.com
-- name: ricebowljr
-  email: alexandre.kervadec@gmail.com
-engine: gotpl
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/buildkiterimusz/charts
+deprecated: true

--- a/stable/keel/README.md
+++ b/stable/keel/README.md
@@ -1,4 +1,8 @@
-# Keel - automated Kubernetes deployments for the rest of us
+# Keel - automated Kubernetes deployments for the rest of us - DEPRECATED
+
+ **This chart is deprecated! You can find the new chart in:**
+ - **Source:** https://github.com/keel-hq/keel/tree/master/chart/keel
+ - **Charts repository:** https://charts.keel.sh
 
 * Website [https://keel.sh](https://keel.sh)
 * User Guide [https://keel.sh/user-guide/](https://keel.sh/user-guide/)

--- a/stable/keel/templates/NOTES.txt
+++ b/stable/keel/templates/NOTES.txt
@@ -1,3 +1,5 @@
+#### THIS CHART IS DEPRECATED! ####
+
 1. The {{ template "keel.fullname" . }} is getting provisioned in your cluster. After a few minutes, you can run the following to verify.
 
 To verify that {{ template "keel.fullname" . }} has started, run:


### PR DESCRIPTION
Signed-off-by: rimas <rmocius@gmail.com>

Deprecating keel chart in preparation for the new Helm Distributed repo (hub).
`keel` chart is already hosted at https://charts.keel.sh
