### PR TITLE
Zeppelin: add Ingress and nodeSelector

### DIFF
--- a/stable/zeppelin/Chart.yaml
+++ b/stable/zeppelin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 name: zeppelin
-version: 1.0.2
+version: 1.1.0
 appVersion: 0.7.2
 home: https://zeppelin.apache.org/
 sources:

--- a/stable/zeppelin/Chart.yaml
+++ b/stable/zeppelin/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Web-based notebook that enables data-driven, interactive data analytics and collaborative documents with SQL, Scala and more.
 name: zeppelin
-version: 1.0.1
+version: 1.0.2
 appVersion: 0.7.2
 home: https://zeppelin.apache.org/
 sources:

--- a/stable/zeppelin/README.md
+++ b/stable/zeppelin/README.md
@@ -27,13 +27,10 @@ The following table lists the configurable parameters of the Zeppelin chart and 
 | `hadoop.configMapName`               | Name of the hadoop config map to use (must be in same namespace)  | `hadoop-config`                                            |
 | `hadoop.configPath`                  | Path in the Zeppelin image where the Hadoop config is mounted     | `/usr/hadoop-2.7.3/etc/hadoop`                             |
 | `ingress.enabled`                    | Enable ingress                                                    | `false`                                                    |
-| `ingress.certManager`                | Add annotations for cert-manager                                  | `false`                                                    |
-| `ingress.host`                       | Hostname of the Zeppelin installation                             | `zeppelin.local`                                           |
+| `ingress.annotations`                | Ingress annotations                                               | `{}`                                                       |
+| `ingress.hosts`                      | Ingress Hostnames                                                 | `["zeppelin.local"]`                                       |
 | `ingress.path`                       | Path within the URL structure                                     | `/`                                                        |
-| `ingress.tls`                        | Utilize TLS backend in ingress                                    | `false`                                                    |
-| `ingress.tlsSecretName`              | TLS secret name                                                   | `zeppelin-tls-secret`                                      |
-| `ingress.nginx.basicAuth`            | Enable NGINX ingress controller basic auth                        | `false`                                                    |
-| `ingress.nginx.authSecret`           | Secret name for NGINX basic auth                                  | `zeppelin-auth-secret`                                     |
+| `ingress.tls`                        | Ingress TLS configuration                                         | `[]`                                                       |
 | `nodeSelecor`                        | Node selector for the Zeppelin deployment                         | `{}`                                                       |
 
 ## Related charts

--- a/stable/zeppelin/README.md
+++ b/stable/zeppelin/README.md
@@ -26,6 +26,15 @@ The following table lists the configurable parameters of the Zeppelin chart and 
 | `hadoop.useConfigMap`                | Use external Hadoop configuration for Spark executors             | `false`                                                    |
 | `hadoop.configMapName`               | Name of the hadoop config map to use (must be in same namespace)  | `hadoop-config`                                            |
 | `hadoop.configPath`                  | Path in the Zeppelin image where the Hadoop config is mounted     | `/usr/hadoop-2.7.3/etc/hadoop`                             |
+| `ingress.enabled`                    | Enable ingress                                                    | `false`                                                    |
+| `ingress.certManager`                | Add annotations for cert-manager                                  | `false`                                                    |
+| `ingress.host`                       | Hostname of the Zeppelin installation                             | `zeppelin.local`                                           |
+| `ingress.path`                       | Path within the URL structure                                     | `/`                                                        |
+| `ingress.tls`                        | Utilize TLS backend in ingress                                    | `false`                                                    |
+| `ingress.tlsSecretName`              | TLS secret name                                                   | `zeppelin-tls-secret`                                      |
+| `ingress.nginx.basicAuth`            | Enable NGINX ingress controller basic auth                        | `false`                                                    |
+| `ingress.nginx.authSecret`           | Secret name for NGINX basic auth                                  | `zeppelin-auth-secret`                                     |
+| `nodeSelecor`                        | Node selector for the Zeppelin deployment                         | `{}`                                                       |
 
 ## Related charts
 

--- a/stable/zeppelin/templates/deployment.yaml
+++ b/stable/zeppelin/templates/deployment.yaml
@@ -59,3 +59,7 @@ spec:
           configMap:
             name: {{ .Values.hadoop.configMapName }}
 {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}

