### PR TITLE
[stable][sentry] Allow usage of existing secrets for sensitive data 

### DIFF
--- a/stable/sentry/Chart.yaml
+++ b/stable/sentry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Sentry is a cross-platform crash reporting and aggregation platform.
 name: sentry
-version: 1.0.0
+version: 1.1.0
 appVersion: 9.0
 keywords:
   - debugging

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -56,63 +56,63 @@ $ kubectl delete job/sentry-db-init job/sentry-user-create
 
 The following table lists the configurable parameters of the Sentry chart and their default values.
 
-| Parameter                            | Description                                 | Default                                                    |
-| -------------------------------      | -------------------------------             | ---------------------------------------------------------- |
-| `image.repository`                   | Sentry image                                | `library/sentry`                                           |
-| `image.tag`                          | Sentry image tag                            | `9.0`                                                      |
-| `imagePullPolicy`                    | Image pull policy                           | `IfNotPresent`                                             |
+| Parameter                       | Description                                             | Default                                                    |
+| ------------------------------- | -------------------------------                         | ---------------------------------------------------------- |
+| `image.repository`              | Sentry image                                            | `library/sentry`                                           |
+| `image.tag`                     | Sentry image tag                                        | `9.0`                                                      |
+| `imagePullPolicy`               | Image pull policy                                       | `IfNotPresent`                                             |
 | `sentrySecret`                  | Sentry Secret Key                                       | `nil`                                                      |
 | `existingSentrySecret`          | Name of existing secret to use for Sentry Secret        | `nil`                                                      |
-| `web.podAnnotations`                 | Web pod annotations                         | `{}`                                                       |
-| `web.replicacount`                   | Amount of web pods to run                   | `1`                                                        |
-| `web.resources.limits`               | Web resource limits                         | `{cpu: 500m, memory: 500Mi}`                               |
-| `web.resources.requests`             | Web resource requests                       | `{cpu: 300m, memory: 300Mi}`                               |
-| `web.env`                            | Additional web environment variables        | `[{name: GITHUB_APP_ID}, {name: GITHUB_API_SECRET}]`       |
-| `web.nodeSelector`                   | Node labels for web pod assignment          | `{}`                                                       |
-| `web.affinity`                       | Affinity settings for web pod assignment    | `{}`                                                       |
-| `web.schedulerName`                  | Name of an alternate scheduler for web pod  | `nil`                                                      |
-| `web.tolerations`                    | Toleration labels for web pod assignment    | `[]`                                                       |
-| `cron.podAnnotations`                | Cron pod annotations                        | `{}`                                                       |
-| `cron.replicacount`                  | Amount of cron pods to run                  | `1`                                                        |
-| `cron.resources.limits`              | Cron resource limits                        | `{cpu: 200m, memory: 200Mi}`                               |
-| `cron.resources.requests`            | Cron resource requests                      | `{cpu: 100m, memory: 100Mi}`                               |
-| `cron.nodeSelector`                  | Node labels for cron pod assignment         | `{}`                                                       |
-| `cron.affinity`                      | Affinity settings for cron pod assignment   | `{}`                                                       |
-| `cron.schedulerName`                 | Name of an alternate scheduler for cron pod | `nil`                                                      |
-| `cron.tolerations`                   | Toleration labels for cron pod assignment   | `[]`                                                       |
-| `worker.podAnnotations`              | Worker pod annotations                      | `{}`                                                       |
-| `worker.replicacount`                | Amount of worker pods to run                | `2`                                                        |
-| `worker.resources.limits`            | Worker resource limits                      | `{cpu: 300m, memory: 500Mi}`                               |
-| `worker.resources.requests`          | Worker resource requests                    | `{cpu: 100m, memory: 100Mi}`                               |
-| `worker.nodeSelector`                | Node labels for worker pod assignment       | `{}`                                                       |
-| `worker.schedulerName`               | Name of an alternate scheduler for worker   | `nil`                                                      |
-| `worker.affinity`                    | Affinity settings for worker pod assignment | `{}`                                                       |
-| `worker.tolerations`                 | Toleration labels for worker pod assignment | `[]`                                                       |
-| `user.create`                        | Create the default admin                    | `true`                                                     |
-| `user.email`                         | Username for default admin                  | `admin@sentry.local`                                       |
+| `web.podAnnotations`            | Web pod annotations                                     | `{}`                                                       |
+| `web.replicacount`              | Amount of web pods to run                               | `1`                                                        |
+| `web.resources.limits`          | Web resource limits                                     | `{cpu: 500m, memory: 500Mi}`                               |
+| `web.resources.requests`        | Web resource requests                                   | `{cpu: 300m, memory: 300Mi}`                               |
+| `web.env`                       | Additional web environment variables                    | `[{name: GITHUB_APP_ID}, {name: GITHUB_API_SECRET}]`       |
+| `web.nodeSelector`              | Node labels for web pod assignment                      | `{}`                                                       |
+| `web.affinity`                  | Affinity settings for web pod assignment                | `{}`                                                       |
+| `web.schedulerName`             | Name of an alternate scheduler for web pod              | `nil`                                                      |
+| `web.tolerations`               | Toleration labels for web pod assignment                | `[]`                                                       |
+| `cron.podAnnotations`           | Cron pod annotations                                    | `{}`                                                       |
+| `cron.replicacount`             | Amount of cron pods to run                              | `1`                                                        |
+| `cron.resources.limits`         | Cron resource limits                                    | `{cpu: 200m, memory: 200Mi}`                               |
+| `cron.resources.requests`       | Cron resource requests                                  | `{cpu: 100m, memory: 100Mi}`                               |
+| `cron.nodeSelector`             | Node labels for cron pod assignment                     | `{}`                                                       |
+| `cron.affinity`                 | Affinity settings for cron pod assignment               | `{}`                                                       |
+| `cron.schedulerName`            | Name of an alternate scheduler for cron pod             | `nil`                                                      |
+| `cron.tolerations`              | Toleration labels for cron pod assignment               | `[]`                                                       |
+| `worker.podAnnotations`         | Worker pod annotations                                  | `{}`                                                       |
+| `worker.replicacount`           | Amount of worker pods to run                            | `2`                                                        |
+| `worker.resources.limits`       | Worker resource limits                                  | `{cpu: 300m, memory: 500Mi}`                               |
+| `worker.resources.requests`     | Worker resource requests                                | `{cpu: 100m, memory: 100Mi}`                               |
+| `worker.nodeSelector`           | Node labels for worker pod assignment                   | `{}`                                                       |
+| `worker.schedulerName`          | Name of an alternate scheduler for worker               | `nil`                                                      |
+| `worker.affinity`               | Affinity settings for worker pod assignment             | `{}`                                                       |
+| `worker.tolerations`            | Toleration labels for worker pod assignment             | `[]`                                                       |
+| `user.create`                   | Create the default admin                                | `true`                                                     |
+| `user.email`                    | Username for default admin                              | `admin@sentry.local`                                       |
 | `user.existingUserSecret`       | Name of existing secret to use for Sentry user password | `nil`                                                      |
