### PR TITLE
[stable/jaeger-operator] disabling rbac no longer creates role

### DIFF
--- a/stable/jaeger-operator/Chart.yaml
+++ b/stable/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.8.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/stable/jaeger-operator/templates/role.yaml
+++ b/stable/jaeger-operator/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -42,3 +43,4 @@ rules:
   - ingresses
   verbs:
   - "*"
+{{- end }}


### PR DESCRIPTION
Signed-off-by: moody <moody.saada@agolo.com>

#### What this PR does / why we need it:

Disabling rbac currently still tries to create a Role instance. This PR is a bugfix for this.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
