### PR TITLE
[stable/grafana] Busybox doesn't have a 1.3.0 image, it does have a 1.30 and 1.30.0

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.21.3
+version: 1.21.4
 appVersion: 5.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -48,7 +48,7 @@ downloadDashboardsImage:
 
 chownDataImage:
   repository: busybox
-  tag: 1.3.0
+  tag: 1.30.0
   pullPolicy: IfNotPresent
 
 ## Pod Annotations


### PR DESCRIPTION
@zanhsieh @rtluckie

#### What this PR does / why we need it:

Grafana fails to startup due to chown container not being available

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
