### PR TITLE
Allow setting metabase's ingress path

### DIFF
--- a/stable/metabase/Chart.yaml
+++ b/stable/metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The easy, open source way for everyone in your company to ask questions
   and learn from data.
 name: metabase
-version: 0.4.3
+version: 0.4.4
 appVersion: v0.30.1
 maintainers:
 - name: pmint93

--- a/stable/metabase/README.md
+++ b/stable/metabase/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the Metabase chart and 
 | service.annotations    | Service annotations                                        | {}                |
 | ingress.enabled        | Enable ingress controller resource                         | false             |
 | ingress.hosts          | Ingress resource hostnames                                 | null              |
+| ingress.path           | Ingress path                                               | /                 |
 | ingress.labels         | Ingress labels configuration                               | null              |
 | ingress.annotations    | Ingress annotations configuration                          | null              |
 | ingress.tls            | Ingress TLS configuration                                  | null              |

--- a/stable/metabase/templates/ingress.yaml
+++ b/stable/metabase/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "metabase.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
+{{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -23,7 +24,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/stable/metabase/values.yaml
+++ b/stable/metabase/values.yaml
@@ -60,6 +60,8 @@ ingress:
   # Used to create Ingress record (should used with service.type: ClusterIP).
   hosts:
     # - metabase.domain.com
+  # The ingress path. Useful to host metabase on a subpath, such as `/metabase`.
+  path: /
   labels:
     # Used to add custom labels to the Ingress
     # Useful if for example you have multiple Ingress controllers and want your Ingress controllers to bind to specific Ingresses


### PR DESCRIPTION
Signed-off-by: Kevin Pullin <kevin.pullin@gmail.com>

#### What this PR does / why we need it:

This PR allows for configuring the ingress path of the metabase ingress definition.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [X] Variables are documented in the README.md

/CC @pmint93 