### PR TITLE
Kong - Add option to enable TLS and non TLS ports at the same time

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.6.7
+version: 0.6.8
 appVersion: 0.14.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -67,15 +67,14 @@ and their default values.
 | admin.ingress.hosts            | List of ingress hosts.                                                           | `[]`                |
 | admin.ingress.path             | Ingress path.                                                                    | `/`                 |
 | admin.ingress.annotations      | Ingress annotations. See documentation for your ingress controller for details   | `{}`                |
-| proxy.useOnlyTLS               | Use only TLS for the proxy port                                                  | true                |
-| proxy.useOnlyNonTLS            | Use only non TLS for the proxy port                                              | false               |
-| proxy.useTLSAndNonTLS          | Use TLS and non TLS for the proxy port                                           | false               |
-| TLSPorts.servicePort           | Service port to use for TLS                                                      | 8443                |
-| TLSPorts.containerPort         | Container port to use for TLS                                                    | 8443                |
-| TLSPorts.nodePort              | NodePort to use for TLS                                                          | 32443               |
-| nonTLSPorts.servicePort        | Service port to use for non TLS                                                  | 8000                |
-| nonTLSPorts.containerPort      | Container port to use for non TLS                                                | 8000                |
-| nonTLSPorts.nodePort           | NodePort to use for nont TLS                                                     | 32000               |
+| proxy.http.enabled             | Enables http on the proxy                                                        | false               |
+| proxy.http.servicePort         | Service port to use for http                                                     | 8000                |
+| proxy.http.containerPort       | Container port to use for http                                                   | 8000                |
+| proxy.http.nodePort            | Node port to use for http                                                        | 32080               |
+| proxy.tls.enabled              | Enables TLS on the proxy                                                         | true                |
+| proxy.tls.enableTlsOffload     | Used when the cloud loadbalancer should offload TLS                              | 8443                |
+| proxy.tls.containerPort        | Container port to use for TLS                                                    | 8443                |
+| proxy.tls.nodePort             | Node port to use for TLS                                                         | 32443               |
 | proxy.type                     | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                     | `NodePort`          |
 | proxy.loadBalancerSourceRanges | Limit proxy access to CIDRs if set and service type is `LoadBalancer`            | `[]`                |
 | proxy.loadBalancerIP           | To reuse an existing ingress static IP for the admin service                     |                     |

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -182,3 +182,45 @@ https://github.com/Kong/kubernetes-ingress-controller/blob/master/docs/custom-ty
 | readinessProbe   | Kong ingress controllers readiness probe    |                                                                              |
 | livenessProbe    | Kong ingress controllers liveness probe     |                                                                              |
 | ingressClass     | The ingress-class value for controller      | nginx
+
+### AWS
+
+#### Offload TLS on the ELB
+
+This describes a method to offload the TLS termination at the ELB and forward non encrypted
+payload onto Kong.
+
+Topology:
+```
+Internet <---> (SSL/443/HTTPS) ELB (offloads SSL/HTTP) <----> (HTTP) Kong (HTTP) <----> (HTTP) pod
+               (80/HTTP)
+```
+
+Settings to update:
+```
+proxy:
+  # If you want to specify annotations for the proxy service, uncomment the following
+  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:xxxxxxxxxx:certificate/xxxxxxxxx
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+
+  http:
+    enabled: true
+    servicePort: 80
+    containerPort: 8000
+
+  tls:
+    enabled: true
+    enableTlsOffload: true
+    servicePort: 443
+```
+
+To create an internal ELB instead add the following annotation:
+```
+service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+```
+
+The ELB will listen on port 80 and 443 external to the cluster.

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -67,10 +67,15 @@ and their default values.
 | admin.ingress.hosts            | List of ingress hosts.                                                           | `[]`                |
 | admin.ingress.path             | Ingress path.                                                                    | `/`                 |
 | admin.ingress.annotations      | Ingress annotations. See documentation for your ingress controller for details   | `{}`                |
