### PR TITLE
Parameterize all images for mysql chart

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.10.2
+version: 0.10.3
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.10.3
+version: 0.11.0
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -48,6 +48,10 @@ The following table lists the configurable parameters of the MySQL chart and the
 | -------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `image`                                      | `mysql` image repository.                                                                    | `mysql`                                              |
 | `imageTag`                                   | `mysql` image tag.                                                                           | `5.7.14`                                             |
+| `busybox.image`                                    | `busybox` image repository.                                                                    | `busybox`                                            |
+| `busybox.tag`                                | `busybox` image tag.                                                                           | `latest`                                             |
+| `testFramework.image`                              | `test-framework` image repository.                                                                    | `dduportal/bats`                                            |
+| `testFramework.tag`                          | `test-framework` image tag.                                                                           | `0.4.0`                                             |
 | `imagePullPolicy`                            | Image pull policy                                                                            | `IfNotPresent`                                       |
 | `existingSecret`                             | Use Existing secret for Password details                                                     | `nil`                                                |
 | `extraVolumes`                               | Additional volumes as a string to be passed to the `tpl` function                            |                                                      |

--- a/stable/mysql/README.md
+++ b/stable/mysql/README.md
@@ -49,9 +49,9 @@ The following table lists the configurable parameters of the MySQL chart and the
 | `image`                                      | `mysql` image repository.                                                                    | `mysql`                                              |
 | `imageTag`                                   | `mysql` image tag.                                                                           | `5.7.14`                                             |
 | `busybox.image`                                    | `busybox` image repository.                                                                    | `busybox`                                            |
-| `busybox.tag`                                | `busybox` image tag.                                                                           | `latest`                                             |
+| `busybox.tag`                                | `busybox` image tag.                                                                           | `1.29.3`                                             |
 | `testFramework.image`                              | `test-framework` image repository.                                                                    | `dduportal/bats`                                            |
-| `testFramework.tag`                          | `test-framework` image tag.                                                                           | `0.4.0`                                             |
+| `testFramework.tag`                          | `test-framework` image tag.                                                                           | `0.4.0`                                              |
 | `imagePullPolicy`                            | Image pull policy                                                                            | `IfNotPresent`                                       |
 | `existingSecret`                             | Use Existing secret for Password details                                                     | `nil`                                                |
 | `extraVolumes`                               | Additional volumes as a string to be passed to the `tpl` function                            |                                                      |

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       initContainers:
       - name: "remove-lost-found"
-        image: "busybox:1.25.0"
+        image: "{{ .Values.busybox.image}}:{{ .Values.busybox.tag}}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         command:  ["rm", "-fr", "/var/lib/mysql/lost+found"]
         volumeMounts:

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       initContainers:
       - name: "remove-lost-found"
-        image: "{{ .Values.busybox.image}}:{{ .Values.busybox.tag}}"
+        image: "{{ .Values.busybox.image}}:{{ .Values.busybox.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         command:  ["rm", "-fr", "/var/lib/mysql/lost+found"]
         volumeMounts:

--- a/stable/mysql/templates/tests/test.yaml
+++ b/stable/mysql/templates/tests/test.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   initContainers:
     - name: test-framework
-      image: dduportal/bats:0.4.0
+      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag}}"
       command:
       - "bash"
       - "-c"

--- a/stable/mysql/templates/tests/test.yaml
+++ b/stable/mysql/templates/tests/test.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   initContainers:
     - name: test-framework
-      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag}}"
+      image: "{{ .Values.testFramework.image}}:{{ .Values.testFramework.tag }}"
       command:
       - "bash"
       - "-c"

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -4,6 +4,14 @@
 image: "mysql"
 imageTag: "5.7.14"
 
+busybox:
+  image: "busybox"
+  tag: "latest"
+
+testFramework:
+  image: "dduportal/bats"
+  tag: "0.4.0"
+
 ## Specify password for root user
 ##
 ## Default: random 10 character string

--- a/stable/mysql/values.yaml
+++ b/stable/mysql/values.yaml
@@ -6,7 +6,7 @@ imageTag: "5.7.14"
 
 busybox:
   image: "busybox"
-  tag: "latest"
+  tag: "1.29.3"
 
 testFramework:
   image: "dduportal/bats"


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Provide values for test-framework and busybox image to allow alternate registries to be used when this chart is used on a Kubernetes cluster that cannot pull from docker hub.

#### Which issue this PR fixes
  - fixes #9985

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ X] Chart Version bumped
- [ X] Variables are documented in the README.md