### PR TITLE
make sure init.sh works with sh in addition to bash

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.0.2
+version: 3.0.3
 appVersion: 4.0.11
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -40,21 +40,21 @@ data:
     MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
     REDIS_CONF=/data/conf/redis.conf
     SENTINEL_CONF=/data/conf/sentinel.conf
-    
+
     set -e
-    function sentinel_update(){
+    sentinel_update(){
         echo "Updating sentinel config"
         sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \n/" $SENTINEL_CONF
     }
 
-    function redis_update(){
+    redis_update(){
         echo "Updating redis config"
         echo "slaveof $1 {{ .Values.redis.port }}" >> $REDIS_CONF
     }
 
-    function setup_defaults(){
+    setup_defaults(){
         echo "Setting up defaults"
-        if [[ "$HOSTNAME" == "{{ template "redis-ha.fullname" . }}-server-0" ]]; then
+        if [ "$HOSTNAME" = "{{ template "redis-ha.fullname" . }}-server-0" ]; then
             echo "Setting this pod as the default master"
             sed -i "s/^.*slaveof.*//" $REDIS_CONF
             sentinel_update "$POD_IP"
@@ -66,17 +66,17 @@ data:
         fi
     }
 
-    function find_master(){
+    find_master(){
         echo "Attempting to find master"
-        if [[ ! `redis-cli -h $MASTER{{ if .Values.auth }} -a $AUTH{{ end }} ping` ]]; then
+        if [ ! $(redis-cli -h $MASTER{{ if .Values.auth }} -a $AUTH{{ end }} ping) ]; then
            echo "Can't ping master, attempting to force failover"
-           if redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel failover {{ .Values.redis.masterGroupName }} | grep -q 'NOGOODSLAVE' ; then 
+           if redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel failover {{ .Values.redis.masterGroupName }} | grep -q 'NOGOODSLAVE' ; then
                setup_defaults
                return 0
            fi
            sleep 10
            MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
-           if [[ "$MASTER" ]]; then
+           if [ -n "$MASTER" ]; then
                sentinel_update $MASTER
                redis_update $MASTER
            else
@@ -96,12 +96,12 @@ data:
     cp /readonly-config/redis.conf $REDIS_CONF
     cp /readonly-config/sentinel.conf $SENTINEL_CONF
 
-    if [[ "$MASTER" ]]; then
+    if [ -n "$MASTER" ]; then
         find_master
     else
         setup_defaults
     fi
-    if [[ "$AUTH" ]]; then
+    if [ -n "$AUTH" ]; then
         echo "Setting auth values"
         sed -i "s/replace-default-auth/$AUTH/" $REDIS_CONF $SENTINEL_CONF
     fi


### PR DESCRIPTION
#### What this PR does / why we need it:

init.sh had been using some syntax that does not work in sh, yet it was being invoked with sh. this makes it more posix compatible, and it works for me now.

#### Special notes for your reviewer:

I didn't know if I should bump the chart version, @ssalaues . UPDATE: ci failed, so i bumped it.