### PR TITLE
Undoing PR #9807

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,4 +12,3 @@ approvers:
   - mattfarina
   - davidkarlsen
   - paulczar
-  - cpanato


### PR DESCRIPTION
I would like to start by saying that this change does not reflect on @cpanato in any way. We appreciate the contributions and this was an error on our part.

The top level OWNERS file in the charts repo is reserved for charts maintainers. The governance process (documented [here](https://github.com/helm/community/blob/master/governance/governance.md#project-maintainers)) has certain things we must do before adding someone as a charts maintainer. Unfortunately, we did not do our due diligence here.

This PR undoes the change.

As a follow-up, I will followup on the formal process if @cpanato is interested. @cpanato has contributed a lot (see [devstats here](https://helm.devstats.cncf.io/d/9/developers-summary?orgId=1)) and is worth discussing.

