### PR TITLE
[stable/coredns] Fix wrong service account ref

### DIFF
--- a/stable/coredns/Chart.yaml
+++ b/stable/coredns/Chart.yaml
@@ -1,5 +1,5 @@
 name: coredns
-version: 1.2.4
+version: 1.2.5
 appVersion: 1.3.1
 description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
 keywords:

--- a/stable/coredns/templates/clusterrolebinding.yaml
+++ b/stable/coredns/templates/clusterrolebinding.yaml
@@ -19,6 +19,6 @@ roleRef:
   name: {{ template "coredns.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "coredns.fullname" . }}
+  name: {{ template "coredns.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Fixes #10191

Signed-off-by: Seongjin Cho <sjcho@wisefour.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Fixes wrong service account ref in ClusterRoleBinding, which is causing error when using custom service account name.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #10191

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
