### PR TITLE
Allow the override of the preconfigure command

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5.10
+* [87b3a755](https://github.com/kubernetes/charts/commit/87b3a755):
+  - Allow the override of the preconfigure command
+
 ### 1.5.9
 * [6547ba84](https://github.com/kubernetes/charts/commit/6547ba84):
   - Introduces the ability to configure agent service accounts

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.5.9
+version: 1.5.10
 appVersion: 18.11.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/README.md
+++ b/stable/gocd/README.md
@@ -71,6 +71,7 @@ The following tables list the configurable parameters of the GoCD chart and thei
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `server.enabled`                           | Enable GoCD Server. Supported values are `true`, `false`. When enabled, the GoCD server deployment is done on helm install.  | `true`              |
 | `server.shouldPreconfigure`                | Preconfigure GoCD Server to have a default elastic agent profile and Kubernetes elastic agent plugin settings. Supported values are `true`, `false`.  | `true`              |
+| `server.preconfigureCommand`               | Preconfigure GOCD Server with a custom command (shell,python, etc ...). Supported value is a list. | `["/bin/bash", "/preconfigure_server.sh"]`|
 | `server.image.repository`                  | GoCD server image                                                                                             | `gocd/gocd-server`  |
 | `server.image.tag`                         | GoCD server image tag                                                                                         | `.Chart.appVersion` |
 | `server.image.pullPolicy`                  | Image pull policy                                                                                             | `IfNotPresent`      |

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -111,7 +111,8 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/bash","/preconfigure_server.sh"]
+                command:
+{{ toYaml .Values.server.preconfigureCommand | indent 18 }}                
           {{- end }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -25,6 +25,9 @@ server:
   # Note: If this value is set to true, then, the serviceAccount.name is configured for the GoCD server pod. The service account token is mounted as a secret and is used in the lifecycle hook.
   # Note: An attempt to preconfigure the GoCD server is made. There are cases where the pre-configuration can fail and the GoCD server starts with an empty config.
   shouldPreconfigure: true
+  preconfigureCommand:
+    - "/bin/bash"
+    - "/preconfigure_server.sh"
   image:
     # server.image.repository is the GoCD Server image name
     repository: "gocd/gocd-server"


### PR DESCRIPTION
#### What this PR does / why we need it:

When deploying gocd in a kubernetes cluster, we would like to preconfigure the server
with custom settings. This can be done by a script shell or by a python script.

Before we could only specify if we want the server to be preconfigured but
there was no way to override the configuration script.

With this change, one can write a script, put it in a configmap, mount this configmap
on the pod and override the preconfigure command using 'preconfigureCommand'.

For example :

preconfigureCommand:
  - "/usr/bin/python"
  - "/preconfigure.py"

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
@arvindsv @bdpiparva @GaneshSPatil @varshavaradarajan @maheshp : let me know if this change suites you

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Fatih KARAKAS <fakarakas@gmail.com>