### PR TITLE
[stable/redis] Avoid creating a Deployment for a test client to check connectivity with Redis

### DIFF
--- a/stable/redis/Chart.yaml
+++ b/stable/redis/Chart.yaml
@@ -1,5 +1,5 @@
 name: redis
-version: 5.1.0
+version: 5.1.1
 appVersion: 4.0.11
 description: Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 keywords:

--- a/stable/redis/templates/NOTES.txt
+++ b/stable/redis/templates/NOTES.txt
@@ -43,7 +43,7 @@ To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run --namespace {{ .Release.Namespace }} {{ template "redis.fullname" . }}-client --rm --tty -i \
+   kubectl run --namespace {{ .Release.Namespace }} {{ template "redis.fullname" . }}-client --rm --tty -i --restart='Never' \
    {{ if .Values.usePassword }} --env REDIS_PASSWORD=$REDIS_PASSWORD \{{ end }}
    {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}--labels="{{ template "redis.name" . }}-client=true" \{{- end }}
    --image {{ template "redis.image" . }} -- bash


### PR DESCRIPTION

Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

Adapt NOTES.txt so it doesn't create a deployment for pods used to test connectivity.

More info: From `kubectl run --help | grep Never`:

> --restart='Always': The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  
> If set to 'Always' a deployment is created, if set to 'OnFailure' a job is created, if set to 'Never', a regular pod is created. For the latter two --replicas must be 1.  
> Default 'Always', for CronJobs `Never`.