### PR TITLE
Agentserviceaccounts

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5.9
+* [6547ba84](https://github.com/kubernetes/charts/commit/6547ba84):
+  - Introduces the ability to configure agent service accounts
+
 ### 1.5.8
 * [cee475aa](https://github.com/kubernetes/charts/commit/cee475aa):
   - Enable extra volume mounts without persistence

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.5.8
+version: 1.5.9
 appVersion: 18.11.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -15,7 +15,7 @@ To quickly build your first pipeline while learning key GoCD concepts, visit the
 - Kubernetes 1.8+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
 - LoadBalancer support or Ingress Controller
-- Ensure that the service account used for starting tiller has enough permissions to create a role. 
+- Ensure that the service account used for starting tiller has enough permissions to create a role.
 
 ## Setup
 
@@ -39,7 +39,7 @@ $ kubectl create clusterrolebinding clusterRoleBinding \
 ## Installing the Chart
 
 Refer the [GoCD website](https://www.gocd.org/kubernetes) for getting started with GoCD on Helm.
- 
+
 To install the chart with the release name `gocd-app`:
 
 ```bash
@@ -99,23 +99,23 @@ The following tables list the configurable parameters of the GoCD chart and thei
 #### Preconfiguring the GoCD Server
 
 Based on the information available about the Kubernetes cluster, the [Kubernetes elastic agent](https://github.com/gocd/kubernetes-elastic-agents) plugin settings can be configured. A default elastic agent profile too is created so that users can concentrate on building their CD pipeline.
-A simple first pipeline is created in order to bootstrap the getting started experience for users. 
+A simple first pipeline is created in order to bootstrap the getting started experience for users.
 
-If you are comfortable with GoCD and feel that there is no need to preconfigure the server, then you can override `server.shouldPreconfigure` to be false. 
+If you are comfortable with GoCD and feel that there is no need to preconfigure the server, then you can override `server.shouldPreconfigure` to be false.
 
-**Note: If the GoCD server is started with an existing config from a persistent volume, set the value of `server.shouldPreconfigure` to `false`.** 
+**Note: If the GoCD server is started with an existing config from a persistent volume, set the value of `server.shouldPreconfigure` to `false`.**
 
 ```bash
 $ helm install --namespace gocd --name gocd-app --set server.shouldPreconfigure=false stable/gocd
 ```
 
-We are using the `postStart` container lifecycle hook to configure the plugin settings and the elastic agent profile. On starting the container, an attempt is made to configure the GoCD server. 
+We are using the `postStart` container lifecycle hook to configure the plugin settings and the elastic agent profile. On starting the container, an attempt is made to configure the GoCD server.
 
 ```bash
 $ kubectl get pods --namespace gocd
 ```
 
-The above command will show the pod state. This will be in `ContainerCreating` till the preconfigure script exits. 
+The above command will show the pod state. This will be in `ContainerCreating` till the preconfigure script exits.
 
 ```bash
 $ kubectl describe pods --namespace gocd
@@ -134,7 +134,7 @@ This command provides the information on how to access the GoCD server.
 The cases when the attempt to preconfigure the GoCD server fails:
 
 1. The service account token mounted as a secret for the GoCD server pod does not have sufficient permissions. The API call to configure the plugin settings will fail.
-2. If the GoCD server is started with an existing configuration with security configured, then the API calls in the preconfigure script will fail. 
+2. If the GoCD server is started with an existing configuration with security configured, then the API calls in the preconfigure script will fail.
 
 #### SSH keys
 For accessing repositories over SSH in GoCD server, you need to add SSH keys to the GoCD server.
@@ -163,6 +163,8 @@ $ kubectl create secret generic gocd-server-ssh \
 | `agent.resources`                         | GoCD agent resource requests and limits                                                                                                                                          | `{}`                |
 | `agent.nodeSelector`                      | GoCD agent nodeSelector for pod labels                                                                                                                                           | `{}`                |
 | `agent.affinity`                         | GoCD agent affinity                                                                                                                                                               | `{}`                |
+| `agent.serviceAccount.reuseTopLevelServiceAccount`                   |  Specifies whether the top level service account (also used by the server) should be reused as the service account for gocd agents                                 | `nil`                        |
+| `agent.serviceAccount.name`                   |  If reuseTopLevelServiceAccount is false, this field specifies the name of an existing service account to be associated with gocd agents. By default (name field is empty), no service account is created for gocd agents | `nil`                        |
 | `agent.env.goServerUrl`                   | GoCD Server Url. If nil, discovers the GoCD server service if its available on the Kubernetes cluster                                                                            | `nil`                        |
 | `agent.env.agentAutoRegisterKey`          | GoCD Agent autoregister key                                                                                                                                                      | `nil`                        |
 | `agent.env.agentAutoRegisterResources`    | Comma separated list of GoCD Agent resources                                                                                                                                     | `nil`                        |
@@ -207,7 +209,7 @@ $ kubectl create secret generic gocd-agent-ssh \
 
 ## Persistence
 
-By default, the GoCD helm chart supports dynamic volume provisioning. This means that the standard storage class with a default provisioner provided by various cloud platforms used. 
+By default, the GoCD helm chart supports dynamic volume provisioning. This means that the standard storage class with a default provisioner provided by various cloud platforms used.
 Refer to the [Kubernetes blog](http://blog.kubernetes.io/2017/03/dynamic-provisioning-and-storage-classes-kubernetes.html) to know more about the default provisioners across platforms.
 
 > **Note**: The reclaim policy for most default volume provisioners is `delete`. This means that, the persistent volume provisioned using the default provisioner will be deleted along with the data when the PVC gets deleted.
@@ -330,7 +332,7 @@ If RBAC is enabled,
 | `rbac.roleRef`                                | An existing role that can be bound to the gocd service account.                     | `nil`                |
 | `serviceAccount.create`                       | Specifies whether a service account should be created.                              | `true`               |
 | `serviceAccount.name`                         | Name of the service account.                                                        | `nil`                |
- 
+
 If `rbac.create=false`, the service account that will be used, either the default or one that's created, will not have the cluster scope or pod privileges to use with the Kubernetes EA plugin.
 A cluster role binding must be created like below:
 

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -357,19 +357,16 @@ Service account can be configured specifically for agents. This configuration al
 
 | Parameter | Description | Default |
 | --------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------- |
-| `agent.serviceAccount.reuseTopLevelServiceAccount`                   |  Specifies whether the top level service account (also used by the server) should be reused as the service account for gocd agents                                 | `nil`                        |
+| `agent.serviceAccount.reuseTopLevelServiceAccount`                   |  Specifies whether the top level service account (also used by the server) should be reused as the service account for gocd agents                                 | false                        |
 | `agent.serviceAccount.name`                   |  If reuseTopLevelServiceAccount is false, this field specifies the name of an existing service account to be associated with gocd agents. By default (name field is empty), no service account is created for gocd agents | `nil`                        |
 
 Possible states:
 
 |State | Effect                                                                         |
 |------|--------------------------------------------------|
-|reuseTopLevelServiceAccount = false and name = empty|The default service account for the namespace will be used.|
+|reuseTopLevelServiceAccount = false and name = empty|The service account 'default' will be used.|
 |reuseTopLevelServiceAccount = false and name = 'agentSA'|The 'agentSA' service account will be used. The service account needs to exist and bound with the appropriate role. |
-|reuseTopLevelServiceAccount = true| The GoCD service account will be created and used for the agents in the specified namespace. The permissions associated with the GoCD SA are defined here - [Cluser role privileges](#cluster-role-privileges).  |
-
- SA and bind it with the appropriate role themselves. May be provide examples or commands for role and role bindings?
-reuseTopLevelServiceAccount = true => GoCD SA will be created and used for the agents in the specified namespace. The permissions associated with the GoCD SA are defined here - [Cluser role privileges](#cluster-role-privileges).
+|reuseTopLevelServiceAccount = true| The GoCD service account will be created and used for the agents in the specified namespace. The permissions associated with the GoCD SA are defined here - [Cluster role privileges](#cluster-role-privileges).  |
 
 # License
 

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -163,8 +163,6 @@ $ kubectl create secret generic gocd-server-ssh \
 | `agent.resources`                         | GoCD agent resource requests and limits                                                                                                                                          | `{}`                |
 | `agent.nodeSelector`                      | GoCD agent nodeSelector for pod labels                                                                                                                                           | `{}`                |
 | `agent.affinity`                         | GoCD agent affinity                                                                                                                                                               | `{}`                |
-| `agent.serviceAccount.reuseTopLevelServiceAccount`                   |  Specifies whether the top level service account (also used by the server) should be reused as the service account for gocd agents                                 | `nil`                        |
-| `agent.serviceAccount.name`                   |  If reuseTopLevelServiceAccount is false, this field specifies the name of an existing service account to be associated with gocd agents. By default (name field is empty), no service account is created for gocd agents | `nil`                        |
 | `agent.env.goServerUrl`                   | GoCD Server Url. If nil, discovers the GoCD server service if its available on the Kubernetes cluster                                                                            | `nil`                        |
 | `agent.env.agentAutoRegisterKey`          | GoCD Agent autoregister key                                                                                                                                                      | `nil`                        |
 | `agent.env.agentAutoRegisterResources`    | Comma separated list of GoCD Agent resources                                                                                                                                     | `nil`                        |
@@ -313,11 +311,13 @@ To mount a `ConfigMap` containing `/docker-entrypoint.d/` scripts:
 The RBAC section is for users who want to use the Kubernetes Elastic Agent Plugin with GoCD. The Kubernetes elastic agent plugin for GoCD brings up pods on demand while running a job.
 If RBAC is enabled,
  1. A cluster role is created by default and the following privileges are provided.
-    Privileges:
+
+    <a name="cluster-role-privileges"></a>Cluser role privileges:
       - nodes: list, get
       - events: list, watch
       - namespace: list, get
       - pods, pods/log: *
+
 
  2. A cluster role binding to bind the specified service account with the cluster role.
 
@@ -350,6 +350,26 @@ The gocd service account can be associated with an existing role in the namespac
 ```bash
 helm install --namespace gocd --name gocd-app --set rbac.roleRef=ROLE_NAME stable/gocd
 ```
+
+#### Agent service account:
+
+Service account can be configured specifically for agents. This configuration also allows for the reuse of the top level service account that is used to configure the server pod. The various settings and their possible states are described below:
+
+| Parameter | Description | Default |
+| --------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------- |
+| `agent.serviceAccount.reuseTopLevelServiceAccount`                   |  Specifies whether the top level service account (also used by the server) should be reused as the service account for gocd agents                                 | `nil`                        |
+| `agent.serviceAccount.name`                   |  If reuseTopLevelServiceAccount is false, this field specifies the name of an existing service account to be associated with gocd agents. By default (name field is empty), no service account is created for gocd agents | `nil`                        |
+
+Possible states:
+
+|State | Effect                                                                         |
+|------|--------------------------------------------------|
+|reuseTopLevelServiceAccount = false and name = empty|The default service account for the namespace will be used.|
+|reuseTopLevelServiceAccount = false and name = 'agentSA'|The 'agentSA' service account will be used. The service account needs to exist and bound with the appropriate role. |
+|reuseTopLevelServiceAccount = true| The GoCD service account will be created and used for the agents in the specified namespace. The permissions associated with the GoCD SA are defined here - [Cluser role privileges](#cluster-role-privileges).  |
+
+ SA and bind it with the appropriate role themselves. May be provide examples or commands for role and role bindings?
+reuseTopLevelServiceAccount = true => GoCD SA will be created and used for the agents in the specified namespace. The permissions associated with the GoCD SA are defined here - [Cluser role privileges](#cluster-role-privileges).
 
 # License
 

--- a/stable/gocd/templates/_helpers.tpl
+++ b/stable/gocd/templates/_helpers.tpl
@@ -42,6 +42,6 @@ Create the name of the service account to use for agents
 {{- if .Values.agent.serviceAccount.reuseTopLevelServiceAccount -}}
     {{ template "gocd.serviceAccountName" . }}
 {{- else -}}
-    {{ .Values.agent.serviceAccount.name }}
+    {{ default "default" .Values.agent.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/stable/gocd/templates/_helpers.tpl
+++ b/stable/gocd/templates/_helpers.tpl
@@ -34,3 +34,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use for agents
+*/}}
+{{- define "gocd.agentServiceAccountName" -}}
+{{- if .Values.agent.serviceAccount.reuseTopLevelServiceAccount -}}
+    {{ template "gocd.serviceAccountName" . }}
+{{- else -}}
+    {{ .Values.agent.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/gocd/templates/configmap.yaml
+++ b/stable/gocd/templates/configmap.yaml
@@ -51,11 +51,11 @@ data:
           },
           {
             "key": "PodConfiguration",
-            "value": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: pod-name-prefix-{\\\\{ POD_POSTFIX }\\\\}\n  labels:\n    app: web\nspec:\n  containers:\n    - name: gocd-agent-container-{\\\\{ CONTAINER_POSTFIX }\\\\}\n      image: {\\\\{ GOCD_AGENT_IMAGE }\\\\}:{\\\\{ LATEST_VERSION }\\\\}\n      securityContext:\n        privileged: true"
+            "value": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: pod-name-prefix-{\\\\{ POD_POSTFIX }\\\\}\n  labels:\n    app: web\nspec:\n  serviceAccountName: {{ template "gocd.agentServiceAccountName" . }}\n  containers:\n    - name: gocd-agent-container-{\\\\{ CONTAINER_POSTFIX }\\\\}\n      image: gocd/gocd-agent-docker-dind:v{{ .Chart.AppVersion }}\n      securityContext:\n        privileged: true"
           },
           {
             "key": "SpecifiedUsingPodConfiguration",
-            "value": "false"
+            "value": "true"
           },
           {
             "key": "Privileged",

--- a/stable/gocd/templates/configmap.yaml
+++ b/stable/gocd/templates/configmap.yaml
@@ -51,7 +51,7 @@ data:
           },
           {
             "key": "PodConfiguration",
-            "value": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: pod-name-prefix-{\\\\{ POD_POSTFIX }\\\\}\n  labels:\n    app: web\nspec:\n  serviceAccountName: {{ template "gocd.agentServiceAccountName" . }}\n  containers:\n    - name: gocd-agent-container-{\\\\{ CONTAINER_POSTFIX }\\\\}\n      image: gocd/gocd-agent-docker-dind:v{{ .Chart.AppVersion }}\n      securityContext:\n        privileged: true"
+            "value": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: pod-name-prefix-{{ `{{ POD_POSTFIX }}` }}\n  labels:\n    app: web\nspec:\n  serviceAccountName: {{ template "gocd.agentServiceAccountName" . }}\n  containers:\n    - name: gocd-agent-container-{{ `{{ CONTAINER_POSTFIX }}` }}\n      image: gocd/gocd-agent-docker-dind:v{{ .Chart.AppVersion }}\n      securityContext:\n        privileged: true"
           },
           {
             "key": "SpecifiedUsingPodConfiguration",

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -26,7 +26,13 @@ spec:
         release: {{ .Release.Name | quote }}
         component: agent
     spec:
-      {{- if or .Values.agent.persistence.enabled (or .Values.agent.security.ssh.enabled .Values.agent.persistence.extraVolumes) }}
+      {{- if .Values.agent.serviceAccount.reuseTopLevelServiceAccount }}
+      serviceAccountName: {{ template "gocd.serviceAccountName" . }}
+      {{- else if .Values.agent.serviceAccount.name }}
+      serviceAccountName: {{ .Values.agent.serviceAccount.name }}
+      {{- end }}
+
+      {{- if or .Values.agent.persistence.enabled .Values.agent.security.ssh.enabled }}
       volumes:
       {{- end }}
       {{- if .Values.agent.persistence.enabled }}

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -26,12 +26,7 @@ spec:
         release: {{ .Release.Name | quote }}
         component: agent
     spec:
-      {{- if .Values.agent.serviceAccount.reuseTopLevelServiceAccount }}
-      serviceAccountName: {{ template "gocd.serviceAccountName" . }}
-      {{- else if .Values.agent.serviceAccount.name }}
-      serviceAccountName: {{ .Values.agent.serviceAccount.name }}
-      {{- end }}
-
+      serviceAccountName: {{ template "gocd.agentServiceAccountName" . }}
       {{- if or .Values.agent.persistence.enabled .Values.agent.security.ssh.enabled }}
       volumes:
       {{- end }}

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -175,7 +175,7 @@ agent:
     # specifies whether the top level service account (also used by the server) should be reused as the service account for gocd agents
     reuseTopLevelServiceAccount: false
     # if reuseTopLevelServiceAccount is false, this field specifies the name of an existing service account to be associated with gocd agents
-    # by default (name field is empty), no service account is created for gocd agents
+    # If field is empty, the default service account for that namespace will be used.
     name:
 
   # agent.replicaCount is the GoCD Agent replicas Count. Specify the number of GoCD agents to run

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -170,6 +170,14 @@ server:
       secretName: gocd-server-ssh
 
 agent:
+  # specifies overrides for agent specific service account creation
+  serviceAccount:
+    # specifies whether the top level service account (also used by the server) should be reused as the service account for gocd agents
+    reuseTopLevelServiceAccount: false
+    # if reuseTopLevelServiceAccount is false, this field specifies the name of an existing service account to be associated with gocd agents
+    # by default (name field is empty), no service account is created for gocd agents
+    name:
+
   # agent.replicaCount is the GoCD Agent replicas Count. Specify the number of GoCD agents to run
   replicaCount: 0
   # agent.deployStrategy is the strategy explained in detail at https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -175,7 +175,7 @@ agent:
     # specifies whether the top level service account (also used by the server) should be reused as the service account for gocd agents
     reuseTopLevelServiceAccount: false
     # if reuseTopLevelServiceAccount is false, this field specifies the name of an existing service account to be associated with gocd agents
-    # If field is empty, the default service account for that namespace will be used.
+    # If field is empty, the service account "default" will be used.
     name:
 
   # agent.replicaCount is the GoCD Agent replicas Count. Specify the number of GoCD agents to run


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds the capability to specify a service account for agents. Also allows for the reuse of the top level service account that is used to configure the server pod. In order to allow the elastic agents to use this configuration, elastic agent profiles now use pod yaml for configuration by default.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
