### PR TITLE
Add timeouts options for traefik

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.56.1
+version: 1.56.2
 appVersion: 1.7.6
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -208,7 +208,10 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `tracing.zipkin.id128Bit`              | Use Zipkin 128 bit root span IDs                                                                                             | `true`                                            |
 | `tracing.datadog.localAgentHostPort`   | Location of the Datadog agent where spans will be sent                                                                       | `127.0.0.1:8126`                                  |
 | `tracing.datadog.debug`                | Enables Datadog debugging                                                                                                    | `false`                                           |
-| `tracing.datadog.globalTag`            | Apply shared tag in a form of Key:Value to all the traces                                                                    | `""`                                           |
+| `tracing.datadog.globalTag`            | Apply shared tag in a form of Key:Value to all the traces                                                                    | `""`                                              |
+| `timeouts.readTimeout`                 | The maximum duration for reading the entire request, including the body. If zero, no timeout exists.                         | `"0s"`                                            |
+| `timeouts.writeTimeout`                | The maximum duration before timing out writes of the response. If zero, no timeout exists.                                   | `"0s"`                                            |
+| `timeouts.idleTimeout`                 | The maximum duration an idle (keep-alive) connection will remain idle before closing itself. If zero, no timeout exists.   | `"0s"`                                            |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/traefik/templates/configmap.yaml
+++ b/stable/traefik/templates/configmap.yaml
@@ -353,3 +353,13 @@ data:
         {{- end }}
       {{- end }}
     {{- end }}
+    [respondingTimeouts]
+      {{- if ne (.Values.timeouts.readTimeout | quote) "" }}
+      readTimeout = {{ .Values.timeouts.readTimeout | quote }}
+      {{- end }}
+      {{- if ne (.Values.timeouts.writeTimeout | quote) "" }}
+      writeTimeout = {{ .Values.timeouts.writeTimeout | quote }}
+      {{- end }}
+      {{- if ne (.Values.timeouts.idleTimeout | quote) "" }}
+      idleTimeout = {{ .Values.timeouts.idleTimeout | quote }}
+      {{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -131,6 +131,10 @@ kvprovider:
     #   insecureSkipVerify: true
 
     ## only relevant for etcd
+timeouts:
+  readTimeout: 0s
+  writeTimeout: 0s
+  idleTimeout: 180s
 
 
 acme:


### PR DESCRIPTION
#### What this PR does / why we need it:
Add Traefik [Responding Timeouts](https://docs.traefik.io/configuration/commons/#responding-timeouts) configuration options in traefik chart.

#### Which issue this PR fixes
No issues related.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
