### PR TITLE
stable/unifi:  Replace "addSetfcap" option with simply adding that capability when "runAsRoot" is not set to true

### DIFF
--- a/stable/unifi/Chart.yaml
+++ b/stable/unifi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 5.9.29
 description: Ubiquiti Network's Unifi Controller
 name: unifi
-version: 0.2.5
+version: 0.2.6
 keywords:
   - ubiquiti
   - unifi

--- a/stable/unifi/README.md
+++ b/stable/unifi/README.md
@@ -74,10 +74,9 @@ The following tables lists the configurable parameters of the Unifi chart and th
 | `ingress.hosts`                              | Ingress accepted hostnames                                                                                             | `chart-example.local`        |
 | `ingress.tls`                                | Ingress TLS configuration                                                                                              | `[]`                         |
 | `timezone`                                   | Timezone the Unifi controller should run as, e.g. 'America/New York'                                                   | `UTC`                        |
-| `runAsRoot`                                  | Run the controller as UID0 (root user)                                                                                 | `false`                      |
+| `runAsRoot`                                  | Run the controller as UID0 (root user); if set to false, will give container SETFCAP instead                           | `false`                      |
 | `UID`                                        | Run the controller as user UID                                                                                         | `999`                        |
 | `GID`                                        | Run the controller as group GID                                                                                        | `999`                        |
-| `addSetfcap`                                 | Give the controller container the SETFCAP capability; this is necessary when not running as root                       | `true`                       |
 | `mongodb.enabled`                            | Use external MongoDB for data storage                                                                                  | `false`                      |
 | `mongodb.dbUri`                              | external MongoDB URI                                                                                                   | `mongodb://mongo/unifi`      |
 | `mongodb.statDbUri`                          | external MongoDB statdb URI                                                                                            | `mongodb://mongo/unifi_stat` |

--- a/stable/unifi/templates/deployment.yaml
+++ b/stable/unifi/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: stun
               containerPort: 3478
               protocol: UDP
-          {{- if .Values.addSetfcap }}
+          {{- if not .Values.runAsRoot }}
           securityContext:
             capabilities:
               add:

--- a/stable/unifi/values.yaml
+++ b/stable/unifi/values.yaml
@@ -109,7 +109,6 @@ ingress:
 timezone: UTC
 
 runAsRoot: false
-addSetfcap: true
 UID: 999
 GID: 999
 


### PR DESCRIPTION

#### What this PR does / why we need it:
Switches from an explicit `addSetfcap` option to setting that capability when `runAsRoot` is not set to true

#### Which issue this PR fixes
No issue filed, but we discussed in the comments on #10143

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
