### PR TITLE
[stable/nginx-ingress] add servicemonitor resource

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 1.1.1
+version: 1.1.2
 appVersion: 0.21.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -123,6 +123,8 @@ Parameter | Description | Default
 `controller.metrics.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `controller.metrics.service.servicePort` | Prometheus metrics service port | `9913`
 `controller.metrics.service.type` | type of Prometheus metrics service to create | `ClusterIP`
+`controller.metrics.serviceMonitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false`
+`controller.metrics.serviceMonitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`
 `controller.customTemplate.configMapName` | configMap containing a custom nginx template | `""`
 `controller.customTemplate.configMapKey` | configMap key containing the nginx template | `""`
 `controller.headers` | configMap key:value pairs containing the [custom headers](https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-headers) for Nginx | `{}`
@@ -175,6 +177,7 @@ as described [here](https://github.com/kubernetes/ingress-nginx/blob/master/docs
 ```console
 $ helm install stable/nginx-ingress --set controller.extraArgs.v=2
 ```
+> **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## PodDisruptionBudget
 Note that the PodDisruptionBudget resource will only be defined if the replicaCount is greater than one,
@@ -190,27 +193,7 @@ $ helm install stable/nginx-ingress --name my-release \
     --set controller.metrics.enabled=true
 ```
 
-You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you need to create a ServiceMonitor as follows:
-
-```yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: nginx-ingress-service-monitor
-spec:
-  jobLabel: nginx-ingress
-  selector:
-    matchLabels:
-      app: nginx-ingress
-      release: <RELEASE>
-  namespaceSelector:
-    matchNames:
-      - <RELEASE_NAMESPACE>
-  endpoints:
-    - port: metrics
-      interval: 30s
-```
-> **Tip**: You can use the default [values.yaml](values.yaml)
+You can add Prometheus annotations to the metrics service using `controller.metrics.service.annotations`. Alternatively, if you use the Prometheus Operator, you can enable ServiceMonitor creation using `controller.metrics.serviceMonitor.enabled`.
 
 ## ExternalDNS Service configuration
 

--- a/stable/nginx-ingress/templates/controller-servicemonitor.yaml
+++ b/stable/nginx-ingress/templates/controller-servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "nginx-ingress.controller.fullname" . }}
+  labels:
+    app: {{ template "nginx-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.controller.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.controller.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "nginx-ingress.name" . }}
+      component: "{{ .Values.controller.name }}"
+      release: {{ .Release.Name }}
+{{- end }}

--- a/stable/nginx-ingress/values.yaml
+++ b/stable/nginx-ingress/values.yaml
@@ -274,6 +274,10 @@ controller:
       servicePort: 9913
       type: ClusterIP
 
+    serviceMonitor:
+      enabled: false
+      additionalLabels: {}
+
   lifecycle: {}
 
   priorityClassName: ""


### PR DESCRIPTION
Signed-off-by: Sébastien Prud'homme <sebastien.prudhomme@gmail.com>

#### What this PR does / why we need it:

This PR add an option to create a ServiceMonitor resource for people who use the Prometheus Operator.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
