### PR TITLE
[stable/grafana] Fix persistence by chowning /var/lib/grafana

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.21.2
+version: 1.21.3
 appVersion: 5.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -57,8 +57,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.size`                        | Size of persistent volume claim               | `10Gi`                                                  |
 | `persistence.existingClaim`               | Use an existing PVC to persist data           | `nil`                                                   |
 | `persistence.storageClassName`            | Type of persistent volume claim               | `nil`                                                   |
-| `persistence.accessModes`                 | Persistence access modes                      | `[]`                                                    |
-| `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `""`                                                    |
+| `persistence.accessModes`                 | Persistence access modes                      | `[ReadWriteOnce]`                                       |
+| `persistence.subPath`                     | Mount a sub dir of the persistent volume      | `nil`                                                   |
 | `schedulerName`                           | Alternate scheduler name                      | `nil`                                                   |
 | `env`                                     | Extra environment variables passed to pods    | `{}`                                                    |
 | `envFromSecret`                           | Name of a Kubenretes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -48,8 +48,8 @@ spec:
 {{- end }}
 {{- if .Values.persistence.enabled }}
         - name: init-chown-data
-          image: busybox
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.chownDataImage.repository }}:{{ .Values.chownDataImage.tag }}"
+          imagePullPolicy: {{ .Values.chownDataImage.pullPolicy }}
           securityContext:
             runAsUser: 0
           command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsUser }}", "/var/lib/grafana"]

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -43,8 +43,24 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-{{- if .Values.dashboards }}
+{{- if (.Values.persistence.enabled) or (.Values.dashboards) }}
       initContainers:
+{{- end }}
+{{- if .Values.persistence.enabled }}
+        - name: init-chown-data
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsUser }}", "/var/lib/grafana"]
+          volumeMounts:
+            - name: storage
+              mountPath: "/var/lib/grafana"
+{{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+{{- end }}
+{{- end }}
+{{- if .Values.dashboards }}
         - name: download-dashboards
           image: "{{ .Values.downloadDashboardsImage.repository }}:{{ .Values.downloadDashboardsImage.tag }}"
           imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
@@ -55,7 +71,9 @@ spec:
               subPath: download_dashboards.sh
             - name: storage
               mountPath: "/var/lib/grafana"
+{{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
+{{- end }}
           {{- range .Values.extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
@@ -119,7 +137,9 @@ spec:
               subPath: ldap.toml
             - name: storage
               mountPath: "/var/lib/grafana"
+{{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
+{{- end }}
 {{- if .Values.dashboards }}
   {{- range $provider, $dashboards := .Values.dashboards }}
     {{- range $key, $value := $dashboards }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -105,9 +105,9 @@ affinity: {}
 persistence:
   enabled: false
   # storageClassName: default
-  # accessModes:
-  #   - ReadWriteOnce
-  # size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
   # annotations: {}
   # subPath: ""
   # existingClaim:

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -46,6 +46,11 @@ downloadDashboardsImage:
   tag: latest
   pullPolicy: IfNotPresent
 
+chownDataImage:
+  repository: busybox
+  tag: 1.3.0
+  pullPolicy: IfNotPresent
+
 ## Pod Annotations
 # podAnnotations: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes a bunch of nonsense and finger pointing about persistence. Upstream isn't changing their docker image to chown volumes on start - they've had a year to do it and numerous issues here and on https://github.com/grafana/grafana. Let's just fix it here.

#### Which issue this PR fixes
  - #4156
  - #5576
  - #5635
  - #5102
  - #8857
  - #9660
  - #10116
  - #10276
  - #10306

#### Special notes for your reviewer:

Let's not have a broken chart for users one second longer, just merge this damn thing. See #10306 for how this has gone on *for far too long*.

What this changes is that if a user does `--set persistence.enabled=true` it just works. No other settings, no having to finagle with `persistence.size` or `persistence.accessModes={ReadWriteOnce}`, no having to manually `kubectl run` and mount the PV to chown it, no manually modifying the deployment with an additional init container. All of that nonsense is fixed by just following a few of the tips people laid out, and basically resubmitting #5576.

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
