### PR TITLE
[stable/gocd] extra volume mounts without persistence

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5.8
+* [cee475aa](https://github.com/kubernetes/charts/commit/cee475aa):
+  - Enable extra volume mounts without persistence
+
 ### 1.5.7
 * [c663a531](https://github.com/kubernetes/charts/commit/c663a531):
   - Bump up GoCD app version to 18.11.0

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.5.7
+version: 1.5.8
 appVersion: 18.11.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -26,16 +26,16 @@ spec:
         release: {{ .Release.Name | quote }}
         component: agent
     spec:
-      {{- if or .Values.agent.persistence.enabled .Values.agent.security.ssh.enabled }}
+      {{- if or .Values.agent.persistence.enabled (or .Values.agent.security.ssh.enabled .Values.agent.persistence.extraVolumes) }}
       volumes:
       {{- end }}
       {{- if .Values.agent.persistence.enabled }}
         - name: goagent-vol
           persistentVolumeClaim:
             claimName: {{ .Values.agent.persistence.existingClaim | default (printf "%s-%s" (include "gocd.fullname" .) "agent")  }}
-        {{- if ne (len .Values.agent.persistence.extraVolumes) 0 }}
+      {{- end }}
+      {{- if ne (len .Values.agent.persistence.extraVolumes) 0 }}
 {{ toYaml .Values.agent.persistence.extraVolumes | indent 8 }}
-        {{- end }}
       {{- end }}
       {{- if .Values.agent.security.ssh.enabled }}
         - name: ssh-secrets
@@ -105,7 +105,7 @@ spec:
               port: 8152
             initialDelaySeconds: {{ .Values.agent.healthCheck.initialDelaySeconds }}
           {{- end }}
-          {{- if or .Values.agent.persistence.enabled .Values.agent.security.ssh.enabled }}
+          {{- if or .Values.agent.persistence.enabled (or .Values.agent.security.ssh.enabled .Values.agent.persistence.extraVolumeMounts) }}
           volumeMounts:
           {{- end }}
           {{- if .Values.agent.persistence.enabled }}
@@ -115,9 +115,9 @@ spec:
             - name: {{ .Values.agent.persistence.name.dockerEntryPoint }}
               mountPath: /docker-entrypoint.d
               subPath: {{ .Values.agent.persistence.subpath.dockerEntryPoint }}
-            {{- if ne (len .Values.agent.persistence.extraVolumeMounts) 0 }}
+          {{- end }}
+          {{- if ne (len .Values.agent.persistence.extraVolumeMounts) 0 }}
 {{ toYaml .Values.agent.persistence.extraVolumeMounts | indent 12 }}
-            {{- end }}
           {{- end }}
           {{- if .Values.agent.security.ssh.enabled }}
             - name: ssh-secrets

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         component: server
     spec:
       serviceAccountName: {{ template "gocd.serviceAccountName" . }}
-      {{- if or .Values.server.shouldPreconfigure (or .Values.server.persistence.enabled .Values.server.security.ssh.enabled) }}
+      {{- if or .Values.server.shouldPreconfigure (or .Values.server.persistence.enabled (or .Values.server.security.ssh.enabled .Values.server.persistence.extraVolumes)) }}
       volumes:
       {{- end }}
       {{- if .Values.server.shouldPreconfigure }}
@@ -38,9 +38,9 @@ spec:
         - name: goserver-vol
           persistentVolumeClaim:
             claimName: {{ .Values.server.persistence.existingClaim | default (printf "%s-%s" (include "gocd.fullname" .) "server") }}
-        {{- if ne (len .Values.server.persistence.extraVolumes) 0 }}
+      {{- end }}
+      {{- if ne (len .Values.server.persistence.extraVolumes) 0 }}
 {{ toYaml .Values.server.persistence.extraVolumes | indent 8 }}
-        {{- end }}
       {{- end }}
       {{- if .Values.server.security.ssh.enabled }}
         - name: ssh-secrets
@@ -80,7 +80,7 @@ spec:
             initialDelaySeconds: {{ .Values.server.healthCheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.healthCheck.periodSeconds }}
             failureThreshold: {{ .Values.server.healthCheck.failureThreshold }}
-          {{- if or .Values.server.shouldPreconfigure (or .Values.server.persistence.enabled .Values.server.security.ssh.enabled) }}
+          {{- if or .Values.server.shouldPreconfigure (or .Values.server.persistence.enabled (or .Values.server.security.ssh.enabled .Values.server.persistence.extraVolumeMounts)) }}
           volumeMounts:
           {{- end }}
           {{- if .Values.server.shouldPreconfigure }}
@@ -98,9 +98,9 @@ spec:
             - name: {{ .Values.server.persistence.name.dockerEntryPoint }}
               mountPath: /docker-entrypoint.d
               subPath: {{ .Values.server.persistence.subpath.dockerEntryPoint }}
-            {{- if ne (len .Values.server.persistence.extraVolumeMounts) 0 }}
+          {{- end }}
+          {{- if ne (len .Values.server.persistence.extraVolumeMounts) 0 }}
 {{ toYaml .Values.server.persistence.extraVolumeMounts | indent 12 }}
-            {{- end }}
           {{- end }}
           {{- if .Values.server.security.ssh.enabled }}
             - name: ssh-secrets


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR makes `{server,agent}.persistence.{extraVolumes,extraVolumeMounts}` functional even if persistence is disabled. Mounting additional volumes makes sense even without persistence, for example for mounting an emptyDir docker volume into the agent when using docker-in-docker (this is actually my main motivation for this PR: I'm using the docker-in-docker gocd agent image and without mounting `/var/lib/docker` into a kubernetes volume, a docker volume is used that is apparently not tracked by the kubernetes ressource control. After some time this volume fills with images and since kubernetes doesn't realize this pod is responsible, the node sometimes just crashes).

#### Special notes for your reviewer:

@arvindsv @GaneshSPatil @varshavaradarajan One might argue that used like this, the variables `extraVolumes` and `extraVolumeMounts` should better be located at `agent.extraVolumeMounts` etc. However that would break compatibility and I think the current location still makes sense.

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