-| proxy.useTLS                   | Secure Proxy traffic                                                             | `true`              |
-| proxy.servicePort              | TCP port on which the Kong Proxy Service is exposed                              | `8443`              |
-| proxy.containerPort            | TCP port on which the Kong app listens for Proxy traffic                         | `8443`              |
-| proxy.nodePort                 | Node port when service type is `NodePort`                                        |                     |
+| proxy.useOnlyTLS               | Use only TLS for the proxy port                                                  | true                |
+| proxy.useOnlyNonTLS            | Use only non TLS for the proxy port                                              | false               |
+| proxy.useTLSAndNonTLS          | Use TLS and non TLS for the proxy port                                           | false               |
+| TLSPorts.servicePort           | Service port to use for TLS                                                      | 8443                |
+| TLSPorts.containerPort         | Container port to use for TLS                                                    | 8443                |
+| TLSPorts.nodePort              | NodePort to use for TLS                                                          | 32443               |
+| nonTLSPorts.servicePort        | Service port to use for non TLS                                                  | 8000                |
+| nonTLSPorts.containerPort      | Container port to use for non TLS                                                | 8000                |
+| nonTLSPorts.nodePort           | NodePort to use for nont TLS                                                     | 32000               |
 | proxy.type                     | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                     | `NodePort`          |
 | proxy.loadBalancerSourceRanges | Limit proxy access to CIDRs if set and service type is `LoadBalancer`            | `[]`                |
 | proxy.loadBalancerIP           | To reuse an existing ingress static IP for the admin service                     |                     |

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -33,3 +33,19 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the KONG_PROXY_LISTEN value string
+*/}}
+{{- define "kong.kongProxyListenValue" -}}
+{{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled -}}
+   0.0.0.0:{{ .Values.proxy.http.containerPort }},0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl
+{{ else }}
+{{- if .Values.proxy.http.enabled -}}
+   0.0.0.0:{{ .Values.proxy.http.containerPort }}
+{{- end -}}
+{{- if .Values.proxy.tls.enabled -}}
+   0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -38,6 +38,10 @@ Create the name of the service account to use
 Create the KONG_PROXY_LISTEN value string
 */}}
 {{- define "kong.kongProxyListenValue" -}}
+{{- if and .Values.proxy.http.enabled .Values.proxy.tls.enableTlsOffload -}}
+  0.0.0.0:{{ .Values.proxy.http.containerPort }}
+{{ else }}
+
 {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled -}}
    0.0.0.0:{{ .Values.proxy.http.containerPort }},0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl
 {{ else }}
@@ -48,4 +52,8 @@ Create the KONG_PROXY_LISTEN value string
    0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl
 {{- end -}}
 {{- end -}}
+
+{{- end }}
+
+
 {{- end }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -76,21 +76,8 @@ spec:
         - name: KONG_ADMIN_LISTEN
           value: 0.0.0.0:{{ .Values.admin.containerPort }}
         {{- end }}
-        {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled }}
         - name: KONG_PROXY_LISTEN
-          value: "0.0.0.0:{{ .Values.proxy.http.containerPort }},0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl"
-        {{ else }}
-
-        {{- if .Values.proxy.http.enabled }}
-        - name: KONG_PROXY_LISTEN
-          value: "0.0.0.0:{{ .Values.proxy.http.containerPort }}"
-        {{- end }}
-        {{- if .Values.proxy.tls.enabled }}
-        - name: KONG_PROXY_LISTEN
-          value: "0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl"
-        {{- end }}
-
-        {{- end }}
+          value: {{ template "kong.kongProxyListenValue" . }}
         - name: KONG_NGINX_DAEMON
           value: "off"
         - name: KONG_PROXY_ACCESS_LOG

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -76,17 +76,20 @@ spec:
         - name: KONG_ADMIN_LISTEN
           value: 0.0.0.0:{{ .Values.admin.containerPort }}
         {{- end }}
-        {{- if .Values.proxy.useOnlyTLS }}
+        {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled }}
         - name: KONG_PROXY_LISTEN
-          value: "0.0.0.0:{{ .Values.proxy.TLSPorts.containerPort }} ssl"
+          value: "0.0.0.0:{{ .Values.proxy.http.containerPort }},0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl"
+        {{ else }}
+
+        {{- if .Values.proxy.http.enabled }}
+        - name: KONG_PROXY_LISTEN
+          value: "0.0.0.0:{{ .Values.proxy.http.containerPort }}"
         {{- end }}
-        {{- if .Values.proxy.useOnlyNonTLS }}
+        {{- if .Values.proxy.tls.enabled }}
         - name: KONG_PROXY_LISTEN
