### PR TITLE
Initial Release for vSphere Container Storage Interface (CSI) Chart

### DIFF
--- a/incubator/vsphere-csi/Chart.yaml
+++ b/incubator/vsphere-csi/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: 0.1.0
+description: A vSphere Container Storage Interface (CSI) Driver Helm chart for Kubernetes
+name: vsphere-csi
+version: 0.1.0
+keywords:
+  - vsphere
+  - vmware
+  - cloud
+  - provider
+  - storage
+  - CSI
+home: https://github.com/kubernetes/cloud-provider-vsphere
+icon: https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/docs/vmware_logo.png
+sources:
+  - http://gcr.io/cloud-provider-vsphere/vsphere-csi
+maintainers:
+  - name: dvonthenen
+    email: vonthenend@vmware.com

--- a/incubator/vsphere-csi/OWNERS
+++ b/incubator/vsphere-csi/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- dvonthenen
+reviewers:
+- dvonthenen

--- a/incubator/vsphere-csi/README.md
+++ b/incubator/vsphere-csi/README.md
@@ -1,0 +1,95 @@
+# vSphere Container Storage Interface (CSI) Driver
+
+[vSphere Container Storage Interface (CSI) Driver](https://github.com/kubernetes/cloud-provider-vsphere) handles cloud specific functionality for provisioning storage for Kubernetes workloads on VMware vSphere infrastructure.
+
+## Introduction
+
+This chart deploys all components required to run the external vSphere CSI as described on it's [GitHub page](https://github.com/kubernetes/cloud-provider-vsphere).
+
+## Prerequisites
+
+- Has been tested on Kubernetes 1.11, 1.12, and 1.13.
+- Assumes your Kubernetes cluster has been configured to provision storage from a Container Storage Interface implementation. Please take a look at configuration guidelines located in the [Kubernetes documentation](https://kubernetes-csi.github.io/docs/Setup.html).
+
+## Installing the Chart
+
+To install this chart with the release name `myrel` and by providing a vCenter information/credentials, run the following command:
+
+```bash
+$ helm install incubator/vsphere-csi --name myrel --set cfg.enabled=true --set cfg.vcenter=<vCenter IP> --set cfg.username=<vCenter Username> --set cfg.password=<vCenter Password> --set cfg.datacenter=<vCenter Datacenter>
+```
+
+> **Tip**: List all releases using `helm list --all`
+
+If you want to provide your own `vsphere.conf` and Kubernetes secret `vspherecsi` in the `kube-system` namespace, you can learn more about the `vsphere.conf` and `vspherecsi` secret by reading the following [doucmentation](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/deploying_csi_vsphere_with_rbac.md) and then running the following command:
+
+```bash
+$ helm install incubator/vsphere-csi --name myrel
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `myrel` deployment:
+
+```bash
+$ helm delete myrel
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+> **Tip**: To permanently remove the release, run `helm delete --purge myrel`
+
+*IMPORTANT:* Deleting this chart even with doing a `--purge` does *not* delete the CRDs associated with this chart. You can download the following [CRD definitions](https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/manifests/csi/vsphere-csi-crd.yaml) and run the following command `kubectl delete -f vsphere-csi-crd.yaml` to remove them.
+
+## Configuration
+
+The following table lists the configurable parameters of the vSphere CSI chart and their default values.
+
+|             Parameter                         |            Description              |                    Default                 |
+|-----------------------------------------------|-------------------------------------|--------------------------------------------|
+| `csi.cfg.enable`                              | Create a vsphere.conf               |  false                                     |
+| `csi.cfg.vcenter`                             | vCenter IP in vsphere.conf          |  "10.0.0.1"                                |
+| `csi.cfg.username`                            | vCenter username in vsphere.conf    |  "user"                                    |
+| `csi.cfg.password`                            | vCenter password in vsphere.conf    |  "pass"                                    |
+| `csi.cfg.datacenter`                          | Datacenters in vsphere.conf         |  "dc"                                      |
+| `csi.controller.annotations`                  | Annotations for Controller component|  nil                                       |
+| `csi.controller.image`                        | Image for Controller component      |  gcr.io/cloud-provider-vsphere/vsphere-csi |
+| `csi.controller.tag`                          | Tag for Controller component        |  latest release                            |
+| `csi.controller.pullPolicy`                   | Controller component pullPolicy     |  IfNotPresent                              |
+| `csi.controller.cmdline.logging`              | Logging level                       |  2                                         |
+| `csi.controller.cmdline.cloudConfig.dir`      | vSphere conf directory              |  /etc/cloud                                |
+| `csi.controller.cmdline.cloudConfig.file`     | vSphere conf filename               |  vsphere.conf                              |
+| `csi.controller.cmdline.kubeConfig.configMap` | Use a configMap for kubeConfig      |  nil                                       |
+| `csi.controller.cmdline.kubeConfig.dir`       | kubeConfig directory                |  /etc/kubernetes                           |
+| `csi.controller.cmdline.kubeConfig.file`      | kubeConfig filename                 |  controller-manager.conf                   |
+| `csi.controller.cmdline.caCerts.configMap`    | Use a configMap for caCerts         |  nil                                       |
+| `csi.controller.cmdline.caCerts.dir`          | caCerts directory                   |  /etc/ssl/certs                            |
+| `csi.controller.cmdline.k8sCerts.configMap`   | Use a configMap for k8sCerts        |  nil                                       |
+| `csi.controller.cmdline.k8sCerts.dir`         | k8sCerts directory                  |  /etc/kubernetes/pki                       |
+| `csi.controller.podAnnotations`               | Annotations for Controller component|  nil                                       |
+| `csi.controller.podLabels`                    | Labels for Controller component     |  nil                                       |
+| `csi.controller.replicaCount`                 | Number of instances                 |  1                                         |
+| `csi.controller.serviceAccountName`           | ServiceAccount for Controller       |  vsphere-csi-controller                    |
+| `csi.node.annotations`                        | Annotations for Node pod            |  nil                                       |
+| `csi.node.image`                              | Image for vSphere CSI node          |  gcr.io/cloud-provider-vsphere/vsphere-csi |
+| `csi.node.tag`                                | Tag for Node component              |  latest                                    |
+| `csi.node.pullPolicy`                         | Node component pullPolicy           |  IfNotPresent                              |
+| `csi.node.cmdline.logging`                    | Logging level                       |  2                                         |
+| `csi.node.podAnnotations`                     | Annotations for Node component      |  nil                                       |
+| `csi.node.podLabels`                          | Labels for Node component           |  nil                                       |
+| `csi.node.replicaCount`                       | Number of instances                 |  1                                         |
+| `csi.node.serviceAccountName`                 | ServiceAccount for Node             |  vsphere-csi-node                          |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name myrel \
+    --set csi.pullPolicy=Always \
+    incubator/vsphere-csi
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart.
+
+### Image tags
+
+vSphere CSI offers a multitude of [tags](https://github.com/kubernetes/cloud-provider-vsphere/releases) for the various components used in this chart.

--- a/incubator/vsphere-csi/templates/NOTES.txt
+++ b/incubator/vsphere-csi/templates/NOTES.txt
@@ -1,0 +1,6 @@
+The vSphere CSI Driver has been installed.
+
+To learn how to create your own StorageClass and PersistentVolumeClaim,
+please visit the following:
+
+https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/deploying_csi_vsphere_with_rbac.md

--- a/incubator/vsphere-csi/templates/_helpers.tpl
+++ b/incubator/vsphere-csi/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "csi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "csi.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "csi.controller.name" -}}
+{{- $nameGlobalOverride := printf "%s-controller" (include "csi.fullname" .) -}}
+{{- if .Values.csi.controller.fullnameOverride -}}
+{{- printf "%s" .Values.csi.controller.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $nameGlobalOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified node name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "csi.node.name" -}}
+{{- $nameGlobalOverride := printf "%s-node" (include "csi.fullname" .) -}}
+{{- if .Values.csi.node.fullnameOverride -}}
+{{- printf "%s" .Values.csi.node.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $nameGlobalOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/incubator/vsphere-csi/templates/vsphere-csi-cm.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-cm.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.cfg.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: csi-config
+  namespace: kube-system
+data:
+  vsphere.conf: |
+    [Global]
+    # properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    port = "443" #Optional
+    insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
+    # settings for using k8s secret
+    secret-name = "vspherecsi"
+    secret-namespace = "kube-system"
+
+    [VirtualCenter "{{ .Values.cfg.vcenter }}"]
+    datacenters = "{{ .Values.cfg.datacenter }}"
+    # port, insecure-flag will be used from Global section.
+{{- end -}}

--- a/incubator/vsphere-csi/templates/vsphere-csi-controller-r.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-controller-r.yaml
@@ -1,0 +1,47 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-attacher-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]

--- a/incubator/vsphere-csi/templates/vsphere-csi-controller-rb.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-controller-rb.yaml
@@ -1,0 +1,25 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.csi.controller.serviceAccountName }}
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.csi.controller.serviceAccountName }}
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io

