### PR TITLE
[stable/sumologic-fluentd] Set K8S_NODE_NAME to improve caching

### DIFF
--- a/stable/sumologic-fluentd/Chart.yaml
+++ b/stable/sumologic-fluentd/Chart.yaml
@@ -1,5 +1,5 @@
 name: sumologic-fluentd
-version: 0.8.0
+version: 0.8.1
 appVersion: 2.1.0
 description: Sumologic Log Collector
 keywords:

--- a/stable/sumologic-fluentd/templates/daemonset.yaml
+++ b/stable/sumologic-fluentd/templates/daemonset.yaml
@@ -61,6 +61,10 @@ spec:
                 secretKeyRef:
                   name: "{{ template "sumologic-fluentd.fullname" . }}"
                   key: collector-url
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: FLUENTD_SOURCE
               value: {{ quote .Values.sumologic.fluentdSource }}
             {{- if .Values.sumologic.fluentdUserConfigDir }}


### PR DESCRIPTION
Passes the node name to each pod as `K8S_NODE_NAME`. A fluentd plugin used within the chart's image watches pods and gets more cache hits if it knows its node name.

See also: https://github.com/SumoLogic/fluentd-kubernetes-sumologic/pull/103