### PR TITLE
Fix outdated names of rabbit default user and password varaibles

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -1,7 +1,7 @@
 name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.8
-version: 1.14.4
+version: 1.14.5
 description: Highly available RabbitMQ cluster, the open source message broker
   software that implements the Advanced Message Queuing Protocol (AMQP).
 keywords:

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -179,12 +179,12 @@ spec:
             - name: RABBIT_CAPABILITIES
               value: "{{ .Values.prometheus.exporter.capabilities }}"
             {{- end }}  
-            - name: RABBIT_USER
+            - name: RABBIT_DEFAULT_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ template "rabbitmq-ha.secretName" . }}
                   key: rabbitmq-username
-            - name: RABBIT_PASSWORD
+            - name: RABBIT_DEFAULT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "rabbitmq-ha.secretName" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

According to new documentation, rabbitmq has no user/password variables, instead it has default_user/default_password variables.

This may lead to confusing situations when password in secret is ok, but one cannot connect to MQ using it.

#### Which issue this PR fixes
  - fixes #10065 

#### Special notes for your reviewer:

See https://hub.docker.com/_/rabbitmq/ for details.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
