### PR TITLE
[stable/prometheus-adapter] readOnlyFilesystem

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.2.2
+version: v0.2.3
 appVersion: v0.4.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -28,7 +28,6 @@ spec:
         allowPrivilegeEscalation: false
         capabilities:
           drop: ["all"]
-        readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 10001
       serviceAccountName: {{ template "k8s-prometheus-adapter.serviceAccountName" . }}
@@ -42,9 +41,8 @@ spec:
 {{- if .Values.tls.enable }}
         - --tls-cert-file=/var/run/serving-cert/tls.crt
         - --tls-private-key-file=/var/run/serving-cert/tls.key
-{{- else }}
-        - --cert-dir=/tmp/cert
 {{- end }}
+        - --cert-dir=/tmp/cert
         - --logtostderr=true
         - --prometheus-url={{ .Values.prometheus.url }}:{{ .Values.prometheus.port }}
         - --metrics-relist-interval={{ .Values.metricsRelistInterval }}
@@ -69,10 +67,14 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- end }}
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /etc/adapter/
           name: config
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
 {{- if .Values.tls.enable }}
         - mountPath: /var/run/serving-cert
           name: volume-serving-cert
@@ -94,6 +96,8 @@ spec:
       - name: config
         configMap:
           name: {{ template "k8s-prometheus-adapter.fullname" . }}
+      - name: tmp
+        emptyDir: {}
 {{- if .Values.tls.enable }}
       - name: volume-serving-cert
         secret:


### PR DESCRIPTION
#### What this PR does / why we need it:
Update to my previous PR #10036 to correctly enable a readOnlyFileSystem. Previously I put readOnlyFileSystem=true in the pod securityContext, but it's only available in the container level securityContext. It didn't cause any issues during helm install or upgrade so I didn't realize, just didn't make it read only. This required the cert-dir to be an emptyDir so self-signed certs can be generated there. Also removed conditionality of cert-dir since according to documentation for --cert-dir `If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored`

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
