### PR TITLE
[stable/cert-manager] Add securityContext to cert-manager deployment pods

### DIFF
--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.5.2
+version: v0.5.3
 appVersion: v0.5.2
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/Chart.yaml
+++ b/stable/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.5.3
+version: v0.6.0
 appVersion: v0.5.2
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/stable/cert-manager/README.md
+++ b/stable/cert-manager/README.md
@@ -67,6 +67,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `serviceAccount.create` | If `true`, create a new service account | `true` |
 | `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `resources` | CPU/memory resource requests/limits | |
+| `securityContext.enabled` | Enable security context | `false` |
+| `securityContext.fsGroup` | Group ID for the container | `1001` |
+| `securityContext.runAsUser` | User ID for the container | `1001` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |

--- a/stable/cert-manager/templates/deployment.yaml
+++ b/stable/cert-manager/templates/deployment.yaml
@@ -109,3 +109,8 @@ spec:
       dnsConfig:
 {{ toYaml .Values.podDnsConfig | indent 8 }}
 {{- end }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+{{- end }}

--- a/stable/cert-manager/values.yaml
+++ b/stable/cert-manager/values.yaml
@@ -47,6 +47,13 @@ resources: {}
   #   cpu: 10m
   #   memory: 32Mi
 
+# Pod Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  enabled: false
+  fsGroup: 1001
+  runAsUser: 1001
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the ability to run cert-manager deployment pods with a non-root user which enables cert manager to work with PodSecurityPolicy defaults.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
