### PR TITLE
[stable/concourse] makes Web probes configurable

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.2.0
+version: 3.4.0
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/README.md
+++ b/stable/concourse/README.md
@@ -73,6 +73,8 @@ The following table lists the configurable parameters of the Concourse chart and
 | `web.nameOverride` | Override the Concourse Web components name | `nil` |
 | `web.replicas` | Number of Concourse Web replicas | `1` |
 | `web.resources` | Concourse Web resource requests and limits | `{requests: {cpu: "100m", memory: "128Mi"}}` |
+| `web.readinessProbe` | Readiness Probe settings | `{"httpGet":{"path":"/api/v1/info","port":"atc"}}` |
+| `web.livenessProbe` | Liveness Probe settings | `{"failureThreshold":5,"httpGet":{"path":"/api/v1/info","port":"atc"},"initialDelaySeconds":10,"periodSeconds":15,"timeoutSeconds":3}` |
 | `web.additionalAffinities` | Additional affinities to apply to web pods. E.g: node affinity | `{}` |
 | `web.env` | Configure additional environment variables for the web containers | `[]` |
 | `web.annotations`| Concourse Web deployment annotations | `nil` |

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -894,17 +894,9 @@ spec:
               containerPort: {{ .Values.concourse.web.prometheus.bindPort }}
             {{- end }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: atc
-            initialDelaySeconds: 120
-            timeoutSeconds: 5
+{{ toYaml .Values.web.livenessProbe | indent 12 }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: atc
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
+{{ toYaml .Values.web.readinessProbe | indent 12 }}
           resources:
 {{ toYaml .Values.web.resources | indent 12 }}
           volumeMounts:

--- a/stable/concourse/values.yaml
+++ b/stable/concourse/values.yaml
@@ -650,6 +650,27 @@ web:
   ##
   replicas: 1
 
+  ## Configures the liveness probe used to determine
+  ## if the Web component is up.
+  ## Note.: if you're upgrading Concourse from one version
+  ## to another, the probe will probably fail for some time
+  ## before migrations are finished - in such situations,
+  ## either consider bumping the values set here.
+  livenessProbe:
+    failureThreshold: 5
+    httpGet:
+      path: /api/v1/info
+      port: atc
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+
+  ## Configures the readiness probes.
+  readinessProbe:
+    httpGet:
+      path: /api/v1/info
+      port: atc
+
   ## Configure resource requests and limits.
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Following the example set by the grafana chart (see [1]), this commit
turns `web` probes into configurable entities.

It also makes use of `/api/v1/info` as the default endpoint for
performing the requests against so `web` doesn't return the whole
initial page as a return value (instead, just a very small json from
`/api/v1/info`).

#### Which issue this PR fixes

#### Special notes for your reviewer:

I wondered if I should do the same for the worker, but for now I left that as not configurable given that under the next release of Concourse (soon!) those probes could get replaced by regular `httpGet` with the improvements that are planned for worker healthchecking.

I bumped a minor as it changes the default value for the initial delay (which was 120s). Please let me know how you feel about that.

thx!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
