### PR TITLE
[stable/postgresql] Allow enabling/disabling volume-permissions Init container

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 3.3.0
+version: 3.4.0
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/README.md
+++ b/stable/postgresql/README.md
@@ -45,80 +45,81 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the PostgreSQL chart and their default values.
 
-|         Parameter                             |                Description                           |                            Default                        |
-|-----------------------------------------------|------------------------------------------------------|---------------------------------------------------------- |
-| `global.imageRegistry`                        | Global Docker Image registry                         | `nil`                                                     |
-| `image.registry`                              | PostgreSQL Image registry                            | `docker.io`                                               |
-| `image.repository`                            | PostgreSQL Image name                                | `bitnami/postgresql`                                      |
-| `image.tag`                                   | PostgreSQL Image tag                                 | `{VERSION}`                                               |
-| `image.pullPolicy`                            | PostgreSQL Image pull policy                         | `Always`                                                  |
-| `image.pullSecrets`                           | Specify Image pull secrets                           | `nil` (does not add image pull secrets to deployed pods)  |
-| `image.debug`                                 | Specify if debug values should be set                | `false`                                                   |
-| `volumePermissions.image.registry`            | Init container volume-permissions image registry     | `docker.io`                                               |
-| `volumePermissions.image.repository`          | Init container volume-permissions image name         | `bitnami/minideb`                                         |
-| `volumePermissions.image.tag`                 | Init container volume-permissions image tag          | `latest`                                                  |
-| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy  | `Always`                                                  |
-| `volumePermissions.securityContext.runAsUser` | User ID for the init container                       | `0`                                                       |
-| `usePasswordFile`                             | Have the secrets mounted as a file instead of env vars                 | `false`                                                   |
-| `replication.enabled`                         | Would you like to enable replication                 | `false`                                                   |
-| `replication.user`                            | Replication user                                     | `repl_user`                                               |
-| `replication.password`                        | Replication user password                            | `repl_password`                                           |
-| `replication.slaveReplicas`                   | Number of slaves replicas                            | `1`                                                       |
-| `existingSecret`                              | Name of existing secret to use for PostgreSQL passwords        | `nil`                                                     |
-| `postgresqlUsername`                          | PostgreSQL admin user                                | `postgres`                                                |
-| `postgresqlPassword`                          | PostgreSQL admin password                            | _random 10 character alphanumeric string_                 |
-| `postgresqlDatabase`                          | PostgreSQL database                                  | `nil`                                                     |
-| `postgresqlConfiguration`                     | Runtime Config Parameters                            | `nil`                                                     |
-| `pgHbaConfiguration`                          | Content of pg\_hba.conf                              | `nil (do not create pg_hba.conf)`                         |
-| `initdbScripts`                               | List of initdb scripts                               | `nil`                                                     |
-| `service.type`                                | Kubernetes Service type                              | `ClusterIP`                                               |
-| `service.port`                                | PostgreSQL port                                      | `5432`                                                    |
-| `service.nodePort`                            | Kubernetes Service nodePort                          | `nil`                                                     |
-| `service.annotations`                         | Annotations for PostgreSQL service                   | {}                                                        |
-| `service.loadBalancerIP`                      | loadBalancerIP if service type is `LoadBalancer`     | `nil`                                                     |
-| `persistence.enabled`                         | Enable persistence using PVC                         | `true`                                                    |
-| `persistence.existingClaim`                   | Provide an existing `PersistentVolumeClaim`          | `nil`                                                     |
-| `persistence.mountPath`                       | Path to mount the volume at                          | `/bitnami/postgresql`                                     |
-| `persistence.storageClass`                    | PVC Storage Class for PostgreSQL volume              | `nil`                                                     |
-| `persistence.accessMode`                      | PVC Access Mode for PostgreSQL volume                | `ReadWriteOnce`                                           |
-| `persistence.size`                            | PVC Storage Request for PostgreSQL volume            | `8Gi`                                                     |
-| `persistence.annotations`                     | Annotations for the PVC                              | `{}`                                                      |
-| `master.nodeSelector`                         | Node labels for pod assignment (postgresql master)       | `{}`                                                  |
-| `master.affinity`                             | Affinity labels for pod assignment (postgresql master)   | `{}`                                                  |
-| `master.tolerations`                          | Toleration labels for pod assignment (postgresql master) | `[]`                                                  |
-| `slave.nodeSelector`                          | Node labels for pod assignment (postgresql slave)        | `{}`                                                  |
-| `slave.affinity`                              | Affinity labels for pod assignment (postgresql slave)    | `{}`                                                  |
-| `slave.tolerations`                           | Toleration labels for pod assignment (postgresql slave)  | `[]`                                                  |
-| `terminationGracePeriodSeconds`               | Seconds the pod needs to terminate gracefully        | `nil`                                                     |
-| `resources`                                   | CPU/Memory resource requests/limits                  | Memory: `256Mi`, CPU: `250m`                              |
-| `securityContext.enabled`                     | Enable security context                              | `true`                                                    |
-| `securityContext.fsGroup`                     | Group ID for the container                           | `1001`                                                    |
-| `securityContext.runAsUser`                   | User ID for the container                            | `1001`                                                    |
-| `livenessProbe.enabled`                       | Would you like a livessProbed to be enabled          |  `true`                                                   |
-| `networkPolicy.enabled`                       | Enable NetworkPolicy                                 | `false`                                                   |
-| `networkPolicy.allowExternal`                 | Don't require client label for connections           | `true`                                                    |
-| `livenessProbe.initialDelaySeconds`           | Delay before liveness probe is initiated             |  30                                                       |
-| `livenessProbe.periodSeconds`                 | How often to perform the probe                       |  10                                                       |
-| `livenessProbe.timeoutSeconds`                | When the probe times out                             |  5                                                        |
-| `livenessProbe.failureThreshold`              | Minimum consecutive failures for the probe to be considered failed after having succeeded.    |  6             |
-| `livenessProbe.successThreshold`              | Minimum consecutive successes for the probe to be considered successful after having failed   |  1             |
-| `readinessProbe.enabled`                      | would you like a readinessProbe to be enabled        |  `true`                                                   |
-| `readinessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated             |  5                                                        |
-| `readinessProbe.periodSeconds`                | How often to perform the probe                       |  10                                                       |
-| `readinessProbe.timeoutSeconds`               | When the probe times out                             |  5                                                        |
-| `readinessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.    |  6             |
-| `readinessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed   |  1             |
-| `metrics.enabled`                             | Start a prometheus exporter                          | `false`                                                   |
-| `metrics.service.type`                        | Kubernetes Service type                              |  `ClusterIP`                                              |
-| `metrics.service.annotations`                 | Additional annotations for metrics exporter pod      |  `{}`                                                     |
-| `metrics.service.loadBalancerIP`              | loadBalancerIP if redis metrics service type is `LoadBalancer` | `nil`                                         |
-| `metrics.image.registry`                      | PostgreSQL Image registry                            | `docker.io`                                               |
-| `metrics.image.repository`                    | PostgreSQL Image name                                | `wrouesnel/postgres_exporter`                             |
-| `metrics.image.tag`                           | PostgreSQL Image tag                                 | `{VERSION}`                                               |
-| `metrics.image.pullPolicy`                    | PostgreSQL Image pull policy                         | `IfNotPresent`                                            |
-| `metrics.image.pullSecrets`                   | Specify Image pull secrets                           | `nil` (does not add image pull secrets to deployed pods)  |
-| `extraEnv`                                    | Any extra environment variables you would like to pass on to the pod | `{}`                                    |
-| `updateStrategy`                              | Update strategy policy                               | `{type: "onDelete"}`                                      |
+|         Parameter                             |                Description                              |                           Default                        |
+|-----------------------------------------------|---------------------------------------------------------|--------------------------------------------------------- |
+| `global.imageRegistry`                        | Global Docker Image registry                            | `nil`                                                    |
+| `image.registry`                              | PostgreSQL Image registry                               | `docker.io`                                              |
+| `image.repository`                            | PostgreSQL Image name                                   | `bitnami/postgresql`                                     |
+| `image.tag`                                   | PostgreSQL Image tag                                    | `{VERSION}`                                              |
+| `image.pullPolicy`                            | PostgreSQL Image pull policy                            | `Always`                                                 |
+| `image.pullSecrets`                           | Specify Image pull secrets                              | `nil` (does not add image pull secrets to deployed pods) |
+| `image.debug`                                 | Specify if debug values should be set                   | `false`                                                  |
+| `volumePermissions.image.registry`            | Init container volume-permissions image registry        | `docker.io`                                              |
+| `volumePermissions.image.repository`          | Init container volume-permissions image name            | `bitnami/minideb`                                        |
+| `volumePermissions.image.tag`                 | Init container volume-permissions image tag             | `latest`                                                 |
+| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy     | `Always`                                                 |
+| `volumePermissions.enabled`                   | Enable init container                                   | `true`                                                   |
+| `volumePermissions.securityContext.runAsUser` | User ID for the init container                          | `0`                                                      |
+| `usePasswordFile`                             | Have the secrets mounted as a file instead of env vars  | `false`                                                  |
+| `replication.enabled`                         | Would you like to enable replication                    | `false`                                                  |
+| `replication.user`                            | Replication user                                        | `repl_user`                                              |
+| `replication.password`                        | Replication user password                               | `repl_password`                                          |
+| `replication.slaveReplicas`                   | Number of slaves replicas                               | `1`                                                      |
+| `existingSecret`                              | Name of existing secret to use for PostgreSQL passwords | `nil`                                                    |
+| `postgresqlUsername`                          | PostgreSQL admin user                                   | `postgres`                                               |
+| `postgresqlPassword`                          | PostgreSQL admin password                               | _random 10 character alphanumeric string_                |
+| `postgresqlDatabase`                          | PostgreSQL database                                     | `nil`                                                    |
+| `postgresqlConfiguration`                     | Runtime Config Parameters                               | `nil`                                                    |
+| `pgHbaConfiguration`                          | Content of pg\_hba.conf                                 | `nil (do not create pg_hba.conf)`                        |
+| `initdbScripts`                               | List of initdb scripts                                  | `nil`                                                    |
+| `service.type`                                | Kubernetes Service type                                 | `ClusterIP`                                              |
+| `service.port`                                | PostgreSQL port                                         | `5432`                                                   |
+| `service.nodePort`                            | Kubernetes Service nodePort                             | `nil`                                                    |
+| `service.annotations`                         | Annotations for PostgreSQL service                      | {}                                                       |
+| `service.loadBalancerIP`                      | loadBalancerIP if service type is `LoadBalancer`        | `nil`                                                    |
+| `persistence.enabled`                         | Enable persistence using PVC                            | `true`                                                   |
+| `persistence.existingClaim`                   | Provide an existing `PersistentVolumeClaim`             | `nil`                                                    |
+| `persistence.mountPath`                       | Path to mount the volume at                             | `/bitnami/postgresql`                                    |
+| `persistence.storageClass`                    | PVC Storage Class for PostgreSQL volume                 | `nil`                                                    |
+| `persistence.accessMode`                      | PVC Access Mode for PostgreSQL volume                   | `ReadWriteOnce`                                          |
+| `persistence.size`                            | PVC Storage Request for PostgreSQL volume               | `8Gi`                                                    |
+| `persistence.annotations`                     | Annotations for the PVC                                 | `{}`                                                     |
+| `master.nodeSelector`                         | Node labels for pod assignment (master nodes)           | `{}`                                                     |
+| `master.affinity`                             | Affinity labels for pod assignment (master nodes)       | `{}`                                                     |
+| `master.tolerations`                          | Toleration labels for pod assignment (master nodes)     | `[]`                                                     |
+| `slave.nodeSelector`                          | Node labels for pod assignment (slave nodes)            | `{}`                                                     |
+| `slave.affinity`                              | Affinity labels for pod assignment (slave nodes)        | `{}`                                                     |
+| `slave.tolerations`                           | Toleration labels for pod assignment (slave nodes)      | `[]`                                                     |
+| `terminationGracePeriodSeconds`               | Seconds the pod needs to terminate gracefully           | `nil`                                                    |
+| `resources`                                   | CPU/Memory resource requests/limits                     | Memory: `256Mi`, CPU: `250m`                             |
+| `securityContext.enabled`                     | Enable security context                                 | `true`                                                   |
+| `securityContext.fsGroup`                     | Group ID for the container                              | `1001`                                                   |
+| `securityContext.runAsUser`                   | User ID for the container                               | `1001`                                                   |
+| `livenessProbe.enabled`                       | Would you like a livessProbed to be enabled             |  `true`                                                  |
+| `networkPolicy.enabled`                       | Enable NetworkPolicy                                    | `false`                                                  |
+| `networkPolicy.allowExternal`                 | Don't require client label for connections              | `true`                                                   |
+| `livenessProbe.initialDelaySeconds`           | Delay before liveness probe is initiated                |  30                                                      |
+| `livenessProbe.periodSeconds`                 | How often to perform the probe                          |  10                                                      |
+| `livenessProbe.timeoutSeconds`                | When the probe times out                                |  5                                                       |
+| `livenessProbe.failureThreshold`              | Minimum consecutive failures for the probe to be considered failed after having succeeded | `6`                    |
+| `livenessProbe.successThreshold`              | Minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
+| `readinessProbe.enabled`                      | would you like a readinessProbe to be enabled           |  `true`                                                  |
+| `readinessProbe.initialDelaySeconds`          | Delay before liveness probe is initiated                |  5                                                       |
+| `readinessProbe.periodSeconds`                | How often to perform the probe                          |  10                                                      |
+| `readinessProbe.timeoutSeconds`               | When the probe times out                                |  5                                                       |
+| `readinessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded | `6`                    |
+| `readinessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed | `1`                  |
+| `metrics.enabled`                             | Start a prometheus exporter                             | `false`                                                  |
+| `metrics.service.type`                        | Kubernetes Service type                                 |  `ClusterIP`                                             |
+| `metrics.service.annotations`                 | Additional annotations for metrics exporter pod         |  `{}`                                                    |
+| `metrics.service.loadBalancerIP`              | loadBalancerIP if redis metrics service type is `LoadBalancer` | `nil`                                             |
+| `metrics.image.registry`                      | PostgreSQL Image registry                               | `docker.io`                                              |
+| `metrics.image.repository`                    | PostgreSQL Image name                                   | `wrouesnel/postgres_exporter`                            |
+| `metrics.image.tag`                           | PostgreSQL Image tag                                    | `{VERSION}`                                              |
+| `metrics.image.pullPolicy`                    | PostgreSQL Image pull policy                            | `IfNotPresent`                                           |
+| `metrics.image.pullSecrets`                   | Specify Image pull secrets                              | `nil` (does not add image pull secrets to deployed pods) |
+| `extraEnv`                                    | Any extra environment variables you would like to pass on to the pod | `{}`                                        |
+| `updateStrategy`                              | Update strategy policy                                  | `{type: "onDelete"}`                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -52,7 +52,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and .Values.persistence.enabled .Values.securityContext.enabled}}
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled .Values.securityContext.enabled }}
       initContainers:
       - name: init-chmod-data
         image: {{ template "postgresql.volumePermissions.image" . }}
@@ -70,7 +70,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /bitnami/postgresql
-      {{ end }}
+      {{- end }}
       containers:
       - name: {{ template "postgresql.fullname" . }}
         image: {{ template "postgresql.image" . }}

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -52,7 +52,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled .Values.securityContext.enabled }}
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
       initContainers:
       - name: init-chmod-data
         image: {{ template "postgresql.volumePermissions.image" . }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and .Values.persistence.enabled .Values.securityContext.enabled}}
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled .Values.securityContext.enabled }}
       initContainers:
       - name: init-chmod-data
         image: {{ template "postgresql.volumePermissions.image" . }}
@@ -74,7 +74,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /bitnami/postgresql
-      {{ end }}
+      {{- end }}
       containers:
       - name: {{ template "postgresql.fullname" . }}
         image: {{ template "postgresql.image" . }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled .Values.securityContext.enabled }}
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
       initContainers:
       - name: init-chmod-data
         image: {{ template "postgresql.volumePermissions.image" . }}

--- a/stable/postgresql/values-production.yaml
+++ b/stable/postgresql/values-production.yaml
@@ -34,11 +34,17 @@ image:
 ## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
 ##
 volumePermissions:
+  enabled: true
   image:
     registry: docker.io
     repository: bitnami/minideb
     tag: latest
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
     pullPolicy: Always
+  ## Init container Security Context
   securityContext:
     runAsUser: 0
 

--- a/stable/postgresql/values.yaml
+++ b/stable/postgresql/values.yaml
@@ -34,11 +34,17 @@ image:
 ## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
 ##
 volumePermissions:
+  enabled: true
   image:
     registry: docker.io
     repository: bitnami/minideb
     tag: latest
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
     pullPolicy: Always
+  ## Init container Security Context
   securityContext:
     runAsUser: 0
 


### PR DESCRIPTION

Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR allow the user to disable the initContainer by setting `volumePermissions.enabled=false` so this Helm Chart can be used on K8s clusters with `PodSecurityPolicy` set to `RunAsNonRoot`.

#### Which issue this PR fixes

  - fixes #9844