### PR TITLE
[stable/prestashop] Fix Svc configuration

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 6.0.1
+version: 6.0.2
 appVersion: 1.7.5-0
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/stable/prestashop/templates/svc.yaml
+++ b/stable/prestashop/templates/svc.yaml
@@ -29,4 +29,4 @@ spec:
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- end }}
   selector:
-    app: "{{ template "prestashop.fullname" . }}"
+    app: "{{ template "prestashop.name" . }}"

--- a/stable/prestashop/values.yaml
+++ b/stable/prestashop/values.yaml
@@ -144,7 +144,7 @@ service:
   # HTTP Port
   port: 80
   # HTTPS Port
-  httpsPort: 44
+  httpsPort: 443
   ## loadBalancerIP for the PrestaShop Service (optional, cloud specific)
   ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
   ## loadBalancerIP


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

The selector used on the service is wrong. This PR fixes it.
On the other hand it fixes the `values.yaml` so the port 443 is used for https.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
