### PR TITLE
[stable/kubernetes-dashboard] New backend-protocol ingress-nginx annotations

### DIFF
--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 name: kubernetes-dashboard
-version: 0.10.1
-appVersion: 1.10.2
+version: 0.10.2
+appVersion: 1.10.1
 description: General-purpose web UI for Kubernetes clusters
 keywords:
 - kubernetes

--- a/stable/kubernetes-dashboard/Chart.yaml
+++ b/stable/kubernetes-dashboard/Chart.yaml
@@ -1,6 +1,6 @@
 name: kubernetes-dashboard
 version: 0.10.1
-appVersion: 1.10.1
+appVersion: 1.10.2
 description: General-purpose web UI for Kubernetes clusters
 keywords:
 - kubernetes

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -80,9 +80,9 @@ ingress:
   ##
   # annotations:
   #   kubernetes.io/ingress.class: nginx
-  ## Annotations below are relevant if you plan to use TLS with
-  ## enableInsecureLogin set to true
   #   kubernetes.io/tls-acme: 'true'
+  ## If you plan to use TLS backend with enableInsecureLogin set to false
+  ## (default), you need to uncomment the below.
   ## If you use ingress-nginx < 0.21.0
   #   nginx.ingress.kubernetes.io/secure-backends: "true"
   ## if you use ingress-nginx >= 0.21.0

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -80,8 +80,14 @@ ingress:
   ##
   # annotations:
   #   kubernetes.io/ingress.class: nginx
-  #   nginx.ingress.kubernetes.io/secure-backends: "true"
+  ## Annotations below are relevant if you plan to use TLS with
+  ## enableInsecureLogin set to true
   #   kubernetes.io/tls-acme: 'true'
+  ## If you use ingress-nginx < 0.21.0
+  #   nginx.ingress.kubernetes.io/secure-backends: "true"
+  ## if you use ingress-nginx >= 0.21.0
+  #   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+
 
   ## Kubernetes Dashboard Ingress path
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:
A recent update to ingress-nginx replaced the `secure-backend` annotation with `backend-protocol` (see https://github.com/kubernetes/ingress-nginx/commit/859b298d42b6e3a5d02535ddca0ac91e799b2e8b#diff-22831cc5ba236c8cc0f471b5b39e13a4L52).

A few comments around here tells people to fix their ingress > pod communication by using `secure-backend` which used to be the universal solution and now, depending on your ingress-nginx version, it may or may not be the solution anymore.

I thought that adding the 2 cases in the `values.yaml` would help to figure this one out.

#### Which issue this PR fixes
It relates to #4204 which is closed but came back from the dead...

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
