### PR TITLE
Add statefulset as controller option for unifi

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.9.29
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.2.1
+version: 0.2.2
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -39,6 +39,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `image.repository`         | Image repository | `jacobalberty/unifi` |
 | `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/jacobalberty/unifi/tags/).| `5.8.23`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `controller`               | Controller used for deploying the Unifi pods. Possible values: daemonset or statefulset | `deployment`
 | `guiService.type`             | Kubernetes service type for the Unifi GUI | `ClusterIP` |
 | `guiService.port`             | Kubernetes port where the Unifi GUI is exposed| `8443` |
 | `guiService.annotations`      | Service annotations for the Unifi GUI | `{}` |

--- a/stable/unifi/templates/statefulset.yaml
+++ b/stable/unifi/templates/statefulset.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.controller "deployment" }}
+{{- if eq .Values.controller "statefulset" }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ template "unifi.fullname" . }}
   labels:

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -9,6 +9,8 @@ image:
   tag: 5.9.29
   pullPolicy: IfNotPresent
 
+controller: deployment
+
 guiService:
   type: ClusterIP
   port: 8443


### PR DESCRIPTION
Signed-off-by: Mattias Gees <mattias.gees@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Allow to deploy the unifi controller as a statefulset. This is useful because data can be saved on disk and this allows an upgrade path for that.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
