### PR TITLE
[stable/kube-state-metrics] Fix indentation of priorityClassName

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.12.0
+version: 0.12.1
 appVersion: 1.4.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
-      {{- if .Values.priorityClassName }}
-        priorityClassName: {{ .Values.priorityClassName }}
-      {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         args:


### PR DESCRIPTION
Signed-off-by: Chris O'Brien <chrisob91@gmail.com>
@fiunchinho

#### What this PR does / why we need it:
#9478 contained incorrect indentation on the deployment's `priorityClassName`.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:
Tested and working while setting `priorityClassName`.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
