### PR TITLE
[stable/kong] add support to enable HTTP and HTTPS traffic simultaneously

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.6.9
+version: 0.6.10
 appVersion: 0.14.1

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.6.10
+version: 0.7.0
 appVersion: 0.14.1

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -67,10 +67,6 @@ and their default values.
 | admin.ingress.hosts            | List of ingress hosts.                                                           | `[]`                |
 | admin.ingress.path             | Ingress path.                                                                    | `/`                 |
 | admin.ingress.annotations      | Ingress annotations. See documentation for your ingress controller for details   | `{}`                |
-| proxy.useTLS                   | Secure Proxy traffic                                                             | `true`              |
-| proxy.servicePort              | TCP port on which the Kong Proxy Service is exposed                              | `443`               |
-| proxy.containerPort            | TCP port on which the Kong app listens for Proxy traffic                         | `8443`              |
-| proxy.nodePort                 | Node port when service type is `NodePort`                                        |                     |
 | proxy.http.enabled             | Enables http on the proxy                                                        | false               |
 | proxy.http.servicePort         | Service port to use for http                                                     | 80                  |
 | proxy.http.containerPort       | Container port to use for http                                                   | 8000                |

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -71,6 +71,13 @@ and their default values.
 | proxy.servicePort              | TCP port on which the Kong Proxy Service is exposed                              | `8443`              |
 | proxy.containerPort            | TCP port on which the Kong app listens for Proxy traffic                         | `8443`              |
 | proxy.nodePort                 | Node port when service type is `NodePort`                                        |                     |
+| proxy.http.enabled             | Enables http on the proxy                                                        | false               |
+| proxy.http.servicePort         | Service port to use for http                                                     | 8000                |
+| proxy.http.containerPort       | Container port to use for http                                                   | 8000                |
+| proxy.http.nodePort            | Node port to use for http                                                        | 32080               |
+| proxy.tls.enabled              | Enables TLS on the proxy                                                         | true                |
+| proxy.tls.containerPort        | Container port to use for TLS                                                    | 8443                |
+| proxy.tls.nodePort             | Node port to use for TLS                                                         | 32443               |
 | proxy.type                     | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                     | `NodePort`          |
 | proxy.loadBalancerSourceRanges | Limit proxy access to CIDRs if set and service type is `LoadBalancer`            | `[]`                |
 | proxy.loadBalancerIP           | To reuse an existing ingress static IP for the admin service                     |                     |

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -68,7 +68,7 @@ and their default values.
 | admin.ingress.path             | Ingress path.                                                                    | `/`                 |
 | admin.ingress.annotations      | Ingress annotations. See documentation for your ingress controller for details   | `{}`                |
 | proxy.useTLS                   | Secure Proxy traffic                                                             | `true`              |
-| proxy.servicePort              | TCP port on which the Kong Proxy Service is exposed                              | `8443`              |
+| proxy.servicePort              | TCP port on which the Kong Proxy Service is exposed                              | `443`               |
 | proxy.containerPort            | TCP port on which the Kong app listens for Proxy traffic                         | `8443`              |
 | proxy.nodePort                 | Node port when service type is `NodePort`                                        |                     |
 | proxy.http.enabled             | Enables http on the proxy                                                        | false               |

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -67,7 +67,7 @@ and their default values.
 | admin.ingress.hosts            | List of ingress hosts.                                                           | `[]`                |
 | admin.ingress.path             | Ingress path.                                                                    | `/`                 |
 | admin.ingress.annotations      | Ingress annotations. See documentation for your ingress controller for details   | `{}`                |
-| proxy.http.enabled             | Enables http on the proxy                                                        | false               |
+| proxy.http.enabled             | Enables http on the proxy                                                        | true               |
 | proxy.http.servicePort         | Service port to use for http                                                     | 80                  |
 | proxy.http.containerPort       | Container port to use for http                                                   | 8000                |
 | proxy.http.nodePort            | Node port to use for http                                                        | 32080               |

