### PR TITLE
[stable/graphite] Fix missing image tag in init container spec

### DIFF
--- a/stable/graphite/Chart.yaml
+++ b/stable/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.4
+version: 0.1.5
 appVersion: "1.1.4-10"
 description: Graphite metrics server
 name: graphite

--- a/stable/graphite/templates/deployment.yaml
+++ b/stable/graphite/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       initContainers:
       - name: create-syncdb
-        image: {{ .Values.image.repository }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         command: [ "sh", "-c", "test -f /opt/graphite/storage/graphite.db || /usr/bin/expect /usr/local/bin/django_admin_init.exp"]
         volumeMounts:
           - name: {{ template "graphite.fullname" . }}-pvc


### PR DESCRIPTION
#### What this PR does / why we need it:

Graphite recently changed their initialization scripts in 1.1.5-x. The init container using `:latest` resulted in a failure to run the init script and a crash loop.

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
