### PR TITLE
[stable/minio] Add ability to create multiple buckets

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.3.0
+version: 2.3.1
 appVersion: RELEASE.2018-12-06T01-27-43Z
 keywords:
 - storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -141,6 +141,7 @@ The following table lists the configurable parameters of the Minio chart and the
 | `defaultBucket.name`       | Bucket name                         | `bucket`                                                |
 | `defaultBucket.policy`     | Bucket policy                       | `none`                                                  |
 | `defaultBucket.purge`      | Purge the bucket if already exists  | `false`                                                 |
+| `buckets`                  | List of buckets to create after minio install  | `[]`                                         |
 | `s3gateway.enabled`        | Use minio as a [s3 gateway](https://github.com/minio/minio/blob/master/docs/gateway/s3.md)| `false` |
 | `s3gateway.replicas`       | Number of s3 gateway instances to run in parallel | `4` |
 | `azuregateway.enabled`     | Use minio as an [azure gateway](https://docs.minio.io/docs/minio-gateway-for-azure)| `false`  |

--- a/stable/minio/templates/_helper_create_bucket.txt
+++ b/stable/minio/templates/_helper_create_bucket.txt
@@ -71,5 +71,13 @@ createBucket() {
 
 # Try connecting to Minio instance
 connectToMinio
+
+{{- if or .Values.defaultBucket.enabled }}
 # Create the bucket
 createBucket {{ .Values.defaultBucket.name }} {{ .Values.defaultBucket.policy }} {{ .Values.defaultBucket.purge }}
+{{ else if .Values.buckets }}
+# Create the buckets
+{{- range .Values.buckets }}
+createBucket {{ .name }} {{ .policy }} {{ .purge }} 
+{{- end }}
+{{- end }}

--- a/stable/minio/templates/post-install-create-bucket-job.yaml
+++ b/stable/minio/templates/post-install-create-bucket-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.defaultBucket.enabled }}
+{{- if or .Values.defaultBucket.enabled .Values.buckets }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/stable/minio/values.yaml
+++ b/stable/minio/values.yaml
@@ -156,6 +156,17 @@ defaultBucket:
   ## Purge if bucket exists already
   purge: false
 
+## Create multiple buckets after minio install
+## Enabling `defaultBucket` will take priority over this list
+##
+buckets: []
+  # - name: bucket1
+  #   policy: none
+  #   purge: false
+  # - name: bucket2
+  #   policy: none
+  #   purge: false
+
 s3gateway:
   enabled: false
   replicas: 4


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Currently the minio chart only allows one bucket to be created when the application starts. This PR adds a list of buckets to be provided that can create any number of buckets as part of the post hook job.

#### Which issue this PR fixes
  - fixes #10075

#### Special notes for your reviewer:

This Feature has been added in such a way to keep the current behavior around the defaultBucket.enabled flag stable as removing this would break current setups.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
