### PR TITLE
[stable/mattermost-te] bump mm-te to 5.5.1

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 1.4.1
-appVersion: 5.5.0
+version: 1.4.2
+appVersion: 5.5.1
 keywords:
 - mattermost
 - communication

--- a/stable/mattermost-team-edition/README.md
+++ b/stable/mattermost-team-edition/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the Mattermost Team Edi
 Parameter                            | Description                                                                                     | Default
 ---                                  | ---                                                                                             | ---
 `image.repository`                   | container image repository                                                                      | `mattermost/mattermost-team-edition`
-`image.tag`                          | container image tag                                                                             | `5.5.0`
+`image.tag`                          | container image tag                                                                             | `5.5.1`
 `image.imagePullPolicy`              | container image pull policy                                                                     | `IfNotPresent`
 `initContainerImage.repository`      | init container image repository                                                                 | `appropriate/curl`
 `initContainerImage.tag`             | init container image tag                                                                        | `latest`

--- a/stable/mattermost-team-edition/values.yaml
+++ b/stable/mattermost-team-edition/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mattermost/mattermost-team-edition
-  tag: 5.5.0
+  tag: 5.5.1
   imagePullPolicy: IfNotPresent
 
 initContainerImage:


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump mm-te to 5.5.1

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
