### PR TITLE
Fix log pointer path in container + make hostPath configurable

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.13.0
+version: 1.14.0
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/README.md
+++ b/stable/datadog/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the Datadog chart and t
 | `datadog.env`               | Additional Datadog environment variables | `nil`                               |
 | `datadog.logsEnabled`       | Enable log collection              | `nil`                                     |
 | `datadog.logsConfigContainerCollectAll` | Collect logs from all containers | `nil`                           |
+| `datadog.logsPointerHostPath` | Host path to store the log tailing state in | `/var/lib/datadog-agent/logs`   |
 | `datadog.apmEnabled`        | Enable tracing from the host       | `nil`                                     |
 | `datadog.processAgentEnabled` | Enable live process monitoring   | `nil`                                     |
 | `datadog.checksd`           | Additional custom checks as python code  | `nil`                               |

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -173,7 +173,7 @@ spec:
           {{- end }}
           {{- if .Values.datadog.logsEnabled }}
           - name: pointerdir
-            mountPath: /var/lib/datadog-agent/logs
+            mountPath: /opt/datadog-agent/run
           {{- end }}
           {{- if .Values.datadog.processAgentEnabled }}
           - name: passwd
@@ -221,7 +221,7 @@ spec:
         {{- end }}
         {{- if .Values.datadog.logsEnabled }}
         - hostPath:
-            path: /var/lib/datadog-agent/logs
+            path: {{ default "/var/lib/datadog-agent/logs" .Values.datadog.logsPointerHostPath | quote }}
           name: pointerdir
         {{- end }}
         {{- if .Values.datadog.processAgentEnabled }}


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
* Fix the log registry volume's mount path inside the container, set it to the standard `/opt/datadog-agent/run`
  - fixes #9700 
* Make the hostPath configurable with the new `datadog.logsPointerHostPath` option (feature request)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
