### PR TITLE
[.github templates] ask for the involved chart at the top of the template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,9 @@
 <!-- Thanks for filing an issue! Before hitting the button, please answer these questions. It's helpful to search the existing GitHub issues first. It's likely that another user has already reported the issue you're facing, or it's a known issue that we're already aware of-->
 
+**Which chart is this about?**
+
+[stable/placeholder]
+
 **Is this a request for help?**:
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,10 @@ very quickly. Please check the results. We would like these checks to pass befor
 even continue reviewing your changes.
 -->
 
+### Which chart does this PR modifiy?
+
+[stable/placeholder]
+
 #### What this PR does / why we need it:
 
 #### Which issue this PR fixes


### PR DESCRIPTION
#### What this PR does / why we need it:

Here I offer a way to get the chart related to an issue or a pull request prominently at the top of the template.

#### Special notes for your reviewer:

Until we can enforce having the chart name in the issue / pull request title this can help.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] ~Chart Version bumped~
- [ ] ~Variables are documented in the README.md~
