### PR TITLE
[stable/hackmd] bump hackmd to 1.2.1-alpine

### DIFF
--- a/stable/hackmd/Chart.yaml
+++ b/stable/hackmd/Chart.yaml
@@ -1,7 +1,7 @@
 name: hackmd
 apiVersion: v1
-version: "0.1.1"
-appVersion: "1.0.1"
+version: "1.0.0"
+appVersion: "1.2.1-alpine"
 description: Realtime collaborative markdown notes on all platforms.
 icon: https://hackmd.io/favicon.png
 keywords:

--- a/stable/hackmd/README.md
+++ b/stable/hackmd/README.md
@@ -28,7 +28,7 @@ Parameter | Description | Default
 --------- | ----------- | -------
 `replicaCount` | How many replicas to run. | 1
 `image.repository` | Name of the image to run, without the tag. | [hackmdio/hackmd](https://github.com/hackmdio/docker-hackmd)
-`image.tag` | The image tag to use. | 1.0.1-ce
+`image.tag` | The image tag to use. | 1.2.1-alpine
 `image.pullPolicy` | The kubernetes image pull policy. | IfNotPresent
 `service.name` | The kubernetes service name to use. | hackmd
 `service.type` | The kubernetes service type to use. | ClusterIP

--- a/stable/hackmd/values.yaml
+++ b/stable/hackmd/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: hackmdio/hackmd
-  tag: 1.0.1-ce-alpine
+  tag: 1.2.1-alpine
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
#### What this PR does / why we need it:
- bump  hackmd to 1.2.1-alpine
- bump chart version to 1.0.0 since this chart is in stable folder


#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
