### PR TITLE
[stable/gce-ingress] bump gce-ingress to 1.4.0

### DIFF
--- a/stable/gce-ingress/Chart.yaml
+++ b/stable/gce-ingress/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.1.1"
+appVersion: "1.4.0"
 description: A GCE Ingress Controller
 name: gce-ingress
-version: 1.0.0
+version: 1.1.0
 keywords:
   - ingress
   - gce

--- a/stable/gce-ingress/README.md
+++ b/stable/gce-ingress/README.md
@@ -47,7 +47,7 @@ Parameter | Description | Default
 --- | --- | ---
 `controller.name` | name of the controller component | `controller`
 `controller.image.repository` | controller container image repository | `k8s.gcr.io/ingress-gce-glbc-amd64`
-`controller.image.tag` | controller container image tag | `v1.1.1`
+`controller.image.tag` | controller container image tag | `v1.4.0`
 `controller.image.pullPolicy` | controller container image pull policy | `IfNotPresent`
 `controller.config` | gce ConfigMap entries | none
 `controller.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`

--- a/stable/gce-ingress/values.yaml
+++ b/stable/gce-ingress/values.yaml
@@ -46,7 +46,7 @@ controller:
   replicaCount: 1
   image:
     repository: k8s.gcr.io/ingress-gce-glbc-amd64
-    tag: v1.1.1
+    tag: v1.4.0
     pullPolicy: IfNotPresent
   resources: {}
     # requests:


### PR DESCRIPTION
#### What this PR does / why we need it:
bump gce-ingress to 1.4.0

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
