### PR TITLE
[incubator/kafka] Fix external.enabled true issues and topic modification issue

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.13.3
+version: 0.13.4
 appVersion: 5.0.1
 keywords:
 - kafka

--- a/incubator/kafka/templates/configmap-config.yaml
+++ b/incubator/kafka/templates/configmap-config.yaml
@@ -27,6 +27,7 @@ data:
     echo "Applying runtime configuration using {{ .Values.image }}:{{ .Values.imageTag }}"
   {{- range $n, $topic := .Values.topics }}
     {{- if and $topic.partitions $topic.replicationFactor $topic.reassignPartitions }}
+    kafka-topics --zookeeper {{ $zk }} --create --if-not-exists --force --topic {{ $topic.name }} --partitions {{ $topic.partitions }} --replication-factor {{ $topic.replicationFactor }}
     kafka-topics --zookeeper {{ $zk }} --alter --force --topic {{ $topic.name }} --partitions {{ $topic.partitions }} || true
     cat << EOF > {{ $topic.name }}-increase-replication-factor.json
       {"version":1, "partitions":[

--- a/incubator/kafka/templates/configmap-config.yaml
+++ b/incubator/kafka/templates/configmap-config.yaml
@@ -27,6 +27,7 @@ data:
     echo "Applying runtime configuration using {{ .Values.image }}:{{ .Values.imageTag }}"
   {{- range $n, $topic := .Values.topics }}
     {{- if and $topic.partitions $topic.replicationFactor $topic.reassignPartitions }}
+    kafka-topics --zookeeper {{ $zk }} --alter --force --topic {{ $topic.name }} --partitions {{ $topic.partitions }} || true
     cat << EOF > {{ $topic.name }}-increase-replication-factor.json
       {"version":1, "partitions":[
         {{- $partitions := (int $topic.partitions) }}

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -52,7 +52,7 @@ spec:
       nodePort: {{ $externalListenerPort }}
       {{- end }}
       protocol: TCP
-  {{- if eq $root.Values.external.type "LoadBalancer" }}
+  {{- if and $root.Values.external.loadBalancerIP (eq $root.Values.external.type "LoadBalancer") }}
   loadBalancerIP: {{ index $root.Values.external.loadBalancerIP $i }}
   {{- end }}
   selector:

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -47,7 +47,7 @@ spec:
       {{- else }}
       port: {{ $servicePort }}
       {{- end }}
-      targetPort: {{ $externalListenerPort }}
+      targetPort: {{ $servicePort }}
       {{- if eq $root.Values.external.type "NodePort" }}
       nodePort: {{ $externalListenerPort }}
       {{- end }}

--- a/incubator/kafka/templates/service-brokers-external.yaml
+++ b/incubator/kafka/templates/service-brokers-external.yaml
@@ -8,7 +8,6 @@
     {{- $externalListenerPort := add $root.Values.external.firstListenerPort $i }}
     {{- $responsiblePod := printf "%s-%d" (printf "%s" $fullName) $i }}
     {{- $distinctPrefix := printf "%s-%d" $dnsPrefix $i }}
-    {{- $loadBalancerIP := index $root.Values.external.loadBalancerIP $i }}
 ---
 apiVersion: v1
 kind: Service
@@ -54,7 +53,7 @@ spec:
       {{- end }}
       protocol: TCP
   {{- if eq $root.Values.external.type "LoadBalancer" }}
-  loadBalancerIP: {{ $loadBalancerIP }}
+  loadBalancerIP: {{ index $root.Values.external.loadBalancerIP $i }}
   {{- end }}
   selector:
     app: {{ include "kafka.name" $root }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -168,7 +168,7 @@ configurationOverrides:
   # "controlled.shutdown.enable": true
   # "controlled.shutdown.max.retries": 100
 
-  ## Options required for external access via NodePort
+  ## Options required for external access
   ## ref:
   ## - http://kafka.apache.org/documentation/#security_configbroker
   ## - https://cwiki.apache.org/confluence/display/KAFKA/KIP-103%3A+Separation+of+Internal+and+External+traffic
@@ -178,6 +178,7 @@ configurationOverrides:
   #   EXTERNAL://kafka.cluster.local:$((31090 + ${KAFKA_BROKER_ID}))
   # "listener.security.protocol.map": |-
   #   PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+  # "listeners": "PLAINTEXT://0.0.0.0:9092,EXTERNAL://0.0.0.0:19092"
 
 ## set extra ENVs
 #   key: "value"


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes #9781 and #9695 where the chart only works when external.enabled is true, if external.type is LoadBalancer and LoadBalancerIP Is set.

Also fixes failure to increase partition count of a topic when reassignPartitions is true and both replicationFactor and partitions are set.

#### Which issue this PR fixes
  - fixes #9781 
  - fixes #9695 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
