### PR TITLE
[stable/redis-ha] Fix split brain issue

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.0.3
+version: 3.0.4
 appVersion: 4.0.11
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/NOTES.txt
+++ b/stable/redis-ha/templates/NOTES.txt
@@ -1,11 +1,14 @@
-Redis cluster can be accessed via port {{ .Values.redis.port }} on the following DNS name from within your cluster:
+Redis can be accessed via port {{ .Values.redis.port }} and Sentinel can be accessed via port {{ .Values.sentinel.port }} on the following DNS name from within your cluster:
 {{ template "redis-ha.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To connect to your Redis server:
 
 {{- if .Values.auth }}
-1. Get the randomly generated redis password:
+1. To retrieve the redis password:
+   On MacOS:
    echo $(kubectl get secret {{ template "redis-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 -D)
+   On Linux:
+   echo $(kubectl get secret {{ template "redis-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 -d)
 
 2. Connect to the Redis master pod that you can use as a client. By default the {{ template "redis-ha.fullname" . }}-server-0 pod is configured as the master:
 

--- a/stable/redis-ha/templates/NOTES.txt
+++ b/stable/redis-ha/templates/NOTES.txt
@@ -5,10 +5,7 @@ To connect to your Redis server:
 
 {{- if .Values.auth }}
 1. To retrieve the redis password:
-   On MacOS:
-   echo $(kubectl get secret {{ template "redis-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 -D)
-   On Linux:
-   echo $(kubectl get secret {{ template "redis-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 -d)
+   echo $(kubectl get secret {{ template "redis-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 --decode)
 
 2. Connect to the Redis master pod that you can use as a client. By default the {{ template "redis-ha.fullname" . }}-server-0 pod is configured as the master:
 

--- a/stable/redis-ha/templates/_helpers.tpl
+++ b/stable/redis-ha/templates/_helpers.tpl
@@ -13,10 +13,17 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "redis-ha.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
+{{- end -}}
+{{- end -}}
 
 {{- /*
 Credit: @technosophos

--- a/stable/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/stable/redis-ha/templates/redis-ha-announce-service.yaml
@@ -1,0 +1,33 @@
+{{- $fullName := include "redis-ha.fullname" . }}
+{{- $replicas := int .Values.replicas }}
+{{- $root := . }}
+{{- range $i := until $replicas }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-announce-{{ $i }}
+  labels:
+{{ include "labels.standard" $root | indent 4 }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  {{- if $root.Values.serviceAnnotations }}
+{{ toYaml $root.Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+  - name: server
+    port: {{ $root.Values.redis.port }}
+    protocol: TCP
+    targetPort: redis
+  - name: sentinel
+    port: {{ $root.Values.sentinel.port }}
+    protocol: TCP
+    targetPort: sentinel
+  selector:
+    release: {{ $root.Release.Name }}
+    app: {{ include "redis-ha.name" $root }}
+    "statefulset.kubernetes.io/pod-name": {{ $fullName }}-server-{{ $i }}
+{{- end }}

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -47,7 +47,6 @@ data:
     SENTINEL_CONF=/data/conf/sentinel.conf
     SENTINEL_PORT={{ .Values.sentinel.port }}
     SERVICE={{ template "redis-ha.fullname" . }}
-    SKIP_DEFAULTS={{- if .Values.skipInit }}"true"{{- end }}
     set -eu
 
     sentinel_update() {
@@ -96,9 +95,7 @@ data:
         if [ "$(redis-cli -h "$MASTER"{{ if .Values.auth }} -a "$AUTH"{{ end }} ping)" != "PONG" ]; then
            echo "Can't ping master, attempting to force failover"
            if redis-cli -h "$SERVICE" -p "$SENTINEL_PORT" sentinel failover "$MASTER_GROUP" | grep -q 'NOGOODSLAVE' ; then 
-               if [ "$SKIP_DEFAULTS" != "true" ]; then
-                   setup_defaults
-               fi
+               setup_defaults
                return 0
            fi
            sleep 10
@@ -128,9 +125,10 @@ data:
         exit 1
     elif [ "$MASTER" ]; then
         find_master
-    elif [ "$SKIP_DEFAULTS" != "true" ]; then
+    else
         setup_defaults
     fi
+
     if [ "${AUTH:-}" ]; then
         echo "Setting auth values"
         sed -i "s/replace-default-auth/$AUTH/" "$REDIS_CONF" "$SENTINEL_CONF"

--- a/stable/redis-ha/templates/redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/redis-ha-configmap.yaml
@@ -38,45 +38,71 @@ data:
 
   init.sh: |
     HOSTNAME="$(hostname)"
+    INDEX="${HOSTNAME##*-}"
     MASTER="$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+    MASTER_GROUP="{{ .Values.redis.masterGroupName }}"
+    QUORUM="{{ .Values.sentinel.quorum }}"
     REDIS_CONF=/data/conf/redis.conf
+    REDIS_PORT={{ .Values.redis.port }}
     SENTINEL_CONF=/data/conf/sentinel.conf
-    
-    set -e
+    SENTINEL_PORT={{ .Values.sentinel.port }}
+    SERVICE={{ template "redis-ha.fullname" . }}
+    SKIP_DEFAULTS={{- if .Values.skipInit }}"true"{{- end }}
+    set -eu
+
     sentinel_update() {
         echo "Updating sentinel config"
-        sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \\n/" "$SENTINEL_CONF"
+        sed -i "1s/^/$(cat sentinel-id)\\n/" "$SENTINEL_CONF"
+        sed -i "2s/^/sentinel monitor $MASTER_GROUP $1 $REDIS_PORT $QUORUM \\n/" "$SENTINEL_CONF"
+        echo "sentinel announce-ip $ANNOUNCE_IP" >> $SENTINEL_CONF
+        echo "sentinel announce-port $SENTINEL_PORT" >> $SENTINEL_CONF
     }
 
     redis_update() {
         echo "Updating redis config"
-        echo "slaveof $1 {{ .Values.redis.port }}" >> "$REDIS_CONF"
+        echo "slaveof $1 $REDIS_PORT" >> "$REDIS_CONF"
+        echo "slave-announce-ip $ANNOUNCE_IP" >> $REDIS_CONF
+        echo "slave-announce-port $REDIS_PORT" >> $REDIS_CONF
+    }
+
+    copy_config() {
+        if [ -f "$SENTINEL_CONF" ]; then
+            grep "sentinel myid" "$SENTINEL_CONF" > sentinel-id || true
+        fi
+        cp /readonly-config/redis.conf "$REDIS_CONF"
+        cp /readonly-config/sentinel.conf "$SENTINEL_CONF"
     }
 
     setup_defaults() {
         echo "Setting up defaults"
-        if [ "$HOSTNAME" = "{{ template "redis-ha.fullname" . }}-server-0" ]; then
+        if [ "$INDEX" = "0" ]; then
             echo "Setting this pod as the default master"
             sed -i "s/^.*slaveof.*//" "$REDIS_CONF"
-            sentinel_update "$POD_IP"
+            sentinel_update "$ANNOUNCE_IP"
         else
+            DEFAULT_MASTER="$(getent hosts "$SERVICE-announce-0" | awk '{ print $1 }')"
+            if [ -z "$DEFAULT_MASTER" ]; then
+                echo "Unable to resolve host"
+                exit 1
+            fi
             echo "Setting default slave config.."
-            echo "slaveof {{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }} {{ .Values.redis.port }}" >> "$REDIS_CONF"
-            sentinel_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
-            redis_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
+            redis_update "$DEFAULT_MASTER"
+            sentinel_update "$DEFAULT_MASTER"
         fi
     }
 
     find_master() {
         echo "Attempting to find master"
-        if [ ! "$(redis-cli -h "$MASTER"{{ if .Values.auth }} -a "$AUTH"{{ end }} ping)" ]; then
+        if [ "$(redis-cli -h "$MASTER"{{ if .Values.auth }} -a "$AUTH"{{ end }} ping)" != "PONG" ]; then
            echo "Can't ping master, attempting to force failover"
-           if redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel failover {{ .Values.redis.masterGroupName }} | grep -q 'NOGOODSLAVE' ; then 
-               setup_defaults
+           if redis-cli -h "$SERVICE" -p "$SENTINEL_PORT" sentinel failover "$MASTER_GROUP" | grep -q 'NOGOODSLAVE' ; then 
+               if [ "$SKIP_DEFAULTS" != "true" ]; then
+                   setup_defaults
+               fi
                return 0
            fi
            sleep 10
-           MASTER="$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+           MASTER="$(redis-cli -h $SERVICE -p $SENTINEL_PORT sentinel get-master-addr-by-name $MASTER_GROUP | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
            if [ "$MASTER" ]; then
                sentinel_update "$MASTER"
                redis_update "$MASTER"
@@ -92,17 +118,20 @@ data:
     }
 
     mkdir -p /data/conf/
+
     echo "Initializing config.."
+    copy_config
 
-    cp /readonly-config/redis.conf "$REDIS_CONF"
-    cp /readonly-config/sentinel.conf "$SENTINEL_CONF"
-
-    if [ "$MASTER" ]; then
+    ANNOUNCE_IP=$(getent hosts "$SERVICE-announce-$INDEX" | awk '{ print $1 }')
+    if [ -z "$ANNOUNCE_IP" ]; then
+        "Could not resolve the announce ip for this pod"
+        exit 1
+    elif [ "$MASTER" ]; then
         find_master
-    else
+    elif [ "$SKIP_DEFAULTS" != "true" ]; then
         setup_defaults
     fi
-    if [ "$AUTH" ]; then
+    if [ "${AUTH:-}" ]; then
         echo "Setting auth values"
         sed -i "s/replace-default-auth/$AUTH/" "$REDIS_CONF" "$SENTINEL_CONF"
     fi

--- a/stable/redis-ha/templates/redis-ha-healthchecks.yaml
+++ b/stable/redis-ha/templates/redis-ha-healthchecks.yaml
@@ -15,7 +15,7 @@ data:
     SENTINEL_PORT={{ .Values.sentinel.port }}
     REDIS_PORT={{ .Values.redis.port }}
     NUM_SLAVES=$(redis-cli -p "$SENTINEL_PORT" sentinel master {{ .Values.redis.masterGroupName }} | awk '/num-slaves/{getline; print}')
-    MIN_SLAVES=$(({{ .Values.sentinel.quorum }} / 2))
+    MIN_SLAVES={{ index .Values.redis.config "min-slaves-to-write" }}
 
     if [ "$1" = "$SENTINEL_PORT" ]; then
         if redis-cli -p "$SENTINEL_PORT" sentinel ckquorum "$MASTER_GROUP" | grep -q NOQUORUM ; then

--- a/stable/redis-ha/templates/redis-ha-healthchecks.yaml
+++ b/stable/redis-ha/templates/redis-ha-healthchecks.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "redis-ha.fullname" . }}-probes
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "redis-ha.fullname" . }}
+data:
+  check-quorum.sh: |
+    #!/bin/sh
+    set -eu
+    MASTER_GROUP="{{ .Values.redis.masterGroupName }}"
+    SENTINEL_PORT={{ .Values.sentinel.port }}
+    REDIS_PORT={{ .Values.redis.port }}
+    NUM_SLAVES=$(redis-cli -p "$SENTINEL_PORT" sentinel master {{ .Values.redis.masterGroupName }} | awk '/num-slaves/{getline; print}')
+    MIN_SLAVES=$(({{ .Values.sentinel.quorum }} / 2))
+
+    if [ "$1" = "$SENTINEL_PORT" ]; then
+        if redis-cli -p "$SENTINEL_PORT" sentinel ckquorum "$MASTER_GROUP" | grep -q NOQUORUM ; then
+            echo "ERROR: NOQUORUM. Sentinel quorum check failed, not enough sentinels found"
+            exit 1
+        fi
+    elif [ "$1" = "$REDIS_PORT" ]; then
+        if [ "$MIN_SLAVES" -gt "$NUM_SLAVES" ]; then
+            echo "Could not find enough replicating slaves. Needed $MIN_SLAVES but found $NUM_SLAVES"
+            exit 1
+        fi
+    fi
+    sh /probes/readiness.sh "$1"
+
+  readiness.sh: |
+    #!/bin/sh
+    set -eu
+    CHECK_SERVER="$(redis-cli -p "$1"{{ if .Values.auth }} -a "$AUTH"{{ end }} ping)"
+
+    if [ "$CHECK_SERVER" != "PONG" ]; then
+        echo "Server check failed with: $CHECK_SERVER"
+        exit 1
+    fi

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -56,10 +56,6 @@ spec:
               name: {{ template "redis-ha.fullname" . }}
               key: auth
 {{- end }}
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         volumeMounts:
         - name: config
           mountPath: /readonly-config

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -17,7 +17,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/redis-ha-configmap.yaml") . | sha256sum }}
+        checksum/init-config: {{ include (print $.Template.BasePath "/redis-ha-configmap.yaml") . | sha256sum }}
+        checksum/probe-config: {{ include (print $.Template.BasePath "/redis-ha-healthchecks.yaml") . | sha256sum }}
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
@@ -47,8 +48,8 @@ spec:
         - sh
         args:
         - /readonly-config/init.sh
-        env:
 {{- if .Values.auth }}
+        env:
         - name: AUTH
           valueFrom:
             secretKeyRef:
@@ -73,14 +74,22 @@ spec:
         - redis-server
         args:
         - /data/conf/redis.conf
+{{- if .Values.auth }}
+        env:
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis-ha.fullname" . }}
+              key: auth
+{{- end }}
         livenessProbe:
           exec:
-            command: ["redis-cli", "ping"]
+            command: [ "sh", "/probes/check-quorum.sh", "{{ .Values.redis.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         readinessProbe:
           exec:
-            command: ["redis-cli", "ping"]
+            command: ["sh", "/probes/readiness.sh", "{{ .Values.redis.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         resources:
@@ -91,6 +100,8 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: data
+        - mountPath: /probes
+          name: probes
       - name: sentinel
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -98,14 +109,22 @@ spec:
           - redis-sentinel
         args:
           - /data/conf/sentinel.conf
+{{- if .Values.auth }}
+        env:
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis-ha.fullname" . }}
+              key: auth
+{{- end }}
         livenessProbe:
           exec:
-            command: ["redis-cli", "-p", "{{ .Values.sentinel.port }}", "ping"]
+            command: [ "sh", "/probes/check-quorum.sh", "{{ .Values.sentinel.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         readinessProbe:
           exec:
-            command: ["redis-cli", "-p", "{{ .Values.sentinel.port }}", "ping"]
+            command: ["sh", "/probes/readiness.sh", "{{ .Values.sentinel.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         resources:
@@ -116,10 +135,15 @@ spec:
         volumeMounts:
         - mountPath: /data
           name: data
+        - mountPath: /probes
+          name: probes
       volumes:
       - name: config
         configMap:
           name: {{ template "redis-ha.fullname" . }}-configmap
+      - name: probes
+        configMap:
+          name: {{ template "redis-ha.fullname" . }}-probes
 {{- if .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
+++ b/stable/redis-ha/templates/tests/test-redis-ha-configmap.yaml
@@ -8,18 +8,29 @@ metadata:
     "helm.sh/hook": test-success
 spec:
   containers:
-  - name: shellcheck
+  - name: check-init
     image: koalaman/shellcheck:v0.5.0
-    command:
-    - shellcheck
+    args:
     - --shell=sh
     - /readonly-config/init.sh
     volumeMounts:
     - name: config
       mountPath: /readonly-config
       readOnly: true
+  - name: check-probes
+    image: koalaman/shellcheck:v0.5.0
+    args:
+    - --shell=sh
+    - /probes/check-quorum.sh
+    volumeMounts:
+    - name: probes
+      mountPath: /probes
+      readOnly: true
   volumes:
   - name: config
     configMap:
       name: {{ template "redis-ha.fullname" . }}-configmap
+  - name: probes
+    configMap:
+      name: {{ template "redis-ha.fullname" . }}-probes
   restartPolicy: Never

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -8,11 +8,6 @@ image:
 ## replicas number for each component
 replicas: 3
 
-# This allows the init process to create a default master when it cannot find 
-# one. In certain cases of network partitions, disabling this can be useful
-# for debugging
-skipInit: false
-
 ## Redis specific configuration options
 redis:
   port: 6379

--- a/stable/redis-ha/values.yaml
+++ b/stable/redis-ha/values.yaml
@@ -8,6 +8,11 @@ image:
 ## replicas number for each component
 replicas: 3
 
+# This allows the init process to create a default master when it cannot find 
+# one. In certain cases of network partitions, disabling this can be useful
+# for debugging
+skipInit: false
+
 ## Redis specific configuration options
 redis:
   port: 6379


### PR DESCRIPTION
#### What this PR does / why we need it:
Major:
Fixes issues where network partitions can result in a split-brain #9488 
  - Better init script that better handles recovery from the split-brain
  - Retained Sentinel IDs
  - Better probes

Minor:
Fixes name override options #9568

---
Part of the root issue of #9488 in that whenever a pod is deleted/recreated, it gets assigned a new IP address causing the remaining quorum to lose track of the down pod after rescheduling. In ideal scenarios this is okay because the init container will find and attach to an existing quorum. However in the case of a network partition this can easily result in the split-brain issue.

These changes leverage the stable IP of a Kubernetes service mapped to the notion of an "Announce IP" in redis/sentinel that allow for more stable operation and discovery. This is necessary because both Redis and Sentinel will resolve DNS names and only persist the corresponding IP in the config not the DNS name. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #9568, fixes #9488

#### Special notes for your reviewer:
In my test lab, these fixes allow for the the init to fail and crash, preventing the issue from occurring.

cc @aianus 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md