--- a/stable/kong/README.md
+++ b/stable/kong/README.md
@@ -72,11 +72,12 @@ and their default values.
 | proxy.containerPort            | TCP port on which the Kong app listens for Proxy traffic                         | `8443`              |
 | proxy.nodePort                 | Node port when service type is `NodePort`                                        |                     |
 | proxy.http.enabled             | Enables http on the proxy                                                        | false               |
-| proxy.http.servicePort         | Service port to use for http                                                     | 8000                |
+| proxy.http.servicePort         | Service port to use for http                                                     | 80                  |
 | proxy.http.containerPort       | Container port to use for http                                                   | 8000                |
 | proxy.http.nodePort            | Node port to use for http                                                        | 32080               |
 | proxy.tls.enabled              | Enables TLS on the proxy                                                         | true                |
 | proxy.tls.containerPort        | Container port to use for TLS                                                    | 8443                |
+| proxy.tls.servicePort          | Service port to use for TLS                                                      | 8443                |
 | proxy.tls.nodePort             | Node port to use for TLS                                                         | 32443               |
 | proxy.type                     | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                     | `NodePort`          |
 | proxy.loadBalancerSourceRanges | Limit proxy access to CIDRs if set and service type is `LoadBalancer`            | `[]`                |

--- a/stable/kong/templates/NOTES.txt
+++ b/stable/kong/templates/NOTES.txt
@@ -37,7 +37,11 @@ use one of the addresses listed below
 
 2. Kong Proxy can be accessed inside the cluster using:
      DNS={{ template "kong.fullname" . }}-proxy.{{ .Release.Namespace }}.svc.cluster.local
-     PORT={{ .Values.proxy.servicePort }}
+     {{- if .Values.proxy.tls.enabled -}}
+        PORT={{ .Values.proxy.tls.servicePort }}
+     {{- else -}}
+        PORT={{ .Values.proxy.http.servicePort }}
+     {{- end -}}
 
 
 To connect from outside the K8s cluster:
@@ -69,5 +73,9 @@ use one of the addresses listed below
 
      # Execute the following commands to route the connection to proxy SSL port:
      export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }}, app={{ template "kong.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.proxy.servicePort }}:{{ .Values.proxy.servicePort }}
+     {{- if .Values.proxy.tls.enabled -}}
+        kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.proxy.tls.servicePort }}:{{ .Values.proxy.tls.servicePort }}
+     {{- else -}}
+        kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.proxy.http.servicePort }}:{{ .Values.proxy.http.servicePort }}
+     {{- end -}}
    {{- end }}

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -33,3 +33,21 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the KONG_PROXY_LISTEN value string
+*/}}
+{{- define "kong.kongProxyListenValue" -}}
+
+{{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled -}}
+   0.0.0.0:{{ .Values.proxy.http.containerPort }},0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl
+{{- else -}}
+{{- if .Values.proxy.http.enabled -}}
+   0.0.0.0:{{ .Values.proxy.http.containerPort }}
+{{- end -}}
+{{- if .Values.proxy.tls.enabled -}}
+   0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl
+{{- end -}}
+{{- end -}}
+
+{{- end }}

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -51,3 +51,14 @@ Create the KONG_PROXY_LISTEN value string
 {{- end -}}
 
 {{- end }}
+
+{{/*
+Create the ingress servicePort value string
+*/}}
+{{- define "kong.ingress.servicePort" -}}
+{{- if .Values.proxy.tls.enabled -}}
+   {{ .Values.proxy.tls.servicePort }}
+{{- else -}}
+   {{ .Values.proxy.http.servicePort }}
+{{- end -}}
+{{- end -}}

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -76,13 +76,8 @@ spec:
         - name: KONG_ADMIN_LISTEN
           value: 0.0.0.0:{{ .Values.admin.containerPort }}
         {{- end }}
-        {{- if .Values.proxy.useTLS }}
         - name: KONG_PROXY_LISTEN
