### PR TITLE
[stable/grafana] Fix PodSecurityPolicy for persistence init container

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,5 +1,5 @@
 name: grafana
-version: 1.23.0
+version: 1.23.1
 appVersion: 5.4.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/podsecuritypolicy.yaml
+++ b/stable/grafana/templates/podsecuritypolicy.yaml
@@ -19,7 +19,19 @@ spec:
   privileged: false
   allowPrivilegeEscalation: false
   requiredDropCapabilities:
-    - ALL
+    # Default set from Docker, without DAC_OVERRIDE or CHOWN
+    - FOWNER
+    - FSETID
+    - KILL
+    - SETGID
+    - SETUID
+    - SETPCAP
+    - NET_BIND_SERVICE
+    - NET_RAW
+    - SYS_CHROOT
+    - MKNOD
+    - AUDIT_WRITE
+    - SETFCAP
   volumes:
     - 'configMap'
     - 'emptyDir'


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adjusts PodSecurityPolicy to include the capabilities required by the `init-chown-data` container. This fixes a regression which prevented the chart from being installed with `persistence.enabled: true` on clusters with the PodSecurityPolicy admission controller enabled.

#### Which issue this PR fixes
  - fixes #10453 

#### Special notes for your reviewer:
By default, root processes in unprivileged containers are granted a set of capabilities that grant a restricted set of powers. The current PodSecurityPolicy (if enforced) causes those capabilities to be dropped, which prevents the `chown` command from completing successfully.

This PR replaces the `ALL` in `requiredDropCapabilities` with Docker's default set minus two capabilities: CHOWN and DAC_OVERRIDE. The first of these capabilities is necessary to change a file's owner, the second is necessary to permit `chown` to traverse directories to which root doesn't otherwise have access (e.g. owned by 472:472 with mode 770).

Strictly speaking DAC_OVERRIDE isn't necessary, only `DAC_READ_SEARCH` is, but as it's not included in the default set using it is slightly more complex. I don't think there's much practical benefit since by default the only process with any capabilities at all is the `chown` process (everything else runs as 472 and gets no capabilities at all).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
