### PR TITLE
[stable/kong] specify ingress class for Ingress Controller

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.6.7
+version: 0.6.8
 appVersion: 0.14.1

--- a/stable/kong/templates/controller-deployment.yaml
+++ b/stable/kong/templates/controller-deployment.yaml
@@ -120,6 +120,7 @@ spec:
         - --publish-service={{ .Release.Namespace }}/{{ template "kong.fullname" . }}-proxy
         # Set the ingress class
         - --ingress-class={{ .Values.ingressController.ingressClass }}
+        - --election-id=kong-ingress-controller-leader-{{ .Values.ingressController.ingressClass }}
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
If multiple Kong Ingress controllers are deployed with different
ingress-class parameters to satisfy different kinds of ingresses
in the same k8s cluster,
they will attempt to take aquire leader status on the same
election key, meaning only one of the ingress-class will ever be
satisfied.

This change ensures that a unique key is used for leader election for
every ingress-class.

Signed-off-by: Harry Bagdi <harrybagdi@gmail.com>