-          value: "0.0.0.0:{{ .Values.proxy.containerPort }} ssl"
-        {{- else }}
-        - name: KONG_PROXY_LISTEN
-          value: 0.0.0.0:{{ .Values.proxy.containerPort }}
-        {{- end }}
+          value: {{ template "kong.kongProxyListenValue" . }}
         - name: KONG_NGINX_DAEMON
           value: "off"
         - name: KONG_PROXY_ACCESS_LOG
@@ -116,9 +111,26 @@ spec:
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           protocol: TCP
+        {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled }}
         - name: proxy
-          containerPort: {{ .Values.proxy.containerPort }}
+          containerPort: {{ .Values.proxy.http.containerPort }}
           protocol: TCP
+        - name: proxy-tls
+          containerPort: {{ .Values.proxy.tls.containerPort }}
+          protocol: TCP
+        {{ else }}
+
+        {{- if .Values.proxy.http.enabled }}
+        - name: proxy
+          containerPort: {{ .Values.proxy.http.containerPort }}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.proxy.tls.enabled }}
+        - name: proxy-tls
+          containerPort: {{ .Values.proxy.tls.containerPort }}
+          protocol: TCP
+        {{- end }}
+        {{- end }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:

--- a/stable/kong/templates/deployment.yaml
+++ b/stable/kong/templates/deployment.yaml
@@ -111,15 +111,6 @@ spec:
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           protocol: TCP
-        {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled }}
-        - name: proxy
-          containerPort: {{ .Values.proxy.http.containerPort }}
-          protocol: TCP
-        - name: proxy-tls
-          containerPort: {{ .Values.proxy.tls.containerPort }}
-          protocol: TCP
-        {{ else }}
-
         {{- if .Values.proxy.http.enabled }}
         - name: proxy
           containerPort: {{ .Values.proxy.http.containerPort }}
@@ -129,7 +120,6 @@ spec:
         - name: proxy-tls
           containerPort: {{ .Values.proxy.tls.containerPort }}
           protocol: TCP
-        {{- end }}
         {{- end }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}

--- a/stable/kong/templates/ingress-proxy.yaml
+++ b/stable/kong/templates/ingress-proxy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.proxy.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := .Values.proxy.servicePort -}}
+{{- $servicePort := include "kong.ingress.servicePort" . -}}
 {{- $path := .Values.proxy.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -25,22 +25,6 @@ spec:
   {{- end }}
   {{- end }}
   ports:
-  {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled }}
-  - name: kong-proxy
-    port: {{ .Values.proxy.http.servicePort }}
-    targetPort: {{ .Values.proxy.http.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.http.nodePort))) }}
-    nodePort: {{ .Values.proxy.http.nodePort }}
-  {{- end }}
-  - name: kong-proxy-tls
-    port: {{ .Values.proxy.tls.servicePort }}
-    targetPort: {{ .Values.proxy.tls.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.tls.nodePort))) }}
-    nodePort: {{ .Values.proxy.tls.nodePort }}
-  {{- end }}
-
-  {{ else }}
-
   {{- if .Values.proxy.http.enabled }}
   - name: kong-proxy
     port: {{ .Values.proxy.http.servicePort }}
@@ -58,7 +42,6 @@ spec:
   {{- end }}
   {{- end }}
 
-  {{- end }}
 
   selector:
     app: {{ template "kong.name" . }}

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -32,6 +32,7 @@ spec:
   {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.http.nodePort))) }}
     nodePort: {{ .Values.proxy.http.nodePort }}
   {{- end }}
+    protocol: TCP
   {{- end }}
   {{- if or .Values.proxy.tls.enabled }}
   - name: kong-proxy-tls
@@ -40,6 +41,7 @@ spec:
   {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.tls.nodePort))) }}
     nodePort: {{ .Values.proxy.tls.nodePort }}
   {{- end }}
+    protocol: TCP
   {{- end }}
 
 

--- a/stable/kong/templates/service-kong-proxy.yaml
+++ b/stable/kong/templates/service-kong-proxy.yaml
@@ -25,13 +25,41 @@ spec:
   {{- end }}
   {{- end }}
   ports:
+  {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled }}
   - name: kong-proxy
