### PR TITLE
[stable/ark] Add hook tolerations and nodeselector

### DIFF
--- a/stable/ark/Chart.yaml
+++ b/stable/ark/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.9.1
 description: A Helm chart for ark
 name: ark
-version: 1.2.5
+version: 1.2.6
 home: https://github.com/heptio/ark
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
 

--- a/stable/ark/templates/hook-delete.yaml
+++ b/stable/ark/templates/hook-delete.yaml
@@ -37,4 +37,12 @@ spec:
           configMap:
             name: {{ template "ark.fullname" . }}
       serviceAccountName: {{ template "ark.hookServiceAccount" . }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 {{- end -}}

--- a/stable/ark/templates/hook-deploy.yaml
+++ b/stable/ark/templates/hook-deploy.yaml
@@ -37,4 +37,12 @@ spec:
           configMap:
             name: {{ template "ark.fullname" . }}
       serviceAccountName: {{ template "ark.hookServiceAccount" . }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

This is needed to allow the `hook-` jobs to run in environments consisting only of tainted nodes.

The jobs are assumed to be runnable on the same nodes as the main deployment, so they use the same values. If this assumption proves invalid, new hook-specific values could be added in future.

#### Which issue this PR fixes

  - fixes #9537

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
