### PR TITLE
[stable/prometheus] harmonization of regex references without braces

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.1.1
+version: 8.1.2
 appVersion: 2.5.0
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -970,7 +970,7 @@ serverFiles:
           - source_labels: [__meta_kubernetes_node_name]
             regex: (.+)
             target_label: __metrics_path__
-            replacement: /api/v1/nodes/${1}/proxy/metrics
+            replacement: /api/v1/nodes/$1/proxy/metrics
 
 
       - job_name: 'kubernetes-nodes-cadvisor'
@@ -1002,7 +1002,7 @@ serverFiles:
         # This configuration will work only on kubelet 1.7.3+
         # As the scrape endpoints for cAdvisor have changed
         # if you are using older version you need to change the replacement to
-        # replacement: /api/v1/nodes/${1}:4194/proxy/metrics
+        # replacement: /api/v1/nodes/$1:4194/proxy/metrics
         # more info here https://github.com/coreos/prometheus-operator/issues/633
         relabel_configs:
           - action: labelmap
@@ -1012,7 +1012,7 @@ serverFiles:
           - source_labels: [__meta_kubernetes_node_name]
             regex: (.+)
             target_label: __metrics_path__
-            replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
 
       # Scrape config for service endpoints.
       #


### PR DESCRIPTION
Signed-off-by: Pierre DEMAGNY <pierre.demagny@citymeo.fr>

#### What this PR does / why we need it:
This PR harmonizes regex references in values.yaml. There were some references with braces, some without. Removed all occurences of reference with braces to avoid breaking external tools like [Terraform Template Provider](https://www.terraform.io/docs/providers/template/index.html), for example:

```hcl
data "template_file" "prometheus_tmpl" {
  template = "${file("templates/values-prometheus.yaml.tmpl")}"

  vars {
    PROMETHEUS_INGRESS_HOST   = "${local.workspace["prometheus_ingress_host"]}"
    PROMETHEUS_INGRESS_PATH   = "${local.workspace["prometheus_ingress_path"]}"
  }
}
```
```yaml
server:
...
  ingress:
...
    ## Prometheus server Ingress hostnames with optional path
    ## Must be provided if Ingress is enabled
    ##
    hosts:
      - ${PROMETHEUS_INGRESS_HOST}${PROMETHEUS_INGRESS_PATH}
    #   - domain.com/prometheus
```

Regex references of the form ${n} are interpolated by Terraform's Template Provider, so for example in:
```yaml
      - job_name: 'kubernetes-nodes'
...
        kubernetes_sd_configs:
          - role: node

        relabel_configs:
          - action: labelmap
            regex: __meta_kubernetes_node_label_(.+)
          - target_label: __address__
            replacement: kubernetes.default.svc:443
          - source_labels: [__meta_kubernetes_node_name]
            regex: (.+)
            target_label: __metrics_path__
            replacement: /api/v1/nodes/${1}/proxy/metrics
```
My `__metrics_path__` end up with `/api/v1/nodes/1/proxy/metrics` and the 'kubernetes-nodes' job does not work.

When using regex references of the form $n, they are not interpolated and labelling magic works:
```yaml
      - job_name: 'kubernetes-nodes'
...
        kubernetes_sd_configs:
          - role: node

        relabel_configs:
          - action: labelmap
            regex: __meta_kubernetes_node_label_(.+)
          - target_label: __address__
            replacement: kubernetes.default.svc:443
          - source_labels: [__meta_kubernetes_node_name]
            regex: (.+)
            target_label: __metrics_path__
            replacement: /api/v1/nodes/$1/proxy/metrics
```
My `__metrics_path__` end up with `/api/v1/nodes/<node_name>/proxy/metrics` where <node_name> is the name of each of my nodes and the 'kubernetes-nodes' job works.

#### Which issue this PR fixes
There were no open issues for this.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped