### PR TITLE
add helm test configs server,alertmanager

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.1.0
+version: 8.1.1
 appVersion: 2.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/templates/_helpers.tpl
+++ b/stable/prometheus/templates/_helpers.tpl
@@ -29,6 +29,12 @@ component: {{ .Values.alertmanager.name | quote }}
 {{ include "prometheus.common.matchLabels" . }}
 {{- end -}}
 
+{{- define "prometheus.alertmanager.test.labels" -}}
+component: {{ printf "test-%s" .Values.alertmanager.name | quote }}
+{{ include "prometheus.common.matchLabels" . }}
+{{ include "prometheus.common.metaLabels" . }}
+{{- end -}}
+
 {{- define "prometheus.kubeStateMetrics.labels" -}}
 {{ include "prometheus.kubeStateMetrics.matchLabels" . }}
 {{ include "prometheus.common.metaLabels" . }}
@@ -67,6 +73,12 @@ component: {{ .Values.pushgateway.name | quote }}
 {{- define "prometheus.server.matchLabels" -}}
 component: {{ .Values.server.name | quote }}
 {{ include "prometheus.common.matchLabels" . }}
+{{- end -}}
+
+{{- define "prometheus.server.test.labels" -}}
+component: {{ printf "test-%s" .Values.server.name | quote }}
+{{ include "prometheus.common.matchLabels" . }}
+{{ include "prometheus.common.metaLabels" . }}
 {{- end -}}
 
 {{/*

--- a/stable/prometheus/templates/tests/test-conf-alertmanager.yaml
+++ b/stable/prometheus/templates/tests/test-conf-alertmanager.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.alertmanager.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-conf-{{ template "prometheus.alertmanager.fullname" . }}
+  labels:
+    {{- include "prometheus.alertmanager.test.labels" . | nindent 4 }}
+    test: test-config
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: test
+    image: "{{ .Values.alertmanager.image.repository }}:{{ .Values.alertmanager.image.tag }}"
+    command:
+      - amtool
+    args:
+      - check-config
+      - /etc/config/alertmanager.yml
+    volumeMounts:
+      - mountPath: /etc/config/
+        name: config-volume
+        readOnly: true
+  volumes:
+    - name: config-volume
+      configMap:
+        name: {{ if .Values.alertmanager.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.alertmanager.configMapOverrideName }}{{- else }}{{ template "prometheus.alertmanager.fullname" . }}{{- end }}
+  restartPolicy: Never
+{{- end -}}

--- a/stable/prometheus/templates/tests/test-conf-server.yaml
+++ b/stable/prometheus/templates/tests/test-conf-server.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-conf-{{ template "prometheus.server.fullname" . }}
+  labels:
+    {{- include "prometheus.server.test.labels" . | nindent 4 }}
+    test: test-config
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: test
+    image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+    command:
+      - promtool
+    args:
+      - check
+      - config
+      - /etc/config/prometheus.yml
+    volumeMounts:
+      - mountPath: /etc/config/
+        name: config-volume
+        readOnly: true
+  volumes:
+    - name: config-volume
+      configMap:
+        name: {{ if .Values.server.configMapOverrideName }}{{ .Release.Name }}-{{ .Values.server.configMapOverrideName }}{{- else }}{{ template "prometheus.server.fullname" . }}{{- end }}
+  restartPolicy: Never


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

adds [helm test](https://docs.helm.sh/helm/helm_test/) for prom configs `server,alertmanager` 

base output 
```
RUNNING: test-conf-prometheus-server
PASSED: test-conf-prometheus-server
RUNNING: test-conf-prometheus-alertmanager
PASSED: test-conf-prometheus-alertmanager
```

due later helm limitations 

```sh
kubectl logs -n $NAMESPACE -l release=$RELEASE,test       # 1)
kubectl delete po -n $NAMESPACE -l release=$RELEASE,test  # 2)
```

1) output/logs is valuable especially if there are any issues and dynamic configs 
```
Checking '/etc/config/alertmanager.yml'  SUCCESS
Found:
 - global config
 - route
 - 0 inhibit rules
 - 1 receivers
 - 0 templates

Checking /etc/config/prometheus.yml
  SUCCESS: 2 rule files found

Checking /etc/config/rules
  SUCCESS: 0 rules found

Checking /etc/config/alerts
  SUCCESS: 42 rules found
```

2) clenup terminated pods `helm test --cleanup` is good but see point above


#### Which issue this PR fixes

None

#### Special notes for your reviewer:

If OK to go forward with it I may add to README.
Original background story
- as CI pre-deploy test since helm knows best which/where config files it has.
- using `helm test` requires having existing release out hence something like 
```
alertmanager:
  enabled: true
  replicaCount: 0
kubeStateMetrics:
  enabled: false
  replicaCount: 0
pushgateway:
  enabled: false
  replicaCount: 0
server:
  replicaCount: 0
  ingress:
    enabled: false
nodeExporter:
  enabled: false
```
Finally 
- decided to change how configs are passed to helm values 
- use `promtool/amtool` on this files skipping `helm deploy`
- cost: 
  - need to know versions of images for promtool/amtool to match what is current Prometheus chart 
  - more complex then `helm test` 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md