-          value: "0.0.0.0:{{ .Values.proxy.nonTLSPorts.containerPort }}"
+          value: "0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl"
         {{- end }}
-        {{- if .Values.proxy.useTLSAndNonTLS }}
-        - name: KONG_PROXY_LISTEN
-          value: "0.0.0.0:{{ .Values.proxy.nonTLSPorts.containerPort }},0.0.0.0:{{ .Values.proxy.TLSPorts.containerPort }} ssl"
+
         {{- end }}
         - name: KONG_NGINX_DAEMON
           value: "off"
@@ -121,24 +124,29 @@ spec:
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           protocol: TCP
-        {{- if .Values.proxy.useOnlyTLS }}
-        - name: proxy-tls
-          containerPort: {{ .Values.proxy.TLSPorts.containerPort }}
-          protocol: TCP
-        {{- end }}
-        {{- if .Values.proxy.useOnlyNonTLS }}
+
+        {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled }}
         - name: proxy
-          containerPort: {{ .Values.proxy.nonTLSPorts.containerPort }}
-          protocol: TCP
-        {{- end }}
-        {{- if .Values.proxy.useTLSAndNonTLS }}
-        - name: proxy
-          containerPort: {{ .Values.proxy.nonTLSPorts.containerPort }}
+          containerPort: {{ .Values.proxy.http.containerPort }}
           protocol: TCP
         - name: proxy-tls
-          containerPort: {{ .Values.proxy.TLSPorts.containerPort }}
+          containerPort: {{ .Values.proxy.tls.containerPort }}
+          protocol: TCP
+        {{ else }}
+
+        {{- if .Values.proxy.http.enabled }}
+        - name: proxy
+          containerPort: {{ .Values.proxy.http.containerPort }}
           protocol: TCP
         {{- end }}
+        {{- if .Values.proxy.tls.enabled }}
+        - name: proxy-tls
+          containerPort: {{ .Values.proxy.tls.containerPort }}
+          protocol: TCP
+        {{- end }}
+
+        {{- end }}
+
 
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -76,12 +76,17 @@ spec:
         - name: KONG_ADMIN_LISTEN
           value: 0.0.0.0:{{ .Values.admin.containerPort }}
         {{- end }}
-        {{- if .Values.proxy.useTLS }}
+        {{- if .Values.proxy.useOnlyTLS }}
         - name: KONG_PROXY_LISTEN
-          value: "0.0.0.0:{{ .Values.proxy.containerPort }} ssl"
-        {{- else }}
+          value: "0.0.0.0:{{ .Values.proxy.TLSPorts.containerPort }} ssl"
+        {{- end }}
+        {{- if .Values.proxy.useOnlyNonTLS }}
         - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:{{ .Values.proxy.containerPort }}
+          value: "0.0.0.0:{{ .Values.proxy.nonTLSPorts.containerPort }}"
+        {{- end }}
+        {{- if .Values.proxy.useTLSAndNonTLS }}
+        - name: KONG_PROXY_LISTEN
+          value: "0.0.0.0:{{ .Values.proxy.nonTLSPorts.containerPort }},0.0.0.0:{{ .Values.proxy.TLSPorts.containerPort }} ssl"
         {{- end }}
         - name: KONG_NGINX_DAEMON
           value: "off"
@@ -116,9 +121,25 @@ spec:
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           protocol: TCP
-        - name: proxy
-          containerPort: {{ .Values.proxy.containerPort }}
+        {{- if .Values.proxy.useOnlyTLS }}
+        - name: proxy-tls
+          containerPort: {{ .Values.proxy.TLSPorts.containerPort }}
           protocol: TCP
+        {{- end }}
+        {{- if .Values.proxy.useOnlyNonTLS }}
+        - name: proxy
+          containerPort: {{ .Values.proxy.nonTLSPorts.containerPort }}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.proxy.useTLSAndNonTLS }}
+        - name: proxy
+          containerPort: {{ .Values.proxy.nonTLSPorts.containerPort }}
+          protocol: TCP
+        - name: proxy-tls
+          containerPort: {{ .Values.proxy.TLSPorts.containerPort }}
+          protocol: TCP
+        {{- end }}
+
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -25,13 +25,40 @@ spec:
   {{- end }}
   {{- end }}
   ports:
