### PR TITLE
Revert "[stable/concourse] Moves prometheus annotation to deployment"

### DIFF
--- a/stable/concourse/Chart.yaml
+++ b/stable/concourse/Chart.yaml
@@ -1,5 +1,5 @@
 name: concourse
-version: 3.5.0
+version: 3.5.1
 appVersion: 4.2.2
 description: Concourse is a simple and scalable CI system.
 icon: https://avatars1.githubusercontent.com/u/7809479

--- a/stable/concourse/templates/web-deployment.yaml
+++ b/stable/concourse/templates/web-deployment.yaml
@@ -15,13 +15,7 @@ spec:
         app: {{ template "concourse.web.fullname" . }}
         release: "{{ .Release.Name }}"
       annotations:
-        {{- if .Values.concourse.web.prometheus.enabled }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: {{ .Values.concourse.web.prometheus.bindPort | quote }}
-        {{- end }}
-        {{- range $key, $value := .Values.web.annotations }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+{{ toYaml .Values.web.annotations | indent 8 }}
     spec:
     {{- with .Values.web.nodeSelector }}
       nodeSelector:

--- a/stable/concourse/templates/web-svc.yaml
+++ b/stable/concourse/templates/web-svc.yaml
@@ -8,7 +8,13 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-{{ toYaml .Values.web.service.annotations | indent 4 }}
+    {{- range $key, $value := .Values.web.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- if .Values.concourse.web.prometheus.enabled }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.concourse.web.prometheus.bindPort | quote }}
+    {{- end }}
 spec:
   type: {{ .Values.web.service.type }}
   {{ if .Values.web.service.loadBalancerSourceRanges }}


### PR DESCRIPTION
#### What this PR does / why we need it:

As pointed out by @william-tran , there's a possible problem regarding using the chart with Prometheus-operator if we move it the pod annotations (see discussion at https://github.com/helm/charts/pull/9536#issuecomment-454133112).

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

cc @william-tran 