### PR TITLE
[stable/node-problem-detector] adds custom-plugin-monitor config

### DIFF
--- a/stable/node-problem-detector/Chart.yaml
+++ b/stable/node-problem-detector/Chart.yaml
@@ -1,5 +1,5 @@
 name: node-problem-detector
-version: "1.1.2"
+version: "1.1.3"
 appVersion: v0.6.1
 home: https://github.com/kubernetes/node-problem-detector
 description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters for this chart and their d
 | `rbac.create`                     | RBAC                                       | `true`                                                       |
 | `resources`                       | Pod resource requests and limits           | `{}`                                                         |
 | `settings.log_monitors`           | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
-| `settings.custom_plugin_monitors` | Custom plugin monitor config files         | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
+| `settings.custom_plugin_monitors` | Custom plugin monitor config files         | `[]`                                                         |
 | `serviceAccount.create`           | Whether a ServiceAccount should be created | `true`                                                       |
 | `serviceAccount.name`             | Name of the ServiceAccount to create       | Generated value from template                                |
 | `tolerations`                     | Optional daemonset tolerations             | `[]`                                                         |

--- a/stable/node-problem-detector/README.md
+++ b/stable/node-problem-detector/README.md
@@ -34,21 +34,22 @@ Custom System log monitor config files can be created, see [here](https://github
 
 The following table lists the configurable parameters for this chart and their default values.
 
-| Parameter               | Description                                | Default                                                      |
-| ------------------------|--------------------------------------------|--------------------------------------------------------------|
-| `affinity`              | Map of node/pod affinities                 | `{}`                                                         |
-| `annotations`           | Optional daemonset annotations             | `{}`                                                         |
-| `fullnameOverride`      | Override the fullname of the chart         | `nil`                                                        |
-| `image.pullPolicy`      | Image pull policy                          | `IfNotPresent`                                               |
-| `image.repository`      | Image                                      | `k8s.gcr.io/node-problem-detector`                           |
-| `image.tag`             | Image tag                                  | `v0.6.1`                                                     |
-| `nameOverride`          | Override the name of the chart             | `nil`                                                        |
-| `rbac.create`           | RBAC                                       | `true`                                                       |
-| `resources`             | Pod resource requests and limits           | `{}`                                                         |
-| `settings.log_monitors` | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
-| `serviceAccount.create` | Whether a ServiceAccount should be created | `true`                                                       |
-| `serviceAccount.name`   | Name of the ServiceAccount to create       | Generated value from template                                |
-| `tolerations`           | Optional daemonset tolerations             | `[]`                                                         |
+| Parameter                         | Description                                | Default                                                      |
+| ----------------------------------|--------------------------------------------|--------------------------------------------------------------|
+| `affinity`                        | Map of node/pod affinities                 | `{}`                                                         |
+| `annotations`                     | Optional daemonset annotations             | `{}`                                                         |
+| `fullnameOverride`                | Override the fullname of the chart         | `nil`                                                        |
+| `image.pullPolicy`                | Image pull policy                          | `IfNotPresent`                                               |
+| `image.repository`                | Image                                      | `k8s.gcr.io/node-problem-detector`                           |
+| `image.tag`                       | Image tag                                  | `v0.6.1`                                                     |
+| `nameOverride`                    | Override the name of the chart             | `nil`                                                        |
+| `rbac.create`                     | RBAC                                       | `true`                                                       |
+| `resources`                       | Pod resource requests and limits           | `{}`                                                         |
+| `settings.log_monitors`           | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
+| `settings.custom_plugin_monitors` | Custom plugin monitor config files         | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
+| `serviceAccount.create`           | Whether a ServiceAccount should be created | `true`                                                       |
+| `serviceAccount.name`             | Name of the ServiceAccount to create       | Generated value from template                                |
+| `tolerations`                     | Optional daemonset tolerations             | `[]`                                                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
 

--- a/stable/node-problem-detector/templates/daemonset.yaml
+++ b/stable/node-problem-detector/templates/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
           command:
             - "/bin/sh"
             - "-c"
-            - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}/config/{{ $monitor }}{{- end }}"
+            - "exec /node-problem-detector --logtostderr --system-log-monitors={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}/config/{{ $monitor }}{{- end }} {{- if .Values.settings.custom_plugin_monitors }} --custom-plugin-monitors={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }}"
           securityContext:
             privileged: true
           env:

--- a/stable/node-problem-detector/values.yaml
+++ b/stable/node-problem-detector/values.yaml
@@ -2,6 +2,7 @@ settings:
   log_monitors:
     - kernel-monitor.json
     - docker-monitor.json
+  custom_plugin_monitors: []
 
 hostpath:
   logdir: /var/log/


### PR DESCRIPTION
#### What this PR does / why we need it:
- Adds `--custom-plugin-monitors` flag to the node-problem-detector daemonset run command.
- Adds `settings.custom_plugin_monitors` so custom-monitors can be run with the correct flag.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/10430

#### Special notes for your reviewer:
Does not fix the crashloopbackoff of NPD, but just adds the ability to add any monitor-config to be run under `--custom-plugin-monitors`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
