### PR TITLE
[stable/falco] add extraArgs

### DIFF
--- a/stable/falco/CHANGELOG.md
+++ b/stable/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Sysdig Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.5.6
+
+* Allow extra container args
+
 ## v0.5.5
 
 * Update correct slack example

--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 0.5.5
+version: 0.5.6
 appVersion: 0.13.0
 description: Sysdig Falco
 keywords:

--- a/stable/falco/README.md
+++ b/stable/falco/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Falco chart and the
 | `image.tag`                                     | The image tag to pull                                                | `0.13.0`                                                                               |
 | `image.pullPolicy`                              | The image pull policy                                                | `IfNotPresent`                                                                               |
 | `resources`                                     | Specify container resources                                          | `{}`                                                                                   |
+| `extraArgs`                                     | Specify additional container args                                    | `[]`                                                                                   |
 | `rbac.create`                                   | If true, create & use RBAC resources                                 | `true`                                                                                 |
 | `serviceAccount.create`                         | Create serviceAccount                                                | `true`                                                                                 |
 | `serviceAccount.name`                           | Use this value as serviceAccountName                                 | ` `                                                                                    |

--- a/stable/falco/templates/daemonset.yaml
+++ b/stable/falco/templates/daemonset.yaml
@@ -30,7 +30,16 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           securityContext:
             privileged: true
-          args: [ "/usr/bin/falco", "-K", "/var/run/secrets/kubernetes.io/serviceaccount/token", "-k", "https://kubernetes.default", "-pk"]
+          args:
+            - /usr/bin/falco
+            - -K
+            - /var/run/secrets/kubernetes.io/serviceaccount/token
+            - -k
+            - https://kubernetes.default
+            - -pk
+        {{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 12 }}
+        {{- end }}
           env:
           {{- if .Values.ebpf.enabled }}
             - name: SYSDIG_BPF_PROBE

--- a/stable/falco/values.yaml
+++ b/stable/falco/values.yaml
@@ -17,6 +17,8 @@ resources: {}
   #   cpu: 20m
   #   memory: 128Mi
 
+extraArgs: []
+
 rbac:
   # Create and use rbac resources
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows users to specify extra container args.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
