### PR TITLE
Add Warning Regarding Schema Registry Release Name

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.1.1
+version: 1.1.2
 appVersion: 5.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/README.md
+++ b/incubator/schema-registry/README.md
@@ -19,6 +19,14 @@ https://docs.confluent.io/current/schema-registry/docs/design.html#kafka-coordin
 ## Installing the Chart
 You can install the chart with the release name `mysr` as below.
 
+---
+**Warning:** DO NOT USE `schema-registry` AS NAME.
+
+Using `schema-registry` as the name will result in a `CrashloopBackoff` / `Error` container, as Kubernetes will inject an environment variable into each pod, `SCHEMA_REGISTRY_PORT: N`; which the Schema Registry entrypoint assumes is broken configuration and exits.
+
+---
+
+
 ```console
 $ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
 $ helm install --name mysr incubator/schema-registry


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds a warning about naming the schema registry release `schema-registry`, which will result in a broken schema registry.

This was introduced [here](https://github.com/helm/charts/commit/b7314f6205f81323f8d89dcafc260ef43ac59876#diff-6327a4355e2b9600224922433ce0191a)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
