### PR TITLE
[cert-manager-issuers] New Chart

### DIFF
--- a/incubator/cert-manager-issuers/.helmignore
+++ b/incubator/cert-manager-issuers/.helmignore
@@ -1,0 +1,24 @@
+# OWNERS file for Kubernetes
+OWNERS
+
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/incubator/cert-manager-issuers/Chart.yaml
+++ b/incubator/cert-manager-issuers/Chart.yaml
@@ -1,5 +1,6 @@
 name: cert-manager-issuers
 version: v0.0.4
+appVersion: v0.5.2
 description: A Helm chart for cert-manager issuers
 home: https://github.com/afirth/site-cluster
 keywords:

--- a/incubator/cert-manager-issuers/Chart.yaml
+++ b/incubator/cert-manager-issuers/Chart.yaml
@@ -1,0 +1,13 @@
+name: cert-manager-issuers
+version: v0.0.4
+description: A Helm chart for cert-manager issuers
+home: https://github.com/afirth/site-cluster
+keywords:
+  - cert-manager
+  - kube-lego
+  - letsencrypt
+  - tls
+  - clusterissuer
+maintainers:
+  - name: afirth
+    email: maintainer@alfirth.com

--- a/incubator/cert-manager-issuers/OWNERS
+++ b/incubator/cert-manager-issuers/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- afirth
+reviewers:
+- afirth

--- a/incubator/cert-manager-issuers/README.md
+++ b/incubator/cert-manager-issuers/README.md
@@ -1,0 +1,58 @@
+# cert-manager-issuers
+
+## Quickstart
+
+To setup the [letsencrypt](https://letsencrypt.org/) staging and prod http01 ACME endpoints as ClusterIssuers (so you can use the kube-lego style ingress annotation `kubernetes.io/tls-acme: "true"`):
+
+### Install cert-manager
+
+First install the [cert-manager chart](https://github.com/helm/charts/tree/master/stable/cert-manager) with the ingress shim set up:
+
+```
+$ helm install --name my-cert-manager-release \
+--set ingressShim.defaultIssuerName=letsencrypt-prod,ingressShim.defaultIssuerKind=ClusterIssuer \
+stable/cert-manager
+```
+
+### Install the issuers
+
+Then install this chart with the default values.yaml and your email address:
+
+```
+$ helm install --name my-cert-manager-issuers-release \
+-f values.yaml \
+--set email=<you@example.com> \
+incubator/cert-manager-issuers
+```
+
+### Verifying
+
+```
+kubectl logs -l app=cert-manager
+```
+
+should show your certificates being provisioned. Note that you _must_ set a valid email address per letsencrypt TOS. @example.com addresses will not work.
+
+## Values
+
+### Commonly used values
+
+| Parameter                         | Description                                | Default                                                   |
+| --------------------------------- | ------------------------------------------ | --------------------------------------------------------- |
+| `email`            | email to use for acme registration               | `you@example.com`                                                     |
+
+It is recommended to provide more issuers using a `values.yaml` file. The two letsencrypt http01 endpoints are provided as [ClusterIssuers](http://docs.cert-manager.io/en/latest/reference/issuers.html). Emails set inside an `issuer` override the global one.
+
+## FAQ
+
+### Why isn't this chart part of cert-manager?
+
+Due to technical limitations of helm v2, custom resource definitions must be created before a custom resource can be defined. This means that no issuers are included in the [cert-manager helm chart](https://github.com/helm/charts/tree/master/stable/cert-manager), as they would fail to create.
+
+## Stability
+
+This chart is in alpha. Backwards incompatible changes will be avoided if possible, but no guarantees.
+
+## Contributing
+
+PRs are welcome.

--- a/incubator/cert-manager-issuers/templates/NOTES.txt
+++ b/incubator/cert-manager-issuers/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Try
+$ kubectl get clusterissuers
+or
+$ kubectl get issuers --namespace={{ $.Release.Namespace }}

--- a/incubator/cert-manager-issuers/templates/_helpers.tpl
+++ b/incubator/cert-manager-issuers/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cert-manager-issuers.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cert-manager-issuers.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cert-manager-issuers.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/incubator/cert-manager-issuers/templates/issuers.yaml
+++ b/incubator/cert-manager-issuers/templates/issuers.yaml
@@ -1,0 +1,28 @@
+{{- $email := .Values.email -}}
+{{- $release := .Release -}}
+
+{{- range $issuer := .Values.issuers }}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: {{ .kind }}
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    app: {{ template "cert-manager-issuers.name" $ }}
+    chart: {{ template "cert-manager-issuers.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+spec:
+  acme:
+    server: {{ .server }}
+    {{- if .email }}
+    email: {{ .email }}
+    {{- else }}
+    email: {{ $email }}
+    {{- end }}
+    privateKeySecretRef:
+      name: {{ .name }}
+{{ toYaml .method | indent 4 }}
+
+{{- end }}

--- a/incubator/cert-manager-issuers/values.yaml
+++ b/incubator/cert-manager-issuers/values.yaml
@@ -1,0 +1,21 @@
+# Default values for cert-manager-issuers
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+email: "you@example.com"
+
+issuers:
+  - kind: ClusterIssuer
+    # optional override, otherwise values.email is used
+    # email: "you@example.com"
+    name: letsencrypt-staging
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    method:
+      http01: {}
+  - kind: ClusterIssuer
+    # optional override, otherwise values.email is used
+    # email: "you@example.com"
+    name: letsencrypt-prod
+    server: https://acme-v02.api.letsencrypt.org/directory
+    method:
+      http01: {}


### PR DESCRIPTION
By default, the cert-manager chart doesn't come with any issuers configured. This is because the CRD hasn't been created, but it provides an unpleasant user experience compared to kube-lego. The [documentation](http://docs.cert-manager.io/en/latest/tutorials/acme/migrating-from-kube-lego.html) is convoluted, and while the application installs exclusively with helm, the issuers are managed manually.

This chart aims to provide a simple way to mimic the kube-lego setup and manage issuers and cluster-issuers inside the helm ecosystem, without losing the flexibility that cert-manager provides.