### PR TITLE
[stable/kubewatch] Allow disabling Slack notificaitons and use other alternatives

### DIFF
--- a/stable/kubewatch/Chart.yaml
+++ b/stable/kubewatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: kubewatch
-version: 0.5.3
+version: 0.6.0
 apiVersion: v1
 appVersion: v0.0.4
 home: https://github.com/bitnami-labs/kubewatch

--- a/stable/kubewatch/README.md
+++ b/stable/kubewatch/README.md
@@ -53,15 +53,20 @@ The following table lists the configurable parameters of the kubewatch chart and
 | `serviceAccount.create`                  | If true, create a serviceAccount     | `true`                            |
 | `serviceAccount.name`                    | existing ServiceAccount to use (ignored if rbac.create=true) | ``        |
 | `resources`                              | pod resource requests & limits       | `{}`                              |
+| `slack.enabled`                          | Enable Slack notifications           | `true`                            |
 | `slack.channel`                          | Slack channel to notify              | `""`                              |
 | `slack.token`                            | Slack API token                      | `""`                              |
+| `hipchat.enabled`                        | Enable HipChat notifications         | `false`                           |
 | `hipchat.url`                            | HipChat URL                          | `""`                              |
 | `hipchat.room`                           | HipChat room to notify               | `""`                              |
 | `hipchat.token`                          | HipChat token                        | `""`                              |
+| `mattermost.enabled`                     | Enable Mattermost notifications      | `false`                           |
 | `mattermost.channel`                     | Mattermost channel to notify         | `""`                              |
 | `mattermost.username`                    | Mattermost user to notify            | `""`                              |
 | `mattermost.url`                         | Mattermost URL                       | `""`                              |
+| `flock.enabled`                          | Enable Flock notifications           | `false`                           |
 | `flock.url`                              | Flock URL                            | `""`                              |
+| `webhook.enabled`                        | Enable Webhook notifications         | `false`                           |
 | `webhook.url`                            | Webhook URL                          | `""`                              |
 | `tolerations`                            | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`                              |
 | `resourcesToWatch`                       | list of resources which kubewatch should watch and notify slack                                                             | `{pod: true, deployment: true}`   |

--- a/stable/kubewatch/templates/configmap.yaml
+++ b/stable/kubewatch/templates/configmap.yaml
@@ -10,23 +10,23 @@ metadata:
 data:
   .kubewatch.yaml: |
     handler:
-{{- if .Values.slack }}
+{{- if .Values.slack.enabled }}
       slack:
 {{ toYaml .Values.slack | indent 8 }}
 {{- end }}
-{{- if .Values.hipchat }}
+{{- if .Values.hipchat.enabled }}
       hipchat:
 {{ toYaml .Values.hipchat | indent 8 }}
 {{- end }}
-{{- if .Values.mattermost }}
+{{- if .Values.mattermost.enabled }}
       mattermost:
 {{ toYaml .Values.mattermost | indent 8 }}
 {{- end }}
-{{- if .Values.flock }}
+{{- if .Values.flock.enabled }}
       flock:
 {{ toYaml .Values.flock | indent 8 }}
 {{- end }}
-{{- if .Values.webhook }}
+{{- if .Values.webhook.enabled }}
       webhook:
 {{ toYaml .Values.webhook | indent 8 }}
 {{- end }}

--- a/stable/kubewatch/values.yaml
+++ b/stable/kubewatch/values.yaml
@@ -5,25 +5,29 @@
 #   imageRegistry:
 
 slack:
+  enabled: true
   # Slack channel to notify
   channel: "XXXX"
-
   # Slack bots token. Create using: https://my.slack.com/services/new/bot
   # and invite the bot to your channel using: /join @botname
   token: "XXXX"
 
-# hipchat:
-#   room: ""
-#   token: ""
-#   url: ""
-# mattermost:
-#   channel: ""
-#   url: ""
-#   username: ""
-# flock:
-#   url: ""
-# webhook:
-#   url: ""
+hipchat:
+  enabled: false
+  # room: ""
+  # token: ""
+  # url: ""
+mattermost:
+  enabled: false
+  # channel: ""
+  # url: ""
+  # username: ""
+flock:
+  enabled: false
+  # url: ""
+webhook:
+  enabled: false
+  # url: ""
 
 # Resources to watch
 resourcesToWatch:


### PR DESCRIPTION

Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allows the user to easily enable/disable those notifications that are desired.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/9596
