### PR TITLE
upgrade to kube-ops-view 0.9. Uses metrics api instead of heapster

### DIFF
--- a/stable/kube-ops-view/Chart.yaml
+++ b/stable/kube-ops-view/Chart.yaml
@@ -1,6 +1,6 @@
 name: kube-ops-view
-version: 0.5.0
-appVersion: 0.8.1
+version: 0.6.0
+appVersion: 0.9
 description: Kubernetes Operational View - read-only system dashboard for multiple
   K8s clusters
 keywords:

--- a/stable/kube-ops-view/templates/clusterrole.yaml
+++ b/stable/kube-ops-view/templates/clusterrole.yaml
@@ -12,8 +12,7 @@ rules:
 - apiGroups: [""]
   resources: ["nodes", "pods"]
   verbs: ["list"]
-- apiGroups: [""]
-  resources: ["services/proxy"]
-  resourceNames: ["heapster"]
-  verbs: ["get"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["nodes", "pods"]
+  verbs: ["get", "list"]
 {{- end -}}

--- a/stable/kube-ops-view/values.yaml
+++ b/stable/kube-ops-view/values.yaml
@@ -2,7 +2,7 @@
 replicaCount: 1
 image:
   repository: hjacobs/kube-ops-view
-  tag: 0.8.1
+  tag: 0.9
   pullPolicy: IfNotPresent
 service:
   # annotations:


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>


#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

Upgrade to latest kube-ops-view, 0.9

#### Special notes for your reviewer:
This version replaces use of heapster with metrics api, hence change in role-permissions:
https://github.com/hjacobs/kube-ops-view/blob/master/deploy/auth.yaml
https://github.com/hjacobs/kube-ops-view/pull/177

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
