### PR TITLE
Adding chart for cluster-autoscaler overprovisioning

### DIFF
--- a/stable/cluster-overprovisioner/.helmignore
+++ b/stable/cluster-overprovisioner/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Installs the a deployment that overprovisions the cluster
 name: cluster-overprovisioner
+home: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
 version: 0.1.0
 maintainers:
 - name: max-rocket-internet

--- a/stable/cluster-overprovisioner/Chart.yaml
+++ b/stable/cluster-overprovisioner/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Installs the a deployment that overprovisions the cluster
+name: cluster-overprovisioner
+version: 0.1.0
+maintainers:
+- name: max-rocket-internet
+  email: max.williams@deliveryhero.com
+- name: mmingorance-dh
+  email: miguel.mingorance@deliveryhero.com
+engine: gotpl
+icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
+keywords:
+- cluster
+- autoscaling
+- overprovision
+- cluster-autoscaler
+sources:
+- https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler
+- https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler
+- https://github.com/kubernetes/kubernetes/tree/master/build/pause

--- a/stable/cluster-overprovisioner/OWNERS
+++ b/stable/cluster-overprovisioner/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- max-rocket-internet
+- mmingorance-dh
+reviewers:
+- max-rocket-internet
+- mmingorance-dh

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -1,0 +1,58 @@
+# Cluster overprovisioner
+
+This chart provide a buffer for cluster autoscaling to allow overprovisioning of cluster nodes. This is desired when you have work loads that need to scale up quickly without waiting for the new cluster nodes to be created and join the cluster.
+
+It works but creating a deployment that creates pods of a lower than default `PriorityClass`. These pods request resources from the cluster but don't actually consume any resources. These pods are then evicted allowing other normal pods are created while also triggering a scale-up by the [cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler).
+
+This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).
+
+## Prerequisites
+
+- Kubernetes 1.11+ with Beta APIs enabled or 1.8-1.10 with alpha APIs enabled
+- Configure the `cluster-autoscaler` for [your k8s version](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler). Usually just add `extraArgs.expendable-pods-priority-cutoff=-10` setting.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` and default configuration:
+
+```shell
+$ helm install --name my-release stable/cluster-overprovisioner
+```
+
+## Uninstalling the Chart
+
+To delete the chart:
+
+```shell
+$ helm delete my-release
+```
+
+## Configuration
+
+Some thought or experimentation is required to set `deployment.resources` and `deployment.replicaCount` correctly. Aspects such as cluster size, costs and size of buffer required should be considered.
+
+The following table lists the configurable parameters for this chart and their default values.
+
+| Parameter                      | Description                                       | Default           |
+| -------------------------------|---------------------------------------------------|-------------------|
+| `priorityClass.name`           | Name of the overprovision priorityClass           | `overprovision`   |
+| `priorityClass.value`          | Priority value of the overprovision priorityClass | `-1`              |
+| `priorityClassDefault.name`    | Name of the default priorityClass                 | `default`         |
+| `priorityClassDefault.value`   | Priority value of the default priorityClass       | `0`               |
+| `replicaCount`                 | Number of replicas                                | `1`               |
+| `resources`                    | Resources for the overprovision pods              | `{}`              |
+| `image.repository`             | Image repository                                  | `k8s.gcr.io/pause`|
+| `image.tag`                    | Image tag                                         | `3.1`             |
+| `image.pullPolicy`             | Container pull policy                             | `IfNotPresent`    |
+| `affinity`                     | Map of node/pod affinities                        | `{}`              |
+| `nodeSelector`                 | Node labels for pod assignment                    | `{}`              |
+| `annotations`                  | Optional deployment annotations                   | `{}`              |
+| `fullnameOverride`             | Override the fullname of the chart                | `nil`             |
+| `nameOverride`                 | Override the name of the chart                    | `nil`             |
+| `tolerations`                  | Optional deployment tolerations                   | `[]`              |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
+
+```shell
+$ helm install --name my-release stable/cluster-overprovisioner --values values.yaml
+```

--- a/stable/cluster-overprovisioner/README.md
+++ b/stable/cluster-overprovisioner/README.md
@@ -33,23 +33,23 @@ Some thought or experimentation is required to set `deployment.resources` and `d
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter                      | Description                                       | Default           |
-| -------------------------------|---------------------------------------------------|-------------------|
-| `priorityClass.name`           | Name of the overprovision priorityClass           | `overprovision`   |
-| `priorityClass.value`          | Priority value of the overprovision priorityClass | `-1`              |
-| `priorityClassDefault.name`    | Name of the default priorityClass                 | `default`         |
-| `priorityClassDefault.value`   | Priority value of the default priorityClass       | `0`               |
-| `replicaCount`                 | Number of replicas                                | `1`               |
-| `resources`                    | Resources for the overprovision pods              | `{}`              |
-| `image.repository`             | Image repository                                  | `k8s.gcr.io/pause`|
-| `image.tag`                    | Image tag                                         | `3.1`             |
-| `image.pullPolicy`             | Container pull policy                             | `IfNotPresent`    |
-| `affinity`                     | Map of node/pod affinities                        | `{}`              |
-| `nodeSelector`                 | Node labels for pod assignment                    | `{}`              |
-| `annotations`                  | Optional deployment annotations                   | `{}`              |
-| `fullnameOverride`             | Override the fullname of the chart                | `nil`             |
-| `nameOverride`                 | Override the name of the chart                    | `nil`             |
-| `tolerations`                  | Optional deployment tolerations                   | `[]`              |
+| Parameter                          | Description                                       | Default           |
+| -----------------------------------|---------------------------------------------------|-------------------|
+| `priorityClassOverprovision.name`  | Name of the overprovision priorityClass           | `overprovision`   |
+| `priorityClassOverprovision.value` | Priority value of the overprovision priorityClass | `-1`              |
+| `priorityClassDefault.name`        | Name of the default priorityClass                 | `default`         |
+| `priorityClassDefault.value`       | Priority value of the default priorityClass       | `0`               |
+| `replicaCount`                     | Number of replicas                                | `1`               |
+| `resources`                        | Resources for the overprovision pods              | `{}`              |
+| `image.repository`                 | Image repository                                  | `k8s.gcr.io/pause`|
+| `image.tag`                        | Image tag                                         | `3.1`             |
+| `image.pullPolicy`                 | Container pull policy                             | `IfNotPresent`    |
+| `affinity`                         | Map of node/pod affinities                        | `{}`              |
+| `nodeSelector`                     | Node labels for pod assignment                    | `{}`              |
+| `annotations`                      | Optional deployment annotations                   | `{}`              |
+| `fullnameOverride`                 | Override the fullname of the chart                | `nil`             |
+| `nameOverride`                     | Override the name of the chart                    | `nil`             |
+| `tolerations`                      | Optional deployment tolerations                   | `[]`              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/cluster-overprovisioner/templates/NOTES.txt
+++ b/stable/cluster-overprovisioner/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that the cluster-overprovisioner pods have started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ template "cluster-overprovisioner.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"

