### PR TITLE
[stable/fluent-bit] bump fluent-bit to 1.0.2

### DIFF
--- a/stable/fluent-bit/Chart.yaml
+++ b/stable/fluent-bit/Chart.yaml
@@ -1,6 +1,6 @@
 name: fluent-bit
-version: 1.3.0
-appVersion: 1.0.1
+version: 1.3.2
+appVersion: 1.0.2
 description: Fast and Lightweight Log/Data Forwarder for Linux, BSD and OSX
 keywords:
 - logging

--- a/stable/fluent-bit/README.md
+++ b/stable/fluent-bit/README.md
@@ -94,8 +94,8 @@ The following table lists the configurable parameters of the Fluent-Bit chart an
 | `filter.kubeTag`                   | Optional top-level tag for matching in filter         | `kube`                                 |
 | `filter.mergeJSONLog`                   | If the log field content is a JSON string map, append the map fields as part of the log structure         | `true`                                 |
 | `image.fluent_bit.repository`      | Image                                      | `fluent/fluent-bit`                               |
-| `image.fluent_bit.tag`             | Image tag                                  | `1.0.1`                                          |
-| `image.pullPolicy`                 | Image pull policy                          | `Always`                                          |
+| `image.fluent_bit.tag`             | Image tag                                  | `1.0.2`                                          |
+| `image.pullPolicy`                 | Image pull policy                          | `IfNotPresent`                                          |
 | `image.pullSecrets`                | Specify image pull secrets                 | `nil`                                             |
 | `input.tail.memBufLimit`           | Specify Mem_Buf_Limit in tail input        | `5MB`                                             |
 | `input.tail.path`           | Specify log file(s) through the use of common wildcards.        | `/var/log/containers/*.log`                                             |

--- a/stable/fluent-bit/values.yaml
+++ b/stable/fluent-bit/values.yaml
@@ -5,8 +5,8 @@ on_minikube: false
 image:
   fluent_bit:
     repository: fluent/fluent-bit
-    tag: 1.0.1
-  pullPolicy: Always
+    tag: 1.0.2
+  pullPolicy: IfNotPresent
 
 # When enabled, exposes json and prometheus metrics on {{ .Release.Name }}-metrics service
 metrics:


### PR DESCRIPTION
#### What this PR does / why we need it:
- bump fluent-bit to 1.0.2

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
