### PR TITLE
[stable/aws-es-proxy] New chart for HTTP request signing reverse proxy for Amazon Elasticsearch service

### DIFF
--- a/stable/aws-es-proxy/.helmignore
+++ b/stable/aws-es-proxy/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/aws-es-proxy/Chart.yaml
+++ b/stable/aws-es-proxy/Chart.yaml
@@ -1,0 +1,17 @@
+name: aws-es-proxy
+version: 1.0.0
+apiVersion: v1
+appVersion: 0.8
+home: https://github.com/abutaha/aws-es-proxy
+description: An webapp sitting between your HTTP client (browser, curl, etc...) and Amazon Elasticsearch service
+keywords:
+- amazon-elasticsearch-service
+- aws-iam
+- reverse-proxy
+- request-signing
+maintainers:
+- name: mumoshu
+  email: ykuoka@gmail.com
+sources:
+- https://github.com/abutaha/aws-es-proxy
+engine: gotpl

--- a/stable/aws-es-proxy/OWNERS
+++ b/stable/aws-es-proxy/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- mumoshu
+reviewers:
+- mumoshu

--- a/stable/aws-es-proxy/README.md
+++ b/stable/aws-es-proxy/README.md
@@ -55,6 +55,8 @@ Parameter | Description | Default
 `podLabels` | additional labesl to add to each pod | `{}`
 `replicaCount` | desired number of pods | `1`
 `resources` | pod resource requests & limits | `{}`
+`readinessProbe.enabled` | enable liveness probe, which is disabled by default to pass charts ci builds without actual AWS credentials | `false`
+`livenessProbe.enabled` | enable readiness probe, which is disabled by default to pass charts ci builds without actual AWS credentials | `false`
 `service.port` | port for the service | `9200`
 `service.type` | type of service | `ClusterIP`
 `tolerations` | List of node taints to tolerate | `[]`

