### PR TITLE
[stable/sentry] Support existingSecret for smtp-password

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.0.1
+version: 1.0.2
 appVersion: 9.0
 keywords:
   - debugging

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -91,7 +91,11 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if .Values.email.existingSecret }}
+              name: {{ .Values.email.existingSecret }}
+            {{- else }}
               name: {{ template "fullname" . }}
+            {{- end }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -75,7 +75,11 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if .Values.email.existingSecret }}
+              name: {{ .Values.email.existingSecret }}
+            {{- else }}
               name: {{ template "fullname" . }}
+            {{- end }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -75,7 +75,11 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if .Values.email.existingSecret }}
+              name: {{ .Values.email.existingSecret }}
+            {{- else }}
               name: {{ template "fullname" . }}
+            {{- end }}
               key: smtp-password
         - name: SENTRY_USER_PASSWORD
           valueFrom:

--- a/stable/sentry/templates/secrets.yaml
+++ b/stable/sentry/templates/secrets.yaml
@@ -14,7 +14,9 @@ data:
   {{ else }}
   sentry-secret: {{ randAlphaNum 40 | b64enc | quote }}
   {{ end }}
+  {{- if not .Values.email.existingSecret }}
   smtp-password: {{ default "" .Values.email.password | b64enc | quote }}
+  {{ end }}
   {{ if .Values.user.password }}
   user-password: {{ .Values.user.password | b64enc | quote }}
   {{ else }}

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -90,7 +90,11 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if .Values.email.existingSecret }}
+              name: {{ .Values.email.existingSecret }}
+            {{- else }}
               name: {{ template "fullname" . }}
+            {{- end }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -91,7 +91,11 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if .Values.email.existingSecret }}
+              name: {{ .Values.email.existingSecret }}
+            {{- else }}
               name: {{ template "fullname" . }}
+            {{- end }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows using an existingSecret for smtp-password.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
