### PR TITLE
[stable/memcached] Add maxItemSize config to memcached chart

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 2.3.1
+version: 2.3.2
 appVersion: 1.5.6
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `imagePullPolicy`         | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
 | `memcached.verbosity`     | Verbosity level (v, vv, or vvv) | Un-set.                                                 |
 | `memcached.maxItemMemory` | Max memory for items (in MB)    | `64`                                                    |
+| `memcached.maxItemSize`   | Max size for each item          | `1M`                                                    |
 | `metrics.enabled`         | Expose metrics in prometheus format | false                                               |
 | `metrics.image`           | The image to pull and run for the metrics exporter | A recent official memcached tag      |
 | `metrics.imagePullPolicy` | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
         command:
         - memcached
         - -m {{ .Values.memcached.maxItemMemory  }}
+        - -I {{ .Values.memcached.maxItemSize }}
         {{- if .Values.memcached.extendedOptions }}
         - -o
         - {{ .Values.memcached.extendedOptions }}

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -26,6 +26,7 @@ memcached:
   ## ref: https://github.com/memcached/memcached/wiki/ConfiguringServer#commandline-arguments
   ##
   maxItemMemory: 64
+  maxItemSize: 1M
   verbosity: v
   extendedOptions: modern
 


### PR DESCRIPTION
Signed-off-by: Elias Tandel Barrionovo <elias.tandel@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Later versions of memcached allow for the user to specify the maximum size of each cache entry when starting the server. This PR adds this option to the memcached chart so we can overload it if needed.

#### Which issue this PR fixes

#### Special notes for your reviewer:

@gtaylor @olemarkus @kennethaasan 
memcached's default value for this config is 1mb, so that's what I put as the default to the variable.
BTW, this is my first contribution to helm/charts, so please let me know if I did anything wrong and how to improve the PR. Thanks!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
