### PR TITLE
[stable/metallb] Update readme with correct values format

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.8.2
+version: 0.8.3
 
 name: metallb
 appVersion: 0.7.3

--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -93,7 +93,7 @@ can provide it in the `config` parameter. The configuration format is
 
 ```console
 $ cat values.yaml
-config:
+configInline:
   peers:
   - peer-address: 10.0.0.1
     peer-asn: 64512


### PR DESCRIPTION
Signed-off-by: Lennart Jern <lennart.jern@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

The values format for metallb was changed in [this commit](https://github.com/helm/charts/commit/e4b0bc8e59394b5d0935638b28c0a49347695b88) but the `README.md` was not updated to reflect this change.
This PR updates the readme example with the new values format.

#### Which issue this PR fixes

I could not find an open issue for this.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
