### PR TITLE
[stable/prometheus-adapter] Upgrading to v0.4.0

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 name: prometheus-adapter
-version: v0.2.0
-appVersion: v0.2.1
+version: v0.2.1
+appVersion: v0.4.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter
 keywords:

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -38,7 +38,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
 | `affinity`                      | Node affinity                                                                   | `{}`                                        |
 | `image.repository`              | Image repository                                                                | `directxman12/k8s-prometheus-adapter-amd64` |
-| `image.tag`                     | Image tag                                                                       | `v0.2.1`                                    |
+| `image.tag`                     | Image tag                                                                       | `v0.4.0`                                    |
 | `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
 | `logLevel`                      | Log level                                                                       | `4`                                         |
 | `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `30s`                                       |

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -3,7 +3,7 @@ affinity: {}
 
 image:
   repository: directxman12/k8s-prometheus-adapter-amd64
-  tag: v0.2.1
+  tag: v0.4.0
   pullPolicy: IfNotPresent
 
 logLevel: 4


### PR DESCRIPTION
Signed-off-by: Harshal Shah <harshal2623@gmail.com>

#### What this PR does / why we need it:
This PR upgrades prometheus adapter to v0.4.0 from v0.2.1

#### Which issue this PR fixes

- reduces the amount of logspam by moving commonly ignorable "error" messages about label association from the ERROR verbosity level to a high-level INFO log.
- [FEATURE] Add support for resource metrics API metrics.k8s.io/v1beta1 (#106)
- [BUGFIX] Update deps to Kube 1.11.3 to fix request header auth with normal client auth (#110)
- Support custom CA certificate when communicating with Prometheus

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
