### PR TITLE
fix deprecated setting in README.md

### DIFF
--- a/stable/metallb/Chart.yaml
+++ b/stable/metallb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.8.3
+version: 0.8.4
 
 name: metallb
 appVersion: 0.7.3

--- a/stable/metallb/README.md
+++ b/stable/metallb/README.md
@@ -101,7 +101,7 @@ configInline:
   address-pools:
   - name: default
     protocol: bgp
-    cidr:
+    addresses:
     - 198.51.100.0/24
 
 $ helm install --name metallb -f values.yaml stable/metallb


### PR DESCRIPTION
`cidr` should read `addresses` on line 104

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
  - Incorrect value in readme.md 

#### Special notes for your reviewer:
 
Non-breaking change to chart documentation.
