### PR TITLE
[stable/traefik] HorizontalPodAutoscaler

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.59.2
+version: 1.60.0
 appVersion: 1.7.7
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/README.md
+++ b/stable/traefik/README.md
@@ -216,6 +216,7 @@ The following table lists the configurable parameters of the Traefik chart and t
 | `tracing.datadog.localAgentHostPort`   | Location of the Datadog agent where spans will be sent                                                                       | `127.0.0.1:8126`                                  |
 | `tracing.datadog.debug`                | Enables Datadog debugging                                                                                                    | `false`                                           |
 | `tracing.datadog.globalTag`            | Apply shared tag in a form of Key:Value to all the traces                                                                    | `""`                                           |
+| `autoscaling`                          | HorizontalPodAutoscaler for the traefik Deployment                                                                           | `{}`                                           |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/stable/traefik/templates/hpa.yaml
+++ b/stable/traefik/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.autoscaling }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "traefik.fullname" . }}
+  labels:
+    app: {{ template "traefik.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "traefik.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+{{ toYaml .Values.autoscaling.metrics | indent 4 }}
+{{- end }}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -374,7 +374,7 @@ tracing:
   #   localAgentHostPort: "127.0.0.1:8126"
   #   debug: false
   #   globalTag: ""
-  
+
 ## Create HorizontalPodAutoscaler object.
 ##
 autoscaling: {}

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -377,15 +377,15 @@ tracing:
 
 ## Create HorizontalPodAutoscaler object.
 ##
-autoscaling: {}
-# minReplicas: 1
-# maxReplicas: 10
-# metrics:
-# - type: Resource
-#   resource:
-#     name: cpu
-#     targetAverageUtilization: 60
-# - type: Resource
-#   resource:
-#     name: memory
-#     targetAverageUtilization: 60
+# autoscaling:
+#   minReplicas: 1
+#   maxReplicas: 10
+#   metrics:
+#   - type: Resource
+#     resource:
+#       name: cpu
+#       targetAverageUtilization: 60
+#   - type: Resource
+#     resource:
+#       name: memory
+#       targetAverageUtilization: 60

--- a/stable/traefik/values.yaml
+++ b/stable/traefik/values.yaml
@@ -374,3 +374,18 @@ tracing:
   #   localAgentHostPort: "127.0.0.1:8126"
   #   debug: false
   #   globalTag: ""
+  
+## Create HorizontalPodAutoscaler object.
+##
+autoscaling: {}
+# minReplicas: 1
+# maxReplicas: 10
+# metrics:
+# - type: Resource
+#   resource:
+#     name: cpu
+#     targetAverageUtilization: 60
+# - type: Resource
+#   resource:
+#     name: memory
+#     targetAverageUtilization: 60


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Adds an HorizontalPodAutoscaler option targeting the Deployment

#### Which issue this PR fixes

No known issue

#### Special notes for your reviewer:

Modeled after `stable/nginx-ingress` but decided to read the whole "metrics" definition as yaml from values instead of restrict them to cpu and memory.

Also bumped the version to the next minor version given that introduces a new API.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
