### PR TITLE
[stable/kong] For Cassandra: Fix install migration and add basic wait-for-db

### DIFF
--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -11,4 +11,4 @@ name: kong
 sources:
 - https://github.com/Kong/kong
 version: 0.9.3
-appVersion: 1.0.0
+appVersion: 1.0.2

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.9.1
+version: 0.9.2
 appVersion: 1.0.0

--- a/stable/kong/Chart.yaml
+++ b/stable/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/kong
-version: 0.9.2
+version: 0.9.3
 appVersion: 1.0.0

--- a/stable/kong/templates/_helpers.tpl
+++ b/stable/kong/templates/_helpers.tpl
@@ -62,3 +62,32 @@ Create the ingress servicePort value string
    {{ .Values.proxy.http.servicePort }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Create dbHost
+This can be used to simplify certain aspects of the chart which
+normally have to choose between Postgres values and Cassandra values.
+For instance, in the initContainers command.
+*/}}
+{{- define "kong.dbHost" -}}
+{{- if .Values.cassandra.enabled -}}
+    {{ template "kong.cassandra.fullname" . }}
+{{- else if .Values.postgresql.enabled -}}
+    {{ template "kong.postgresql.fullname" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create dbPort
+This can be used to simplify certain aspects of the chart which
+normally have to choose between Postgres values and Cassandra values.
+For instance, in the initContainers command.
+*/}}
+{{- define "kong.dbPort" -}}
+{{- if .Values.cassandra.enabled -}}
+    {{ .Values.cassandra.config.ports.cql }}
+{{- else if .Values.postgresql.enabled -}}
+    {{ .Values.postgresql.service.port }}
+{{- end -}}
+{{- end -}}

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -31,31 +31,14 @@ spec:
       {{- end }}
       {{- if or (.Values.postgresql.enabled) (.Values.cassandra.enabled)  }}
       initContainers:
-      {{- if .Values.postgresql.enabled }}
       - name: wait-for-postgres
         image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
-        - name: KONG_PG_HOST
-          value: {{ template "kong.postgresql.fullname" . }}
-        - name: KONG_PG_PORT
-          value: "{{ .Values.postgresql.service.port }}"
-        - name: KONG_PG_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
-              key: postgresql-password
-        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
-      {{- end }}
-      {{- if .Values.cassandra.enabled }}
-      - name: wait-for-cassandra
-        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
-        env:
-        - name: KONG_CASSANDRA_CONTACT_POINTS
-          value: {{ template "kong.cassandra.fullname" . }}
-        - name: KONG_CASSANDRA_CQL_PORT
-          value: "{{ .Values.cassandra.config.ports.cql }}"
-        command: [ "/bin/sh", "-c", "until nc -zv $KONG_CASSANDRA_CONTACT_POINTS $KONG_CASSANDRA_CQL_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
-      {{- end }}
+        - name: KONG_DB_HOST
+          value: {{ template "kong.dbHost" . }}
+        - name: KONG_DB_PORT
+          value: {{ template "kong.dbPort" . }}
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_DB_HOST $KONG_DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations

--- a/stable/kong/templates/migrations-post-upgrade.yaml
+++ b/stable/kong/templates/migrations-post-upgrade.yaml
@@ -29,10 +29,11 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.postgresql.enabled }}
+      {{- if or (.Values.postgresql.enabled) (.Values.cassandra.enabled)  }}
       initContainers:
+      {{- if .Values.postgresql.enabled }}
       - name: wait-for-postgres
-        image: busybox
+        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
@@ -44,6 +45,17 @@ spec:
               name: {{ template "kong.postgresql.fullname" . }}
               key: postgresql-password
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+      {{- end }}
+      {{- if .Values.cassandra.enabled }}
+      - name: wait-for-cassandra
+        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        env:
+        - name: KONG_CASSANDRA_CONTACT_POINTS
+          value: {{ template "kong.cassandra.fullname" . }}
+        - name: KONG_CASSANDRA_CQL_PORT
+          value: "{{ .Values.cassandra.config.ports.cql }}"
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_CASSANDRA_CONTACT_POINTS $KONG_CASSANDRA_CQL_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -29,10 +29,11 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.postgresql.enabled }}
+      {{- if or (.Values.postgresql.enabled) (.Values.cassandra.enabled)  }}
       initContainers:
+      {{- if .Values.postgresql.enabled }}
       - name: wait-for-postgres
-        image: busybox
+        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
         - name: KONG_PG_HOST
           value: {{ template "kong.postgresql.fullname" . }}
