### PR TITLE
Fixes 9925

### DIFF
--- a/stable/minecraft/Chart.yaml
+++ b/stable/minecraft/Chart.yaml
@@ -1,5 +1,5 @@
 name: minecraft
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.13.1
 home: https://minecraft.net/
 description: Minecraft server

--- a/stable/minecraft/values.yaml
+++ b/stable/minecraft/values.yaml
@@ -22,7 +22,7 @@ minecraftServer:
   # One of: LATEST, SNAPSHOT, or a specific version (ie: "1.7.9").
   version: "1.13.1"
   # This can be one of empty string, "FORGE", "SPIGOT", "BUKKIT", "PAPER", "FTB", "SPONGEVANILLA"; empty string will produce a vanilla server
-  type:
+  type: ""
   # If type is set to FORGE, this sets the version; this is ignored if forgeInstallerUrl is set
   forgeVersion:
   # If type is set to SPONGEVANILLA, this sets the version


### PR DESCRIPTION
#### What this PR does / why we need it:

The default `values.yaml` doesn't include a value for the `type`, meaning it is unset, but the comparison in `deployment.yaml` expects it to be a string. This forces it to be an empty string.

#### Which issue this PR fixes:
*fixed #9925

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
