### PR TITLE
[stable/stackdriver-exporter] Fix deployment chart values and README to match new fields

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -67,6 +67,11 @@ Parameter                           | Description                          | Def
 `service.type`                      | Type of service to create            | `ClusterIP`
 `service.httpPort`                  | Port for the http service            | `9255`
 `stackdriver.projectId`             | GCP Project ID                       | ``
+`stackdriver.maxRetries`            | Max number of retries on 503         | `0`
+`stackdriver.httpTimeout`           | How long to wait for result from SD  | `10s`
+`stackdriver.maxBackoff`            | Max time for wait in exp backoff     | `5s`
+`stackdriver.backoffJitter`         | Amount of jitter in exp backoff      | `1s`
+`stackdriver.retryStatuses`         | HTTP code to trigger a retry	       | `503`
 `stackdriver.metrics.typePrefixes`  | Comma separated Metric Type prefixes | ``
 `stackdriver.metrics.interval`      | Metrics interval to request from GCP | `5m`
 `stackdriver.metrics.offset`        | Offset (into the past) to request    | `0s`

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -48,15 +48,15 @@ spec:
             - name: STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH
               value: {{ .Values.web.path | quote }}
             - name: STACKDRIVER_EXPORTER_MAX_RETRIES
-              value: {{ .Values.maxRetries | quote }}
+              value: {{ .Values.stackdriver.maxRetries | quote }}
             - name: STACKDRIVER_EXPORTER_HTTP_TIMEOUT
-              value: {{ .Values.httpTimeout | quote }}
+              value: {{ .Values.stackdriver.httpTimeout | quote }}
             - name: STACKDRIVER_EXPORTER_MAX_BACKOFF_DURATION
-              value: {{ .Values.maxBackoff | quote }}
+              value: {{ .Values.stackdriver.maxBackoff | quote }}
             - name: STACKDRIVER_EXPORTER_BACKODFF_JITTER_BASE
-              value: {{ .Values.backoffJitter | quote }}
+              value: {{ .Values.stackdriver.backoffJitter | quote }}
             - name: STACKDRIVER_EXPORTER_RETRY_STATUSES
-              value: {{ .Values.retryStatuses | quote}}
+              value: {{ .Values.stackdriver.retryStatuses | quote}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:


### PR DESCRIPTION
Signed-off-by: YITAEK HWANG <yitaek@gmail.com>

#### What this PR does / why we need it:
Recent changes to chart v0.0.6 breaks on deployment since new fields added via new Docker image defaults to null values. I fixed the default values to point to those values in values.yaml file and updated documentation accordingly. 

#### Special notes for your reviewer:
@apenney Thanks for maintaining this chart!

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md