### PR TITLE
[stable/graphite] Graphite statefulset

### DIFF
--- a/stable/graphite/Chart.yaml
+++ b/stable/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.6
+version: 0.2.0
 appVersion: "1.1.5-3"
 description: Graphite metrics server
 name: graphite

--- a/stable/graphite/Chart.yaml
+++ b/stable/graphite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-version: 0.1.5
-appVersion: "1.1.4-10"
+version: 0.1.6
+appVersion: "1.1.5-3"
 description: Graphite metrics server
 name: graphite
 home: https://graphiteapp.org/

--- a/stable/graphite/Chart.yaml
+++ b/stable/graphite/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.4
+version: 0.1.5
 appVersion: "1.1.4-10"
 description: Graphite metrics server
 name: graphite

--- a/stable/graphite/README.md
+++ b/stable/graphite/README.md
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of the Graphite chart and 
 |             Parameter          |            Description                       |                  Default               |
 |--------------------------------|----------------------------------------------|----------------------------------------|
 | `image.repository`             | Docker image repo                            | `graphiteapp/graphite-statsd`          |
-| `image.tag`                    | Docker image                                 | `1.1.4-10`                                |
+| `image.tag`                    | Docker image                                 | `1.1.5-3`                                |
 | `image.pullPolicy`             | Docker image pull policy                     | `IfNotPresent`                         |
 | `service.type`                 | Service type                                 | `ClusterIP`                            |
 | `service.port`                 | Service port of Graphite UI                  | `8080`                                 |

--- a/stable/graphite/templates/deployment.yaml
+++ b/stable/graphite/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       initContainers:
       - name: create-syncdb
-        image: {{ .Values.image.repository }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         command: [ "sh", "-c", "test -f /opt/graphite/storage/graphite.db || /usr/bin/expect /usr/local/bin/django_admin_init.exp"]
         volumeMounts:
           - name: {{ template "graphite.fullname" . }}-pvc

--- a/stable/graphite/templates/statefulset.yaml
+++ b/stable/graphite/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "graphite.fullname" . }}

--- a/stable/graphite/templates/statefulset.yaml
+++ b/stable/graphite/templates/statefulset.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: apps/v1beta1
+kind: StatefulSet
 metadata:
   name: {{ template "graphite.fullname" . }}
   labels:
@@ -8,25 +8,19 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  strategy:
-    type: Recreate
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: {{ template "graphite.name" . }}
       release: {{ .Release.Name }}
+  serviceName: {{ template "graphite.name" . }}
   template:
     metadata:
       labels:
         app: {{ template "graphite.name" . }}
         release: {{ .Release.Name }}
     spec:
-      initContainers:
-      - name: create-syncdb
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        command: [ "sh", "-c", "test -f /opt/graphite/storage/graphite.db || /usr/bin/expect /usr/local/bin/django_admin_init.exp"]
-        volumeMounts:
-          - name: {{ template "graphite.fullname" . }}-pvc
-            mountPath: /opt/graphite/storage/
       containers:
       - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         name: {{ .Chart.Name }}

--- a/stable/graphite/values.yaml
+++ b/stable/graphite/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: graphiteapp/graphite-statsd
-  tag: 1.1.4-10
+  tag: 1.1.5-3
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
#### What this PR does / why we need it:

Graphite has some weird performance glitches with 1.1.4-10, the prior version, and this resulted in metrics being delayed or not appearing at all for over half an hour (tested with persistence enabled and disabled).

The init container is no longer necessary in 1.1.5, simplifying implementation, something I missed in #10305.

The StatefulSet better models how Graphite considers its individual components. In my testing I noticed that when restarting pods, the Graphite UI would be littered with old pod names. It looks like Graphite is sensitive to the identities of the different services - it is designed to be clustered after all.

#### Special notes for your reviewer:

If this is merged, #10305 is not necessary.

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
