### PR TITLE
[stable/mariadb] Allow including gzip files as initdb scripts

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.2.4
+version: 5.2.5
 appVersion: 10.1.37
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -18,7 +18,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 ## Prerequisites
 
-- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.10+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart

--- a/stable/mariadb/templates/initialization-configmap.yaml
+++ b/stable/mariadb/templates/initialization-configmap.yaml
@@ -9,6 +9,11 @@ metadata:
     chart: {{ template "mariadb.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+binaryData:
+{{- $root := . }}
+{{- range $path, $bytes := .Files.Glob "files/docker-entrypoint-initdb.d/*.sql.gz" }}
+  {{ base $path }}: {{ $root.Files.Get $path | b64enc | quote }}
+{{- end }}
 data:
-{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|sql|sql.gz]").AsConfig | indent 2 }}
+{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql}").AsConfig | indent 2 }}
 {{ end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

### What this PR does / why we need it:

GZIP files must be treated as **binaryData** on configMaps. This PR ensures that those init scripts compressed on that format are mounted as binaries.