### PR TITLE
[stable/mattermost-team-edition] fix harcoded init image

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 1.4.0
+version: 1.4.1
 appVersion: 5.5.0
 keywords:
 - mattermost

--- a/stable/mattermost-team-edition/README.md
+++ b/stable/mattermost-team-edition/README.md
@@ -43,36 +43,36 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Mattermost Team Edition chart and their default values.
 
-Parameter                      | Description                                                                                     | Default
----                            | ---                                                                                             | ---
-`image.repository`             | container image repository                                                                      | `mattermost/mattermost-team-edition`
-`image.tag`                    | container image tag                                                                             | `5.5.0`
-`image.imagePullPolicy`        | container image pull policy                                                                     | `IfNotPresent`
-`initImage.repository`         | init container image repository                                                                 | `appropriate/curl`
-`initImage.tag`                | init container image tag                                                                        | `latest`
-`initImage.imagePullPolicy`    | container image pull policy                                                                     | `IfNotPresent`
-`revisionHistoryLimit`         | How many old ReplicaSets for Mattermost Deployment you want to retain                           | `1`
-`config.SiteUrl`               | The URL that users will use to access Mattermost. ie `https://mattermost.mycompany.com`         |  ``
-`config.SiteName`              | Name of service shown in login screens and UI                                                   | `Mattermost`
-`config.FilesAccessKey`        | The AWS Access Key, if you want store the files on S3                                           | ``
-`config.FilesSecretKey`        | The AWS Secret Key                                                                              | ``
-`config.FileBucketName`        | The S3 bucket name                                                                              | ``
-`config.SMTPHost`              | Location of SMTP email server                                                                   | ``
-`config.SMTPPort`              | Port of SMTP email server                                                                       | ``
-`config.SMTPUsername`          | The username for authenticating to the SMTP server                                              | ``
-`config.SMTPPassword`          | The password associated with the SMTP username                                                  | ``
-`config.FeedbackEmail`         | Address displayed on email account used when sending notification emails from Mattermost system | ``
-`config.FeedbackName`          | Name displayed on email account used when sending notification emails from Mattermost system    | ``
-`config.enableSignUpWithEmail` | Allow team creation and account signup using email and password.                                | `true`
-`ingress.enabled`              | if `true`, an ingress is created                                                                | `false`
-`ingress.hosts`                | a list of ingress hosts                                                                         | `[mattermost.example.com]`
-`ingress.tls`                  | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
-`mysql.mysqlRootPassword`      | Root Password for Mysql (Opcional)                                                              |  ""
-`mysql.mysqlUser`              | Username for Mysql (Required)                                                                   |  ""
-`mysql.mysqlPassword`          | User Password for Mysql (Required)                                                              |  ""
-`mysql.mysqlDatabase`          | Database name (Required)                                                                        |  "mattermost"
-`extraEnvVars`                 | Extra environments variables to be used in the deployments                                      |
-`extraInitContainers`          | Additional init containers. Passed through the `tpl` function                                   | ``
+Parameter                            | Description                                                                                     | Default
+---                                  | ---                                                                                             | ---
+`image.repository`                   | container image repository                                                                      | `mattermost/mattermost-team-edition`
+`image.tag`                          | container image tag                                                                             | `5.5.0`
+`image.imagePullPolicy`              | container image pull policy                                                                     | `IfNotPresent`
+`initContainerImage.repository`      | init container image repository                                                                 | `appropriate/curl`
+`initContainerImage.tag`             | init container image tag                                                                        | `latest`
+`initContainerImage.imagePullPolicy` | container image pull policy                                                                     | `IfNotPresent`
+`revisionHistoryLimit`               | How many old ReplicaSets for Mattermost Deployment you want to retain                           | `1`
+`config.SiteUrl`                     | The URL that users will use to access Mattermost. ie `https://mattermost.mycompany.com`         |  ``
+`config.SiteName`                    | Name of service shown in login screens and UI                                                   | `Mattermost`
+`config.FilesAccessKey`              | The AWS Access Key, if you want store the files on S3                                           | ``
+`config.FilesSecretKey`              | The AWS Secret Key                                                                              | ``
+`config.FileBucketName`              | The S3 bucket name                                                                              | ``
+`config.SMTPHost`                    | Location of SMTP email server                                                                   | ``
+`config.SMTPPort`                    | Port of SMTP email server                                                                       | ``
+`config.SMTPUsername`                | The username for authenticating to the SMTP server                                              | ``
+`config.SMTPPassword`                | The password associated with the SMTP username                                                  | ``
+`config.FeedbackEmail`               | Address displayed on email account used when sending notification emails from Mattermost system | ``
+`config.FeedbackName`                | Name displayed on email account used when sending notification emails from Mattermost system    | ``
+`config.enableSignUpWithEmail`       | Allow team creation and account signup using email and password.                                | `true`
+`ingress.enabled`                    | if `true`, an ingress is created                                                                | `false`
+`ingress.hosts`                      | a list of ingress hosts                                                                         | `[mattermost.example.com]`
+`ingress.tls`                        | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
+`mysql.mysqlRootPassword`            | Root Password for Mysql (Opcional)                                                              |  ""
+`mysql.mysqlUser`                    | Username for Mysql (Required)                                                                   |  ""
+`mysql.mysqlPassword`                | User Password for Mysql (Required)                                                              |  ""
+`mysql.mysqlDatabase`                | Database name (Required)                                                                        |  "mattermost"
+`extraEnvVars`                       | Extra environments variables to be used in the deployments                                      |
+`extraInitContainers`                | Additional init containers. Passed through the `tpl` function                                   | ``
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/mattermost-team-edition/README.md
+++ b/stable/mattermost-team-edition/README.md
@@ -43,32 +43,36 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Mattermost Team Edition chart and their default values.
 
