### PR TITLE
add Google Cloud Platform Pub/Sub Emulator for Kafka Chart

### DIFF
--- a/stable/kafka-pubsub-emulator/.helmignore
+++ b/stable/kafka-pubsub-emulator/.helmignore
@@ -1,0 +1,28 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# sources and build files
+src
+demo
+go
+target
+*pom.xml
+checkstyle.xml

--- a/stable/kafka-pubsub-emulator/Chart.yaml
+++ b/stable/kafka-pubsub-emulator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0.0.0"
-description: A Helm chart for the GCP Kafka PubSub Emulator
+description: A Helm chart for the GCP Kafka PubSub Emulator - https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
 keywords:
   - google cloud platform
   - kafka
@@ -11,4 +11,6 @@ keywords:
 name: kafka-pubsub-emulator
 sources:
   - https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
+maintainers:
+  - riccardomc
 version: 0.1.0

--- a/stable/kafka-pubsub-emulator/Chart.yaml
+++ b/stable/kafka-pubsub-emulator/Chart.yaml
@@ -9,8 +9,8 @@ keywords:
   - pubsub
   - queue
 name: kafka-pubsub-emulator
+maintainers:
+  - name: riccardomc
 sources:
   - https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
-maintainers:
-  - riccardomc
 version: 0.1.0

--- a/stable/kafka-pubsub-emulator/Chart.yaml
+++ b/stable/kafka-pubsub-emulator/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 appVersion: "1.0.0.0"
-description: A Helm chart for the GCP Kafka PubSub Emulator - https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
+description: A Helm chart for the GCP Kafka PubSub Emulator
+home: https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
 keywords:
   - google cloud platform
   - kafka

--- a/stable/kafka-pubsub-emulator/Chart.yaml
+++ b/stable/kafka-pubsub-emulator/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: "1.0.0.0"
+description: A Helm chart for the GCP Kafka PubSub Emulator
+keywords:
+  - google cloud platform
+  - kafka
+  - kafka-pubsub-emulator
+  - messaging
+  - pubsub
+  - queue
+name: kafka-pubsub-emulator
+sources:
+  - https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator
+version: 0.1.0

--- a/stable/kafka-pubsub-emulator/README.md
+++ b/stable/kafka-pubsub-emulator/README.md
@@ -28,8 +28,7 @@ This chart will create:
 ### Installation
 
 ```
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-helm install --name emulator incubator/kafka-pubsub-emulator
+helm install --name emulator stable/kafka-pubsub-emulator
 ```
 
 ### Configuration