@@ -44,6 +45,17 @@ spec:
               name: {{ template "kong.postgresql.fullname" . }}
               key: postgresql-password
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+      {{- end }}
+      {{- if .Values.cassandra.enabled }}
+      - name: wait-for-cassandra
+        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        env:
+        - name: KONG_CASSANDRA_CONTACT_POINTS
+          value: {{ template "kong.cassandra.fullname" . }}
+        - name: KONG_CASSANDRA_CQL_PORT
+          value: "{{ .Values.cassandra.config.ports.cql }}"
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_CASSANDRA_CONTACT_POINTS $KONG_CASSANDRA_CQL_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations

--- a/stable/kong/templates/migrations-pre-upgrade.yaml
+++ b/stable/kong/templates/migrations-pre-upgrade.yaml
@@ -31,31 +31,14 @@ spec:
       {{- end }}
       {{- if or (.Values.postgresql.enabled) (.Values.cassandra.enabled)  }}
       initContainers:
-      {{- if .Values.postgresql.enabled }}
       - name: wait-for-postgres
         image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
-        - name: KONG_PG_HOST
-          value: {{ template "kong.postgresql.fullname" . }}
-        - name: KONG_PG_PORT
-          value: "{{ .Values.postgresql.service.port }}"
-        - name: KONG_PG_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
-              key: postgresql-password
-        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
-      {{- end }}
-      {{- if .Values.cassandra.enabled }}
-      - name: wait-for-cassandra
-        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
-        env:
-        - name: KONG_CASSANDRA_CONTACT_POINTS
-          value: {{ template "kong.cassandra.fullname" . }}
-        - name: KONG_CASSANDRA_CQL_PORT
-          value: "{{ .Values.cassandra.config.ports.cql }}"
-        command: [ "/bin/sh", "-c", "until nc -zv $KONG_CASSANDRA_CONTACT_POINTS $KONG_CASSANDRA_CQL_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
-      {{- end }}
+        - name: KONG_DB_HOST
+          value: {{ template "kong.dbHost" . }}
+        - name: KONG_DB_PORT
+          value: {{ template "kong.dbPort" . }}
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_DB_HOST $KONG_DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -26,31 +26,14 @@ spec:
       {{- end }}
       {{- if or (.Values.postgresql.enabled) (.Values.cassandra.enabled)  }}
       initContainers:
-      {{- if .Values.postgresql.enabled }}
       - name: wait-for-postgres
         image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
-        - name: KONG_PG_HOST
-          value: {{ template "kong.postgresql.fullname" . }}
-        - name: KONG_PG_PORT
-          value: "{{ .Values.postgresql.service.port }}"
-        - name: KONG_PG_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ template "kong.postgresql.fullname" . }}
-              key: postgresql-password
-        command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
-      {{- end }}
-      {{- if .Values.cassandra.enabled }}
-      - name: wait-for-cassandra
-        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
-        env:
-        - name: KONG_CASSANDRA_CONTACT_POINTS
-          value: {{ template "kong.cassandra.fullname" . }}
-        - name: KONG_CASSANDRA_CQL_PORT
-          value: "{{ .Values.cassandra.config.ports.cql }}"
-        command: [ "/bin/sh", "-c", "until nc -zv $KONG_CASSANDRA_CONTACT_POINTS $KONG_CASSANDRA_CQL_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]      
-      {{- end }}
+        - name: KONG_DB_HOST
+          value: {{ template "kong.dbHost" . }}
+        - name: KONG_DB_PORT
+          value: {{ template "kong.dbPort" . }}
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_DB_HOST $KONG_DB_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations

--- a/stable/kong/templates/migrations.yaml
+++ b/stable/kong/templates/migrations.yaml
@@ -24,8 +24,9 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if .Values.postgresql.enabled }}
+      {{- if or (.Values.postgresql.enabled) (.Values.cassandra.enabled)  }}
       initContainers:
+      {{- if .Values.postgresql.enabled }}
       - name: wait-for-postgres
         image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
         env:
@@ -39,6 +40,17 @@ spec:
               name: {{ template "kong.postgresql.fullname" . }}
               key: postgresql-password
         command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+      {{- end }}
