### PR TITLE
Add configurable `podAnnotations` to openvpn chart

### DIFF
--- a/stable/openvpn/Chart.yaml
+++ b/stable/openvpn/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to install an openvpn server inside a kubernetes clust
   generation is also part of the deployment, and this chart will generate client keys
   as needed.
 name: openvpn
-version: 3.10.0
+version: 3.11.0
 appVersion: 1.1.0
 maintainers:
 - name: jfelten

--- a/stable/openvpn/README.md
+++ b/stable/openvpn/README.md
@@ -73,6 +73,7 @@ Parameter | Description | Default
 `persistence.storageClass`     | Storage class of backing PVC                                         | `nil`
 `persistence.accessMode`       | Use volume as ReadOnly or ReadWrite                                  | `ReadWriteOnce`
 `persistence.size`             | Size of data volume                                                  | `2M`
+`podAnnotations`               | Key-value pairs to add as pod annotations                            | `{}`
 `openvpn.OVPN_NETWORK`         | Network allocated for openvpn clients                                | `10.240.0.0`
 `openvpn.OVPN_SUBNET`          | Network subnet allocated for openvpn                                 | `255.255.0.0`
 `openvpn.OVPN_PROTO`           | Protocol used by openvpn tcp or udp                                  | `tcp`

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -25,9 +25,7 @@ spec:
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/config-openvpn.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}
-          {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
-          {{- end }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
       containers:

--- a/stable/openvpn/templates/openvpn-deployment.yaml
+++ b/stable/openvpn/templates/openvpn-deployment.yaml
@@ -24,6 +24,11 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print .Template.BasePath "/config-openvpn.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+          {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/stable/openvpn/values.yaml
+++ b/stable/openvpn/values.yaml
@@ -26,6 +26,10 @@ service:
   # annotations:
   #   external-dns.alpha.kubernetes.io/hostname: vpn.example.com
   annotations: {}
+## Here annotations can be added to the openvpn pod
+# podAnnotations:
+#   backup.ark.heptio.com/backup-volumes: certs
+podAnnotations: {}
 
 resources:
   limits:


### PR DESCRIPTION
#### What this PR does / why we need it:

Use case is using `ark` + `restic` to take backups which requires pods
with persistent data to be annotated like:
```
kubectl annotate pod openvpn-6cff5449-wl48k backup.ark.heptio.com/backup-volumes=certs
```

Signed-off-by: Lyle Franklin <lylejfranklin@gmail.com>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
