### PR TITLE
[Kong] updating configmap name in the role

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.7.1
+version: 0.7.2
 appVersion: 0.14.1

--- a/stable/kong/templates/controller-rbac-role.yaml
+++ b/stable/kong/templates/controller-rbac-role.yaml
@@ -28,7 +28,7 @@ rules:
       # Here: "<ingress-controller-leader>-<nginx>"
       # This has to be adapted if you change either parameter
       # when launching the nginx-ingress-controller.
-      - "kong-ingress-controller-leader-kong-{{ .Values.ingressController.ingressClass }}"
+      - "kong-ingress-controller-leader-{{ .Values.ingressController.ingressClass }}-{{ .Values.ingressController.ingressClass }}"
     verbs:
       - get
       - update


### PR DESCRIPTION
Signed-off-by: garland <garlandk@gmail.com>

#### What this PR does / why we need it:
I sent this PR a few days ago thinking this solved it:  https://github.com/helm/charts/pull/10263

Using this helm chart after this change with different ingress class names it didnt work as expected.  With some additional testing with the names, it seems to double up the ingress class name and appends it to the configmap name.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
