### PR TITLE
[stable/grafana] Improve support for existing secrets

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.23.1
+version: 1.24.0
 appVersion: 5.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -80,7 +80,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sidecar.datasources.enabled`             | Enabled the cluster wide search for datasources and adds/updates/deletes them in grafana |`false`       |
 | `sidecar.datasources.label`               | Label that config maps with datasources should have to be added | `false`                               |
 | `sidecar.datasources.searchNamespace`     | If specified, the sidecar will search for datasources config-maps inside this namespace. Otherwise the namespace in which the sidecar is running will be used. It's also possible to specify ALL to search in all namespaces | `nil`                               |
-| `smtp.existingSecret`                     | The name of an existing secret containing the SMTP credentials, this must have the keys `user` and `password`. | `""` |
+| `smtp.existingSecret`                     | The name of an existing secret containing the SMTP credentials. | `""`                                  |
+| `smtp.userKey`                            | The key in the existing SMTP secret containing the username. | `"user"`                                 |
+| `smtp.passwordKey`                        | The key in the existing SMTP secret containing the password. | `"password"`                             |
+| `admin.existingSecret`                    | The name of an existing secret containing the admin credentials. | `""`                                 |
+| `admin.userKey`                           | The key in the existing admin secret containing the username. | `"admin-user"`                          |
+| `admin.passwordKey`                       | The key in the existing admin secret containing the password. | `"admin-password"`                      |
 | `rbac.create`                             | Create and use RBAC resources | `true` |
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true` |
 | `rbac.pspUseAppArmor`                     | Enforce AppArmor in created PodSecurityPolicy (requires `rbac.pspEnabled`)  | `true` |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -132,9 +132,11 @@ spec:
             - name: config
               mountPath: "/etc/grafana/grafana.ini"
               subPath: grafana.ini
+            {{- if not .Values.admin.existingSecret }}
             - name: ldap
               mountPath: "/etc/grafana/ldap.toml"
               subPath: ldap.toml
+            {{- end }}
             - name: storage
               mountPath: "/var/lib/grafana"
 {{- if .Values.persistence.subPath }}
@@ -199,13 +201,13 @@ spec:
             - name: GF_SECURITY_ADMIN_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "grafana.fullname" . }}
-                  key: admin-user
+                  name: {{ .Values.admin.existingSecret | default (include "grafana.fullname" .) }}
+                  key: {{ .Values.admin.userKey | default "admin-user" }}
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "grafana.fullname" . }}
-                  key: admin-password
+                  name: {{ .Values.admin.existingSecret | default (include "grafana.fullname" .) }}
+                  key: {{ .Values.admin.passwordKey | default "admin-password" }}
             {{- if .Values.plugins }}
             - name: GF_INSTALL_PLUGINS
               valueFrom:
@@ -218,12 +220,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.smtp.existingSecret }}
-                  key: user
+                  key: {{ .Values.smtp.userKey | default "user" }}
             - name: GF_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.smtp.existingSecret }}
-                  key: password
+                  key: {{ .Values.smtp.passwordKey | default "password" }}
             {{- end }}
 {{- range $key, $value := .Values.env }}
             - name: "{{ $key }}"
@@ -270,6 +272,7 @@ spec:
             name: {{ $name }}
           {{- end }}
         {{- end }}
+        {{- if not .Values.admin.existingSecret }}
         - name: ldap
           secret:
             {{- if .Values.ldap.existingSecret }}
@@ -280,6 +283,7 @@ spec:
             items:
               - key: ldap-toml
                 path: ldap.toml
+        {{- end }}
         - name: storage
       {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/stable/grafana/templates/secret.yaml
+++ b/stable/grafana/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.admin.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,3 +19,4 @@ data:
   {{- if not .Values.ldap.existingSecret }}
   ldap-toml: {{ .Values.ldap.config | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -118,8 +118,15 @@ persistence:
   # subPath: ""
   # existingClaim:
 
+# Administrator credentials when not using an existing secret (see below)
 adminUser: admin
 # adminPassword: strongpassword
+
+# Use an existing secret for the admin user.
+admin:
+  existingSecret: ""
+  userKey: admin-user
+  passwordKey: admin-password
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
@@ -264,8 +271,10 @@ ldap:
 ## ref: http://docs.grafana.org/installation/configuration/#smtp
 smtp:
   # `existingSecret` is a reference to an existing secret containing the smtp configuration
-  # for Grafana in keys `user` and `password`.
+  # for Grafana.
   existingSecret: ""
+  userKey: "user"
+  passwordKey: "password"
 
 ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
 ## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards


### PR DESCRIPTION
Signed-off-by: Julian Schlichtholz <jschlichtholz@salesforce.com>

#### What this PR does / why we need it:
Add support for using an already existing admin secret (similarly to the existing SMTP secret support).
Extend the existing SMTP secret support to allow custom keys.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
