### PR TITLE
Updating image to 0.21.0, and chart to 1.0.0 because stable

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 name: nginx-ingress
-version: 0.31.0
-appVersion: 0.20.0
+version: 1.0.0
+appVersion: 0.21.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -47,7 +47,7 @@ Parameter | Description | Default
 --- | --- | ---
 `controller.name` | name of the controller component | `controller`
 `controller.image.repository` | controller container image repository | `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`
-`controller.image.tag` | controller container image tag | `0.20.0`
+`controller.image.tag` | controller container image tag | `0.21.0`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.image.runAsUser` | User ID of the controller process. Value depends on the Linux distribution used inside of the container image. By default uses debian one. | `33`
 `controller.config` | nginx ConfigMap entries | none

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -5,7 +5,7 @@ controller:
   name: controller
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.20.0"
+    tag: "0.21.0"
     pullPolicy: IfNotPresent
     # www-data -> uid 33
     runAsUser: 33


### PR DESCRIPTION
Signed-off-by: Naseem Ullah <naseemkullah@gmail.com>

#### What this PR does / why we need it:

Image update, for more details please see: https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.21.0

#### Special notes for your reviewer: 

Update chart version to 1.0.0 as all charts in stable repo should be >= 1.0.0 from my understanding.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
