### PR TITLE
[stable/fluentd-elasticsearch] Add support for priorityClasses

### DIFF
--- a/stable/fluentd-elasticsearch/Chart.yaml
+++ b/stable/fluentd-elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-elasticsearch
-version: 2.0.7
+version: 2.0.8
 appVersion: 2.3.2
 home: https://www.fluentd.org/
 description: DEPRECATED! - A Fluentd Helm chart for Kubernetes with Elasticsearch output

--- a/stable/fluentd-elasticsearch/README.md
+++ b/stable/fluentd-elasticsearch/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the Fluentd elasticsear
 | `nodeSelector`                     | Optional daemonset nodeSelector            | `{}`                                                       |
 | `podSecurityPolicy.annotations`    | Specify pod annotations in the pod security policy | `{}`                                               |
 | `podSecurityPolicy.enabled`        | Specify if a pod security policy must be created   | `false`                                            |
+| `priorityClassName`                | Optional PriorityClass for pods            | `""`                                                       |
 | `rbac.create`                      | RBAC                                       | `true`                                                     |
 | `resources.limits.cpu`             | CPU limit                                  | `100m`                                                     |
 | `resources.limits.memory`          | Memory limit                               | `500Mi`                                                    |

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -29,12 +29,14 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         kubernetes.io/cluster-service: "true"
       annotations:
+        {{- if semverCompare "< 1.13" .Capabilities.KubeVersion.GitVersion }}
         # This annotation ensures that fluentd does not get evicted if the node
         # supports critical pod annotation based priority scheme.
         # Note that this does not guarantee admission on the nodes (#40573).
         # NB! this annotation is deprecated as of version 1.13 and will be removed in 1.14.
         # ref: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}

--- a/stable/fluentd-elasticsearch/templates/daemonset.yaml
+++ b/stable/fluentd-elasticsearch/templates/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 {{- if .Values.annotations }}
-  annotations:    
+  annotations:
 {{ toYaml .Values.annotations | indent 4 }}
 {{- end }}
 spec:
@@ -28,10 +28,12 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         kubernetes.io/cluster-service: "true"
-      # This annotation ensures that fluentd does not get evicted if the node
-      # supports critical pod annotation based priority scheme.
-      # Note that this does not guarantee admission on the nodes (#40573).
       annotations:
+        # This annotation ensures that fluentd does not get evicted if the node
+        # supports critical pod annotation based priority scheme.
+        # Note that this does not guarantee admission on the nodes (#40573).
+        # NB! this annotation is deprecated as of version 1.13 and will be removed in 1.14.
+        # ref: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
         scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
@@ -39,6 +41,9 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ include "fluentd-elasticsearch.fullname" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
       - name: {{ include "fluentd-elasticsearch.fullname" . }}
         image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/fluentd-elasticsearch/values.yaml
+++ b/stable/fluentd-elasticsearch/values.yaml
@@ -6,6 +6,12 @@ image:
   tag: v2.3.2
   pullPolicy: IfNotPresent
 
+# Specify to use specific priorityClass for pods
+# ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority
+# Pods to make scheduling of the pending Pod possible.
+priorityClassName: ""
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
Signed-off-by: Art3mK <artem@kayalaynen.ru>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

According to [this](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/) `scheduler.alpha.kubernetes.io/critical-pod` annotation is deprecated in 1.13 and will be removed in 1.14. This PR allows user to specify priority class for pods

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

ping @monotek 