### PR TITLE
[stable/cert-manager] add priorityClassName option

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.5.2
+version: v0.5.3
 appVersion: v0.5.2
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `podDnsPolicy` | Optional cert-manager pod [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy) |  |
 | `podDnsConfig` | Optional cert-manager pod [DNS configurations](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-config) |  |
 | `podLabels` | Labels to add to the cert-manager pod | `{}` |
+| `priorityClassName`| Priority class name for cert-manager pods | `""` |
 | `http_proxy` | Value of the `HTTP_PROXY` environment variable in the cert-manager pod | |
 | `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
 | `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -69,6 +69,8 @@ ingressShim: {}
   # defaultACMEChallengeType: ""
   # defaultACMEDNS01ChallengeProvider: ""
 
+priorityClassName: ""
+
 webhook:
   enabled: false
 


### PR DESCRIPTION
Signed-off-by: Art3mK <artem@kayalaynen.ru>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR allows users to specify priority class (see [docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) for cert-manager pods

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
