### PR TITLE
[stable/mariadb] Use hooks to cleanup after deletion (POC)

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mariadb
-version: 5.3.1
+version: 5.4.0
 appVersion: 10.1.37
 description: Fast, reliable, scalable, and easy to use open-source relational database system. MariaDB Server is intended for mission-critical, heavy-load production systems as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
 keywords:

--- a/stable/mariadb/README.md
+++ b/stable/mariadb/README.md
@@ -129,6 +129,13 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `metrics.image.tag`                       | Exporter image tag                                  | `v0.10.0`                                                         |
 | `metrics.image.pullPolicy`                | Exporter image pull policy                          | `IfNotPresent`                                                    |
 | `metrics.resources`                       | Exporter resource requests/limit                    | `nil`                                                             |
+| `hooks.enabled`                           | Use hooks to cleanup once the release is deleted    | `false`                                                           |
+| `hooks.cleanClaims`                       | Remove PVCs once the release is deleted             | `false`                                                           |
+| `hooks.image.registry`                    | Kubectl image registry                              | `docker.io`                                                       |
+| `hooks.image.repository`                  | Kubectl image name                                  | `bitnami/kubectl`                                                 |
+| `hooks.image.tag`                         | Kubectl image tag                                   | `1.12.3`                                                          |
+| `hooks.image.pullPolicy`                  | Kubectl image pull policy                           | `IfNotPresent`                                                    |
+| `rbac.create`                             | Whether create RBAC resources or not                | `true`                                                            |
 
 The above parameters map to the env variables defined in [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](http://github.com/bitnami/bitnami-docker-mariadb) image documentation.
 

--- a/stable/mariadb/templates/NOTES.txt
+++ b/stable/mariadb/templates/NOTES.txt
@@ -34,9 +34,11 @@ To connect to your database:
       mysql -h {{ template "slave.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local -uroot -p {{ .Values.db.name }}
 {{- end }}
 
+{{- if not .Values.hooks.enabled }}
 To upgrade this helm chart:
 
   1. Obtain the password as described on the 'Administrator credentials' section and set the 'rootUser.password' parameter as shown below:
 
       ROOT_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "mariadb.fullname" . }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
       helm upgrade {{ .Release.Name }} stable/mariadb --set rootUser.password=$ROOT_PASSWORD
+{{- end }}

--- a/stable/mariadb/templates/_helpers.tpl
+++ b/stable/mariadb/templates/_helpers.tpl
@@ -27,6 +27,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "mariadb-slave" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "mariadb-cleanup-hook.fullname" -}}
+{{ template "mariadb.fullname" . }}-cleanup-hook
+{{- end -}}
+
 {{- define "mariadb.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -62,6 +66,29 @@ Return the proper metrics image name
 {{- $repositoryName := .Values.metrics.image.repository -}}
 {{- $tag := .Values.metrics.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+
+{{/*
+Return the proper hooks image name
+*/}}
+{{- define "hooks.image" -}}
+{{- $registryName :=  .Values.hooks.image.registry -}}
+{{- $repositoryName := .Values.hooks.image.repository -}}
+{{- $tag := .Values.hooks.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{ template "mariadb.initdbScriptsCM" . }}

--- a/stable/mariadb/templates/cleanup-job.yaml
+++ b/stable/mariadb/templates/cleanup-job.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.hooks.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "mariadb-cleanup-hook.fullname" . }}
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+  labels:
+    app: "{{ template "mariadb.name" . }}"
+    chart: "{{ template "mariadb.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: "{{ template "mariadb.name" . }}"
+        release: {{ .Release.Name | quote }}
+    spec:
+      containers:
+      - name: kubectl
+        image: {{ template "hooks.image" . }}
+        command:
+        - /bin/sh
+        args:
+        - -ec
+        - |
+          kubectl delete secret -n {{ .Release.Namespace }} {{ template "mariadb.fullname" . }} || true
+        {{- if .Values.hooks.cleanClaims }}
+          kubectl delete pvc -n {{ .Release.Namespace }} $(kubectl get pvc -n {{ .Release.Namespace }} -l app="{{ template "mariadb.name" . }}",release={{ .Release.Name | quote }} -o jsonpath='{.items[*].metadata.name}') || true
+        {{- end }}
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "mariadb-cleanup-hook.fullname" . }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+{{- end }}

--- a/stable/mariadb/templates/cleanup-role.yaml
+++ b/stable/mariadb/templates/cleanup-role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.hooks.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "mariadb-cleanup-hook.fullname" . }}
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-weight: "-10"
+  labels:
+    app: "{{ template "mariadb.name" . }}"
+    chart: "{{ template "mariadb.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  {{- if .Values.hooks.cleanClaims }}
+  - persistentvolumeclaims
+  {{- end }}
+  - secrets
+  verbs:
+  {{- if .Values.hooks.cleanClaims }}
+  - list
+  {{- end }}
+  - delete
+{{- end }}
+{{- end }}

--- a/stable/mariadb/templates/cleanup-rolebinding.yaml
+++ b/stable/mariadb/templates/cleanup-rolebinding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.hooks.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "mariadb-cleanup-hook.fullname" . }}
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-weight: "-10"
+  labels:
+    app: "{{ template "mariadb.name" . }}"
+    chart: "{{ template "mariadb.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "mariadb-cleanup-hook.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "mariadb-cleanup-hook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/stable/mariadb/templates/cleanup-serviceaccount.yaml
+++ b/stable/mariadb/templates/cleanup-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.hooks.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "mariadb-cleanup-hook.fullname" . }}
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook-weight: "-10"
+  labels:
+    app: "{{ template "mariadb.name" . }}"
+    chart: "{{ template "mariadb.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- end }}

