### PR TITLE
[stable/prometheus-cloudwatch-exporter] Add existing secret for aws c…

### DIFF
--- a/stable/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/stable/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.2.1
+version: 0.2.2
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/stable/prometheus-cloudwatch-exporter/README.md
+++ b/stable/prometheus-cloudwatch-exporter/README.md
@@ -48,6 +48,7 @@ The following table lists the configurable parameters of the Cloudwatch Exporter
 | `image.repository`          | Image                                                  | `prom/cloudwatch-exporter` |
 | `image.tag`                 | Image tag                                              | `cloudwatch_exporter-0.5.0`                   |
 | `image.pullPolicy`          | Image pull policy                                      | `IfNotPresent`             |
+| `existingSecret`            | Use an existing secret for aws credentials             | `""`                       |
 | `service.type`              | Service type                                           | `ClusterIP`                |
 | `service.port`              | The service port                                       | `80`                       |
 | `service.portName`          | The name of the service port                           | `http`                     |
@@ -82,3 +83,6 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 $ helm install --name my-release -f values.yaml stable/prometheus-cloudwatch-exporter
 ```
+## Custom Secret
+
+`existingSecret` can be used to override the default secret.yaml provided

--- a/stable/prometheus-cloudwatch-exporter/templates/_helpers.tpl
+++ b/stable/prometheus-cloudwatch-exporter/templates/_helpers.tpl
@@ -30,3 +30,11 @@ Create chart name and version as used by the chart label.
 {{- define "prometheus-cloudwatch-exporter.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "prometheus-cloudwatch-exporter.secretName" -}}
+{{ default (include "prometheus-cloudwatch-exporter.fullname" .) .Values.existingSecret }}
+{{- end -}}

--- a/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/deployment.yaml
@@ -30,19 +30,19 @@ spec:
             - /cloudwatch_exporter.jar
             - "{{ .Values.service.targetPort }}"
             - /config/config.yaml
-        {{- if not .Values.aws.role }}
-        {{- if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
+        {{- if or (not .Values.aws.role) (.Values.existingSecret) }}
+        {{- if or (and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id) (.Values.existingSecret) }}
           env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   key: aws_access_key_id
-                  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+                  name: {{ template "prometheus-cloudwatch-exporter.secretName" . }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   key: aws_secret_access_key
-                  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+                  name: {{ template "prometheus-cloudwatch-exporter.secretName" . }}
           {{- end }}
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/prometheus-cloudwatch-exporter/templates/secrets.yaml
+++ b/stable/prometheus-cloudwatch-exporter/templates/secrets.yaml
@@ -1,19 +1,21 @@
-{{- if not .Values.aws.role }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
-  labels:
-    app: {{ template "prometheus-cloudwatch-exporter.name" . }}
-    chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-type: Opaque
-data:
-  {{ if .Values.aws.aws_access_key_id }}
-  aws_access_key_id: {{ .Values.aws.aws_access_key_id | b64enc | quote }}
-  {{ end }}
-  {{ if .Values.aws.aws_secret_access_key }}
-  aws_secret_access_key: {{ .Values.aws.aws_secret_access_key | b64enc | quote }}
-  {{ end }}
+{{- if not .Values.existingSecret -}}
+  {{- if not .Values.aws.role }}
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: {{ template "prometheus-cloudwatch-exporter.fullname" . }}
+    labels:
+      app: {{ template "prometheus-cloudwatch-exporter.name" . }}
+      chart: {{ template "prometheus-cloudwatch-exporter.chart" . }}
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+  type: Opaque
+  data:
+    {{ if .Values.aws.aws_access_key_id }}
+    aws_access_key_id: {{ .Values.aws.aws_access_key_id | b64enc | quote }}
+    {{ end }}
+    {{ if .Values.aws.aws_secret_access_key }}
+    aws_secret_access_key: {{ .Values.aws.aws_secret_access_key | b64enc | quote }}
+    {{ end }}
+  {{- end }}
 {{- end }}

--- a/stable/prometheus-cloudwatch-exporter/values.yaml
+++ b/stable/prometheus-cloudwatch-exporter/values.yaml
@@ -29,7 +29,12 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+
+## Specify an existing secret holding the aws credentials
+existingSecret: ""
+
 aws:
+  ## only used if no existing secret is specified
   region: eu-west-1
   role:
   # Note: Do not specify the aws_access_key_id abd aws_secret_access_key if you specified role before


### PR DESCRIPTION


<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This change adds functionality to use an existing secret for AWS credentials. It is useful when managing the secrets apart from the helm charts when using for example sealed secrets. 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
