### PR TITLE
[stable/mm-te] bump mm-te to 5.6.1

### DIFF
--- a/stable/mattermost-team-edition/Chart.yaml
+++ b/stable/mattermost-team-edition/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 2.1.0
-appVersion: 5.6.0
+version: 2.1.1
+appVersion: 5.6.1
 keywords:
 - mattermost
 - communication

--- a/stable/mattermost-team-edition/README.md
+++ b/stable/mattermost-team-edition/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the Mattermost Team Edi
 Parameter                            | Description                                                                                     | Default
 ---                                  | ---                                                                                             | ---
 `image.repository`                   | container image repository                                                                      | `mattermost/mattermost-team-edition`
-`image.tag`                          | container image tag                                                                             | `5.6.0`
+`image.tag`                          | container image tag                                                                             | `5.6.1`
 `image.imagePullPolicy`              | container image pull policy                                                                     | `IfNotPresent`
 `initContainerImage.repository`      | init container image repository                                                                 | `appropriate/curl`
 `initContainerImage.tag`             | init container image tag                                                                        | `latest`
@@ -78,7 +78,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```bash
 $ helm install --name my-release \
-  --set image.tag=5.5.0 \
+  --set image.tag=5.6.1 \
   --set mysql.mysqlUser=sampleUser \
   --set mysql.mysqlPassword=samplePassword \
   stable/mattermost-team-edition

--- a/stable/mattermost-team-edition/values.yaml
+++ b/stable/mattermost-team-edition/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mattermost/mattermost-team-edition
-  tag: 5.6.0
+  tag: 5.6.1
   imagePullPolicy: IfNotPresent
 
 initContainerImage:


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump mm-te to 5.6.1

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
