### PR TITLE
[stable/jenkins] Add support for Jenkins Configuration as Code plugin

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.26.0
+version: 0.27.0
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -191,8 +191,8 @@ Master:
           systemMessage: "Jenkins configured automatically by Jenkins Configuration as Code Plugin\n\n"
 ```
 
-In contrast to adding xml configuration files these settings are reapplied during every Jenkins restart and when you apply
-the configuration in the plugin ui.
+Every configuration changes triggers a Jenkins restart during which the settings are reapplied.
+
 
 ## Adding customized labels
 

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -82,6 +82,9 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.Affinity`                 | Affinity settings                    | `{}`                                                                         |
 | `Master.Tolerations`              | Toleration labels for pod assignment | `{}`                                                                         |
 | `Master.PodAnnotations`           | Annotations for master pod           | `{}`                                                                         |
+| `Master.ConfigurationAsCode.Enabled` | Enable configuration as code         | `false`                                                                   |
+| `Master.ConfigurationAsCode.PluginVersion` | Version of configuration as code plugin (only used if `configuration-as-code` not part of `Master.InstallPlugins` | `1.4` |
+| `Master.ConfigurationAsCode.AdditionalConfig` | Add additional configuration as code config files | `{}`                                                |
 | `NetworkPolicy.Enabled`           | Enable creation of NetworkPolicy resources. | `false`                                                               |
 | `NetworkPolicy.ApiVersion`        | NetworkPolicy ApiVersion             | `extensions/v1beta1`                                                         |
 | `rbac.install`                    | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                                       |
@@ -168,6 +171,28 @@ AdditionalConfig:
       clientKey: testKey
       clientURL: testUrl
 ```
+
+## Using Configuration as Code
+
+`Master.ConfigurationAsCode.Enabled` can be used to enable [Jenkins Configuration as Code Plugin](https://github.com/jenkinsci/configuration-as-code-plugin).
+It automatically adds it to `Master.InstallPlugins` unless it's already specified there.
+
+The plugin version being used can be customized via `Master.ConfigurationAsCode.PluginVersion`.
+
+Below is an example how you can customize the system message by providing `Master.ConfigurationAsCode.AdditionalConfig`:
+
+```yaml
+Master:
+  ConfigurationAsCode:
+    Enabled: true
+    AdditionalConfig:
+      testConfig.yaml: |-
+        jenkins:
+          systemMessage: "Jenkins configured automatically by Jenkins Configuration as Code Plugin\n\n"
+```
+
+In contrast to adding xml configuration files these settings are reapplied during every Jenkins restart and when you apply
+the configuration in the plugin ui.
 
 ## Adding customized labels
 

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -254,6 +254,11 @@ data:
 {{- range $index, $val := .Values.Master.InstallPlugins }}
 {{ $val | indent 4 }}
 {{- end }}
+{{- if .Values.Master.ConfigurationAsCode.Enabled }}
+    {{- if not (contains "configuration-as-code" (quote .Values.Master.InstallPlugins)) }}
+    configuration-as-code:{{ .Values.Master.ConfigurationAsCode.PluginVersion }}
+    {{- end}}
+{{- end }}
 {{- end }}
 {{ else }}
 {{ include "override_config_map" . }}

--- a/stable/jenkins/templates/configmap-jenkins-config-as-code.yaml
+++ b/stable/jenkins/templates/configmap-jenkins-config-as-code.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.Master.ConfigurationAsCode.Enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}-casc
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+data:
+  jenkins.yaml: |
+    jenkins:
+      numExecutors: 0
+{{ if .Values.Master.ConfigurationAsCode.AdditionalConfig }}
+{{- toYaml .Values.Master.ConfigurationAsCode.AdditionalConfig | indent 2 }}
+{{- end }}
+{{- end }}

--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -28,6 +28,9 @@ spec:
         component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        {{- if .Values.Master.ConfigurationAsCode.Enabled }}
+        checksum/casc: {{ include (print $.Template.BasePath "/configmap-jenkins-config-as-code.yaml") . | sha256sum }}
+        {{- end}}
         {{- if .Values.Master.PodAnnotations }}
 {{ toYaml .Values.Master.PodAnnotations | indent 8 }}
         {{- end }}
@@ -113,6 +116,10 @@ spec:
           args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]
           {{- end }}
           env:
+            {{- if .Values.Master.ConfigurationAsCode.Enabled }}
+            - name: CASC_JENKINS_CONFIG
+              value: "/var/jenkins_casc"
+            {{- end}}
             - name: JAVA_TOOL_OPTIONS
               value: "{{ default "" .Values.Master.JavaOpts}}"
             - name: JENKINS_OPTS
@@ -185,6 +192,12 @@ spec:
               mountPath: /var/jenkins_config
               name: jenkins-config
               readOnly: true
+            {{- if .Values.Master.ConfigurationAsCode.Enabled }}
+            -
+              mountPath: /var/jenkins_casc
+              name: jenkins-config-as-code
+              readOnly: false
+            {{- end }}
             {{- if .Values.Master.CredentialsXmlSecret }}
             -
               mountPath: /var/jenkins_credentials
@@ -220,6 +233,12 @@ spec:
       - name: jenkins-config
         configMap:
           name: {{ template "jenkins.fullname" . }}
+      {{- if .Values.Master.ConfigurationAsCode.Enabled }}
+      - name: jenkins-config-as-code
+        configMap:
+          defaultMode: 420
+          name: {{ template "jenkins.fullname" . }}-casc
+      {{- end }}
       {{- if .Values.Master.CredentialsXmlSecret }}
       - name: jenkins-credentials
         secret:

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -104,6 +104,10 @@ Master:
     - workflow-aggregator:2.5
     - credentials-binding:1.16
     - git:3.9.1
+  ConfigurationAsCode:
+    Enabled: false
+    PluginVersion: 1.4
+    AdditionalConfig: {}
   # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   # ScriptApproval:
   #   - "method groovy.json.JsonSlurperClassic parseText java.lang.String"


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR adds support for the [Configuration as Code Plugin](https://github.com/jenkinsci/configuration-as-code-plugin). This provides users of this chart with an easy way to customize Jenkins configuration

In comparison to the xml approach it has the following advantages:
- it's easier to read
- configuration can be reapplied
  If you reapply the XML configuration then all the settings of those XML files are overwritten, no matter if that file has manually been changed. By using the configuration as code plugin only those settings which are specified within the yaml files are updated. That's especially useful for settings which are stored in `config.xml` which is used by many plugins.

To stay backwards compatible the configuration as code plugin is disabled by default. I verified that the generated files are identical compared to the previous version (using a static password and ignoring the test pod).

I added the plugin to the plugins.txt to ensure that the plugin is installed in case this feature is enabled. There is a configuration option `Master.ConfigurationAsCode.PluginVersion` which allows to specify the plugin version. In case the plugin is already specified as part of `Master.InstallPlugins` nothing is added to avoid duplicate dependency of the plugin and having version conflicts.

#### Special notes for your reviewer:
In the future this could be used to migrate existing XML to yaml configurations. As this allows updating values. Would be great if @lachie83 and @viglesiasce as maintainers of the chart could give me feedback if you like that idea. In that case I can try to submit PRs for the config migration.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md


