### PR TITLE
Correction to cluster agent deployment toleration attributes

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.11.1
+version: 1.11.2
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -117,6 +117,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `clusterAgent.resources.limits.cpu`      | CPU resource limits                | `200m`                                    |
 | `clusterAgent.resources.requests.memory` | Memory resource requests           | `256Mi`                                   |
 | `clusterAgent.resources.limits.memory`   | Memory resource limits             | `256Mi`                                   |
+| `clusterAgent.tolerations`               | List of node taints to tolerate    | `[]`                                      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -91,7 +91,7 @@ spec:
         {{- end }}
       {{- if .Values.clusterAgent.tolerations }}
       tolerations:
-{{ toYaml .Values.deployment.tolerations | indent 8 }}
+{{ toYaml .Values.clusterAgent.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.clusterAgent.affinity }}
       affinity:


### PR DESCRIPTION
Signed-off-by: Joe Hohertz <joe@viafoura.com>

#### What this PR does / why we need it:

Correction to cluster agent deployment toleration attributes
Was taking it from the wrong config section.
Also list the attribute in the README as it was missing.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