-| `email.from_address`                 | Email notifications are from                | `smtp`                                                     |
-| `email.host`                         | SMTP host for sending email                 | `smtp`                                                     |
-| `email.port`                         | SMTP port                                   | `25`                                                       |
-| `email.user`                         | SMTP user                                   | `nil`                                                      |
-| `email.password`                     | SMTP password                               | `nil`                                                      |
-| `email.use_tls`                      | SMTP TLS for security                       | `false`                                                    |
-| `email.enable_replies`               | Allow email replies                         | `false`                                                    |
+| `email.from_address`            | Email notifications are from                            | `smtp`                                                     |
+| `email.host`                    | SMTP host for sending email                             | `smtp`                                                     |
+| `email.port`                    | SMTP port                                               | `25`                                                       |
+| `email.user`                    | SMTP user                                               | `nil`                                                      |
+| `email.password`                | SMTP password                                           | `nil`                                                      |
+| `email.use_tls`                 | SMTP TLS for security                                   | `false`                                                    |
+| `email.enable_replies`          | Allow email replies                                     | `false`                                                    |
 | `email.existingEmailSecret`     | Name of existing secret to use for Sentry smtp password | `nil`                                                      |
-| `service.type`                       | Kubernetes service type                     | `LoadBalancer`                                             |
-| `service.name`                       | Kubernetes service name                     | `sentry`                                                   |
-| `service.externalPort`               | Kubernetes external service port            | `9000`                                                     |
-| `service.internalPort`               | Kubernetes internal service port            | `9000`                                                     |
-| `ingress.enabled`                    | Enable ingress controller resource          | `false`                                                    |
-| `ingress.annotations`                | Ingress annotations                         | `{}`                                                       |
-| `ingress.hostname`                   | URL to address your Sentry installation     | `sentry.local`                                             |
-| `ingress.tls`                        | Ingress TLS configuration                   | `[]`                                                       |
-| `persistence.enabled`                | Enable persistence using PVC                | `true`                                                     |
-| `persistence.storageClass`           | PVC Storage Class                           | `nil` (uses alpha storage class annotation)                |
-| `persistence.accessMode`             | PVC Access Mode                             | `ReadWriteOnce`                                            |
-| `persistence.size`                   | PVC Storage Request                         | `10Gi`                                                     |
-| `config.configYml`                   | Sentry config.yml file                      | ``                                                         |
-| `config.sentryConfPy`                | Sentry sentry.conf.py file                  | ``                                                         |
+| `service.type`                  | Kubernetes service type                                 | `LoadBalancer`                                             |
+| `service.name`                  | Kubernetes service name                                 | `sentry`                                                   |
+| `service.externalPort`          | Kubernetes external service port                        | `9000`                                                     |
+| `service.internalPort`          | Kubernetes internal service port                        | `9000`                                                     |
+| `ingress.enabled`               | Enable ingress controller resource                      | `false`                                                    |
+| `ingress.annotations`           | Ingress annotations                                     | `{}`                                                       |
+| `ingress.hostname`              | URL to address your Sentry installation                 | `sentry.local`                                             |
+| `ingress.tls`                   | Ingress TLS configuration                               | `[]`                                                       |
+| `persistence.enabled`           | Enable persistence using PVC                            | `true`                                                     |
+| `persistence.storageClass`      | PVC Storage Class                                       | `nil` (uses alpha storage class annotation)                |
+| `persistence.accessMode`        | PVC Access Mode                                         | `ReadWriteOnce`                                            |
+| `persistence.size`              | PVC Storage Request                                     | `10Gi`                                                     |
+| `config.configYml`              | Sentry config.yml file                                  | ``                                                         |
+| `config.sentryConfPy`           | Sentry sentry.conf.py file                              | ``                                                         |
 
 Dependent charts can also have values overwritten. Preface values with postgresql.* or redis.*
 

