### PR TITLE
Add and deprecate incubator/artifactory

### DIFF
--- a/incubator/artifactory/.helmignore
+++ b/incubator/artifactory/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/artifactory/Chart.yaml
+++ b/incubator/artifactory/Chart.yaml
@@ -1,6 +1,7 @@
 name: artifactory
 home: https://www.jfrog.com/artifactory/
 version: 5.2.1
+appVersion: 5.2.0
 description: DEPRECATED Universal Repository Manager supporting all major packaging formats, build tools and CI servers.
 keywords:
 - artifactory

--- a/incubator/artifactory/Chart.yaml
+++ b/incubator/artifactory/Chart.yaml
@@ -1,0 +1,14 @@
+name: artifactory
+home: https://www.jfrog.com/artifactory/
+version: 5.2.1
+description: DEPRECATED Universal Repository Manager supporting all major packaging formats, build tools and CI servers.
+keywords:
+- artifactory
+- jfrog
+sources:
+  - https://bintray.com/jfrog/product/JFrog-Artifactory-Pro/view
+  - https://github.com/JFrogDev
+icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png
+## Deprecated following https://github.com/helm/charts/blob/master/PROCESSES.md#deprecating-a-chart
+## Chart is now maintained in https://github.com/jfrog/charts
+deprecated: true

--- a/incubator/artifactory/README.md
+++ b/incubator/artifactory/README.md
@@ -1,0 +1,60 @@
+# JFrog Artifactory Helm Chart - DEPRECATED
+**This chart is deprecated! You can find the new chart in:**
+- **Sources:** https://github.com/jfrog/charts
+- **Charts repository:** https://charts.jfrog.io
+```bash
+helm repo add jfrog https://charts.jfrog.io
+```
+
+## Prerequisites Details
+
+* Artifactory Pro trial license [get one from here](https://www.jfrog.com/artifactory/free-trial/)
+
+## Todo
+
+* Implement Support of Reverse proxy for Docker Repo using Nginx
+* Smarter upscaling/downscaling
+
+## Chart Details
+This chart will do the following:
+
+* Deploy Artifactory-oss
+* Deploy Artifactory-Pro
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release incubator/artifactory
+```
+
+Note: By default it will run Artifactory-oss to run Artifactory-Pro uncomment image in value.yaml or use following command
+```bash
+$ helm install --name my-release --set image=docker.bintray.io/jfrog/artifactory-pro incubator/artifactory
+```
+
+## Deleting the Charts
+
+Deletion of the PetSet doesn't cascade to deleting associated Pods and PVCs. To delete them:
+
+```
+ $ helm delete my-release
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the artifactory chart and their default values.
+
+|         Parameter         |           Description             |                         Default                          |
+|---------------------------|-----------------------------------|----------------------------------------------------------|
+| `Image`                   | Container image name              | `docker.bintray.io/jfrog/artifactory-oss`                |
+| `ImageTag`                | Container image tag               | `5.2.0`                                                 |
+| `ImagePullPolicy`         | Container pull policy             | `Always`                                                 |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+
+## Useful links
+https://www.jfrog.com
+https://www.jfrog.com/confluence/

--- a/incubator/artifactory/templates/NOTES.txt
+++ b/incubator/artifactory/templates/NOTES.txt
@@ -1,0 +1,24 @@
+#### THIS CHART IS DEPRECATED! ####
+
+Get the Artifactory URL to visit by running these commands in the same shell:
+{{- if contains "NodePort" .Values.ServiceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/
+
+{{- else if contains "LoadBalancer" .Values.ServiceType }}
+**** NOTE: It may take a few minutes for the LoadBalancer IP to be available.                      ****
+****       You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}' ****
+  export SERVICE_IP=$(kubectl get svc {{ template "fullname" . }} --namespace {{ .Release.Namespace }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.httpPort }}/
+
+{{- else if contains "ClusterIP"  .Values.ServiceType }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:{{ .Values.httpPort }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.httpPort }}:{{ .Values.httpPort }}
+
+{{- end }}
+
+Default credential for Artifactory:
+user: admin
+password: password

--- a/incubator/artifactory/templates/_helpers.tpl
+++ b/incubator/artifactory/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{define "name"}}{{default "artifactory" .Values.nameOverride | trunc 24 }}{{end}}
+
+{{/*
+Create a default fully qualified app name.
+
+We truncate at 24 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+*/}}
+{{define "fullname"}}
+{{- $name := default "artifactory" .Values.nameOverride -}}
+{{printf "%s-%s" .Release.Name $name | trunc 24 -}}
+{{end}}

--- a/incubator/artifactory/templates/deployment.yaml
+++ b/incubator/artifactory/templates/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{template "fullname" .}}
+  labels:
+    app: {{ template "fullname" . }}
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+spec:
+  replicas: {{default 1 .Values.replicaCount}}
+  template:
+    metadata:
+      labels:
+        app: {{template "fullname" .}}
+        release: {{.Release.Name | quote }}
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}
+        image: "{{ .Values.image}}:{{ .Values.imageTag}}"
+        imagePullPolicy: {{default "IfNotPresent" .Values.ImagePullPolicy}}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - containerPort: 8081
+          name: http
+        volumeMounts:
+        - name: etc
+          mountPath: /var/opt/jfrog/artifactory/etc
+        - name: logs
+          mountPath: /var/opt/jfrog/artifactory/logs
+        - name: data
+          mountPath: /var/opt/jfrog/artifactory/data
+      volumes:
+        - name: data
+        - name: logs
+        - name: etc

