### PR TITLE
Add reconnect_on_error to elasticsearch plugin

### DIFF
--- a/stable/fluentd-elasticsearch/Chart.yaml
+++ b/stable/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.0.3
+version: 2.0.4
 appVersion: 2.3.2
 home: https://www.fluentd.org/
 description: A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/stable/fluentd-elasticsearch/values.yaml
+++ b/stable/fluentd-elasticsearch/values.yaml
@@ -464,6 +464,7 @@ configMaps:
       ssl_version "#{ENV['OUTPUT_SSL_VERSION']}"
       logstash_format true
       logstash_prefix "#{ENV['LOGSTASH_PREFIX']}"
+      reconnect_on_error true
       <buffer>
         @type file
         path /var/log/fluentd-buffers/kubernetes.system.buffer


### PR DESCRIPTION
Signed-off-by: Rauny Brandão <rauny.brandao@gmail.com>

#### What this PR does / why we need it:

I'm using the Elasticsearch from **AWS**, and after 3 ~ 4 hours the following error started to show up:

```
fluentd-elasticsearch 2018-12-28 10:51:00 +0000 [warn]: [elasticsearch] failed to flush the buffer. 
retry_time=1 next_retry_seconds=2018-12-28 10:51:32 +0000 chunk="57d8706f1f6196cc31829c29ca209a04" 
error_class=Elasticsearch::Transport::Transport::Error error="Cannot get new connection from pool."
```

But after adding the option `reconnect_on_error true` the problem was solved.

```
fluentd-elasticsearch 2018-12-28 10:51:10 +0000 
[info]: [elasticsearch] Connection opened to Elasticsearch cluster => {:host=>"elasticsearch.region.es.amazonaws.com", :port=>443, :scheme=>"https"}

fluentd-elasticsearch-w852m fluentd-elasticsearch 2018-12-28 10:51:12 +0000 
[warn]: [elasticsearch] retry succeeded. chunk_id="57d8706f1f6196cc31829c29ca209a04"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
