### PR TITLE
[incubator/haproxy-ingress] Updates and new features inspired by nginx-ingress chart

### DIFF
--- a/incubator/haproxy-ingress/Chart.yaml
+++ b/incubator/haproxy-ingress/Chart.yaml
@@ -1,6 +1,6 @@
 name: haproxy-ingress
-version: 0.0.4
-appVersion: 0.6.0
+version: 0.0.5
+appVersion: 0.7.0
 home: https://github.com/jcmoraisjr/haproxy-ingress
 description: Ingress controller implementation for haproxy loadbalancer.
 icon: http://www.haproxy.org/img/HAProxyCommunityEdition_60px.png

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -98,8 +98,8 @@ Parameter | Description | Default
 `controller.service.externalIPs` | list of IP addresses at which the controller services are available | `[]`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
 `controller.service.loadBalancerSourceRanges` |  | `[]`
-`controller.service.targetPorts.httpPorts` | The http ports to open, that map to the Ingress' port 80. Each entry specifies a `port` and an optional `nodePort`. | `[ port: 80 ]`
-`controller.service.targetPorts.httpsPorts` | The https ports to open, that map to the Ingress' port 443. Each entry specifies a `port` and an optional `nodePort`. | `[ port: 443 ]`
+`controller.service.httpPorts` | The http ports to open, that map to the Ingress' port 80. Each entry specifies a `port` and an optional `nodePort`. | `[ port: 80 ]`
+`controller.service.httpsPorts` | The https ports to open, that map to the Ingress' port 443. Each entry specifies a `port` and an optional `nodePort`. | `[ port: 443 ]`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
 `controller.stats.enabled` | whether to enable exporting stats |  `false`
 `controller.stats.port` | The port number used haproxy-ingress-controller for haproxy statistics | `1936`

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -1,6 +1,6 @@
 # haproxy-ingress
 
