### PR TITLE
[stable/fluentd] Add support for configuring elasticsearch scheme and ssl_version

### DIFF
--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 1.0.1
+version: 1.1.0
 appVersion: v2.3.1
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/Chart.yaml
+++ b/stable/fluentd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Fluentd Elasticsearch Helm chart for Kubernetes.
 icon: https://raw.githubusercontent.com/fluent/fluentd-docs/master/public/logo/Fluentd_square.png
 name: fluentd
-version: 1.0.0
+version: 1.0.1
 appVersion: v2.3.1
 home: https://www.fluentd.org/
 sources:

--- a/stable/fluentd/templates/deployment.yaml
+++ b/stable/fluentd/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
             value: {{ .Values.output.host | quote }}
           - name: OUTPUT_PORT
             value: {{ .Values.output.port | quote }}
+          - name: OUTPUT_SCHEME
+            value: {{ .Values.output.scheme | quote }}
+          - name: OUTPUT_SSL_VERSION
+            value: {{ .Values.output.sslVersion | quote }}
           - name: OUTPUT_BUFFER_CHUNK_LIMIT
             value: {{ .Values.output.buffer_chunk_limit | quote }}
           - name: OUTPUT_BUFFER_QUEUE_LIMIT

--- a/stable/fluentd/values.yaml
+++ b/stable/fluentd/values.yaml
@@ -12,6 +12,8 @@ image:
 output:
   host: elasticsearch-client.default.svc.cluster.local
   port: 9200
+  scheme: http
+  sslVersion: TLSv1
   buffer_chunk_limit: 2M
   buffer_queue_limit: 8
 
@@ -86,6 +88,8 @@ configMaps:
       # Replace with the host/port to your Elasticsearch cluster.
       host "#{ENV['OUTPUT_HOST']}"
       port "#{ENV['OUTPUT_PORT']}"
+      scheme "#{ENV['OUTPUT_SCHEME']}"
+      ssl_version "#{ENV['OUTPUT_SSL_VERSION']}"
       logstash_format true
       <buffer>
         @type file


### PR DESCRIPTION
- Allows end users to connect Fluentd to Elasticsearch over HTTPS
- Uses the same defaults as the underlying `out_elasticsearch` plugin (see github.com/uken/fluent-plugin-elasticsearch as of commit 573c39a)
  - [`scheme`](https://github.com/uken/fluent-plugin-elasticsearch/blob/573c39a757c2ef11449e327daa88f87e9961c4ee/lib/fluent/plugin/out_elasticsearch.rb#L59)
  - [`ssl_version`](https://github.com/uken/fluent-plugin-elasticsearch/blob/573c39a757c2ef11449e327daa88f87e9961c4ee/lib/fluent/plugin/out_elasticsearch.rb#L92)

Signed-off-by: Thomas Lovett <tklovett@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Amazon Elasticsearch Service exposes an endpoint over HTTPS, for example `https://vpc-elasticsearch-somelongid.us-west-2.es.amazonaws.com/`. Prior to this commit, the stable/fluentd chart did not allow direct configuration of the `scheme` or `ssl_version` parameters on the [`out_elasticsearch`](https://docs.fluentd.org/v1.0/articles/out_elasticsearch). Thus it was only possible to connect over the default scheme (`http`) and not `https`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

No relevant issues exist for chart `stable/fluentd`.

Relates to #8110 and #4168, which are similar fixes for the other `stable/fluentd-elasticsearch` chart.

#### Special notes for your reviewer:

cc @rendhalver 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (*Note:* no README.md exists -- should I make it?)

