### PR TITLE
[stable/sentry] Refactor charts for reduced boilerplate on env variables and add existingSecrets

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.0.1
+version: 1.1.0
 appVersion: 9.0
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -61,6 +61,7 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `image.repository`                   | Sentry image                                | `library/sentry`                                           |
 | `image.tag`                          | Sentry image tag                            | `9.0`                                                      |
 | `imagePullPolicy`                    | Image pull policy                           | `IfNotPresent`                                             |
+| `existingSecret`                     | Name of existing secret for passwords       | `nil`                                                      |
 | `web.podAnnotations`                 | Web pod annotations                         | `{}`                                                       |
 | `web.replicacount`                   | Amount of web pods to run                   | `1`                                                        |
 | `web.resources.limits`               | Web resource limits                         | `{cpu: 500m, memory: 500Mi}`                               |

--- a/stable/sentry/templates/NOTES.txt
+++ b/stable/sentry/templates/NOTES.txt
@@ -18,4 +18,11 @@
 
   USER: {{ .Values.user.email }}
   Get login password with
+
+  {{- if not .Values.existingSecret }}
     kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.user-password}" | base64 --decode
+  {{- else }}
+    kubectl get secret --namespace {{ .Release.Namespace }} .Values.existingSecret -o jsonpath="{.data.user-password}" | base64 --decode
+  {{- end }}
+
+

--- a/stable/sentry/templates/_helpers.tpl
+++ b/stable/sentry/templates/_helpers.tpl
@@ -25,15 +25,107 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Create a default fully qualified postgresql subchart name.
 */}}
-{{- define "postgresql.fullname" -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- define "postgresql-fullname" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.postgresql.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- define "redis.fullname" -}}
-{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified redis subchart name.
+*/}}
+{{- define "redis-fullname" -}}
+{{- if .Values.redis.fullnameOverride -}}
+{{- .Values.redis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.redis.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a smtp fullname
+*/}}
 {{- define "smtp.fullname" -}}
 {{- printf "%s-%s" .Release.Name "smtp" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Generate standard environment configuration.
+*/}}
+{{- define "sentry.standardEnv" }}
+env:
+- name: SENTRY_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+    {{- if .Values.existingSecret }}
+      name: {{ .Values.existingSecret }}
+    {{- else }}
+      name: {{ template "fullname" . }}
+    {{- end }}
+      key: sentry-secret
+- name: SENTRY_DB_USER
+  value: {{ default "sentry" .Values.postgresql.postgresqlUsername | quote }}
+- name: SENTRY_DB_NAME
+  value: {{ default "sentry" .Values.postgresql.postgresqlDatabase | quote }}
+- name: SENTRY_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+    {{- if .Values.postgresql.existingSecret }}
+      name: {{ .Values.postgresql.existingSecret }}
+    {{- else }}
+      name: {{ template "postgresql-fullname" . }}
+    {{- end }}
+      key: postgresql-password
+- name: SENTRY_POSTGRES_HOST
+  value: {{ template "postgresql-fullname" . }}
+- name: SENTRY_POSTGRES_PORT
+  value: "5432"
+- name: SENTRY_REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+    {{- if .Values.redis.existingSecret }}
+      name: {{ .Values.redis.existingSecret }}
+    {{- else }}
+      name: {{ template "redis-fullname" . }}
+    {{- end }}
+      key: redis-password
+- name: SENTRY_REDIS_HOST
+  value: {{ template "redis-fullname" . }}-master
+- name: SENTRY_REDIS_PORT
+  value: {{ default "6379" .Values.redis.master.port | quote }}
+- name: SENTRY_EMAIL_HOST
+  value: {{ default "" .Values.smtpHost | quote }}
+- name: SENTRY_EMAIL_PORT
+  value: {{ default "" .Values.smtpPort | quote }}
+- name: SENTRY_EMAIL_USER
+  value: {{ default "" .Values.smtpUser | quote }}
+- name: SENTRY_EMAIL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+    {{- if .Values.existingSecret }}
+      name: {{ .Values.existingSecret }}
+    {{- else }}
+      name: {{ template "fullname" . }}
+    {{- end }}
+      key: smtp-password
+      optional: true
+- name: SENTRY_EMAIL_USE_TLS
+  value: {{ .Values.email.use_tls | quote }}
+- name: SENTRY_SERVER_EMAIL
+  value: {{ .Values.email.from_address | quote }}
+{{- end -}}
+

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -46,57 +46,7 @@ spec:
         args: ["run", "cron"]
         ports:
         - containerPort: {{ .Values.service.internalPort }}
