### PR TITLE
[stable/sumlogic-fluentd] Supply SumoLogic collector URL via existing secret

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.8.1
+version: 0.8.2
 appVersion: 2.1.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/README.md
+++ b/stable/sumologic-fluentd/README.md
@@ -62,7 +62,8 @@ The following table lists the configurable parameters of the sumologic-fluentd c
 | `podAnnotations` | Annotations to add to the DaemonSet's Pods | `{}` |
 | `tolerations` | List of node taints to tolerate (requires Kubernetes >= 1.6) | `[]` |
 | `updateStrategy` | `OnDelete` or `RollingUpdate` (requires Kubernetes >= 1.6) | `OnDelete` |
-| `sumologic.collectorUrl` | An HTTP collector in SumoLogic that the container can send logs to via HTTP | `Nil` You must provide your own |
+| `sumologic.collectorUrl` | An HTTP collector in SumoLogic that the container can send logs to via HTTP | `Nil` You must provide your own value |
+| `sumologic.collectorUrlExistingSecret` | If set, use the secret with the name provided instead of creating a new one | `Nil` You must reference an existing secret |
 | `sumologic.fluentdSource` | The fluentd input source, `file` or `systemd` | `file` |
 | `sumologic.fluentdUserConfigDir` | A directory of user-defined fluentd configuration files, which must be in the `*.conf` directory in the container | `/fluentd/conf.d/user` |
 | `sumologic.flushInterval` | How frequently to push logs to sumo, in seconds | `5` |
@@ -169,12 +170,12 @@ $ helm install --name my-release stable/sumologic-fluentd --set rbac.create=true
 
 ### Excluding and Including data
 
-You have several options controlling the filtering of data that gets sent to Sumo Logic.  
+You have several options controlling the filtering of data that gets sent to Sumo Logic.
 
 #### Excluding data using environment variables
 
 There are several environment variables that can exclude data.  The following table show which  environment variables affect which Fluentd sources.
-                                                                
+
 | Environment Variable | Containers | Docker | Kubernetes | Systemd |
 |----------------------|------------|--------|------------|---------|
 | `EXCLUDE_CONTAINER_REGEX` | ✔ | ✘ | ✘ | ✘ |

--- a/stable/sumologic-fluentd/templates/NOTES.txt
+++ b/stable/sumologic-fluentd/templates/NOTES.txt
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.collectorUrl -}}
+{{- if (or (.Values.sumologic.collectorUrlExistingSecret) (.Values.sumologic.collectorUrl)) -}}
 Sumo Logic agents are spinning up on each node in your cluster. After a few
 minutes, you should see logs available in Sumo Logic.
 
@@ -14,9 +14,9 @@ SumoLogic.
       sumologic.com/exclude: "true"
 
 {{- else -}}
-###########################################################
-####  ERROR: You did not set a sumologic.collectorUrl  ####
-###########################################################
+#################################################################################################
+####  ERROR: You did not set sumologic.collectorUrl or sumologic.collectorUrlExistingSecret  ####
+#################################################################################################
 
 This deployment will be incomplete until you provide your collector URL, from Sumo Logic.
 

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.collectorUrl -}}
+{{- if (or (.Values.sumologic.collectorUrlExistingSecret) (.Values.sumologic.collectorUrl)) -}}
 # Sumologic collector URL is required
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -52,14 +52,18 @@ spec:
               {{- else }}
             - name: fluentd-user-conf
               mountPath: /fluentd/conf.d/user
-              readOnly: true           
+              readOnly: true
               {{- end }}
             {{- end }}
           env:
             - name: COLLECTOR_URL
               valueFrom:
                 secretKeyRef:
+            {{- if .Values.sumologic.collectorUrlExistingSecret }}
+                  name: "{{ .Values.sumologic.collectorUrlExistingSecret }}"
+            {{- else }}
                   name: "{{ template "sumologic-fluentd.fullname" . }}"
+            {{- end }}
                   key: collector-url
             - name: K8S_NODE_NAME
               valueFrom:

--- a/stable/sumologic-fluentd/templates/secrets.yaml
+++ b/stable/sumologic-fluentd/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.sumologic.collectorUrlExistingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,3 +14,4 @@ metadata:
 type: Opaque
 data:
   collector-url: {{ default "MISSING" .Values.sumologic.collectorUrl | b64enc | quote }}
+{{- end }}

--- a/stable/sumologic-fluentd/values.yaml
+++ b/stable/sumologic-fluentd/values.yaml
@@ -21,7 +21,10 @@ updateStrategy: OnDelete
 sumologic:
   ## You'll need to set this to sumo collector, before the agent will run.
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#sumologic
-  collectorUrl: ""
+  # collectorUrl:
+
+  ## Use existing Secret which stores collector url instead of creating a new one
+  # collectorUrlExistingSecret:
 
   ## The source of fluentd logs, either file or systemd
   fluentdSource: file


### PR DESCRIPTION
Signed-off-by: Mike Robinet <mike.robinet@smartthings.com>

#### What this PR does / why we need it:

This adds the ability to specify the SumoLogic collector URL via an existing secret similar to what [can be done for the DataDog chart](https://github.com/helm/charts/blob/master/stable/datadog/README.md#configuration). This allows developers to use things like [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) to create the secret and keeps the secret values from being retrieved in plaintext using `helm get`.

#### Which issue this PR fixes

No related issue exists.

#### Special notes for your reviewer:

If both `sumologic.collectorUrl` and `sumologic.collectorUrlExistingSecret` are set then `sumologic.collectorUrlExistingSecret` wins, similar to the DataDog chart. 

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@flah00 @frankreno @darend 
