### PR TITLE
Metricbeat: Configurations for tolerations and nodeSelector

### DIFF
--- a/stable/metricbeat/Chart.yaml
+++ b/stable/metricbeat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with metricbeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: metricbeat
-version: 0.4.1
+version: 0.4.2
 appVersion: 6.5.1
 home: https://www.elastic.co/products/beats/metricbeat
 sources:

--- a/stable/metricbeat/README.md
+++ b/stable/metricbeat/README.md
@@ -49,9 +49,13 @@ The following table lists the configurable parameters of the metricbeat chart an
 | `daemonset.modules.<name>.config`   | The content of the modules configuration file consumed by metricbeat deployed as daemonset, which is assumed to collect metrics in each nodes. See the [metricbeat.reference.yml](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-reference-yml.html) for full details |
 | `daemonset.modules.<name>.enabled`  | If true, enable configuration | |
 | `daemonset.podAnnotations`          | Pod annotations for daemonset | |
+| `daemonset.nodeSelector`            | Pod node selector for daemonset | `{}` |
+| `daemonset.tolerations`             | Pod taint tolerations for daemonset | `[{"key": "node-role.kubernetes.io/master", "operator": "Exists", "effect": "NoSchedule"}]` |
 | `deployment.modules.<name>.config`  | The content of the modules configuration file consumed by metricbeat deployed as deployment, which is assumed to collect cluster-level metrics. See the [metricbeat.reference.yml](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-reference-yml.html) for full details ||
 | `deployment.modules.<name>.enabled` | If true, enable configuration ||
 | `deployment.podAnnotations`         | Pod annotations for deployment | |
+| `deployment.nodeSelector`           | Pod node selector for deployment | `{}` |
+| `deployment.tolerations`             | Pod taint tolerations for deployment | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/metricbeat/templates/daemonset.yaml
+++ b/stable/metricbeat/templates/daemonset.yaml
@@ -110,10 +110,14 @@ spec:
       serviceAccountName: {{ template "metricbeat.serviceAccountName" . }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+{{- if .Values.daemonset.tolerations }}
       tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
+{{ toYaml .Values.daemonset.tolerations | indent 6 }}
+{{- end }}
+{{- if .Values.daemonset.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.daemonset.nodeSelector | indent 8 }}
+{{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/stable/metricbeat/templates/deployment.yaml
+++ b/stable/metricbeat/templates/deployment.yaml
@@ -69,6 +69,14 @@ spec:
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.deployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.deployment.tolerations | indent 6 }}
+{{- end }}
+{{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+{{- end }}
       volumes:
       - name: metricbeat-config
         secret:

--- a/stable/metricbeat/values.yaml
+++ b/stable/metricbeat/values.yaml
@@ -6,6 +6,11 @@ image:
 # The instances created by daemonset retrieve most metrics from the host
 daemonset:
   podAnnotations: []
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  nodeSelector: {}
   config:
     metricbeat.config:
       modules:
@@ -61,6 +66,8 @@ daemonset:
 # The instance created by deployment retrieves metrics that are unique for the whole cluster, like Kubernetes events or kube-state-metrics
 deployment:
   podAnnotations: []
+  tolerations: []
+  nodeSelector: {}
   config:
     metricbeat.config:
       modules:


### PR DESCRIPTION
Hello @at-k @mumoshu !

I thought it would be nice to have customizable tolerations and node selectors for pods. I heavily rely on tolerations on my cluster, for example,  others may too.

#### What this PR does / why we need it:
It allows setting tolerations and node selector for metricbeat pods separately for daemonset & deployment.

#### Which issue this PR fixes
-

#### Special notes for your reviewer:
-

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
