### PR TITLE
[stable/prometheus-operator] Conditional creation of etcd rule

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 1.5.2
+version: 1.5.3
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/templates/alertmanager/rules/kube-etcd.rules.yaml
+++ b/stable/prometheus-operator/templates/alertmanager/rules/kube-etcd.rules.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.defaultRules.create }}
+{{- if and .Values.defaultRules.create .Values.kubeEtcd.enabled }}
 # these rules synced manually from https://github.com/etcd-io/etcd/blob/master/Documentation/etcd-mixin/mixin.libsonnet
 apiVersion: {{ printf "%s/v1" (.Values.prometheusOperator.crdApiGroup | default "monitoring.coreos.com") }}
 kind: PrometheusRule


### PR DESCRIPTION
#### What this PR does / why we need it:

We generally don't want the Prometheus etcd rule to be created
when `kubeEtcd.enabled` is set to `false`.

#### Which issue this PR fixes

The Prometheus etcd rule is created even if `kubeEtcd.enabled`
is set to `false`.

Ping @gianrubio 