### PR TITLE
[stable/prometheus-adapter] v0.4.1, readOnlyRootFilesystem, fixes

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 name: prometheus-adapter
-version: v0.2.1
-appVersion: v0.4.0
+version: v0.2.2
+appVersion: v0.4.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter
 keywords:

--- a/stable/prometheus-adapter/README.md
+++ b/stable/prometheus-adapter/README.md
@@ -38,10 +38,10 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
 | `affinity`                      | Node affinity                                                                   | `{}`                                        |
 | `image.repository`              | Image repository                                                                | `directxman12/k8s-prometheus-adapter-amd64` |
-| `image.tag`                     | Image tag                                                                       | `v0.4.0`                                    |
+| `image.tag`                     | Image tag                                                                       | `v0.4.1`                                    |
 | `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
 | `logLevel`                      | Log level                                                                       | `4`                                         |
-| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `30s`                                       |
+| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `1m`                                        |
 | `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
 | `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
 | `prometheus.port`               | Port of where we can find the Prometheus service                                | `9090`                                      |

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -28,6 +28,7 @@ spec:
         allowPrivilegeEscalation: false
         capabilities:
           drop: ["all"]
+        readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 10001
       serviceAccountName: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}

--- a/stable/prometheus-adapter/values.yaml
+++ b/stable/prometheus-adapter/values.yaml
@@ -3,12 +3,12 @@ affinity: {}
 
 image:
   repository: directxman12/k8s-prometheus-adapter-amd64
-  tag: v0.4.0
+  tag: v0.4.1
   pullPolicy: IfNotPresent
 
 logLevel: 4
 
-metricsRelistInterval: 30s
+metricsRelistInterval: 1m
 
 nodeSelector: {}
 
@@ -30,7 +30,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-resources:
+resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi


### PR DESCRIPTION
#### What this PR does / why we need it:
- Bump version to v0.4.1
- Set readOnlyRootFilesystem to true to improve security
- Increases default metricsRelistInterval to 1m as recommended by [upstream](https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/64) to address issues with unavailable metrics
- Fixes the below error on helm install/upgrade:
```
Warning: Building values map for chart 'prometheus-adapter'. Skipped value (map[]) for 'resources', as it is not a table.
```

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
