### PR TITLE
[incubator/schema-registry] Add JMX & Secrets support in Schema Registry

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.0.2
+version: 1.0.3
 appVersion: 4.1.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -90,4 +90,6 @@ The following table lists the configurable parameters of the SchemaRegistry char
 | `ingress.labels` | Additional labels for the ingress | `{}` |
 | `ingress.tls.enabled` | Enable TLS for the Ingress | `false` |
 | `ingress.tls.secretName` | Name of the Kubernetes `Secret` object to obtain the TLS certificate from | `schema-registry-tls` |
-
+| `jmx.enabled` | Enable JMX? | `true` |
+| `jmx.port` | set JMX port | `5555` |
+| `secrets` | Pass any secrets to the pods.The secret will be mounted to a specific path if required | `[]` |

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             value: {{ .Values.sasl.scram.clientUser }}
           - name: SCRAM_CLIENT_PASSWORD
             {{- if (hasKey .Values.sasl.scram "useExistingSecret") }}
-            valueFrom: 
+            valueFrom:
 {{ toYaml .Values.sasl.scram.useExistingSecret.clientPassword | indent 14 -}}
             {{- else }}
             valueFrom:
@@ -63,6 +63,10 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.servicePort }}
+            {{- if .Values.jmx.enabled }}
+            - containerPort: {{ .Values.jmx.port }}
+              name: jmx
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -114,12 +118,23 @@ spec:
           - name: SCHEMA_REGISTRY_OPTS
             value: "{{ .Values.schemaRegistryOpts }}"
           {{- end }}
+          {{- if .Values.jmx.enabled }}
+          - name: JMX_PORT
+            value: "{{ .Values.jmx.port }}"
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
           {{- if .Values.sasl.scram.enabled }}
           - name: jaasconfig
             mountPath: {{ .Values.sasl.configPath | quote }}
+          {{- end }}
+          {{- range $secret := .Values.secrets }}
+            {{- if $secret.mountPath }}
+          - name: {{ include "schema-registry.fullname" $ }}-{{ $secret.name }}
+            mountPath: {{ $secret.mountPath }}
+            readOnly: true
+            {{- end }}
           {{- end }}
       volumes:
       {{- if .Values.sasl.scram.enabled }}
@@ -129,4 +144,8 @@ spec:
         configMap:
           name: {{ template "schema-registry.fullname" . }}
       {{- end }}
-          
+      {{- range .Values.secrets }}
+      - name: {{ include "schema-registry.fullname" $ }}-{{ .name }}
+        secret:
+          secretName: {{ .name }}
+      {{- end }}

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -124,5 +124,5 @@ jmx:
 ## Pass any secrets to the pods. The secret will be mounted to a
 ## specific path (in addition to environment variable) if required.
 secrets: []
-#- name: myZkSecret
-#  mountPath: /opt/zookeeper/secret
+# - name: myZkSecret
+# mountPath: /opt/zookeeper/secret

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -114,3 +114,15 @@ ingress:
   tls:
     enabled: false
     secretName: schema-registry-tls
+
+## Provide JMX Port
+jmx:
+  enabled: true
+  port: 5555
+
+## Useful if using any Keystore/Trusttore for Authorization.
+## Pass any secrets to the pods. The secret will be mounted to a
+## specific path (in addition to environment variable) if required.
+secrets: []
+#- name: myZkSecret
+#  mountPath: /opt/zookeeper/secret


### PR DESCRIPTION
Signed-off-by: Akshay Agrawal <aagrawal@zendesk.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR will make following changes

1. Add JMX support in Deployment for Schema registry. This will open up ports
2. Add K8s Secrets to be mounted in pods. This is necessary if we need to add trustore/keystore to Schema Registry for SSL authentication via K8s secrets.

#### Which issue this PR fixes
N/A -- Misleading / unused property

#### Special notes for your reviewer:
N/A
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
