### PR TITLE
[stable/kong] add a variable to allow skipping installing CRDs

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.6.4
+version: 0.6.5
 appVersion: 0.14.1

--- a/stable/kong/templates/crd-kongconsumer.yaml
+++ b/stable/kong/templates/crd-kongconsumer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressController.enabled -}}
+{{- if and .Values.ingressController.enabled .Values.ingressController.installCRDs -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/stable/kong/templates/crd-kongcredential.yaml
+++ b/stable/kong/templates/crd-kongcredential.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressController.enabled -}}
+{{- if and .Values.ingressController.enabled .Values.ingressController.installCRDs -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/stable/kong/templates/crd-kongingress.yaml
+++ b/stable/kong/templates/crd-kongingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressController.enabled -}}
+{{- if and .Values.ingressController.enabled .Values.ingressController.installCRDs -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/stable/kong/templates/crd-kongplugins.yaml
+++ b/stable/kong/templates/crd-kongplugins.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressController.enabled -}}
+{{- if and .Values.ingressController.enabled .Values.ingressController.installCRDs -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -183,6 +183,8 @@ ingressController:
     successThreshold: 1
     timeoutSeconds: 5
 
+  installCRDs: true
+
   rbac:
     # Specifies whether RBAC resources should be created
     create: true


### PR DESCRIPTION
If one wishes to install multiple instances of Ingress controller with
different classes, then there needs to be an option to skip installing
CRDs multiple times.

Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
