### PR TITLE
recent change broke additional service monitors

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 1.4.0
+version: 1.4.1
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
+++ b/stable/prometheus-operator/templates/prometheus/servicemonitors.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: List
 items:
 {{- range .Values.prometheus.additionalServiceMonitors }}
-  - apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
+  - apiVersion: {{ printf "%s/v1" ($.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
     kind: ServiceMonitor
     metadata:
       name: {{ .name }}


### PR DESCRIPTION
 by not breaking out of range scope to get other variables. fixed.

#### What this PR does / why we need it:

recent change broke additional service monitors by not breaking out of range scope to get at the new crdApiGroup variable. This fixes that.

#### Which issue this PR fixes

No existing issue to my knowledge

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md

@gianrubio 