### PR TITLE
[stable/prometheus-operator] Update grafana dep to support non-apparmored platforms

### DIFF
--- a/stable/prometheus-operator/Chart.yaml
+++ b/stable/prometheus-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: prometheus-operator
 sources:
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 1.6.0
+version: 1.7.0
 appVersion: 0.26.0
 home: https://github.com/coreos/prometheus-operator
 keywords:

--- a/stable/prometheus-operator/README.md
+++ b/stable/prometheus-operator/README.md
@@ -225,6 +225,7 @@ The following tables lists the configurable parameters of the prometheus-operato
 | `grafana.sidecar.dashboards.label` | If the sidecar is enabled, configmaps with this label will be loaded into Grafana as dashboards | `grafana_dashboard` |
 | `grafana.sidecar.datasources.enabled` | Enable the Grafana sidecar to automatically load dashboards with a label `{{ grafana.sidecar.datasources.label }}=1` | `true` |
 | `grafana.sidecar.datasources.label` | If the sidecar is enabled, configmaps with this label will be loaded into Grafana as datasources configurations | `grafana_datasource` |
+| `grafana.rbac.pspUseAppArmor` | Enforce AppArmor in created PodSecurityPolicy (requires rbac.pspEnabled) | `true` |
 
 ### Exporters
 | Parameter | Description | Default |

--- a/stable/prometheus-operator/requirements.lock
+++ b/stable/prometheus-operator/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.1.0
 - name: grafana
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.19.1
-digest: sha256:e5a44a77570b8d95815a44fe20e60c6269b265624a5f09be81eb4f16a4e6843a
-generated: 2018-12-31T18:30:11.81573+01:00
+  version: 1.24.2
+digest: sha256:d7c161ede3f397ea69b587691ff66b259c9ff4cf4744dd88a02c8db442db986b
+generated: 2019-01-14T16:40:33.892687423+01:00

--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
     condition: nodeExporter.enabled
 
   - name: grafana
-    version: 1.19.*
+    version: 1.24.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: grafana.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Enabling podsecuritypolicies on a platform that doesn't support AppArmor blocks the grafana pod:

`prometheus-operator-grafana-7654f69d89-6bv7c             0/3       Blocked   0          10m       <none>          k8s-prod-worker01   <none>`

From the logs on the worker:

`Jan 14 15:25:30 k8s-worker01 kubelet[1449]: E0114 15:25:30.905603    1449 pod_workers.go:186] Error syncing pod 5d47043b-180f-11e9-88e5-ee0b78fdb5a4 ("prometheus-operator-grafana-7654f69d89-6bv7c_prometheus(5d47043b-180f-11e9-88e5-ee0b78fdb5a4)"), skipping: pod cannot be run: Cannot enforce AppArmor: AppArmor is not enabled on the host`

Updating the grafana dependency to 1.24 allows use to set rbac.pspUseAppArmor, which in turns makes it work again:

`prometheus-operator-grafana-597c79cb45-rhpzh             3/3       Running   0          51s       10.234.87.250   k8s-prod-worker02   <none>`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
