### PR TITLE
[stable/chartmuseum] Fix typo in service labels template condition

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 1.8.1
+version: 1.8.2
 appVersion: 0.8.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png

--- a/stable/chartmuseum/templates/service.yaml
+++ b/stable/chartmuseum/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
 {{- end }}
   labels:
 {{ include "chartmuseum.labels.standard" . | indent 4 }}
-{{- if .Values.service.annotations }}
+{{- if .Values.service.labels }}
 {{ toYaml .Values.service.labels | indent 4 }}
 {{- end }}
 {{- if .Values.service.annotations }}


### PR DESCRIPTION
There is evidently a small typo in a service labels template condition. Installing this chart with custom annotations but no labels ends with following error:

```
Error: YAML parse error on chartmuseum/templates/service.yaml: error converting YAML to JSON: yaml: line 11: could not find expected ':'
```