### PR TITLE
[stable/helm] initialize chart in helm repo

### DIFF
--- a/stable/hoard/.helmignore
+++ b/stable/hoard/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/hoard/.helmignore
+++ b/stable/hoard/.helmignore
@@ -15,6 +15,7 @@
 *.bak
 *.tmp
 *~
+OWNERS
 # Various IDEs
 .project
 .idea/

--- a/stable/hoard/Chart.yaml
+++ b/stable/hoard/Chart.yaml
@@ -1,0 +1,23 @@
+name: hoard
+version: 0.6.0
+appVersion: 1.1.5
+description: Hoard is a stateless, deterministically encrypted, content-addressed object store
+home: https://github.com/monax/hoard
+icon: https://pbs.twimg.com/profile_images/781959787856687105/76s1CJER_400x400.jpg
+keywords:
+- s3
+- aws
+- gcp
+- envelope encryption
+- content addressable
+- distributed file storage
+maintainers:
+- name: compleatang
+  email: casey@monax.io
+- name: gregdhill
+  email: greg.hill@monax.io
+sources:
+- https://github.com/monax/hoard
+apiVersion: v1
+engine: gotpl
+deprecated: false

--- a/stable/hoard/OWNERS
+++ b/stable/hoard/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- compleatang
+- gregdhill
+reviewers:
+- compleatang
+- gregdhill

