### PR TITLE
[stable/concourse] Fix variable references in NOTES.txt

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.0.1
+version: 3.0.2
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/NOTES.txt
+++ b/stable/concourse/templates/NOTES.txt
@@ -1,7 +1,7 @@
 
 * Concourse can be accessed:
 
-  * Within your cluster, at the following DNS name at port {{ .Values.concourse.atcPort }}:
+  * Within your cluster, at the following DNS name at port {{ .Values.concourse.web.bindPort }}:
 
     {{ template "concourse.web.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
@@ -25,12 +25,12 @@
            You can watch the status of by running 'kubectl get svc -w {{ template "concourse.web.fullname" . }}'
 
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "concourse.web.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    echo http://$SERVICE_IP:{{ .Values.concourse.atcPort }}
+    echo http://$SERVICE_IP:{{ .Values.concourse.web.bindPort }}
     {{- else if contains "ClusterIP"  .Values.web.service.type }}
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "concourse.web.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
     echo "Visit http://127.0.0.1:8080 to use Concourse"
-    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.concourse.atcPort }}
+    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.concourse.web.bindPort }}
     {{- end }}
   {{- end }}
 * If this is your first time using Concourse, follow the tutorials at https://concourse-ci.org/tutorials.html


### PR DESCRIPTION
`.Values.concourse.atcPort` has been replaced with `.Values.concourse.web.bindPort`
in 263bc80322056455c7120b51f1992a40667ec686.
So the references in NOTES.txt should also be updated.

Signed-off-by: Noburou TANIGUCHI <dev@nota.m001.jp>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

In the Concourse chart, `.Values.concourse.atcPort` has been replaced with `.Values.concourse.web.bindPort` in 263bc80322056455c7120b51f1992a40667ec686.
So the references in NOTES.txt should also be updated.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
  NOTE: The explanation of the variable `concourse.atcPort` seems intentionally removed in 263bc80322056455c7120b51f1992a40667ec686, so it is not re-added in this pull request.
