### PR TITLE
[stable/postgresql] Bad formatting in README

### DIFF
--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -64,7 +64,6 @@ The following tables lists the configurable parameters of the PostgreSQL chart a
 | `replication.password`                        | Replication user password                            | `repl_password`                                           |
 | `replication.slaveReplicas`                   | Number of slaves replicas                            | `1`                                                       |
 | `existingSecret`                              | Name of existing secret to use for postgresl passwords        | `nil`                                                     |
-
 | `postgresqlUsername`                          | PostgreSQL admin user                                | `postgres`                                                |
 | `postgresqlPassword`                          | PostgreSQL admin password                            | _random 10 character alphanumeric string_                 |
 | `postgresqlDatabase`                          | PostgreSQL database                                  | `nil`                                                     |


### PR DESCRIPTION
Fixed some bad markdown in the chart's README.md.
