### PR TITLE
Support changing the kind

### DIFF
--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 2.3.1
+version: 2.3.2
 appVersion: 1.5.6
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/Chart.yaml
+++ b/stable/memcached/Chart.yaml
@@ -1,5 +1,5 @@
 name: memcached
-version: 2.3.2
+version: 2.4.0
 appVersion: 1.5.6
 description: Free & open source, high-performance, distributed memory object caching
   system.

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `metrics.resources`       | CPU/Memory resource requests/limits for the metrics exporter | `{}`                       |
 | `extraContainers`         | Container sidecar definition(s) as string | Un-set                                        |
 | `extraVolumes`            | Volume definitions to add as string | Un-set                                              |
-| `statefulSet`             | Deploy as a StatefulSet, or a Deployment | true                                           |
+| `statefulSet`             | Install as StatefulSet or Deployment | StatefulSet                                        |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).
 

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `metrics.resources`       | CPU/Memory resource requests/limits for the metrics exporter | `{}`                       |
 | `extraContainers`         | Container sidecar definition(s) as string | Un-set                                        |
 | `extraVolumes`            | Volume definitions to add as string | Un-set                                              |
-| `statefulSet`             | Install as StatefulSet or Deployment | StatefulSet                                        |
+| `kind`                    | Install as StatefulSet or Deployment | StatefulSet                                        |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).
 

--- a/stable/memcached/README.md
+++ b/stable/memcached/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `metrics.resources`       | CPU/Memory resource requests/limits for the metrics exporter | `{}`                       |
 | `extraContainers`         | Container sidecar definition(s) as string | Un-set                                        |
 | `extraVolumes`            | Volume definitions to add as string | Un-set                                              |
+| `statefulSet`             | Deploy as a StatefulSet, or a Deployment | true                                           |
 
 The above parameters map to `memcached` params. For more information please refer to the [Memcached documentation](https://github.com/memcached/memcached/wiki/ConfiguringServer).
 

--- a/stable/memcached/templates/NOTES.txt
+++ b/stable/memcached/templates/NOTES.txt
@@ -1,3 +1,6 @@
+{{- if not .Values.statefulSet }}
+Warning: Memcached has been deployed as deployment, state may not be preserved across node restarts!
+{{ end }}
 Memcached can be accessed via port 11211 on the following DNS name from within your cluster:
 {{ template "memcached.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 

--- a/stable/memcached/templates/NOTES.txt
+++ b/stable/memcached/templates/NOTES.txt
@@ -1,6 +1,3 @@
-{{- if not .Values.statefulSet }}
-Warning: Memcached has been deployed as deployment, state may not be preserved across node restarts!
-{{ end }}
 Memcached can be accessed via port 11211 on the following DNS name from within your cluster:
 {{ template "memcached.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1beta1
-kind: {{ .Values.statefulSet | ternary "StatefulSet" "Deployment" }}
+kind: {{ .Values.kind }}
 metadata:
   name: {{ template "memcached.fullname" . }}
   labels:

--- a/stable/memcached/templates/statefulset.yaml
+++ b/stable/memcached/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1beta1
-kind: StatefulSet
+kind: {{ .Values.statefulSet | ternary "StatefulSet" "Deployment" }}
 metadata:
   name: {{ template "memcached.fullname" . }}
   labels:

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -33,8 +33,8 @@ memcached:
 serviceAnnotations: {}
 #  prometheus.io/scrape: "true"
 
-## Set to false to release a Deployment, rather than a StatefulSet
-statefulSet: true
+## StatefulSet or Deployment
+kind: StatefulSet
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/memcached/values.yaml
+++ b/stable/memcached/values.yaml
@@ -33,6 +33,9 @@ memcached:
 serviceAnnotations: {}
 #  prometheus.io/scrape: "true"
 
+## Set to false to release a Deployment, rather than a StatefulSet
+statefulSet: true
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
Signed-off-by: Jeff Fouchard <jeff.fouchard@fullscript.com>

#### What this PR does / why we need it:
Allows setting the "kind" of the object deployed by Kubernetes from `StatefulSet` to `Deployment`.  We need this because we deploy single node Memcached clusters for ephemeral environments, but that setup breaks node draining since it cannot move those pods. 

#### Special notes for your reviewer:
Service still functions as expected with both kinds, and `helm upgrade` functions as expected.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
