### PR TITLE
[proposal] adding cpanato to owners file on root

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,3 +12,4 @@ approvers:
   - mattfarina
   - davidkarlsen
   - paulczar
+  - cpanato


### PR DESCRIPTION
Looks like a regular trusted collaborator cannot add lgtm in pr that he is not part of the owners file for the specific chart.

I am helping to review PRs and offloading some chart maintainers for some time now and notice the lgtm did not work anymore for me as explained above.

I would like to propose to add myself in the owners file and then I can contribute more, I spoke with @davidkarlsen before open this PR and I think I have his support.
If the chart maintainers do not agree, no problem we can close the PR and live continue 😄 
I'm also willing to help in the CI if needed.

