### PR TITLE
Traefik - Adding in configurable readinessprobe and liveness probe

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.54.0
+version: 1.56.0
 appVersion: 1.7.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -207,6 +207,28 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `tracing.datadog.localAgentHostPort`   | Location of the Datadog agent where spans will be sent                                                                       | `127.0.0.1:8126`                                  |
 | `tracing.datadog.debug`                | Enables Datadog debugging                                                                                                    | `false`                                           |
 | `tracing.datadog.globalTag`            | Apply shared tag in a form of Key:Value to all the traces                                                                    | `""`                                           |
+| `readinessProbe.tcpSocket.enabled`            | Enable readinessProbe tcpsocket                                                                    | `true`                                           |
+| `readinessProbe.tcpSocket.port`            | Set readinessProbe tcp port                                                                    | `80`                                           |
+| `readinessProbe.httpGet.enabled`            | Enable readinessProbe httpGet                                                                    | `false`                                           |
+| `readinessProbe.httpGet.path`            | Set readinessProbe httpGet path                                                                    | `None`                                           |
+| `readinessProbe.httpGet.port`            | Set readinessProbe httpGet port                                                                    | `None`                                           |
+| `readinessProbe.httpGet.scheme`            | Set readinessProbe httpGet scheme `HTTP` or `HTTPS`                                                                    | `None`                                           |
+| `readinessProbe.failureThreshold`            | Set readinessProbe failure threshold tcpsocket                                                                    | `1`                                           |
+| `readinessProbe.initialDelaySeconds`            | Set readinessProbe initial delay in seconds                                                                    | `10`                                           |
+| `readinessProbe.periodSeconds`            | Set readinessProbe seconds between checks                                                                    | `10`                                           |
+| `readinessProbe.successThreshold`            | Set readinessProbe success threshold tcpsocket                                                                    | `1`                                           |
+| `readinessProbe.timeoutSeconds`            | Set readinessProbe timeout in seconds                                                                    | `2`                                           |
+| `livenessProbe.tcpSocket.enabled`            | Enable livenessProbe tcpsocket                                                                    | `true`                                           |
+| `livenessProbe.tcpSocket.port`            | Set livenessProbe tcp port                                                                    | `80`                                           |
+| `livenessProbe.httpGet.enabled`            | Enable livenessProbe httpGet                                                                    | `false`                                           |
+| `livenessProbe.httpGet.path`            | Set livenessProbe httpGet path                                                                    | `None`                                           |
+| `livenessProbe.httpGet.port`            | Set livenessProbe httpGet port                                                                    | `None`                                           |
+| `livenessProbe.httpGet.scheme`            | Set livenessProbe httpGet scheme `HTTP` or `HTTPS`                                                                    | `None`                                           |
+| `livenessProbe.failureThreshold`            | Set livenessProbe failure threshold tcpsocket                                                                    | `3`                                           |
+| `livenessProbe.initialDelaySeconds`            | Set livenessProbe initial delay in seconds                                                                    | `10`                                           |
+| `livenessProbe.periodSeconds`            | Set livenessProbe seconds between checks                                                                    | `10`                                           |
+| `livenessProbe.successThreshold`            | Set livenessProbe success threshold tcpsocket                                                                    | `1`                                           |
+| `livenessProbe.timeoutSeconds`            | Set livenessProbe timeout in seconds                                                                    | `2`                                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -65,21 +65,49 @@ spec:
             cpu: {{ .Values.cpuLimit | quote }}
             memory: {{ .Values.memoryLimit | quote }}
         readinessProbe:
+          {{- if .Values.readinessProbe.tcpSocket.enabled }}
           tcpSocket:
-            port: 80
-          failureThreshold: 1
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+            port: {{ .Values.readinessProbe.tcpSocket.port }}
+          {{- end }}
+          {{- if .Values.readinessProbe.httpGet.enabled }}
+          httpGet:
+            {{- if .Values.readinessProbe.httpGet.port }}
+            port: {{ .Values.readinessProbe.httpGet.port }}
+            {{- end }}
+            {{- if .Values.readinessProbe.httpGet.path }}
+            path: {{ .Values.readinessProbe.httpGet.path | quote }}
+            {{- end }}
+            {{- if .Values.readinessProbe.httpGet.scheme }}
+            scheme: {{ .Values.readinessProbe.httpGet.scheme | quote }}
+            {{- end }}
+          {{- end }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         livenessProbe:
+          {{- if .Values.livenessProbe.tcpSocket.enabled }}
           tcpSocket:
-            port: 80
-          failureThreshold: 3
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 2
+            port: {{ .Values.livenessProbe.tcpSocket.port }}
+          {{- end }}
+          {{- if .Values.livenessProbe.httpGet.enabled }}
+          httpGet:
+            {{- if .Values.livenessProbe.httpGet.port }}
+            port: {{ .Values.livenessProbe.httpGet.port }}
+            {{- end }}
+            {{- if .Values.livenessProbe.httpGet.path }}
+            path: {{ .Values.livenessProbe.httpGet.path | quote }}
+            {{- end }}
+            {{- if .Values.livenessProbe.httpGet.scheme }}
+            scheme: {{ .Values.livenessProbe.httpGet.scheme | quote }}
+            {{- end }}
+          {{- end }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         {{- if and .Values.acme.enabled (eq .Values.acme.challengeType "dns-01") .Values.acme.dnsProvider.name }}
         env:
         {{- range $k, $_ := (index .Values.acme.dnsProvider .Values.acme.dnsProvider.name) }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -351,3 +351,34 @@ tracing:
   #   localAgentHostPort: "127.0.0.1:8126"
   #   debug: false
   #   globalTag: ""
+
+# Health check overrides
+readinessProbe:
+  tcpSocket:
+    enabled: true
+    port: 80
+  httpGet:
+    enabled: false
+    # port: 80
+    # path: /
+    # scheme: HTTP
+  failureThreshold: 1
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2
+
+livenessProbe:
+  tcpSocket:
+    enabled: true
+    port: 80
+  httpGet:
+    enabled: false
+    # port: 80
+    # path: /
+    # scheme: HTTP
+  failureThreshold: 3
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 2


### PR DESCRIPTION
#### What this PR does / why we need it:

When using the chart as it stands you cannot configure the readiness or liveness
since these values are hard coded directly into the deployment. This creates
issues when trying to use upstream HTTPS load balancers since some of these such as
GCP infer there values from the readiness.

This change configures these be the same as current defaults but allow configuring
and overriding of these settings.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Rick Box <boxrick@gmail.com>