-        env:
-        - name: SENTRY_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: sentry-secret
-        - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresUser | quote }}
-        - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresDatabase | quote }}
-        - name: SENTRY_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.postgresql.existingSecret }}
-              name: {{ .Values.postgresql.existingSecret }}
-            {{- else }}
-              name: {{ template "postgresql.fullname" . }}
-            {{- end }}
-              key: postgres-password
-        - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
-        - name: SENTRY_REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.redis.existingSecret }}
-              name: {{ .Values.redis.existingSecret }}
-            {{- else }}
-              name: {{ template "redis.fullname" . }}
-            {{- end }}
-              key: redis-password
-        - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.fullname" . }}-master
-        - name: SENTRY_REDIS_PORT
-          value: "6379"
-        - name: SENTRY_EMAIL_HOST
-          value: {{ default "" .Values.email.host | quote }}
-        - name: SENTRY_EMAIL_PORT
-          value: {{ default "" .Values.email.port | quote }}
-        - name: SENTRY_EMAIL_USER
-          value: {{ default "" .Values.email.user | quote }}
-        - name: SENTRY_EMAIL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: smtp-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
+{{- include "sentry.standardEnv" . | indent 8 }}
 {{- if .Values.cron.env }}
 {{ toYaml .Values.cron.env | indent 8 }}
 {{- end }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -30,57 +30,7 @@ spec:
       - name: db-init-job
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command: ["sentry","upgrade","--noinput"]
-        env:
-        - name: SENTRY_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: sentry-secret
-        - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresUser | quote }}
-        - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresDatabase | quote }}
-        - name: SENTRY_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.postgresql.existingSecret }}
-              name: {{ .Values.postgresql.existingSecret }}
-            {{- else }}
-              name: {{ template "postgresql.fullname" . }}
-            {{- end }}
-              key: postgres-password
-        - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
-        - name: SENTRY_REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.redis.existingSecret }}
-              name: {{ .Values.redis.existingSecret }}
-            {{- else }}
-              name: {{ template "redis.fullname" . }}
-            {{- end }}
-              key: redis-password
-        - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.fullname" . }}-master
-        - name: SENTRY_REDIS_PORT
-          value: "6379"
-        - name: SENTRY_EMAIL_HOST
-          value: {{ default "" .Values.smtpHost | quote }}
-        - name: SENTRY_EMAIL_PORT
-          value: {{ default "" .Values.smtpPort | quote }}
-        - name: SENTRY_EMAIL_USER
-          value: {{ default "" .Values.smtpUser | quote }}
-        - name: SENTRY_EMAIL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: smtp-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
+{{- include "sentry.standardEnv" . | indent 8 }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -30,62 +30,16 @@ spec:
       - name: user-create-job
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command: ["sentry","createuser","--no-input","--email", "{{ .Values.user.email }}", "--superuser","--password","$(SENTRY_USER_PASSWORD)"]
-        env:
-        - name: SENTRY_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: sentry-secret
-        - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresUser | quote }}
-        - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresDatabase | quote }}
-        - name: SENTRY_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.postgresql.existingSecret }}
-              name: {{ .Values.postgresql.existingSecret }}
-            {{- else }}
-              name: {{ template "postgresql.fullname" . }}
-            {{- end }}
-              key: postgres-password
-        - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
-        - name: SENTRY_REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.redis.existingSecret }}
-              name: {{ .Values.redis.existingSecret }}
-            {{- else }}
-              name: {{ template "redis.fullname" . }}
-            {{- end }}
-              key: redis-password
-        - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.fullname" . }}-master
-        - name: SENTRY_REDIS_PORT
-          value: "6379"
-        - name: SENTRY_EMAIL_HOST
-          value: {{ default "" .Values.smtpHost | quote }}
-        - name: SENTRY_EMAIL_PORT
-          value: {{ default "" .Values.smtpPort | quote }}
-        - name: SENTRY_EMAIL_USER
-          value: {{ default "" .Values.smtpUser | quote }}
-        - name: SENTRY_EMAIL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: smtp-password
+{{- include "sentry.standardEnv" . | indent 8 }}
         - name: SENTRY_USER_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if .Values.existingSecret }}
+              name: {{ .Values.existingSecret }}
+            {{- else }}
               name: {{ template "fullname" . }}
