### PR TITLE
nfs-client-provisioner: Allow namespacing of NFS provisioner components

### DIFF
--- a/stable/nfs-client-provisioner/Chart.yaml
+++ b/stable/nfs-client-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 3.1.0
 description: nfs-client is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-client-provisioner
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
-version: 1.2.0
+version: 1.2.1
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
 maintainers:

--- a/stable/nfs-client-provisioner/templates/deployment.yaml
+++ b/stable/nfs-client-provisioner/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "nfs-client-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "nfs-client-provisioner.name" . }}
     chart: {{ template "nfs-client-provisioner.chart" . }}

--- a/stable/nfs-client-provisioner/templates/persistentvolumeclaim.yaml
+++ b/stable/nfs-client-provisioner/templates/persistentvolumeclaim.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvc-{{ template "nfs-client-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/stable/nfs-client-provisioner/templates/podsecuritypolicy.yaml
+++ b/stable/nfs-client-provisioner/templates/podsecuritypolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "nfs-client-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "nfs-client-provisioner.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/stable/nfs-client-provisioner/templates/role.yaml
+++ b/stable/nfs-client-provisioner/templates/role.yaml
@@ -8,6 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: leader-locking-{{ template "nfs-client-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/stable/nfs-client-provisioner/templates/rolebinding.yaml
+++ b/stable/nfs-client-provisioner/templates/rolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: leader-locking-{{ template "nfs-client-provisioner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "nfs-client-provisioner.serviceAccountName" . }}

--- a/stable/nfs-client-provisioner/templates/serviceaccount.yaml
+++ b/stable/nfs-client-provisioner/templates/serviceaccount.yaml
@@ -8,4 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "nfs-client-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
If there is a need to install the NFS provisioner into a different
namespace due to permission requirements, or simply better organization,
respecting the --namespace paramter when passed to Helm would solve for
these use cases.

I left the namespace out of ClusterRole, ClusterRoleBinding,
PersistentVolume, and StorageClass because these objects do not support
namespacing within Kubernetes.

**Steps to reproduce/test**

Generate the helm template from the original master chart and my fork:
```
helm template work/kubernetes/master_charts/stable/nfs-client-provisioner --name nfs-prov-test --namespace aux-system --set storageClass.name=nfs-test --set nfs.server=192.168.1.10 --set nfs.path=/sanpath --set nfs.mountOptions='{noatime,vers=3}' > nfs-prev.yaml

helm template work/kubernetes/charts/stable/nfs-client-provisioner --name nfs-prov-test --namespace aux-system --set storageClass.name=nfs-test --set nfs.server=192.168.1.10 --set nfs.path=/sanpath --set nfs.mountOptions='{noatime,vers=3}' > nfs-namespaced.yaml
```

The only difference is the added namespace fields:
```
> git diff nfs-prev.yaml nfs-namespaced.yaml 
diff --git a/nfs-prev.yaml b/nfs-namespaced.yaml
index 0fc1eb8..37243e1 100644
--- a/nfs-prev.yaml
+++ b/nfs-namespaced.yaml
@@ -47,6 +47,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvc-nfs-prov-test-nfs-client-provisioner
+  namespace: aux-system
 spec:
   accessModes:
     - ReadWriteOnce
@@ -71,6 +72,7 @@ metadata:
     heritage: Tiller
     release: nfs-prov-test
   name: nfs-prov-test-nfs-client-provisioner
+  namespace: aux-system
 ---
 # Source: nfs-client-provisioner/templates/clusterrole.yaml
 
@@ -130,6 +132,7 @@ metadata:
     heritage: Tiller
     release: nfs-prov-test
   name: leader-locking-nfs-prov-test-nfs-client-provisioner
+  namespace: aux-system
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]
@@ -147,6 +150,7 @@ metadata:
     heritage: Tiller
     release: nfs-prov-test
   name: leader-locking-nfs-prov-test-nfs-client-provisioner
+  namespace: aux-system
 subjects:
   - kind: ServiceAccount
     name: nfs-prov-test-nfs-client-provisioner
@@ -162,6 +166,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nfs-prov-test-nfs-client-provisioner
+  namespace: aux-system
   labels:
     app: nfs-client-provisioner
     chart: nfs-client-provisioner-1.2.0
```

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

It allows the components of the NFS client provisioner to be namespaced.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
