### PR TITLE
[stable/jenkins] allow numExecutors in config to use variable from values file

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.26.0
+version: 0.26.1
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -35,7 +35,10 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.ImageTag`                 | Master image tag                     | `lts`                                                                     |
 | `Master.ImagePullPolicy`          | Master image pull policy             | `Always`                                                                     |
 | `Master.ImagePullSecret`          | Master image pull secret             | Not set                                                                      |
-| `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
+| `Master.Component`                | k8s selector key                     | `jenkins-master` 
+
+| `Master.NumExecutors`             | Set NumExecutors for Jenkins         | 0 
+
 | `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
 | `Master.SecurityRealm`            | Custom Security Realm                | Not set                                                                      |
 | `Master.AuthorizationStrategy`    | Jenkins XML job config for AuthorizationStrategy | Not set                                                                      |

--- a/stable/jenkins/templates/config.yaml
+++ b/stable/jenkins/templates/config.yaml
@@ -10,7 +10,7 @@ data:
     <hudson>
       <disabledAdministrativeMonitors/>
       <version>{{ .Values.Master.ImageTag }}</version>
-      <numExecutors>0</numExecutors>
+      <numExecutors>{{ .Values.Master.NumExecutors }}</numExecutors>
       <mode>NORMAL</mode>
       <useSecurity>{{ .Values.Master.UseSecurity }}</useSecurity>
 {{- if not (empty .Values.Master.AuthorizationStrategy ) }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -15,6 +15,7 @@ Master:
   ImagePullPolicy: "Always"
 # ImagePullSecret: jenkins
   Component: "jenkins-master"
+  NumExecutors: 0
   UseSecurity: true
   # SecurityRealm:
   # Optionally configure a different AuthorizationStrategy using Jenkins XML


### PR DESCRIPTION
#### What this PR does / why we need it:
This will allow users to set the numExecutors for Jenkins on startup after helm install without having to change the config.yaml file or using the Jenkins UI to configure the numExecutors.

#### Special notes for your reviewer:
Will allow users to easily use values.yaml file for everything instead of having to make specific changes to other template files.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
