### PR TITLE
[stable/mongodb] Avoid using default values with empty strings

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 5.1.0
+version: 5.1.1
 appVersion: 4.0.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -67,8 +67,10 @@ spec:
               name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
               key: mongodb-root-password
         {{- end }}
+        {{- if .Values.mongodbUsername }}
         - name: MONGODB_USERNAME
-          value: {{ default "" .Values.mongodbUsername | quote }}
+          value: {{ .Values.mongodbUsername | quote }}
+        {{- end }}
         {{- if and .Values.mongodbUsername .Values.mongodbDatabase }}
         - name: MONGODB_PASSWORD
           valueFrom:
@@ -78,16 +80,20 @@ spec:
         {{- end }}
         - name: MONGODB_SYSTEM_LOG_VERBOSITY
           value: {{ .Values.mongodbSystemLogVerbosity | quote}}
+        {{- if .Values.mongodbDatabase }}
         - name: MONGODB_DATABASE
-          value: {{ default "" .Values.mongodbDatabase | quote }}
+          value: {{ .Values.mongodbDatabase | quote }}
+        {{- end }}
         - name: MONGODB_ENABLE_IPV6
         {{- if .Values.mongodbEnableIPv6 }}
           value: "yes"
         {{- else }}
           value: "no"
         {{- end }}
+        {{- if .Values.mongodbExtraFlags }}
         - name: MONGODB_EXTRA_FLAGS
-          value: {{ default "" .Values.mongodbExtraFlags | join " " }}
+          value: {{ .Values.mongodbExtraFlags | join " " }}
+        {{- end }}
         ports:
         - name: mongodb
           containerPort: 27017

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -96,8 +96,10 @@ spec:
           {{- else }}
             value: "no"
           {{- end }}
+          {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
-            value: {{ default "" .Values.mongodbExtraFlags | join " " }}
+            value: {{ .Values.mongodbExtraFlags | join " " }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -81,10 +81,14 @@ spec:
           - name: MONGODB_ADVERTISED_HOSTNAME
             value: "$(MONGODB_POD_NAME).{{ template "mongodb.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
             {{- end }}
+          {{- if .Values.mongodbUsername }}
           - name: MONGODB_USERNAME
             value: {{ .Values.mongodbUsername | quote }}
+          {{- end }}
+          {{- if .Values.mongodbDatabase }}
           - name: MONGODB_DATABASE
             value: {{ .Values.mongodbDatabase | quote }}
+          {{- end }}
             {{- if .Values.usePassword }}
             {{- if or .Values.mongodbPassword .Values.existingSecret }}
           - name: MONGODB_PASSWORD
@@ -110,8 +114,10 @@ spec:
           {{- else }}
             value: "no"
           {{- end }}
+          {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
-            value: {{ default "" .Values.mongodbExtraFlags | join " " }}
+            value: {{ .Values.mongodbExtraFlags | join " " }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -102,8 +102,10 @@ spec:
           {{- else }}
             value: "no"
           {{- end }}
+          {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
-            value: {{ default "" .Values.mongodbExtraFlags | join " " }}
+            value: {{ .Values.mongodbExtraFlags | join " " }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

We're seeing a weird behaviour when setting env. variables with the empty string `""` on certain K8s environments. This PR avoids this by only setting the corresponding env. variables when a value is needed.

#### Which issue this PR fixes

  - fixes https://github.com/helm/charts/issues/10539

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
