### PR TITLE
[stable/nginx-ingress] Revert #7933 which broke upgrading

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 1.0.2
+version: 1.1.0
 appVersion: 0.21.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -18,9 +18,7 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "nginx-ingress.controller.fullname" . }}
 spec:
-{{- if .Values.controller.service.clusterIP }}
   clusterIP: "{{ .Values.controller.service.clusterIP }}"
-{{- end }}
 {{- if .Values.controller.service.externalIPs }}
   externalIPs:
 {{ toYaml .Values.controller.service.externalIPs | indent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Upgrading nginx-ingress is broken since https://github.com/helm/charts/pull/7933

#### Which issue this PR fixes
  - fixes https://github.com/helm/charts/issues/9227

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
