### PR TITLE
Add /dev/shm mount to Firefox deployments

### DIFF
--- a/stable/selenium/Chart.yaml
+++ b/stable/selenium/Chart.yaml
@@ -1,5 +1,5 @@
 name: selenium
-version: 0.15.0
+version: 0.15.1
 appVersion: 3.14.0
 description: Chart for selenium grid
 keywords:

--- a/stable/selenium/templates/firefox-deployment.yaml
+++ b/stable/selenium/templates/firefox-deployment.yaml
@@ -78,10 +78,18 @@ spec:
             - name: TZ
               value: {{ .Values.firefox.timeZone | quote }}
             {{- end }}
+          volumeMounts:
+{{ if .Values.firefox.volumeMounts -}}
+{{ toYaml .Values.firefox.volumeMounts | indent 12 }}
+{{- end }}
           resources:
 {{ toYaml .Values.firefox.resources | indent 12 }}
       hostAliases:
 {{ toYaml .Values.global.hostAliases | indent 8 }}
+      volumes:
+{{ if .Values.firefox.volumes -}}
+{{ toYaml .Values.firefox.volumes | indent 8 }}
+{{- end }}
       nodeSelector:
 {{- if .Values.firefox.nodeSelector }}
 {{ toYaml .Values.firefox.nodeSelector | indent 8  }}

--- a/stable/selenium/values.yaml
+++ b/stable/selenium/values.yaml
@@ -315,6 +315,19 @@ firefox:
   ## ref: http://openjdk.java.net/groups/jmx/
   # jmxPort: 4000
 
+  ## User defined volumes
+  ## ref: https://kubernetes.io/docs/user-guide/volumes/
+  volumes:
+    ## https://github.com/kubernetes/kubernetes/pull/34928#issuecomment-277952723
+    ## https://bugzilla.mozilla.org/show_bug.cgi?id=1338771#c10
+    ## Firefox wants more than 64mb of shared memory. Docker/k8s default to 64mb.
+    - name: dshm
+      emptyDir:
+        medium: Memory
+  volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   resources:
@@ -379,6 +392,19 @@ firefoxDebug:
   ##   -Dcom.sun.management.jmxremote.ssl=false
   ## ref: http://openjdk.java.net/groups/jmx/
   # jmxPort: 4000
+
+  ## User defined volumes
+  ## ref: https://kubernetes.io/docs/user-guide/volumes/
+  volumes:
+    ## https://github.com/kubernetes/kubernetes/pull/34928#issuecomment-277952723
+    ## https://bugzilla.mozilla.org/show_bug.cgi?id=1338771#c10
+    ## Firefox wants more than 64mb of shared memory. Docker/k8s default to 64mb.
+    - name: dshm
+      emptyDir:
+        medium: Memory
+  volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
 
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Signed-off-by: Jonathan Ross Rogers <jrogers@emphasys-software.com>

#### What this PR does / why we need it:
Firefox deployment lacks /dev/shm mount.

#### Which issue this PR fixes
  - fixes #9880 
  - fixes #11679 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
