### PR TITLE
[stable/rabbitmq-ha] Allow defintions to be overwritten in existing secret

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.8
-version: 1.14.4
+version: 1.15.0
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -220,7 +220,13 @@ $ helm install --name my-release --set existingConfigMap=true stable/rabbitmq-ha
 ### Custom Secret
 
 Similar to custom ConfigMap, `existingSecret` can be used to override the default secret.yaml provided, and
-`rabbitmqCert.existingSecret` can be used to override the default certificates.
+`rabbitmqCert.existingSecret` can be used to override the default certificates. The custom secret must provide
+the following keys: 
+
+* `rabbitmq-user`
+* `rabbitmq-password`
+* `rabbitmq-erlang-cookie`
+* `definitions.json` (the name can be altered by setting the `definitionsSource`)
 
 ### Prometheus Monitoring & Alerts
 

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -77,6 +77,7 @@ and their default values.
 | `definitions.exchanges`                        | Pre-created exchanges | `""` |
 | `definitions.bindings`                         | Pre-created bindings | `""` |
 | `definitions.policies`                         | HA policies to add to definitions.json | `""` |
+| `definitionsSource`                            | Use this key within an existing secret to reference the definitions specification | `"definitions.json"` |
 | `image.pullPolicy`                             | Image pull policy                                                                                                                                                                                     | `Always` if `image` tag is `latest`, else `IfNotPresent`   |
 | `image.repository`                             | RabbitMQ container image repository                                                                                                                                                                   | `rabbitmq`                                                 |
 | `image.tag`                                    | RabbitMQ container image tag                                                                                                                                                                          | `3.7-alpine`                                               |

--- a/stable/rabbitmq-ha/templates/secret.yaml
+++ b/stable/rabbitmq-ha/templates/secret.yaml
@@ -18,7 +18,7 @@ data:
   rabbitmq-username: {{ .Values.rabbitmqUsername | b64enc | quote }}
   rabbitmq-password: {{ .Values.rabbitmqPassword | b64enc | quote }}
   rabbitmq-erlang-cookie: {{ .Values.rabbitmqErlangCookie | default (randAlphaNum 32) | b64enc | quote }}
-  definitions.json: {{ include "rabbitmq-ha.definitions" . | b64enc | quote }}
+  {{ .Values.defintionsSource }}: {{ include "rabbitmq-ha.definitions" . | b64enc | quote }}
 {{ end }}
 {{- if and .Values.rabbitmqCert.enabled (not .Values.rabbitmqCert.existingSecret) }}
 ---

--- a/stable/rabbitmq-ha/templates/secret.yaml
+++ b/stable/rabbitmq-ha/templates/secret.yaml
@@ -18,7 +18,7 @@ data:
   rabbitmq-username: {{ .Values.rabbitmqUsername | b64enc | quote }}
   rabbitmq-password: {{ .Values.rabbitmqPassword | b64enc | quote }}
   rabbitmq-erlang-cookie: {{ .Values.rabbitmqErlangCookie | default (randAlphaNum 32) | b64enc | quote }}
-  {{ .Values.defintionsSource }}: {{ include "rabbitmq-ha.definitions" . | b64enc | quote }}
+  {{ .Values.definitionsSource }}: {{ include "rabbitmq-ha.definitions" . | b64enc | quote }}
 {{ end }}
 {{- if and .Values.rabbitmqCert.enabled (not .Values.rabbitmqCert.existingSecret) }}
 ---

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -155,11 +155,10 @@ spec:
               mountPath: /var/lib/rabbitmq
             - name: config
               mountPath: /etc/rabbitmq
-            {{- if not .Values.existingSecret }}
+              readOnly: true
             - name: definitions
               mountPath: /etc/definitions
               readOnly: true
-            {{- end }}
             {{- if .Values.rabbitmqCert.enabled }}
             - name: cert
               mountPath: /etc/cert
@@ -234,14 +233,12 @@ spec:
         - name: configmap
           configMap:
             name: {{ template "rabbitmq-ha.fullname" . }}
-        {{- if not .Values.existingSecret }}
         - name: definitions
           secret:
-            secretName: {{ template "rabbitmq-ha.fullname" . }}
+            secretName: {{ template "rabbitmq-ha.secretName" . }}
             items:
-            - key: definitions.json
+            - key: {{ .Values.definitionsSource }}
               path: definitions.json
-        {{- end }}
         {{- if .Values.rabbitmqCert.enabled }}
         - name: cert
           secret:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -155,7 +155,6 @@ spec:
               mountPath: /var/lib/rabbitmq
             - name: config
               mountPath: /etc/rabbitmq
-              readOnly: true
             - name: definitions
               mountPath: /etc/definitions
               readOnly: true

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -13,6 +13,10 @@ managementPassword: E9R3fjZm4ejFkVFE
 extraConfig: |
 #  queue_master_locator = min-masters
 
+## Definitions specification within the secret, will always be mounted
+## at /etc/definitions/defintions.json
+definitionsSource: definitions.json
+
 ## Place any additional plugins to enable in /etc/rabbitmq/enabled_plugins
 ## Ref: https://www.rabbitmq.com/plugins.html
 extraPlugins: |


### PR DESCRIPTION

#### What this PR does / why we need it:

It is currently not possible to use an existing secret and have users, vhosts, etc. configured in a `definitions.json` that uses the values from the secret.

#### Which issue this PR fixes
  - fixes #8510

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
