### PR TITLE
[stable/concourse] Generate random password to local user by default

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.0.1
+version: 3.1.0
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -116,7 +116,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `rbac.apiVersion` | RBAC version | `v1beta1` |
 | `rbac.webServiceAccountName` | Name of the service account to use for web pods if `rbac.create` is `false` | `default` |
 | `rbac.workerServiceAccountName` | Name of the service account to use for workers if `rbac.create` is `false` | `default` |
-| `secrets.localUsers` | Create concourse local users. Default username and password are test:test *See [values.yaml](values.yaml)* |
+| `secrets.localUsers` | Create concourse local users. Default username is `test` and default password is randomly generated. *See [values.yaml](values.yaml)* |
 | `secrets.create` | Create the secret resource from the following values. *See [Secrets](#secrets)* | `true` |
 | `secrets.hostKey` | Concourse Host Private Key | *See [values.yaml](values.yaml)* |
 | `secrets.hostKeyPub` | Concourse Host Public Key | *See [values.yaml](values.yaml)* |

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -5,6 +5,17 @@
 
     {{ template "concourse.web.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
+  {{- if .Values.concourse.web.localAuth.enabled }}
+
+  * Grab the local users credentials:
+
+    kubectl get \
+      --namespace {{ .Release.Namespace }} \
+      secrets {{ .Release.Name }}-concourse \
+      -o 'jsonpath={.data.local-users}' | base64 -D
+
+  {{- end -}}
+
   {{- if .Values.web.ingress.enabled }}
 
   * From outside the cluster, the URL(s) are:
@@ -33,6 +44,7 @@
     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.concourse.atcPort }}
     {{- end }}
   {{- end }}
+
 * If this is your first time using Concourse, follow the tutorials at https://concourse-ci.org/tutorials.html
 {{- if contains "naive" .Values.concourse.worker.baggageclaim.driver }}
 

--- a/stable/concourse/templates/secrets.yaml
+++ b/stable/concourse/templates/secrets.yaml
@@ -27,7 +27,11 @@ data:
   old-encryption-key: {{ default "" .Values.secrets.oldEncryptionKey | b64enc | quote }}
   {{- end }}
   {{- if .Values.concourse.web.localAuth.enabled }}
+  {{- if .Values.secrets.localUsers }}
   local-users: {{ .Values.secrets.localUsers | b64enc | quote }}
+  {{- else }}
+  local-users: {{ printf "%s:%s" "test" (randAlphaNum 40) | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.concourse.web.auth.cf.enabled }}
   cf-client-id: {{ template "concourse.secret.required" dict "key" "cfClientId" "is" "concourse.web.auth.cf.enabled" "root" . }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -981,8 +981,13 @@ rbac:
 ##
 secrets:
 
-  ## List of username:bcrypted_password combinations for all your local concourse users.
-  localUsers: "test:$2a$10$sDB6AsH2HheOWHILrnHVJOCZq/GYtUYE02ypJJTQBmWJNivYNhP3y"
+  ## List of username:password combinations for all your local users.
+  ## The password can be bcrypted - if so, it must have a minimum cost of 10.
+  ##
+  ## By default, a `test` user is created with a randomly generated password.
+  ##
+  # localUsers: "test:$2a$10$sDB6AsH2HheOWHILrnHVJOCZq/GYtUYE02ypJJTQBmWJNivYNhP3y"
+
   ## Create the secret resource from the following values. Set this to
   ## false to manage these secrets outside Helm.
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR moves us towards not using a default fixed password for the `test` local user, but instead, generate a random one.

It follows what `stable/grafana` does: 

https://github.com/helm/charts/blob/f7455e2e1e2182a9925029bc8f42dd8a832f8885/stable/grafana/templates/secret.yaml#L14-L17

#### Which issue this PR fixes

- fixes #8568

#### Special notes for your reviewer:

This is my first PR to `helm/charts`, please let me know if I need to do anything else, or if you think this is going to break something else / is not desired.

Thx!

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

cc @frodenas @william-tran