+            {{- end }}
               key: user-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
         volumeMounts:
         - mountPath: /etc/sentry
           name: config

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,3 +21,4 @@ data:
   {{ else }}
   user-password: {{ randAlphaNum 16 | b64enc | quote }}
   {{ end }}
+{{- end }}

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -45,57 +45,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}
-        env:
-        - name: SENTRY_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: sentry-secret
-        - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresUser | quote }}
-        - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresDatabase | quote }}
-        - name: SENTRY_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.postgresql.existingSecret }}
-              name: {{ .Values.postgresql.existingSecret }}
-            {{- else }}
-              name: {{ template "postgresql.fullname" . }}
-            {{- end }}
-              key: postgres-password
-        - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
-        - name: SENTRY_REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.redis.existingSecret }}
-              name: {{ .Values.redis.existingSecret }}
-            {{- else }}
-              name: {{ template "redis.fullname" . }}
-            {{- end }}
-              key: redis-password
-        - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.fullname" . }}-master
-        - name: SENTRY_REDIS_PORT
-          value: "6379"
-        - name: SENTRY_EMAIL_HOST
-          value: {{ default "" .Values.email.host | quote }}
-        - name: SENTRY_EMAIL_PORT
-          value: {{ default "" .Values.email.port | quote }}
-        - name: SENTRY_EMAIL_USER
-          value: {{ default "" .Values.email.user | quote }}
-        - name: SENTRY_EMAIL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: smtp-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
+{{- include "sentry.standardEnv" . | indent 8 }}
 {{- if .Values.web.env }}
 {{ toYaml .Values.web.env | indent 8 }}
 {{- end }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -46,57 +46,7 @@ spec:
         args: ["run", "worker"]
         ports:
         - containerPort: {{ .Values.service.internalPort }}
-        env:
-        - name: SENTRY_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: sentry-secret
-        - name: SENTRY_DB_USER
-          value: {{ default "sentry" .Values.postgresUser | quote }}
-        - name: SENTRY_DB_NAME
-          value: {{ default "sentry" .Values.postgresDatabase | quote }}
-        - name: SENTRY_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.postgresql.existingSecret }}
-              name: {{ .Values.postgresql.existingSecret }}
-            {{- else }}
-              name: {{ template "postgresql.fullname" . }}
-            {{- end }}
-              key: postgres-password
-        - name: SENTRY_POSTGRES_HOST
-          value: {{ template "postgresql.fullname" . }}
-        - name: SENTRY_POSTGRES_PORT
-          value: "5432"
-        - name: SENTRY_REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-            {{- if .Values.redis.existingSecret }}
-              name: {{ .Values.redis.existingSecret }}
-            {{- else }}
-              name: {{ template "redis.fullname" . }}
-            {{- end }}
-              key: redis-password
-        - name: SENTRY_REDIS_HOST
-          value: {{ template "redis.fullname" . }}-master
-        - name: SENTRY_REDIS_PORT
-          value: "6379"
-        - name: SENTRY_EMAIL_HOST
-          value: {{ default "" .Values.email.host | quote }}
-        - name: SENTRY_EMAIL_PORT
-          value: {{ default "" .Values.email.port | quote }}
-        - name: SENTRY_EMAIL_USER
-          value: {{ default "" .Values.email.user | quote }}
-        - name: SENTRY_EMAIL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "fullname" . }}
-              key: smtp-password
-        - name: SENTRY_EMAIL_USE_TLS
-          value: {{ .Values.email.use_tls | quote }}
-        - name: SENTRY_SERVER_EMAIL
-          value: {{ .Values.email.from_address | quote }}
+{{- include "sentry.standardEnv" . | indent 8 }}
 {{- if .Values.worker.env }}
 {{ toYaml .Values.worker.env | indent 8 }}
 {{- end }}

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -9,6 +9,9 @@ image:
   imagePullSecrets: []
   # - name:
 
+# Add an existing secret to override the {{ template "fullname" . }} secret files
+existingSecret:
+
 # How many web UI instances to run
 web:
   replicacount: 1


### PR DESCRIPTION
#### What this PR does / why we need it:

- Reduce boilerplate code
- Enhance readability
- Adds possibility to use an existing secret

#### Which issue this PR fixes

- Refactor charts for reduced boilerplate on env variables
- Refactor the template "redis.fullname" and "redis.fullname" to
take account of a potential nameOverride or fullNameOverride as is
possible in the redis and postgresql parent charts respectively
- Add a reference to existingSecret to allow to use a user added secret instead of 
the standard secret for parent chart and subcharts

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