--- a/stable/zeppelin/templates/ingress.yaml
+++ b/stable/zeppelin/templates/ingress.yaml
@@ -1,35 +1,38 @@
 {{- if .Values.ingress.enabled }}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $fullName := printf "%s-zeppelin" .Release.Name -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-zeppelin
+  name: {{ $fullName }}
   labels:
     app: {{ template "zeppelin.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
   annotations:
-    {{- if .Values.ingress.certManager }} 
-    kubernetes.io/tls-acme: "true"
-    {{- end }}
-    {{- if .Values.ingress.nginx.basicAuth }}
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.nginx.authSecret }}
-    nginx.ingress.kubernetes.io/auth-realm: "Zeppelin - Authentication Required"
-    {{- end }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   rules:
-  - host: {{ .Values.ingress.host }}
+  {{- range .Values.ingress.hosts }}
+  - host: {{ . | quote }}
     http:
       paths:
-      - path: {{ .Values.ingress.path }}
-        backend:
-          serviceName: {{ .Release.Name }}-zeppelin
-          servicePort: 8080
-  {{- if .Values.ingress.tls }}
-  tls:
-  - secretName: {{ .Values.ingress.tlsSecretName }}
-    hosts:
-    - {{ .Values.ingress.host }}
+        - path: {{ $ingressPath }}
+          backend:
+            serviceName: {{ $fullName }}
+            servicePort: 8080
   {{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/zeppelin/templates/ingress.yaml
+++ b/stable/zeppelin/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-zeppelin
+  labels:
+    app: {{ template "zeppelin.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- if .Values.ingress.certManager }} 
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- if .Values.ingress.nginx.basicAuth }}
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.nginx.authSecret }}
+    nginx.ingress.kubernetes.io/auth-realm: "Zeppelin - Authentication Required"
+    {{- end }}
+spec:
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: {{ .Values.ingress.path }}
+        backend:
+          serviceName: {{ .Release.Name }}-zeppelin
+          servicePort: 8080
+  {{- if .Values.ingress.tls }}
+  tls:
+  - secretName: {{ .Values.ingress.tlsSecretName }}
+    hosts:
+    - {{ .Values.ingress.host }}
+  {{- end }}
+{{- end }}

--- a/stable/zeppelin/values.yaml
+++ b/stable/zeppelin/values.yaml
@@ -17,13 +17,15 @@ spark:
 
 ingress:
   enabled: false
-  certManager: false
-  host: zeppelin.local
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    # nginx.ingress.kubernetes.io/auth-secret: zeppelin-tls-secret
   path: /
-  tls: false
-  tlsSecretName: zeppelin-tls-secret
-  nginx:
-    basicAuth: false
-    authSecret: zeppelin-auth-secret
+  hosts:
+    - zeppelin.local
+  tls: []
+    # - secretName: zeppelin-tls-secret
+    #   hosts: zeppelin.local
 
 nodeSelector: {}

--- a/stable/zeppelin/values.yaml
+++ b/stable/zeppelin/values.yaml
@@ -27,4 +27,3 @@ ingress:
     authSecret: zeppelin-auth-secret
 
 nodeSelector: {}
-

--- a/stable/zeppelin/values.yaml
+++ b/stable/zeppelin/values.yaml
@@ -14,3 +14,17 @@ spark:
   driverMemory: 1g
   executorMemory: 1g
   numExecutors: 2
+
+ingress:
+  enabled: false
+  certManager: false
+  host: zeppelin.local
+  path: /
+  tls: false
+  tlsSecretName: zeppelin-tls-secret
+  nginx:
+    basicAuth: false
+    authSecret: zeppelin-auth-secret
+
+nodeSelector: {}
+


### PR DESCRIPTION
#### What this PR does / why we need it:
This adds the possibility to enable Ingress and nodeSelector for Zeppelin. The ingress resource allows to access the interface via IngressController, with TLS encryption (optionally with cert-manager) and also optionally configure NGINX basic authentication. Authenticating via shiro is more complex, but since basic auth is optional perhaps someone could add it later on. The nodeSelector allows to control where the Zeppelin server will land, this is useful for some of my use cases. For instance I have some GPU nodes in which I want Zeppelin to land in order to use Tensorflow.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