--- a/incubator/vsphere-csi/templates/vsphere-csi-controller-sa.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-controller-sa.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ .Values.csi.controller.serviceAccountName }}
+  namespace: kube-system

--- a/incubator/vsphere-csi/templates/vsphere-csi-controller-ss.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-controller-ss.yaml
@@ -1,0 +1,125 @@
+
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: {{ template "csi.controller.name" . }}
+  namespace: kube-system
+  labels:
+    app: {{ template "csi.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.csi.controller.annotations }}
+  annotations:
+{{ toYaml .Values.csi.controller.annotations | indent 4 }}
+{{- end }}
+spec:
+  serviceName: vsphere-csi-controller
+  replicas: {{ .Values.csi.controller.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "csi.name" . }}
+        component: controller
+        role: vsphere-csi
+        release: {{ .Release.Name }}
+{{- if .Values.csi.controller.podLabels }}
+{{ toYaml .Values.csi.controller.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.csi.controller.podAnnotations }}
+      annotations:
+{{ toYaml .Values.csi.controller.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccount: {{ .Values.csi.controller.serviceAccountName }}
+      containers:
+        - name: csi-provisioner
+          image: {{ .Values.csi.provisioner.image }}:{{ .Values.csi.provisioner.tag }}
+          imagePullPolicy: {{ .Values.csi.provisioner.pullPolicy }}
+          args:
+            - "--provisioner=io.k8s.cloud-provider-vsphere.vsphere"
+            - "--csi-address=$(ADDRESS)"
+            - "--v={{ .Values.csi.provisioner.cmdline.logging }}"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: {{ .Values.csi.attacher.image }}:{{ .Values.csi.attacher.tag }}
+          imagePullPolicy: {{ .Values.csi.attacher.pullPolicy }}
+          args:
+            - "--v={{ .Values.csi.attacher.cmdline.logging }}"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: vsphere-csi-controller
+          image: {{ .Values.csi.controller.image }}:{{ .Values.csi.controller.tag }}
+          imagePullPolicy: {{ .Values.csi.controller.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.csi.controller.cmdline.additionalParams }}
+            - name: {{ $key | replace "." "_" | replace "-" "_" | upper }}
+              value: {{ $value }}
+            {{- end }}
+            - name: VSPHERE_KUBE_CONFIG
+              value: "*"
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+          volumeMounts:
+            - mountPath: {{ .Values.csi.controller.cmdline.k8sCerts.dir }}
+              name: k8s-certs
+              readOnly: true
+            - mountPath: {{ .Values.csi.controller.cmdline.caCerts.dir }}
+              name: ca-certs
+              readOnly: true
+            - mountPath: {{ .Values.csi.controller.cmdline.kubeConfig.dir }}/{{ .Values.csi.controller.cmdline.kubeConfig.file }}
+              name: kubeconfig
+              readOnly: true
+            - mountPath: {{ .Values.csi.controller.cmdline.cloudConfig.dir }}
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
+      volumes:
+        - name: k8s-certs
+        {{- if .Values.csi.controller.cmdline.k8sCerts.configMap }}
+          configMap:
+            name: {{ .Values.csi.controller.cmdline.k8sCerts.configMap }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.csi.controller.cmdline.k8sCerts.dir }}
+            type: DirectoryOrCreate
+        {{- end }}
+        - name: ca-certs
+        {{- if .Values.csi.controller.cmdline.caCerts.configMap }}
+          configMap:
+            name: {{ .Values.csi.controller.cmdline.caCerts.configMap }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.csi.controller.cmdline.caCerts.dir }}
+            type: DirectoryOrCreate
+        {{- end }}
+        - name: kubeconfig
+        {{- if .Values.csi.controller.cmdline.kubeConfig.configMap }}
+          configMap:
+            name: {{ .Values.csi.controller.cmdline.kubeConfig.configMap }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.csi.controller.cmdline.kubeConfig.dir }}/{{ .Values.csi.controller.cmdline.kubeConfig.file }}
+            type: FileOrCreate
+        {{- end }}
+        - name: vsphere-config-volume
+          configMap:
+            name: csi-config
+        - name: socket-dir
+          emptyDir: {}

--- a/incubator/vsphere-csi/templates/vsphere-csi-crd.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-crd.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: csinodeinfos.csi.storage.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: csi.storage.k8s.io
+  names:
+    kind: CSINodeInfo
+    plural: csinodeinfos
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        csiDrivers:
+          description: List of CSI drivers running on the node and their properties.
+          items:
+            properties:
+              driver:
+                description: The CSI driver that this object refers to.
+                type: string
+              nodeID:
+                description: The node from the driver point of view.
+                type: string
+              topologyKeys:
+                description: List of keys supported by the driver.
+                items:
+                  type: string
+                type: array
+          type: array
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: csidrivers.csi.storage.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  group: csi.storage.k8s.io
+  names:
+    kind: CSIDriver
+    plural: csidrivers
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: Specification of the CSI Driver.
+          properties:
+            attachRequired:
+              description: Indicates this CSI volume driver requires an attach operation,
+                and that Kubernetes should call attach and wait for any attach operation
+                to complete before proceeding to mount.
+              type: boolean
+            podInfoOnMountVersion:
+              description: Indicates this CSI volume driver requires additional pod
+                information (like podName, podUID, etc.) during mount operations.
+              type: string
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# CSIDriverRegistry feature gate needs to be enabled
+apiVersion: csi.storage.k8s.io/v1alpha1
+kind: CSIDriver
+metadata:
+  name: io.k8s.cloud-provider-vsphere.vsphere
+  annotations:
+    "helm.sh/hook": crd-install
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  attachRequired: true
+  podInfoOnMountVersion: "v1"

--- a/incubator/vsphere-csi/templates/vsphere-csi-node-ds.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-node-ds.yaml
@@ -1,0 +1,103 @@
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: {{ template "csi.node.name" . }}
+  namespace: kube-system
+  labels:
+    app: {{ template "csi.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: node
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.csi.node.annotations }}
+  annotations:
+{{ toYaml .Values.csi.node.annotations | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "csi.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "csi.name" . }}
+        component: controller
+        role: vsphere-csi
+        release: {{ .Release.Name }}
+{{- if .Values.csi.node.podLabels }}
+{{ toYaml .Values.csi.node.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.csi.node.podAnnotations }}
+      annotations:
+{{ toYaml .Values.csi.node.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccount: {{ .Values.csi.node.serviceAccountName }}
+      hostNetwork: true
+      containers:
+        - name: driver-registrar
+          image: {{ .Values.csi.registrar.image }}:{{ .Values.csi.registrar.tag }}
+          imagePullPolicy: {{ .Values.csi.registrar.pullPolicy }}
+          args:
+            - "--v={{ .Values.csi.registrar.cmdline.logging }}"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins_registry/io.k8s.cloud-provider-vsphere.vsphere/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi/
+            - name: registration-dir
+              mountPath: /registration/
+        - name: vsphere-csi-node
+          image: {{ .Values.csi.node.image }}:{{ .Values.csi.node.tag }}
+          imagePullPolicy: {{ .Values.csi.node.pullPolicy }}
+          env:
+            {{- range $key, $value := .Values.csi.node.cmdline.additionalParams }}
+            - name: {{ $key | replace "." "_" | replace "-" "_" | upper }}
+              value: {{ $value }}
+            {{- end }}
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: "node"
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: device-dir
+              mountPath: /dev
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/io.k8s.cloud-provider-vsphere.vsphere
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev

--- a/incubator/vsphere-csi/templates/vsphere-csi-node-r.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-node-r.yaml
@@ -1,0 +1,10 @@
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-driver-registrar-role
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/incubator/vsphere-csi/templates/vsphere-csi-node-rb.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-node-rb.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-driver-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.csi.node.serviceAccountName }}
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-driver-registrar-role
+  apiGroup: rbac.authorization.k8s.io

--- a/incubator/vsphere-csi/templates/vsphere-csi-node-sa.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-node-sa.yaml
@@ -1,0 +1,6 @@
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.csi.node.serviceAccountName }}
+  namespace: kube-system

--- a/incubator/vsphere-csi/templates/vsphere-csi-s.yaml
+++ b/incubator/vsphere-csi/templates/vsphere-csi-s.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.cfg.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vspherecsi
+  namespace: kube-system
+data:
+  {{ .Values.cfg.vcenter }}.username: {{ .Values.cfg.username | b64enc }}
+  {{ .Values.cfg.vcenter }}.password: {{ .Values.cfg.password | b64enc }}
+{{- end -}}

--- a/incubator/vsphere-csi/values.yaml
+++ b/incubator/vsphere-csi/values.yaml
@@ -1,0 +1,87 @@
+# Default values for vSphere-CSI.
+# This is a YAML-formatted file.
+# vSohere-CSI values are grouped by component
+
+cfg:
+  enabled: false
+  vcenter: "10.0.0.1"
+  username: "user"
+  password: "pass"
+  datacenter: "dc"
+
+csi:
+
+  #
+  # Kubernetes specific components for CSI
+  #
+  provisioner:
+    image: quay.io/k8scsi/csi-provisioner
+    tag: v1.0.1
+    pullPolicy: IfNotPresent
+    cmdline:
+      logging: 2
+  attacher:
+    image: quay.io/k8scsi/csi-attacher
+    tag: v1.0.1
+    pullPolicy: IfNotPresent
+    cmdline:
+      logging: 2
+  registrar:
+    image: quay.io/k8scsi/csi-node-driver-registrar
+    tag: v1.0.1
+    pullPolicy: IfNotPresent
+    cmdline:
+      logging: 2
+  #
+  # Kubernetes specific components for CSI
+  #
+
+  # vSphere CSI controller components
+  controller:
+    annotations: {}
+    image: gcr.io/cloud-provider-vsphere/vsphere-csi
+    tag: v0.1.1
+    pullPolicy: IfNotPresent
+    cmdline:
+      logging: 2
+      # Location of the cloud configmap to be mounted on the filesystem
+      cloudConfig:
+        dir: "/etc/cloud"
+        file: "vsphere.conf"
+      # kubeConfigConfigMap defined the ConfigMap name in place of using volume
+      # containing the Kubeconfig file
+      kubeConfig:
+        configMap: null
+        dir: "/etc/kubernetes"
+        file: "controller-manager.conf"
+      # caCertsConfigMap defined the ConfigMap name in place of using volume
+      # containing the CACerts file
+      caCerts:
+        configMap: null
+        dir: /etc/ssl/certs
+      # k8sCerts to be used to access the kubernetes api server
+      k8sCerts:
+        configMap: null
+        dir: /etc/kubernetes/pki
+      additionalParams: {}
+    replicaCount: 1
+    serviceAccountName: vsphere-csi-controller
+    podAnnotations: {}
+    ## Additional pod labels
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    podLabels: {}
+
+  # vSphere CSI node components
+  node:
+    annotations: {}
+    image: gcr.io/cloud-provider-vsphere/vsphere-csi
+    tag: v0.1.1
+    pullPolicy: IfNotPresent
+    cmdline:
+      logging: 2
+      additionalParams: {}
+    serviceAccountName: vsphere-csi-node
+    podAnnotations: {}
+    ## Additional pod labels
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    podLabels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
This introduces the initial release for the vSphere Container Storage Interface (CSI) Chart located at https://github.com/kubernetes/cloud-provider-vsphere. There is a move to take all the external storage providers from in-tree to out-of-tree (link: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/container-storage-interface.md). This Helm Chart will enable users to consume the out-of-tree vSphere CSI driver/implementation easier by providing a simple deployment mechanism via Helm.

#### Special notes for your reviewer:
Tested using:
- vSphere CSI image 0.1.1
- Kubernetes cluster 1.11.3, 1.12.2, and 1.13.1 configured for an external CSI implementation
- vSphere 6.7

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] ~Chart Version bumped~ Initial release
- [x] Variables are documented in the README.md
