### PR TITLE
Exposed more config options

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,6 +1,6 @@
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.1.4
+version: 0.1.5
 appVersion: v1alpha1-0.5-2.4.0
 kubeVersion: ">=1.8.0-0"
 keywords:

--- a/incubator/sparkoperator/README.md
+++ b/incubator/sparkoperator/README.md
@@ -21,13 +21,22 @@ Note that you need to use the `--namespace` flag during `helm install` to specif
 
 The following table lists the configurable parameters of the Spark operator chart and their default values.
 
-| Parameter                 | Description                                           | Default                                |
-| ------------------------- | ----------------------------------------------------- | -------------------------------------- |
-| `operatorImageName`       | The name of the operator image                        | `gcr.io/spark-operator/spark-operator` |
-| `operatorVersion`         | The version of the operator to install                | `v2.4.0-v1alpha1-latest`               |
-| `sparkJobNamespace`       | K8s namespace where Spark jobs are to be deployed.    | `default`                              |
-| `enableWebhook`           | Whether to enable mutating admission webhook          | false                                   |
-| `enableMetrics`           | Whether to expose metrics to be scraped by Premetheus | true                                   |
+| Parameter                 | Description                                                  | Default                                |
+| ------------------------- | ------------------------------------------------------------ | -------------------------------------- |
+| `operatorImageName`       | The name of the operator image                               | `gcr.io/spark-operator/spark-operator` |
+| `operatorVersion`         | The version of the operator to install                       | `v2.4.0-v1alpha1-latest`               |
+| `imagePullPolicy`         | Docker image pull policy                                     | `IfNotPresent`                         |
+| `sparkJobNamespace`       | K8s namespace where Spark jobs are to be deployed            | `default`                              |
+| `enableWebhook`           | Whether to enable mutating admission webhook                 | false                                   |
+| `enableMetrics`           | Whether to expose metrics to be scraped by Premetheus        | true                                   |
+| `controllerThreads`       | Number of worker threads used by the SparkApplication controller | 10                                     |
+| `installCrds`             | Whether to install CRDs                                      | true                                   |
+| `metricsPort`             | Port for the metrics endpoint                                | 10254                                  |
+| `metricsEndpoint`         | Metrics endpoint                                             | "/metrics"                             |
+| `metricsPrefix`           | Prefix for the metrics                                       | ""                                     |
+| `namespace`               | The Kubernetes namespace to manage. Will manage custom resource objects of the managed CRD types for the whole cluster if set to empty string. | ""                                     |
+| `resyncInterval`          | Informer resync interval in seconds                          | 30                                     |
+| `webhookPort`             | Service port of the webhook server                           | 8080                                   |                                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. 
 

--- a/incubator/sparkoperator/templates/spark-operator-deployment.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-deployment.yaml
@@ -26,8 +26,8 @@ spec:
       {{- if .Values.enableMetrics }}
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "10254"
-        prometheus.io/path: "/metrics"
+        prometheus.io/port: "{{ .Values.metricsPort }}"
+        prometheus.io/path: {{ .Values.metricsEndpoint }}
       {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
@@ -53,19 +53,27 @@ spec:
         {{- end }}
         {{- if .Values.enableMetrics }}
         ports:
-          - containerPort: 10254
+          - containerPort: {{ .Values.metricsPort }}
         {{ end }}
         command: ["/usr/bin/spark-operator"]
         args:
-        - -logtostderr
+        - -v=2
         - -namespace={{ .Values.sparkJobNamespace }}
+        - -install-crds={{ .Values.installCrds }}
+        - -controller-threads={{ .Values.controllerThreads }}
+        - -resync-interval={{ .Values.resyncInterval }}
+        - -logtostderr
         {{- if .Values.enableMetrics }}
         - -enable-metrics=true
         - -metrics-labels=app_type
+        - -metrics-port={{ .Values.metricsPort }}
+        - -metrics-endpoint={{ .Values.metricsEndpoint }}
+        - -metrics-prefix={{ .Values.metricsPrefix }}
         {{- end }}
         {{- if .Values.enableWebhook }}
         - -enable-webhook=true
         - -webhook-svc-namespace={{ .Release.Namespace }}
+        - -webhook-port={{ .Values.webhookPort }}
         - -webhook-svc-name={{ include "sparkoperator.fullname" . }}-webhook
         - -webhook-config-name={{ include "sparkoperator.fullname" . }}-webhook-config
         {{- end }}

--- a/incubator/sparkoperator/values.yaml
+++ b/incubator/sparkoperator/values.yaml
@@ -1,6 +1,5 @@
 operatorImageName: gcr.io/spark-operator/spark-operator
 operatorVersion: v2.4.0-v1alpha1-latest
-
 imagePullPolicy: IfNotPresent
 
 rbac:
@@ -18,3 +17,11 @@ sparkJobNamespace: default
 
 enableWebhook: false
 enableMetrics: true
+
+controllerThreads: 10
+installCrds: true
+metricsPort: 10254
+metricsEndpoint: "/metrics"
+metricsPrefix: ""
+resyncInterval: 30
+webhookPort: 8080


### PR DESCRIPTION
This is the old PR reinstated. Also added verbosity 2 logging to show the generated spark-submit command by default in the operator pod log.