### PR TITLE
[stable/ghost] Set Ghost Protocol to 'http' by default

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 6.2.0
+version: 6.2.1
 appVersion: 2.9.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -37,7 +37,7 @@ volumePermissions:
 ## Ghost protocol, host and path to create application URLs
 ## ref: https://github.com/bitnami/bitnami-docker-ghost#configuration
 ##
-ghostProtocol: https
+ghostProtocol: http
 # ghostHost:
 ghostPath: /
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

As described in the link below, the default value for Ghost Protocol should be 'http':

https://github.com/bitnami/bitnami-docker-ghost#user-and-site-configuration

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
