### PR TITLE
[stable/keycloak] Expose JGROUPS port (default 7600) [#9849]

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.0.5
+version: 4.0.6
 appVersion: 4.5.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/templates/headless-service.yaml
+++ b/stable/keycloak/templates/headless-service.yaml
@@ -1,3 +1,4 @@
+{{- $highAvailability := gt (int .Values.keycloak.replicas) 1 -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,6 +16,12 @@ spec:
       port: {{ .Values.keycloak.service.port }}
       targetPort: http
       protocol: TCP
+  {{- if $highAvailability }}
+    - name: jgroups
+      port: {{ .Values.keycloak.service.jgroupsPort }}
+      targetPort: jgroups
+      protocol: TCP
+  {{- end }}
   selector:
     app: {{ template "keycloak.name" . }}
     release: "{{ .Release.Name }}"

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -92,6 +92,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          {{- if $highAvailability }}
+            - name: jgroups
+              containerPort: 7600
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /{{ .Values.keycloak.basepath }}/

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -162,6 +162,9 @@ keycloak:
 
     port: 80
 
+    # Optional: jGroups port for high availability clustering
+    jgroupsPort: 7600
+
   ## Ingress configuration.
   ## ref: https://kubernetes.io/docs/user-guide/ingress/
   ingress:


### PR DESCRIPTION
Fixes #9849, changes expose 7600 port which is used in JGroups cluster formation process. 
Chart maintainer: @unguiculus. 

After testing I found one issue. Following warning raised couple times in Keycloak log file:
```
WARN  [org.jgroups.protocols.TCP] (TQ-Bundler-7,ejb,keycloak-2) JGRP000032: keycloak-2: no physical address for keycloak-0, dropping message
WARN  [org.jgroups.protocols.TCP] (TQ-Bundler-7,ejb,keycloak-2) JGRP000032: keycloak-2: no physical address for keycloak-1, dropping message
```

Instance details (gke istio 1.0.2):
```
INFO [org.infinispan.remoting.transport.jgroups.JGroupsTransport] (MSC service thread 1-1) ISPN000079: Channel ejb local address is keycloak-2, physical addresses are [10.56.0.72:7600]

# Hostname
host 10.56.0.72
72.0.56.10.in-addr.arpa domain name pointer keycloak-2.keycloak-headless.keycloak.svc.cluster.local.
```

I don't have much expertise with JGroups but this may be related to fact that *keycloak-2* phyiscal address is for *keycloak-headless* Service (instead of keycloak-http?). Some insight from maintainer (@unguiculus) may be very helpful :).