### PR TITLE
[stable/gocd] optional init containers

### DIFF
--- a/stable/gocd/CHANGELOG.md
+++ b/stable/gocd/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.6.0
+* [7002dac](https://github.com/kubernetes/charts/commit/7002dac):
+  - add option to specify init containers and restart policy for server and agent
+
 ### 1.5.13
 * [223b59f](https://github.com/kubernetes/charts/commit/223b59f):
   - Fix typo in README.

--- a/stable/gocd/Chart.yaml
+++ b/stable/gocd/Chart.yaml
@@ -1,6 +1,6 @@
 name: gocd
 home: https://www.gocd.org/
-version: 1.5.13
+version: 1.6.0
 appVersion: 18.12.0
 description: GoCD is an open-source continuous delivery server to model and visualize complex workflows with ease.
 icon: https://gocd.github.io/assets/images/go-icon-black-192x192.png

--- a/stable/gocd/templates/gocd-agent-deployment.yaml
+++ b/stable/gocd/templates/gocd-agent-deployment.yaml
@@ -43,6 +43,10 @@ spec:
           secret:
             secretName: {{ .Values.agent.security.ssh.secretName }}
       {{- end }}
+      {{- if .Values.agent.initContainers }}
+      initContainers:
+{{ toYaml .Values.agent.initContainers | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "gocd.name" . }}-agent
           {{- if .Values.agent.image.tag }}
@@ -127,6 +131,7 @@ spec:
           {{- end }}
           securityContext:
             privileged: {{ .Values.agent.privileged }}
+      restartPolicy: {{ .Values.agent.restartPolicy }}
     {{- if .Values.agent.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.agent.nodeSelector | indent 8 }}

--- a/stable/gocd/templates/gocd-server-deployment.yaml
+++ b/stable/gocd/templates/gocd-server-deployment.yaml
@@ -47,6 +47,10 @@ spec:
           secret:
             secretName: {{ .Values.server.security.ssh.secretName }}
       {{- end }}
+      {{- if .Values.server.initContainers }}
+      initContainers:
+{{ toYaml .Values.server.initContainers | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "gocd.name" . }}-server
           {{- if .Values.server.image.tag }}
@@ -116,6 +120,7 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.server.resources | indent 12 }}
+      restartPolicy: {{ .Values.server.restartPolicy }}
     {{- if .Values.server.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.server.nodeSelector | indent 8 }}

--- a/stable/gocd/values.yaml
+++ b/stable/gocd/values.yaml
@@ -47,6 +47,23 @@ server:
   #     cpu: 100m
   #     memory: 1024Mi
 
+  # specify init containers, e.g. to prepopulate home directories etc
+  initContainers: []
+  #  - name: download-kubectl
+  #    image: "ellerbrock/alpine-bash-curl-ssl:latest"
+  #    imagePullPolicy: "IfNotPresent"
+  #    volumeMounts:
+  #      - name: kubectl
+  #        mountPath: /download
+  #    workingDir: /download
+  #    command: ["/bin/bash"]
+  #    args:
+  #      - "-c"
+  #      - 'curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl'
+
+  # specify restart policy for server
+  restartPolicy: Always
+
   ## Additional GoCD server pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   nodeSelector: {}
@@ -254,6 +271,23 @@ agent:
     #   readOnly: true
     # - name: gocd-agent-init-scripts
     #   mountPath: /docker-entrypoint.d/
+
+  # specify init containers, e.g. to prepopulate home directories etc
+  initContainers: []
+  #  - name: download-kubectl
+  #    image: "ellerbrock/alpine-bash-curl-ssl:latest"
+  #    imagePullPolicy: "IfNotPresent"
+  #    volumeMounts:
+  #      - name: kubectl
+  #        mountPath: /download
+  #    workingDir: /download
+  #    command: ["/bin/bash"]
+  #    args:
+  #      - "-c"
+  #      - 'curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl'
+
+  # specify restart policy for agents
+  restartPolicy: Always
 
   # agent.privileged is needed for running Docker-in-Docker (DinD) agents
   privileged: false


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
@arvindsv @GaneshSPatil @varshavaradarajan This PR adds variables to the gocd helm chart that allow specifying init containers for server and agent deployments. I would like to have this option since I need to download kubectl into the agents before they start to be able to roll out new builds into our kubernetes cluster. Besides this there should be many more possible applications for init containers

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
