### PR TITLE
Allow to override probes, make agent probe less strict

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.12.0
+version: 1.13.0
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -90,6 +90,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.resources.limits.cpu` | CPU resource limits             | `200m`                                    |
 | `datadog.resources.requests.memory` | Memory resource requests   | `256Mi`                                   |
 | `datadog.resources.limits.memory` | Memory resource limits       | `256Mi`                                   |
+| `datadog.livenessProbe`     | Overrides the default liveness probe | exec /probe.sh                          |
 | `daemonset.podAnnotations`  | Annotations to add to the DaemonSet's Pods | `nil`                             |
 | `daemonset.tolerations`     | List of node taints to tolerate (requires Kubernetes >= 1.6) | `nil`           |
 | `daemonset.nodeSelector`    | Node selectors                     | `nil`                                     |
@@ -120,6 +121,8 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `clusterAgent.resources.requests.memory` | Memory resource requests           | `256Mi`                                   |
 | `clusterAgent.resources.limits.memory`   | Memory resource limits             | `256Mi`                                   |
 | `clusterAgent.tolerations`               | List of node taints to tolerate    | `[]`                                      |
+| `clusterAgent.livenessProbe`             | Overrides the default liveness probe | http port 443 if external metrics enabled       |
+| `clusterAgent.readinessProbe`            | Overrides the default readiness probe | http port 443 if external metrics enabled      |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -85,18 +85,26 @@ spec:
 {{- if .Values.clusterAgent.env }}
 {{ toYaml .Values.clusterAgent.env | indent 10 }}
 {{- end }}
-        {{- if .Values.clusterAgent.metricsProvider.enabled }}
+{{- if .Values.clusterAgent.livenessProbe }}
+        livenessProbe:
+{{ toYaml .Values.clusterAgent.livenessProbe | indent 10 }}
+{{- else if .Values.clusterAgent.metricsProvider.enabled }}
         livenessProbe:
           httpGet:
             port: 443
             path: /healthz
             scheme: HTTPS
+{{- end }}
+{{- if .Values.clusterAgent.readinessProbe }}
+        readinessProbe:
+{{ toYaml .Values.clusterAgent.readinessProbe | indent 10 }}
+{{- else if .Values.clusterAgent.metricsProvider.enabled}}
         readinessProbe:
           httpGet:
             port: 443
             path: /healthz
             scheme: HTTPS
-        {{- end }}
+{{- end }}
       {{- if .Values.clusterAgent.tolerations }}
       tolerations:
 {{ toYaml .Values.clusterAgent.tolerations | indent 8 }}

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -183,12 +183,18 @@ spec:
 {{- if .Values.datadog.volumeMounts }}
 {{ toYaml .Values.datadog.volumeMounts | indent 10 }}
 {{- end }}
+{{- if .Values.datadog.livenessProbe }}
+        livenessProbe:
+{{ toYaml .Values.datadog.livenessProbe | indent 10 }}
+{{- else }}
         livenessProbe:
           exec:
             command:
             - ./probe.sh
           initialDelaySeconds: 15
           periodSeconds: 5
+          failureThreshold: 6
+{{- end }}
       volumes:
         {{- if .Values.datadog.useCriSocketVolume }}
         - hostPath:

--- a/stable/datadog/templates/deployment.yaml
+++ b/stable/datadog/templates/deployment.yaml
@@ -112,12 +112,18 @@ spec:
 {{- if .Values.datadog.volumeMounts }}
 {{ toYaml .Values.datadog.volumeMounts | indent 10 }}
 {{- end }}
+{{- if .Values.datadog.livenessProbe }}
+        livenessProbe:
+{{ toYaml .Values.datadog.livenessProbe | indent 10 }}
+{{- else }}
         livenessProbe:
           exec:
             command:
             - ./probe.sh
           initialDelaySeconds: 15
           periodSeconds: 5
+          failureThreshold: 6
+{{- end }}
       volumes:
         {{- if .Values.datadog.useCriSocketVolume }}
         - hostPath:

--- a/stable/datadog/values.yaml
+++ b/stable/datadog/values.yaml
@@ -114,6 +114,15 @@ clusterAgent:
       cpu: 200m
       memory: 256Mi
 
+  ## Override the agent's liveness probe logic from the default:
+  ## In case of issues with the probe, you can disable it with the
+  ## following values, to allow easier investigating:
+  # livenessProbe:
+  #   exec:
+  #     command: ["/bin/true"]
+  ## Override the cluster-agent's readiness probe logic from the default:
+  # readinessProbe:
+
 datadog:
   ## You'll need to set this to your Datadog API key before the agent will run.
   ## ref: https://app.datadoghq.com/account/settings#agent/kubernetes
@@ -251,6 +260,13 @@ datadog:
   ## Provide a mapping of Kubernetes Annotations to Datadog Tags
   # podAnnotationsAsTags:
   #     iam.amazonaws.com/role: kube_iamrole
+
+  ## Override the agent's liveness probe logic from the default:
+  ## In case of issues with the probe, you can disable it with the
+  ## following values, to allow easier investigating:
+  # livenessProbe:
+  #   exec:
+  #     command: ["/bin/true"]
 
   ## datadog-agent resource requests and limits
   ## Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
* Allow to override the liveness and readiness probes in the values
* The the agent's default failureThreshold to 6, to allow 45 seconds before the container is killed. 30 seconds is not enough when the agent has a lot to initialise

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