+      {{- if .Values.cassandra.enabled }}
+      - name: wait-for-cassandra
+        image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+        env:
+        - name: KONG_CASSANDRA_CONTACT_POINTS
+          value: {{ template "kong.cassandra.fullname" . }}
+        - name: KONG_CASSANDRA_CQL_PORT
+          value: "{{ .Values.cassandra.config.ports.cql }}"
+        command: [ "/bin/sh", "-c", "until nc -zv $KONG_CASSANDRA_CONTACT_POINTS $KONG_CASSANDRA_CQL_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]      
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations
@@ -64,8 +76,8 @@ spec:
         {{- end }}
         {{- if .Values.cassandra.enabled }}
         - name: KONG_CASSANDRA_CONTACT_POINTS
-          value: {{ template "kong.cassandra.fullname" . }}
+          value: "{{ template "kong.cassandra.fullname" . }}"
         {{- end }}
-        command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
+        command: [ "/bin/sh", "-c", "kong migrations bootstrap && kong migrations finish && kong migrations up && kong migrations finish" ]
       restartPolicy: OnFailure
 {{- end }}


### PR DESCRIPTION
Signed-off-by: stackedsax <ascammon@hotmail.com>

#### What this PR does / why we need it:

I tried the helm install with cassandra as the db and it failed to run the migrations cleanly.  The process would 'work' only when I: 

1.  run the `helm install`, wait until the `migrations` template is 'completed' and the kong deployment is stuck in the 'Init' phase
2. run a `helm upgrade` to kick off the `migrations-pre-upgrade` and `migrations-post-upgrade` templates

I'd be happy to be told that I'm doing something wrong, but if this is what others are seeing it's clearly not ideal.

After some digging, the problem was that even though Cassandra's 9042 port is open, it's not quite ready to run the `migration bootstrap`.  The bootstrap would start but in the middle of the migration the `migrations` template errors and restarts.  When it spins up the second time, it thinks that the bootstrap is finished and goes to a 'Completed' state.  

Indeed, running `kong migrations bootstap` at this point returns 'database already bootstrapped'.  However, running `kong migrations list` returns:
```
executed migrations:
core: 000_base, 001_14_to_15, 002_15_to_1
oauth2: 000_base_oauth2, 001_14_to_15, 002_15_to_10
acl: 000_base_acl
database has pending migrations:
acl: 001_14_to_15
database has new migrations available:
jwt: 000_base_jwt, 001_14_to_15
basic-auth: 000_base_basic_auth, 001_14_to_15
key-auth: 000_base_key_auth, 001_14_to_15
rate-limiting: 000_base_rate_limiting, 001_14_to_15, 002_15_to_10
hmac-auth: 000_base_hmac_auth, 001_14_to_15
response-ratelimiting: 000_base_response_rate_limiting, 001_14_to_15, 002_15_to_10
run 'kong migrations up' to proceed
```
So, it looked to me like the failed bootstrap needed to be 'finished' and then another migration run and finished before the database would be ready to go.

Even though it may look as ugly as sin, I added a `&& kong migrations finish && kong migrations up && kong migrations finish` to the command that the `migrations` template runs.  Now, when the `migrations` template spins up after the first error, it finishes the bootstrap and runs the rest of the migrations.  Additionally, this doesn't affect the postgres installation negatively.

In the process of debugging this, I tried various approaches: 

- I added an initContainer to all of the migrations templates hoping that simply waiting for port 9042 to become active would help.  It didn't.  
- I tried raising the various `db-timeout` and `lock-timeout` parameters for `kong migrations` but no dice.  
- I tried waiting for a cqlsh command to return successfully, but that yielded the same behavior as the netcat version and also required a significant chunk of ugly code to be run as a single command to install cqlsh in the first place.  
- Lastly, I considered installing nodetool but that would require cassandra's JMX port to be open to external connections.  This, in turn, requires a number of environment variables to be set and to modify the base cassandra image by copying in a jmx password file, a la:
   - https://gist.github.com/franzwong/a7f36d7e45076f85f3832dc0c2dc0c0e (This seemed out of scope... and I also wasn't completely convinced that `nodetool status` wouldn't report the cluster up too early as well)

So after all of that, I fell back to the somewhat ugly but predictable method outlined above.  I left in the netcat initContainer stuff because I thought that was a reasonable thing to do.

#### Special notes for your reviewer:
If it helps in your testing, I used something like this to switch back and forth between databases :

`helm install -n testkong01 . --set env.database=cassandra --set cassandra.enabled=true --set postgresql.enabled=false`

##### Variables Documentation
 
I think there are a bunch of other things to clean up in this chart around the cassandra parameters.  I'd like to put that work in a separate PR, if that's alright.

For example, I used the parameter `cassandra.config.ports.cql` as the KONG_CASSANDRA_CQL_PORT since that is the parameter that the Cassandra chart uses.  I notice the kong chart suggests a `cassandra_port` parameter, but I don't see it used in any template.  Likewise, the `env.cassandra_repl_factor` is not used anywhere.  

Meanwhile, the `cassandra_contact_points` parameter is not used in any template but my guess is that it should be used whenever the environment variable `KONG_CASSANDRA_CONTACT_POINTS` is set so that the contact points aren't merely `{{ template "kong.cassandra.fullname" . }}`.  For example:

- https://github.com/helm/charts/blob/master/stable/kong/templates/deployment.yaml#L60

I thought removing or adding or changing parameter names might require more discussion so I wanted a different PR to deal with that.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