--- a/stable/mariadb/templates/secrets.yaml
+++ b/stable/mariadb/templates/secrets.yaml
@@ -5,34 +5,37 @@ metadata:
   name: {{ template "mariadb.fullname" . }}
   labels:
     app: "{{ template "mariadb.name" . }}"
-    chart: {{ template "mariadb.chart" . }}
+    chart: "{{ template "mariadb.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed
 type: Opaque
 data:
   {{- if .Values.rootUser.password }}
-  mariadb-root-password: "{{ .Values.rootUser.password | b64enc }}"
-  {{- else if (not .Values.rootUser.forcePassword) }}
-  mariadb-root-password: "{{ randAlphaNum 10 | b64enc }}"
-  {{ else }}
+  mariadb-root-password: {{ .Values.rootUser.password | b64enc | quote }}
+  {{- else if .Values.rootUser.forcePassword }}
   mariadb-root-password: {{ required "A MariaDB Root Password is required!" .Values.rootUser.password }}
+  {{ else }}
+  mariadb-root-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- if .Values.db.user }}
   {{- if .Values.db.password }}
-  mariadb-password: "{{ .Values.db.password | b64enc }}"
-  {{- else if (not .Values.db.forcePassword) }}
-  mariadb-password: "{{ randAlphaNum 10 | b64enc }}"
-  {{- else }}
+  mariadb-password: {{ .Values.db.password | b64enc | quote }}
+  {{- else if .Values.db.forcePassword }}
   mariadb-password: {{ required "A MariaDB Database Password is required!" .Values.db.password }}
+  {{- else }}
+  mariadb-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- if .Values.replication.enabled }}
   {{- if .Values.replication.password }}
-  mariadb-replication-password: "{{ .Values.replication.password | b64enc }}"
-  {{- else if (not .Values.replication.forcePassword) }}
-  mariadb-replication-password: "{{ randAlphaNum 10 | b64enc }}"
-  {{- else }}
+  mariadb-replication-password: {{ .Values.replication.password | b64enc | quote }}
+  {{- else if .Values.replication.forcePassword }}
   mariadb-replication-password: {{ required "A MariaDB Replication Password is required!" .Values.replication.password }}
+  {{- else }}
+  mariadb-replication-password: {{ randAlphaNum 10 | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/mariadb/values-production.yaml
+++ b/stable/mariadb/values-production.yaml
@@ -215,7 +215,6 @@ master:
 slave:
   replicas: 2
 
-
   ## Mariadb Slave additional pod annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   # annotations:
@@ -304,14 +303,52 @@ slave:
     successThreshold: 1
     failureThreshold: 3
 
+## Prometheus exporter
+##
 metrics:
   enabled: true
+  ## MySQL Server Exporter image
+  ## ref: https://hub.docker.com/r/bitnami/kubectl/tags/
+  ##
   image:
     registry: docker.io
     repository: prom/mysqld-exporter
     tag: v0.10.0
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
     pullPolicy: IfNotPresent
   resources: {}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9104"
+
+## Hooks are used to cleanup once a release is deleted
+##
+hooks:
+  enabled: false
+  ## Remove PVCs once the release is deleted
+  ## Warning: data will be lost
+  ##
+  cleanClaims: false
+  rbac:
+  ## Bitnami kubectl image
+  ## ref: https://hub.docker.com/r/bitnami/kubectl/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/kubectl
+    tag: 1.12.3
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+
+## RBAC support
+## ref: https://docs.bitnami.com/kubernetes/how-to/configure-rbac-in-your-kubernetes-cluster/
+##
+rbac:
+  # Whether create RBAC resources or not
+  create: true

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -303,14 +303,52 @@ slave:
     successThreshold: 1
     failureThreshold: 3
 
+## Prometheus exporter
+##
 metrics:
   enabled: false
+  ## MySQL Server Exporter image
+  ## ref: https://hub.docker.com/r/bitnami/kubectl/tags/
+  ##
   image:
     registry: docker.io
     repository: prom/mysqld-exporter
     tag: v0.10.0
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
     pullPolicy: IfNotPresent
   resources: {}
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9104"
+
+## Hooks are used to cleanup once a release is deleted
+##
+hooks:
+  enabled: false
+  ## Remove PVCs once the release is deleted
+  ## Warning: data will be lost
+  ##
+  cleanClaims: false
+  rbac:
+  ## Bitnami kubectl image
+  ## ref: https://hub.docker.com/r/bitnami/kubectl/tags/
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/kubectl
+    tag: 1.12.3
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+
+## RBAC support
+## ref: https://docs.bitnami.com/kubernetes/how-to/configure-rbac-in-your-kubernetes-cluster/
+##
+rbac:
+  # Whether create RBAC resources or not
+  create: true


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This is a PoC to use **Helm hooks** to avoid recreating secrets when upgrading the chart. To do so, a **pre-install** hook is used in the secret.

As a consequence of these changes, once the release is deleted from the cluster, there'll be an extra resource to remove from the cluster, the secret. To solve this, a **job** (with a **post-delete** hook) with extra rbac permissions is used to cleanup the cluster.

Both hooks will be disabled by default.

This PR also allows the user to remove the PVCs generated by the master/slave's statefulsets. This option is disabled by default since the data will be removed unless a database backup is done previously.

This is a POC I'd like to discuss with @unguiculus @prydonius @desaintmartin @tompizmor @carrodher before adopting it on other charts.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the **README.md**
