### PR TITLE
sonarqube chart: Fix nil annotations warning

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.13.0
+version: 0.13.1
 appVersion: 7.4
 keywords:
   - coverage

--- a/stable/sonarqube/templates/ingress.yaml
+++ b/stable/sonarqube/templates/ingress.yaml
@@ -10,10 +10,12 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{ if .Values.ingress.annotations}}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
+{{- end }}
 spec:
   rules:
     {{- range $host := .Values.ingress.hosts }}

--- a/stable/sonarqube/templates/service.yaml
+++ b/stable/sonarqube/templates/service.yaml
@@ -10,10 +10,12 @@ metadata:
   {{- range $key, $value := .Values.service.labels }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
+{{ if .Values.service.annotations}}
   annotations:
     {{- range $key, $value := .Values.service.annotations }}
-      {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ $value | quote }}
     {{- end }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -29,7 +29,7 @@ service:
   externalPort: 9000
   internalPort: 9000
   labels:
-  annotations:
+  annotations: {}
   # May be used in example for internal load balancing in GCP:
   # cloud.google.com/load-balancer-type: Internal
   loadBalancerSourceRanges:
@@ -40,12 +40,12 @@ ingress:
   # Used to create an Ingress record.
   hosts:
     - sonar.organization.com
-  annotations:
+  annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   # This property allows for reports up to a certain size to be uploaded to SonarQube
   # nginx.ingress.kubernetes.io/proxy-body-size: "8m"
-  tls:
+  tls: {}
   # Secrets must be manually created in the namespace.
   # - secretName: chart-example-tls
   #   hosts:


### PR DESCRIPTION
This PR fixes an issue when you are using a values file with no service annotations. You get a warning saying: **"Merging destination map for chart 'sonarqube'. The destination item 'annotations' is a table and ignoring the source 'annotations' as it has a non-table value of: <nil>"**

The fix includes:
- Removes the annotations empty item when there is non defined in the values file.
- By default the annotations is an empty object in the values file.