### PR TITLE
Add ability to set number of replicas

### DIFF
--- a/stable/metrics-server/Chart.yaml
+++ b/stable/metrics-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.3.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 name: metrics-server
-version: 2.0.4
+version: 2.1.0
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/stable/metrics-server/README.md
+++ b/stable/metrics-server/README.md
@@ -18,3 +18,4 @@ Parameter | Description | Default
 `tolerations` | List of node taints to tolerate (requires Kubernetes >=1.6) | `[]`
 `nodeSelector` | Node labels for pod assignment | `{}`
 `affinity` | Node affinity | `{}`
+`replicas` | Number of replicas | `1`

--- a/stable/metrics-server/templates/metrics-server-deployment.yaml
+++ b/stable/metrics-server/templates/metrics-server-deployment.yaml
@@ -12,6 +12,7 @@ spec:
     matchLabels:
       app: {{ template "metrics-server.name" . }}
       release: {{ .Release.Name }}
+  replicas: {{ .Values.replicas }}
   template:
     metadata:
       labels:

--- a/stable/metrics-server/values.yaml
+++ b/stable/metrics-server/values.yaml
@@ -34,3 +34,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+replicas: 1


### PR DESCRIPTION
Signed-off-by: Joe Hohertz <joe@viafoura.com>

@olemarkus 
@kennethaasan 

#### What this PR does / why we need it:

Allows running multiple replicas of the metrics server if so desired where it was not possible to set this before.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
