### PR TITLE
[stable/mongodb] Fix chart not being upgradable when replicaset is enabled.

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 4.10.1
+version: 5.0.0
 appVersion: 4.0.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -174,3 +174,14 @@ The allowed extensions are `.sh`, and `.js`.
 The [Bitnami MongoDB](https://github.com/bitnami/bitnami-docker-mongodb) image stores the MongoDB data and configurations at the `/bitnami/mongodb` path of the container.
 
 The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
+
+## Upgrading
+
+### To 5.0.0
+
+When enabling replicaset configuration, backwards compatibility is not guaranteed unless you modify the labels used on the chart's statefulsets.
+Use the workaround below to upgrade from versions previous to 5.0.0. The following example assumes that the release name is `my-release`:
+
+```consoloe
+$ kubectl delete statefulset my-release-mongodb-arbiter my-release-mongodb-primary my-release-mongodb-secondary --cascade=false
+```

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       app: {{ template "mongodb.name" . }}
       release: {{ .Release.Name }}
-      chart: {{ template "mongodb.chart" . }}
       component: arbiter
   serviceName: {{ template "mongodb.fullname" . }}-headless
   replicas: {{ .Values.replicaSet.replicas.arbiter }}

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "mongodb.name" . }}
-      chart: {{ template "mongodb.chart" . }}
       release: {{ .Release.Name }}
       component: primary
   template:

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       app: {{ template "mongodb.name" . }}
       release: {{ .Release.Name }}
-      chart: {{ template "mongodb.chart" . }}
       component: secondary
   podManagementPolicy: "Parallel"
   serviceName: {{ template "mongodb.fullname" . }}-headless


### PR DESCRIPTION

Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR fixes a known issue to upgrade the chart when deployment/statefulsets contain labels that depend on the chart's version.

#### Which issue this PR fixes
  - fixes #7680

