### PR TITLE
[stable/selenium] Customisable selenium probe path

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.13.0
+version: 0.14.0
 appVersion: 3.14.0
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/README.md
+++ b/stable/selenium/README.md
@@ -74,6 +74,9 @@ The following table lists the configurable parameters of the Selenium chart and 
 | `hub.ingress.path` | The path for this ingress from which to route the traffic to the selenium hub | `/` |
 | `hub.ingress.hosts` | The list hosts for which this ingress should resolve the selenium hub | `[selenium-hub.local]` |
 | `hub.ingress.tls` | The tls secret to configure ssl for this ingress | `[]` |
+| `hub.readinessTimeout` | Timeout for hub readiness probe in seconds | `1` |
+| `hub.livenessTimeout` | Timeout for hub liveness probe in seconds | `1` |
+| `hub.probePath` | Path for readiness and liveness probes to check | `/wd/hub/status` |
 | `chrome.enabled` | Schedule a chrome node pod | `false` |
 | `chrome.image` | The selenium node chrome image | `selenium/node-chrome` |
 | `chrome.tag` | The selenium node chrome tag | `3.14.0` |

--- a/stable/selenium/templates/hub-deployment.yaml
+++ b/stable/selenium/templates/hub-deployment.yaml
@@ -32,14 +32,14 @@ spec:
               name: http
           livenessProbe:
             httpGet:
-              path: /wd/hub/status
+              path: {{ .Values.hub.probePath }}
               port: {{ .Values.hub.port }}
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: {{ .Values.hub.livenessTimeout }}
           readinessProbe:
             httpGet:
-              path: /wd/hub/status
+              path: {{ .Values.hub.probePath }}
               port: {{ .Values.hub.port }}
             initialDelaySeconds: {{ .Values.hub.readinessDelay }}
             timeoutSeconds: {{ .Values.hub.readinessTimeout }}

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -25,14 +25,17 @@ hub:
   ## The port which the hub listens on
   port: 4444
 
-  ## Timeout for probe Hub readiness via HTTP request on Hub status
+  ## Timeout for probe Hub readiness via HTTP request on hub.probePath
   readinessTimeout: 1
 
   ## Initial delay before performing the first readinessProbe
   readinessDelay: 15
 
-  ## Timeout for probe Hub liveness via HTTP request on Hub status
+  ## Timeout for probe Hub liveness via HTTP request on hub.probePath
   livenessTimeout: 1
+
+  ## Path for checking readiness and liveness via HTTP Request
+  probePath: "/wd/hub/status"
 
   ## Set the JAVA_TOOL_OPTIONS environment variable
   ## If you find your selenium hub is OOMKilled, try adding -XX:+UseSerialGC


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Allows customising the path used for readiness and liveness probes. I'm adding this as a the current value doesn't work when using selenium V2 (the recommended endpoint is `/grid/api/hub/status`)

#### Special notes for your reviewer:
I have deployed a V2 selenium grid locally and confirmed that it does start correctly without any other changes to the chart

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
