### PR TITLE
[stable/wordpress] Bump major in the chart version because a major in the app version

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 4.0.1
+version: 5.0.0
 appVersion: 5.0.0
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png


### PR DESCRIPTION
As part of https://github.com/helm/charts/pull/9809 we should increase the major version and not the patch one.