### PR TITLE
[stable/bitcoind] Change deployment type to Recreate

### DIFF
--- a/stable/bitcoind/Chart.yaml
+++ b/stable/bitcoind/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: bitcoind
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.15.1
 description: Bitcoin is an innovative payment network and a new kind of money.
 keywords:

--- a/stable/bitcoind/templates/deployment.yaml
+++ b/stable/bitcoind/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: {{ template "bitcoind.name" . }}


### PR DESCRIPTION
Signed-off-by: Tom Dickman <tdickman@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This updates bitcoind to use the `Recreate` deployment strategy rather than the default (RollingUpdate). This uses a persistent volume, so as is the second pod fails to start during a rolling deploy since it is unable to mount the volume.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md