### PR TITLE
[stable/redis] allowing redis-exporter to talk to redis when NetworkPolicy is enabled

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 4.3.0
+version: 4.3.1
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/metrics-deployment.yaml
+++ b/stable/redis/templates/metrics-deployment.yaml
@@ -21,9 +21,6 @@ spec:
         chart: {{ template "redis.chart" . }}
         role: metrics
         app: {{ template "redis.name" . }}
-        {{- if and .Values.networkPolicy.enabled (not .Values.networkPolicy.allowExternal) }}
-        {{ template "redis.fullname" . }}-client: "true"
-        {{- end }}
       {{- if .Values.metrics.podLabels }}
 {{ toYaml .Values.metrics.podLabels | indent 8 }}
       {{- end }}

--- a/stable/redis/templates/metrics-deployment.yaml
+++ b/stable/redis/templates/metrics-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         chart: {{ template "redis.chart" . }}
         role: metrics
         app: {{ template "redis.name" . }}
+        {{- if and .Values.networkPolicy.enabled (not .Values.networkPolicy.allowExternal) }}
+        {{ template "redis.fullname" . }}-client: "true"
+        {{- end }}
       {{- if .Values.metrics.podLabels }}
 {{ toYaml .Values.metrics.podLabels | indent 8 }}
       {{- end }}

--- a/stable/redis/templates/networkpolicy.yaml
+++ b/stable/redis/templates/networkpolicy.yaml
@@ -22,6 +22,13 @@ spec:
         - podSelector:
             matchLabels:
               {{ template "redis.fullname" . }}-client: "true"
+        {{- if .Values.metrics.enabled }}
+        - podSelector:
+            matchLabels:
+              release: "{{ .Release.Name }}"
+              role: metrics
+              app: {{ template "redis.name" . }}
+        {{- end }}
       {{- end }}
     {{- if .Values.metrics.enabled }}
     # Allow prometheus scrapes for metrics


### PR DESCRIPTION
#### What this PR does / why we need it:

If `networkPolicy.enabled` is set to `true` and `networkPolicy.allowExternal` is set to `false`, redis-exporter pods do not have access to the monitored endpoints. This PR adds the required label to monitoring pods.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X ] Chart Version bumped