--- a/stable/aws-es-proxy/README.md
+++ b/stable/aws-es-proxy/README.md
@@ -1,0 +1,75 @@
+# aws-es-proxy
+
+[aws-es-proxy](https://github.com/abutaha/aws-es-proxy) is a small web server application sitting between your HTTP client (browser, curl, etc...) and Amazon Elasticsearch service.
+
+## TL;DR;
+
+```console
+$ helm install stable/aws-es-proxy --set config.endpoint=https://dummy-host.ap-southeast-2.es.amazonaws.com
+```
+
+## Introduction
+
+This chart bootstraps an aws-es-proxy deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install stable/aws-es-proxy --name my-release --set config.endpoint=https://dummy-host.ap-southeast-2.es.amazonaws.com
+```
+
+The command deploys aws-es-proxy on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the aws-es-proxy chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`affinity` | node/pod affinities | None
+`config.awsSecretAccessKey` | value of AWS_ACCESS_KEY_ID envvar. This is required when you don't specify a pod annotation for [kube2iam](https://github.com/jtblin/kube2iam) or [kiam](https://github.com/uswitch/kiam) to provide pods an AWS IAM role | None
+`config.awsAccessKeyID` | value of AWS_SECRET_ACCESS_KEY envvar. This is required when you don't specify a pod annotation for [kube2iam](https://github.com/jtblin/kube2iam) or [kiam](https://github.com/uswitch/kiam) to provide pods an AWS IAM role | None
+`config.endpoint` | Amazon ElasticSearch Endpoint (e.g: https://dummy-host.eu-west-1.es.amazonaws.com) | None, but required
+`config.pretty` | Prettify verbose and file output | `false`
+`config.verbose` | Print user requests | `false`
+`extraArgs` | key:value list of extra arguments to give the binary | `{}`
+`image.pullPolicy` | Image pull policy | `IfNotPresent`
+`image.repository` | Image repository | `abutaha/aws-es-proxy`
+`image.tag` | Image tag | `0.8`
+`imagePullSecrets` | Specify image pull secrets | `nil` (does not add image pull secrets to deployed pods)
+`ingress.enabled` | enable ingress | `false`
+`nodeSelector` | node labels for pod assignment | `{}`
+`podAnnotations` | annotations to add to each pod. Include `iam.amazonaws.com/role: ROLE_ARN` to provide pods an AWS IAM role via kube2iam or kiam  | `{}`
+`podLabels` | additional labesl to add to each pod | `{}`
+`replicaCount` | desired number of pods | `1`
+`resources` | pod resource requests & limits | `{}`
+`service.port` | port for the service | `9200`
+`service.type` | type of service | `ClusterIP`
+`tolerations` | List of node taints to tolerate | `[]`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install stable/aws-es-proxy --name my-release \
+  --set=image.tag=v0.8,resources.limits.cpu=200m
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install stable/aws-es-proxy --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/aws-es-proxy/templates/NOTES.txt
+++ b/stable/aws-es-proxy/templates/NOTES.txt
@@ -1,0 +1,3 @@
+To verify that aws-es-proxy has started, run:
+
+  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "aws-es-proxy.fullname" . }}"

--- a/stable/aws-es-proxy/templates/_helpers.tpl
+++ b/stable/aws-es-proxy/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-es-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-es-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-es-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/aws-es-proxy/templates/deployment.yaml
+++ b/stable/aws-es-proxy/templates/deployment.yaml
@@ -57,14 +57,28 @@ spec:
           - containerPort: 9200
             name: http
             protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /_cluster/health
             port: http
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /_cluster/health
             port: http
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.imagePullSecrets }}

--- a/stable/aws-es-proxy/templates/deployment.yaml
+++ b/stable/aws-es-proxy/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "aws-es-proxy.name" . }}
+    chart: {{ template "aws-es-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "aws-es-proxy.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "aws-es-proxy.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ toYaml .Values.config | sha256sum }}
+    {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
+      labels:
+        app: {{ template "aws-es-proxy.name" . }}
+        release: "{{ .Release.Name }}"
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - ./aws-es-proxy
+        {{- range $key, $value := .Values.extraArgs }}
+          {{- if $value }}
+          - -{{ $key }}={{ $value }}
+          {{- else }}
+          - -{{ $key }}
+          {{- end }}
+        {{- end }}
+          - -listen
+          - 0.0.0.0:9200
+          - -endpoint
+          - {{ required "endpoint is required" .Values.config.endpoint }}
+        {{- if .Values.config.pretty }}
+          - -pretty
+        {{- end }}
+        {{- if .Values.config.verbose }}
+          - -verbose
+        {{- end }}
+        envFrom:
+        - secretRef:
+            name: {{ template "aws-es-proxy.fullname" . }}
+        ports:
+          - containerPort: 9200
+            name: http
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: http
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}

--- a/stable/aws-es-proxy/templates/ingress.yaml
+++ b/stable/aws-es-proxy/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "aws-es-proxy.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    app: {{ template "aws-es-proxy.name" . }}
+    chart: {{ template "aws-es-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "aws-es-proxy.fullname" . }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/stable/aws-es-proxy/templates/secret.yaml
+++ b/stable/aws-es-proxy/templates/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "aws-es-proxy.name" . }}
+    chart: {{ template "aws-es-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "aws-es-proxy.fullname" . }}
+type: Opaque
+data:
+  {{if .Values.config.awsAccessKeyID -}}
+  AWS_ACCESS_KEY_ID: {{ .Values.config.awsAccessKeyID | b64enc | quote }}
+  {{end -}}
+  {{if .Values.config.awsSecretAccessKey -}}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.config.awsSecretAccessKey | b64enc | quote }}
+  {{end -}}

--- a/stable/aws-es-proxy/templates/service.yaml
+++ b/stable/aws-es-proxy/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "aws-es-proxy.name" . }}
+    chart: {{ template "aws-es-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "aws-es-proxy.fullname" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "aws-es-proxy.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/aws-es-proxy/values.yaml
+++ b/stable/aws-es-proxy/values.yaml
@@ -21,6 +21,25 @@ extraArgs: {}
   # -log-to-file
   # -no-sign-reqs
 
+# livenessProbe is disabled by default to pass helm/charts ci builds without actual AWS credentials
+livenessProbe:
+  enabled: false
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 10
+  successThreshold: 1
+  failureThreshold: 10
+
+# readinessProbe is disabled by default to pass helm/charts ci builds without actual AWS credentials
+readinessProbe:
+  # enabled is a flag used to enable readiness probe
+  enabled: false
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 10
+  successThreshold: 1
+  failureThreshold: 10
+
 service:
   type: ClusterIP
   port: 9200

--- a/stable/aws-es-proxy/values.yaml
+++ b/stable/aws-es-proxy/values.yaml
@@ -1,0 +1,66 @@
+# aws-es-proxy specific coniguration
+config:
+  # awsSecretAccessKey: "XXXXXXX"
+  # awsAccessKeyID: "XXXXXXXX"
+  endpoint: https://test-es-somerandomvalue.eu-west-1.es.amazonaws.com
+  pretty: false
+  verbose: false
+
+image:
+  repository: "abutaha/aws-es-proxy"
+  tag: "0.8"
+  pullPolicy: "IfNotPresent"
+
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# imagePullSecrets:
+  # - name: myRegistryKeySecretName
+
+extraArgs: {}
+  # -log-to-file
+  # -no-sign-reqs
+
+service:
+  type: ClusterIP
+  port: 9200
+  annotations: {}
+
+ingress:
+  enabled: false
+  path: /
+  # Used to create an Ingress record.
+  # hosts:
+    # - chart-example.local
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
+  # tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
+
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+podAnnotations: {}
+podLabels: {}
+replicaCount: 1


### PR DESCRIPTION
This is a revival of #5820 that is fixed to pass the charts CI without actual AWS creds, and rebased onto the latest master.

---

Manually verified to work by installing it with:

```console
$ helm upgrade esproxy ./ --install \
  --set config.awsSecretAccessKey=MYSECRETKEY \
  --set config.awsAccessKeyID=MYKEYID \
  --set config.endpoint=https://your-aws-es-domain \
  --set config.verbose=true \
  --set podAnnotations.foo=bar
```

From another ubuntu pod, fetching elasticsearch indices on AWS Elasticsearch Service cluster:

```console
root@xenial-1527645050:/# curl esproxy-aws-es-proxy:9200/_cat/indices
yellow open myindex ogrlJsTIQrSJoPvnNMhxxw 5 1 271 0 256.5kb 256.5kb
green  open .kibana    NETaiYeLT-iSu87VSucE9w 1 0   3 1  15.6kb  15.6kb
```

 And then reading logs:

```console
$ stern es-proxy
esproxy-aws-es-proxy-86c8cdc58b-ld6bv aws-es-proxy 2018/05/30 02:14:06 Listening on 0.0.0.0:9200...
esproxy-aws-es-proxy-86c8cdc58b-ld6bv aws-es-proxy 2018/05/30 02:14:09 Generated fresh AWS Credentials object
esproxy-aws-es-proxy-86c8cdc58b-ld6bv aws-es-proxy 2018/05/30 02:14:10  -> GET; 172.17.0.1:54772; /_cluster/health; ; 200; 0.328s
*snip*
esproxy-aws-es-proxy-86c8cdc58b-ld6bv aws-es-proxy 2018/05/30 02:33:36  -> GET; 172.17.0.6:46446; /_cat/indices; ; 200; 0.030s
```

Templates and values.yaml is mostly similar to stable/oauth2-proxy's.
The main difference is `config:` in values.yaml, which directly reflects aws-es-proxy's own configuration file.