--- a/incubator/artifactory/templates/svc.yaml
+++ b/incubator/artifactory/templates/svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{template "fullname" .}}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app: {{template "fullname" .}}
+spec:
+  ports:
+  - port: {{default 8081 .Values.httpPort}}
+    targetPort: 8081
+    protocol: TCP
+    name: http
+  selector:
+    app: {{template "fullname" .}}
+  type: {{.Values.ServiceType}}

--- a/incubator/artifactory/values.yaml
+++ b/incubator/artifactory/values.yaml
@@ -1,0 +1,30 @@
+# Default values for Artifactory.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+Name: artifactory
+Component: "Artifactory"
+
+## Uncomment following line if you want to run Artifactory-Pro
+#image: "docker.bintray.io/jfrog/artifactory-pro"
+image: "docker.bintray.io/jfrog/artifactory-oss"
+imageTag: "5.2.0"
+imagePullPolicy: "Always"
+replicaCount: 1
+httpPort: 8081
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer
+##
+ServiceType: ClusterIP
+resources:
+  requests:
+    memory: 2048Mi
+    cpu: 200m
+
+## Persist data to a persitent volume
+persistence:
+  enabled: true
+  storageClass: generic
+  accessMode: ReadWriteOnce
+  size: 8Gi

--- a/incubator/artifactory/values.yaml
+++ b/incubator/artifactory/values.yaml
@@ -7,7 +7,7 @@ Name: artifactory
 Component: "Artifactory"
 
 ## Uncomment following line if you want to run Artifactory-Pro
-#image: "docker.bintray.io/jfrog/artifactory-pro"
+# image: "docker.bintray.io/jfrog/artifactory-pro"
 image: "docker.bintray.io/jfrog/artifactory-oss"
 imageTag: "5.2.0"
 imagePullPolicy: "Always"


### PR DESCRIPTION
#### What this PR does / why we need it:
Why - The incubator version of artifactory is shown in the new helm hub (https://hub.helm.sh/charts/incubator/artifactory). It should not be shown.
What - Add a deprecated incubator/artifactory (was moved to stable long ago) in order to fix https://github.com/helm/hub/issues/17.

#### Which issue this PR fixes
- fixes https://github.com/helm/hub/issues/17

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
