### PR TITLE
Add configurable `podAnnotations` to unifi chart

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.9.29
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.2.1
+version: 0.2.2
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -88,6 +88,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `nodeSelector`             | Node labels for pod assignment | `{}` |
 | `tolerations`              | Toleration labels for pod assignment | `[]` |
 | `affinity`                 | Affinity settings for pod assignment | `{}` |
+| `podAnnotations`           | Key-value pairs to add as pod annotations | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/unifi/templates/deployment.yaml
+++ b/stable/unifi/templates/deployment.yaml
@@ -18,6 +18,12 @@ spec:
       labels:
         app: {{ template "unifi.name" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -151,3 +151,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podAnnotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Use case is using `ark` + `restic` to take backups which requires pods
with persistent data to be annotated like:
```
kubectl annotate pod unifi-55f6dcc44c-khbrk backup.ark.heptio.com/backup-volumes=unifi-data
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
