### PR TITLE
Docs: Added the missing `nodeExporter.service.hostPort` configuration parameter with its default port 9100

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 7.4.5
+version: 7.4.6
 appVersion: 2.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -188,6 +188,7 @@ Parameter | Description | Default
 `nodeExporter.service.annotations` | annotations for node-exporter service | `{prometheus.io/scrape: "true"}`
 `nodeExporter.service.clusterIP` | internal node-exporter cluster service IP | `None`
 `nodeExporter.service.externalIPs` | node-exporter service external IP addresses | `[]`
+`nodeExporter.service.hostPort` | node-exporter service host port | `9100`
 `nodeExporter.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `nodeExporter.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `nodeExporter.service.servicePort` | node-exporter service port | `9100`


### PR DESCRIPTION
Added the missing `nodeExporter.service.hostPort` configuration parameter with its default port 9100

#### What this PR does / why we need it:
The template uses an undocumented configuration parameter (see https://github.com/helm/charts/blob/master/stable/prometheus/templates/node-exporter-daemonset.yaml#L56). This PR adds it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
