### PR TITLE
[stable/home-assistant] Add option to pass imagePullSecrets to Home Assistant pod

### DIFF
--- a/stable/home-assistant/Chart.yaml
+++ b/stable/home-assistant/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.84.6
 description: Home Assistant
 name: home-assistant
-version: 0.5.0
+version: 0.5.1
 keywords:
 - home-assistant
 - hass

--- a/stable/home-assistant/README.md
+++ b/stable/home-assistant/README.md
@@ -38,6 +38,7 @@ The following tables lists the configurable parameters of the Sentry chart and t
 | `image.repository`         | Image repository | `homeassistant/home-assistant` |
 | `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/homeassistant/home-assistant/tags/).| `0.84.6`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
+| `image.pullSecrets`        | Secrets to use when pulling the image | `[]` |
 | `service.type`             | Kubernetes service type for the home-assistant GUI | `ClusterIP` |
 | `service.port`             | Kubernetes port where the home-assistant GUI is exposed| `8123` |
 | `service.annotations`      | Service annotations for the home-assistant GUI | `{}` |

--- a/stable/home-assistant/templates/deployment.yaml
+++ b/stable/home-assistant/templates/deployment.yaml
@@ -19,6 +19,12 @@ spec:
         app: {{ template "home-assistant.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range . }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }} 
       {{- end }}

--- a/stable/home-assistant/values.yaml
+++ b/stable/home-assistant/values.yaml
@@ -8,6 +8,7 @@ image:
   repository: homeassistant/home-assistant
   tag: 0.84.6
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 service:
   type: ClusterIP


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `image.pullSecrets` as an option to be passed in via `values.yaml`, adding support for pulling HomeAssistant container images from private repositories

#### Special notes for your reviewer:

I am assuming this will be reviewed after #10297, hence the out-of-sequence version

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
