### PR TITLE
Fix clusterchecks leader election

### DIFF
--- a/stable/datadog/Chart.yaml
+++ b/stable/datadog/Chart.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 1.15.0
+version: 1.15.1
 appVersion: 6.6.0
 description: DataDog Agent
 keywords:

--- a/stable/datadog/templates/NOTES.txt
+++ b/stable/datadog/templates/NOTES.txt
@@ -53,6 +53,9 @@ Create an application key at https://app.datadoghq.com/account/settings#api
 Because you enabled the Cluster Agent but did not provide a token, a random token was generated.
 This token is used to secure the communication between the Agents and the Cluster Agent.
 
+Make sure to recreate all pods on upgrade (with the --recreate-pods flag) to ensure all
+agents use the same shared token.
+
   {{- end }}
 
 {{- end }}

--- a/stable/datadog/templates/cluster-agent-deployment.yaml
+++ b/stable/datadog/templates/cluster-agent-deployment.yaml
@@ -74,6 +74,8 @@ spec:
           {{- if .Values.datadog.collectEvents }}
           - name: DD_COLLECT_KUBERNETES_EVENTS
             value: {{ .Values.datadog.collectEvents | quote}}
+          - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
+            value: {{ template "datadog.clusterAgent.fullname" . }}
           {{- end }}
           - name: DD_CLUSTER_AGENT_AUTH_TOKEN
             valueFrom:


### PR DESCRIPTION
#### What this PR does / why we need it:

- Propagate the `DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME` envvar to the cluster-agent pods, as we use this service name to get the IP of the leader: https://github.com/DataDog/datadog-agent/pull/2706
- Reword the install note of no cluster-agent token is set: the secret will churn on chart upgrade and all pods need to be recreated to use the new secret.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
