### PR TITLE
[incubator/kube-spot-termination-notice-handler] Refactor templates according to guidelines and chart best practices

### DIFF
--- a/incubator/kube-spot-termination-notice-handler/Chart.yaml
+++ b/incubator/kube-spot-termination-notice-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Watch and action AWS spot termination events
 name: kube-spot-termination-notice-handler
-version: 0.4.0
+version: 0.5.0
 appVersion: 1.10.8-1
 home: https://github.com/kube-aws/kube-spot-termination-notice-handler
 source:

--- a/incubator/kube-spot-termination-notice-handler/templates/_helpers.tpl
+++ b/incubator/kube-spot-termination-notice-handler/templates/_helpers.tpl
@@ -11,8 +11,12 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/incubator/kube-spot-termination-notice-handler/templates/_helpers.tpl
+++ b/incubator/kube-spot-termination-notice-handler/templates/_helpers.tpl
@@ -15,7 +15,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/incubator/kube-spot-termination-notice-handler/templates/_helpers.tpl
+++ b/incubator/kube-spot-termination-notice-handler/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "kube-spot-termination-notice-handler.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "kube-spot-termination-notice-handler.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -28,7 +28,7 @@ Create the name of the service account to use
 */}}
 {{- define "kube-spot-termination-notice-handler.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "kube-spot-termination-notice-handler.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/incubator/kube-spot-termination-notice-handler/templates/daemonset.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/daemonset.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "kube-spot-termination-notice-handler.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "kube-spot-termination-notice-handler.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "kube-spot-termination-notice-handler.name" . }}
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "kube-spot-termination-notice-handler.serviceAccountName" . }}

--- a/incubator/kube-spot-termination-notice-handler/templates/rbac.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/rbac.yaml
@@ -2,15 +2,15 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "kube-spot-termination-notice-handler.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "kube-spot-termination-notice-handler.fullname" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "kube-spot-termination-notice-handler.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
@@ -20,9 +20,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "kube-spot-termination-notice-handler.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "kube-spot-termination-notice-handler.fullname" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/incubator/kube-spot-termination-notice-handler/templates/serviceaccount.yaml
+++ b/incubator/kube-spot-termination-notice-handler/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "kube-spot-termination-notice-handler.serviceAccountName" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "kube-spot-termination-notice-handler.fullname" . }}
     chart: {{ .Chart.Name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}


### PR DESCRIPTION
### _UPDATE_

#10286 supersedes this PR. 
____

#### What this PR does / why we need it:

- Added `fullnameOverride` value.  This values value, being commonly used in other charts too, allows to override the result of `fullname` template function, so user can customize the name of resources
created by a helm chart.
- Fixed release name duplication in the `fullname` template.  This practice, also commonly used in other helm charts, allows to get rid of duplication and meaningless names of resources when the release name contains the chart name (or "nameOverride" if defined).
- Prepend template names with the chart name

Template names are global. According to helm chart guidelines, these should be prepended
with the chart name to avoid collisions:
https://github.com/helm/helm/blob/master/docs/chart_best_practices/templates.md#names-of-defined-templates
It's already done for `serviceAccountName`, so I fixed that to the rest of templates too.

All changes in this PR should be backward compatible. Since it adds a new value, I bumped the minor version of this Chart.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] ~Variables are documented in the README.md~ As I can see from other charts, `nameOverride` and `fullnameOverride` values are not usually documented. But let me know if I should do that in `values.yaml` and `README.md` 

cc: @GabrielNicolasAvellaneda 