### PR TITLE
[stable/minio] Fix probes to use correct HTTP scheme

### DIFF
--- a/stable/minio/Chart.yaml
+++ b/stable/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Minio is a high performance distributed object storage server, designed for large-scale private cloud infrastructure.
 name: minio
-version: 2.2.0
+version: 2.2.1
 appVersion: RELEASE.2018-12-06T01-27-43Z
 keywords:
 - storage

--- a/stable/minio/README.md
+++ b/stable/minio/README.md
@@ -124,7 +124,7 @@ The following table lists the configurable parameters of the Minio chart and the
 | `nodeSelector`             | Node labels for pod assignment      | `{}`                                                    |
 | `affinity`                 | Affinity settings for pod assignment | `{}`                                                   |
 | `tolerations`              | Toleration labels for pod assignment | `[]`                                                   |
-| `tls.enable`               | Enable TLS for Minio server | `false`                                                         |
+| `tls.enabled`              | Enable TLS for Minio server | `false`                                                         |
 | `tls.certSecret`           | Kubernetes Secret with `public.crt` and `private.key` files. | `""`                           |
 | `livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated        | `5`                               |
 | `livenessProbe.periodSeconds`        | How often to perform the probe                  | `30`                              |

--- a/stable/minio/templates/deployment.yaml
+++ b/stable/minio/templates/deployment.yaml
@@ -125,6 +125,9 @@ spec:
             {{- end}}
           livenessProbe:
             httpGet:
+              {{- if .Values.tls.enabled }}
+              scheme: HTTPS
+              {{- end }}
               path: /minio/health/live
               port: service
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -134,6 +137,9 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
+              {{- if .Values.tls.enabled }}
+              scheme: HTTPS
+              {{- end }}
               path: /minio/health/ready
               port: service
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}


### PR DESCRIPTION
- use HTTPs probes when TLS is enabled
- minor documentation fix

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Liveness/readiness probes didn't work when used with TLS.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #10126

#### Special notes for your reviewer:
@minio

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed

