### PR TITLE
move datasources to init container.

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.26.1
+version: 2.0.0
 appVersion: 5.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -122,7 +122,7 @@ data:
 
 ## Sidecar for datasources
 
-If the parameter `sidecar.datasources.enabled` is set, a sidecar container is deployed in the grafana pod. This container watches all config maps in the cluster and filters out the ones with a label as defined in `sidecar.datasources.label`. The files defined in those configmaps are written to a folder and accessed by grafana on startup. Using these yaml files, the data sources in grafana can be modified.
+If the parameter `sidecar.datasources.enabled` is set, an init container is deployed in the grafana pod. This container lists all config maps in the cluster and filters out the ones with a label as defined in `sidecar.datasources.label`. The files defined in those configmaps are written to a folder and accessed by grafana on startup. Using these yaml files, the data sources in grafana can be imported. The configmaps must be created before `helm install` so that the datasources init container can list the configmaps.
 
 Example datasource config adapted from [Grafana](http://docs.grafana.org/administration/provisioning/#example-datasource-config-file):
 ```

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-{{- if ( or .Values.persistence.enabled .Values.dashboards ) }}
+{{- if ( or .Values.persistence.enabled .Values.dashboards .Values.sidecar.datasources.enabled) }}
       initContainers:
 {{- end }}
 {{- if ( and .Values.persistence.enabled .Values.persistence.initChownData ) }}
@@ -80,6 +80,27 @@ spec:
               readOnly: {{ .readOnly }}
           {{- end }}
 {{- end }}
+{{- if .Values.sidecar.datasources.enabled }}
+        - name: {{ template "grafana.name" . }}-sc-datasources
+          image: "{{ .Values.sidecar.image }}"
+          imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
+          env:
+            - name: METHOD
+              value: LIST
+            - name: LABEL
+              value: "{{ .Values.sidecar.datasources.label }}"
+            - name: FOLDER
+              value: "/etc/grafana/provisioning/datasources"
+            {{- if .Values.sidecar.datasources.searchNamespace }}
+            - name: NAMESPACE
+              value: "{{ .Values.sidecar.datasources.searchNamespace }}"
+            {{- end }}
+          resources:
+{{ toYaml .Values.sidecar.resources | indent 12 }}
+          volumeMounts:
+            - name: sc-datasources-volume
+              mountPath: "/etc/grafana/provisioning/datasources"
+{{- end}}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
@@ -105,25 +126,6 @@ spec:
           volumeMounts:
             - name: sc-dashboard-volume
               mountPath: {{ .Values.sidecar.dashboards.folder | quote }}
-{{- end}}
-{{- if .Values.sidecar.datasources.enabled }}
-        - name: {{ template "grafana.name" . }}-sc-datasources
-          image: "{{ .Values.sidecar.image }}"
-          imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
-          env:
-            - name: LABEL
-              value: "{{ .Values.sidecar.datasources.label }}"
-            - name: FOLDER
-              value: "/etc/grafana/provisioning/datasources"
-            {{- if .Values.sidecar.datasources.searchNamespace }}
-            - name: NAMESPACE
-              value: "{{ .Values.sidecar.datasources.searchNamespace }}"
-            {{- end }}
-          resources:
-{{ toYaml .Values.sidecar.resources | indent 12 }}
-          volumeMounts:
-            - name: sc-datasources-volume
-              mountPath: "/etc/grafana/provisioning/datasources"
 {{- end}}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -292,7 +292,7 @@ smtp:
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
 sidecar:
-  image: kiwigrid/k8s-sidecar:0.0.6
+  image: xuxinkun/k8s-sidecar:0.0.7
   imagePullPolicy: IfNotPresent
   resources:
 #   limits:


### PR DESCRIPTION
To close pr https://github.com/helm/charts/pull/8637.
Datasources configmap must be collected before grafana startup. So, datasources container part is moved from `containers` to `init-containers`. And a new enviroment `METHOD=LIST` is added for datasource init container.
BTW, a new feature supporting `METHOD` is added for k8s-sidecar. If env METHOD is LIST, the program will just list the configmaps needed and then exit. To see more, pls visit https://github.com/xuxinkun/k8s-sidecar/tree/0.0.7  