-    port: {{ .Values.proxy.servicePort }}
-    targetPort: {{ .Values.proxy.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.nodePort))) }}
-    nodePort: {{ .Values.proxy.nodePort }}
+    port: {{ .Values.proxy.http.servicePort }}
+    targetPort: {{ .Values.proxy.http.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.http.nodePort))) }}
+    nodePort: {{ .Values.proxy.http.nodePort }}
   {{- end }}
-    protocol: TCP
+  - name: kong-proxy-tls
+    port: {{ .Values.proxy.tls.servicePort }}
+    targetPort: {{ .Values.proxy.tls.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.tls.nodePort))) }}
+    nodePort: {{ .Values.proxy.tls.nodePort }}
+  {{- end }}
+
+  {{ else }}
+
+  {{- if .Values.proxy.http.enabled }}
+  - name: kong-proxy
+    port: {{ .Values.proxy.http.servicePort }}
+    targetPort: {{ .Values.proxy.http.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.http.nodePort))) }}
+    nodePort: {{ .Values.proxy.http.nodePort }}
+  {{- end }}
+  {{- end }}
+  {{- if or .Values.proxy.tls.enabled }}
+  - name: kong-proxy-tls
+    port: {{ .Values.proxy.tls.servicePort }}
+    targetPort: {{ .Values.proxy.tls.containerPort }}
+  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.tls.nodePort))) }}
+    nodePort: {{ .Values.proxy.tls.nodePort }}
+  {{- end }}
+  {{- end }}
+
+  {{- end }}
+
   selector:
     app: {{ template "kong.name" . }}
     release: {{ .Release.Name }}

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -56,13 +56,13 @@ proxy:
     enabled: true
     servicePort: 80
     containerPort: 8000
-    #nodePort: 32080
+    # nodePort: 32080
 
   tls:
     enabled: true
     servicePort: 443
     containerPort: 8443
-    #nodePort: 32443
+    # nodePort: 32443
 
   type: NodePort
 

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -54,13 +54,13 @@ proxy:
   # HTTP plain-text traffic
   http:
     enabled: false
-    servicePort: 8000
+    servicePort: 80
     containerPort: 8000
     nodePort: 32080
 
   tls:
     enabled: true
-    servicePort: 8443
+    servicePort: 443
     containerPort: 8443
     nodePort: 32443
 

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -51,10 +51,19 @@ proxy:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # HTTPS traffic on the proxy port
-  useTLS: true
-  servicePort: 8443
-  containerPort: 8443
+  # HTTP plain-text traffic
+  http:
+    enabled: false
+    servicePort: 8000
+    containerPort: 8000
+    nodePort: 32080
+
+  tls:
+    enabled: true
+    servicePort: 8443
+    containerPort: 8443
+    nodePort: 32443
+
   type: NodePort
   # Set a nodePort which is available
   # nodePort: 32443

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -56,17 +56,16 @@ proxy:
     enabled: true
     servicePort: 80
     containerPort: 8000
-    nodePort: 32080
+    #nodePort: 32080
 
   tls:
     enabled: true
     servicePort: 443
     containerPort: 8443
-    nodePort: 32443
+    #nodePort: 32443
 
   type: NodePort
-  # Set a nodePort which is available
-  # nodePort: 32443
+
   # Kong proxy ingress settings.
   ingress:
     # Enable/disable exposure using ingress.

--- a/stable/kong/values.yaml
+++ b/stable/kong/values.yaml
@@ -53,7 +53,7 @@ proxy:
 
   # HTTP plain-text traffic
   http:
-    enabled: false
+    enabled: true
     servicePort: 80
     containerPort: 8000
     nodePort: 32080


### PR DESCRIPTION
#### What this PR does / why we need it:

Curently you can only enable http or tls.  This separates out the controls of enable both the http and tls ports on kong and lets you enable both.

#### Special notes for your reviewer:
Original PR with TLS offloading.  This is the reduce PR with just enabling controls for http and tls independently

https://github.com/helm/charts/pull/10003/files#diff-bd36c84be1fb63f9d09295a16068a4a4R195

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