--- a/stable/sentry/README.md
+++ b/stable/sentry/README.md
@@ -61,6 +61,8 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `image.repository`                   | Sentry image                                | `library/sentry`                                           |
 | `image.tag`                          | Sentry image tag                            | `9.0`                                                      |
 | `imagePullPolicy`                    | Image pull policy                           | `IfNotPresent`                                             |
+| `sentrySecret`                  | Sentry Secret Key                                       | `nil`                                                      |
+| `existingSentrySecret`          | Name of existing secret to use for Sentry Secret        | `nil`                                                      |
 | `web.podAnnotations`                 | Web pod annotations                         | `{}`                                                       |
 | `web.replicacount`                   | Amount of web pods to run                   | `1`                                                        |
 | `web.resources.limits`               | Web resource limits                         | `{cpu: 500m, memory: 500Mi}`                               |
@@ -88,6 +90,7 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `worker.tolerations`                 | Toleration labels for worker pod assignment | `[]`                                                       |
 | `user.create`                        | Create the default admin                    | `true`                                                     |
 | `user.email`                         | Username for default admin                  | `admin@sentry.local`                                       |
+| `user.existingUserSecret`       | Name of existing secret to use for Sentry user password | `nil`                                                      |
 | `email.from_address`                 | Email notifications are from                | `smtp`                                                     |
 | `email.host`                         | SMTP host for sending email                 | `smtp`                                                     |
 | `email.port`                         | SMTP port                                   | `25`                                                       |
@@ -95,6 +98,7 @@ The following table lists the configurable parameters of the Sentry chart and th
 | `email.password`                     | SMTP password                               | `nil`                                                      |
 | `email.use_tls`                      | SMTP TLS for security                       | `false`                                                    |
 | `email.enable_replies`               | Allow email replies                         | `false`                                                    |
+| `email.existingEmailSecret`     | Name of existing secret to use for Sentry smtp password | `nil`                                                      |
 | `service.type`                       | Kubernetes service type                     | `LoadBalancer`                                             |
 | `service.name`                       | Kubernetes service name                     | `sentry`                                                   |
 | `service.externalPort`               | Kubernetes external service port            | `9000`                                                     |

--- a/stable/sentry/templates/NOTES.txt
+++ b/stable/sentry/templates/NOTES.txt
@@ -18,4 +18,4 @@
 
   USER: {{ .Values.user.email }}
   Get login password with
-    kubectl get secret --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath="{.data.user-password}" | base64 --decode
+    kubectl get secret --namespace {{ .Release.Namespace }} {{ template "sentry.userSecret" . }} -o jsonpath="{.data.user-password}" | base64 --decode

