### PR TITLE
Ignite documentation adjustments

### DIFF
--- a/stable/ignite/Chart.yaml
+++ b/stable/ignite/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.7.0"
 description: Apache Ignite is an open-source distributed database, caching and processing platform designed to store and compute on large volumes of data across a cluster of nodes.
 name: ignite
-version: 1.0.0
+version: 1.0.1
 keywords:
 - java
 - datagrid

--- a/stable/ignite/README.md
+++ b/stable/ignite/README.md
@@ -20,12 +20,11 @@ variables. Please note that default persistence configuration is for AWS EBS.
 ```console
 helm install --name my-release \
     --set persistence.enabled=true \
-    --set persistence.size=100Gi \
-    --set wal_persistence.enabled=true \
-    --set wal_persistence.size=8Gi \
+    --set persistence.persistenceVolume.size=100Gi \
+    --set persistence.walVolume.size=8Gi \
     stable/ignite
 ```
 
 To configure persistence for other volume plugins you should edit
-`persistence.provisioner` and `persistence.provisioner_parameters` variables.
-(and the same variables for `wal_persistence` section).
+`persistence.persistenceVolume.provisioner` and `persistence.persistenceVolume.provisioner_parameters` variables.
+(and the same variables for `persistence.walVolume` section). The chart creates 2 StorageClass resources, you can read about it's configurartion [here](https://kubernetes.io/docs/concepts/storage/storage-classes/).


### PR DESCRIPTION
Update README:

- so it matches actual variables structure 
- add link to StorageClass documentation, so it's easier for users to configure persistence layer

Current README has incorrect persistence variables structure description.