### PR TITLE
[stable/prestashop] Add ingress

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 5.0.2
+version: 6.0.0
 appVersion: 1.7.5-0
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/stable/prestashop/README.md
+++ b/stable/prestashop/README.md
@@ -47,70 +47,80 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the PrestaShop chart and their default values.
 
-|               Parameter               |                                         Description                                          |                         Default                         |
-|---------------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| `global.imageRegistry`                | Global Docker image registry                                                                 | `nil`                                                   |
-| `image.registry`                      | PrestaShop image registry                                                                    | `docker.io`                                             |
-| `image.repository`                    | PrestaShop image name                                                                        | `bitnami/prestashop`                                    |
-| `image.tag`                           | PrestaShop image tag                                                                         | `{VERSION}`                                             |
-| `image.pullPolicy`                    | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `image.pullSecrets`                   | Specify image pull secrets                                                                   | `nil`                                                   |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                  | `80`                                          |
-| `service.httpsPort`                    | Service HTTPS port                   | `443`                                          |
-| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
-| `service.nodePorts.https`                | Kubernetes https node port                 | `""`                                                    |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
-| `service.loadBalancerIP`   | LoadBalancer service IP address       | `""`                                               |
-| `prestashopHost`                      | PrestaShop host to create application URLs                                                   | `nil`                                                   |
-| `prestashopUsername`                  | User of the application                                                                      | `user@example.com`                                      |
-| `prestashopPassword`                  | Application password                                                                         | _random 10 character long alphanumeric string_          |
-| `prestashopEmail`                     | Admin email                                                                                  | `user@example.com`                                      |
-| `prestashopFirstName`                 | First Name                                                                                   | `Bitnami`                                               |
-| `prestashopLastName`                  | Last Name                                                                                    | `Name`                                                  |
-| `prestashopCookieCheckIP`             | Whether to check the cookie's IP address or not                                              | `no`                                                    |
-| `smtpHost`                            | SMTP host                                                                                    | `nil`                                                   |
-| `smtpPort`                            | SMTP port                                                                                    | `nil`                                                   |
-| `smtpUser`                            | SMTP user                                                                                    | `nil`                                                   |
-| `smtpPassword`                        | SMTP password                                                                                | `nil`                                                   |
-| `smtpProtocol`                        | SMTP protocol [`ssl`, `tls`]                                                                 | `nil`                                                   |
-| `allowEmptyPassword`                  | Allow DB blank passwords                                                                     | `yes`                                                   |
-| `externalDatabase.host`               | Host of the external database                                                                | `nil`                                                   |
-| `externalDatabase.port`               | SMTP protocol [`ssl`, `none`]                                                                | `3306`                                                  |
-| `externalDatabase.user`               | Existing username in the external db                                                         | `bn_prestashop`                                         |
-| `externalDatabase.password`           | Password for the above username                                                              | `nil`                                                   |
-| `externalDatabase.database`           | Name of the existing database                                                                | `bitnami_prestashop`                                    |
-| `mariadb.enabled`                     | Whether to use the MariaDB chart                                                             | `true`                                                  |
-| `mariadb.db.name`                     | Database name to create                                                                      | `bitnami_prestashop`                                    |
-| `mariadb.db.user`                     | Database user to create                                                                      | `bn_prestashop`                                         |
-| `mariadb.db.password`                 | Password for the database                                                                    | `nil`                                                   |
-| `mariadb.rootUser.password`           | MariaDB admin password                                                                       | `nil`                                                   |
-| `sessionAffinity`                     | Configures the session affinity                                                              | `None`                                                  |
-| `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                                  |
-| `persistence.storageClass`            | PVC Storage Class for PrestaShop volume                                                      | `nil` (uses alpha storage class annotation)             |
-| `persistence.existingClaim`           | An Existing PVC name for Apache volume                                                       | `nil` (uses alpha storage class annotation)             |
-| `persistence.accessMode`              | PVC Access Mode for PrestaShop volume                                                        | `ReadWriteOnce`                                         |
-| `persistence.size`                    | PVC Storage Request for PrestaShop volume                                                    | `8Gi`                                                   |
-| `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                            |
-| `livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                     | 600                                                     |
-| `livenessProbe.periodSeconds`         | How often to perform the probe                                                               | 3                                                       |
-| `livenessProbe.timeoutSeconds`        | When the probe times out                                                                     | 5                                                       |
-| `livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                       |
-| `livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                       |
-| `readinessProbe.initialDelaySeconds`  | Delay before readiness probe is initiated                                                    | 30                                                      |
-| `readinessProbe.periodSeconds`        | How often to perform the probe                                                               | 3                                                       |
-| `readinessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                                       |
-| `readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                       |
-| `readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                       |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `nil`                                                |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
+|               Parameter               |                                         Description                                          |                         Default                              |
+|---------------------------------------|----------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `global.imageRegistry`                | Global Docker image registry                                                                 | `nil`                                                        |
+| `image.registry`                      | PrestaShop image registry                                                                    | `docker.io`                                                  |
+| `image.repository`                    | PrestaShop image name                                                                        | `bitnami/prestashop`                                         |
+| `image.tag`                           | PrestaShop image tag                                                                         | `{VERSION}`                                                  |
+| `image.pullPolicy`                    | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent`      |
+| `image.pullSecrets`                   | Specify image pull secrets                                                                   | `nil`                                                        |
+| `service.type`                        | Kubernetes Service type                                                                      | `LoadBalancer`                                               |
+| `service.port`                        | Service HTTP port                                                                            | `80`                                                         |
+| `service.httpsPort`                   | Service HTTPS port                                                                           | `443`                                                        |
+| `service.nodePorts.http`              | Kubernetes http node port                                                                    | `""`                                                         |
+| `service.nodePorts.https`             | Kubernetes https node port                                                                   | `""`                                                         |
+| `service.externalTrafficPolicy`       | Enable client source IP preservation                                                         | `Cluster`                                                    |
+| `service.loadBalancerIP          `    | LoadBalancer service IP address                                                              | `""`                                                         |
+| `ingress.enabled`                     | Enable ingress controller resource                                                           | `false`                                                      |
+| `ingress.certManager`                 | Add annotations for cert-manager                                                             | `false`                                                      |
+| `ingress.annotations`                 | Ingress annotations                                                                          | `[]`                                                         |
+| `ingress.hosts[0].name`               | Hostname to your PrestaShop installation                                                     | `prestashop.local`                                           |
+| `ingress.hosts[0].path`               | Path within the url structure                                                                | `/`                                                          |
+| `ingress.hosts[0].tls`                | Utilize TLS backend in ingress                                                               | `false`                                                      |
+| `ingress.hosts[0].tlsSecret`          | TLS Secret (certificates)                                                                    | `prestashop.local-tls`                                       |
+| `ingress.secrets[0].name`             | TLS Secret Name                                                                              | `nil`                                                        |
+| `ingress.secrets[0].certificate`      | TLS Secret Certificate                                                                       | `nil`                                                        |
+| `ingress.secrets[0].key`              | TLS Secret Key                                                                               | `nil`                                                        |
+| `prestashopHost`                      | PrestaShop host to create application URLs (when ingress, it will be ignored)                | `nil`                                          |
+| `prestashopUsername`                  | User of the application                                                                      | `user@example.com`                                           |
+| `prestashopPassword`                  | Application password                                                                         | _random 10 character long alphanumeric string_               |
+| `prestashopEmail`                     | Admin email                                                                                  | `user@example.com`                                           |
+| `prestashopFirstName`                 | First Name                                                                                   | `Bitnami`                                                    |
+| `prestashopLastName`                  | Last Name                                                                                    | `Name`                                                       |
+| `prestashopCookieCheckIP`             | Whether to check the cookie's IP address or not                                              | `no`                                                         |
+| `smtpHost`                            | SMTP host                                                                                    | `nil`                                                        |
+| `smtpPort`                            | SMTP port                                                                                    | `nil`                                                        |
+| `smtpUser`                            | SMTP user                                                                                    | `nil`                                                        |
+| `smtpPassword`                        | SMTP password                                                                                | `nil`                                                        |
+| `smtpProtocol`                        | SMTP protocol [`ssl`, `tls`]                                                                 | `nil`                                                        |
+| `allowEmptyPassword`                  | Allow DB blank passwords                                                                     | `yes`                                                        |
+| `externalDatabase.host`               | Host of the external database                                                                | `nil`                                                        |
+| `externalDatabase.port`               | SMTP protocol [`ssl`, `none`]                                                                | `3306`                                                       |
+| `externalDatabase.user`               | Existing username in the external db                                                         | `bn_prestashop`                                              |
+| `externalDatabase.password`           | Password for the above username                                                              | `nil`                                                        |
+| `externalDatabase.database`           | Name of the existing database                                                                | `bitnami_prestashop`                                         |
+| `mariadb.enabled`                     | Whether to use the MariaDB chart                                                             | `true`                                                       |
+| `mariadb.db.name`                     | Database name to create                                                                      | `bitnami_prestashop`                                         |
+| `mariadb.db.user`                     | Database user to create                                                                      | `bn_prestashop`                                              |
+| `mariadb.db.password`                 | Password for the database                                                                    | `nil`                                                        |
+| `mariadb.rootUser.password`           | MariaDB admin password                                                                       | `nil`                                                        |
+| `sessionAffinity`                     | Configures the session affinity                                                              | `None`                                                       |
+| `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                                       |
+| `persistence.storageClass`            | PVC Storage Class for PrestaShop volume                                                      | `nil` (uses alpha storage class annotation)                  |
+| `persistence.existingClaim`           | An Existing PVC name for Apache volume                                                       | `nil` (uses alpha storage class annotation)                  |
+| `persistence.accessMode`              | PVC Access Mode for PrestaShop volume                                                        | `ReadWriteOnce`                                              |
+| `persistence.size`                    | PVC Storage Request for PrestaShop volume                                                    | `8Gi`                                                        |
+| `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                                 |
+| `livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                     | 600                                                          |
+| `livenessProbe.periodSeconds`         | How often to perform the probe                                                               | 3                                                            |
+| `livenessProbe.timeoutSeconds`        | When the probe times out                                                                     | 5                                                            |
+| `livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                            |
+| `livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                            |
+| `readinessProbe.initialDelaySeconds`  | Delay before readiness probe is initiated                                                    | 30                                                           |
+| `readinessProbe.periodSeconds`        | How often to perform the probe                                                               | 3                                                            |
+| `readinessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                                            |
+| `readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                            |
+| `readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                            |
+| `podAnnotations`                      | Pod annotations                                                                              | `{}`                                                         |
+| `metrics.enabled`                     | Start a side-car prometheus exporter                                                         | `false`                                                      |
+| `metrics.image.registry`              | Apache exporter image registry                                                               | `docker.io`                                                  |
+| `metrics.image.repository`            | Apache exporter image name                                                                   | `lusotycoon/apache-exporter`                                 |
+| `metrics.image.tag`                   | Apache exporter image tag                                                                    | `v0.5.0`                                                     |
+| `metrics.image.pullPolicy`            | Image pull policy                                                                            | `IfNotPresent`                                               |
+| `metrics.image.pullSecrets`           | Specify docker-registry secret names as an array                                             | `nil`                                                        |
+| `metrics.podAnnotations`              | Additional annotations for Metrics exporter pod                                              | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                   | Exporter resource requests/limit                                                             | {}                                                           |
 
 The above parameters map to the env variables defined in [bitnami/prestashop](http://github.com/bitnami/bitnami-docker-prestashop). For more information please refer to the [bitnami/prestashop](http://github.com/bitnami/bitnami-docker-prestashop) image documentation.
 

--- a/stable/prestashop/templates/NOTES.txt
+++ b/stable/prestashop/templates/NOTES.txt
@@ -3,7 +3,6 @@
 {{- if empty (include "prestashop.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
-See {{ (index .Values.ingress.hosts 0).name }}
 ###############################################################################
 
 This deployment will be incomplete until you configure PrestaShop with a resolvable

--- a/stable/prestashop/templates/NOTES.txt
+++ b/stable/prestashop/templates/NOTES.txt
@@ -3,6 +3,7 @@
 {{- if empty (include "prestashop.host" .) -}}
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
+See {{ (index .Values.ingress.hosts 0).name }}
 ###############################################################################
 
 This deployment will be incomplete until you configure PrestaShop with a resolvable

--- a/stable/prestashop/templates/_helpers.tpl
+++ b/stable/prestashop/templates/_helpers.tpl
@@ -16,6 +16,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prestashop.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -38,10 +45,16 @@ Note, returns 127.0.0.1 if using ClusterIP.
 {{/*
 Gets the host to be used for this application.
 If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
+When using Ingress, it will be set to the Ingress hostname.
 */}}
 {{- define "prestashop.host" -}}
+{{- if .Values.ingress.enabled }}
+{{- $host := (index .Values.ingress.hosts 0).name | default "" -}}
+{{- default (include "prestashop.serviceIP" .) $host -}}
+{{- else -}}
 {{- $host := index .Values (printf "%sHost" .Chart.Name) | default "" -}}
 {{- default (include "prestashop.serviceIP" .) $host -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "prestashop.fullname" . }}
   labels:
-    app: "{{ template "prestashop.fullname" . }}"
+    app: "{{ template "prestashop.name" . }}"
     chart: "{{ template "prestashop.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       labels:
-        app: "{{ template "prestashop.fullname" . }}"
+        app: "{{ template "prestashop.name" . }}"
         chart: "{{ template "prestashop.chart" . }}"
         release: {{ .Release.Name | quote }}
 {{- if or .Values.podAnnotations .Values.metrics.enabled }}

--- a/stable/prestashop/templates/deployment.yaml
+++ b/stable/prestashop/templates/deployment.yaml
@@ -4,10 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "prestashop.fullname" . }}
   labels:
-    app: {{ template "prestashop.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "prestashop.fullname" . }}"
+    chart: "{{ template "prestashop.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   selector:
     matchLabels:
@@ -16,9 +16,9 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "prestashop.fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
+        app: "{{ template "prestashop.fullname" . }}"
+        chart: "{{ template "prestashop.chart" . }}"
+        release: {{ .Release.Name | quote }}
 {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
   {{- if .Values.podAnnotations }}

--- a/stable/prestashop/templates/externaldb-secrets.yaml
+++ b/stable/prestashop/templates/externaldb-secrets.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  name: "{{ template "prestashop.fullname" . }}-externaldb"
   labels:
-    app: "{{ template "prestashop.fullname" . }}"
+    app: "{{ template "prestashop.name" . }}-externaldb"
     chart: "{{ template "prestashop.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/prestashop/templates/externaldb-secrets.yaml
+++ b/stable/prestashop/templates/externaldb-secrets.yaml
@@ -4,10 +4,10 @@ kind: Secret
 metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
   labels:
-    app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "prestashop.fullname" . }}"
+    chart: "{{ template "prestashop.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
   db-password: {{ default "" .Values.externalDatabase.password | b64enc | quote }}

--- a/stable/prestashop/templates/ingress.yaml
+++ b/stable/prestashop/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "prestashop.fullname" . }}
+  labels:
+    app: "{{ template "prestashop.name" . }}"
+    chart: "{{ template "prestashop.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+    {{- if .Values.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  {{- range .Values.ingress.hosts }}
+  - host: {{ .name }}
+    http:
+      paths:
+      - path: {{ default "/" .path }}
+        backend:
+          serviceName: "{{ template "prestashop.fullname" $ }}"
+          servicePort: http
+  {{- end }}
+  tls:
+  {{- range .Values.ingress.hosts }}
+  {{- if .tls }}
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/prestashop/templates/prestashop-pvc.yaml
+++ b/stable/prestashop/templates/prestashop-pvc.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 metadata:
   name: {{ template "prestashop.fullname" . }}-prestashop
   labels:
-    app: {{ template "prestashop.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "prestashop.fullname" . }}"
+    chart: "{{ template "prestashop.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/prestashop/templates/prestashop-pvc.yaml
+++ b/stable/prestashop/templates/prestashop-pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "prestashop.fullname" . }}-prestashop
   labels:
-    app: "{{ template "prestashop.fullname" . }}"
+    app: "{{ template "prestashop.name" . }}"
     chart: "{{ template "prestashop.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/prestashop/templates/secrets.yaml
+++ b/stable/prestashop/templates/secrets.yaml
@@ -3,10 +3,10 @@ kind: Secret
 metadata:
   name: {{ template "prestashop.fullname" . }}
   labels:
-    app: {{ template "prestashop.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "prestashop.fullname" . }}"
+    chart: "{{ template "prestashop.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
   {{ if .Values.prestashopPassword }}

--- a/stable/prestashop/templates/secrets.yaml
+++ b/stable/prestashop/templates/secrets.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ template "prestashop.fullname" . }}
   labels:
-    app: "{{ template "prestashop.fullname" . }}"
+    app: "{{ template "prestashop.name" . }}"
     chart: "{{ template "prestashop.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/prestashop/templates/svc.yaml
+++ b/stable/prestashop/templates/svc.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "prestashop.fullname" . }}
   labels:
-    app: {{ template "prestashop.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "prestashop.fullname" . }}"
+    chart: "{{ template "prestashop.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
@@ -29,4 +29,4 @@ spec:
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- end }}
   selector:
-    app: {{ template "prestashop.fullname" . }}
+    app: "{{ template "prestashop.fullname" . }}"

--- a/stable/prestashop/templates/svc.yaml
+++ b/stable/prestashop/templates/svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "prestashop.fullname" . }}
   labels:
-    app: "{{ template "prestashop.fullname" . }}"
+    app: "{{ template "prestashop.name" . }}"
     chart: "{{ template "prestashop.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/prestashop/templates/tls-secrets.yaml
+++ b/stable/prestashop/templates/tls-secrets.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "prestashop.name" $ }}
+    chart: {{ template "prestashop.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+{{- end }}
+{{- end }}

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -82,7 +82,6 @@ externalDatabase:
   ## Database name
   database: bitnami_prestashop
 
-
 ## SMTP mail delivery configuration
 ## ref: https://github.com/bitnami/bitnami-docker-prestashop/#smtp-configuration
 ##
@@ -160,6 +159,52 @@ service:
   ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Local
+
+## Configure the ingress resource that allows you to access the
+## PrestaShop installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  enabled: false
+
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  certManager: false
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations:
+  #  kubernetes.io/ingress.class: nginx
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: prestashop.local
+    path: /
+
+    # Set this to true in order to enable TLS on the ingress record
+    tls: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: prestashop.local-tls
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: prestashop.local-tls
+  #   key:
+  #   certificate:
 
 ## Control where client requests go, to the same pod or round-robin
 ## Values: ClientIP or None


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

Add Ingress support to the chart. We should close https://github.com/helm/charts/pull/9801 in favor of this PR. Instead of using multiples Ingress object, this PR uses the same Ingress object with different rules per host defined.

#### Which issue this PR fixes

  - fixes #9359

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
