### PR TITLE
[cluster-autoscaler] Add explicit support for the CA --regional flag.

### DIFF
--- a/stable/cluster-autoscaler/Chart.yaml
+++ b/stable/cluster-autoscaler/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 description: Scales worker nodes within autoscaling groups.
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 name: cluster-autoscaler
-version: 0.11.0
+version: 0.11.1
 appVersion: 1.13.1
 home: https://github.com/kubernetes/autoscaler
 sources:
-- https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
-- https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler
+  - https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+  - https://github.com/spotinst/kubernetes-autoscaler/tree/master/cluster-autoscaler
 maintainers:
-- name: mgoodness
-  email: mgoodness@gmail.com
+  - name: mgoodness
+    email: mgoodness@gmail.com
 engine: gotpl

--- a/stable/cluster-autoscaler/README.md
+++ b/stable/cluster-autoscaler/README.md
@@ -131,6 +131,7 @@ Parameter | Description | Default
 `rbac.pspEnabled` | Must be used with `rbac.create` true. If true, creates & uses RBAC resources required in the cluster with [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) enabled. | `false`
 `replicaCount` | desired number of pods | `1`
 `priorityClassName` | priorityClassName | `nil`
+`regional` | Support Regional Managed Instance Groups (GCE) | `false`
 `resources` | pod resource requests & limits | `{}`
 `service.annotations` | annotations to add to service | none
 `service.clusterIP` | IP address to assign to service | `""`

--- a/stable/cluster-autoscaler/templates/deployment.yaml
+++ b/stable/cluster-autoscaler/templates/deployment.yaml
@@ -60,10 +60,12 @@ spec:
           {{- if eq .Values.cloudProvider "gce" }}
             - --cloud-config={{ .Values.cloudConfigPath }}
             {{- end }}
+          {{- if .Values.regional }}
+            - --regional=true
+            {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
           {{- end }}
-
           env:
           {{- if eq .Values.cloudProvider "aws" }}
             - name: AWS_REGION

--- a/stable/cluster-autoscaler/values.yaml
+++ b/stable/cluster-autoscaler/values.yaml
@@ -1,25 +1,25 @@
 autoDiscovery:
-# Only cloudProvider `aws` and `gce` are supported by auto-discovery at this time
-# AWS: Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
-  clusterName:  # cluster.local
+  # Only cloudProvider `aws` and `gce` are supported by auto-discovery at this time
+  # AWS: Set tags as described in https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#auto-discovery-setup
+  clusterName: # cluster.local
 
 autoscalingGroups: []
 # At least one element is required if not using autoDiscovery
-  # - name: asg1
-  #   maxSize: 2
-  #   minSize: 1
-  # - name: asg2
-  #   maxSize: 2
-  #   minSize: 1
+# - name: asg1
+#   maxSize: 2
+#   minSize: 1
+# - name: asg2
+#   maxSize: 2
+#   minSize: 1
 
 autoscalingGroupsnamePrefix: []
 # At least one element is required if not using autoDiscovery
-  # - name: ig01
-  #   maxSize: 10
-  #   minSize: 0
-  # - name: ig02
-  #   maxSize: 10
-  #   minSize: 0
+# - name: ig01
+#   maxSize: 10
+#   minSize: 0
+# - name: ig02
+#   maxSize: 10
+#   minSize: 0
 
 # Required if cloudProvider=aws
 awsRegion: us-east-1
@@ -99,7 +99,12 @@ rbac:
   ##
   serviceAccountName: default
 
-resources: {}
+# GCP: Whether the underlying instance groups are regional (as opposed to zonal)
+# https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups
+regional: false
+
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 300Mi
@@ -135,11 +140,13 @@ spotinst:
 ## Are you using Prometheus Operator?
 serviceMonitor:
   enabled: false
-  interval: "10s"
-   # Namespace Prometheus is installed in
-  namespace: monitoring
-   ## Defaults to whats used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
-   ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
-   ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
+  interval:
+    "10s"
+    # Namespace Prometheus is installed in
+  namespace:
+    monitoring
+    ## Defaults to whats used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
+    ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
+    ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
   selector:
     prometheus: kube-prometheus


### PR DESCRIPTION
#### What this PR does / why we need it:

This patch adds explicit support for the `--regional` flag of the Cluster Autoscaler, and defaults to false.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
