### PR TITLE
[stable/kafka-manager] Fix issue with auth for configuration job.

### DIFF
--- a/stable/kafka-manager/Chart.yaml
+++ b/stable/kafka-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: kafka-manager
-version: 1.0.0
+version: 1.1.0
 appVersion: 1.3.3.18
 kubeVersion: "^1.8.0-0"
 description: A tool for managing Apache Kafka.

--- a/stable/kafka-manager/templates/configmap.yaml
+++ b/stable/kafka-manager/templates/configmap.yaml
@@ -12,9 +12,9 @@ metadata:
 data:
   addClusters.sh: |
     #!/bin/bash
-    set -ex
+    set -e
     {{- range $cluster := .Values.clusters }}
-    {{ printf "curl http://%s:9000/clusters -X POST " (include "kafka-manager.fullname" $) -}}
+    {{ printf "curl http://%s:9000/clusters -X POST -f " (include "kafka-manager.fullname" $) -}}
     {{- printf "-d name=%s " (default "default" $cluster.name) -}}
     {{- printf "-d zkHosts=%s " (default (include "kafka-manager.zkHosts" $) $cluster.zkHosts ) -}}
     {{- printf "-d kafkaVersion=%s " (default "1.0.0" $cluster.kafkaVersion) -}}
@@ -46,6 +46,6 @@ data:
     {{- printf "-d tuning.kafkaManagedOffsetGroupCacheSize=%s " (default "1000000" $cluster.tuning.kafkaManagedOffsetGroupCacheSize) -}}
     {{- printf "-d tuning.kafkaManagedOffsetGroupExpireDays=%s " (default "7" $cluster.tuning.kafkaManagedOffsetGroupExpireDays) -}}
     {{- printf "-d securityProtocol=%s " (default "PLAINTEXT" $cluster.securityProtocol) -}}
-    {{- printf "|| exit 1;" -}}
+    {{- printf "$( if $KAFKA_MANAGER_AUTH_ENABLED; then echo -u $KAFKA_MANAGER_USERNAME:$KAFKA_MANAGER_PASSWORD ; fi ) " -}}
     {{- end -}}
 {{- end -}}

--- a/stable/kafka-manager/templates/job.yaml
+++ b/stable/kafka-manager/templates/job.yaml
@@ -29,6 +29,19 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/script/addClusters.sh"]
+          env:
+            - name: KAFKA_MANAGER_AUTH_ENABLED
+              value: {{ .Values.basicAuth.enabled | quote }}
+            - name: KAFKA_MANAGER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kafka-manager.fullname" . }}
+                  key: basicAuthUsername
+            - name: KAFKA_MANAGER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kafka-manager.fullname" . }}
+                  key: basicAuthPassword
           volumeMounts:
             - name: script-volume
               mountPath: "/usr/local/script"


### PR DESCRIPTION
#### What this PR does / why we need it:
Current `kafka-manager` chart was not able to configure cluster when basic auth is enabled. Kafka manager was deployed successful even when curl failed.

#### Special notes for your reviewer:
I changed error handling for curl and load basic auth credential via job env. Now when curl return something different than 2xx job would failed. Change tested on our two environment. 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
