### PR TITLE
[stable/keycloak] Control default user creation (enabled by default)

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.0.6
+version: 4.0.7
 appVersion: 4.5.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -50,6 +50,7 @@ Parameter | Description | Default
 `keycloak.image.pullPolicy` | The Keycloak image pull policy | `IfNotPresent`
 `keycloak.image.pullSecrets` | Image pull secrets | `[]`
 `keycloak.basepath` | Path keycloak is hosted at | `auth`
+`keycloak.createUser` | Create initial Keycloak admin user | `true`
 `keycloak.username` | Username for the initial Keycloak admin user | `keycloak`
 `keycloak.password` | Password for the initial Keycloak admin user. If not set, a random 10 characters password is created | `""`
 `keycloak.extraInitContainers` | Additional init containers, e. g. for providing themes, etc. Passed through the `tpl` function and thus to be configured a string | `""`

--- a/stable/keycloak/templates/keycloak-secret.yaml
+++ b/stable/keycloak/templates/keycloak-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.keycloak.createUser true }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,4 +14,5 @@ data:
   password: {{ .Values.keycloak.password | b64enc | quote }}
 {{- else }}
   password: {{ randAlphaNum 10 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/stable/keycloak/templates/statefulset.yaml
+++ b/stable/keycloak/templates/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
           command:
             - /scripts/keycloak.sh
           env:
-          {{- if .Release.IsInstall }}
+          {{- if and (eq .Values.keycloak.createUser true) (.Release.IsInstall) }}
             - name: KEYCLOAK_USER
               value: {{ .Values.keycloak.username }}
             - name: KEYCLOAK_PASSWORD

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -41,6 +41,9 @@ keycloak:
   ## Additional arguments to start command e.g. -Dkeycloak.import= to load a realm
   extraArgs: ""
 
+  ## Create initial Keycloak user
+  createUser: true
+
   ## Username for the initial Keycloak admin user
   username: keycloak
 


### PR DESCRIPTION
This commit allow to disable initial admin user account creation process for Chart *stable/keycloak*.

/assign @unguiculus


