### PR TITLE
CockroachDB: allow init job to connect with network policies

### DIFF
--- a/stable/cockroachdb/Chart.yaml
+++ b/stable/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 2.0.7
+version: 2.0.8
 appVersion: 2.1.2
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/stable/cockroachdb/templates/cluster-init.yaml
+++ b/stable/cockroachdb/templates/cluster-init.yaml
@@ -8,6 +8,11 @@ metadata:
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
 spec:
   template:
+{{- if and (.Values.NetworkPolicy.Enabled) (not .Values.NetworkPolicy.AllowExternal) }}
+    metadata:
+      labels:
+        {{.Release.Name}}-{{.Values.Component}}-client: "true"
+{{- end }}
     spec:
 {{- if .Values.Secure.Enabled }}
       serviceAccountName: {{ template "cockroachdb.serviceAccountName" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Sets client label on init job when NetworkPolicy.Enabled and !NetworkPolicy.AllowExternal (otherwise the init command is never issued, the init job loops forever and the cluster never starts)

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped