### PR TITLE
[stable/mariadb] Add parameter to enable debug logs on MariaDB images

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.2.5
+version: 5.2.6
 appVersion: 10.1.37
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `image.tag`                               | MariaDB Image tag                                   | `{VERSION}`                                                       |
 | `image.pullPolicy`                        | MariaDB image pull policy                           | `Always` if `imageTag` is `latest`, else `IfNotPresent`           |
 | `image.pullSecrets`                       | Specify image pull secrets                          | `nil` (does not add image pull secrets to deployed pods)          |
+| `image.debug`                             | Specify if debug logs should be enabled             | `false`                                                           |
 | `service.type`                            | Kubernetes service type                             | `ClusterIP`                                                       |
 | `service.clusterIp`                       | Specific cluster IP when service type is cluster IP. Use None for headless service | `nil`                              |
 | `service.port`                            | MySQL service port                                  | `3306`                                                            |

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -84,6 +84,10 @@ spec:
         image: {{ template "mariadb.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        {{- if .Values.image.debug}}
+        - name: BITNAMI_DEBUG
+          value: "true"
+        {{- end }}
         - name: MARIADB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/stable/mariadb/templates/slave-statefulset.yaml
+++ b/stable/mariadb/templates/slave-statefulset.yaml
@@ -85,6 +85,10 @@ spec:
         image: {{ template "mariadb.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        {{- if .Values.image.debug}}
+        - name: BITNAMI_DEBUG
+          value: "true"
+        {{- end }}
         - name: MARIADB_REPLICATION_MODE
           value: "slave"
         - name: MARIADB_MASTER_HOST

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -23,6 +23,11 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+  ## Set to true if you would like to see extra information on logs
+  ## It turns BASH and NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
+  debug: false
+
 service:
   ## Kubernetes service type, ClusterIP and NodePort are supported at present
   type: ClusterIP

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -23,6 +23,11 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+  ## Set to true if you would like to see extra information on logs
+  ## It turns BASH and NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
+  debug: false
+
 service:
   ## Kubernetes service type, ClusterIP and NodePort are supported at present
   type: ClusterIP


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR adds a parameter that makes very easy to enable debug logs on MariaDB docker image.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
