### PR TITLE
[stable/kong] Update Kong role to match users params

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.7.0
-appVersion: 0.14.2
+version: 0.7.1
+appVersion: 0.14.1

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -13,4 +13,4 @@ name: kong
 sources:
 - https://github.com/Kong/kong
 version: 0.7.0
-appVersion: 0.14.1
+appVersion: 0.14.2

--- a/stable/kong/templates/controller-rbac-role.yaml
+++ b/stable/kong/templates/controller-rbac-role.yaml
@@ -28,7 +28,7 @@ rules:
       # Here: "<ingress-controller-leader>-<nginx>"
       # This has to be adapted if you change either parameter
       # when launching the nginx-ingress-controller.
-      - "ingress-controller-leader-nginx"
+      - "kong-ingress-controller-leader-kong-{{ .Values.ingressController.ingressClass }}"
     verbs:
       - get
       - update


### PR DESCRIPTION
Signed-off-by: garland <garlandk@gmail.com>

#### What this PR does / why we need it:
The `resourceName` for the leader election configmap is hardcoded into the Role.  If the kong controller restarts or it was not the one that created the configmap, it is denied on being able to access it.  In turn the kong controller does not update any new items that comes up or changes.

I see the following errors in the Kong controller ingress-controller logs.

```
E1227 00:07:20.754146       5 leaderelection.go:258] Failed to update lock: configmaps "kong-ingress-controller-leader-kong-kong" is forbidden: User "system:serviceaccount:dev-kong:dev-kong-kong" cannot update configmaps in the namespace "dev-kong"
```

By setting this to the proper name, I dont get this error in the logs anymore and the routes works as expected after restarts.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
