### PR TITLE
[incubator/schema-registry] improve/fix secrets to allow JKS

### DIFF
--- a/incubator/schema-registry/Chart.yaml
+++ b/incubator/schema-registry/Chart.yaml
@@ -1,6 +1,6 @@
 name: schema-registry
 home: https://docs.confluent.io/current/schema-registry/docs/index.html
-version: 1.1.1
+version: 1.1.2
 appVersion: 5.0.1
 keywords:
   - confluent

--- a/incubator/schema-registry/templates/deployment.yaml
+++ b/incubator/schema-registry/templates/deployment.yaml
@@ -126,6 +126,19 @@ spec:
           - name: JMX_PORT
             value: "{{ .Values.jmx.port }}"
           {{- end }}
+          {{- if .Values.secrets }}
+            {{- range $secret := .Values.secrets }}
+              {{- if not $secret.mountPath }}
+                {{- range $key := $secret.keys }}
+          - name: {{ (print $secret.name "_" $key) | upper | replace "." "_" | replace "-" "_"}}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $secret.name }}
+                key: {{ $key }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -128,9 +128,18 @@ jmx:
   enabled: true
   port: 5555
 
-## Useful if using any Keystore/Trusttore for Authorization.
-## Pass any secrets to the pods. The secret will be mounted to a
-## specific path (in addition to environment variable) if required.
+## Pass any secrets to the pods. The secrets will be mounted to a specfic path
+## OR presented as Environment Variables. Environment variable names are 
+## generated as: `<secretName>_<secretKey>` (All upper case)
+## note: Keystore/Truststore are binary and should always be presented as files.
 secrets: []
-# - name: myZkSecret
-# mountPath: /opt/zookeeper/secret
+# - name: schema-registry-jks
+#   keys:
+#     - ksr-server.truststore.jks
+#     - ksr-server.keystore.jks
+#   mountPath: /secrets
+# - name: schema-registry-jks-pw
+#   keys:
+#     - ssl_truststore_password
+#     - ssl_keystore_password
+#     - ssl_key_password

--- a/incubator/schema-registry/values.yaml
+++ b/incubator/schema-registry/values.yaml
@@ -129,7 +129,7 @@ jmx:
   port: 5555
 
 ## Pass any secrets to the pods. The secrets will be mounted to a specfic path
-## OR presented as Environment Variables. Environment variable names are 
+## OR presented as Environment Variables. Environment variable names are
 ## generated as: `<secretName>_<secretKey>` (All upper case)
 ## note: Keystore/Truststore are binary and should always be presented as files.
 secrets: []


### PR DESCRIPTION
Signed-off-by: Ben Tucker <ben_tucker@hotmail.com>

#### What this PR does / why we need it:
This PR is to allow secrets to be presented to the container as mounts OR environment variables, specifically for Java Trust and Java Keystores + their passwords.  I tried to match the pattern of similar charts, such as the Kafka one. 

#### Special notes for your reviewer:
Presenting a (binary) JKS file as an environmental variable won't work, it has to be a file.  
Are you happy with the updated version, should I have gone a minor one? 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
