### PR TITLE
[incubator/cassandra] update backup tag to enable file streaming

### DIFF
--- a/incubator/cassandra/Chart.yaml
+++ b/incubator/cassandra/Chart.yaml
@@ -1,5 +1,5 @@
 name: cassandra
-version: 0.9.3
+version: 0.9.4
 appVersion: 3.11.3
 description: Apache Cassandra is a free and open-source distributed database management
   system designed to handle large amounts of data across many commodity servers, providing

--- a/incubator/cassandra/README.md
+++ b/incubator/cassandra/README.md
@@ -126,7 +126,7 @@ The following table lists the configurable parameters of the Cassandra chart and
 | `backup.schedule`                    | Keyspaces to backup, each with cron time        |                                                            |
 | `backup.annotations`                 | Backup pod annotations                          | iam.amazonaws.com/role: `cain`                             |
 | `backup.image.repo`                  | Backup image repository                         | `nuvo/cain`                                                |
-| `backup.image.tag`                   | Backup image tag                                | `0.2.0`                                                    |
+| `backup.image.tag`                   | Backup image tag                                | `0.3.0`                                                    |
 | `backup.env`                         | Backup environment variables                    | AWS_REGION: `us-east-1`                                    |
 | `backup.resources`                   | Backup CPU/Memory resource requests/limits      | Memory: `1Gi`, CPU: `1`                                    |
 | `backup.destination`                 | Destination to store backup artifacts           | `s3://bucket/cassandra`                                    |

--- a/incubator/cassandra/values.yaml
+++ b/incubator/cassandra/values.yaml
@@ -159,7 +159,7 @@ backup:
 
   image:
     repos: nuvo/cain
-    tag: 0.2.0
+    tag: 0.3.0
 
   # Add additional environment variables
   env:


### PR DESCRIPTION
Signed-off-by: Maor <maor.friedman@nuvo-group.com>

#### What this PR does / why we need it:
Currently the backup job of cassandra saves files to local memory.
The new version streams file instead of saving them to memory.

#### Which issue this PR fixes
  - fixes #9717
  - closes #9717

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
