### PR TITLE
[stable/mariadb] Allow using existingClaim as 'data' directory

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.3.0
+version: 5.3.1
 appVersion: 10.1.37
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -77,9 +77,9 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `master.affinity`                         | Master affinity (in addition to master.antiAffinity when set)  | `{}`                                                   |
 | `master.antiAffinity`                     | Master pod anti-affinity policy                     | `soft`                                                            |
 | `master.tolerations`                      | List of node taints to tolerate (master)            | `[]`                                                              |
-| `master.persistence.enabled`              | Enable persistence using a `PersistentVolumeClaim`  | `true`                                                            |
+| `master.persistence.enabled`              | Enable persistence using PVC                        | `true`                                                            |
 | `master.persistence.existingClaim`        | Provide an existing `PersistentVolumeClaim`         | `nil`                                                             |
-| `master.persistence.mountPath`            | Configure existing `PersistentVolumeClaim` mount path  | `""`                                                           |
+| `master.persistence.mountPath`            | Path to mount the volume at                         | `/bitnami/mariadb`                                                |
 | `master.persistence.annotations`          | Persistent Volume Claim annotations                 | `{}`                                                              |
 | `master.persistence.storageClass`         | Persistent Volume Storage Class                     | ``                                                                |
 | `master.persistence.accessModes`          | Persistent Volume Access Modes                      | `[ReadWriteOnce]`                                                 |

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -142,7 +142,7 @@ spec:
 {{ toYaml .Values.master.resources | indent 10 }}
         volumeMounts:
         - name: data
-          mountPath: {{ .Values.persistence.mountPath }}
+          mountPath: {{ .Values.master.persistence.mountPath }}
         {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           mountPath: /docker-entrypoint-initdb.d
@@ -196,10 +196,10 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.master.persistence.existingClaim }}
-{{- else if not .Values.persistence.enabled }}
+{{- else if not .Values.master.persistence.enabled }}
         - name: data
           emptyDir: {}
-{{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- else if and .Values.master.persistence.enabled (not .Values.master.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/stable/mariadb/templates/master-statefulset.yaml
+++ b/stable/mariadb/templates/master-statefulset.yaml
@@ -142,20 +142,16 @@ spec:
 {{ toYaml .Values.master.resources | indent 10 }}
         volumeMounts:
         - name: data
-          mountPath: /bitnami/mariadb
+          mountPath: {{ .Values.persistence.mountPath }}
         {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           mountPath: /docker-entrypoint-initdb.d
         {{- end }}
-{{- if .Values.master.config }}
+        {{- if .Values.master.config }}
         - name: config
           mountPath: /opt/bitnami/mariadb/conf/my.cnf
           subPath: my.cnf
-{{- if .Values.master.persistence.existingClaim }}
-        - name: {{ .Values.master.persistence.existingClaim }}
-          mountPath: {{ .Values.master.persistence.mountPath }}
-{{- end }}
-{{- end }}
+       {{- end }}
 {{- if .Values.metrics.enabled }}
       - name: metrics
         image: {{ template "metrics.image" . }}
@@ -186,11 +182,6 @@ spec:
 {{ toYaml .Values.metrics.resources | indent 10 }}
 {{- end }}
       volumes:
-        {{- if and .Values.master.persistence.enabled .Values.master.persistence.existingClaim }}
-        - name: {{ .Values.master.persistence.existingClaim }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.master.persistence.existingClaim }}
-        {{ end }}
         {{- if .Values.master.config }}
         - name: config
           configMap:
@@ -201,7 +192,14 @@ spec:
           configMap:
             name: {{ template "mariadb.initdbScriptsCM" . }}
         {{- end }}
-{{- if .Values.master.persistence.enabled }}
+{{- if and .Values.master.persistence.enabled .Values.master.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.master.persistence.existingClaim }}
+{{- else if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -225,7 +223,4 @@ spec:
         storageClassName: {{ .Values.master.persistence.storageClass | quote }}
       {{- end }}
       {{- end }}
-{{- else }}
-        - name: "data"
-          emptyDir: {}
 {{- end }}

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -138,7 +138,7 @@ master:
     enabled: true
     # Enable persistence using an existing PVC
     # existingClaim:
-    # mountPath:
+    mountPath: /bitnami/mariadb
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -149,7 +149,7 @@ master:
     # storageClass: "-"
     ## Persistent Volume Claim annotations
     ##
-    annotations:
+    annotations: {}
     ## Persistent Volume Access Mode
     ##
     accessModes:

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -138,7 +138,7 @@ master:
     enabled: true
     # Enable persistence using an existing PVC
     # existingClaim:
-    # mountPath:
+    mountPath: /bitnami/mariadb
     ## Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -149,7 +149,7 @@ master:
     # storageClass: "-"
     ## Persistent Volume Claim annotations
     ##
-    annotations:
+    annotations: {}
     ## Persistent Volume Access Mode
     ##
     accessModes:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

Currently it's not possible to use an existingClaim to be mounted at `/bitnami/mariadb` (the data directory) since a PVC is created using that mountPoint. This PR disables creating a PVC when there's an existing PVC so the mountPoint is free to be used.

#### Which issue this PR fixes

  - fixes #10322

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
