### PR TITLE
[stable/chaoskube] Add pod annotations

### DIFF
--- a/stable/chaoskube/Chart.yaml
+++ b/stable/chaoskube/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: chaoskube
-version: 0.10.0
+version: 0.11.0
 appVersion: 0.10.0
 description: Chaoskube periodically kills random pods in your Kubernetes cluster.
 home: https://github.com/linki/chaoskube

--- a/stable/chaoskube/README.md
+++ b/stable/chaoskube/README.md
@@ -61,6 +61,7 @@ $ helm install stable/chaoskube --set dryRun=false
 | `tolerations`             | Toleration labels for pod assignment                | `[]`                             |
 | `affinity`                | Affinity settings for pod assignment                | `{}`                             |
 | `minimumAge`              | Set minimum pod age to filter pod by                | `0s`                             |
+| `podAnnotations`	    | Annotations for the chaoskube pod			  | `{}`			     |
 
 Setting label and namespaces selectors from the shell can be tricky but is possible (example with zsh):
 

--- a/stable/chaoskube/templates/deployment.yaml
+++ b/stable/chaoskube/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     metadata:
       labels:
 {{ include "labels.standard" . | indent 8 }}
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       containers:
         - name: {{ .Values.name }}

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -77,10 +77,7 @@ affinity: {}
   #           app: chaoskube
 
 podAnnotations: {}
-  ##  Annotations for the chaoskube pod.
-  #   
-  #   podAnnotations:
-  #      prometheus.io/scrape: "true"
-  #      prometheus.io/port: "8080"
-  #
-  #
+  ## Annotations for the chaoskube pod.
+  #  podAnnotations:
+  #    prometheus.io/scrape: "true"
+  #    prometheus.io/port: "8080"

--- a/stable/chaoskube/values.yaml
+++ b/stable/chaoskube/values.yaml
@@ -75,3 +75,12 @@ affinity: {}
   #       labelSelector:
   #         matchLabels:
   #           app: chaoskube
+
+podAnnotations: {}
+  ##  Annotations for the chaoskube pod.
+  #   
+  #   podAnnotations:
+  #      prometheus.io/scrape: "true"
+  #      prometheus.io/port: "8080"
+  #
+  #


### PR DESCRIPTION
Signed-off-by: Rahul Varghese <rahul.varghese@qlik.com>

Add the ability to specify pod annotations through
`values.yaml`.

Tested and verified that annotations are included in the existing pod.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ x] Variables are documented in the README.md
