### PR TITLE
[stable/postgresql] fix broken usage of existing PVC (#9832)

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 3.1.3
+version: 3.1.4
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -11,8 +11,6 @@ metadata:
 spec:
   serviceName: {{ template "postgresql.fullname" . }}-headless
   replicas: {{ .Values.replication.slaveReplicas }}
-  updateStrategy:
-    type: RollingUpdate
   selector:
     matchLabels:
       app: {{ template "postgresql.name" . }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -151,10 +151,8 @@ spec:
         volumeMounts:
         - name: custom-init-scripts
           mountPath: /docker-entrypoint-initdb.d
-        {{- if .Values.persistence.enabled }}
         - name: data
           mountPath: {{ .Values.persistence.mountPath }}
-        {{ end }}
         {{ if or (.Files.Glob "files/postgresql.conf") .Values.postgresqlConfiguration }}
         - name: postgresql-config
           mountPath: /opt/bitnami/postgresql/conf/postgresql.conf
@@ -225,6 +223,9 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}
+{{- else if not .Values.persistence.enabled }}
+      - name: data
+        emptyDir: {}
 {{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   serviceName: {{ template "postgresql.fullname" . }}-headless
   replicas: 1
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.updateStrategy.type }}
   selector:
     matchLabels:
       app: {{ template "postgresql.name" . }}
@@ -252,5 +252,3 @@ spec:
       {{- end }}
       {{- end }}
 {{- end }}
-  updateStrategy:
-    type: {{ .Values.updateStrategy.type }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -213,11 +213,6 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
-      {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
-      - name: {{ .Values.persistence.existingClaim }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.persistence.existingClaim }}
-      {{- end }}
       {{ if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration }}
       - name: postgresql-config
         configMap:
@@ -226,7 +221,11 @@ spec:
       - name: custom-init-scripts
         configMap:
           name: {{ template "postgresql.fullname" . }}-init-scripts
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim }}
+{{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -251,9 +250,6 @@ spec:
         storageClassName: "{{ .Values.persistence.storageClass }}"
       {{- end }}
       {{- end }}
-{{- else }}
-      - name: data
-        emptyDir: {}
 {{- end }}
   updateStrategy:
     type: {{ .Values.updateStrategy.type }}


### PR DESCRIPTION
#### What this PR does / why we need it:
- postgresql could not use existing PVCs

#### Which issue this PR fixes
- fixes #9832 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (all variables remain unchanged)

#### Notes

-  [Results of test runs attached](https://github.com/helm/charts/files/2660839/tests.zip) to see the diff between 3.0.0 and 3.0.1.
- Tested.

Commandline used for creating the test files:

```bash
for a in 1 2 3 ; do 
    helm install . -n unittest --dry-run --debug -f v$a.yaml \
        | sed -n '/statefulset.yaml/,/---/p' \
        | yq -t r - > v${a}_fix.yaml ; done
```