### PR TITLE
[stable/nats] metrics image registry takes value from global

### DIFF
--- a/stable/nats/Chart.yaml
+++ b/stable/nats/Chart.yaml
@@ -1,5 +1,5 @@
 name: nats
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.3.0
 description: An open-source, cloud-native messaging system
 keywords:

--- a/stable/nats/templates/_helpers.tpl
+++ b/stable/nats/templates/_helpers.tpl
@@ -69,5 +69,13 @@ Return the proper image name (for the metrics image)
 {{- $registryName :=  .Values.metrics.image.registry -}}
 {{- $repositoryName := .Values.metrics.image.repository -}}
 {{- $tag := .Values.metrics.image.tag | toString -}}
-{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
This chart uses two different images from docker.io registry. It is possible to override the value of each registry separately but in case you want to assign the sale value to both registries there is no way to do it by setting just a single value.

There is a `global.imageRegistry` parameter on the values file, but it just overrides the registry of the main container. Metrics container is not setting the registry depending on this global value. Which makes the global value quite useless.

This simple change in the helpers file will allow metrics container to set the registry of its image from the global parameter as well.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
