### PR TITLE
Allow extraArgs to contain false values

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.11.1
+version: 0.11.2
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - --cloud-config={{ .Values.cloudConfigPath }}
             {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
-            - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+            - --{{ $key }}={{ $value }}
           {{- end }}
 
           env:


### PR DESCRIPTION
#### What this PR does / why we need it:
A previous PR (#3297) added behavior to convert a value like `extraArgs.log-to-stderr=true` to an argument in the format `--log-to-stderr`. However, this prevents users from disabling flags which default to `true` like `skip-nodes-with-local-storage`.

#### Which issue this PR fixes
  - fixes #9280

#### Special notes for your reviewer:
This is my first time contributing to this repo so minor nitpicks/suggestions are welcome.

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
