### PR TITLE
Only pass POSTGRESQL_DATABASE if it is set

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 2.7.9
+version: 2.7.10
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -110,8 +110,10 @@ spec:
               name: {{ template "postgresql.fullname" . }}
             {{- end }}  
               key: postgresql-password
+        {{- if .Values.postgresqlDatabase }}
         - name: POSTGRESQL_DATABASE
           value: {{ .Values.postgresqlDatabase | quote }}
+        {{- end }}
         - name: POD_IP
           valueFrom: { fieldRef: { fieldPath: status.podIP } }
 {{- if .Values.extraEnv }}


### PR DESCRIPTION
Not specifying the postgresqlDatabase config value will create a database named ``<nil>`` but should instead do not create any database at all.

This change fixes this issue.

Running ``helm install --debug --dry-run stable/postgresql --set replication.enabled=true --name postgres`` will show the rendered template as:

       env:
        - name: POSTGRESQL_REPLICATION_MODE
          value: "master"
        - name: POSTGRESQL_REPLICATION_USER
          value: "repl_user"
        - name: POSTGRESQL_REPLICATION_PASSWORD
          valueFrom:
            secretKeyRef:
              name: raw-data-2-postgresql
              key: postgresql-replication-password
        - name: POSTGRESQL_USERNAME
          value: "postgres"
        - name: POSTGRESQL_PASSWORD
          valueFrom:
            secretKeyRef:
              name: raw-data-2-postgresql
              key: postgresql-password
        - name: POSTGRESQL_DATABASE
          value: "<nil>"
        - name: POD_IP
          valueFrom: { fieldRef: { fieldPath: status.podIP } }

Please also note that after the chart is deployed you get a ``<nil>`` named database.

	postgres=# \l
	                             List of databases
	   Name    |  Owner   | Encoding | Collate | Ctype |   Access privileges   
	-----------+----------+----------+---------+-------+-----------------------
	 <nil>     | postgres | UTF8     | C       | C     | 
	 postgres  | postgres | UTF8     | C       | C     | 
	 template0 | postgres | UTF8     | C       | C     | =c/postgres          +
	           |          |          |         |       | postgres=CTc/postgres
	 template1 | postgres | UTF8     | C       | C     | =c/postgres          +
	           |          |          |         |       | postgres=CTc/postgres
	(4 rows)

After this change, you can see POSTGRESQL_DATABASE env variable correctly set to the specified value:

 ``helm install --debug --dry-run . --set replication.enabled=true --name postgres``

       env:                                                                                                                              
        - name: POSTGRESQL_REPLICATION_MODE                                                                                               
          value: "master"                                                                                                                 
        - name: POSTGRESQL_REPLICATION_USER                                                                                               
          value: "repl_user"                                                                                                              
        - name: POSTGRESQL_REPLICATION_PASSWORD                                                                                           
          valueFrom:                                                                                                                      
            secretKeyRef:                                                                                                                 
              name: postgres-postgresql                                                                                                   
              key: postgresql-replication-password                                                                                        
        - name: POSTGRESQL_USERNAME                                                                                                       
          value: "postgres"                                                                                                               
        - name: POSTGRESQL_PASSWORD                                                                                                       
          valueFrom:                                                                                                                      
            secretKeyRef:         
              name: postgres-postgresql                              
              key: postgresql-password                               
        - name: POD_IP            
          valueFrom: { fieldRef: { fieldPath: status.podIP } }      


 ``helm install --debug --dry-run . --set replication.enabled=true,postgresqlDatabase=my-db --name postgres``

      env:
        - name: POSTGRESQL_REPLICATION_MODE
          value: "master"         
        - name: POSTGRESQL_REPLICATION_USER
          value: "repl_user"      
        - name: POSTGRESQL_REPLICATION_PASSWORD
          valueFrom:                                                 
            secretKeyRef:         
              name: postgres-postgresql
              key: postgresql-replication-password
        - name: POSTGRESQL_USERNAME
          value: "postgres"       
        - name: POSTGRESQL_PASSWORD
          valueFrom:              
            secretKeyRef:         
              name: postgres-postgresql
              key: postgresql-password                               
        - name: POSTGRESQL_DATABASE
          value: "my-db"
        - name: POD_IP
          valueFrom: { fieldRef: { fieldPath: status.podIP } }

Please note that **POSTGRESQL_DATABASE** is set after only setting the value ``postgresqlDatatabase`` config value.
