### PR TITLE
[stable/mariadb] Avoid creating a Deployment for a test client to check connectivity with MariaDB

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.2.3
+version: 5.2.4
 appVersion: 10.1.37
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/templates/NOTES.txt
+++ b/stable/mariadb/templates/NOTES.txt
@@ -21,7 +21,7 @@ To connect to your database:
 
   1. Run a pod that you can use as a client:
 
-      kubectl run {{ template "mariadb.fullname" . }}-client --rm --tty -i --image  {{ template "mariadb.image" . }} --namespace {{ .Release.Namespace }} --command -- bash
+      kubectl run {{ template "mariadb.fullname" . }}-client --rm --tty -i --restart='Never' --image  {{ template "mariadb.image" . }} --namespace {{ .Release.Namespace }} --command -- bash
 
   2. To connect to master service (read/write):
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adapt NOTES.txt so it doesn't create a deployment for pods used to test connectivity.

More info: From `kubectl run --help | grep Never`:

> --restart='Always': The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  
> If set to 'Always' a deployment is created, if set to 'OnFailure' a job is created, if set to 'Never', a regular pod is created. For the latter two --replicas must be 1.  
> Default 'Always', for CronJobs `Never`.
