### PR TITLE
[stable/rabbitmq] Reduce readiness/liveness probes frequency

### DIFF
--- a/stable/rabbitmq/Chart.yaml
+++ b/stable/rabbitmq/Chart.yaml
@@ -1,5 +1,5 @@
 name: rabbitmq
-version: 4.0.2
+version: 4.0.3
 appVersion: 3.7.9
 description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
 keywords:

--- a/stable/rabbitmq/README.md
+++ b/stable/rabbitmq/README.md
@@ -88,8 +88,8 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | `ingress.annotations`                | ingress annotations as an array                  | []                                                      |
 | `livenessProbe.enabled`              | would you like a livenessProbed to be enabled    | `true`                                                  |
 | `livenessProbe.initialDelaySeconds`  | number of seconds                                | 120                                                     |
-| `livenessProbe.timeoutSeconds`       | number of seconds                                | 5                                                       |
-| `livenessProbe.periodSeconds`        | number of seconds                                | 5                                                       |
+| `livenessProbe.timeoutSeconds`       | number of seconds                                | 20                                                      |
+| `livenessProbe.periodSeconds`        | number of seconds                                | 30                                                      |
 | `livenessProbe.failureThreshold`     | number of failures                               | 6                                                       |
 | `livenessProbe.successThreshold`     | number of successes                              | 1                                                       |
 | `readinessProbe.enabled`             | would you like a readinessProbe to be enabled    | `true`                                                  |

--- a/stable/rabbitmq/values-production.yaml
+++ b/stable/rabbitmq/values-production.yaml
@@ -196,16 +196,16 @@ ingress:
 livenessProbe:
   enabled: true
   initialDelaySeconds: 120
-  timeoutSeconds: 5
-  periodSeconds: 5
+  timeoutSeconds: 20
+  periodSeconds: 30
   failureThreshold: 6
   successThreshold: 1
 
 readinessProbe:
   enabled: true
   initialDelaySeconds: 10
-  timeoutSeconds: 3
-  periodSeconds: 5
+  timeoutSeconds: 20
+  periodSeconds: 30
   failureThreshold: 3
   successThreshold: 1
 

--- a/stable/rabbitmq/values.yaml
+++ b/stable/rabbitmq/values.yaml
@@ -193,16 +193,16 @@ ingress:
 livenessProbe:
   enabled: true
   initialDelaySeconds: 120
-  timeoutSeconds: 5
-  periodSeconds: 5
+  timeoutSeconds: 20
+  periodSeconds: 30
   failureThreshold: 6
   successThreshold: 1
 
 readinessProbe:
   enabled: true
   initialDelaySeconds: 10
-  timeoutSeconds: 3
-  periodSeconds: 5
+  timeoutSeconds: 20
+  periodSeconds: 30
   failureThreshold: 3
   successThreshold: 1
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

Currently, **readiness/liveness** probes are executed every 5 seconds which is causing high CPU usage on certain clusters. This PR increases the timeoutSeconds & periodSeconds of these probes to reduce the frequency so they reduce the impact on the cluster performance.

#### Which issue this PR fixes

  - fixes #3855

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
