### PR TITLE
[stable/ghost] Re-define ingress/smtp configuration

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 6.1.9
+version: 6.2.0
 appVersion: 2.9.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -66,6 +66,11 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `ghostPassword`                     | Application password                                          | Randomly generated                                       |
 | `ghostEmail`                        | Admin email                                                   | `user@example.com`                                       |
 | `ghostBlogTitle`                    | Ghost Blog name                                               | `User's Blog`                                            |
+| `smtpHost`                          | SMTP host                                                     | `nil`                                                    |
+| `smtpPort`                          | SMTP port                                                     | `nil`                                                    |
+| `smtpUser`                          | SMTP user                                                     | `nil`                                                    |
+| `smtpPassword`                      | SMTP password                                                 | `nil`                                                    |
+| `smtpService`                       | SMTP service                                                  | `nil`                                                    |
 | `allowEmptyPassword`                | Allow DB blank passwords                                      | `yes`                                                    |
 | `serviceType`                       | Kubernetes Service type                                       | `LoadBalancer`                                           |
 | `securityContext.enabled`           | Enable security context                                       | `true`                                                   |

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -71,18 +71,18 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `securityContext.enabled`           | Enable security context                                       | `true`                                                   |
 | `securityContext.fsGroup`           | Group ID for the container                                    | `1001`                                                   |
 | `securityContext.runAsUser`         | User ID for the container                                     | `1001`                                                   |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                    | `80`                                          |
-| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
-| `service.externalTrafficPolicy`      | Enable client source IP preservation                       | `Cluster`                                     |
-| `service.loadBalancerIP`      | LoadBalancerIP for the Ghost service                       | ``                                     |
+| `service.type`                      | Kubernetes Service type                                       | `LoadBalancer`                                           |
+| `service.port`                      | Service HTTP port                                             | `80`                                                     |
+| `service.nodePorts.http`            | Kubernetes http node port                                     | `""`                                                     |
+| `service.externalTrafficPolicy`     | Enable client source IP preservation                          | `Cluster`                                                |
+| `service.loadBalancerIP`            | LoadBalancerIP for the Ghost service                          | ``                                                       |
 | `ingress.enabled`                   | Enable ingress controller resource                            | `false`                                                  |
+| `ingress.annotations`               | Ingress annotations                                           | `[]`                                                     |
+| `ingress.certManager`               | Add annotations for cert-manager                              | `false`                                                  |
 | `ingress.hosts[0].name`             | Hostname to your Ghost installation                           | `ghost.local`                                            |
 | `ingress.hosts[0].path`             | Path within the url structure                                 | `/`                                                      |
 | `ingress.hosts[0].tls`              | Utilize TLS backend in ingress                                | `false`                                                  |
-| `ingress.hosts[0].certManager`      | Add annotations for cert-manager                              | `false`                                                  |
 | `ingress.hosts[0].tlsSecret`        | TLS Secret (certificates)                                     | `ghost.local-tls-secret`                                 |
-| `ingress.hosts[0].annotations`      | Annotations for this host's ingress record                    | `[]`                                                     |
 | `ingress.secrets[0].name`           | TLS Secret Name                                               | `nil`                                                    |
 | `ingress.secrets[0].certificate`    | TLS Secret Certificate                                        | `nil`                                                    |
 | `ingress.secrets[0].key`            | TLS Secret Key                                                | `nil`                                                    |

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -4,20 +4,20 @@ kind: Deployment
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: "{{ template "ghost.name" . }}"
+    app: "{{ template "ghost.fullname" . }}"
     chart: "{{ template "ghost.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
   selector:
     matchLabels:
-      app: "{{ template "ghost.name" . }}"
+      app: "{{ template "ghost.fullname" . }}"
       release: {{ .Release.Name | quote }}
   replicas: 1
   template:
     metadata:
       labels:
-        app: "{{ template "ghost.name" . }}"
+        app: "{{ template "ghost.fullname" . }}"
         chart: "{{ template "ghost.chart" . }}"
         release: {{ .Release.Name | quote }}
     spec:

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -4,22 +4,22 @@ kind: Deployment
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: {{ template "ghost.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "ghost.name" . }}"
+    chart: "{{ template "ghost.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "ghost.fullname" . }}
-      release: "{{ .Release.Name }}"
+      app: "{{ template "ghost.name" . }}"
+      release: {{ .Release.Name | quote }}
   replicas: 1
   template:
     metadata:
       labels:
-        app: {{ template "ghost.fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
+        app: "{{ template "ghost.name" . }}"
+        chart: "{{ template "ghost.chart" . }}"
+        release: {{ .Release.Name | quote }}
     spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -102,19 +102,29 @@ spec:
           value: {{ .Values.ghostEmail | quote }}
         - name: BLOG_TITLE
           value: {{ .Values.ghostBlogTitle | quote }}
+        {{- if .Values.smtpHost }}
         - name: SMTP_HOST
           value: {{ .Values.smtpHost | quote }}
+        {{- end }}
+        {{- if .Values.smtpPort }}
         - name: SMTP_PORT
           value: {{ .Values.smtpPort | quote }}
+        {{- end }}
+        {{- if .Values.smtpUser }}
         - name: SMTP_USER
           value: {{ .Values.smtpUser | quote }}
+        {{- end }}
+        {{- if .Values.smtpPassword }}
         - name: SMTP_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "ghost.fullname" . }}
               key: smtp-password
