### PR TITLE
Added ability to configure daemonset update strategy

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-cloudwatch
-version: 0.5.3
+version: 0.6.3
 appVersion: v0.12.43-cloudwatch
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the Fluentd Cloudwatch 
 | `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true)              | `default`                             |
 | `tolerations`                   | Add tolerations                                                           | `[]`                                  |
 | `extraVars`                     | Add pod environment variables (must be specified as a single line object) | `[]`                                  |
+| `updateStrategy`                | Define daemonset update strategy                                          | `OnDelete`                            |
 
 Starting with fluentd-kubernetes-daemonset v0.12.43-cloudwatch, the container runs as user fluentd. To be able to write pos files to the host system, you'll need to run fluentd as root. Add the following extraVars value to run as root.
 

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -85,3 +85,5 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -43,6 +43,9 @@ rbac:
 extraVars: []
 # - "{ name: NODE_NAME, valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }"
 
+updateStrategy:
+  type: OnDelete
+
 fluentdConfig: |
   <match fluent.**>
     type null


### PR DESCRIPTION
Signed-off-by: sanjevsunder <sanjev.sunder@servicerocket.com>

#### What this PR does / why we need it:
Provides the ability to configure fluentd-cloudwatch [daemonset update strategy](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy).

#### Which issue this PR fixes
None created for this.

#### Special notes for your reviewer:
@jmcarp 
@icereval 
@kenden 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
