### PR TITLE
Make the secret config optional so it does not override

### DIFF
--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,6 +1,5 @@
 name: oauth2-proxy
 version: 0.8.0
-deprecated: true
 apiVersion: v1
 appVersion: 2.2
 home: https://github.com/bitly/oauth2_proxy

--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,12 +1,10 @@
 name: oauth2-proxy
-version: 0.7.0
-# This chart is deprecated and no longer maintained as it's upstream has been abandoned.
-# For details deprecation, including how to un-deprecate a chart see the PROCESSES.md file.
+version: 0.8.0
 deprecated: true
 apiVersion: v1
 appVersion: 2.2
-home: http://www.videntity.com/
-description: DEPRECATED A reverse proxy that provides authentication with Google, Github or other providers
+home: https://github.com/bitly/oauth2_proxy
+description: A reverse proxy that provides authentication with Google, Github or other providers
 keywords:
 - kubernetes
 - oauth
@@ -17,3 +15,6 @@ keywords:
 sources:
 - https://github.com/bitly/oauth2_proxy
 engine: gotpl
+maintainers:
+  - name: timm088
+    email: 8890118+timm088@users.noreply.github.com

--- a/stable/oauth2-proxy/Chart.yaml
+++ b/stable/oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 name: oauth2-proxy
-version: 0.6.0
+version: 0.7.0
 # This chart is deprecated and no longer maintained as it's upstream has been abandoned.
 # For details deprecation, including how to un-deprecate a chart see the PROCESSES.md file.
 deprecated: true

--- a/stable/oauth2-proxy/README.md
+++ b/stable/oauth2-proxy/README.md
@@ -1,7 +1,5 @@
 # oauth2-proxy
 
-**N.B., this chart is deprecated and is no longer maintained as it's upstream [has been abandoned](https://github.com/bitly/oauth2_proxy/issues/628#issuecomment-417121636).**
-
 [oauth2-proxy](https://github.com/bitly/oauth2_proxy) is a reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
 
 **Note - at this time, there is a known incompatibility between `oauth2-proxy` version 2.2 (which is its latest release) and `nginx-ingress` versions >= 0.9beta12. To utilize this chart at this time please use nginx-ingress version 0.9beta11**

--- a/stable/oauth2-proxy/templates/NOTES.txt
+++ b/stable/oauth2-proxy/templates/NOTES.txt
@@ -4,16 +4,16 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "test.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "oauth2-proxy.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ include "test.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "test.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+           You can watch the status of by running 'kubectl get svc -w {{ include "oauth2-proxy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "oauth2-proxy.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "test.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "oauth2-proxy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}

--- a/stable/oauth2-proxy/templates/NOTES.txt
+++ b/stable/oauth2-proxy/templates/NOTES.txt
@@ -1,1 +1,19 @@
-Note this chart is deprecated and is no longer maintained because upstream was abandoned. 
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "test.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "test.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "test.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "test.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config }}
+{{- if not .Values.config.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/oauth2-proxy/templates/secret.yaml
+++ b/stable/oauth2-proxy/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.config }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
   client-secret: {{ .Values.config.clientSecret | b64enc | quote }}
   client-id: {{ .Values.config.clientID | b64enc | quote }}
+{{- end }}

--- a/stable/oauth2-proxy/values.yaml
+++ b/stable/oauth2-proxy/values.yaml
@@ -12,6 +12,26 @@ config:
   #   pass_basic_auth = false
   #   pass_access_token = true
   configFile: ""
+  # If user has an existing k8s secret they would like to use instead of generating them:
+  # existingSecret:
+  #   # Where to find the client ID
+  #   clientID:
+  #     secretKeyRef:
+  #       name: "client-id"
+  #       key: "client-id"
+  #   # Where to find the client secret
+  #   clientSecret:
+  #     secretKeyRef:
+  #       name: "client-secret"
+  #       key: "client-secret"
+  #   # Where to find the cookie secret
+  #   cookieSecret:
+  #     secretKeyRef:
+  #       name: "cookie-secret"
+  #       key: "cookie-secret"
+
+nameOverride: ""
+fullnameOverride: ""
 
 image:
   repository: "a5huynh/oauth2_proxy"


### PR DESCRIPTION
#### What this PR does / why we need it:

Many users still utilise oauth2-proxy
Secrets should be configurable to allow for management of sensitive oauth2 keys and cookies outside of this chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X ] Chart Version bumped
- [X ] Variables are documented in the README.md
