### PR TITLE
[mcrouter] - Remove hipphen causing issue and rise memcached requirement version

### DIFF
--- a/stable/mcrouter/Chart.yaml
+++ b/stable/mcrouter/Chart.yaml
@@ -1,6 +1,6 @@
 name: mcrouter
 home: https://github.com/facebook/mcrouter
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.36.0
 description: Mcrouter is a memcached protocol router for scaling memcached deployments.
 sources:

--- a/stable/mcrouter/requirements.lock
+++ b/stable/mcrouter/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: memcached
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.2.1
-digest: sha256:342fd8a36b897cdc41548e6e77941825bdecaf126ec57cf463199a807c96f2d0
-generated: 2017-09-19T15:18:34.538200001-07:00
+  version: 2.4.0
+digest: sha256:2bf9ae03113a2f233fc61b7179fe37ab939fac7f544c1a4d127c1a9607159edd
+generated: 2018-12-11T20:59:16.635607543+01:00

--- a/stable/mcrouter/requirements.yaml
+++ b/stable/mcrouter/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: memcached
-  version: 1.2.1
+  version: 2.4.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mcrouter.memcached.enabled

--- a/stable/mcrouter/templates/statefulset.yaml
+++ b/stable/mcrouter/templates/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 5
             podAffinityTerm:
-            - topologyKey: "kubernetes.io/hostname"
+              topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchLabels:
                   app:  {{ template "fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When using mcrouter with soft affinity, we got the issue describe below

#### Which issue this PR fixes
Error: release mcrouter failed: StatefulSet in version "v1beta1" cannot be handled as a StatefulSet: v1beta1.StatefulSet.Spec: v1beta1.StatefulSetSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Affinity: v1.Affinity.PodAntiAffinity: v1.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm: v1.WeightedPodAffinityTerm.PodAffinityTerm: readObjectStart: expect { or n, but found [, error found in #10 byte of ...|ityTerm":[{"labelSel|..., bigger context ...|ulingIgnoredDuringExecution":[{"podAffinityTerm":[{"labelSelector":{"matchLabels":{"app":"mcrouter-m|...

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
