### PR TITLE
[stable/metricbeat] Update metricbeat to 6.5.4 and added required cluster role permission for kubelet auth

### DIFF
--- a/stable/metricbeat/Chart.yaml
+++ b/stable/metricbeat/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 description: A Helm chart to collect Kubernetes logs with metricbeat
 icon: https://www.elastic.co/assets/blt47799dcdcf08438d/logo-elastic-beats-lt.svg
 name: metricbeat
-version: 0.4.3
-appVersion: 6.5.1
+version: 0.4.4
+appVersion: 6.5.4
 home: https://www.elastic.co/products/beats/metricbeat
 sources:
 - https://www.elastic.co/guide/en/beats/metricbeat/current/index.html

--- a/stable/metricbeat/templates/clusterrole.yaml
+++ b/stable/metricbeat/templates/clusterrole.yaml
@@ -25,6 +25,10 @@ rules:
   - statefulsets
   - deployments
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - nodes/stats
+  verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 {{- end -}}

--- a/stable/metricbeat/values.yaml
+++ b/stable/metricbeat/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.elastic.co/beats/metricbeat
-  tag: 6.5.1
+  tag: 6.5.4
   pullPolicy: IfNotPresent
 
 # The instances created by daemonset retrieve most metrics from the host
@@ -62,7 +62,14 @@ daemonset:
             - container
             - volume
           period: 10s
+          host: ${NODE_NAME}
           hosts: ["localhost:10255"]
+          # If using Red Hat OpenShift remove the previous hosts entry and
+          # uncomment these settings:
+          # hosts: ["https://${HOSTNAME}:10250"]
+          # bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          # ssl.certificate_authorities:
+            # - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 # The instance created by deployment retrieves metrics that are unique for the whole cluster, like Kubernetes events or kube-state-metrics
 deployment:
   podAnnotations: []


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes forbidden issue with kubelet stats/summary endpoint:

```
[root@hostname metricbeat]# curl https://localhost:10250/stats/summary   --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --header "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k
Forbidden (user=system:serviceaccount:logging:metricbeat, verb=get, resource=nodes, subresource=stats)
```
Updates metricbeat to 6.5.4


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