-  - name: kong-proxy
-    port: {{ .Values.proxy.servicePort }}
-    targetPort: {{ .Values.proxy.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.nodePort))) }}
-    nodePort: {{ .Values.proxy.nodePort }}
+
+  {{- if .Values.proxy.useOnlyTLS }}
+  - name: kong-proxy-tls
+    port: {{ .Values.proxy.TLSPorts.servicePort }}
+    targetPort: {{ .Values.proxy.TLSPorts.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.TLSPorts.nodePort))) }}
+    nodePort: {{ .Values.proxy.TLSPorts.nodePort }}
   {{- end }}
-    protocol: TCP
+  {{- end }}
+
+  {{- if .Values.proxy.useOnlyNonTLS }}
+  - name: kong-proxy
+    port: {{ .Values.proxy.nonTLSPorts.servicePort }}
+    targetPort: {{ .Values.proxy.nonTLSPorts.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.nonTLSPorts.nodePort))) }}
+    nodePort: {{ .Values.proxy.nonTLSPorts.nodePort }}
+  {{- end }}
+  {{- end }}
+
+  {{- if .Values.proxy.useTLSAndNonTLS }}
+  - name: kong-proxy-tls
+    port: {{ .Values.proxy.TLSPorts.servicePort }}
+    targetPort: {{ .Values.proxy.TLSPorts.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.TLSPorts.nodePort))) }}
+    nodePort: {{ .Values.proxy.TLSPorts.nodePort }}
+  {{- end }}
+  - name: kong-proxy
+    port: {{ .Values.proxy.nonTLSPorts.servicePort }}
+    targetPort: {{ .Values.proxy.nonTLSPorts.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.nonTLSPorts.nodePort))) }}
+    nodePort: {{ .Values.proxy.nonTLSPorts.nodePort }}
+  {{- end }}
+  {{- end }}
+
   selector:
     app: {{ template "kong.name" . }}
     release: {{ .Release.Name }}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -25,38 +25,43 @@ spec:
   {{- end }}
   {{- end }}
   ports:
-
-  {{- if .Values.proxy.useOnlyTLS }}
-  - name: kong-proxy-tls
-    port: {{ .Values.proxy.TLSPorts.servicePort }}
-    targetPort: {{ .Values.proxy.TLSPorts.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.TLSPorts.nodePort))) }}
-    nodePort: {{ .Values.proxy.TLSPorts.nodePort }}
-  {{- end }}
-  {{- end }}
-
-  {{- if .Values.proxy.useOnlyNonTLS }}
+  {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled }}
   - name: kong-proxy
-    port: {{ .Values.proxy.nonTLSPorts.servicePort }}
-    targetPort: {{ .Values.proxy.nonTLSPorts.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.nonTLSPorts.nodePort))) }}
-    nodePort: {{ .Values.proxy.nonTLSPorts.nodePort }}
+    port: {{ .Values.proxy.http.servicePort }}
+    targetPort: {{ .Values.proxy.http.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.http.nodePort))) }}
+    nodePort: {{ .Values.proxy.http.nodePort }}
+  {{- end }}
+  - name: kong-proxy-tls
+    port: {{ .Values.proxy.tls.servicePort }}
+    targetPort: {{ .Values.proxy.tls.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.tls.nodePort))) }}
+    nodePort: {{ .Values.proxy.tls.nodePort }}
+  {{- end }}
+
+  {{ else }}
+
+  {{- if .Values.proxy.http.enabled }}
+  - name: kong-proxy
+    port: {{ .Values.proxy.http.servicePort }}
+    targetPort: {{ .Values.proxy.http.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.http.nodePort))) }}
+    nodePort: {{ .Values.proxy.http.nodePort }}
+  {{- end }}
+  {{- end }}
+  {{- if or .Values.proxy.tls.enabled .Values.proxy.tls.enableTlsOffload }}
+  - name: kong-proxy-tls
+    port: {{ .Values.proxy.tls.servicePort }}
+    {{- if .Values.proxy.tls.enableTlsOffload }}
+    targetPort: {{ .Values.proxy.http.containerPort }}
+    {{ else }}
+    targetPort: {{ .Values.proxy.tls.containerPort }}
+    {{- end }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.tls.nodePort))) }}
+    nodePort: {{ .Values.proxy.tls.nodePort }}
   {{- end }}
   {{- end }}
 
