### PR TITLE
[stable/spinnaker] fixes yaml code blocks formatting in README

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.1.6
+version: 1.1.7
 appVersion: 1.9.1
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/README.md
+++ b/stable/spinnaker/README.md
@@ -64,27 +64,27 @@ for Spinnaker. If you want to add arbitrary clusters need to do the following:
 
 Spinnaker will only give you access to Docker images that have been whitelisted, if you're using a private registry or a private repository you also need to provide credentials.  Update the following values of the chart to do so:
 
-    ```yaml
-    dockerRegistries:
-    - name: dockerhub
-      address: index.docker.io
-      repositories:
-        - library/alpine
-        - library/ubuntu
-        - library/centos
-        - library/nginx
-    # - name: gcr
-    #   address: https://gcr.io
-    #   username: _json_key
-    #   password: '<INSERT YOUR SERVICE ACCOUNT JSON HERE>'
-    #   email: 1234@5678.com
-    ```
+```yaml
+dockerRegistries:
+- name: dockerhub
+  address: index.docker.io
+  repositories:
+    - library/alpine
+    - library/ubuntu
+    - library/centos
+    - library/nginx
+# - name: gcr
+#   address: https://gcr.io
+#   username: _json_key
+#   password: '<INSERT YOUR SERVICE ACCOUNT JSON HERE>'
+#   email: 1234@5678.com
+```
 
 You can provide passwords as a Helm value, or you can use a pre-created secret containing your registry passwords.  The secret should have an item per Registry in the format: `<registry name>: <password>`. In which case you'll specify the secret to use in `dockerRegistryAccountSecret` like so:
 
-    ```yaml
-    dockerRegistryAccountSecret: myregistry-secrets
-    ```
+```yaml
+dockerRegistryAccountSecret: myregistry-secrets
+```
 
 ## Specifying persistent storage
 


### PR DESCRIPTION
Fixes YAML code blocks markdown rendering in `stable/spinnaker` chart.

#### What this PR does / why we need it:
This PR fixes yaml code blocks rendering in stable/spinnaker chart.

#### Special notes for your reviewer:
* This PR only includes a README change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md

@viglesiasce 