### PR TITLE
[stable/home-assistant] Add option to inject environment vars from secrets

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.81.2
 description: Home Assistant
 name: home-assistant
-version: 0.4.1
+version: 0.4.2
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -58,6 +58,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `persistence.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.accessMode`  | Persistence access modes | `ReadWriteMany` |
 | `extraEnv`          | Extra ENV vars to pass to the home-assistant container | `{}` |
+| `extraEnvSecrets`   | Extra env vars to pass to the home-assistant container from k8s secrets - see `values.yaml` for an example | `{}` |
 | `configurator.enabled`     | Enable the optional [configuration UI](https://github.com/danielperna84/hass-configurator) | `false` |
 | `configurator.image.repository`         | Image repository | `billimek/hass-configurator-docker` |
 | `configurator.image.tag`                | Image tag | `x86_64-0.3.0`|

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -49,6 +49,13 @@ spec:
             - name: {{ $key }}
               value: {{ $value }}
             {{- end }}
+            {{- range $name, $opts := .Values.extraEnvSecrets }}
+            - name: {{ $name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $opts.secret }}
+                  key: {{ $opts.key }}
+            {{- end }}
           volumeMounts:
           - mountPath: /config
             name: config

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -55,10 +55,20 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
 
-## Additional hass-configurator container environment variable
+## Additional hass container environment variable
 ## For instance to add a http_proxy
 ##
 extraEnv: {}
+
+## Additional hass container environment variable from k8s secrets
+## For instance to add a password
+## can use `!env_var` in the home assistant configuration to reference these variables
+extraEnvSecrets:
+  # Example
+  # This will set ${MQTT_PASSWORD} to the 'password' key from the 'mqtt' secret
+  # MQTT_PASSWORD:
+  #   secret: mqtt
+  #   key: password
 
 configurator:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

Add an `extraEnvSecrets` option to that can be set through values. This option allows the user to inject environment variables into the home assistant container that are populated from Kubernetes secrets.

This is useful when paired with the `!env_var` [YAML directive](https://www.home-assistant.io/docs/configuration/yaml/#using-environment-variables) in the home assistant config file

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
