### PR TITLE
Fix ingress path for anchoreApi in stable/anchore-engine

### DIFF
--- a/stable/anchore-engine/Chart.yaml
+++ b/stable/anchore-engine/Chart.yaml
@@ -1,5 +1,5 @@
 name: anchore-engine
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.3.0
 description: Anchore container analysis and policy evaluation engine service
 keywords:

--- a/stable/anchore-engine/values.yaml
+++ b/stable/anchore-engine/values.yaml
@@ -147,7 +147,7 @@ anchoreApi:
   # Used to create Ingress record for the anchore engine external API (api service)
   # (should used with service.type: ClusterIP or NodePort depending on platform)
   ingress:
-    path: /v1/*
+    path: /v1
     # You can bound on specific hostnames
     # hosts:
     #   - anchore-api.local


### PR DESCRIPTION
#### What this PR does / why we need it:
The default value of anchoreApi.ingress.path in stable/anchore-engine/values.yaml is '/v1/*' which results in a non-working Ingress entry in NGINX. Set value to '/v1'

#### Special notes for your reviewer:
Tested with: Kubernetes 1.11.5, nginx-ingress-0.30.0 

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
