### PR TITLE
[stable/certmanager] Add a note about the helm version in prerequisites

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.5.2
+version: v0.5.3
 appVersion: v0.5.2
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -9,6 +9,7 @@ to renew certificates at an appropriate time before expiry.
 ## Prerequisites
 
 - Kubernetes 1.7+
+- Helm v2.12.1+ (see [#5054](https://github.com/helm/helm/issues/5054))
 
 ## Installing the Chart
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Add a note in the doc that the latest version of the chart is only compatible with helm 2.12.1+
Hopefully this will prevent people from having to dig into the issues / PR of the project.

#### Which issue this PR fixes
None open

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
