### PR TITLE
Allow for creating cluster-wide jaeger operators

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 1.1.0
+version: 1.2.0
 appVersion: 1.8.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/README.md
+++ b/stable/jaeger-operator/README.md
@@ -51,6 +51,7 @@ Parameter | Description | Default
 `nodeSelector` | Node labels for pod assignment | `{}`
 `tolerations` | Toleration labels for pod assignment | `[]`
 `affinity` | Affinity settings for pod assignment | `{}`
+'env.WATCH_NAMESPACE` | `Namespace to watch for jaeger resources` | `"" - all namespaces`
 
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#Installing the Chart) section.

--- a/stable/jaeger-operator/templates/deployment.yaml
+++ b/stable/jaeger-operator/templates/deployment.yaml
@@ -32,10 +32,10 @@ spec:
             name: metrics
           args: ["start"]
           env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
             - name: OPERATOR_NAME
               value: {{ include "jaeger-operator.fullname" . | quote }}
           resources:

--- a/stable/jaeger-operator/templates/role-binding.yaml
+++ b/stable/jaeger-operator/templates/role-binding.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbac.create }}
+{{- if .Values.env.WATCH_NAMESPACE }}
 kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}
@@ -14,7 +18,11 @@ subjects:
   namespace: {{ .Release.Namespace }}
   name: {{ include "jaeger-operator.serviceAccountName" . }}
 roleRef:
+  {{- if .Values.env.WATCH_NAMESPACE }}
   kind: Role
+  {{- else }}
+  kind: ClusterRole
+  {{- end }}
   name: {{ include "jaeger-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/stable/jaeger-operator/templates/role.yaml
+++ b/stable/jaeger-operator/templates/role.yaml
@@ -1,4 +1,8 @@
+{{- if .Values.env.WATCH_NAMESPACE }}
 kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}

--- a/stable/jaeger-operator/values.yaml
+++ b/stable/jaeger-operator/values.yaml
@@ -30,3 +30,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+env:
+  # Empty value will enable the operator for all namespaces
+  WATCH_NAMESPACE: ""


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
This PR allows running a cluster-wide jaeger-operator as well as specifying a particular namespace to watch.

#### Which issue this PR fixes
  - fixes #9298

#### Special notes for your reviewer:
Not sure whether this should be considered a braking change. I assumed it's not. The controversial bit would be that now, by default all namespaces will be watched as opposed to the one where the operator was deployed.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
