### PR TITLE
[stable/spinnaker] spec.volumeClaimTemplates.metadata.labels must not contain chart label 

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.9.1
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/_helpers.tpl
+++ b/stable/spinnaker/templates/_helpers.tpl
@@ -32,3 +32,12 @@ A set of common selector labels for resources.
 app: {{ include "spinnaker.fullname" . | quote }}
 release: {{ .Release.Name | quote }}
 {{- end -}}
+
+{{/*
+Labels for resources with immutable fields
+This template must not contain chart label or any other label changing over time.
+*/}}
+{{- define "spinnaker.standard-persistence-labels" -}}
+app: {{ include "spinnaker.fullname" . | quote }}
+release: {{ .Release.Name | quote }}
+{{- end -}}

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -117,7 +117,7 @@ spec:
   - metadata:
       name: halyard-home
       labels:
-{{ include "spinnaker.standard-selector-labels" . | indent 8 }}
+{{ include "spinnaker.standard-persistence-labels" . | indent 8 }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -117,7 +117,7 @@ spec:
   - metadata:
       name: halyard-home
       labels:
-{{ include "spinnaker.standard-labels" . | indent 8 }}
+{{ include "spinnaker.standard-selector-labels" . | indent 8 }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrading spinnaker helm chart from version A to B causes an issue due to `spec.volumeClaimTemplates.metadata.labels`. Indeed, one of the label is the Chart version, and this label is now changing from A to B which is not possible since `spec.volumeClaimTemplates` is immutable. 

This problem is highlighted in the Helm Chart [REVIEW_GUIDELINES](https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md#statefulset)

> spec.volumeClaimTemplates.metadata.labels must have both app and release labels, and **must not** contain chart label or any label containing a version of the chart, because spec.volumeClaimTemplates is immutable.

#### Special notes for your reviewer:

This is re-using the `standard-selector-labels` template to avoid repetition. Happy to create another template, for example: `standard-persistence-labels` that contains the same label from `standard-selector-labels`

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