--- a/stable/kafka-pubsub-emulator/README.md
+++ b/stable/kafka-pubsub-emulator/README.md
@@ -1,0 +1,80 @@
+# Pub/Sub Emulator for Kafka
+
+This chart packages the [Pub/Sub Emulator for
+Kafka](https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator) which
+implements an emulation layer on top of an existing
+[Kafka](https://kafka.apache.org/) cluster.
+
+## Prerequisites
+* Kubernetes 1.4+ with Beta APIs enabled
+* A Kafka cluster
+
+
+## Chart Details
+This chart will create:
+
+1. A
+   [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+   with a single replica running the Pub/Sub Emulator for Kafka
+
+2. A
+   [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+   exposing the Pub/Sub Emulator for Kafka
+
+3. A [ConfigMap](https://kubernetes.io/docs/tutorials/configuration/) that
+   holds the configuration for the Pub/Sub Emulator for Kafka that will be
+   mounted by the Pods in the Deployment above
+
+### Installation
+
+```
+helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+helm install --name emulator incubator/kafka-pubsub-emulator
+```
+
+### Configuration
+
+You can provide the configuration of the Pub/Sub Emulator for Kafka using the
+`emulatorConfig` key in `values.yaml`. Refer to the [Configuration
+Options](https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator#configuration-options)
+section in the original repository for details.
+
+You will need to specify at least your Kafka Bootstrap Servers, for example:
+
+```
+helm install --name emulator \
+    --set emulatorConfig.kafka.bootstrapServers='kafka1:9092\,kafka2:9092\,kafka3:9092'
+```
+
+|Parameter|Description|Default|
+| - | - | - |
+| `image.repository` | Image repository | `us.gcr.io/kafka-pubsub-emulator/kafka-pubsub-emulator`
+| `image.tag` | Image tag | `1.0.0.0`
+| `service.type` | Service type | `LoadBalancer`
+| `service.port` | Service port | `80`
+| `ingress.enabled` | Enable ingress controller resource | `false`
+| `ingress.annotations` | Annotations for the ingress record | `[]`
+| `ingress.hosts` | Hostname to Pub/Sub Emulator for Kafka installation | `[emulator.local]`
+| `ingress.path` | Path within the url structure | `/`
+| `ingress.tls ` | TLS configuration | `[]`
+| `livenessProbe.tcpSocket.port`| Liveness probe target port | `8080`
+| `livenessProbe.initialDelaySeconds`| Liveness probe initial delay | `5`
+| `readinessProbe.tcpSocket.port`| readiness probe target port | `8080`
+| `readinessProbe.initialDelaySeconds`| readiness probe initial delay | `5`
+| `emulatorConfig.server.port` | Port for the Emulator to listen on | `8080`
+| `emulatorConfig.kafka.bootstrapServers` | Kafka bootstrap servers | `[]`
+
+## Use the Emulator
+
+According to Google Cloud Pub/Sub
+[documentation](https://cloud.google.com/pubsub/docs/emulator), [Google Cloud
+Client
+Libraries](https://cloud.google.com/pubsub/docs/reference/libraries#gcloud-libraries)
+support using a Pub/Sub emulator by setting the `PUBSUB_EMULATOR_HOST`
+environment variable, for example, on Linux:
+```
+export PUBSUB_EMULATOR_HOST=$SERVICE_IP:$SERVICE_PORT
+./my_pubsub_application
+```
+Where `$SERVICE_IP` and `$SERVICE_PORT` depend on the way you expose the
+service outside of your Kubernetes cluster.

--- a/stable/kafka-pubsub-emulator/templates/NOTES.txt
+++ b/stable/kafka-pubsub-emulator/templates/NOTES.txt
@@ -1,0 +1,28 @@
+1. Set the PUBSUB_EMULATOR_HOST environment variable:
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kafka-pubsub-emulator.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export PUBSUB_EMULATOR_HOST=$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "kafka-pubsub-emulator.fullname" . }}'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "kafka-pubsub-emulator.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export PUBSUB_EMULATOR_HOST=$SERVICE_IP:{{ .Values.service.port }}
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "kafka-pubsub-emulator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export PUBSUB_EMULATOR_HOST=127.0.0.1:8080
+  kubectl port-forward $POD_NAME 8080:80
+
+2. Google Pub/Sub Client libraries will automatically use the address in
+the PUBSUB_EMULATOR_HOST environment variable.
+
+{{- end }}

--- a/stable/kafka-pubsub-emulator/templates/_helpers.tpl
+++ b/stable/kafka-pubsub-emulator/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-pubsub-emulator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kafka-pubsub-emulator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-pubsub-emulator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/kafka-pubsub-emulator/templates/configmap.yaml
+++ b/stable/kafka-pubsub-emulator/templates/configmap.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafka-pubsub-emulator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    helm.sh/chart: {{ include "kafka-pubsub-emulator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  application.yaml: |
+{{ toYaml .Values.emulatorConfig | indent 4 }}

--- a/stable/kafka-pubsub-emulator/templates/deployment.yaml
+++ b/stable/kafka-pubsub-emulator/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "kafka-pubsub-emulator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    helm.sh/chart: {{ include "kafka-pubsub-emulator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "kafka-pubsub-emulator.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["--configuration.location","/etc/config/application.yaml"]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml . | indent 12 }}
+          {{- end}}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml . | indent 12 }}
+          {{- end}}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/kafka-pubsub-emulator/templates/ingress.yaml
+++ b/stable/kafka-pubsub-emulator/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kafka-pubsub-emulator.fullname" . -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    helm.sh/chart: {{ include "kafka-pubsub-emulator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/stable/kafka-pubsub-emulator/templates/service.yaml
+++ b/stable/kafka-pubsub-emulator/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka-pubsub-emulator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    helm.sh/chart: {{ include "kafka-pubsub-emulator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "kafka-pubsub-emulator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/kafka-pubsub-emulator/values.yaml
+++ b/stable/kafka-pubsub-emulator/values.yaml
@@ -1,0 +1,81 @@
+# Default values for kafka-pubsub-emulator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: us.gcr.io/kafka-pubsub-emulator/kafka-pubsub-emulator
+  tag: 1.0.0.0
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: LoadBalancer
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - emulator.local
+  tls: []
+  #  - secretName: emulator-tls
+  #    hosts:
+  #      - emulator.local
+
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+
+readinessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+ #
+ # Kafka Pub/Sub Emulator configuration
+ #
+emulatorConfig:
+  server:
+    port: 8080
+  kafka:
+    bootstrapServers: []
+    consumer:
+      subscriptions:
+        - name: subscription-topic1
+          topic: topic1
+          ackDeadlineSeconds: 10
+      properties:
+        max.poll.records: 2000
+    producer:
+      topics:
+        - topic1
+      properties:
+        linger.ms: 5
+        batch.size: 1000000
+        buffer.memory: 32000000


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR introduces an Helm Chart for [Google Cloud Platform Pub/Sub Emulator for Kafka](https://github.com/GoogleCloudPlatform/kafka-pubsub-emulator). See the project GitHub page for additional details.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Variables are documented in the README.md
