### PR TITLE
[stable/external-dns] Conditionally set cloudflare flags

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ description:
   Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 1.3.0
+version: 1.3.1
 appVersion: 0.5.9
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/deployment.yaml
+++ b/stable/external-dns/templates/deployment.yaml
@@ -61,8 +61,10 @@ spec:
             - --{{ $key }}
             {{- end }}
           {{- end }}
-          {{- if .Values.cloudflare.proxied }}
+          {{- if eq .Values.provider "cloudflare" }}
+            {{- if .Values.cloudflare.proxied }}
             - --cloudflare-proxied
+            {{- end }}
           {{- end }}
           {{- if .Values.aws.zoneType }}
             - --aws-zone-type={{ .Values.aws.zoneType }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Any cloudflare flags are only relevant when using the cloudflare provider. This simplifies the generated config when using any other provider.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped