### PR TITLE
[stable/concourse] Adds imagepullSecrets support

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.4.1
+version: 3.5.0
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the Concourse chart and
 | `image` | Concourse image | `concourse/concourse` |
 | `imageTag` | Concourse image version | `4.2.2` |
 | `imagePullPolicy` | Concourse image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | Array of imagePullSecrets in the namespace for pulling images | `[]` |
 | `web.nameOverride` | Override the Concourse Web components name | `nil` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -30,6 +30,12 @@ spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "concourse.web.fullname" . }}{{ else }}{{ .Values.rbac.webServiceAccountName }}{{ end }}
       tolerations:
 {{ toYaml .Values.web.tolerations | indent 8 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ template "concourse.web.fullname" . }}
           {{- if .Values.imageDigest }}

--- a/stable/concourse/templates/worker-statefulset.yaml
+++ b/stable/concourse/templates/worker-statefulset.yaml
@@ -28,6 +28,12 @@ spec:
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "concourse.worker.fullname" . }}{{ else }}{{ .Values.rbac.workerServiceAccountName }}{{ end }}
       tolerations:
 {{ toYaml .Values.worker.tolerations | indent 8 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       containers:
         - name: {{ template "concourse.worker.fullname" . }}

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -25,6 +25,13 @@ imageTag: "4.2.2"
 ##
 imagePullPolicy: IfNotPresent
 
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+# imagePullSecrets:
+#   - myRegistrKeySecretName
+
 ## Configuration values for Concourse.
 ## ref: https://concourse-ci.org/setting-up.html
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Without the ability to set `imagePullSecrets` we're not able to perform the retrieval of a concourse image pushed to a registry that requires authentication.

#### Which issue this PR fixes

- fixes #9228

#### Special notes for your reviewer:

I verified it by pushing `cirocosta/concourse:4.2.1` to DockerHub as a private repo and then setting the secret in k8s.

By templating it, we can see that it gets properly set in the final yaml:

```yaml
# kubectl create secret docker-registry regcred \
# 	--docker-server=https://index.docker.io/v1/ \
# 	--docker-username=$username \
# 	--docker-password=$password \
# 	--docker-email=$email
# helm template \
#    --set=imagePullSecrets[0]=regcred \
#    --set=image=cirocosta/concourse 
#    --set=imageTag=4.2.1 \
#   .
...
      tolerations:
        []
      imagePullSecrets:
        - name: regcred
      containers:
        - name: RELEASE-NAME-web
          image: "cirocosta/concourse:4.2.1"
...
```

and then seeing that k8s is able to properly pull the image and have concourse running.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

cc @william-tran @frodenas 