### PR TITLE
[stable/traefik] update traefik chart source location

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.55.0
+version: 1.55.1
 appVersion: 1.7.4
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:
@@ -11,7 +11,7 @@ keywords:
 home: https://traefik.io/
 sources:
 - https://github.com/containous/traefik
-- https://github.com/krancour/charts/tree/master/traefik
+- https://github.com/helm/charts/tree/master/stable/traefik
 maintainers:
 - name: krancour
   email: kent.rancourt@microsoft.com


### PR DESCRIPTION
- make the helm repo the canonical source for the chart

trivial, docs, traefik chart

Signed-off-by: Mark Ayers <mark@philoserf.com>