+        {{- end }}
+        {{- if .Values.smtpService }}
         - name: SMTP_SERVICE
           value: {{ .Values.smtpService | quote }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 2368

--- a/stable/ghost/templates/ingress.yaml
+++ b/stable/ghost/templates/ingress.yaml
@@ -1,36 +1,37 @@
 {{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: "{{- printf "%s-%s" .name $.Release.Name | trunc 63 | trimSuffix "-" -}}"
+  name: {{ template "ghost.fullname" . }}
   labels:
-    app: {{ template "ghost.fullname" $ }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    app: "{{ template "ghost.name" . }}"
+    chart: "{{ template "ghost.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
-    {{- if .certManager }}
+    {{- if .Values.ingress.certManager }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
-    {{- range $key, $value := .annotations }}
+    {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
+  {{- range .Values.ingress.hosts }}
   - host: {{ .name }}
     http:
       paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ template "ghost.fullname" $ }}
-            servicePort: 80
-{{- if .tls }}
+      - path: {{ default "/" .path }}
+        backend:
+          serviceName: {{ template "ghost.fullname" $ }}
+          servicePort: http
+  {{- end }}
   tls:
+  {{- range .Values.ingress.hosts }}
+  {{- if .tls }}
   - hosts:
     - {{ .name }}
     secretName: {{ .tlsSecret }}
-{{- end }}
----
-{{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/stable/ghost/templates/ingress.yaml
+++ b/stable/ghost/templates/ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: "{{ template "ghost.name" . }}"
+    app: "{{ template "ghost.fullname" . }}"
     chart: "{{ template "ghost.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/ghost/templates/pvc.yaml
+++ b/stable/ghost/templates/pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: "{{ template "ghost.name" . }}"
+    app: "{{ template "ghost.fullname" . }}"
     chart: "{{ template "ghost.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/ghost/templates/pvc.yaml
+++ b/stable/ghost/templates/pvc.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: {{ template "ghost.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "ghost.name" . }}"
+    chart: "{{ template "ghost.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/stable/ghost/templates/secrets.yaml
+++ b/stable/ghost/templates/secrets.yaml
@@ -3,15 +3,17 @@ kind: Secret
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: {{ template "ghost.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "ghost.name" . }}"
+    chart: "{{ template "ghost.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  {{ if .Values.ghostPassword }}
+  {{- if .Values.ghostPassword }}
   ghost-password: {{ .Values.ghostPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   ghost-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
+  {{- end }}
+  {{- if .Values.smtpPassword }}
   smtp-password: {{ default "" .Values.smtpPassword | b64enc | quote }}
+  {{- end }}

--- a/stable/ghost/templates/secrets.yaml
+++ b/stable/ghost/templates/secrets.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: "{{ template "ghost.name" . }}"
+    app: "{{ template "ghost.fullname" . }}"
     chart: "{{ template "ghost.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}

--- a/stable/ghost/templates/svc.yaml
+++ b/stable/ghost/templates/svc.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: {{ template "ghost.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app: "{{ template "ghost.name" . }}"
+    chart: "{{ template "ghost.chart" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
@@ -23,4 +23,4 @@ spec:
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}
   selector:
-    app: {{ template "ghost.fullname" . }}
+    app: "{{ template "ghost.name" . }}"

--- a/stable/ghost/templates/svc.yaml
+++ b/stable/ghost/templates/svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "ghost.fullname" . }}
   labels:
-    app: "{{ template "ghost.name" . }}"
+    app: "{{ template "ghost.fullname" . }}"
     chart: "{{ template "ghost.chart" . }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
@@ -23,4 +23,4 @@ spec:
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}
   selector:
-    app: "{{ template "ghost.name" . }}"
+    app: "{{ template "ghost.fullname" . }}"

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -199,28 +199,29 @@ ingress:
   ## Set to true to enable ingress record generation
   enabled: false
 
+  ## Set this to true in order to add the corresponding annotations for cert-manager
+  certManager: false
+
+  ## Ingress annotations done as key:value pairs
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  annotations:
+  #  kubernetes.io/ingress.class: nginx
+
   ## The list of hostnames to be covered with this ingress record.
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
   hosts:
   - name: ghost.local
+    path: /
 
     ## Set this to true in order to enable TLS on the ingress record
-    ## A side effect of this will be that the backend ghost service will be connected at port 443
     tls: false
-
-    ## Set this to true in order to add the corresponding annotations for cert-manager
-    certManager: false
 
     ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
     tlsSecret: ghost.local-tls
-
-    ## Ingress annotations done as key:value pairs
-    ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
-    ##
-    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
-    annotations:
-    #  kubernetes.io/ingress.class: nginx
 
   secrets:
   ## If you're providing your own certificates, please use this to add the certificates as secrets


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR fixes an issue on certain env. when not specifying SMTP settings and reconfigure the way we create ingress rules. Instead of using multiples Ingress object, this PR uses the same Ingress object with different rules per host defined.


#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