-Parameter                 | Description                       | Default
----                       | ---                               | ---
-`image.repository`        | container image repository        | `mattermost/mattermost-team-edition`
-`image.tag`               | container image tag               | `5.5.0`
-`revisionHistoryLimit`    | How many old ReplicaSets for Mattermost Deployment you want to retain   | `1`
-`config.SiteUrl`          | The URL that users will use to access Mattermost. ie `https://mattermost.mycompany.com`       |  ``
-`config.SiteName`         | Name of service shown in login screens and UI         | `Mattermost`
-`config.FilesAccessKey`   | The AWS Access Key, if you want store the files on S3         | ``
-`config.FilesSecretKey`   | The AWS Secret Key        | ``
-`config.FileBucketName`   | The S3 bucket name                                                                                  | ``
-`config.SMTPHost`         | Location of SMTP email server                                                                       | ``
-`config.SMTPPort`         | Port of SMTP email server                                                                           | ``
-`config.SMTPUsername`     | The username for authenticating to the SMTP server                                                  | ``
-`config.SMTPPassword`     | The password associated with the SMTP username                                                      | ``
-`config.FeedbackEmail`    | Address displayed on email account used when sending notification emails from Mattermost system     | ``
-`config.FeedbackName`     | Name displayed on email account used when sending notification emails from Mattermost system        | ``
-`config.enableSignUpWithEmail` | Allow team creation and account signup using email and password. | `true`
-`ingress.enabled`         | if `true`, an ingress is created                                                                    | `false`
-`ingress.hosts`           | a list of ingress hosts       | `[mattermost.example.com]`
-`ingress.tls`             | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items      | `[]`
-`mysql.mysqlRootPassword` | Root Password for Mysql (Opcional)        |  ""
-`mysql.mysqlUser`         | Username for Mysql (Required)         |  ""
-`mysql.mysqlPassword`     | User Password for Mysql (Required)        |  ""
-`mysql.mysqlDatabase`     | Database name (Required)      |  "mattermost"
-`extraEnvVars` | Extra environments variables to be used in the deployments|
-`extraInitContainers` | Additional init containers. Passed through the `tpl` function| ``
+Parameter                      | Description                                                                                     | Default
+---                            | ---                                                                                             | ---
+`image.repository`             | container image repository                                                                      | `mattermost/mattermost-team-edition`
+`image.tag`                    | container image tag                                                                             | `5.5.0`
+`image.imagePullPolicy`        | container image pull policy                                                                     | `IfNotPresent`
+`initImage.repository`         | init container image repository                                                                 | `appropriate/curl`
+`initImage.tag`                | init container image tag                                                                        | `latest`
+`initImage.imagePullPolicy`    | container image pull policy                                                                     | `IfNotPresent`
+`revisionHistoryLimit`         | How many old ReplicaSets for Mattermost Deployment you want to retain                           | `1`
+`config.SiteUrl`               | The URL that users will use to access Mattermost. ie `https://mattermost.mycompany.com`         |  ``
+`config.SiteName`              | Name of service shown in login screens and UI                                                   | `Mattermost`
+`config.FilesAccessKey`        | The AWS Access Key, if you want store the files on S3                                           | ``
+`config.FilesSecretKey`        | The AWS Secret Key                                                                              | ``
+`config.FileBucketName`        | The S3 bucket name                                                                              | ``
+`config.SMTPHost`              | Location of SMTP email server                                                                   | ``
+`config.SMTPPort`              | Port of SMTP email server                                                                       | ``
+`config.SMTPUsername`          | The username for authenticating to the SMTP server                                              | ``
+`config.SMTPPassword`          | The password associated with the SMTP username                                                  | ``
+`config.FeedbackEmail`         | Address displayed on email account used when sending notification emails from Mattermost system | ``
+`config.FeedbackName`          | Name displayed on email account used when sending notification emails from Mattermost system    | ``
+`config.enableSignUpWithEmail` | Allow team creation and account signup using email and password.                                | `true`
+`ingress.enabled`              | if `true`, an ingress is created                                                                | `false`
+`ingress.hosts`                | a list of ingress hosts                                                                         | `[mattermost.example.com]`
+`ingress.tls`                  | a list of [IngressTLS](https://v1-8.docs.kubernetes.io/docs/api-reference/v1.8/#ingresstls-v1beta1-extensions) items | `[]`
+`mysql.mysqlRootPassword`      | Root Password for Mysql (Opcional)                                                              |  ""
+`mysql.mysqlUser`              | Username for Mysql (Required)                                                                   |  ""
+`mysql.mysqlPassword`          | User Password for Mysql (Required)                                                              |  ""
+`mysql.mysqlDatabase`          | Database name (Required)                                                                        |  "mattermost"
+`extraEnvVars`                 | Extra environments variables to be used in the deployments                                      |
+`extraInitContainers`          | Additional init containers. Passed through the `tpl` function                                   | ``
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/mattermost-team-edition/templates/deployment.yaml
+++ b/stable/mattermost-team-edition/templates/deployment.yaml
@@ -30,8 +30,8 @@ spec:
       initContainers:
       {{- if not .Values.externalDB.enabled }}
       - name: "init-mysql"
-        image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
-        imagePullPolicy: {{ .Values.image.initImagePullPolicy }}
+        image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
+        imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
         command: ["sh", "-c", "until curl --max-time 5 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
       {{- end }}
       {{- if .Values.extraInitContainers }}

--- a/stable/mattermost-team-edition/templates/deployment.yaml
+++ b/stable/mattermost-team-edition/templates/deployment.yaml
@@ -30,8 +30,8 @@ spec:
       initContainers:
       {{- if not .Values.externalDB.enabled }}
       - name: "init-mysql"
-        image: "appropriate/curl:latest"
-        imagePullPolicy: "IfNotPresent"
+        image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+        imagePullPolicy: {{ .Values.image.initImagePullPolicy }}
         command: ["sh", "-c", "until curl --max-time 5 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
       {{- end }}
       {{- if .Values.extraInitContainers }}

--- a/stable/mattermost-team-edition/values.yaml
+++ b/stable/mattermost-team-edition/values.yaml
@@ -6,7 +6,7 @@ image:
   tag: 5.5.0
   imagePullPolicy: IfNotPresent
 
-initImage:
+initContainerImage:
   repository: appropriate/curl
   tag: latest
   imagePullPolicy: IfNotPresent

--- a/stable/mattermost-team-edition/values.yaml
+++ b/stable/mattermost-team-edition/values.yaml
@@ -6,6 +6,11 @@ image:
   tag: 5.5.0
   imagePullPolicy: IfNotPresent
 
+initImage:
+  repository: appropriate/curl
+  tag: latest
+  imagePullPolicy: IfNotPresent
+
 ## How many old ReplicaSets for Mattermost Deployment you want to retain
 revisionHistoryLimit: 1
 


### PR DESCRIPTION
Signed-off-by: Sébastien Prud'homme <sebastien.prudhomme@gmail.com>

#### What this PR does / why we need it:

#### Which issue this PR fixes

Allow installing the chart in environments without internet access, by allowing overriding init image.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
