### PR TITLE
Added priority class name option in the logstash

### DIFF
--- a/stable/logstash/Chart.yaml
+++ b/stable/logstash/Chart.yaml
@@ -3,7 +3,7 @@ description: Logstash is an open source, server-side data processing pipeline
 icon: https://www.elastic.co/assets/blt86e4472872eed314/logo-elastic-logstash-lt.svg
 home: https://www.elastic.co/products/logstash
 name: logstash
-version: 1.3.0
+version: 1.4.0
 appVersion: 6.5.0
 sources:
 - https://www.docker.elastic.co

--- a/stable/logstash/README.md
+++ b/stable/logstash/README.md
@@ -91,6 +91,7 @@ The following table lists the configurable parameters of the chart and its defau
 | `ingress.hosts`                 | Ingress accepted hostnames                         | `["logstash.cluster.local"]`                     |
 | `ingress.tls`                   | Ingress TLS configuration                          | `[]`                                             |
 | `resources`                     | Pod resource requests & limits                     | `{}`                                             |
+| `priorityClassName`             | priorityClassName                                  | `nil`                                            |
 | `nodeSelector`                  | Node selector                                      | `{}`                                             |
 | `tolerations`                   | Tolerations                                        | `[]`                                             |
 | `affinity`                      | Affinity or Anti-Affinity                          | `{}`                                             |

--- a/stable/logstash/templates/statefulset.yaml
+++ b/stable/logstash/templates/statefulset.yaml
@@ -35,6 +35,9 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       securityContext:
         runAsUser: 1000
         fsGroup: 1000

--- a/stable/logstash/values.yaml
+++ b/stable/logstash/values.yaml
@@ -84,6 +84,8 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+priorityClassName: ""
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:
It adds pod priority class option to logstash, as the rest of elk stack has it.  

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
