### PR TITLE
Added options to allow custom variables in the fluentd conf files

### DIFF
--- a/stable/fluentd-elasticsearch/Chart.yaml
+++ b/stable/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 1.3.0
+version: 1.4.0
 appVersion: 2.3.1
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/stable/fluentd-elasticsearch/README.md
+++ b/stable/fluentd-elasticsearch/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `elasticsearch.logstash_prefix`    | Elasticsearch Logstash prefix              | `logstash`                                                 |
 | `elasticsearch.buffer_chunk_limit` | Elasticsearch buffer chunk limit           | `2M`                                                       |
 | `elasticsearch.buffer_queue_limit` | Elasticsearch buffer queue limit           | `8`                                                        |
+| `env`                              | List of environment variables that are added to the fluentd pods   | `{}`                               |
 | `extraVolumeMounts`                | Mount an extra volume, required to mount ssl certificates when elasticsearch has tls enabled |          |
 | `extraVolume`                      | Extra volume                               |                                                            |
 | `image.repository`                 | Image                                      | `gcr.io/google-containers/fluentd-elasticsearch`           |

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -53,8 +53,8 @@ spec:
           value: {{ .Values.elasticsearch.buffer_chunk_limit | quote }}
         - name: OUTPUT_BUFFER_QUEUE_LIMIT
           value: {{ .Values.elasticsearch.buffer_queue_limit | quote }}
-        {{- if .Values.elasticsearch.env }}
-        {{- range $key, $value := .Values.elasticsearch.env }}
+        {{- if .Values.env }}
+        {{- range $key, $value := .Values.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -53,6 +53,12 @@ spec:
           value: {{ .Values.elasticsearch.buffer_chunk_limit | quote }}
         - name: OUTPUT_BUFFER_QUEUE_LIMIT
           value: {{ .Values.elasticsearch.buffer_queue_limit | quote }}
+        {{- if .Values.elasticsearch.env }}
+        {{- range $key, $value := .Values.elasticsearch.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
         - name: K8S_NODE_NAME
           valueFrom:
             fieldRef:

--- a/stable/fluentd-elasticsearch/values.yaml
+++ b/stable/fluentd-elasticsearch/values.yaml
@@ -23,6 +23,11 @@ elasticsearch:
   buffer_chunk_limit: 2M
   buffer_queue_limit: 8
   logstash_prefix: 'logstash'
+  # If you want to add more environment variables, use the env dict
+  # You can then reference these in your config file e.g.:
+  #     user "#{ENV['OUTPUT_USER']}"
+  env:
+    # OUTPUT_USER: my_user
 
 rbac:
   create: true

--- a/stable/fluentd-elasticsearch/values.yaml
+++ b/stable/fluentd-elasticsearch/values.yaml
@@ -23,11 +23,12 @@ elasticsearch:
   buffer_chunk_limit: 2M
   buffer_queue_limit: 8
   logstash_prefix: 'logstash'
-  # If you want to add more environment variables, use the env dict
-  # You can then reference these in your config file e.g.:
-  #     user "#{ENV['OUTPUT_USER']}"
-  env:
-    # OUTPUT_USER: my_user
+
+# If you want to add custom environment variables, use the env dict
+# You can then reference these in your config file e.g.:
+#     user "#{ENV['OUTPUT_USER']}"
+env:
+  # OUTPUT_USER: my_user
 
 rbac:
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows the addition of custom environmental variables in the fluentd pods. This is useful for, for example, adding a username and password to the elasticsearch config.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
