### PR TITLE
Cluster autoscaler clusterrole add jobs

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.11.1
+version: 0.11.2
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -63,6 +63,7 @@ rules:
     - batch
     resources:
       - jobs
+      - cronjobs
     verbs:
       - watch
       - list

--- a/stable/cluster-autoscaler/templates/clusterrole.yaml
+++ b/stable/cluster-autoscaler/templates/clusterrole.yaml
@@ -60,6 +60,14 @@ rules:
       - list
       - get
   - apiGroups:
+    - batch
+    resources:
+      - jobs
+    verbs:
+      - watch
+      - list
+      - get
+  - apiGroups:
       - extensions
     resources:
       - replicasets


### PR DESCRIPTION
@mgoodness 

I got an error that looked like:
```
cluster.go:95] Detailed evaluation: node MyNode cannot be removed: job for my-namespace/my-job is not available: err: jobs.batch "my-job" is forbidden: User "system:serviceaccount:system:cluster-autoscaler-aws-cluster-autoscaler" cannot get jobs.batch in the namespace "my-namespace"
```

So the cluster autoscaler is trying to get jobs but the clusterrole won't let it. Adding the permission rule for `batch.jobs` made this error go away and the autoscaler worked again.

Have also added `cronjobs` to match with https://github.com/kubernetes/autoscaler/pull/1189, though I have not found a canonical set of required permissions for the cluster-autoscaler.