### PR TITLE
[stable/postgresql] Add read-only connection to the replica slaves

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 3.5.0
+version: 3.6.0
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -19,8 +19,10 @@
 
 PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
 
-    {{ template "postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-
+    {{ template "postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local - Read/Write connection
+{{- if .Values.replication.enabled }}
+    {{ template "postgresql.fullname" . }}-read.{{ .Release.Namespace }}.svc.cluster.local - Read only connection
+{{- end }}
 To get the password for "{{ .Values.postgresqlUsername }}" run:
 
     export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "postgresql.fullname" . }}{{ end }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)

--- a/stable/postgresql/templates/svc-read.yaml
+++ b/stable/postgresql/templates/svc-read.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.replication.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "postgresql.fullname" . }}-read
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - name: postgresql
+    port:  {{ .Values.service.port }}
+    targetPort: postgresql
+    {{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+  selector:
+    app: {{ template "postgresql.name" . }}
+    release: {{ .Release.Name | quote }}
+    role: slave
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Javier J. Salmeron Garcia <jsalmeron@bitnami.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
 - Adds a service targeted to the replicas so applications can use read-only connections

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
