### PR TITLE
[stable/fluent-bit]: fix extras indentation and making input.tail.Skip_Long_Lines configurable, add option to disable kubernetes annotations

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluent-bit
-version: 0.16.1
-appVersion: 0.14.6
+version: 0.16.2
+appVersion: 0.14.8
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
 - logging

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -88,7 +88,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `filter.kubeTokenFile`             | Optional custom configmaps       | `/var/run/secrets/kubernetes.io/serviceaccount/token`     |
 | `filter.kubeTag`                   | Optional top-level tag for matching in filter         | `kube`                                 |
 | `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
-| `image.fluent_bit.tag`             | Image tag                                  | `0.14.6`                                          |
+| `image.fluent_bit.tag`             | Image tag                                  | `0.14.8`                                          |
 | `image.pullPolicy`                 | Image pull policy                          | `Always`                                          |
 | `image.pullSecrets`                | Specify image pull secrets                 | `nil`                                             |
 | `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -87,6 +87,7 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `filter.kubeCAFile`                | Optional custom configmaps       | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`    |
 | `filter.kubeTokenFile`             | Optional custom configmaps       | `/var/run/secrets/kubernetes.io/serviceaccount/token`     |
 | `filter.kubeTag`                   | Optional top-level tag for matching in filter         | `kube`                                 |
+| `filter.kubeAnnotations`           | Include or exclude kubernetes pod annotations in the logs         | `On`                       |
 | `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
 | `image.fluent_bit.tag`             | Image tag                                  | `0.14.8`                                          |
 | `image.pullPolicy`                 | Image pull policy                          | `Always`                                          |

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -106,7 +106,6 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `metrics.service.port`             | Port on where metrics should be exposed    | `2020`                                            |
 | `metrics.service.type`             | Service type for metrics                   | `ClusterIP`                                       |
 | `trackOffsets`                     | Specify whether to track the file offsets for tailing docker logs. This allows fluent-bit to pick up where it left after pod restarts but requires access to a `hostPath` | `false` |
-| | | |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -36,7 +36,7 @@ data:
         DB               /tail-db/tail-containers-state.db
         DB.Sync          Normal
 {{- end }}
-{{ .Values.extraInputs | indent 8 }}
+{{ .Values.extraInputs | indent 4 }}
 
     [FILTER]
         Name                kubernetes
@@ -53,7 +53,7 @@ data:
 {{- if .Values.filter.enableExclude }}
         K8S-Logging.Exclude On
 {{- end }}
-{{ .Values.extraFilters | indent 8 }}
+{{ .Values.extraFilters | indent 4 }}
 
 {{ if eq .Values.backend.type "test" }}
     [OUTPUT]
@@ -130,7 +130,7 @@ data:
 {{- end }}
         Format {{ .Values.backend.http.format }}
 {{- end }}
-{{ .Values.extraOutputs | indent 8 }}
+{{ .Values.extraOutputs | indent 4 }}
 
   parsers.conf: |-
 {{- if .Values.parsers.regex }}

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -31,7 +31,7 @@ data:
         Tag              {{ .Values.filter.kubeTag }}.*
         Refresh_Interval 5
         Mem_Buf_Limit    {{ .Values.input.tail.memBufLimit }}
-        Skip_Long_Lines  On
+        Skip_Long_Lines  {{ .Values.input.tail.skipLongLines }}
 {{- if .Values.trackOffsets }}
         DB               /tail-db/tail-containers-state.db
         DB.Sync          Normal

--- a/stable/fluent-bit/templates/config.yaml
+++ b/stable/fluent-bit/templates/config.yaml
@@ -44,6 +44,7 @@ data:
         Kube_URL            {{ .Values.filter.kubeURL }}
         Kube_CA_File        {{ .Values.filter.kubeCAFile }}
         Kube_Token_File     {{ .Values.filter.kubeTokenFile }}
+        Annotations         {{ .Values.filter.kubeAnnotations }}
 {{- if .Values.filter.mergeJSONLog }}
         Merge_Log           On
 {{- end }}

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -5,7 +5,7 @@ on_minikube: false
 image:
   fluent_bit:
     repository: fluent/fluent-bit
-    tag: 0.14.6
+    tag: 0.14.8
   pullPolicy: Always
 
 # When enabled, exposes json and prometheus metrics on {{ .Release.Name }}-metrics service

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -145,6 +145,7 @@ filter:
   kubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   kubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   kubeTag: kube
+  kubeAnnotations: "on"
 # If true, check to see if the log field content is a JSON string map, if so,
 # it append the map fields as part of the log structure.
 #  mergeJSONLog: true

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -138,7 +138,7 @@ nodeSelector: {}
 input:
   tail:
     memBufLimit: 5MB
-    skipLongLines: On
+    skipLongLines: "on"
 
 filter:
   kubeURL: https://kubernetes.default.svc:443

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -138,14 +138,14 @@ nodeSelector: {}
 input:
   tail:
     memBufLimit: 5MB
-    skipLongLines: "on"
+    skipLongLines: "On"
 
 filter:
   kubeURL: https://kubernetes.default.svc:443
   kubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   kubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   kubeTag: kube
-  kubeAnnotations: "on"
+  kubeAnnotations: "On"
 # If true, check to see if the log field content is a JSON string map, if so,
 # it append the map fields as part of the log structure.
 #  mergeJSONLog: true

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -138,6 +138,7 @@ nodeSelector: {}
 input:
   tail:
     memBufLimit: 5MB
