### PR TITLE
[mongodb-replicaset] replace MONGODB_URL with --mongodb.uri

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.8.5
+version: 3.8.6
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -277,12 +277,12 @@ spec:
                 - sh
                 - -ec
                 - >-
-                {{- if .Values.auth.enabled }}
-                  export MONGODB_URL=mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }};
-                {{- else }}
-                  export MONGODB_URL=mongodb://localhost:{{ .Values.port }};
-                {{- end }}
                   /bin/mongodb_exporter
+                {{- if .Values.auth.enabled }}
+                  -mongodb.uri mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }}
+                {{- else }}
+                  -mongodb.uri mongodb://localhost:{{ .Values.port }}
+                {{- end }}
                 {{- if .Values.tls.enabled }}
                   -mongodb.tls
                   -mongodb.tls-ca=/ca/tls.crt

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -231,7 +231,7 @@ spec:
             - >-
               /bin/mongodb_exporter
             {{- if .Values.auth.enabled }}
-              -mongodb.uri mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }}/admin
+              -mongodb.uri mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }}
             {{- else }}
               -mongodb.uri mongodb://localhost:{{ .Values.port }}
             {{- end }}

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -229,12 +229,12 @@ spec:
             - sh
             - -ec
             - >-
-            {{- if .Values.auth.enabled }}
-              export MONGODB_URL=mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }};
-            {{- else }}
-              export MONGODB_URL=mongodb://localhost:{{ .Values.port }};
-            {{- end }}
               /bin/mongodb_exporter
+            {{- if .Values.auth.enabled }}
+              -mongodb.uri mongodb://$METRICS_USER:$METRICS_PASSWORD@localhost:{{ .Values.port }}/admin
+            {{- else }}
+              -mongodb.uri mongodb://localhost:{{ .Values.port }}
+            {{- end }}
             {{- if .Values.tls.enabled }}
               -mongodb.tls
               -mongodb.tls-ca=/ca/tls.crt

--- a/stable/mongodb-replicaset/tests/mongodb-up-test.sh
+++ b/stable/mongodb-replicaset/tests/mongodb-up-test.sh
@@ -26,7 +26,7 @@ replicas() {
 master_pod() {
     for ((i = 0; i < $(replicas); ++i)); do
         response=$(mongo $MONGOARGS "--host=$(pod_name "$i")" "--eval=rs.isMaster().ismaster")
-        if [[ "$response" =~ "true" ]]; then
+        if [[ "$response" == "true" ]]; then
             pod_name "$i"
             break
         fi
@@ -64,7 +64,7 @@ setup() {
 
 @test "Write key to primary" {
     response=$(mongo $MONGOARGS --host=$(master_pod) "--eval=db.test.insert({\"abc\": \"def\"}).nInserted")
-    if [[ ! "$response" =~ "1" ]]; then
+    if [[ ! "$response" -eq 1 ]]; then
         exit 1
     fi
 }


### PR DESCRIPTION
#### What this PR does / why we need it: 
- mongodb-exporter  doesn't work with env variable `MONGODB_URL` after this PR: https://github.com/percona/mongodb_exporter/pull/116. It should be changed to `-mongodb.uri`
- minor test fixes as follow up to https://github.com/helm/charts/pull/9907

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
