### PR TITLE
[stable/prometheus]: allow adding custom containers, volumemounts and volumes to server

### DIFF
--- a/stable/prometheus/Chart.yaml
+++ b/stable/prometheus/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 8.4.6
+version: 8.4.7
 appVersion: 2.6.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -239,6 +239,8 @@ Parameter | Description | Default
 `server.extraHostPathMounts` | Additional Prometheus server hostPath mounts | `[]`
 `server.extraConfigmapMounts` | Additional Prometheus server configMap mounts | `[]`
 `server.extraSecretMounts` | Additional Prometheus server Secret mounts | `[]`
+`server.extraVolumeMounts` | Additional Prometheus server Volume mounts | `[]`
+`server.extraVolumes` | Additional Prometheus server Volumes | `[]`
 `server.configMapOverrideName` | Prometheus server ConfigMap override where full-name is `{{.Release.Name}}-{{.Values.server.configMapOverrideName}}` and setting this value will prevent the default server ConfigMap from being generated | `""`
 `server.ingress.enabled` | If true, Prometheus server Ingress will be created | `false`
 `server.ingress.annotations` | Prometheus server Ingress annotations | `[]`

--- a/stable/prometheus/templates/server-deployment.yaml
+++ b/stable/prometheus/templates/server-deployment.yaml
@@ -139,9 +139,13 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- if .Values.server.extraVolumeMounts }}
+            {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       {{- if .Values.server.sidecarContainers }}
       {{- toYaml .Values.server.sidecarContainers | nindent 8 }}
       {{- end }}
+
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
        {{ toYaml .Values.imagePullSecrets | indent 2 }}
@@ -174,6 +178,9 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end -}}
+{{- if .Values.server.extraVolumes }}
+{{ toYaml .Values.server.extraVolumes | indent 8}}
+{{- end }}
       {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:

--- a/stable/prometheus/templates/server-statefulset.yaml
+++ b/stable/prometheus/templates/server-statefulset.yaml
@@ -136,6 +136,9 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- if .Values.server.extraVolumeMounts }}
+          {{ toYaml .Values.server.extraVolumeMounts | nindent 12 }}
+          {{- end }}
        {{- if .Values.server.sidecarContainers }}
        {{- toYaml .Values.server.sidecarContainers | nindent 8 }}
        {{- end }}
@@ -189,6 +192,9 @@ spec:
           configMap:
             name: {{ .configMap }}
       {{- end }}
+{{- if .Values.server.extraVolumes }}
+{{ toYaml .Values.server.extraVolumes | indent 8}}
+{{- end }}
 {{- if .Values.server.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -553,6 +553,14 @@ server:
   ##
   extraArgs: {}
 
+  ## Additional Prometheus server Volume mounts
+  ##
+  extraVolumeMounts: []
+
+  ## Additional Prometheus server Volumes
+  ##
+  extraVolumes: []
+
   ## Additional Prometheus server hostPath mounts
   ##
   extraHostPathMounts: []


### PR DESCRIPTION
Added configuration options for additional containers, volume mounts and volumes to the prometheus server deployment.

Signed-off-by: Gleb Lesnikov <g.lesnikov@dodopizza.com>

#### What this PR does / why we need it:

Added configuration options for additional containers, volumemounts and volumes to the prometheus server deployment.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md