### PR TITLE
[stable/prometheus-rabbitmq-exporter] Bump to v0.29.0

### DIFF
--- a/stable/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/stable/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.1.4
-appVersion: v0.28.0
+version: 0.2.0
+appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:
-  - https://github.com/kbudde/rabbitmq_exporter
-mantainers:
-  - name: juanchimienti
-    email: juan.chimienti@gmail.com
+- https://github.com/kbudde/rabbitmq_exporter
+maintainers:
+- name: juanchimienti
+  email: juan.chimienti@gmail.com

--- a/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-rabbitmq-exporter.fullname" . }}
@@ -40,20 +40,32 @@ spec:
               value: "{{ .Values.rabbitmq.capabilities }}"
             - name: INCLUDE_QUEUES
               value: "{{ .Values.rabbitmq.include_queues }}"
+            - name: INCLUDE_VHOST
+              value: "{{ .Values.rabbitmq.include_vhost }}"
             - name: SKIP_QUEUES
               value: "{{ .Values.rabbitmq.skip_queues }}"
+            - name: SKIP_VHOST
+              value: "{{ .Values.rabbitmq.skip_vhost }}"
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+              name: publish
           livenessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.internalPort }}
+              port: publish
           readinessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.internalPort }}
+              port: publish
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["all"]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10002
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/stable/prometheus-rabbitmq-exporter/templates/service.yaml
+++ b/stable/prometheus-rabbitmq-exporter/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.externalPort }}
-      targetPort: {{ .Values.service.internalPort }}
+      targetPort: publish
       protocol: TCP
       name: rabbitmq-exporter
   selector:

--- a/stable/prometheus-rabbitmq-exporter/values.yaml
+++ b/stable/prometheus-rabbitmq-exporter/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: kbudde/rabbitmq-exporter
-  tag: v0.28.0
+  tag: v0.29.0
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
@@ -35,7 +35,9 @@ rabbitmq:
   password: guest
   capabilities: bert,no_sort
   include_queues: ".*"
+  include_vhost: ".*"
   skip_queues: "^$"
+  skip_vhost: "^$"
 
 annotations: {}
 #  prometheus.io/scrape: "true"


### PR DESCRIPTION
#### What this PR does / why we need it:
- Bumps rabbitmq-exporter version to v0.29.0
- Adds new include_vhost and skip_vhost options that were added in v0.29.0
- Reduces container privileges to run as non-root and with a readOnlyRootFilesystem
- Use named ports to reduce duplicated templating

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
