### PR TITLE
[stable/nginx-ingress] Allow hostNetwork when PSP is enabled

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 1.1.4
+version: 1.1.5
 appVersion: 0.21.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 1.1.3
+version: 1.1.4
 appVersion: 0.21.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/templates/podsecuritypolicy.yaml
+++ b/stable/nginx-ingress/templates/podsecuritypolicy.yaml
@@ -20,7 +20,11 @@ spec:
     #- 'projected'
     - 'secret'
     #- 'downwardAPI'
+  {{- if .Values.controller.hostNetwork }}
+  hostNetwork: true
+  {{- else }}
   hostNetwork: false
+  {{- end }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/stable/nginx-ingress/templates/podsecuritypolicy.yaml
+++ b/stable/nginx-ingress/templates/podsecuritypolicy.yaml
@@ -20,11 +20,7 @@ spec:
     #- 'projected'
     - 'secret'
     #- 'downwardAPI'
-  {{- if .Values.controller.hostNetwork }}
-  hostNetwork: true
-  {{- else }}
-  hostNetwork: false
-  {{- end }}
+  hostNetwork: {{ .Values.controller.hostNetwork | default false }}
   hostIPC: false
   hostPID: false
   runAsUser:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes so PodSecurityPolicy allows using hostNetwork if both are enabled.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
