### PR TITLE
[stable/keycloak] Make test pod and configmap optional

### DIFF
--- a/stable/keycloak/Chart.yaml
+++ b/stable/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.0.6
+version: 4.0.7
 appVersion: 4.5.0.Final
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/stable/keycloak/README.md
+++ b/stable/keycloak/README.md
@@ -97,6 +97,7 @@ Parameter | Description | Default
 `postgresql.postgresUser` | The PostgreSQL user (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
 `postgresql.postgresPassword` | The PostgreSQL password (if `keycloak.persistence.deployPostgres=true`) | `""`
 `postgresql.postgresDatabase` | The PostgreSQL database (if `keycloak.persistence.deployPostgres=true`) | `keycloak`
+`test.enabled` | if `true`, the test Pod and ConfigMap are created | `true`
 `test.image.repository` | Test image repository | `unguiculus/docker-python3-phantomjs-selenium`
 `test.image.tag` | Test image tag | `v1`
 `test.image.pullPolicy` | Test image pull policy | `IfNotPresent`

--- a/stable/keycloak/templates/test/test-configmap.yaml
+++ b/stable/keycloak/templates/test/test-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -53,3 +54,4 @@ data:
     print('URLs match. Login successful.')
 
     driver.quit()
+{{- end -}}

--- a/stable/keycloak/templates/test/test-pod.yaml
+++ b/stable/keycloak/templates/test/test-pod.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -34,3 +35,4 @@ spec:
       configMap:
         name: {{ template "keycloak.fullname" . }}-test
   restartPolicy: Never
+{{- end -}}

--- a/stable/keycloak/values.yaml
+++ b/stable/keycloak/values.yaml
@@ -233,6 +233,7 @@ postgresql:
     enabled: false
 
 test:
+  enabled: true
   image:
     repository: unguiculus/docker-python3-phantomjs-selenium
     tag: v1


### PR DESCRIPTION
#### What this PR does / why we need it:
Makes the test pod and configmap optional (but still enabled by default for backwards compatibility). Currently the pod gets recreated at every helm run (because the name is randomised), which is pretty annoying.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
