### PR TITLE
[stable/nfs-client-provisioner] Minor clarification for arm deployments on README

### DIFF
--- a/stable/nfs-client-provisioner/Chart.yaml
+++ b/stable/nfs-client-provisioner/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 3.1.0
 description: nfs-client is an automatic provisioner that used your *already configured* NFS server, automatically creating Persistent Volumes.
 name: nfs-client-provisioner
 home: https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
-version: 1.2.1
+version: 1.2.2
 sources:
 - https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client
 maintainers:

--- a/stable/nfs-client-provisioner/README.md
+++ b/stable/nfs-client-provisioner/README.md
@@ -8,6 +8,8 @@ The [NFS client provisioner](https://github.com/kubernetes-incubator/external-st
 $ helm install --set nfs.server=x.x.x.x --set nfs.path=/exported/path stable/nfs-client-provisioner
 ```
 
+For **arm** deployments set `image.repository` to `--set image.repository=quay.io/external_storage/nfs-client-provisioner-arm`
+
 ## Introduction
 
 This charts installs custom [storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/) into a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. It also installs a [NFS client provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/nfs-client) into the cluster which dynamically creates persistent volumes from single NFS share.


### PR DESCRIPTION
 I tried to use this chart on an arm-based cluster the pod crashed right after it was started. That's because the default image is for amd64 and the README does not explicitly states the image to use for arm.