### PR TITLE
[stable/jenkins] Fix job definitions in standard values.yaml

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.28.1
+version: 0.28.2
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -120,7 +120,7 @@ Master:
   # master.key and hudson.util.Secret)
   # SecretsFilesSecret: jenkins-secrets
   # Jenkins XML job configs to provision
-  # Jobs: |-
+  # Jobs:
   #   test: |-
   #     <<xml here>>
   CustomConfigMap: false


### PR DESCRIPTION
#### What this PR does / why we need it:
@lachie83 @viglesiasce, this PR fixes a bug which makes "helm install" throw errors when the user add job definitions to values.yaml. 

#### Which issue this PR fixes
The bug is fully described in issue #9992.

  - fixes #9992 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ x ] Chart Version bumped
- [ x ] Variables are documented in the README.md
