### PR TITLE
add/use unified labels for prometheus components

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 7.4.5
+version: 7.4.6
 appVersion: 2.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -9,36 +9,64 @@ Expand the name of the chart.
 {{/*
 Create unified labels for prometheus components
 */}}
-{{- define "prometheus.common.labels" }}
+{{- define "prometheus.common.matchLabels" }}
 app: {{ template "prometheus.name" . }}
-chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-heritage: {{ .Release.Service }}
 release: {{ .Release.Name }}
 {{- end }}
 
+{{- define "prometheus.common.metaLabels" }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+heritage: {{ .Release.Service }}
+{{- end }}
+
 {{- define "prometheus.alertmanager.labels" }}
+{{- include "prometheus.alertmanager.matchLabels" . }}
+{{- include "prometheus.common.metaLabels" . }}
+{{- end }}
+
+{{- define "prometheus.alertmanager.matchLabels" }}
 component: {{ .Values.alertmanager.name | quote }}
-{{- include "prometheus.common.labels" . }}
+{{- include "prometheus.common.matchLabels" . }}
 {{- end }}
 
 {{- define "prometheus.kubeStateMetrics.labels" }}
+{{- include "prometheus.kubeStateMetrics.matchLabels" . }}
+{{- include "prometheus.common.metaLabels" . }}
+{{- end }}
+
+{{- define "prometheus.kubeStateMetrics.matchLabels" }}
 component: {{ .Values.kubeStateMetrics.name | quote }}
-{{- include "prometheus.common.labels" . }}
+{{- include "prometheus.common.matchLabels" . }}
 {{- end }}
 
 {{- define "prometheus.nodeExporter.labels" }}
+{{- include "prometheus.nodeExporter.matchLabels" . }}
+{{- include "prometheus.common.metaLabels" . }}
+{{- end }}
+
+{{- define "prometheus.nodeExporter.matchLabels" }}
 component: {{ .Values.nodeExporter.name | quote }}
-{{- include "prometheus.common.labels" . }}
+{{- include "prometheus.common.matchLabels" . }}
 {{- end }}
 
 {{- define "prometheus.pushgateway.labels" }}
+{{- include "prometheus.pushgateway.matchLabels" . }}
+{{- include "prometheus.common.metaLabels" . }}
+{{- end }}
+
+{{- define "prometheus.pushgateway.matchLabels" }}
 component: {{ .Values.pushgateway.name | quote }}
-{{- include "prometheus.common.labels" . }}
+{{- include "prometheus.common.matchLabels" . }}
 {{- end }}
 
 {{- define "prometheus.server.labels" }}
+{{- include "prometheus.server.matchLabels" . }}
+{{- include "prometheus.common.metaLabels" . }}
+{{- end }}
+
+{{- define "prometheus.server.matchLabels" }}
 component: {{ .Values.server.name | quote }}
-{{- include "prometheus.common.labels" . }}
+{{- include "prometheus.common.matchLabels" . }}
 {{- end }}
 
 {{/*

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -9,65 +9,65 @@ Expand the name of the chart.
 {{/*
 Create unified labels for prometheus components
 */}}
-{{- define "prometheus.common.matchLabels" }}
+{{- define "prometheus.common.matchLabels" -}}
 app: {{ template "prometheus.name" . }}
 release: {{ .Release.Name }}
-{{- end }}
+{{- end -}}
 
-{{- define "prometheus.common.metaLabels" }}
+{{- define "prometheus.common.metaLabels" -}}
 chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 heritage: {{ .Release.Service }}
-{{- end }}
+{{- end -}}
 
-{{- define "prometheus.alertmanager.labels" }}
-{{- include "prometheus.alertmanager.matchLabels" . }}
-{{- include "prometheus.common.metaLabels" . }}
-{{- end }}
+{{- define "prometheus.alertmanager.labels" -}}
+{{ include "prometheus.alertmanager.matchLabels" . }}
+{{ include "prometheus.common.metaLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.alertmanager.matchLabels" }}
+{{- define "prometheus.alertmanager.matchLabels" -}}
 component: {{ .Values.alertmanager.name | quote }}
-{{- include "prometheus.common.matchLabels" . }}
-{{- end }}
+{{ include "prometheus.common.matchLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.kubeStateMetrics.labels" }}
-{{- include "prometheus.kubeStateMetrics.matchLabels" . }}
-{{- include "prometheus.common.metaLabels" . }}
-{{- end }}
+{{- define "prometheus.kubeStateMetrics.labels" -}}
+{{ include "prometheus.kubeStateMetrics.matchLabels" . }}
+{{ include "prometheus.common.metaLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.kubeStateMetrics.matchLabels" }}
+{{- define "prometheus.kubeStateMetrics.matchLabels" -}}
 component: {{ .Values.kubeStateMetrics.name | quote }}
-{{- include "prometheus.common.matchLabels" . }}
-{{- end }}
+{{ include "prometheus.common.matchLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.nodeExporter.labels" }}
-{{- include "prometheus.nodeExporter.matchLabels" . }}
-{{- include "prometheus.common.metaLabels" . }}
-{{- end }}
+{{- define "prometheus.nodeExporter.labels" -}}
+{{ include "prometheus.nodeExporter.matchLabels" . }}
+{{ include "prometheus.common.metaLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.nodeExporter.matchLabels" }}
+{{- define "prometheus.nodeExporter.matchLabels" -}}
 component: {{ .Values.nodeExporter.name | quote }}
-{{- include "prometheus.common.matchLabels" . }}
-{{- end }}
+{{ include "prometheus.common.matchLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.pushgateway.labels" }}
-{{- include "prometheus.pushgateway.matchLabels" . }}
-{{- include "prometheus.common.metaLabels" . }}
-{{- end }}
+{{- define "prometheus.pushgateway.labels" -}}
+{{ include "prometheus.pushgateway.matchLabels" . }}
+{{ include "prometheus.common.metaLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.pushgateway.matchLabels" }}
+{{- define "prometheus.pushgateway.matchLabels" -}}
 component: {{ .Values.pushgateway.name | quote }}
-{{- include "prometheus.common.matchLabels" . }}
-{{- end }}
+{{ include "prometheus.common.matchLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.server.labels" }}
-{{- include "prometheus.server.matchLabels" . }}
-{{- include "prometheus.common.metaLabels" . }}
-{{- end }}
+{{- define "prometheus.server.labels" -}}
+{{ include "prometheus.server.matchLabels" . }}
+{{ include "prometheus.common.metaLabels" . }}
+{{- end -}}
 
-{{- define "prometheus.server.matchLabels" }}
+{{- define "prometheus.server.matchLabels" -}}
 component: {{ .Values.server.name | quote }}
-{{- include "prometheus.common.matchLabels" . }}
-{{- end }}
+{{ include "prometheus.common.matchLabels" . }}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name.

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -9,44 +9,36 @@ Expand the name of the chart.
 {{/*
 Create unified labels for prometheus components
 */}}
-{{- define "prometheus.alertmanager.labels" }}
+{{- define "prometheus.common.labels" }}
 app: {{ template "prometheus.name" . }}
 chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-component: {{ .Values.alertmanager.name | quote }}
 heritage: {{ .Release.Service }}
 release: {{ .Release.Name }}
+{{- end }}
+
+{{- define "prometheus.alertmanager.labels" }}
+component: {{ .Values.alertmanager.name | quote }}
+{{- include "prometheus.common.labels" . }}
 {{- end }}
 
 {{- define "prometheus.kubeStateMetrics.labels" }}
-app: {{ template "prometheus.name" . }}
-chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 component: {{ .Values.kubeStateMetrics.name | quote }}
-heritage: {{ .Release.Service }}
-release: {{ .Release.Name }}
+{{- include "prometheus.common.labels" . }}
 {{- end }}
 
 {{- define "prometheus.nodeExporter.labels" }}
-app: {{ template "prometheus.name" . }}
-chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 component: {{ .Values.nodeExporter.name | quote }}
-heritage: {{ .Release.Service }}
-release: {{ .Release.Name }}
+{{- include "prometheus.common.labels" . }}
 {{- end }}
 
 {{- define "prometheus.pushgateway.labels" }}
-app: {{ template "prometheus.name" . }}
-chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 component: {{ .Values.pushgateway.name | quote }}
-heritage: {{ .Release.Service }}
-release: {{ .Release.Name }}
+{{- include "prometheus.common.labels" . }}
 {{- end }}
 
 {{- define "prometheus.server.labels" }}
-app: {{ template "prometheus.name" . }}
-chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 component: {{ .Values.server.name | quote }}
-heritage: {{ .Release.Service }}
-release: {{ .Release.Name }}
+{{- include "prometheus.common.labels" . }}
 {{- end }}
 
 {{/*

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -7,6 +7,49 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Create unified labels for prometheus components
+*/}}
+{{- define "prometheus.alertmanager.labels" }}
+app: {{ template "prometheus.name" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+component: {{ .Values.alertmanager.name | quote }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+{{- end }}
+
+{{- define "prometheus.kubeStateMetrics.labels" }}
+app: {{ template "prometheus.name" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+component: {{ .Values.kubeStateMetrics.name | quote }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+{{- end }}
+
+{{- define "prometheus.nodeExporter.labels" }}
+app: {{ template "prometheus.name" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+component: {{ .Values.nodeExporter.name | quote }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+{{- end }}
+
+{{- define "prometheus.pushgateway.labels" }}
+app: {{ template "prometheus.name" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+component: {{ .Values.pushgateway.name | quote }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+{{- end }}
+
+{{- define "prometheus.server.labels" }}
+app: {{ template "prometheus.name" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+component: {{ .Values.server.name | quote }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/prometheus/templates/alertmanager-configmap.yaml
+++ b/stable/prometheus/templates/alertmanager-configmap.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.alertmanager.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
 data:
 {{- $root := . -}}

--- a/stable/prometheus/templates/alertmanager-configmap.yaml
+++ b/stable/prometheus/templates/alertmanager-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
 data:
 {{- $root := . -}}

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -3,11 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.alertmanager.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
 spec:
   replicas: {{ .Values.alertmanager.replicaCount }}
@@ -22,9 +18,7 @@ spec:
 {{ toYaml .Values.alertmanager.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "prometheus.name" . }}
-        component: "{{ .Values.alertmanager.name }}"
-        release: {{ .Release.Name }}
+        {{- include "prometheus.alertmanager.labels" . | indent 8 }}
     spec:
 {{- if .Values.alertmanager.affinity }}
       affinity:

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "prometheus.alertmanager.labels" . | indent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      {{- include "prometheus.alertmanager.matchLabels" . | indent 6 }}
   replicas: {{ .Values.alertmanager.replicaCount }}
   {{- if .Values.server.strategy }}
   strategy:

--- a/stable/prometheus/templates/alertmanager-deployment.yaml
+++ b/stable/prometheus/templates/alertmanager-deployment.yaml
@@ -3,12 +3,12 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus.alertmanager.matchLabels" . | indent 6 }}
+      {{- include "prometheus.alertmanager.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.alertmanager.replicaCount }}
   {{- if .Values.server.strategy }}
   strategy:
@@ -21,7 +21,7 @@ spec:
 {{ toYaml .Values.alertmanager.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        {{- include "prometheus.alertmanager.labels" . | indent 8 }}
+        {{- include "prometheus.alertmanager.labels" . | nindent 8 }}
     spec:
 {{- if .Values.alertmanager.affinity }}
       affinity:

--- a/stable/prometheus/templates/alertmanager-ingress.yaml
+++ b/stable/prometheus/templates/alertmanager-ingress.yaml
@@ -10,11 +10,7 @@ metadata:
 {{ toYaml .Values.alertmanager.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.alertmanager.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
 {{- range $key, $value := .Values.alertmanager.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
 {{- end }}

--- a/stable/prometheus/templates/alertmanager-ingress.yaml
+++ b/stable/prometheus/templates/alertmanager-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 {{ toYaml .Values.alertmanager.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
 {{- range $key, $value := .Values.alertmanager.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
 {{- end }}

--- a/stable/prometheus/templates/alertmanager-networkpolicy.yaml
+++ b/stable/prometheus/templates/alertmanager-networkpolicy.yaml
@@ -4,11 +4,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.alertmanager.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/stable/prometheus/templates/alertmanager-networkpolicy.yaml
+++ b/stable/prometheus/templates/alertmanager-networkpolicy.yaml
@@ -4,7 +4,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.alertmanager.fullname" . }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.alertmanager.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
 spec:
   accessModes:

--- a/stable/prometheus/templates/alertmanager-pvc.yaml
+++ b/stable/prometheus/templates/alertmanager-pvc.yaml
@@ -8,11 +8,7 @@ metadata:
 {{ toYaml .Values.alertmanager.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.alertmanager.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
   name: {{ template "prometheus.alertmanager.fullname" . }}
 spec:
   accessModes:

--- a/stable/prometheus/templates/alertmanager-service.yaml
+++ b/stable/prometheus/templates/alertmanager-service.yaml
@@ -44,8 +44,6 @@ spec:
       targetPort: 6783
 {{- end }}
   selector:
-    app: {{ template "prometheus.name" . }}
-    component: "{{ .Values.alertmanager.name }}"
-    release: {{ .Release.Name }}
+    {{- include "prometheus.alertmanager.matchLabels" . | indent 4 }}
   type: "{{ .Values.alertmanager.service.type }}"
 {{- end }}

--- a/stable/prometheus/templates/alertmanager-service.yaml
+++ b/stable/prometheus/templates/alertmanager-service.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ toYaml .Values.alertmanager.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
 {{- if .Values.alertmanager.service.labels }}
 {{ toYaml .Values.alertmanager.service.labels | indent 4 }}
 {{- end }}
@@ -44,6 +44,6 @@ spec:
       targetPort: 6783
 {{- end }}
   selector:
-    {{- include "prometheus.alertmanager.matchLabels" . | indent 4 }}
+    {{- include "prometheus.alertmanager.matchLabels" . | nindent 4 }}
   type: "{{ .Values.alertmanager.service.type }}"
 {{- end }}

--- a/stable/prometheus/templates/alertmanager-service.yaml
+++ b/stable/prometheus/templates/alertmanager-service.yaml
@@ -7,11 +7,7 @@ metadata:
 {{ toYaml .Values.alertmanager.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.alertmanager.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
 {{- if .Values.alertmanager.service.labels }}
 {{ toYaml .Values.alertmanager.service.labels | indent 4 }}
 {{- end }}

--- a/stable/prometheus/templates/alertmanager-serviceaccount.yaml
+++ b/stable/prometheus/templates/alertmanager-serviceaccount.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.alertmanager.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
   name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
 {{- end -}}

--- a/stable/prometheus/templates/alertmanager-serviceaccount.yaml
+++ b/stable/prometheus/templates/alertmanager-serviceaccount.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.alertmanager.labels" . | indent 4 }}
+    {{- include "prometheus.alertmanager.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.alertmanager" . }}
 {{- end -}}

--- a/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
 rules:
   - apiGroups:

--- a/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrole.yaml
@@ -3,11 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.kubeStateMetrics.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
 rules:
   - apiGroups:

--- a/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
@@ -3,11 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.kubeStateMetrics.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-clusterrolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -7,11 +7,7 @@ metadata:
 {{ toYaml .Values.kubeStateMetrics.deploymentAnnotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.kubeStateMetrics.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
 spec:
   replicas: {{ .Values.kubeStateMetrics.replicaCount }}
@@ -22,9 +18,7 @@ spec:
 {{ toYaml .Values.kubeStateMetrics.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "prometheus.name" . }}
-        component: "{{ .Values.kubeStateMetrics.name }}"
-        release: {{ .Release.Name }}
+        {{- include "prometheus.kubeStateMetrics.labels" . | indent 8 }}
 {{- if .Values.kubeStateMetrics.pod.labels }}
 {{ toYaml .Values.kubeStateMetrics.pod.labels | indent 8 }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      {{- include "prometheus.kubeStateMetrics.matchLabels" . | indent 6 }}
   replicas: {{ .Values.kubeStateMetrics.replicaCount }}
   template:
     metadata:

--- a/stable/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.kubeStateMetrics.deploymentAnnotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus.kubeStateMetrics.matchLabels" . | indent 6 }}
+      {{- include "prometheus.kubeStateMetrics.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.kubeStateMetrics.replicaCount }}
   template:
     metadata:
@@ -21,7 +21,7 @@ spec:
 {{ toYaml .Values.kubeStateMetrics.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        {{- include "prometheus.kubeStateMetrics.labels" . | indent 8 }}
+        {{- include "prometheus.kubeStateMetrics.labels" . | nindent 8 }}
 {{- if .Values.kubeStateMetrics.pod.labels }}
 {{ toYaml .Values.kubeStateMetrics.pod.labels | indent 8 }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-networkpolicy.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-networkpolicy.yaml
@@ -4,11 +4,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.kubeStateMetrics.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/stable/prometheus/templates/kube-state-metrics-networkpolicy.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-networkpolicy.yaml
@@ -4,7 +4,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.kubeStateMetrics.fullname" . }}
   labels:
-    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.kubeStateMetrics.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
   name: {{ template "prometheus.serviceAccountName.kubeStateMetrics" . }}
 {{- end -}}

--- a/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-serviceaccount.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.kubeStateMetrics" . }}
 {{- end -}}

--- a/stable/prometheus/templates/kube-state-metrics-svc.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-svc.yaml
@@ -7,11 +7,7 @@ metadata:
 {{ toYaml .Values.kubeStateMetrics.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.kubeStateMetrics.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
 {{- if .Values.kubeStateMetrics.service.labels }}
 {{ toYaml .Values.kubeStateMetrics.service.labels | indent 4 }}
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-svc.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-svc.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ toYaml .Values.kubeStateMetrics.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.kubeStateMetrics.labels" . | indent 4 }}
+    {{- include "prometheus.kubeStateMetrics.labels" . | nindent 4 }}
 {{- if .Values.kubeStateMetrics.service.labels }}
 {{ toYaml .Values.kubeStateMetrics.service.labels | indent 4 }}
 {{- end }}
@@ -35,6 +35,6 @@ spec:
       protocol: TCP
       targetPort: 8080
   selector:
-    {{- include "prometheus.kubeStateMetrics.matchLabels" . | indent 4 }}
+    {{- include "prometheus.kubeStateMetrics.matchLabels" . | nindent 4 }}
   type: "{{ .Values.kubeStateMetrics.service.type }}"
 {{- end }}

--- a/stable/prometheus/templates/kube-state-metrics-svc.yaml
+++ b/stable/prometheus/templates/kube-state-metrics-svc.yaml
@@ -35,8 +35,6 @@ spec:
       protocol: TCP
       targetPort: 8080
   selector:
-    app: {{ template "prometheus.name" . }}
-    component: "{{ .Values.kubeStateMetrics.name }}"
-    release: {{ .Release.Name }}
+    {{- include "prometheus.kubeStateMetrics.matchLabels" . | indent 4 }}
   type: "{{ .Values.kubeStateMetrics.service.type }}"
 {{- end }}

--- a/stable/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/prometheus/templates/node-exporter-daemonset.yaml
@@ -7,12 +7,12 @@ metadata:
 {{ toYaml .Values.nodeExporter.deploymentAnnotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
+    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   name: {{ template "prometheus.nodeExporter.fullname" . }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus.nodeExporter.matchLabels" . | indent 6 }}
+      {{- include "prometheus.nodeExporter.matchLabels" . | nindent 6 }}
   {{- if .Values.nodeExporter.updateStrategy }}
   updateStrategy:
 {{ toYaml .Values.nodeExporter.updateStrategy | indent 4 }}
@@ -24,7 +24,7 @@ spec:
 {{ toYaml .Values.nodeExporter.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        {{- include "prometheus.nodeExporter.labels" . | indent 8 }}
+        {{- include "prometheus.nodeExporter.labels" . | nindent 8 }}
 {{- if .Values.nodeExporter.pod.labels }}
 {{ toYaml .Values.nodeExporter.pod.labels | indent 8 }}
 {{- end }}

--- a/stable/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/prometheus/templates/node-exporter-daemonset.yaml
@@ -7,11 +7,7 @@ metadata:
 {{ toYaml .Values.nodeExporter.deploymentAnnotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
   name: {{ template "prometheus.nodeExporter.fullname" . }}
 spec:
   {{- if .Values.nodeExporter.updateStrategy }}
@@ -25,9 +21,7 @@ spec:
 {{ toYaml .Values.nodeExporter.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "prometheus.name" . }}
-        component: "{{ .Values.nodeExporter.name }}"
-        release: {{ .Release.Name }}
+        {{- include "prometheus.nodeExporter.labels" . | indent 8 }}
 {{- if .Values.nodeExporter.pod.labels }}
 {{ toYaml .Values.nodeExporter.pod.labels | indent 8 }}
 {{- end }}

--- a/stable/prometheus/templates/node-exporter-daemonset.yaml
+++ b/stable/prometheus/templates/node-exporter-daemonset.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
   name: {{ template "prometheus.nodeExporter.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      {{- include "prometheus.nodeExporter.matchLabels" . | indent 6 }}
   {{- if .Values.nodeExporter.updateStrategy }}
   updateStrategy:
 {{ toYaml .Values.nodeExporter.updateStrategy | indent 4 }}

--- a/stable/prometheus/templates/node-exporter-podsecuritypolicy.yaml
+++ b/stable/prometheus/templates/node-exporter-podsecuritypolicy.yaml
@@ -5,11 +5,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
   annotations:
 {{- if .Values.nodeExporter.podSecurityPolicy.annotations }}
 {{ toYaml .Values.nodeExporter.podSecurityPolicy.annotations | indent 4 }}

--- a/stable/prometheus/templates/node-exporter-podsecuritypolicy.yaml
+++ b/stable/prometheus/templates/node-exporter-podsecuritypolicy.yaml
@@ -5,7 +5,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
+    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   annotations:
 {{- if .Values.nodeExporter.podSecurityPolicy.annotations }}
 {{ toYaml .Values.nodeExporter.podSecurityPolicy.annotations | indent 4 }}

--- a/stable/prometheus/templates/node-exporter-role.yaml
+++ b/stable/prometheus/templates/node-exporter-role.yaml
@@ -5,11 +5,7 @@ kind: Role
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: ['extensions']

--- a/stable/prometheus/templates/node-exporter-role.yaml
+++ b/stable/prometheus/templates/node-exporter-role.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
+    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: ['extensions']

--- a/stable/prometheus/templates/node-exporter-rolebinding.yaml
+++ b/stable/prometheus/templates/node-exporter-rolebinding.yaml
@@ -5,11 +5,7 @@ kind: RoleBinding
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/stable/prometheus/templates/node-exporter-rolebinding.yaml
+++ b/stable/prometheus/templates/node-exporter-rolebinding.yaml
@@ -5,7 +5,7 @@ kind: RoleBinding
 metadata:
   name: {{ template "prometheus.nodeExporter.fullname" . }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
+    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/stable/prometheus/templates/node-exporter-service.yaml
+++ b/stable/prometheus/templates/node-exporter-service.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ toYaml .Values.nodeExporter.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
+    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
 {{- if .Values.nodeExporter.service.labels }}
 {{ toYaml .Values.nodeExporter.service.labels | indent 4 }}
 {{- end }}
@@ -35,6 +35,6 @@ spec:
       protocol: TCP
       targetPort: 9100
   selector:
-    {{- include "prometheus.nodeExporter.matchLabels" . | indent 4 }}
+    {{- include "prometheus.nodeExporter.matchLabels" . | nindent 4 }}
   type: "{{ .Values.nodeExporter.service.type }}"
 {{- end -}}

--- a/stable/prometheus/templates/node-exporter-service.yaml
+++ b/stable/prometheus/templates/node-exporter-service.yaml
@@ -35,8 +35,6 @@ spec:
       protocol: TCP
       targetPort: 9100
   selector:
-    app: {{ template "prometheus.name" . }}
-    component: "{{ .Values.nodeExporter.name }}"
-    release: {{ .Release.Name }}
+    {{- include "prometheus.nodeExporter.matchLabels" . | indent 4 }}
   type: "{{ .Values.nodeExporter.service.type }}"
 {{- end -}}

--- a/stable/prometheus/templates/node-exporter-service.yaml
+++ b/stable/prometheus/templates/node-exporter-service.yaml
@@ -7,11 +7,7 @@ metadata:
 {{ toYaml .Values.nodeExporter.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
 {{- if .Values.nodeExporter.service.labels }}
 {{ toYaml .Values.nodeExporter.service.labels | indent 4 }}
 {{- end }}

--- a/stable/prometheus/templates/node-exporter-serviceaccount.yaml
+++ b/stable/prometheus/templates/node-exporter-serviceaccount.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
+    {{- include "prometheus.nodeExporter.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
 {{- end -}}

--- a/stable/prometheus/templates/node-exporter-serviceaccount.yaml
+++ b/stable/prometheus/templates/node-exporter-serviceaccount.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.nodeExporter.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.nodeExporter.labels" . | indent 4 }}
   name: {{ template "prometheus.serviceAccountName.nodeExporter" . }}
 {{- end -}}

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -3,12 +3,12 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    {{- include "prometheus.pushgateway.labels" . | indent 4 }}
+    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus.pushgateway.matchLabels" . | indent 6 }}
+      {{- include "prometheus.pushgateway.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.pushgateway.replicaCount }}
   template:
     metadata:
@@ -17,7 +17,7 @@ spec:
 {{ toYaml .Values.pushgateway.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        {{- include "prometheus.pushgateway.labels" . | indent 8 }}
+        {{- include "prometheus.pushgateway.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "prometheus.serviceAccountName.pushgateway" . }}
 {{- if .Values.pushgateway.priorityClassName }}

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -3,11 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.pushgateway.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.pushgateway.labels" . | indent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
 spec:
   replicas: {{ .Values.pushgateway.replicaCount }}
@@ -18,9 +14,7 @@ spec:
 {{ toYaml .Values.pushgateway.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "prometheus.name" . }}
-        component: "{{ .Values.pushgateway.name }}"
-        release: {{ .Release.Name }}
+        {{- include "prometheus.pushgateway.labels" . | indent 8 }}
     spec:
       serviceAccountName: {{ template "prometheus.serviceAccountName.pushgateway" . }}
 {{- if .Values.pushgateway.priorityClassName }}

--- a/stable/prometheus/templates/pushgateway-deployment.yaml
+++ b/stable/prometheus/templates/pushgateway-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "prometheus.pushgateway.labels" . | indent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      {{- include "prometheus.pushgateway.matchLabels" . | indent 6 }}
   replicas: {{ .Values.pushgateway.replicaCount }}
   template:
     metadata:

--- a/stable/prometheus/templates/pushgateway-ingress.yaml
+++ b/stable/prometheus/templates/pushgateway-ingress.yaml
@@ -10,11 +10,7 @@ metadata:
 {{ toYaml .Values.pushgateway.ingress.annotations | indent 4}}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.pushgateway.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.pushgateway.labels" . | indent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
 spec:
   rules:

--- a/stable/prometheus/templates/pushgateway-ingress.yaml
+++ b/stable/prometheus/templates/pushgateway-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 {{ toYaml .Values.pushgateway.ingress.annotations | indent 4}}
 {{- end }}
   labels:
-    {{- include "prometheus.pushgateway.labels" . | indent 4 }}
+    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.pushgateway.fullname" . }}
 spec:
   rules:

--- a/stable/prometheus/templates/pushgateway-service.yaml
+++ b/stable/prometheus/templates/pushgateway-service.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ toYaml .Values.pushgateway.service.annotations | indent 4}}
 {{- end }}
   labels:
-    {{- include "prometheus.pushgateway.labels" . | indent 4 }}
+    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
 {{- if .Values.pushgateway.service.labels }}
 {{ toYaml .Values.pushgateway.service.labels | indent 4}}
 {{- end }}
@@ -35,6 +35,6 @@ spec:
       protocol: TCP
       targetPort: 9091
   selector:
-    {{- include "prometheus.pushgateway.matchLabels" . | indent 4 }}
+    {{- include "prometheus.pushgateway.matchLabels" . | nindent 4 }}
   type: "{{ .Values.pushgateway.service.type }}"
 {{- end }}

--- a/stable/prometheus/templates/pushgateway-service.yaml
+++ b/stable/prometheus/templates/pushgateway-service.yaml
@@ -7,11 +7,7 @@ metadata:
 {{ toYaml .Values.pushgateway.service.annotations | indent 4}}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.pushgateway.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.pushgateway.labels" . | indent 4 }}
 {{- if .Values.pushgateway.service.labels }}
 {{ toYaml .Values.pushgateway.service.labels | indent 4}}
 {{- end }}

--- a/stable/prometheus/templates/pushgateway-service.yaml
+++ b/stable/prometheus/templates/pushgateway-service.yaml
@@ -35,8 +35,6 @@ spec:
       protocol: TCP
       targetPort: 9091
   selector:
-    app: {{ template "prometheus.name" . }}
-    component: "{{ .Values.pushgateway.name }}"
-    release: {{ .Release.Name }}
+    {{- include "prometheus.pushgateway.matchLabels" . | indent 4 }}
   type: "{{ .Values.pushgateway.service.type }}"
 {{- end }}

--- a/stable/prometheus/templates/pushgateway-serviceaccount.yaml
+++ b/stable/prometheus/templates/pushgateway-serviceaccount.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.pushgateway.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.pushgateway.labels" . | indent 4 }}
   name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
 {{- end -}}

--- a/stable/prometheus/templates/pushgateway-serviceaccount.yaml
+++ b/stable/prometheus/templates/pushgateway-serviceaccount.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.pushgateway.labels" . | indent 4 }}
+    {{- include "prometheus.pushgateway.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.pushgateway" . }}
 {{- end -}}

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 rules:
   - apiGroups:

--- a/stable/prometheus/templates/server-clusterrole.yaml
+++ b/stable/prometheus/templates/server-clusterrole.yaml
@@ -3,11 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 rules:
   - apiGroups:

--- a/stable/prometheus/templates/server-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/server-clusterrolebinding.yaml
@@ -3,11 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/stable/prometheus/templates/server-clusterrolebinding.yaml
+++ b/stable/prometheus/templates/server-clusterrolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 data:
 {{- $root := . -}}

--- a/stable/prometheus/templates/server-configmap.yaml
+++ b/stable/prometheus/templates/server-configmap.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 data:
 {{- $root := . -}}

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -6,12 +6,12 @@ metadata:
 {{ toYaml .Values.server.deploymentAnnotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 spec:
   selector:
     matchLabels:
-      {{- include "prometheus.server.matchLabels" . | indent 6 }}
+      {{- include "prometheus.server.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.server.replicaCount }}
   {{- if .Values.server.strategy }}
   strategy:
@@ -24,7 +24,7 @@ spec:
 {{ toYaml .Values.server.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        {{- include "prometheus.server.labels" . | indent 8 }}
+        {{- include "prometheus.server.labels" . | nindent 8 }}
     spec:
 {{- if .Values.server.affinity }}
       affinity:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- include "prometheus.server.labels" . | indent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 spec:
+  selector:
+    matchLabels:
+      {{- include "prometheus.server.matchLabels" . | indent 6 }}
   replicas: {{ .Values.server.replicaCount }}
   {{- if .Values.server.strategy }}
   strategy:

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -6,11 +6,7 @@ metadata:
 {{ toYaml .Values.server.deploymentAnnotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 spec:
   replicas: {{ .Values.server.replicaCount }}
@@ -25,9 +21,7 @@ spec:
 {{ toYaml .Values.server.podAnnotations | indent 8 }}
     {{- end }}
       labels:
-        app: {{ template "prometheus.name" . }}
-        component: "{{ .Values.server.name }}"
-        release: {{ .Release.Name }}
+        {{- include "prometheus.server.labels" . | indent 8 }}
     spec:
 {{- if .Values.server.affinity }}
       affinity:

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 {{ toYaml .Values.server.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
 {{- range $key, $value := .Values.server.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
 {{- end }}

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -10,11 +10,7 @@ metadata:
 {{ toYaml .Values.server.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
 {{- range $key, $value := .Values.server.ingress.extraLabels }}
     {{ $key }}: {{ $value }}
 {{- end }}

--- a/stable/prometheus/templates/server-networkpolicy.yaml
+++ b/stable/prometheus/templates/server-networkpolicy.yaml
@@ -4,7 +4,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/stable/prometheus/templates/server-networkpolicy.yaml
+++ b/stable/prometheus/templates/server-networkpolicy.yaml
@@ -4,11 +4,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "prometheus.server.fullname" . }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -8,11 +8,7 @@ metadata:
 {{ toYaml .Values.server.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 spec:
   accessModes:

--- a/stable/prometheus/templates/server-pvc.yaml
+++ b/stable/prometheus/templates/server-pvc.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ toYaml .Values.server.persistentVolume.annotations | indent 4 }}
   {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.server.fullname" . }}
 spec:
   accessModes:

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -6,11 +6,7 @@ metadata:
 {{ toYaml .Values.server.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
 {{- if .Values.server.service.labels }}
 {{ toYaml .Values.server.service.labels | indent 4 }}
 {{- end }}

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ toYaml .Values.server.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
 {{- if .Values.server.service.labels }}
 {{ toYaml .Values.server.service.labels | indent 4 }}
 {{- end }}
@@ -37,5 +37,5 @@ spec:
       nodePort: {{ .Values.server.service.nodePort }}
     {{- end }}
   selector:
-    {{- include "prometheus.server.matchLabels" . | indent 4 }}
+    {{- include "prometheus.server.matchLabels" . | nindent 4 }}
   type: "{{ .Values.server.service.type }}"

--- a/stable/prometheus/templates/server-service.yaml
+++ b/stable/prometheus/templates/server-service.yaml
@@ -37,7 +37,5 @@ spec:
       nodePort: {{ .Values.server.service.nodePort }}
     {{- end }}
   selector:
-    app: {{ template "prometheus.name" . }}
-    component: "{{ .Values.server.name }}"
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.matchLabels" . | indent 4 }}
   type: "{{ .Values.server.service.type }}"

--- a/stable/prometheus/templates/server-serviceaccount.yaml
+++ b/stable/prometheus/templates/server-serviceaccount.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "prometheus.server.labels" . | indent 4 }}
+    {{- include "prometheus.server.labels" . | nindent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
 {{- end }}

--- a/stable/prometheus/templates/server-serviceaccount.yaml
+++ b/stable/prometheus/templates/server-serviceaccount.yaml
@@ -3,10 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "prometheus.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    component: "{{ .Values.server.name }}"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    {{- include "prometheus.server.labels" . | indent 4 }}
   name: {{ template "prometheus.serviceAccountName.server" . }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

- adds unified templates for component labels see overall reduction
- adds `selector` (for deployments,  svc)  as best practice 
  - `apps/v1` Deployment requires `selector` https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#selector
  - https://github.com/helm/helm/blob/master/docs/chart_best_practices/pods.md#podtemplates-should-declare-selectors
- bonus: extra labels like i.e.  `chart` for pods

#### Which issue this PR fixes

none https://github.com/helm/charts/pull/9585 is where this started 

#### Special notes for your reviewer:

handle better `include+indent` with `<N spaces>{{- include .... | nindent N }}`
  - https://github.com/helm/helm/blob/master/docs/chart_template_guide/named_templates.md#the-include-function
  - https://github.com/technosophos/common-chart

but  happy to convert back to `{{ include | indent X }}` if that is preferred 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md