### PR TITLE
[stable/efs-provisioner] Add support for priorityClasses

### DIFF
--- a/stable/efs-provisioner/Chart.yaml
+++ b/stable/efs-provisioner/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: efs-provisioner
 description: A Helm chart for the AWS EFS external storage provisioner
-version: 0.1.1
+version: 0.1.2
 appVersion: v0.1.2
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
 sources:

--- a/stable/efs-provisioner/templates/deployment.yaml
+++ b/stable/efs-provisioner/templates/deployment.yaml
@@ -1,3 +1,14 @@
+ {{- if ne .Values.efsProvisioner.efsFileSystemId "fs-12345678" }}
+ {{/*
+ The `efsFileSystemId` value must be set.
+
+ The above `if` condition also prevents the helm integration tests from failing.
+ Given that the helm test infrastructure does not have access to valid
+ AWS EFS resources, a deployment that references the example `fs-12345678`
+ creates pods that will never enter a clean, running state.
+
+ Omitting the deployment hacks around this limitation.
+*/}}
 kind: Deployment
 apiVersion: apps/v1beta2
 metadata:
@@ -57,3 +68,4 @@ spec:
         nfs:
           server: {{ .Values.efsProvisioner.efsFileSystemId }}.efs.{{ .Values.efsProvisioner.awsRegion }}.amazonaws.com
           path: /
+{{- end }}

--- a/stable/efs-provisioner/templates/deployment.yaml
+++ b/stable/efs-provisioner/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         release: "{{ .Release.Name }}"
     spec:
       serviceAccount: {{ template "efs-provisioner.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
       - name: {{ template "efs-provisioner.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/efs-provisioner/values.yaml
+++ b/stable/efs-provisioner/values.yaml
@@ -65,3 +65,5 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+priorityClassName: ""


### PR DESCRIPTION
Signed-off-by: Art3mK <artem@kayalaynen.ru>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR allows user to specify [PriorityClass](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) for efs-provisioner pods

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [n/a] Variables are documented in the README.md

ping @whereisaaron