### PR TITLE
[external-dns] Fix 'error calling eq: invalid type for comparison'

### DIFF
--- a/stable/external-dns/Chart.yaml
+++ b/stable/external-dns/Chart.yaml
@@ -3,7 +3,7 @@ description:
   Configure external DNS servers (AWS Route53, Google CloudDNS and others)
   for Kubernetes Ingresses and Services
 name: external-dns
-version: 1.3.2
+version: 1.3.3
 appVersion: 0.5.9
 home: https://github.com/kubernetes-incubator/external-dns
 sources:

--- a/stable/external-dns/templates/secret.yaml
+++ b/stable/external-dns/templates/secret.yaml
@@ -11,7 +11,7 @@ data:
   credentials: {{ include "external-dns.aws-credentials" . | b64enc | quote }}
   config: {{ include "external-dns.aws-config" . | b64enc | quote }}
 {{- end}}
-{{- if and (eq .Values.provider "google" .Values.google.serviceAccountKey) }}
+{{- if and (eq .Values.provider "google") .Values.google.serviceAccountKey }}
   credentials.json: {{ .Values.google.serviceAccountKey | b64enc | quote }}
 {{- end}}
 {{- if .Values.cloudflare.apiKey }}

--- a/stable/external-dns/values.yaml
+++ b/stable/external-dns/values.yaml
@@ -41,6 +41,7 @@ cloudflare:
 google:
   project: ""
   serviceAccountSecret: ""
+  serviceAccountKey: ""
 
 # Infoblox keys to inject
 infoblox:


### PR DESCRIPTION
#### What this PR does / why we need it: 
This is follow up to the PR https://github.com/helm/charts/pull/8882

#### Which issue this PR fixes
https://github.com/helm/charts/issues/10476

#### Special notes for your reviewer:
I've checked with:
```
provider: aws
aws:
  accessKey: changeme
  secretKey: changeme
  region: changeme
```
and with 
```
provider: google
google:
  project: test
  serviceAccountSecret: test
```
and one more with set `serviceAccountKey` instead of `serviceAccountSecret`.
In all cases, chart was rendered without error described here https://github.com/helm/charts/issues/10476

@linki maybe you can have a look?

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
