### PR TITLE
[stable/datadog] add configuration for datadog intake server (#9715)

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.11.2
+version: 1.12.0
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -68,7 +68,9 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `image.pullSecrets`         | Image pull secrets                 |  `nil`                                    |
 | `rbac.create`               | If true, create & use RBAC resources | `true`                                  |
 | `rbac.serviceAccount`       | existing ServiceAccount to use (ignored if rbac.create=true) | `default`       |
-| `datadog.name`              | Container name if Deamonset or Deployment | `datadog`                          |
+| `datadog.name`              | Container name if Daemonset or Deployment | `datadog`                          |
+| `datadog.site`              | Site ('datadoghq.com' or 'datadoghq.eu') | `nil`                                |
+| `datadog.dd_url`            | Datadog intake server              | `nil`                                     |
 | `datadog.env`               | Additional Datadog environment variables | `nil`                               |
 | `datadog.logsEnabled`       | Enable log collection              | `nil`                                     |
 | `datadog.logsConfigContainerCollectAll` | Collect logs from all containers | `nil`                           |

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -53,6 +53,14 @@ spec:
                 name: {{ template "datadog.appKeySecretName" . }}
                 key: app-key
           {{- end }}
+          {{- if .Values.datadog.site }}
+          - name: DD_SITE
+            value: {{ .Values.datadog.site | quote }}
+          {{- end }}
+          {{- if .Values.datadog.dd_url }}
+          - name: DD_DD_URL
+            value: {{ .Values.datadog.dd_url | quote }}
+          {{- end }}
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -64,6 +64,14 @@ spec:
               secretKeyRef:
                 name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
+          {{- if .Values.datadog.site }}
+          - name: DD_SITE
+            value: {{ .Values.datadog.site | quote }}
+          {{- end }}
+          {{- if .Values.datadog.dd_url }}
+          - name: DD_DD_URL
+            value: {{ .Values.datadog.dd_url | quote }}
+          {{- end }}
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
               secretKeyRef:
                 name: {{ template "datadog.apiSecretName" . }}
                 key: api-key
+          {{- if .Values.datadog.site }}
+          - name: DD_SITE
+            value: {{ .Values.datadog.site | quote }}
+          {{- end }}
+          {{- if .Values.datadog.dd_url }}
+          - name: DD_DD_URL
+            value: {{ .Values.datadog.dd_url | quote }}
+          {{- end }}
           {{- if .Values.datadog.logLevel }}
           - name: DD_LOG_LEVEL
             value: {{ .Values.datadog.logLevel | quote }}

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -135,6 +135,15 @@ datadog:
   ##
   name: datadog
 
+  # The site of the Datadog intake to send Agent data to.
+  # Defaults to 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site.
+  # site: datadoghq.com
+
+  # The host of the Datadog intake server to send Agent data to, only set this option
+  # if you need the Agent to send data to a custom URL.
+  # Overrides the site setting defined in "site".
+  # dd_url: https://app.datadoghq.com
+
   ## Set logging verbosity.
   ## ref: https://github.com/DataDog/docker-dd-agent#environment-variables
   ## Note: For Agent6 (image `datadog/agent`) the valid log levels are


### PR DESCRIPTION
[stable/datadog]

Signed-off-by: Paul Charlton <techguru@byiq.com>

This fixes Issue #9715 

============================================

The latest datadog agent allows configuration of the datadog intake server.

Summary of PR
Add chart values to configure the datadog intake server.
Add environment variable to templates to configure the datadog intake server.