### PR TITLE
datadog cluster agent trigger deployment when secrets updated

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.12.0
+version: 1.13.0
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -18,6 +18,13 @@ spec:
       labels:
         app: {{ template "datadog.clusterAgent.fullname" . }}
       name: {{ template "datadog.clusterAgent.fullname" . }}
+      annotations:
+      {{- if not .Values.datadog.apiKeyExistingSecret }}
+        checksum/apikey-secret: {{ include (print $.Template.BasePath "/apikey-secret.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if not .Values.datadog.appKeyExistingSecret }}
+        checksum/appkey-secret: {{ include (print $.Template.BasePath "/appkey-secret.yaml") . | sha256sum }}
+      {{- end }}
     spec:
       {{- if .Values.clusterAgent.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Signed-off-by: Cristian Radu <16921579+cristian-radu@users.noreply.github.com>

#### What this PR does / why we need it:

PR adds sha-256 checksum annotations of the relevant k8s secret templates associated with the cluster-agent-deployment. This is so that any changes to these secrets (either the values they contain, or the k8s object definitions themselves) will trigger a deployment rolling-update which will cause the cluster agent pods to pick up the changes. 

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped