### PR TITLE
[stable/prometheus-operator] Option to manage alertmanager config externally

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 0.1.30
+version: 0.1.31
 appVersion: "0.25.0"
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -191,6 +191,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `alertmanager.alertmanagerSpec.containers` | Containers allows injecting additional containers. This is meant to allow adding an authentication proxy to an Alertmanager pod. | `[]` |
 | `alertmanager.alertmanagerSpec.priorityClassName` | Priority class assigned to the Pods | `""` |
 | `alertmanager.alertmanagerSpec.additionalPeers` | AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster. | `[]` |
+| `alertmanager.alertmanagerSpec.alertmanagerConfigExternal` | Externally configure Alertmanager Secret. Alertmanager will fail to start if enabled and no secret is created. | `false` |
 
 ### Grafana
 | Parameter | Description | Default |

--- a/stable/prometheus-operator/templates/alertmanager/secret.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.alertmanager.enabled) (eq .Values.alertmanager.alertmanagerConfigExternal false))
+{{- if or (.Values.alertmanager.enabled) (eq .Values.alertmanager.alertmanagerConfigExternal false) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/prometheus-operator/templates/alertmanager/secret.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.alertmanager.enabled) (eq .Values.alertmanager.alertmanagerConfigExternal false)
+{{- if or (.Values.alertmanager.enabled) (eq .Values.alertmanager.alertmanagerConfigExternal false))
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/prometheus-operator/templates/alertmanager/secret.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.alertmanager.enabled }}
+{{- if or (.Values.alertmanager.enabled) (eq .Values.alertmanager.alertmanagerConfigExternal false)
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/prometheus-operator/templates/alertmanager/secret.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.alertmanager.enabled) (eq .Values.alertmanager.alertmanagerConfigExternal false) }}
+{{- if and (.Values.alertmanager.enabled) (eq .Values.alertmanager.alertmanagerConfigExternal false) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -63,6 +63,13 @@ alertmanager:
     minAvailable: 1
     maxUnavailable: ""
 
+
+  ## Managed Alertmanager Externally
+  ## This configuration requires you to create a secret with the same name as originally expected
+  ## {{ template "prometheus-operator.fullname" . }}-alertmanager
+
+  alertmanagerConfigExternal: false
+
   ## Alertmanager configuration directives
   ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
   ##      https://prometheus.io/webtools/alerting/routing-tree-editor/


### PR DESCRIPTION
What this PR does / why we need it:
My company needed to be able to managed alertmanager externally in a repo external to our helm configurations so that engineers inexperienced with helm could make changes more easily. I thought others could use the same ability. 

Which issue this PR fixes
Special notes for your reviewer:
Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

  [x]DCO signed
  [x]Chart Version bumped
  [x]xVariables are documented in the README.md