### PR TITLE
[incubator/kube-spot-termination-notice-handler] add support for ASG detach

### DIFF
--- a/incubator/kube-spot-termination-notice-handler/Chart.yaml
+++ b/incubator/kube-spot-termination-notice-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Watch and action AWS spot termination events
 name: kube-spot-termination-notice-handler
-version: 0.4.0
-appVersion: 1.10.8-1
+version: 0.5.0
+appVersion: 1.12.0-2
 home: https://github.com/kube-aws/kube-spot-termination-notice-handler
 source:
   - https://hub.docker.com/r/kubeaws/kube-spot-termination-notice-handler/

--- a/incubator/kube-spot-termination-notice-handler/README.md
+++ b/incubator/kube-spot-termination-notice-handler/README.md
@@ -10,6 +10,8 @@ The handler watches for Spot termination events, and will do the following if de
 
 * [Optional] Send a message to a Slack channel informing that a termination notice has been received.
 
+* [Optional] Remove the instance from AutoScaling Group, causing ASG to begin replacement process sooner.
+
 ## Installation
 
 You should install into the `kube-system` namespace, but this is not a requirement. The following example assumes this has been chosen.
@@ -35,3 +37,5 @@ You may set these options in your values file:
 * `serviceAccount.create` -  Specifies whether a ServiceAccount should be created. Defaults to `true`.
 
 * `serviceAccount.name` - The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template.
+
+* `detachAsg` - optional - If this is set to any value other than `false`, the spot termination handler will detect (standard) AutoScaling Group, and initiate detach when termination notice is detected. Defaults to `false`.

--- a/incubator/kube-spot-termination-notice-handler/templates/daemonset.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/daemonset.yaml
@@ -28,6 +28,10 @@ spec:
             - name: SLACK_URL
               value: {{ . | quote }}
             {{- end }}
+            {{- with .Values.detachAsg }}
+            - name: DETACH_ASG
+              value: {{ . | quote }}
+            {{- end }}
             - name: POLL_INTERVAL
               value: {{ .Values.pollInterval | quote }}
             - name: CLUSTER

--- a/incubator/kube-spot-termination-notice-handler/values.yaml
+++ b/incubator/kube-spot-termination-notice-handler/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: kubeaws/kube-spot-termination-notice-handler
-  tag: 1.10.8-1
+  tag: 1.12.0-2
   pullPolicy: IfNotPresent
 
 # Poll the metadata every pollInterval seconds for termination events:
@@ -17,6 +17,9 @@ pollInterval: 5
 
 # Silence logspout by default - set to true to enable logs arriving in logspout
 enableLogspout: false
+
+# Trigger instance removal from AutoScaling Group on termination notice
+detachAsg: false
 
 resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
add support for an option to detach from autoscaling group

Signed-off-by: Frode Egeland <egeland@gmail.com>

#### What this PR does / why we need it:
This adds support for taking the affected instance out of the AWS AutoScaling Group (basic ASG only), which will allow a replacement to be requested sooner.

#### Checklist

- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
