### PR TITLE
Added missing clusterrole rules for falco

### DIFF
--- a/stable/falco/CHANGELOG.md
+++ b/stable/falco/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Sysdig Falco Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.5.7
+
+* Added missing RBAC rules, authorizing `list` of `replicasets`, `daemonsets` and `deployments`
+
 ## v0.5.6
 
 * Allow extra container args

--- a/stable/falco/Chart.yaml
+++ b/stable/falco/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: falco
-version: 0.5.6
+version: 0.5.7
 appVersion: 0.13.0
 description: Sysdig Falco
 keywords:

--- a/stable/falco/templates/clusterrole.yaml
+++ b/stable/falco/templates/clusterrole.yaml
@@ -20,6 +20,9 @@ rules:
       - services
       - events
       - configmaps
+      - replicasets
+      - deployments
+      - daemonsets
     verbs:
       - get
       - list


### PR DESCRIPTION
This PR addresses some missing rules for the sysdig/falco RBAC configuration.