### PR TITLE
[stable/docker-registry] Use static container/daemon port

### DIFF
--- a/stable/docker-registry/Chart.yaml
+++ b/stable/docker-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry
 name: docker-registry
-version: 1.6.2
+version: 1.6.3
 appVersion: 2.6.2
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/docker-registry/templates/NOTES.txt
+++ b/stable/docker-registry/templates/NOTES.txt
@@ -15,5 +15,5 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "docker-registry.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.port }}
+  kubectl port-forward $POD_NAME 8080:5000
 {{- end }}

--- a/stable/docker-registry/templates/deployment.yaml
+++ b/stable/docker-registry/templates/deployment.yaml
@@ -46,21 +46,21 @@ spec:
           - serve
           - /etc/docker/registry/config.yml
           ports:
-            - containerPort: {{ .Values.service.port }}
+            - containerPort: 5000
           livenessProbe:
             httpGet:
 {{- if .Values.tlsSecretName }}
               scheme: HTTPS
 {{- end }}
               path: /
-              port: {{ .Values.service.port }}
+              port: 5000
           readinessProbe:
             httpGet:
 {{- if .Values.tlsSecretName }}
               scheme: HTTPS
 {{- end }}
               path: /
-              port: {{ .Values.service.port }}
+              port: 5000
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:

--- a/stable/docker-registry/templates/service.yaml
+++ b/stable/docker-registry/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
     - port: {{ .Values.service.port }}
       protocol: TCP
       name: {{ .Values.service.name }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: 5000
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
       nodePort: {{ .Values.service.nodePort }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This commit ensures the container/daemon port is constant (`5000`), while the service port is configurable with the `service.port` value.

#### Which issue this PR fixes
- fixes #10113

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

@jpds @rendhalver