### PR TITLE
[stable/unifi] Add "addSetfcap" option

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.9.29
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.2.2
+version: 0.2.3
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -75,6 +75,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `ingress.tls`                  | Ingress TLS configuration | `[]` |
 | `timezone`                     | Timezone the Unifi controller should run as, e.g. 'America/New York' | `UTC` |
 | `runAsRoot`                    | Run the controller as UID0 (root user) | `false` |
+| `addSetfcap`                   | Give the controller container the SETFCAP capability; this is necessary when not running as root | `true` |
 | `mongodb.enabled`              | Use external MongoDB for data storage | `false` |
 | `mongodb.dbUri`                | external MongoDB URI | `mongodb://mongo/unifi` |
 | `mongodb.statDbUri`            | external MongoDB statdb URI | `mongodb://mongo/unifi_stat` |

--- a/stable/unifi/templates/deployment.yaml
+++ b/stable/unifi/templates/deployment.yaml
@@ -42,6 +42,12 @@ spec:
             - name: stun
               containerPort: 3478
               protocol: UDP
+          {{- if .Values.addSetfcap }}
+          securityContext:
+            capabilities:
+              add:
+                - SETFCAP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /status

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -109,6 +109,7 @@ ingress:
 timezone: UTC
 
 runAsRoot: false
+addSetfcap: true
 
   # define an external mongoDB instead of using the built-in mongodb
 mongodb:


### PR DESCRIPTION
#### What this PR does / why we need it:
Gives the user an option to add the SETFCAP capability to Unifi container

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
It seems that this capability is required when the controller isn't run as root, so it might make more sense to just enable the capability if `runAsRoot` is set to `false` and not add another `values.yaml` option.  I prefer that, but assume the community would rather have more fine-grained control; if I'm incorrect, I'll update the PR.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
