### PR TITLE
[stable/drone]: NOTES.txt update

### DIFF
--- a/stable/drone/Chart.yaml
+++ b/stable/drone/Chart.yaml
@@ -1,7 +1,7 @@
 name: drone
 home: https://drone.io/
 icon: https://drone.io/apple-touch-icon.png
-version: 1.7.3
+version: 1.7.4
 appVersion: 0.8.6
 description: Drone is a Continuous Delivery system built on container technology
 keywords:

--- a/stable/drone/templates/NOTES.txt
+++ b/stable/drone/templates/NOTES.txt
@@ -45,11 +45,11 @@ control provider:
 
     helm upgrade {{ .Release.Name }} \
       --reuse-values \
-      --set server.env.DRONE_PROVIDER="github" \
-      --set server.env.DRONE_GITHUB="true" \
-      --set server.env.DRONE_ORGS="my-github-org" \
-      --set server.env.DRONE_GITHUB_CLIENT="github-oauth2-client-id" \
-      --set server.envSecrets.drone-server-secrets[0]=DRONE_GITHUB_SECRET \
+      --set 'server.env.DRONE_PROVIDER="github"' \
+      --set 'server.env.DRONE_GITHUB="true"' \
+      --set 'server.env.DRONE_ORGS="my-github-org"' \
+      --set 'server.env.DRONE_GITHUB_CLIENT="github-oauth2-client-id"' \
+      --set 'server.envSecrets.drone-server-secrets[0]=DRONE_GITHUB_SECRET' \
       stable/drone
 
 Currently supported providers:


### PR DESCRIPTION
Using existing `NOTES.txt` resulted with:
`zsh: no matches found: server.envSecrets.drone-server-secrets[0]=DRONE_GITHUB_SECRET`
fixed by adding qoutes around
`--set 'server.envSecrets.drone-server-secrets[0]=DRONE_GITHUB_SECRET'`

trivial, docs, drone chart

Signed-off-by: Mark Ayers <mark@philoserf.com>