### PR TITLE
[node-problem-detector] parameterize location of logdir to make it run on RHEL and upgrade to latest release

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 name: node-problem-detector
-version: "1.0.1"
+version: "1.1.0"
 appVersion: v0.5.0
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,6 +1,6 @@
 name: node-problem-detector
-version: "1.0.1"
-appVersion: v0.5.0
+version: "1.1.0"
+appVersion: v0.6.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes
 icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -41,7 +41,7 @@ The following table lists the configurable parameters for this chart and their d
 | `fullnameOverride`      | Override the fullname of the chart         | `nil`                                                        |
 | `image.pullPolicy`      | Image pull policy                          | `IfNotPresent`                                               |
 | `image.repository`      | Image                                      | `k8s.gcr.io/node-problem-detector`                           |
-| `image.tag`             | Image tag                                  | `v0.5.0`                                                     |
+| `image.tag`             | Image tag                                  | `v0.6.1`                                                     |
 | `nameOverride`          | Override the name of the chart             | `nil`                                                        |
 | `rbac.create`           | RBAC                                       | `true`                                                       |
 | `resources`             | Pod resource requests and limits           | `{}`                                                         |

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
       volumes:
         - name: log
           hostPath:
-            path: /var/log/
+            path: {{ .Values.hostpath.logdir }}
         - name: localtime
           hostPath:
             path: /etc/localtime

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -5,7 +5,7 @@ settings:
 
 image:
   repository: k8s.gcr.io/node-problem-detector
-  tag: v0.5.0
+  tag: v0.6.1
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -3,6 +3,9 @@ settings:
     - /config/kernel-monitor.json
     - /config/docker-monitor.json
 
+hostpath:
+  logdir: /var/log/
+
 image:
   repository: k8s.gcr.io/node-problem-detector
   tag: v0.5.0


### PR DESCRIPTION
Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

#### What this PR does / why we need it:
The logdir needs to be parameterized to suit several distros. RHEL has journal on /run/log

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
See https://github.com/kubernetes/node-problem-detector

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
