### PR TITLE
[stable/nfs-server-provisioner]Change the volume type: emptyDir to hostPath

### DIFF
--- a/stable/nfs-server-provisioner/templates/statefulset.yaml
+++ b/stable/nfs-server-provisioner/templates/statefulset.yaml
@@ -85,7 +85,8 @@ spec:
 {{- if not .Values.persistence.enabled }}
       volumes:
         - name: data
-          emptyDir: {}
+          hostPath:
+            path: /mnt/nfs-server
 {{- end }}
 
 {{- if .Values.persistence.enabled }}


### PR DESCRIPTION
I use this chart to deploy nfs-server, but the volume type uses emptyDir, which will cause application instability when the nfs-server-provisioner pod is restarted.