### PR TITLE
[stable/sonarqube]Add the option to set internalPort when ClusterIP

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.10.2
+version: 0.10.3
 appVersion: 6.7.6
 keywords:
   - coverage

--- a/stable/sonarqube/templates/service.yaml
+++ b/stable/sonarqube/templates/service.yaml
@@ -15,9 +15,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.externalPort }}
-{{- if ne .Values.service.type "ClusterIP" }}
       targetPort: {{ .Values.service.internalPort }}
-{{- end }}
       protocol: TCP
       name: {{ .Values.service.name }}
   selector:


### PR DESCRIPTION
#### What this PR does / why we need it:

When service type is `ClusterIP` and `externalPort` is set to a port not equal to default `9000`, Kubernetes will set targetPort equal to externalPort. So it's require to have the option to set internalPort even with `ClusterIP`, it's necessary when someone needs to bind targetPort to something else than 9000.

#### Which issue this PR fixes

I could not find an open issue for this.

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
