### PR TITLE
Features/kong ingress controller custom ingress class

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.6.5
+version: 0.6.6
 appVersion: 0.14.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -177,3 +177,4 @@ https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/custom-ty
 | image.tag        | Version of the ingress controller           | 0.2.0                                                                        |
 | readinessProbe   | Kong ingress controllers readiness probe    |                                                                              |
 | livenessProbe    | Kong ingress controllers liveness probe     |                                                                              |
+| ingressClass     | The ingress-class value for controller      | nginx

--- a/stable/kong/templates/controller-deployment.yaml
+++ b/stable/kong/templates/controller-deployment.yaml
@@ -118,6 +118,8 @@ spec:
         - --default-backend-service={{ .Release.Namespace }}/{{ template "kong.fullname" . }}-proxy
         # Service from were we extract the IP address/es to use in Ingress status
         - --publish-service={{ .Release.Namespace }}/{{ template "kong.fullname" . }}-proxy
+        # Set the ingress class
+        - --ingress-class={{ .Values.ingressController.ingressClass }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -195,3 +195,6 @@ ingressController:
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     name:
+
+  ingressClass: nginx
+

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -197,4 +197,3 @@ ingressController:
     name:
 
   ingressClass: nginx
-


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR allows the `ingress-class` value to be customized in the values.yaml. This is necessary if someone wants to deploy the kong ingress controller alongside an existing nginx ingress. (See https://github.com/Kong/kubernetes-ingress-controller/issues/166)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
