### PR TITLE
Update image to 0.22.1, and chart to 1.0.0 because stable

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.21.2
+appVersion: 0.22.1
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 0.3.4
+version: 1.0.0
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/README.md
+++ b/stable/prometheus-redis-exporter/README.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters and their default values.
 | ---------------------- | --------------------------------------------------- | ------------------------- |
 | `replicaCount`         | desired number of prometheus-redis-exporter pods    | `1`                       |
 | `image.repository`     | prometheus-redis-exporter image repository          | `oliver006/redis_exporter`|
-| `image.tag`            | prometheus-redis-exporter image tag                 | `v0.21.2`                 |
+| `image.tag`            | prometheus-redis-exporter image tag                 | `v0.22.1`                 |
 | `image.pullPolicy`     | image pull policy                                   | `IfNotPresent`            |
 | `extraArgs`            | extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter#flags)| {}
 | `env`                  | additional environment variables in YAML format. Can be used to pass credentials as env variables (via secret) as per the image readme [here](https://github.com/oliver006/redis_exporter#environment-variables) | {} |

--- a/stable/prometheus-redis-exporter/values.yaml
+++ b/stable/prometheus-redis-exporter/values.yaml
@@ -13,7 +13,7 @@ serviceAccount:
 replicaCount: 1
 image:
   repository: oliver006/redis_exporter
-  tag: v0.21.2
+  tag: v0.22.1
   pullPolicy: IfNotPresent
 extraArgs: {}
 # Additional Environment variables
@@ -27,6 +27,9 @@ service:
   type: ClusterIP
   port: 9121
   annotations: {}
+    # prometheus.io/path: /metrics
+    # prometheus.io/port: "9121"
+    # prometheus.io/scrape: "true"
 resources: {}
 redisAddress: redis://myredis:6379
 annotations: {}


### PR DESCRIPTION

#### What this PR does / why we need it:

Just an image update. Please see https://github.com/oliver006/redis_exporter/releases/tag/v0.22.1 for more details.

#### Special notes for your reviewer:

Chart goes to 1.0.0 as it is my understanding that all charts in stable folder should be >= 1.0.0

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
