### PR TITLE
[stable/wordpress] Avoid setting SMTP env. variables when SMTP parameters are not set

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 5.0.2
+version: 5.0.3
 appVersion: 5.0.2
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/templates/_helpers.tpl
+++ b/stable/wordpress/templates/_helpers.tpl
@@ -47,6 +47,13 @@ Also, we can't use a single if because lazy evaluation is not an option
 {{- end -}}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wordpress.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Return the proper image name (for the metrics image)
 */}}
 {{- define "metrics.image" -}}

--- a/stable/wordpress/templates/deployment.yaml
+++ b/stable/wordpress/templates/deployment.yaml
@@ -3,30 +3,30 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "fullname" . }}"
+    chart: "{{ template "wordpress.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
-      release: "{{ .Release.Name }}"
+      app: "{{ template "fullname" . }}"
+      release: {{ .Release.Name | quote }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
+        app: "{{ template "fullname" . }}"
+        chart: "{{ template "wordpress.chart" . }}"
+        release: {{ .Release.Name | quote }}
 {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
-  {{- if .Values.podAnnotations }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
-  {{- end }}
-  {{- if .Values.metrics.podAnnotations }}
+{{- end }}
+{{- if .Values.metrics.podAnnotations }}
 {{ toYaml .Values.metrics.podAnnotations | indent 8 }}
-  {{- end }}
+{{- end }}
 {{- end }}
     spec:
       {{- if .Values.image.pullSecrets }}
@@ -101,21 +101,33 @@ spec:
           value: {{ .Values.wordpressBlogName | quote }}
         - name: WORDPRESS_TABLE_PREFIX
           value: {{ .Values.wordpressTablePrefix | quote }}
+        {{- if .Values.smtpHost }}
         - name: SMTP_HOST
           value: {{ .Values.smtpHost | quote }}
+        {{- end }}
+        {{- if .Values.smtpPort }}
         - name: SMTP_PORT
           value: {{ .Values.smtpPort | quote }}
+        {{- end }}
+        {{- if .Values.smtpUser }}
         - name: SMTP_USER
           value: {{ .Values.smtpUser | quote }}
+        {{- end }}
+        {{- if .Values.smtpPassword }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "fullname" . }}
               key: smtp-password
+        {{- end }}
+        {{- if .Values.smtpUsername }}
         - name: SMTP_USERNAME
           value: {{ .Values.smtpUsername | quote }}
+        {{- end }}
+        {{- if .Values.smtpProtocol }}
         - name: SMTP_PROTOCOL
           value: {{ .Values.smtpProtocol | quote }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 80
@@ -196,4 +208,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-

--- a/stable/wordpress/templates/externaldb-secrets.yaml
+++ b/stable/wordpress/templates/externaldb-secrets.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
   labels:
     app: {{ printf "%s-%s" .Release.Name "externaldb"  }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: "{{ template "wordpress.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
   db-password: {{ .Values.externalDatabase.password | b64enc | quote }}

--- a/stable/wordpress/templates/ingress.yaml
+++ b/stable/wordpress/templates/ingress.yaml
@@ -5,10 +5,10 @@ kind: Ingress
 metadata:
   name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
   labels:
-    app: {{ template "fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    app: "{{ template "fullname" $ }}"
+    chart: "{{ template "wordpress.chart" $ }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
     {{- if .tls }}
     ingress.kubernetes.io/secure-backends: "true"

--- a/stable/wordpress/templates/pvc.yaml
+++ b/stable/wordpress/templates/pvc.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "fullname" . }}"
+    chart: "{{ template "wordpress.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/wordpress/templates/secrets.yaml
+++ b/stable/wordpress/templates/secrets.yaml
@@ -3,15 +3,17 @@ kind: Secret
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "fullname" . }}"
+    chart: "{{ template "wordpress.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  {{ if .Values.wordpressPassword }}
+  {{- if .Values.wordpressPassword }}
   wordpress-password: {{ default "" .Values.wordpressPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   wordpress-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
-  smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.smtpPassword }}
+  smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
+  {{- end }}

--- a/stable/wordpress/templates/svc.yaml
+++ b/stable/wordpress/templates/svc.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "fullname" . }}"
+    chart: "{{ template "wordpress.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
@@ -26,4 +26,4 @@ spec:
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- end }}
   selector:
-    app: {{ template "fullname" . }}
+    app: "{{ template "fullname" . }}"

--- a/stable/wordpress/templates/tls-secrets.yaml
+++ b/stable/wordpress/templates/tls-secrets.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: {{ .name }}
   labels:
-    app: {{ template "fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    app: "{{ template "fullname" $ }}"
+    chart: "{{ template "wordpress.chart" $ }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR does some refactoring on labels and avoids setting SMTP env. variables when the corresponding parameters are not set.

#### Which issue this PR fixes

  - fixes https://github.com/bitnami/bitnami-docker-wordpress/issues/153

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
