### PR TITLE
[stable/mongodb-replicaset] Fix Helm warning during upgrade

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 3.8.6
+version: 3.8.7
 appVersion: 3.6
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -124,7 +124,7 @@ tls:
   # cakey:
 
 # Entries for the MongoDB config file
-configmap:
+configmap: {}
 
 # Javascript code to execute on each replica at initContainer time
 # This is the recommended way to create indexes on replicasets.


### PR DESCRIPTION
#### What this PR does / why we need it:
When using mongodb-replicaset as a dependent chart and providing a value for the configmap, the following error would be printed to console during helm install/upgrade:
```
Warning: Building values map for chart 'mongodb'. Skipped value (map[]) for 'configmap', as it is not a table.
```

This is due to configmap being empty by default instead of a nested yaml document.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
