### PR TITLE
[stable/jenkins] add support for custom ingress rules

### DIFF
--- a/stable/jenkins/Chart.yaml
+++ b/stable/jenkins/Chart.yaml
@@ -1,6 +1,6 @@
 name: jenkins
 home: https://jenkins.io/
-version: 0.28.4
+version: 0.28.5
 appVersion: lts
 description: Open source continuous integration server. It supports multiple SCM tools
   including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based

--- a/stable/jenkins/README.md
+++ b/stable/jenkins/README.md
@@ -73,6 +73,7 @@ The following tables list the configurable parameters of the Jenkins chart and t
 | `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
 | `Master.Ingress.Path`             | Ingress path                         | Not set                                                                         |
 | `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
+| `Master.Ingress.CustomRules`      | Ingress custom ingress rules in yaml | Not set                                                                      |
 | `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
 | `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
 | `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |

--- a/stable/jenkins/templates/jenkins-master-ingress.yaml
+++ b/stable/jenkins/templates/jenkins-master-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.Master.HostName }}
+{{- if or .Values.Master.HostName .Values.Master.Ingress.CustomRules }}
 apiVersion: {{ .Values.Master.Ingress.ApiVersion }}
 kind: Ingress
 metadata:
@@ -9,6 +9,7 @@ metadata:
   name: {{ template "jenkins.fullname" . }}
 spec:
   rules:
+{{- if .Values.Master.HostName }}
   - host: {{ .Values.Master.HostName | quote }}
     http:
       paths:
@@ -18,6 +19,10 @@ spec:
 {{- if .Values.Master.Ingress.Path }}
         path: {{ .Values.Master.Ingress.Path }}
 {{- end -}}
+{{- end }}
+{{- if .Values.Master.Ingress.CustomRules }}
+{{ toYaml .Values.Master.Ingress.CustomRules | indent 4 }}
+{{- end }}
 {{- if .Values.Master.Ingress.TLS }}
   tls:
 {{ toYaml .Values.Master.Ingress.TLS | indent 4 }}

--- a/stable/jenkins/values.yaml
+++ b/stable/jenkins/values.yaml
@@ -144,6 +144,16 @@ Master:
     # Set this path to JenkinsUriPrefix above or use annotations to rewrite path
     # Path: "/jenkins"
 
+    # Replace or add rules to Master.HostName value
+    # CustomRules:
+    #   - host: jenkins.example.com
+    #     http:
+    #       paths:
+    #       - backend:
+    #           serviceName: jenkins
+    #           servicePort: 8080
+    #         path: /
+
     TLS:
     # - secretName: jenkins.cluster.local
     #   hosts:


### PR DESCRIPTION
This PR add a `Master.Ingress.CustomRules` value to allow more customised values for the ingress (several hosts, more backends...)

It's not a breaking change, It can work with or without `Master.HostName` value.