### PR TITLE
[stable/mongodb-replicaset] Update peer-finder

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.8.0
+version: 3.8.1
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -38,12 +38,12 @@ The following table lists the configurable parameters of the mongodb chart and t
 | `podDisruptionBudget`               | Pod disruption budget                                                     | `{}`                                                |
 | `port`                              | MongoDB port                                                              | `27017`                                             |
 | `imagePullSecrets`                  | Image pull secrets                                                        | `[]`                                                  |
-| `installImage.repository`           | Image name for the install container                                      | `k8s.gcr.io/mongodb-install`                        |
-| `installImage.tag`                  | Image tag for the install container                                       | `0.5`                                               |
+| `installImage.repository`           | Image name for the install container                                      | `unguiculus/mongodb-install`                        |
+| `installImage.tag`                  | Image tag for the install container                                       | `0.7`                                               |
 | `installImage.pullPolicy`           | Image pull policy for the init container that establishes the replica set | `IfNotPresent`                                      |
 | `copyConfigImage.repository`        | Image name for the copy config init container                             | `busybox`                                           |
-| `copyConfigImage.tag`               | Image tag for the copy config init container                              | `latest`                                            |
-| `copyConfigImage.pullPolicy`        | Image pull policy for the copy config init container                      | `Always`                                            |
+| `copyConfigImage.tag`               | Image tag for the copy config init container                              | `1.29.3`                                            |
+| `copyConfigImage.pullPolicy`        | Image pull policy for the copy config init container                      | `IfNotPresent`                                            |
 | `image.repository`                  | MongoDB image name                                                        | `mongo`                                             |
 | `image.tag`                         | MongoDB image tag                                                         | `3.6`                                               |
 | `image.pullPolicy`                  | MongoDB image pull policy                                                 | `IfNotPresent`                                      |

--- a/stable/mongodb-replicaset/install/Dockerfile
+++ b/stable/mongodb-replicaset/install/Dockerfile
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
-MAINTAINER Anirudh Ramanathan <foxish@google.com>
+FROM alpine:3.8
+
+LABEL maintainer="Reinhard Nägele <unguiculus@gmail.com>"
 
 RUN apk update && apk add bash openssl && wget -qO /peer-finder http://storage.googleapis.com/kubernetes-release/pets/peer-finder
 

--- a/stable/mongodb-replicaset/install/Makefile
+++ b/stable/mongodb-replicaset/install/Makefile
@@ -14,14 +14,14 @@
 
 all: push
 
-TAG = 0.6
-PREFIX = staging-k8s.gcr.io/mongodb-install
+TAG = 0.7
+PREFIX = unguiculus/mongodb-install
 
-container:
+build:
 	docker build -t $(PREFIX):$(TAG) .
 
-push: container
-	gcloud docker -- push $(PREFIX):$(TAG)
+push: build
+	docker push $(PREFIX):$(TAG)
 
 clean:
 	docker rmi $(PREFIX):$(TAG)

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -27,8 +27,8 @@ imagePullSecrets: []
 
 # Specs for the Docker image for the init container that establishes the replica set
 installImage:
-  repository: k8s.gcr.io/mongodb-install
-  tag: 0.6
+  repository: unguiculus/mongodb-install
+  tag: 0.7
   pullPolicy: IfNotPresent
 
 # Specs for the Docker image for the copyConfig init container


### PR DESCRIPTION
I created a new install image that contains the latest version of `peer-finder` that has the `-domain` flag. Since I don't have permissions to push to `k8s.gcr.io/mongodb-install` and @foxish no longer has either after leaving Google, I think it makes sense to move the image elsewhere.

Note that this PR only updates the image. The new flag is not used yet.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
