### PR TITLE
[stable/kured] Allow setting imagePullSecrets and nodeSelector from values.yaml

### DIFF
--- a/stable/kured/Chart.yaml
+++ b/stable/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: A Helm chart for kured
 name: kured
-version: 1.0.0
+version: 1.0.1
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: plumdog

--- a/stable/kured/Chart.yaml
+++ b/stable/kured/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: A Helm chart for kured
 name: kured
-version: 1.0.1
+version: 1.1.0
 home: https://github.com/weaveworks/kured
 maintainers:
   - name: plumdog

--- a/stable/kured/README.md
+++ b/stable/kured/README.md
@@ -7,12 +7,14 @@ See https://github.com/weaveworks/kured
 | `image.repository`      | Image repository                                                            | `quay.io/weaveworks/kured` |
 | `image.tag`             | Image tag                                                                   | `master-c42fff3`           |
 | `image.pullPolicy`      | Image pull policy                                                           | `IfNotPresent`             |
+| `image.pullSecrets`     | Image pull secrets                                                          | `[]`                       |
 | `extraArgs`             | Extra arguments to pass to `/usr/bin/kured`. See below.                     | `{}`                       |
 | `rbac.create`           | Create RBAC roles                                                           | `true`                     |
 | `serviceAccount.create` | Create service account roles                                                | `true`                     |
 | `serviceAccount.name`   | Service account name to create (or use if `serviceAccount.create` is false) | (chart fullname)           |
 | `updateStrategy`        | Daemonset update strategy                                                   | `OnDelete`                 |
 | `tolerations`           | Tolerations to apply to the daemonset (eg to allow running on master)       | `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"}]`|
+| `nodeSelector`          | Node Selector for the daemonset (ie, restrict which nodes kured runs on)    | `{}`                       |
 | `podAnnotations`        | Annotations to apply to pods (eg to add Prometheus annotations)             | `{}`                       |
 
 See https://github.com/weaveworks/kured#configuration for values for `extraArgs`. Note that

--- a/stable/kured/templates/daemonset.yaml
+++ b/stable/kured/templates/daemonset.yaml
@@ -31,6 +31,14 @@ spec:
       serviceAccountName: {{ template "kured.serviceAccountName" . }}
       hostPID: true
       restartPolicy: Always
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/kured/values.yaml
+++ b/stable/kured/values.yaml
@@ -3,6 +3,7 @@ image:
   # Appears to be without numbered numbered tags, so using this instead
   tag: 1.1.0
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 extraArgs: {}
 
@@ -18,5 +19,7 @@ updateStrategy: OnDelete
 tolerations:
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
+
+nodeSelector: {}
 
 podAnnotations: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for setting `imagePullSecrets` and `nodeSelector` from `values.yaml`

* Being able to set `imagePullSecrets` is useful if you build your own Kured container (eg, to support architectures other than amd64)
* Being able to set `nodeSelector` is useful to control which nodes Kured will run on (and automatically reboot)

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
