### PR TITLE
[stable/envoy]: optional feature to generate envoy.yaml from golang template

### DIFF
--- a/stable/envoy/Chart.yaml
+++ b/stable/envoy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Envoy is an open source edge and service proxy, designed for cloud-native applications.
 name: envoy
-version: 1.3.0
+version: 1.4.0
 appVersion: 1.9.0
 keywords:
 - envoy
@@ -12,4 +12,6 @@ sources:
 maintainers:
 - name: josdotso
   email: josdotso@cisco.com
+- name: mumoshu
+  email: ykuoka@gmail.com
 icon: https://avatars0.githubusercontent.com/u/30125649

--- a/stable/envoy/OWNERS
+++ b/stable/envoy/OWNERS
@@ -1,4 +1,6 @@
 approvers:
 - josdotso
+- mumoshu
 reviewers:
 - josdotso
+- mumoshu

--- a/stable/envoy/README.md
+++ b/stable/envoy/README.md
@@ -2,4 +2,33 @@
 
 [Envoy](https://www.envoyproxy.io/) is an open source edge and service proxy, designed for cloud-native applications.
 
-All user-configurable settings, default values and some commentary about them can be found in [values.yaml](values.yaml).
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install stable/envoy --name my-release
+```
+
+The command deploys envoy on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the envoy chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`files.envoy\.yaml` | content of a full envoy configuration file as documented in https://www.envoyproxy.io/docs/envoy/latest/configuration/configuration | See [values.yaml](values.yaml)
+`templates.envoy\.yaml` | golang template of a full configuration file. Use the `{{ .Values.foo.bar }}` syntax to embed chart values | See [values.yaml](values.yaml)
+
+All other user-configurable settings, default values and some commentary about them can be found in [values.yaml](values.yaml).

--- a/stable/envoy/templates/configmap.yaml
+++ b/stable/envoy/templates/configmap.yaml
@@ -12,3 +12,7 @@ data:
   {{ $key }}: |-
 {{ $value | default "" | indent 4 }}
 {{- end -}}
+{{- range $key, $value := .Values.templates }}
+  {{ $key }}: |-
+{{ $value | default "" | tpl . | indent 4 }}
+{{- end -}}

--- a/stable/envoy/values.yaml
+++ b/stable/envoy/values.yaml
@@ -183,3 +183,58 @@ files:
               port_value: 443
         tls_context:
           sni: www.google.com
+
+## Uncomment this section to use helm values to dynamically generate enovy.yaml
+# templates:
+#   envoy.yaml: |-
+#     ## refs:
+#     ## - https://www.envoyproxy.io/docs/envoy/latest/start/start#quick-start-to-run-simple-example
+#     ## - https://raw.githubusercontent.com/envoyproxy/envoy/master/configs/google_com_proxy.v2.yaml
+#     admin:
+#       access_log_path: /dev/stdout
+#       address:
+#         socket_address:
+#           address: 0.0.0.0
+#           port_value: {{ .Values.ports.admin.containerPort }}
+
+#     static_resources:
+#       listeners:
+#       - name: listener_0
+#         address:
+#           socket_address:
+#             address: 0.0.0.0
+#             port_value: {{ .Values.ports.n0.containerPort }}
+#         filter_chains:
+#         - filters:
+#           - name: envoy.http_connection_manager
+#             config:
+#               access_log:
+#               - name: envoy.file_access_log
+#                 config:
+#                   path: /dev/stdout
+#               stat_prefix: ingress_http
+#               route_config:
+#                 name: local_route
+#                 virtual_hosts:
+#                 - name: local_service
+#                   domains: ["*"]
+#                   routes:
+#                   - match:
+#                       prefix: "/"
+#                     route:
+#                       host_rewrite: www.google.com
+#                       cluster: service_google
+#               http_filters:
+#               - name: envoy.router
+#       clusters:
+#       - name: service_google
+#         connect_timeout: 0.25s
+#         type: LOGICAL_DNS
+#         dns_lookup_family: V4_ONLY
+#         lb_policy: ROUND_ROBIN
+#         hosts:
+#           - socket_address:
+#               address: google.com
+#               port_value: 443
+#         tls_context:
+#           sni: www.google.com


### PR DESCRIPTION
This feature enables you to make your values.yaml a bit more DRY by referencing chart values from within the envoy.yaml template by using the `{{ .Values.foo.bar }}`.

The following example shows how you can reuse the port numbers defined in `values.yaml`:

- `ports.admin.containerPort`
- `ports.n0.contianerPort`

from within the envoy.yaml template by writing the below template expressions in `templates.envoy\.yaml`:

- `{{ .Values.ports.admin.containerPort }}`
- `{{ .Values.ports.n0.containerPort }}`

```
ports:
  admin:
    containerPort: 9901
    protocol: TCP
  n0:
    containerPort: 10000
    protocol: TCP

# snip

templates:
  envoy.yaml: |-
    ## refs:
    ## - https://www.envoyproxy.io/docs/envoy/latest/start/start#quick-start-to-run-simple-example
    ## - https://raw.githubusercontent.com/envoyproxy/envoy/master/configs/google_com_proxy.v2.yaml
    admin:
      access_log_path: /dev/stdout
      address:
        socket_address:
          address: 0.0.0.0
          port_value: {{ .Values.ports.admin.containerPort }}

    static_resources:
      listeners:
      - name: listener_0
        address:
          socket_address:
            address: 0.0.0.0
            port_value: {{ .Values.ports.n0.containerPort }}
        filter_chains:
        - filters:
          - name: envoy.http_connection_manager
            config:
              access_log:
              - name: envoy.file_access_log
                config:
                  path: /dev/stdout
              stat_prefix: ingress_http
              route_config:
                name: local_route
                virtual_hosts:
                - name: local_service
                  domains: ["*"]
                  routes:
                  - match:
                      prefix: "/"
                    route:
                      host_rewrite: www.google.com
                      cluster: service_google
              http_filters:
              - name: envoy.router
      clusters:
      - name: service_google
        connect_timeout: 0.25s
        type: LOGICAL_DNS
        dns_lookup_family: V4_ONLY
        lb_policy: ROUND_ROBIN
        hosts:
          - socket_address:
              address: google.com
              port_value: 443
        tls_context:
          sni: www.google.com
```

Signed-off-by: Yusuke KUOKA <ykuoka@gmail.com>