+    skipLongLines: On
 
 filter:
   kubeURL: https://kubernetes.default.svc:443


### PR DESCRIPTION
#### What this PR does / why we need it:
There is a bug with identation to add extra outputs, inputs and filters. The indentation should be set to 4, currently it is set to 8 and results in the following error:
```
Fluent-Bit v0.14.6
Copyright (C) Treasure Data

[2018/11/26 18:04:02] [  Error] File /fluent-bit/etc/fluent-bit.conf
[2018/11/26 18:04:02] [  Error] Error in line 23: Each key must have a value
```

And making input tail plugin's `Skip_Long_Lines` option configurable, https://docs.fluentbit.io/manual/input/tail#config. Currently it cannot be changed and is set to On. I would like to configure it to be turned Off. By default it is coded to be turned on. 

And adding an option to disable kubernetes annotations, based on
https://github.com/fluent/fluent-bit/blob/master/plugins/filter_kubernetes/kube_conf.c#L54 and
https://github.com/fluent/fluent-bit/issues/579#issuecomment-386378519. This was tested on my kubernetes cluster and works.

Disabling of kubernetes annotations is very useful, because for some implementations like [datadog autodiscovery](https://docs.datadoghq.com/agent/autodiscovery/?tab=docker), the config is included in the annotations and when annotations are injected by default into each log line, this happens:
```
{"log":"17:01:45,646 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [/etc/logback-standard.xml] at [file:/etc/logback-standard.xml]\n","stream":"stdout","time":"2018-11-26T17:01:45.708131872Z","kubernetes":{"pod_name":"reference-app-5b9545d86c-hm4z4","namespace_name":"reference-app","pod_id":"eb9c2c79-f19c-11e8-99ac-1208343f026a","labels":{"app":"reference-app","chart":"da-generic-0.20.0","heritage":"Tiller","pod-template-hash":"1651018427","release":"reference-app"},"annotations":{"ad.datadoghq.com/reference-app.check_names":"[\\\"reference-app\\\"]","ad.datadoghq.com/reference-app.init_configs":"[{\\\"is_jmx\\\":true,\\\"collect_default_metrics\\\":true,\\\"conf\\\":[{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"OperatingSystem\\\"}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"GarbageCollector\\\",\\\"name\\\":\\\"Copy\\\",\\\"attribute\\\":{\\\"CollectionCount\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.minor_collection_count\\\"},\\\"CollectionTime\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.minor_collection_time\\\"}}}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"GarbageCollector\\\",\\\"name\\\":\\\"PS Scavenge\\\",\\\"attribute\\\":{\\\"CollectionCount\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.minor_collection_count\\\"},\\\"CollectionTime\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.minor_collection_time\\\"}}}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"GarbageCollector\\\",\\\"name\\\":\\\"ParNew\\\",\\\"attribute\\\":{\\\"CollectionCount\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.minor_collection_count\\\"},\\\"CollectionTime\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.minor_collection_time\\\"}}}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"GarbageCollector\\\",\\\"name\\\":\\\"G1 Young Generation\\\",\\\"attribute\\\":{\\\"CollectionCount\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.minor_collection_count\\\"},\\\"CollectionTime\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.minor_collection_time\\\"}}}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"GarbageCollector\\\",\\\"name\\\":\\\"MarkSweepCompact\\\",\\\"attribute\\\":{\\\"CollectionCount\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.major_collection_count\\\"},\\\"CollectionTime\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.major_collection_time\\\"}}}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"GarbageCollector\\\",\\\"name\\\":\\\"PS MarkSweep\\\",\\\"attribute\\\":{\\\"CollectionCount\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.major_collection_count\\\"},\\\"CollectionTime\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.major_collection_time\\\"}}}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"GarbageCollector\\\",\\\"name\\\":\\\"ConcurrentMarkSweep\\\",\\\"attribute\\\":{\\\"CollectionCount\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.major_collection_count\\\"},\\\"CollectionTime\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.major_collection_time\\\"}}}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"GarbageCollector\\\",\\\"name\\\":\\\"G1 Mixed Generation\\\",\\\"attribute\\\":{\\\"CollectionCount\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.major_collection_count\\\"},\\\"CollectionTime\\\":{\\\"metric_type\\\":\\\"gauge\\\",\\\"alias\\\":\\\"jmx.gc.major_collection_time\\\"}}}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"Memory\\\",\\\"attribute\\\":[\\\"HeapMemoryUsage\\\",\\\"NonHeapMemoryUsage\\\"]}},{\\\"include\\\":{\\\"domain\\\":\\\"java.lang\\\",\\\"type\\\":\\\"OperatingSystem\\\",\\\"attribute\\\":[\\\"ProcessCpuLoad\\\"]}}}]}]","ad.datadoghq.com/reference-app.instances":"[{\\\"host\\\": \\\"%%host%%\\\", \\\"port\\\": 7199, \\\"tags\\\": [\\\"reference-app\\\"]}]"},"host":"ip-0-0-0-0.ec2.internal","container_name":"reference-app","docker_id":"94fe42"}}
```


#### Special notes for your reviewer:
bumped the app to latest release version 0.14.8, https://fluentbit.io/announcements/v0.14.8/, https://github.com/fluent/fluent-bit/releases/tag/v0.14.8

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
