### PR TITLE
Add support for SELinux label modification

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.14.0
+version: 1.15.0
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -91,6 +91,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.resources.limits.cpu` | CPU resource limits             | `200m`                                    |
 | `datadog.resources.requests.memory` | Memory resource requests   | `256Mi`                                   |
 | `datadog.resources.limits.memory` | Memory resource limits       | `256Mi`                                   |
+| `datadog.securityContext`   | Allows you to overwrite the default securityContext applied to the container  | `nil`  |
 | `datadog.livenessProbe`     | Overrides the default liveness probe | exec /probe.sh                          |
 | `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
 | `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       {{- if .Values.datadog.securityContext }}
       securityContext:
-{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
+{{ toYaml .Values.datadog.securityContext | indent 8 }}
       {{- end }}
       {{- if .Values.daemonset.useHostNetwork }}
       hostNetwork: {{ .Values.daemonset.useHostNetwork }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -23,6 +23,11 @@ spec:
 {{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.datadog.seLinuxLabel }}
+      securityContext:
+        seLinuxOptions:
+          type: "{{ .Values.datadog.seLinuxLabel }}"
+      {{- end }}
       {{- if .Values.daemonset.useHostNetwork }}
       hostNetwork: {{ .Values.daemonset.useHostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -23,10 +23,9 @@ spec:
 {{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.datadog.seLinuxLabel }}
+      {{- if .Values.datadog.securityContext }}
       securityContext:
-        seLinuxOptions:
-          type: "{{ .Values.datadog.seLinuxLabel }}"
+{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
       {{- end }}
       {{- if .Values.daemonset.useHostNetwork }}
       hostNetwork: {{ .Values.daemonset.useHostNetwork }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -22,6 +22,11 @@ spec:
         checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
         checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
     spec:
+      {{- if .Values.datadog.seLinuxLabel }}
+      securityContext:
+        seLinuxOptions:
+          type: "{{ .Values.datadog.seLinuxLabel }}"
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -22,10 +22,9 @@ spec:
         checksum/confd-config: {{ tpl (toYaml .Values.datadog.confd) . | sha256sum }}
         checksum/checksd-config: {{ tpl (toYaml .Values.datadog.checksd) . | sha256sum }}
     spec:
-      {{- if .Values.datadog.seLinuxLabel }}
+      {{- if .Values.datadog.securityContext }}
       securityContext:
-        seLinuxOptions:
-          type: "{{ .Values.datadog.seLinuxLabel }}"
+{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       {{- if .Values.datadog.securityContext }}
       securityContext:
-{{ toYaml .Values.daemonset.podAnnotations | indent 8 }}
+{{ toYaml .Values.datadog.securityContext | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -129,9 +129,11 @@ datadog:
   ##
   # apiKey:
 
-  ## You can modify the SELinux security context used to run the containers by
+  ## You can modify the security context used to run the containers by
   ## modifying the label type below:
-  # seLinuxLabel: "spc_t"
+  # securityContext:
+  #   seLinuxOptions:
+  #     seLinuxLabel: "spc_t"
 
   ## Use existing Secret which stores API key instead of creating a new one
   # apiKeyExistingSecret:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -129,6 +129,10 @@ datadog:
   ##
   # apiKey:
 
+  ## You can modify the SELinux security context used to run the containers by
+  ## modifying the label type below:
+  # seLinuxLabel: "spc_t"
+
   ## Use existing Secret which stores API key instead of creating a new one
   # apiKeyExistingSecret:
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Add support to Datadog helm chart for SELinux label modification in case a system does not like the default `spc_t` 

@hkaj @irabinovitch @xvello @charlyf

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
