### PR TITLE
[stable/sonarqube] Add sonarWebContext value for readinessProbe and l…

### DIFF
--- a/stable/sonarqube/Chart.yaml
+++ b/stable/sonarqube/Chart.yaml
@@ -1,6 +1,6 @@
 name: sonarqube
 description: Sonarqube is an open sourced code quality scanning tool
-version: 0.13.1
+version: 0.13.2
 appVersion: 7.4
 keywords:
   - coverage

--- a/stable/sonarqube/README.md
+++ b/stable/sonarqube/README.md
@@ -46,6 +46,8 @@ The following table lists the configurable parameters of the Sonarqube chart and
 | `command`                                   | command to run in the container           | `nil` (need to be set prior to 6.7.6, and 7.4)      |
 | `securityContext.fsGroup`                   | Group applied to mounted directories/files|  `999`                                     |
 | `ingress.enabled`                           | Flag for enabling ingress                 | false                                      |
+| `livenessProbe.sonarWebContext`             | SonarQube web context for livenessProbe   | /                                          |
+| `readinessProbe.sonarWebContext`            | SonarQube web context for readinessProbe  | /                                          |
 | `service.type`                              | Kubernetes service type                   | `LoadBalancer`                             |
 | `service.labels`                            | Kubernetes service labels                 | None                                       |
 | `service.annotations`                       | Kubernetes service annotations            | None                                       |

--- a/stable/sonarqube/templates/deployment.yaml
+++ b/stable/sonarqube/templates/deployment.yaml
@@ -101,13 +101,13 @@ spec:
               {{- end }}
           livenessProbe:
             httpGet:
-              path: /sessions/new
+              path: {{ .Values.livenessProbe.sonarWebContext }}sessions/new
               port: {{ .Values.service.internalPort }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /sessions/new
+              path: {{ .Values.readinessProbe.sonarWebContext }}sessions/new
               port: {{ .Values.service.internalPort }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/stable/sonarqube/values.yaml
+++ b/stable/sonarqube/values.yaml
@@ -74,9 +74,11 @@ readinessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30
   failureThreshold: 6
+  sonarWebContext: /
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30
+  sonarWebContext: /
 
 # Set extra env variables. Like proxy settings.
 extraEnv: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a sonarWebContext variable for livenessProbe and readinessProbe so that the deployment will not fail if user has updated the sonar.web.context property using sonarProperties variable.
#### Special notes for your reviewer:
The default value for sonar.web.context property in sonar.properties is root (`/`) but we want it as `https://<applicationGatewayDNS>/sonarqube`. in order to achieve it we have to update sonar.web.context property otherwise resource files like `js/css` will not be rendered.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
