### PR TITLE
[stable/sealed-secrets] Fix sealed secrets service selector

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.7.0
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets

--- a/stable/sealed-secrets/templates/service.yaml
+++ b/stable/sealed-secrets/templates/service.yaml
@@ -12,4 +12,4 @@ spec:
   ports:
     - port: 8080
   selector:
-    name: {{ template "sealed-secrets.fullname" . }}
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:
The current service's selector won't match the pod's name as it is randomly generated.
Using a static annotation fixes the issue.

#### Which issue this PR fixes
None open

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
