### PR TITLE
[stable/sonarqube] Upgrade chart for new sonarqube images

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,7 +1,7 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.10.1
-appVersion: 6.7.3
+version: 0.10.2
+appVersion: 6.7.6
 keywords:
   - coverage
   - security

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -43,6 +43,7 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `image.tag`                                 | `sonarqube` image tag.                    | 6.5                                        |
 | `image.pullPolicy`                          | Image pull policy                         | `IfNotPresent`                             |
 | `image.pullSecret`                          | imagePullSecret to use for private repository      |                                   |
+| `command`                                   | command to run in the container           | `nil` (need to be set prior to 6.7.6, and 7.4)      |
 | `ingress.enabled`                           | Flag for enabling ingress                 | false                                      |
 | `service.type`                              | Kubernetes service type                   | `LoadBalancer`                             |
 | `service.annotations`                       | Kubernetes service annotations            | None                                       |

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -67,15 +67,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
-          command: [
-              "sh",
-              "-ce",
-              "mkdir /scripts &&
-              cp /tmp-script/startup.sh /scripts/startup.sh &&
-              chmod 0755 /scripts/startup.sh &&
-              /scripts/startup.sh
-              "
-            ]
+          {{- if .Values.command }}
+          command: {{ .Values.command }}
+          {{- end }}
           env:
             {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -9,15 +9,15 @@ image:
   # pullSecret: my-repo-secret
 # Starting 6.7.6 and 7.4 official sonarqube docker image, command is not required
 # anymore. For older images, uncomment the following lines.
-#command: [
-#  "sh",
-#  "-ce",
-#  "mkdir /scripts &&
-#  cp /tmp-script/startup.sh /scripts/startup.sh &&
-#  chmod 0755 /scripts/startup.sh &&
-#  /scripts/startup.sh
-#  "
-#  ]
+# command: [
+#   "sh",
+#   "-ce",
+#   "mkdir /scripts &&
+#   cp /tmp-script/startup.sh /scripts/startup.sh &&
+#   chmod 0755 /scripts/startup.sh &&
+#   /scripts/startup.sh
+#   "
+#   ]
 service:
   name: sonarqube
   type: LoadBalancer

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -4,9 +4,20 @@
 replicaCount: 1
 image:
   repository: sonarqube
-  tag: 6.7.3
+  tag: 6.7.6-community
   # If using a private repository, the name of the imagePullSecret to use
   # pullSecret: my-repo-secret
+# Starting 6.7.6 and 7.4 official sonarqube docker image, command is not required
+# anymore. For older images, uncomment the following lines.
+#command: [
+#  "sh",
+#  "-ce",
+#  "mkdir /scripts &&
+#  cp /tmp-script/startup.sh /scripts/startup.sh &&
+#  chmod 0755 /scripts/startup.sh &&
+#  /scripts/startup.sh
+#  "
+#  ]
 service:
   name: sonarqube
   type: LoadBalancer


### PR DESCRIPTION
Update LTS version from 6.7.3 to 6.7.6-community.
    
Starting 6.7.6 and 7.4 sonarsource has changed their docker images.
Images don't need a specific command to be run when starting the
container.
Allow users to override command if needed.
    
Bump chart version.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
It fails to start with new images because it does not start as root and so can not create `/scripts` directory.
Sonarqube change the way docker images start since `6.7.6-community` and `7.4-community`, so
make the  `command` field configurable in order to work with the new images and keep the possibility to start old images.

Also, I update the default version to the last LTS version available: `6.7.3` to `6.7.6-community`.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
