### PR TITLE
[stable/lamp] make the automountServiceAccountToken attribute toggleable for securi…

### DIFF
--- a/stable/lamp/Chart.yaml
+++ b/stable/lamp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Modular and transparent LAMP stack chart supporting PHP-FPM, Release Cloning, LoadBalancer, Ingress, SSL and lots more!
 name: lamp
-version: 0.1.5
+version: 0.1.6
 appVersion: 5.7
 home: https://github.com/lead4good/helm-lamp-stack
 maintainers:

--- a/stable/lamp/templates/deployment.yaml
+++ b/stable/lamp/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
         app: {{ template "lamp.name" . }}
         release: {{ .Release.Name }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       initContainers:
       - name: "init-chown-mysql"
         image: "busybox"

--- a/stable/lamp/values.yaml
+++ b/stable/lamp/values.yaml
@@ -337,3 +337,8 @@ keepSecrets: false
 ## replicaCount > 1 will corrupt your database if one is used. Future releases
 ## might enable elastic scaling via galeradb
 replicaCount: 1
+
+## don't automatically inject a service account token inside the pod
+## only toggle this to true if your application needs read/write
+## access inside the kubernetes namespace.
+automountServiceAccountToken: false


### PR DESCRIPTION
Hello,

It appears there is no explicit definition of the automountServiceAccountToken attribute.
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ 
The default implicit value for that attribut will likely be "true" on most clusters. 

This will lead to the following attributes being pushed by API server at runtime when injecting the deployment.yml : 
```yaml
  serviceAccount: default
  serviceAccountName: default
``` 

Which will lead to the following files being automatically injected inside the containers : 
```bash
lamp-696bf856b8-jtdx8:/# ls /var/run/secrets/kubernetes.io/serviceaccount/
ca.crt	namespace  token
``` 
Those files are useful if your application needs to communicate with the Kubernetes API servers. By default, this service account token has full read/write capabilities inside the same namespace as where the LAMP pod has been instantiated => it could lead to horizontal spread of an evil malware or horizontal privilege escalation if the web application hosted by the LAMP stack is compromised.

My proposal is to make the attribute automountServiceAccountToken toggleable and make it false by default as most LAMP deployments are not meant to have read/write access to the K8S namespace out of the box.