### PR TITLE
WIP: [stable/mongodb-replicaset]: allow changing dbPath

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.7.0
+version: 3.7.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -33,6 +33,7 @@ The following table lists the configurable parameters of the mongodb chart and t
 
 | Parameter                           | Description                                                               | Default                                             |
 | ----------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------- |
+| `dbPath`                            | Corresponds to mongo config `storage.dbPath`                              | `/data/db`                                          | 
 | `replicas`                          | Number of replicas in the replica set                                     | `3`                                                 |
 | `replicaSetName`                    | The name of the replica set                                               | `rs0`                                               |
 | `podDisruptionBudget`               | Pod disruption budget                                                     | `{}`                                                |

--- a/stable/mongodb-replicaset/init/on-start.sh
+++ b/stable/mongodb-replicaset/init/on-start.sh
@@ -78,17 +78,19 @@ shutdown_mongo() {
 }
 
 init_mongod_standalone() {
+
+    mkdir -p $DB_PATH
     if [[ ! -f /init/initMongodStandalone.js ]]; then
         log "Skipping init mongod standalone script"
         return 0
-    elif [[ -z "$(ls -1A /data/db)" ]]; then
+    elif [[ -z "$(ls -1A $DB_PATH)" ]]; then
         log "mongod standalone script currently not supported on initial install"
         return 0
     fi
 
     local port="27018"
     log "Starting a MongoDB instance as standalone..."
-    mongod --config /data/configdb/mongod.conf --dbpath=/data/db "${auth_args[@]}" --port "${port}" --bind_ip=0.0.0.0 2>&1 | tee -a /work-dir/log.txt 1>&2 &
+    mongod --config /data/configdb/mongod.conf --dbpath="$DB_PATH" "${auth_args[@]}" --port "${port}" --bind_ip=0.0.0.0 2>&1 | tee -a /work-dir/log.txt 1>&2 &
     export pid=$!
     trap shutdown_mongo EXIT
     log "Waiting for MongoDB to be ready..."
@@ -153,7 +155,7 @@ init_mongod_standalone
 
 log "Peers: ${peers[*]}"
 log "Starting a MongoDB replica"
-mongod --config /data/configdb/mongod.conf --dbpath=/data/db --replSet="$replica_set" --port="${port}" "${auth_args[@]}" --bind_ip=0.0.0.0 2>&1 | tee -a /work-dir/log.txt 1>&2 &
+mongod --config /data/configdb/mongod.conf --dbpath="$DB_PATH" --replSet="$replica_set" --port="${port}" "${auth_args[@]}" --bind_ip=0.0.0.0 2>&1 | tee -a /work-dir/log.txt 1>&2 &
 pid=$!
 trap shutdown_mongo EXIT
 

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -106,6 +106,8 @@ spec:
               value: {{ .Values.replicaSetName }}
             - name: TIMEOUT
               value: "{{ .Values.init.timeout }}"
+            - name: DB_PATH
+              value: "{{ .Values.dbPath }}"
           {{- if .Values.auth.enabled }}
             - name: AUTH
               value: "true"
@@ -163,7 +165,7 @@ spec:
             - mongod
           args:
             - --config=/data/configdb/mongod.conf
-            - --dbpath=/data/db
+            - --dbpath={{ .Values.dbPath }}
             - --replSet={{ .Values.replicaSetName }}
             - --port=27017
             - --bind_ip=0.0.0.0

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -1,6 +1,6 @@
 replicas: 3
 port: 27017
-
+dbPath: /data/db
 replicaSetName: rs0
 
 podDisruptionBudget: {}


### PR DESCRIPTION
# WIP DO NOT MERGE

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

If you want to use `storage.directoryPerDb` this will crash because the `mongo` user does not and should not have permission to modify the `lost+found` directory that is added to `/data/db` when the volume mounts.

This change maintains the default of `/data/db` for existing users, but allows us to change the path. I would like feedback on a few items:



#### Special notes for your reviewer:

1. Should we allow total freedom or would it be better to restrict this to a sub-directory of `/data/db`.
2. Is `mkdir -p $DB_PATH` on line 82 problematic? There is an existence check on line 86 that this nullifies. Why does that existence check exist?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