-[haproxy-ingress](https://github.com/jcmoraisjr/haproxy-ingress) is an Ingress controller that uses ConfigMap to store the haproxy configuration.
+[haproxy-ingress](https://github.com/jcmoraisjr/haproxy-ingress) is an Ingress controller that uses ConfigMap to store the global haproxy configuration, and ingress annotations to configure per-backend settings.
 
 ## Introduction
 
@@ -38,38 +38,109 @@ Parameter | Description | Default
 `rbac.create` | If true, create & use RBAC resources | `true`
 `serviceAccount.create` | If true, create serviceAccount | `true`
 `serviceAccount.name` | ServiceAccount to be used | ``
-`defaultBackend.name` | name of the default backend component | `ingress-default-backend`
-`defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`
-`defaultBackend.image.tag` | default backend container image repository tag | `1.0`
-`defaultBackend.image.pullPolicy` | default backend container image pullPolicy | `IfNotPresent`
-`defaultBackend.resources.cpu` | default backend cpu resources limit | `10m`
-`defaultBackend.resources.memory` | default backend memory resources limit | `20Mi`
-`defaultBackend.service.name` | name of default backend service to create | `ingress-default-backend`
 `controller.name` | name of the controller component | `controller`
 `controller.image.repository` | controller container image repository | `quay.io/jcmoraisjr/haproxy-ingress`
-`controller.image.tag` | controller container image tag | `v0.6`
+`controller.image.tag` | controller container image tag | `v0.7-beta.4`
 `controller.image.pullPolicy` | controller container image pullPolicy | `IfNotPresent`
-`controller.defaultSslCertificate.secret.namespace` | namespace of default certificate for controller | `{{ .Release.Namespace }}`
-`controller.defaultSslCertificate.secret.name` | name of the secret for default certificate of controller | `""`
+`controller.extraArgs` | extra command line arguments for the haproxy-ingress-controller | `{}`
+`controller.extraEnv` | extra environment variables for the haproxy-ingress-controller | `{}`
+`controller.template` | custom template for haproxy-ingress-controller | `{}`
+`controller.defaultBackendService` | backend service if defualtBackend.enabled==false | `""`
+`controller.ingressClass` | name of the ingress class to route through this controller | `happroxy`
+`controller.healthzPort` | The haproxy health check (monitoring) port | `10253`
+`controller.livenessProbe.path` | The liveness probe path | `/healthz`
+`controller.livenessProbe.port` | The livneness probe port | `10253`
+`controller.livenessProbe.failureThreshold` | The livneness probe failure threshold | `3`
+`controller.livenessProbe.initialDelaySeconds` | The livneness probe initial delay (in seconds) | `10`
+`controller.livenessProbe.periodSeconds` | The livneness probe period (in seconds) | `10`
+`controller.livenessProbe.successThreshold` | The livneness probe success threshold | `1`
+`controller.livenessProbe.timeoutSeconds` | The livneness probe timeout (in seconds) | `1`
+`controller.readinessProbe.path` | The readiness probe path | `/healthz`
+`controller.readinessProbe.port` | The readiness probe port | `10253`
+`controller.readinessProbe.failureThreshold` | The readiness probe failure threshold | `3`
+`controller.readinessProbe.initialDelaySeconds` | The readiness probe initial delay (in seconds) | `10`
+`controller.readinessProbe.periodSeconds` | The readiness probe period (in seconds) | `10`
+`controller.readinessProbe.successThreshold` | The readiness probe success threshold | `1`
+`controller.readinessProbe.timeoutSeconds` | The readiness probe timeout (in seconds) | `1`
+`controller.podAnnotations` | Annotations for the haproxy-ingress-conrtoller pod | `{}`
+`controller.podLabels` | Labels for the haproxy-ingress-conrtoller pod | `{}`
+`controller.securityContext` | Security context settings for the haproxy-ingress-conrtoller pod | `{}`
 `controller.config` | additional haproxy-ingress [ConfigMap entries](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#configmap) | `{}`
-`controller.healthzPort` | The port number for liveness and readiness checks | `10253`
-`controller.hostPorts.enable` | Enable host-ports for selected ports | `false`
-`controller.hostPorts.http` | If `controller.hostPorts.enable` is `true` and this is non-empty sets the hostPort for http | `"80"`
-`controller.hostPorts.https` | If `controller.hostPorts.enable` is `true` and this is non-empty sets the hostPort for https | `"443"`
-`controller.hostPorts.tcp` | If `controller.hostPorts.enable` is `true` use hostport for these ports from `tcp` | `[]`
-`controller.ingressClass` | name of the ingress class to route through this controller | `haproxy`
+`controller.hostNetwork` | Optionally set to true when using CNI based kubernetes installations | `false`
+`controller.dnsPolicy` | Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true' | `ClusterFirst`
+`controller.kind` | Type of deployment, DaemonSet or Deployment | `Deployment`
+`controller.tcp` | TCP [service ConfigMap](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#tcp-services-configmap): `<port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]` | `{}`
+`controller.daemonset.useHostPort` | Set to true to use host ports 80 and 443 | `false`
+`controller.daemonset.hostPorts.http` | If `controller.daemonset.useHostPort` is `true` and this is non-empty sets the hostPort for http | `"80"`
+`controller.daemonset.hostPorts.https` | If `controller.daemonset.useHostPort` is `true` and this is non-empty sets the hostPort for https | `"443"`
+`controller.daemonset.hostPorts.tcp` | If `controller.daemonset.useHostPort` is `true` use hostport for these ports from `tcp` | `[]`
+`controller.updateStrategy` | the update strategy settings | _see defaults below_
+`controller.updateStrategy.type` | the update strategy type to use | `RollingUpdate`
+`controller.updateStrategy.rollingUpdate.maxUnavailable` | the max number of unavailable controllers when doing rolling updates | `1`
+`controller.minReadySeconds` | seconds to avoid killing pods before we are ready | `0`
+`controller.replicaCount` | the number of replicas to deploy (when `controller.kind` is `Deployment`) | `1`
+`controller.minAvailable` | PodDisruptionBudget minimum available controller pods | `1`
 `controller.resources` | controller pod resource requests & limits | `{}`
-`controller.statsPort` | The port number for haproxy statistics | `1936`
+`controller.autoscaling.enabled` | enabling controller horizontal pod autoscaling (when `controller.kind` is `Deployment`) | `false`
+`controller.autoscaling.minReplicas` | minimum number of replicas | 
+`controller.autoscaling.maxReplicas` | maximum number of replicas | 
+`controller.autoscaling.targetCPUUtilizationPercentage` | target cpu utilization | 
+`controller.autoscaling.targetMemoryUtilizationPercentage` | target memory utilization | 
+`controller.autoscaling.customMetrics` | Extra custom metrics to add to the HPA | `[]`
+`controller.tolerations` | to control scheduling to servers with taints | `[]`
+`controller.affinity` | to control scheduling | `{}`
+`controller.nodeSelector` | to control scheduling | `{}`
+`controller.accessLogsSidecar` | enable a sidecar container that collects access logs from haproxy and outputs to stdout | `true`
 `controller.service.annotations` | annotations for controller service | `{}`
 `controller.service.labels` | labels for controller service | `{}`
 `controller.service.clusterIP` | internal controller cluster service IP | `""`
 `controller.service.externalTrafficPolicy` | external traffic policy | `Cluster`
-`controller.service.enableHttp` | if port 80 should be opened for service | `true`
-`controller.service.enableHttps` | if port 443 should be opened for service | `true`
+`controller.service.externalIPs` | list of IP addresses at which the controller services are available | `[]`
 `controller.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
-`controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
+`controller.service.loadBalancerSourceRanges` |  | `[]`
+`controller.service.targetPorts.httpPorts` | The http ports to open, that map to the Ingress' port 80. Each entry specifies a `port` and an optional `nodePort`. | `[ port: 80 ]`
+`controller.service.targetPorts.httpsPorts` | The https ports to open, that map to the Ingress' port 443. Each entry specifies a `port` and an optional `nodePort`. | `[ port: 443 ]`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
-`controller.service.nodePorts.http` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
-`controller.service.nodePorts.https` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`
-`tcp` | TCP [service ConfigMap](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/README.md#tcp-services-configmap): `<port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]` | `{}`
+`controller.stats.enabled` | whether to enable exporting stats |  `false`
+`controller.stats.port` | The port number used haproxy-ingress-controller for haproxy statistics | `1936`
+`controller.stats.service.annotations` | annotations for stats service | `{}`
+`controller.stats.service.clusterIP` | internal stats cluster service IP | `""`
+`controller.stats.service.externalIPs` | list of IP addresses at which the stats service is available | `[]`
+`controller.stats.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`controller.stats.service.loadBalancerSourceRanges` |  | `[]`
+`controller.stats.service.servicePort` | the port number exposed by the stats service | `1936`
+`controller.stats.service.type` | type of controller service to create | `ClusterIP`
+`controller.metrics.enabled` | If `controller.stats.enabled = true` and `controller.metrics.enabled = true`, Prometheus metrics will be exported |  `false`
+`controller.metrics.image.repository` | prometheus exporter container image repository | `quay.io/prometheus/haproxy-exporter`
+`controller.metrics.image.tag` | prometheus exporter image tag | `v0.9.0`
+`controller.metrics.image.pullPolicy` | prometheus exporter image pullPolicy | `IfNotPresent`
+`controller.metrics.service.annotations` | annotations for metrics service | `{}`
+`controller.metrics.service.clusterIP` | internal metrics cluster service IP | `""`
+`controller.metrics.service.externalIPs` | list of IP addresses at which the metrics service is available | `[]`
+`controller.metrics.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`controller.metrics.service.loadBalancerSourceRanges` |  | `[]`
+`controller.metrics.service.servicePort` | the port number exposed by the metrics service | `1936`
+`controller.metrics.service.type` | type of controller service to create | `ClusterIP`
+`defaultBackend.enabled` | whether to use the default backend component | `true`
+`defaultBackend.name` | name of the default backend component | `default-backend`
+`defaultBackend.image.repository` | default backend container image repository | `gcr.io/google_containers/defaultbackend`
+`defaultBackend.image.tag` | default backend container image repository tag | `1.0`
+`defaultBackend.image.pullPolicy` | default backend container image pullPolicy | `IfNotPresent`
+`defaultBackend.tolerations` | to control scheduling to servers with taints | `[]`
+`defaultBackend.affinity` | to control scheduling | `{}`
+`defaultBackend.nodeSelector` | to control scheduling | `{}`
+`defaultBackend.podAnnotations` | Annotations for the default backend pod | `{}`
+`defaultBackend.podLabels` | Labels for the default backend pod | `{}`
+`defaultBackend.replicaCount` | the number of replicas to deploy (when `controller.kind` is `Deployment`) | `1`
+`defaultBackend.minAvailable` | PodDisruptionBudget minimum available default backend pods | `1`
+`defaultBackend.resources` | default backend pod resources | _see defaults below_ 
+`defaultBackend.resources.limits.cpu` | default backend cpu resources limit | `10m`
+`defaultBackend.resources.limits.memory` | default backend memory resources limit | `20Mi`
+`defaultBackend.service.name` | name of default backend service to create | `ingress-default-backend`
+`defaultBackend.service.annotations` | annotations for metrics service | `{}`
+`defaultBackend.service.clusterIP` | internal metrics cluster service IP | `""`
+`defaultBackend.service.externalIPs` | list of IP addresses at which the metrics service is available | `[]`
+`defaultBackend.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
+`defaultBackend.service.loadBalancerSourceRanges` |  | `[]`
+`defaultBackend.service.servicePort` | the port number exposed by the metrics service | `1936`
+`defaultBackend.service.type` | type of controller service to create | `ClusterIP`

--- a/incubator/haproxy-ingress/README.md
+++ b/incubator/haproxy-ingress/README.md
@@ -40,7 +40,7 @@ Parameter | Description | Default
 `serviceAccount.name` | ServiceAccount to be used | ``
 `controller.name` | name of the controller component | `controller`
 `controller.image.repository` | controller container image repository | `quay.io/jcmoraisjr/haproxy-ingress`
-`controller.image.tag` | controller container image tag | `v0.7-beta.4`
+`controller.image.tag` | controller container image tag | `v0.7-beta.5`
 `controller.image.pullPolicy` | controller container image pullPolicy | `IfNotPresent`
 `controller.extraArgs` | extra command line arguments for the haproxy-ingress-controller | `{}`
 `controller.extraEnv` | extra environment variables for the haproxy-ingress-controller | `{}`

--- a/incubator/haproxy-ingress/templates/_helpers.tpl
+++ b/incubator/haproxy-ingress/templates/_helpers.tpl
@@ -33,6 +33,32 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create a default fully qualified controller name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "haproxy-ingress.controller.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.controller.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified default backend name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "haproxy-ingress.defaultBackend.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-%s" .Release.Name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "haproxy-ingress.serviceAccountName" -}}

--- a/incubator/haproxy-ingress/templates/clusterrole.yaml
+++ b/incubator/haproxy-ingress/templates/clusterrole.yaml
@@ -2,6 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   name: {{ template "haproxy-ingress.fullname" . }}
 rules:
   - apiGroups:

--- a/incubator/haproxy-ingress/templates/clusterrolebinding.yaml
+++ b/incubator/haproxy-ingress/templates/clusterrolebinding.yaml
@@ -2,6 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   name: {{ template "haproxy-ingress.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/incubator/haproxy-ingress/templates/controller-configmap.yaml
+++ b/incubator/haproxy-ingress/templates/controller-configmap.yaml
@@ -1,11 +1,19 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "haproxy-ingress.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxy-ingress.controller.fullname" . }}
 data:
   healthz-port: {{ .Values.controller.healthzPort | quote }}
-  stats-port: {{ .Values.controller.statsPort | quote }}
+  stats-port: {{ .Values.controller.stats.port | quote }}
+{{- if .Values.controller.accessLogsSidecar }}
+  syslog-endpoint: "localhost:514"
+{{- end }}
 {{- if .Values.controller.config }}
 {{ toYaml .Values.controller.config | indent 2 }}
 {{- end }}

--- a/incubator/haproxy-ingress/templates/controller-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/controller-deployment.yaml
@@ -1,6 +1,6 @@
-{{- if eq .Values.controller.kind "DaemonSet" }}
+{{- if eq .Values.controller.kind "Deployment" }}
 apiVersion: apps/v1beta2
-kind: DaemonSet
+kind: Deployment
 metadata:
   labels:
     app: {{ template "haproxy-ingress.name" . }}
@@ -10,7 +10,9 @@ metadata:
     heritage: {{ .Release.Service }}
   name: {{ template "haproxy-ingress.controller.fullname" . }}
 spec:
-  updateStrategy:
+  replicas: {{ .Values.controller.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
 {{ toYaml .Values.controller.updateStrategy | indent 4 }}
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   selector:
@@ -19,11 +21,11 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
-      {{- if .Values.controller.podAnnotations }}
       annotations:
 {{- if .Values.controller.template }}
         checksum/config: {{ include (print $.Template.BasePath "/controller-template.yaml") . | sha256sum }}
 {{- end }}
+      {{- if .Values.controller.podAnnotations }}
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
       {{- end }}
       labels:
@@ -57,16 +59,9 @@ spec:
           ports:
             - name: http
               containerPort: 80
-            {{- if (and .Values.controller.daemonset.useHostPort (not (empty .Values.controller.daemonset.hostPorts.http))) }}
-              hostPort: {{ .Values.controller.daemonset.hostPorts.http }}
-            {{- end }}
             - name: https
               containerPort: 443
-            {{- if (and .Values.controller.daemonset.useHostPort (not (empty .Values.controller.daemonset.hostPorts.https))) }}
-              hostPort: {{ .Values.controller.daemonset.hostPorts.https }}
-            {{- end }}
           {{- if .Values.controller.stats.enabled }}
-            - name: stats
             - name: stats
               containerPort: {{ .Values.controller.stats.port }}
               protocol: TCP
@@ -77,13 +72,6 @@ spec:
             - name: "{{ $key }}-tcp"
               containerPort: {{ $key }}
               protocol: TCP
-            {{- if $.Values.controller.daemonset.useHostPort }}
-              {{- range $p := $.Values.controller.daemonset.hostPorts.tcp }}
-                {{- if eq $key $p }}
-              hostPort: {{ $key }}
-                {{- end }}
-              {{- end }}
-            {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:
@@ -181,5 +169,9 @@ spec:
     {{- if .Values.controller.affinity }}
       affinity:
 {{ toYaml .Values.controller.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.controller.securityContext }}
+      securityContext:
+{{ toYaml .Values.controller.securityContext | indent 8 }}
     {{- end }}
 {{- end }}

--- a/incubator/haproxy-ingress/templates/controller-hpa.yaml
+++ b/incubator/haproxy-ingress/templates/controller-hpa.yaml
@@ -1,0 +1,35 @@
+{{- if and (eq .Values.controller.kind "Deployment") .Values.controller.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxy-ingress.controller.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta2
+    kind: Deployment
+    name: {{ template "haproxy-ingress.controller.fullname" . }}
+  minReplicas: {{ .Values.controller.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.controller.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controller.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
+{{- if .Values.controller.autoscaling.customMetrics }}
+{{ toYaml .Values.controller.autoscaling.customMetrics | indent 4 }}
+{{- end }}
+{{- end }}

--- a/incubator/haproxy-ingress/templates/controller-metrics-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-metrics-service.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.controller.stats.enabled .Values.controller.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.metrics.service.annotations }}
+  annotations:
+{{ toYaml .Values.controller.metrics.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "haproxy-ingress.controller.fullname" . }}-metrics
+spec:
+  clusterIP: "{{ .Values.controller.metrics.service.clusterIP }}"
+{{- if .Values.controller.metrics.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.metrics.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.controller.metrics.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.metrics.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.controller.metrics.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.metrics.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.controller.metrics.service.servicePort }}
+      targetPort: metrics
+  selector:
+    app: {{ template "haproxy-ingress.name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.controller.metrics.service.type }}"
+{{- end }}

--- a/incubator/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/incubator/haproxy-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxy-ingress.controller.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "haproxy-ingress.name" . }}
+      release: {{ .Release.Name }}
+      component: "{{ .Values.controller.name }}"
+  minAvailable: {{ .Values.controller.minAvailable }}

--- a/incubator/haproxy-ingress/templates/controller-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-service.yaml
@@ -11,9 +11,10 @@ metadata:
 {{- end }}
     app: {{ template "haproxy-ingress.name" . }}
     chart: {{ template "haproxy-ingress.chart" . }}
+    component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.fullname" . }}
+  name: {{ template "haproxy-ingress.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 {{- if .Values.controller.service.clusterIP }}
@@ -22,28 +23,39 @@ spec:
 {{- if .Values.controller.service.externalTrafficPolicy }}
   externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
 {{- end }}
+{{- if .Values.controller.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.service.externalIPs | indent 4 }}
+{{- end }}
 {{- if .Values.controller.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.controller.service.loadBalancerIP }}"
 {{- end }}
+{{- if .Values.controller.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+{{- if (.Values.controller.service.healthCheckNodePort) }}
+  healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
+{{- end }}
   ports:
-    {{- if .Values.controller.service.enableHttp }}
-    - name: http
-      port: 80
+  {{- range .Values.controller.service.httpPorts }}
+    - name: "{{ .port }}-http"
+      port: {{ .port }}
       protocol: TCP
-      targetPort: {{ .Values.controller.service.targetPorts.http }}
-      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
-      nodePort: {{ .Values.controller.service.nodePorts.http }}
+      targetPort: http
+      {{- if (not (empty .nodePort)) }}
+      nodePort: {{ .nodePort }}
       {{- end }}
-    {{- end }}
-    {{- if .Values.controller.service.enableHttps }}
-    - name: https
-      port: 443
+  {{- end }}
+  {{- range .Values.controller.service.httpsPorts }}
+    - name: "{{ .port }}-https"
+      port: {{ .port }}
       protocol: TCP
-      targetPort: {{ .Values.controller.service.targetPorts.https }}
-      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
-      nodePort: {{ .Values.controller.service.nodePorts.https }}
+      targetPort: https
+      {{- if (not (empty .nodePort)) }}
+      nodePort: {{ .nodePort }}
       {{- end }}
-    {{- end }}
+  {{- end }}
   {{- range $key, $value := .Values.tcp }}
     - name: "{{ $key }}-tcp"
       port: {{ $key }}
@@ -52,5 +64,6 @@ spec:
   {{- end }}
   selector:
     app: {{ template "haproxy-ingress.name" . }}
+    component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
   type: "{{ .Values.controller.service.type }}"

--- a/incubator/haproxy-ingress/templates/controller-stats-service.yaml
+++ b/incubator/haproxy-ingress/templates/controller-stats-service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.controller.stats.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.controller.stats.service.annotations }}
+  annotations:
+{{ toYaml .Values.controller.stats.service.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.controller.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "haproxy-ingress.controller.fullname" . }}-stats
+spec:
+  clusterIP: "{{ .Values.controller.stats.service.clusterIP }}"
+{{- if .Values.controller.stats.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.controller.stats.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.controller.stats.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.controller.stats.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.controller.stats.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.controller.stats.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  ports:
+    - name: stats
+      port: {{ .Values.controller.stats.service.servicePort }}
+      targetPort: stats
+  selector:
+    app: {{ template "haproxy-ingress.name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  type: "{{ .Values.controller.stats.service.type }}"
+{{- end }}

--- a/incubator/haproxy-ingress/templates/controller-template.yaml
+++ b/incubator/haproxy-ingress/templates/controller-template.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.tcp }}
+{{- if .Values.controller.template -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,7 +8,9 @@ metadata:
     component: "{{ .Values.controller.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ template "haproxy-ingress.controller.fullname" . }}-tcp
+  name: {{ template "haproxy-ingress.controller.fullname" . }}-template
 data:
-{{ toYaml .Values.controller.tcp | indent 2 }}
+  haproxy.tmpl: |-
+{{ .Values.controller.template | indent 4 }}
+{{/* .Files.Get "haproxy.tmpl" | indent 4 */}}
 {{- end }}

--- a/incubator/haproxy-ingress/templates/default-backend-deployment.yaml
+++ b/incubator/haproxy-ingress/templates/default-backend-deployment.yaml
@@ -1,13 +1,14 @@
+{{- if .Values.defaultBackend.enabled }}
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   labels:
     app: {{ template "haproxy-ingress.name" . }}
     chart: {{ template "haproxy-ingress.chart" . }}
+    component: "{{ .Values.defaultBackend.name }}"
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ .Values.defaultBackend.name }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "haproxy-ingress.defaultBackend.fullname" . }}
 spec:
   selector:
     matchLabels:
@@ -15,17 +16,39 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+    {{- if .Values.defaultBackend.podAnnotations }}
+      annotations:
+{{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
+    {{- end }}
       labels:
         app: {{ template "haproxy-ingress.name" . }}
+        component: "{{ .Values.defaultBackend.name }}"
         release: {{ .Release.Name }}
+        {{- if .Values.defaultBackend.podLabels }}
+{{ toYaml .Values.defaultBackend.podLabels | indent 8 }}
+        {{- end }}
     spec:
       containers:
         - name: {{ .Values.defaultBackend.name }}
           image: "{{ .Values.defaultBackend.image.repository }}:{{ .Values.defaultBackend.image.tag }}"
           imagePullPolicy: "{{ .Values.defaultBackend.image.pullPolicy }}"
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+              protocol: TCP
           resources:
-            limits:
-              cpu: {{ .Values.defaultBackend.resources.cpu }}
-              memory: {{ .Values.defaultBackend.resources.memory }}
+{{ toYaml .Values.defaultBackend.resources | indent 12 }}
+    {{- if .Values.defaultBackend.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.defaultBackend.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.tolerations }}
+      tolerations:
+{{ toYaml .Values.defaultBackend.tolerations | indent 8 }}
+    {{- end }}
+    {{- if .Values.defaultBackend.affinity }}
+      affinity:
+{{ toYaml .Values.defaultBackend.affinity | indent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: 60
+{{- end }}

--- a/incubator/haproxy-ingress/templates/default-backend-poddisruptionbudget.yaml
+++ b/incubator/haproxy-ingress/templates/default-backend-poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    component: "{{ .Values.defaultBackend.name }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "haproxy-ingress.defaultBackend.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "haproxy-ingress.name" . }}
+      release: {{ .Release.Name }}
+      component: "{{ .Values.defaultBackend.name }}"
+  minAvailable: {{ .Values.defaultBackend.minAvailable }}

--- a/incubator/haproxy-ingress/templates/default-backend-service.yaml
+++ b/incubator/haproxy-ingress/templates/default-backend-service.yaml
@@ -1,15 +1,41 @@
+{{- if .Values.defaultBackend.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.defaultBackend.service.name }}
+{{- if .Values.defaultBackend.service.annotations }}
+  annotations:
+{{ toYaml .Values.defaultBackend.service.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ template "haproxy-ingress.name" . }}
     chart: {{ template "haproxy-ingress.chart" . }}
+    component: "{{ .Values.defaultBackend.name }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  name: {{ template "haproxy-ingress.defaultBackend.fullname" . }}
 spec:
+{{- if .Values.defaultBackend.service.clusterIP }}
+  clusterIP: "{{ .Values.defaultBackend.service.clusterIP }}"
+{{- end }}
+{{- if .Values.defaultBackend.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.defaultBackend.service.externalIPs | indent 4 }}
+{{- end }}
+{{- if .Values.defaultBackend.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.defaultBackend.service.loadBalancerIP }}"
+{{- end }}
+{{- if .Values.defaultBackend.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.defaultBackend.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
   ports:
-    - port: 8080
+    - name: http
+      port: {{ .Values.defaultBackend.service.servicePort }}
+      protocol: TCP
+      targetPort: http
   selector:
     app: {{ template "haproxy-ingress.name" . }}
+    component: "{{ .Values.defaultBackend.name }}"
     release: {{ .Release.Name }}
+  type: "{{ .Values.defaultBackend.service.type }}"
+{{- end }}

--- a/incubator/haproxy-ingress/templates/role.yaml
+++ b/incubator/haproxy-ingress/templates/role.yaml
@@ -2,8 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   name: {{ template "haproxy-ingress.fullname" . }}
-  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/incubator/haproxy-ingress/templates/rolebinding.yaml
+++ b/incubator/haproxy-ingress/templates/rolebinding.yaml
@@ -2,8 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   name: {{ template "haproxy-ingress.fullname" . }}
-  namespace:  {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/incubator/haproxy-ingress/templates/serviceaccount.yaml
+++ b/incubator/haproxy-ingress/templates/serviceaccount.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: {{ template "haproxy-ingress.name" . }}
+    chart: {{ template "haproxy-ingress.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   name: {{ template "haproxy-ingress.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -179,13 +179,12 @@ controller:
     loadBalancerIP: ""
     loadBalancerSourceRanges: []
 
-    targetPorts:
-      httpPorts:
-        - port: 80
-        # nodePort:
-      httpsPorts:
-        - port: 443
-        # nodePort:
+    httpPorts:
+      - port: 80
+      # nodePort:
+    httpsPorts:
+      - port: 443
+      # nodePort:
 
     ## Set external traffic policy to: "Local" to preserve source IP on
     ## providers supporting it

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -10,80 +10,301 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-# Default 404 backend
-defaultBackend:
-  name: ingress-default-backend
-  image:
-    repository: gcr.io/google_containers/defaultbackend
-    tag: "1.0"
-    pullPolicy: IfNotPresent
-  resources:
-    cpu: 10m
-    memory: 20Mi
-
-  service:
-    name: ingress-default-backend
-
 controller:
   name: controller
   image:
     repository: quay.io/jcmoraisjr/haproxy-ingress
-    tag: "v0.6"
+    tag: "v0.7-beta.4"
     pullPolicy: IfNotPresent
 
-  defaultSslCertificate:
-    secret:
-      # If not set, release namespace is used
-      namespace:
-      # Required
-      name:
+  ## Additional command line arguments to pass to haproxy-ingress-controller
+  ## E.g. to specify the default SSL certificate you can use
+  ## extraArgs:
+  ##   default-ssl-certificate: "<namespace>/<secret_name>"
+  ##   reload-strategy: "reusesocket"
+  extraArgs: {}
+
+  ## Additional environment variables to set
+  extraEnvs: []
+  # extraEnvs:
+  #   - name: FOO
+  #     valueFrom:
+  #       secretKeyRef:
+  #         key: FOO
+  #         name: secret-resource
+
+  # custom haproxy template
+  template: ""
+
+  ## Required only if defaultBackend.enabled = false
+  ## Must be <namespace>/<service_name>
+  ##
+  defaultBackendService: ""
+
+  ## Name of the ingress class to route through this controller
+  ##
+  ingressClass: haproxy
+
+  healthzPort: 10253
+
+  ## Liveness and readiness probe values
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    path: /healthz
+    port: 10253
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  readinessProbe:
+    path: /healthz
+    port: 10253
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+
+  ## Annotations to be added to controller pods
+  ##
+  podAnnotations: {}
+
+  ## Labels to be added to the controller pods
+  ##
+  podLabels: {}
+
+  ## Security context settings to be added to the controller pods
+  ##
+  securityContext: {}
+  #  sysctls:
+  #  - name: net.ipv4.ip_local_port_range
+  #    value: "1024 65535"
 
   # ConfigMap to configure haproxy ingress
   config: {}
 
-  # Use host ports?
-  hostPorts:
-    enable: false
-    http: 80
-    https: 443
-    # List of ports from tcp map
-    tcp: []
+  # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
+  # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
+  # is merged
+  hostNetwork: false
 
+  # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.
+  # By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller
+  # to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
+  dnsPolicy: ClusterFirst
 
-  # Name of the ingress class to route through this controller
-  ingressClass: haproxy
+  ## DaemonSet or Deployment
+  ##
+  kind: Deployment
 
-  healthzPort: 10253
-  statsPort: 1936
+  # TCP service key:value pairs
+  # <port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]
+  # https://github.com/jcmoraisjr/haproxy-ingress/tree/v0.6#tcp-services-configmap
+  tcp: {}
+  #  8080: "default/example-tcp-svc:9000"
+
+  ## Use host ports 80 and 443
+  daemonset:
+    useHostPort: false
+
+    hostPorts:
+      http: 80
+      https: 443
+      # List of ports from controller.tcp map
+      tcp: []
+
+  # The update strategy to apply to the Deployment or DaemonSet
+  ##
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+
+  # minReadySeconds to avoid killing pods before we are ready
+  ##
+  minReadySeconds: 0
+
+  # Deployment
+  replicaCount: 1
+
+  # PodDisruptionBudget
+  minAvailable: 1
+
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 64Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 64Mi
+
+  autoscaling:
+    enabled: false
+  #  minReplicas: 1
+  #  maxReplicas: 11
+  #  targetCPUUtilizationPercentage: 50
+  #  targetMemoryUtilizationPercentage: 50
+    customMetrics: []
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  affinity: {}
+
+  ## Node labels for controller pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  accessLogsSidecar: true
 
   service:
     annotations: {}
     labels: {}
     clusterIP: ""
-    externalTrafficPolicy: ""
+
+    ## List of IP addresses at which the controller services are available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
 
     targetPorts:
-      http: 80
-      https: 443
+      httpPorts:
+        - port: 80
+        # nodePort:
+      httpsPorts:
+        - port: 443
+        # nodePort:
+
+    ## Set external traffic policy to: "Local" to preserve source IP on
+    ## providers supporting it
+    ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+    externalTrafficPolicy: ""
+
+    healthCheckNodePort: 0
 
     type: LoadBalancer
+
+  stats:
+    enabled: false
+    port: 1936
+
+    service:
+      annotations: {}
+      clusterIP: ""
+
+      ## List of IP addresses at which the stats service is available
+      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+      ##
+      externalIPs: []
+
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      servicePort: 1936
+      type: ClusterIP
+
+  ## If controller.stats.enabled = true and controller.metrics.enabled = true, Prometheus metrics will be exported
+  ##
+  metrics:
+    enabled: false
+
+    # prometheus exporter for haproxy
+    # https://github.com/prometheus/haproxy_exporter
+    # (scrapes the stats port and exports metrics to prometheus)
+    image:
+      repository: quay.io/prometheus/haproxy-exporter
+      tag: "v0.9.0"
+      pullPolicy: IfNotPresent
+
+    service:
+      annotations: {}
+      # prometheus.io/scrape: "true"
+      # prometheus.io/port: "10254"
+
+      clusterIP: ""
+
+      ## List of IP addresses at which the stats-exporter service is available
+      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+      ##
+      externalIPs: []
+
+      loadBalancerIP: ""
+      loadBalancerSourceRanges: []
+      servicePort: 9101
+      type: ClusterIP
+
+# Default 404 backend
+defaultBackend:
+  ## If false, controller.defaultBackendService must be provided
+  ##
+  enabled: true
+
+  name: default-backend
+  image:
+    repository: gcr.io/google_containers/defaultbackend
+    tag: "1.0"
+    pullPolicy: IfNotPresent
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  affinity: {}
+
+  ## Node labels for default backend pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Annotations to be added to default backend pods
+  ##
+  podAnnotations: {}
+
+  # labels to add to the pod container metadata
+  podLabels: {}
+  #  key: value
+
+  # Deployment
+  replicaCount: 1
+
+  # PodDisruptionBudget
+  minAvailable: 1
+
+  resources:
+    limits:
+      cpu: 10m
+      memory: 20Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 20Mi
+
+  service:
+    name: ingress-default-backend
+    annotations: {}
+    clusterIP: ""
+
+    ## List of IP addresses at which the default backend service is available
+    ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+    ##
+    externalIPs: []
+
     loadBalancerIP: ""
-
-    enableHttp: true
-    enableHttps: true
-
-    # type: NodePort
-    # nodePorts:
-    #   http: 32080
-    #   https: 32443
-    nodePorts:
-      http: ""
-      https: ""
-
-  resources: {}
-
-# TCP service key:value pairs
-# <port>: <namespace>/<servicename>:<portnumber>[:[<in-proxy>][:<out-proxy>]]
-# https://github.com/jcmoraisjr/haproxy-ingress/tree/v0.6#tcp-services-configmap
-tcp: {}
-#  8080: "default/example-tcp-svc:9000"
+    loadBalancerSourceRanges: []
+    servicePort: 8080
+    type: ClusterIP

--- a/incubator/haproxy-ingress/values.yaml
+++ b/incubator/haproxy-ingress/values.yaml
@@ -14,7 +14,7 @@ controller:
   name: controller
   image:
     repository: quay.io/jcmoraisjr/haproxy-ingress
-    tag: "v0.7-beta.4"
+    tag: "v0.7-beta.5"
     pullPolicy: IfNotPresent
 
   ## Additional command line arguments to pass to haproxy-ingress-controller


### PR DESCRIPTION
Updates:

* Upgrade haproxy-ingress to v0.7-beta.5
* Sidecar container for exporting metrics to prometheus
* Sidecar container for collecting haproxy access logs and exporting to stdout

Features inspired by nginx-ingress chart:

* Allow deploying the ingress controller as DaemonSet or Deployment
* Allow autoscaling (hpa) an ingress controller Deployment
* Allow using custom metrics when autoscaling
* Allow setting annotations and labels on the ingress controller
* Allow specifying extra args and extra environment variables for the ingress controller
* Allow specifying hostNetwork, dnsPolicy and securityContext on the ingress controller
* Allow opening multiple http and https public ports in the ingress service
* Allow specifying externalIPs, loadBalancerSourceRanges, healthCheckNodePort on the ingress service
* Allow configuring the default backend and default backend service in more detail
* Allow configuring the liveness and readiness probes for the ingress controller
* Allow using a custom haproxy template
* Added services for stats and metrics
* Added a PodDisruptionBudgets for the haproxy-ingress-controller and default backend

Signed-off-by: Magnus Hyllander <magnus.hyllander@hivestreaming.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Adds many of the features available in the nginx-ingress chart, which increases the ability to use haproxy-ingress as a replacement.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

#### Special notes for your reviewer:
@xianlubird Instead of enabling the external http and https ports using true/false, I enable them by specifying port numbers. This allows mapping several external ports, e.g. both 80 and 8080 for incoming http traffic.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
