### PR TITLE
[stable/acs-engine-autoscaler] Fix install instruction command

### DIFF
--- a/stable/acs-engine-autoscaler/Chart.yaml
+++ b/stable/acs-engine-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within agent pools
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: acs-engine-autoscaler
-version: 2.2.0
+version: 2.2.1
 appVersion: 2.1.1
 home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
 sources:

--- a/stable/acs-engine-autoscaler/README.md
+++ b/stable/acs-engine-autoscaler/README.md
@@ -45,7 +45,7 @@ acsenginecluster:
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install stable/acs-engine-autoscaler
+$ helm install --name my-release stable/acs-engine-autoscaler
 ```
 
 The command deploys acs-engine-autoscaler on the Kubernetes cluster using the supplied configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.


### PR DESCRIPTION
#### What this PR does / why we need it:
##### Expected behaviour: 
* Chart installs with the release name of `my-release`
##### Actual behaviour:
* Chart installs with randomly generated release name


This PR fixes the documented install command so that the chart installs with the release name of `my-release` as documented.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
