### PR TITLE
deprecate acs-engine autoscaler as it is no longer maintained

### DIFF
--- a/stable/acs-engine-autoscaler/Chart.yaml
+++ b/stable/acs-engine-autoscaler/Chart.yaml
@@ -1,14 +1,12 @@
 apiVersion: v1
-description: Scales worker nodes within agent pools
+deprecated: true
+# acs-engine-autoscaler is deprecated. If you wish to use the autoscaler in acs-engine, refer to
+# https://github.com/kubernetes/autoscaler instead.
+description: DEPRECATED Scales worker nodes within agent pools
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: acs-engine-autoscaler
-version: 2.2.1
+version: 2.2.2
 appVersion: 2.1.1
 home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
 sources:
 - https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
-maintainers:
-- name: ritazh
-  email: ritazh@microsoft.com
-- name: wbuchwalter
-  email: wibuch@microsoft.com

--- a/stable/acs-engine-autoscaler/README.md
+++ b/stable/acs-engine-autoscaler/README.md
@@ -1,4 +1,4 @@
-# acs-engine-autoscaler
+# DEPRECATED: acs-engine-autoscaler
 
 [acs-engine-autoscaler](https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler) is a node-level autoscaler for Kubernetes for clusters created with acs-engine.
 

--- a/stable/acs-engine-autoscaler/templates/NOTES.txt
+++ b/stable/acs-engine-autoscaler/templates/NOTES.txt
@@ -1,3 +1,10 @@
+#########################
+####  DEPRECATED     ####
+#########################
+# acs-engine-autoscaler is deprecated.
+# If you wish to use the autoscaler in acs-engine, refer to
+# https://github.com/kubernetes/autoscaler instead.
+
 {{- if and .Values.acsenginecluster.resourcegroup .Values.acsenginecluster.azurespappid .Values.acsenginecluster.azurespsecret .Values.acsenginecluster.azuresptenantid .Values.acsenginecluster.kubeconfigprivatekey .Values.acsenginecluster.clientprivatekey -}}
 
 The acs-engine-autoscaler is getting provisioned in your cluster. After a few minutes, you can run the following to verify.


### PR DESCRIPTION
Acs-engine autoscaler is deprecated. Please see https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler for more details.