--- a/stable/hoard/README.md
+++ b/stable/hoard/README.md
@@ -1,0 +1,75 @@
+# Hoard
+
+[Hoard](https://github.com/monax/hoard) is a stateless, deterministically encrypted, content-addressed object store. It currently supports local persistent storage, [S3](https://aws.amazon.com/s3/) and [GCS](https://cloud.google.com/storage/) backends, though [IPFS](https://ipfs.io) integration is currently under development. Files that are sent to Hoard are symmetrically encrypted, where the secret is the hash of the plaintext file, and then stored in the configured backend - this enables any party with knowledge of the hash or original file to retrieve it from the store.
+
+## Introduction
+
+This chart bootstraps a hoard daemon on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installation
+
+To install the chart with the release name `my-release`, run:
+
+```bash
+$ helm install --name my-release stable/hoard
+```
+
+The [configuration](#configuration) section below lists all possible parameters that can be configured during installation.
+
+
+### S3 Example
+
+To deploy with an S3 backend, use the following command. Please first create appropriate [AWS Credentials](https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html) and apply them to the Kubernetes secret `s3-credentials`.
+
+```bash
+$ helm install --name my-release stable/hoard --set storage.type=s3,storage.prefix="folder",storage.region="eu-central-1",storage.bucket="my-bucket",storage.credentialsSecret="s3-credentials"
+```
+
+## Uninstall
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Hoard chart and its default values.
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `replicaCount` | number of daemons | `1` |
+| `image.repository` | docker image | `"quay.io/monax/hoard"` |
+| `image.tag` | version | `"1.1.5"` |
+| `image.pullPolicy` | pull policy | `"IfNotPresent"` |
+| `storage.type` | backend object store (local, s3 or gcp)| `"local"` |
+| `storage.region` | object store location (non-local) | `""` |
+| `storage.bucket` | object storage container (non-local) | `""` |
+| `storage.prefix` | bucket folder (non-local) | `"hoard"` |
+| `storage.credentialsSecret` | required secret for gcs or s3 | `""` |
+| `persistence.size` | size of local store | `"10Gi"` |
+| `persistence.storageClass` | pvc type | `"standard"` |
+| `persistence.accessMode` | pvc access | `"ReadWriteOnce"` |
+| `persistence.persistentVolumeReclaimPolicy` | pvc policy | `"Retain"` |
+| `persistence.annotations` | optional annotations | `{}` |
+| `persistence.annotations."helm.sh/resource-policy"` | keep pvc | `keep` |
+| `service.type` | type of service | `"ClusterIP"` |
+| `service.port` | default listening port | `53431` |
+| `ingress` | settings for ingress | `{}` |
+| `resources` | pod resources | `{}` |
+| `nodeSelector` | optional settings | `{}` |
+| `tolerations` | optional settings | `[]` |
+| `affinity` | session affinity | `{}` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release stable/hoard
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/hoard
+```

--- a/stable/hoard/templates/NOTES.txt
+++ b/stable/hoard/templates/NOTES.txt
@@ -1,0 +1,1 @@
+You have successfully installed Hoard!

--- a/stable/hoard/templates/_helpers.tpl
+++ b/stable/hoard/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hoard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hoard.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hoard.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/hoard/templates/configmap.yaml
+++ b/stable/hoard/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "hoard.fullname" . }}
+  labels:
+    app: {{ template "hoard.name" . }}
+    chart: {{ template "hoard.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  config.json: |
+{{- if eq .Values.storage.type "s3" }}
+    {"ListenAddress":"tcp://0.0.0.0:{{ .Values.service.port }}","Storage":{"StorageType":"s3","AddressEncoding":"base64","Region":"{{ .Values.storage.region }}","S3Bucket":"{{ .Values.storage.bucket }}","S3Prefix":"{{ .Values.storage.prefix }}","CredentialsProviderChain":[{"Provider":"remote"},{"Provider":"env"}]},"Logging":{"LoggingType":"json","Channels":["info","trace"]}}
+{{- else if eq .Values.storage.type "gcs" }}
+    {"ListenAddress":"tcp://0.0.0.0:{{ .Values.service.port }}","Storage":{"StorageType":"gcs","AddressEncoding":"base64","GCSBucket":"{{ .Values.storage.bucket }}","GCSPrefix":"{{ .Values.storage.prefix }}"},"Logging":{"LoggingType":"json","Channels":["info","trace"]}}
+{{- else }}
+    {"ListenAddress":"tcp://0.0.0.0:{{ .Values.service.port }}","Storage":{"StorageType":"filesystem","AddressEncoding":"base64","RootDirectory":"/data"},"Logging":{"LoggingType":"json","Channels":["info","trace"]}}
+{{- end }}

--- a/stable/hoard/templates/configmap.yaml
+++ b/stable/hoard/templates/configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "hoard.fullname" . }}
+  name: {{ include "hoard.fullname" . }}
   labels:
-    app: {{ template "hoard.name" . }}
-    chart: {{ template "hoard.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hoard.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "hoard.chart" . }}
 data:
   config.json: |
 {{- if eq .Values.storage.type "s3" }}

--- a/stable/hoard/templates/deployment.yaml
+++ b/stable/hoard/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "hoard.fullname" . }}
+  labels:
+    app: {{ template "hoard.name" . }}
+    chart: {{ template "hoard.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "hoard.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "hoard.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: http
+          env:
+{{- if eq .Values.storage.type "s3" }}
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
+                key: access-key-id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
+                key: secret-access-key
+{{- end }}
+{{- if eq .Values.storage.type "gcs" }}
+{{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
+          - name: GCLOUD_SERVICE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
+                key: secret-access-key
+{{- end }}
+          - name: HOARD_JSON_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "hoard.fullname" . }}
+                key: config.json
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - '[ $(echo "marmottes" | hoarctl put | hoarctl get) = "marmottes" ]'
+            initialDelaySeconds: 5
+            periodSeconds: 45
+{{- if eq .Values.storage.type "local" }}
+          volumeMounts:
+          - mountPath: /data
+            name: data-dir
+{{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if eq .Values.storage.type "local" }}
+      volumes:
+        - name: data-dir
+          persistentVolumeClaim:
+            claimName: {{ template "hoard.fullname" $ }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/stable/hoard/templates/deployment.yaml
+++ b/stable/hoard/templates/deployment.yaml
@@ -20,58 +20,58 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - containerPort: {{ .Values.service.port }}
-              name: http
-          env:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+          - containerPort: {{ .Values.service.port }}
+            name: http
+        env:
 {{- if eq .Values.storage.type "s3" }}
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
-                key: access-key-id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
-                key: secret-access-key
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
+              key: access-key-id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
+              key: secret-access-key
 {{- end }}
 {{- if eq .Values.storage.type "gcs" }}
 {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
-          - name: GCLOUD_SERVICE_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
-                key: secret-access-key
+        - name: GCLOUD_SERVICE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "A valid storage credential is required." .Values.storage.credentialsSecret }}
+              key: secret-access-key
 {{- end }}
-          - name: HOARD_JSON_CONFIG
-            valueFrom:
-              configMapKeyRef:
-                name: {{ template "hoard.fullname" . }}
-                key: config.json
-          livenessProbe:
-            exec:
-              command:
-              - sh
-              - -c
-              - '[ $(echo "marmottes" | hoarctl put | hoarctl get) = "marmottes" ]'
-            initialDelaySeconds: 5
-            periodSeconds: 45
+        - name: HOARD_JSON_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "hoard.fullname" . }}
+              key: config.json
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - '[ $(echo "marmottes" | hoarctl put | hoarctl get) = "marmottes" ]'
+          initialDelaySeconds: 5
+          periodSeconds: 45
 {{- if eq .Values.storage.type "local" }}
-          volumeMounts:
-          - mountPath: /data
-            name: data-dir
+        volumeMounts:
+        - mountPath: /data
+          name: data-dir
 {{- end }}
-          resources:
+        resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if eq .Values.storage.type "local" }}
       volumes:
-        - name: data-dir
-          persistentVolumeClaim:
-            claimName: {{ template "hoard.fullname" $ }}
+      - name: data-dir
+        persistentVolumeClaim:
+          claimName: {{ template "hoard.fullname" $ }}
 {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/hoard/templates/deployment.yaml
+++ b/stable/hoard/templates/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "hoard.fullname" . }}
+  name: {{ include "hoard.fullname" . }}
   labels:
-    app: {{ template "hoard.name" . }}
-    chart: {{ template "hoard.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hoard.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "hoard.chart" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/stable/hoard/templates/ingress.yaml
+++ b/stable/hoard/templates/ingress.yaml
@@ -19,21 +19,21 @@ spec:
 {{- if .Values.ingress.tls }}
   tls:
 {{- range .Values.ingress.tls }}
-    - hosts:
+  - hosts:
 {{- range .hosts }}
-        - {{ . }}
+    - {{ . }}
 {{- end }}
       secretName: {{ .secretName }}
 {{- end }}
 {{- end }}
   rules:
 {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+  - host: {{ . }}
+    http:
+      paths:
+      - path: {{ $ingressPath }}
+        backend:
+          serviceName: {{ $fullName }}
+          servicePort: http
 {{- end }}
 {{- end }}

--- a/stable/hoard/templates/ingress.yaml
+++ b/stable/hoard/templates/ingress.yaml
@@ -5,12 +5,12 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "hoard.fullname" . }}
   labels:
-    app: {{ template "hoard.name" . }}
-    chart: {{ template "hoard.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hoard.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "hoard.chart" . }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/stable/hoard/templates/ingress.yaml
+++ b/stable/hoard/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "hoard.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "hoard.name" . }}
+    chart: {{ template "hoard.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+{{- range .Values.ingress.tls }}
+    - hosts:
+{{- range .hosts }}
+        - {{ . }}
+{{- end }}
+      secretName: {{ .secretName }}
+{{- end }}
+{{- end }}
+  rules:
+{{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+{{- end }}
+{{- end }}

--- a/stable/hoard/templates/pvc.yaml
+++ b/stable/hoard/templates/pvc.yaml
@@ -3,10 +3,12 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "hoard.fullname" $ }}
+  name: {{ include "hoard.fullname" . }}
   labels:
-    app: {{ template "hoard.name" $ }}
-    release: {{ $.Release.Name }}
+    app.kubernetes.io/name: {{ include "hoard.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "hoard.chart" . }}
   annotations:
   {{- range $key, $value := $.Values.persistence.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/stable/hoard/templates/pvc.yaml
+++ b/stable/hoard/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if eq .Values.storage.type "local" }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "hoard.fullname" $ }}
+  labels:
+    app: {{ template "hoard.name" $ }}
+    release: {{ $.Release.Name }}
+  annotations:
+  {{- range $key, $value := $.Values.persistence.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ $.Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ $.Values.persistence.size | quote }}
+{{- if $.Values.persistence.storageClass }}
+{{- if (eq "-" $.Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ $.Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/hoard/templates/pvc.yaml
+++ b/stable/hoard/templates/pvc.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ $.Values.persistence.accessMode | quote }}
+  - {{ $.Values.persistence.accessMode | quote }}
   resources:
     requests:
       storage: {{ $.Values.persistence.size | quote }}

--- a/stable/hoard/templates/service.yaml
+++ b/stable/hoard/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "hoard.fullname" . }}
+  labels:
+    app: {{ template "hoard.name" . }}
+    chart: {{ template "hoard.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "hoard.name" . }}
+    release: {{ .Release.Name }}

--- a/stable/hoard/templates/service.yaml
+++ b/stable/hoard/templates/service.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+  - port: {{ .Values.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
   selector:
     app: {{ template "hoard.name" . }}
     release: {{ .Release.Name }}

--- a/stable/hoard/templates/service.yaml
+++ b/stable/hoard/templates/service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "hoard.fullname" . }}
+  name: {{ include "hoard.fullname" . }}
   labels:
-    app: {{ template "hoard.name" . }}
-    chart: {{ template "hoard.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "hoard.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "hoard.chart" . }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/hoard/values.yaml
+++ b/stable/hoard/values.yaml
@@ -1,0 +1,52 @@
+replicaCount: 1
+
+image:
+  repository: quay.io/monax/hoard
+  tag: 1.1.5
+  pullPolicy: IfNotPresent
+
+storage:
+  type: local   # s3 | gcs | local
+  region: ""
+  bucket: ""
+  prefix: hoard
+  credentialsSecret: ""
+
+# only local
+persistence:
+  size: 10Gi
+  storageClass: standard
+  accessMode: ReadWriteOnce
+  persistentVolumeReclaimPolicy: "Retain"
+  annotations:
+    "helm.sh/resource-policy": keep
+
+service:
+  type: ClusterIP
+  port: 53431
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Signed-off-by: greg <greg.hill@monax.io>

This PR adds a stable helm chart for [Hoard](https://github.com/monax/hoard), our go based, multi-backend object store. It deterministically encrypts any file sent to it and stores it at the configured location which may be publicly accessible. For example, [Monax](https://monax.io) uses this technology to save legal documentation in a way which can be referenced on our blockchain and easily audited by permissible legal bodies.

cc: @compleatang 

## Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Variables are documented in the README.md
