### PR TITLE
Clarify tomcat example application location

### DIFF
--- a/stable/tomcat/README.md
+++ b/stable/tomcat/README.md
@@ -23,7 +23,7 @@ To install the chart with the release name `my-release`:
 $ helm install --name my-release stable/tomcat
 ```
 
-This command deploys a tomcat dedicated server with sane defaults.
+This command deploys a tomcat dedicated server with sane defaults. Sample app located at `http://<IP>/sample`
 
 > **Tip**: List all releases using `helm list`
 


### PR DESCRIPTION
It is not obvious to the layman that the included sample tomcat war file from anawaresystems/webarchive has a built in 'hello world' located at `/sample`.  

Right now doing `helm install stable/tomcat` appears to do nothing, unless you navigate to the `/sample` page. 