### PR TITLE
[stable/ghost] Add parameter to configure SMTP 'fromAddress'

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 6.2.2
+version: 6.2.3
 appVersion: 2.10.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `smtpPort`                          | SMTP port                                                     | `nil`                                                    |
 | `smtpUser`                          | SMTP user                                                     | `nil`                                                    |
 | `smtpPassword`                      | SMTP password                                                 | `nil`                                                    |
+| `smtpFromAddress`                   | SMTP from address                                             | `nil`                                                    |
 | `smtpService`                       | SMTP service                                                  | `nil`                                                    |
 | `allowEmptyPassword`                | Allow DB blank passwords                                      | `yes`                                                    |
 | `serviceType`                       | Kubernetes Service type                                       | `LoadBalancer`                                           |

--- a/stable/ghost/templates/deployment.yaml
+++ b/stable/ghost/templates/deployment.yaml
@@ -121,6 +121,10 @@ spec:
               name: {{ template "ghost.fullname" . }}
               key: smtp-password
         {{- end }}
+        {{- if .Values.smtpFromAddress }}
+        - name: SMTP_FROM_ADDRESS
+          value: {{ .Values.smtpFromAddress | quote }}
+        {{- end }}
         {{- if .Values.smtpService }}
         - name: SMTP_SERVICE
           value: {{ .Values.smtpService | quote }}

--- a/stable/ghost/values.yaml
+++ b/stable/ghost/values.yaml
@@ -74,6 +74,7 @@ allowEmptyPassword: "yes"
 # smtpPort:
 # smtpUser:
 # smtpPassword:
+# smtpFromAddress
 # smtpService:
 
 ##


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

As you can check in the link below, a new env. variable has been added to Ghost container that allows to configure the 'fromAddress' in the SMTP settings. This PR adds a parameter to easily set it

https://github.com/bitnami/bitnami-docker-ghost#smtp-configuration

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
