### PR TITLE
[stable/postgresql] enable secret setup only on pre-install hook

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 3.8.0
+version: 3.8.1
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/NOTES.txt
+++ b/stable/postgresql/templates/NOTES.txt
@@ -13,6 +13,12 @@
 
 -------------------------------------------------------------------------------
 {{- end }}
+-------------------------------------------------------------------------------
+ NOTE
+
+  Please note some K8s resources such as Secrets or PVCs should be deleted
+  manually if you delete this release.
+-------------------------------------------------------------------------------
 {{- end }}
 
 ** Please be patient while the chart is being deployed **

--- a/stable/postgresql/templates/secrets.yaml
+++ b/stable/postgresql/templates/secrets.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "postgresql.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed
 type: Opaque
 data:
   {{- if .Values.postgresqlPassword }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
When upgrade your postgresql chart, you don't want to lose your sql password secret. This PR enables secret setup only on pre-install hook.

#### Which issue this PR fixes
No one

#### Special notes for your reviewer:

- @desaintmartin 
- @carrodher

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
