### PR TITLE
Various fixes

### DIFF
--- a/incubator/sparkoperator/Chart.yaml
+++ b/incubator/sparkoperator/Chart.yaml
@@ -1,6 +1,6 @@
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 0.1.5
+version: 0.1.6
 appVersion: v1alpha1-0.5-2.4.0
 kubeVersion: ">=1.8.0-0"
 keywords:

--- a/incubator/sparkoperator/templates/spark-operator-deployment.yaml
+++ b/incubator/sparkoperator/templates/spark-operator-deployment.yaml
@@ -55,7 +55,6 @@ spec:
         ports:
           - containerPort: {{ .Values.metricsPort }}
         {{ end }}
-        command: ["/usr/bin/spark-operator"]
         args:
         - -v=2
         - -namespace={{ .Values.sparkJobNamespace }}
@@ -74,6 +73,6 @@ spec:
         - -enable-webhook=true
         - -webhook-svc-namespace={{ .Release.Namespace }}
         - -webhook-port={{ .Values.webhookPort }}
-        - -webhook-svc-name={{ include "sparkoperator.fullname" . }}-webhook
+        - -webhook-svc-name={{ .Release.Name }}-webhook
         - -webhook-config-name={{ include "sparkoperator.fullname" . }}-webhook-config
         {{- end }}

--- a/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-cleanup-job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: {{ include "sparkoperator.fullname" . }}-cleanup
   annotations:
-    "helm.sh/hook": pre-delete
+    "helm.sh/hook": pre-delete, pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}

--- a/incubator/sparkoperator/templates/webhook-init-job.yaml
+++ b/incubator/sparkoperator/templates/webhook-init-job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: {{ include "sparkoperator.fullname" . }}-init
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
@@ -20,5 +20,5 @@ spec:
       - name: main
         image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
-        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-s", '{{ include "sparkoperator.fullname" . }}-webhook', "-p"]
+        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Release.Namespace }}", "-s", "{{ .Release.Name }}-webhook", "-p"]
 {{ end }}

--- a/incubator/sparkoperator/templates/webhook-service.yaml
+++ b/incubator/sparkoperator/templates/webhook-service.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "sparkoperator.fullname" . }}-webhook
+  name: {{ .Release.Name }}-webhook
   labels:
     app.kubernetes.io/name: {{ include "sparkoperator.name" . }}
     helm.sh/chart: {{ include "sparkoperator.chart" . }}


### PR DESCRIPTION
Fixed three things in this PR.

1. Shortened the webhook service name. Because the long domain name sometimes cause an error when generating the certificate. This [link](https://github.com/certbot/certbot/issues/1915) is about the same issue.
2. Run the init and cleanup job for `helm upgrade`. I've noticed that when the operator is `upgrade`d instead of torn down and re-installed, the webhook secret is not re-created, causing the webhook to stop working.
3. Deleted the explicit specification of `command` in the deployment, because the entrypoint is explicitly set when building the image: [1](https://github.com/lightbend/spark-on-k8s-operator/blob/master/Dockerfile#L37) and [2](https://github.com/lightbend/spark-on-k8s-operator/blob/master/Dockerfile.rh#L53).