### PR TITLE
[stable/aws-cluster-autoscaler] bump aws-cluster-autoscaler to 1.13.1

### DIFF
--- a/stable/aws-cluster-autoscaler/Chart.yaml
+++ b/stable/aws-cluster-autoscaler/Chart.yaml
@@ -3,10 +3,11 @@ deprecated: true
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: aws-cluster-autoscaler
-version: 0.3.3
+version: 1.0.0
+appVersion: 1.13.1
 sources:
   - https://github.com/kubernetes/contrib/tree/master/cluster-autoscaler/cloudprovider/aws
 maintainers:
-  - name: Michael Goodness
+  - name: mgoodness
     email: mgoodness@gmail.com
 engine: gotpl

--- a/stable/aws-cluster-autoscaler/README.md
+++ b/stable/aws-cluster-autoscaler/README.md
@@ -84,7 +84,7 @@ Parameter | Description | Default
 `autoscalingGroups[].minSize` | minimum autoscaling group size | None. You *must* supply at least one.
 `awsRegion` | AWS region | `us-east-1`
 `image.repository` | Image | `k8s.gcr.io/cluster-autoscaler`
-`image.tag` | Image tag | `v0.5.4`
+`image.tag` | Image tag | `v1.13.1`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `extraArgs` | additional container arguments | `{}`
 `nodeSelector` | node labels for pod assignment | `{}`

--- a/stable/aws-cluster-autoscaler/values.yaml
+++ b/stable/aws-cluster-autoscaler/values.yaml
@@ -7,7 +7,7 @@ awsRegion: us-east-1
 
 image:
   repository: k8s.gcr.io/cluster-autoscaler
-  tag: v0.6.1
+  tag: v1.13.1
   pullPolicy: IfNotPresent
 
 extraArgs: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
bump aws-cluster-autoscaler to 1.13.1

bring to latest, 9 months without updates

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