-  {{- if .Values.proxy.useTLSAndNonTLS }}
-  - name: kong-proxy-tls
-    port: {{ .Values.proxy.TLSPorts.servicePort }}
-    targetPort: {{ .Values.proxy.TLSPorts.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.TLSPorts.nodePort))) }}
-    nodePort: {{ .Values.proxy.TLSPorts.nodePort }}
-  {{- end }}
-  - name: kong-proxy
-    port: {{ .Values.proxy.nonTLSPorts.servicePort }}
-    targetPort: {{ .Values.proxy.nonTLSPorts.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.nonTLSPorts.nodePort))) }}
-    nodePort: {{ .Values.proxy.nonTLSPorts.nodePort }}
-  {{- end }}
   {{- end }}
 
   selector:

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -61,7 +61,7 @@ proxy:
   # HTTPS traffic on the proxy port
   tls:
     enabled: true
-    enableTlsOffload: true
+    enableTlsOffload: false
     servicePort: 8443
     containerPort: 8443
     nodePort: 32443

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -51,13 +51,22 @@ proxy:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # HTTPS traffic on the proxy port
-  useTLS: true
-  servicePort: 8443
-  containerPort: 8443
+  # Must only set one to true
+  useOnlyTLS: true
+  useOnlyNonTLS: false
+  useTLSAndNonTLS: false
+
+  TLSPorts:
+    servicePort: 8443
+    containerPort: 8443
+    nodePort: 32443
+  nonTLSPorts:
+    servicePort: 8000
+    containerPort: 8000
+    nodePort: 32000
+
   type: NodePort
-  # Set a nodePort which is available
-  # nodePort: 32443
+
   # Kong proxy ingress settings.
   ingress:
     # Enable/disable exposure using ingress.

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -51,6 +51,13 @@ proxy:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
+  # Example usage with the parameter "enableTlsOffload"
+  # service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+  # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+  # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:xxxxxxxxxx:certificate/xxxxxxxxx
+  # service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+  # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+
   # HTTP plain-text traffic
   http:
     enabled: false
@@ -61,6 +68,10 @@ proxy:
   # HTTPS traffic on the proxy port
   tls:
     enabled: true
+    # This will set the service to enable the tls port but pointing it to the
+    # http containerPort.  The usage of this is to create this topology:
+    # Internet <---> (SSL/443/HTTPS) ELB (offloads SSL/HTTP) <----> (HTTP) Kong (HTTP) <----> (HTTP) pod
+    enableTlsOffload: true
     servicePort: 8443
     containerPort: 8443
     nodePort: 32443

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -51,19 +51,19 @@ proxy:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # Must only set one to true
-  useOnlyTLS: true
-  useOnlyNonTLS: false
-  useTLSAndNonTLS: false
+  # HTTP plain-text traffic
+  http:
+    enabled: false
+    servicePort: 8000
+    containerPort: 8000
+    nodePort: 32080
 
-  TLSPorts:
+  # HTTPS traffic on the proxy port
+  tls:
+    enabled: true
     servicePort: 8443
     containerPort: 8443
     nodePort: 32443
-  nonTLSPorts:
-    servicePort: 8000
-    containerPort: 8000
-    nodePort: 32000
 
   type: NodePort
 

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -51,13 +51,6 @@ proxy:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # Example usage with the parameter "enableTlsOffload"
-  # service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
-  # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-  # service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:xxxxxxxxxx:certificate/xxxxxxxxx
-  # service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-  # service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-
   # HTTP plain-text traffic
   http:
     enabled: false
@@ -68,9 +61,6 @@ proxy:
   # HTTPS traffic on the proxy port
   tls:
     enabled: true
-    # This will set the service to enable the tls port but pointing it to the
-    # http containerPort.  The usage of this is to create this topology:
-    # Internet <---> (SSL/443/HTTPS) ELB (offloads SSL/HTTP) <----> (HTTP) Kong (HTTP) <----> (HTTP) pod
     enableTlsOffload: true
     servicePort: 8443
     containerPort: 8443


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds an option to enable TLS and non TLS ports at the same time.  Currently you can only enable one or the other.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
