### PR TITLE
 [stable/postgresql] secretName in template functions

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 3.1.0
+version: 3.1.1
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -24,7 +24,7 @@ PostgreSQL can be accessed via port 5432 on the following DNS name from within y
 To get the password for "{{ .Values.postgresqlUsername }}" run:
 
     export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} 
-            {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "postgresql.fullname" . }}{{ end }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+            {{ template "postgresql.secretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
 
 To connect to your database run the following command:
 

--- a/stable/postgresql/templates/_helpers.tpl
+++ b/stable/postgresql/templates/_helpers.tpl
@@ -52,6 +52,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Generate chart secret name
+*/}}
+{{- define "postgresql.secretName" -}}
+{{ default (include "postgresql.fullname" .) .Values.existingSecret }}
+{{- end -}}
+
+{{/*
 Return the proper PostgreSQL image name
 */}}
 {{- define "postgresql.image" -}}

--- a/stable/postgresql/templates/secrets.yaml
+++ b/stable/postgresql/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "postgresql.fullname" . }}
+  name: {{ template "postgresql.secretName" . }}
   labels:
     app: {{ template "postgresql.name" . }}
     chart: {{ template "postgresql.chart" . }}

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -93,11 +93,7 @@ spec:
         - name: POSTGRESQL_REPLICATION_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "postgresql.fullname" . }}
-            {{- end }}
+              name: {{ template "postgresql.secretName" . }}
               key: postgresql-replication-password
         - name: POSTGRESQL_MASTER_HOST
           value: {{ template "postgresql.fullname" . }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -96,7 +96,7 @@ spec:
         - name: POSTGRESQL_REPLICATION_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "postgresql.fullname" . }}
+              name: {{ template "postgresql.secretName" . }}
               key: postgresql-replication-password
         {{- end }}
         - name: POSTGRESQL_USERNAME
@@ -104,11 +104,7 @@ spec:
         - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "postgresql.fullname" . }}
-            {{- end }}
+              name: {{ template "postgresql.secretName" . }}
               key: postgresql-password
         {{- if .Values.postgresqlDatabase }}
         - name: POSTGRESQL_DATABASE
@@ -176,11 +172,7 @@ spec:
         - name: DATA_SOURCE_PASS
           valueFrom:
             secretKeyRef:
-            {{- if .Values.existingSecret }}
-              name: {{ .Values.existingSecret }}
-            {{- else }}
-              name: {{ template "postgresql.fullname" . }}
-            {{- end }}
+              name: {{ template "postgresql.secretName" . }}
               key: postgresql-password
         - name: DATA_SOURCE_USER
           value: {{ .Values.postgresqlUsername }}


### PR DESCRIPTION
#### What this PR does / why we need it:
 - Use template functions to define `secretName` (this also allows parent charts to set the name dynamically)
 - Fix secret name for `POSTGRESQL_REPLICATION_PASSWORD` env var when using `existingSecret`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