--- a/stable/cluster-overprovisioner/templates/_helpers.tpl
+++ b/stable/cluster-overprovisioner/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cluster-overprovisioner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cluster-overprovisioner.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cluster-overprovisioner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for PriorityClass.
+*/}}
+{{- define "PriorityClass.apiVersion" -}}
+{{- if semverCompare ">=1.8-0, <1.11-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "v1alpha1" -}}
+{{- else if semverCompare ">=1.11-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/stable/cluster-overprovisioner/templates/deployment.yaml
+++ b/stable/cluster-overprovisioner/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cluster-overprovisioner.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "cluster-overprovisioner.name" . }}
+    helm.sh/chart: {{ include "cluster-overprovisioner.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "cluster-overprovisioner.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "cluster-overprovisioner.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      priorityClassName: {{ .Values.priorityClassOverprovision.name }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/cluster-overprovisioner/templates/priorityclass-default.yaml
+++ b/stable/cluster-overprovisioner/templates/priorityclass-default.yaml
@@ -1,0 +1,12 @@
+apiVersion: scheduling.k8s.io/{{ template "PriorityClass.apiVersion" . }}
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClassDefault.name }}
+  labels:
+    app.kubernetes.io/name: {{ include "cluster-overprovisioner.name" . }}
+    helm.sh/chart: {{ include "cluster-overprovisioner.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+value: {{ .Values.priorityClassDefault.value }}
+globalDefault: true
+description: "Default priority class for all pods"

--- a/stable/cluster-overprovisioner/templates/priorityclass-overprovision.yaml
+++ b/stable/cluster-overprovisioner/templates/priorityclass-overprovision.yaml
@@ -1,0 +1,12 @@
+apiVersion: scheduling.k8s.io/{{ template "PriorityClass.apiVersion" . }}
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClassOverprovision.name }}
+  labels:
+    app.kubernetes.io/name: {{ include "cluster-overprovisioner.name" . }}
+    helm.sh/chart: {{ include "cluster-overprovisioner.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+value: {{ .Values.priorityClassOverprovision.value }}
+globalDefault: false
+description: "Priority class used for overprovision pods"

--- a/stable/cluster-overprovisioner/values.yaml
+++ b/stable/cluster-overprovisioner/values.yaml
@@ -1,0 +1,26 @@
+priorityClassOverprovision:
+  name: overprovisioning
+  value: -1
+
+priorityClassDefault:
+  name: default
+  value: 0
+
+replicaCount: 1
+
+resources: {}
+
+image:
+  repository: k8s.gcr.io/pause
+  tag: 3.1
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
This chart creates an easy way to overprovision a cluster.

#### Special notes for your reviewer:
This approach is the [current recommended method to achieve overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