--- a/stable/sentry/templates/_helpers.tpl
+++ b/stable/sentry/templates/_helpers.tpl
@@ -25,6 +25,39 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create the name for the sentry secret.
+*/}}
+{{- define "sentry.secretSecret" -}}
+    {{- if .Values.existingSentrySecret -}}
+        {{- .Values.existingSentrySecret -}}
+    {{- else -}}
+        {{- template "fullname" . -}}-secret
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the sentry email secret.
+*/}}
+{{- define "sentry.emailSecret" -}}
+    {{- if .Values.email.existingEmailSecret -}}
+        {{- .Values.email.existingEmailSecret -}}
+    {{- else -}}
+        {{- template "fullname" . -}}-email
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the sentry user secret.
+*/}}
+{{- define "sentry.userSecret" -}}
+    {{- if .Values.user.existingUserSecret -}}
+        {{- .Values.user.existingUserSecret -}}
+    {{- else -}}
+        {{- template "fullname" . -}}-user
+    {{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/sentry/templates/cron-deployment.yaml
+++ b/stable/sentry/templates/cron-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.secretSecret" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresUser | quote }}
@@ -91,7 +91,7 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.emailSecret" . }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}

--- a/stable/sentry/templates/hooks/db-init.job.yaml
+++ b/stable/sentry/templates/hooks/db-init.job.yaml
@@ -34,7 +34,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.secretSecret" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresUser | quote }}
@@ -75,7 +75,7 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.emailSecret" . }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}

--- a/stable/sentry/templates/hooks/user-create.job.yaml
+++ b/stable/sentry/templates/hooks/user-create.job.yaml
@@ -34,7 +34,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.secretSecret" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresUser | quote }}
@@ -75,12 +75,12 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.emailSecret" . }}
               key: smtp-password
         - name: SENTRY_USER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.userSecret" . }}
               key: user-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}

--- a/stable/sentry/templates/sentry-email-secret.yaml
+++ b/stable/sentry/templates/sentry-email-secret.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.email.existingEmailSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sentry.emailSecret" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  smtp-password: {{ default "" .Values.email.password | b64enc | quote }}
+{{- end -}}

--- a/stable/sentry/templates/sentry-secret-secret.yaml
+++ b/stable/sentry/templates/sentry-secret-secret.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.existingSentrySecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "sentry.secretSecret" . }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
@@ -14,9 +15,4 @@ data:
   {{ else }}
   sentry-secret: {{ randAlphaNum 40 | b64enc | quote }}
   {{ end }}
-  smtp-password: {{ default "" .Values.email.password | b64enc | quote }}
-  {{ if .Values.user.password }}
-  user-password: {{ .Values.user.password | b64enc | quote }}
-  {{ else }}
-  user-password: {{ randAlphaNum 16 | b64enc | quote }}
-  {{ end }}
+{{- end -}}

--- a/stable/sentry/templates/sentry-user-secret.yaml
+++ b/stable/sentry/templates/sentry-user-secret.yaml
@@ -1,0 +1,18 @@
+{{- if and (.Values.user.create) (not .Values.user.existingUserSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sentry.userSecret" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if .Values.user.password }}
+  user-password: {{ .Values.user.password | b64enc | quote }}
+  {{ else }}
+  user-password: {{ randAlphaNum 16 | b64enc | quote }}
+  {{ end }}
+  {{- end -}}

--- a/stable/sentry/templates/web-deployment.yaml
+++ b/stable/sentry/templates/web-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.secretSecret" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresUser | quote }}
@@ -90,7 +90,7 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.emailSecret" . }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}

--- a/stable/sentry/templates/workers-deployment.yaml
+++ b/stable/sentry/templates/workers-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: SENTRY_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.secretSecret" . }}
               key: sentry-secret
         - name: SENTRY_DB_USER
           value: {{ default "sentry" .Values.postgresUser | quote }}
@@ -91,7 +91,7 @@ spec:
         - name: SENTRY_EMAIL_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}
+              name: {{ template "sentry.emailSecret" . }}
               key: smtp-password
         - name: SENTRY_EMAIL_USE_TLS
           value: {{ .Values.email.use_tls | quote }}

--- a/stable/sentry/values.yaml
+++ b/stable/sentry/values.yaml
@@ -9,6 +9,9 @@ image:
   imagePullSecrets: []
   # - name:
 
+sentrySecret:
+existingSentrySecret:
+
 # How many web UI instances to run
 web:
   replicacount: 1
@@ -69,6 +72,7 @@ user:
   # Default is true as the initial installation.
   create: true
   email: admin@sentry.local
+  existingUserSecret:
 
 # BYO Email server
 # TODO: Add exim4 template
@@ -81,6 +85,7 @@ email:
   user:
   password:
   enable_replies: false
+  existingEmailSecret:
 
 # Name of the service and what port to expose on the pod
 # Don't change these unless you know what you're doing


### PR DESCRIPTION
#### What this PR does / why we need it:
This enable the user to provide an already created secret for sensitive data. This is useful when using gitops and everything is committed.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
