### PR TITLE
[stable/stackdriver-exporter] fix duplicated 'livenessProbe', add 'readinessProbe'

### DIFF
--- a/stable/stackdriver-exporter/Chart.yaml
+++ b/stable/stackdriver-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Stackdriver exporter for Prometheus
 name: stackdriver-exporter
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.6.0
 home: https://www.stackdriver.com/
 sources:

--- a/stable/stackdriver-exporter/README.md
+++ b/stable/stackdriver-exporter/README.md
@@ -56,23 +56,28 @@ deletes the release.
 The following table lists the configurable parameters of the
 Stackdriver-Exporter chart and their default values.
 
-Parameter                           | Description                          | Default
------------------------------------ | ------------------------------------ | --------------------------------
-`replicaCount`                      | Desired number of pods               | `1`
-`restartPolicy`                     | Container restart policy             | `Always`
-`image.repository`                  | Container image repository           | `frodenas/stackdriver-exporter`
-`image.tag`                         | Container image tag                  | `v0.6.0`
-`image.pullPolicy`                  | Container image pull policy          | `IfNotPresent`
-`resources`                         | Resource requests & limits           | `{}`
-`service.type`                      | Type of service to create            | `ClusterIP`
-`service.httpPort`                  | Port for the http service            | `9255`
-`stackdriver.projectId`             | GCP Project ID                       | ``
-`stackdriver.metrics.typePrefixes`  | Comma separated Metric Type prefixes | ``
-`stackdriver.metrics.interval`      | Metrics interval to request from GCP | `5m`
-`stackdriver.metrics.offset`        | Offset (into the past) to request    | `0s`
-`web.listenAddress`                 | Port to listen on                    | `9255`
-`web.path`                          | Path under which to expose metrics   | `/metrics`
-`annotations`                       | Deployment annotations               | `{}`
+Parameter                           | Description                                                                     | Default
+----------------------------------- | ------------------------------------------------------------------------------- | --------------------------------
+`replicaCount`                      | Desired number of pods                                                          | `1`
+`restartPolicy`                     | Container restart policy                                                        | `Always`
+`image.repository`                  | Container image repository                                                      | `frodenas/stackdriver-exporter`
+`image.tag`                         | Container image tag                                                             | `v0.6.0`
+`image.pullPolicy`                  | Container image pull policy                                                     | `IfNotPresent`
+`resources`                         | Resource requests & limits                                                      | `{}`
+`service.type`                      | Type of service to create                                                       | `ClusterIP`
+`service.httpPort`                  | Port for the http service                                                       | `9255`
+`stackdriver.projectId`             | GCP Project ID                                                                  | ``
+`stackdriver.maxRetries`            | Max number of retries that should be attempted on errors from Stackdriver       | `0`
+`stackdriver.httpTimeout`           | How long should Stackdriver_exporter wait for a result from the Stackdriver API | `10s`
+`stackdriver.maxBackoff`            | Max time between each request in an exponential backoff scenario                | `5s`
+`stackdriver.backoffJitter`         | The amount of jitter to introduce in an exponential backoff scenario            | `1s`
+`stackdriver.retryStatuses`         | The HTTP statuses that should trigger a retry                                   | `503`
+`stackdriver.metrics.typePrefixes`  | Comma separated Metric Type prefixes                                            | `compute.googleapis.com/instance/cpu`
+`stackdriver.metrics.interval`      | Metrics interval to request from GCP                                            | `5m`
+`stackdriver.metrics.offset`        | Offset (into the past) to request                                               | `0s`
+`web.listenAddress`                 | Port to listen on                                                               | `9255`
+`web.path`                          | Path under which to expose metrics                                              | `/metrics`
+`annotations`                       | Deployment annotations                                                          | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example,

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -48,15 +48,15 @@ spec:
             - name: STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH
               value: {{ .Values.web.path | quote }}
             - name: STACKDRIVER_EXPORTER_MAX_RETRIES
-              value: {{ .Values.maxRetries | quote }}
+              value: {{ .Values.stackdriver.maxRetries | quote }}
             - name: STACKDRIVER_EXPORTER_HTTP_TIMEOUT
-              value: {{ .Values.httpTimeout | quote }}
+              value: {{ .Values.stackdriver.httpTimeout | quote }}
             - name: STACKDRIVER_EXPORTER_MAX_BACKOFF_DURATION
-              value: {{ .Values.maxBackoff | quote }}
+              value: {{ .Values.stackdriver.maxBackoff | quote }}
             - name: STACKDRIVER_EXPORTER_BACKODFF_JITTER_BASE
-              value: {{ .Values.backoffJitter | quote }}
+              value: {{ .Values.stackdriver.backoffJitter | quote }}
             - name: STACKDRIVER_EXPORTER_RETRY_STATUSES
-              value: {{ .Values.retryStatuses | quote}}
+              value: {{ .Values.stackdriver.retryStatuses | quote}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           ports:

--- a/stable/stackdriver-exporter/templates/deployment.yaml
+++ b/stable/stackdriver-exporter/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
               port: http
             initialDelaySeconds: 30
             timeoutSeconds: 10
-          livenessProbe:
+          readinessProbe:
             httpGet:
               path: /health
               port: http

--- a/stable/stackdriver-exporter/values.yaml
+++ b/stable/stackdriver-exporter/values.yaml
@@ -25,13 +25,13 @@ service:
 stackdriver:
   # The Google Project ID to gather metrics for
   projectId: "FALSE"
-  # Max number of retries that should be attempted on 503 errors from stackdriver
+  # Max number of retries that should be attempted on 503 errors from Stackdriver
   maxRetries: 0
-  # How long should stackdriver_exporter wait for a result from the Stackdriver API
+  # How long should Stackdriver_exporter wait for a result from the Stackdriver API
   httpTimeout: 10s
   # Max time between each request in an exp backoff scenario
   maxBackoff: 5s
-  # The amount of jitter to introduce in a exp backoff scenario
+  # The amount of jitter to introduce in an exp backoff scenario
   backoffJitter: 1s
   # The HTTP statuses that should trigger a retry
   retryStatuses: 503


### PR DESCRIPTION
@apenney 

#### Which issue this PR fixes:
  - duplicated 'livenessProbe', add 'readinessProbe' 
  - container environment variables introduced in chart version `0.0.5` cannot be overwritten and get empty defaults as of incorrect templating

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
