### PR TITLE
[stable/chartmuseum] fix permission denied for persistent volume with app version 0.8.0

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
-description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
+description: Host your own Helm Chart Repository
 name: chartmuseum
 version: 1.8.1
 appVersion: 0.8.0
-home: https://github.com/chartmuseum/chartmuseum
-icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png
+home: https://github.com/helm/chartmuseum
+icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png
 keywords:
 - chartmuseum
 - helm

--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Helm Chart Repository with support for Amazon S3 and Google Cloud Storage
 name: chartmuseum
-version: 1.8.0
+version: 1.8.1
 appVersion: 0.8.0
 home: https://github.com/chartmuseum/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/chartmuseum/master/logo.png

--- a/stable/chartmuseum/README.md
+++ b/stable/chartmuseum/README.md
@@ -39,6 +39,12 @@ By default this chart will not have persistent storage, and the API service
 will be *DISABLED*.  This protects against unauthorized access to the API
 with default configuration values.
 
+In addition, by default, pod `securityContext.fsGroup` is set to `1000`. This
+is the user/group that the ChartMuseum container runs as, and is used to
+enable local persitant storage. If your cluster has DenySecurityContext enabled,
+you can set `securityContext` to `{}` and still use this chart with one of
+the cloud storage options.
+
 For a more robust solution supply helm install with a custom values.yaml
 You are also required to create the StorageClass resource ahead of time:
 ```
@@ -72,7 +78,7 @@ their default values. See values.yaml for all available options.
 | `resources.requests.memory`            | Container requested memory                  | `64Mi`                                              |
 | `serviceAccount.create`                | If true, create the service account         | `false`                                             |
 | `serviceAccount.name`                  | Name of the serviceAccount to create or use | `{{ chartmuseum.fullname }}`                        |
-| `securityContext`                      | Map of securityContext for the pod          | `{}`                                                |
+| `securityContext`                      | Map of securityContext for the pod          | `{ fsGroup: 1000 }`                                 |
 | `nodeSelector`                         | Map of node labels for pod assignment       | `{}`                                                |
 | `tolerations`                          | List of node taints to tolerate             | `[]`                                                |
 | `affinity`                             | Map of node/pod affinities                  | `{}`                                                |

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -137,7 +137,11 @@ serviceAccount:
   create: false
   # name:
 
-securityContext: {}
+# UID/GID 1000 is the default user "chartmuseum" used in
+# the container image starting in v0.8.0 and above
+securityContext:
+  runAsUser: 1000
+  fsGroup: 1000
 
 nodeSelector: {}
 

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -138,9 +138,10 @@ serviceAccount:
   # name:
 
 # UID/GID 1000 is the default user "chartmuseum" used in
-# the container image starting in v0.8.0 and above
+# the container image starting in v0.8.0 and above. This
+# is required for local persistant storage. If your cluster
+# does not allow this, try setting securityContext: {}
 securityContext:
-  runAsUser: 1000
   fsGroup: 1000
 
 nodeSelector: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
New chartmuseum 0.8.0 runs as "chartmuseum" user, which breaks persistent volume. Adding updated default security context

#### Which issue this PR fixes
  - fixes https://github.com/helm/chartmuseum/issues/193

#### Special notes for your reviewer:
n/a

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
