### PR TITLE
[stable/factorio] bump factorio to 0.15.39

### DIFF
--- a/stable/factorio/Chart.yaml
+++ b/stable/factorio/Chart.yaml
@@ -10,5 +10,5 @@ icon: https://us1.factorio.com/assets/img/factorio-logo.png
 sources:
 - https://github.com/games-on-k8s/docker-factorio
 maintainers:
-- name: Greg Taylor
+- name: gtaylor
   email: gtaylor@gc-taylor.com

--- a/stable/factorio/Chart.yaml
+++ b/stable/factorio/Chart.yaml
@@ -1,6 +1,6 @@
 name: factorio
-version: 0.3.1
-appVersion: 0.14.22
+version: 0.4.0
+appVersion: 0.15.39
 description: Factorio dedicated server.
 keywords:
 - game

--- a/stable/factorio/README.md
+++ b/stable/factorio/README.md
@@ -47,11 +47,11 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```bash
 $ helm install --name my-release \
-  --set factorioServer.factorioServer=My Server,ImageTag=0.14.15 \
+  --set factorioServer.factorioServer=My Server,ImageTag=0.15.39 \
     stable/factorio
 ```
 
-The above command deploys Factorio dedicated with a server name of `My Server` and docker-factorio image version `0.14.15`.
+The above command deploys Factorio dedicated with a server name of `My Server` and docker-factorio image version `0.15.39`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 

--- a/stable/factorio/values.yaml
+++ b/stable/factorio/values.yaml
@@ -1,7 +1,7 @@
 # Factorio image version
 # ref: https://quay.io/repository/games_on_k8s/factorio?tab=tags
 image: quay.io/games_on_k8s/factorio
-imageTag: "0.14.22"
+imageTag: 0.15.39
 
 # Configure resource requests and limits
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
#### What this PR does / why we need it:
bump factorio to 0.15.39

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
