### PR TITLE
[stable][airflow] Allow usage of existing secrets for postgres and redis

### DIFF
--- a/stable/airflow/Chart.yaml
+++ b/stable/airflow/Chart.yaml
@@ -1,6 +1,6 @@
 description: Airflow is a platform to programmatically author, schedule and monitor workflows
 name: airflow
-version: 0.12.0
+version: 0.13.0
 appVersion: 1.10.0
 icon: https://airflow.apache.org/_images/pin_large.png
 home: https://airflow.apache.org/

--- a/stable/airflow/README.md
+++ b/stable/airflow/README.md
@@ -159,6 +159,13 @@ $ kubectl create secret generic redshift-user --from-file=redshift-user=~/secret
 ```
 Where `redshift-user.txt` contains the user secret as a single text string.
 
+### Use precreated secret for postgres and redis
+
+You can use a precreated secret for the connection credentials to both postgresql and redis. To do
+so specify in values.yaml `existingAirflowSecret`, where the value is the name of the secret which has
+postgresUser, postgresPassword, and redisPassword defined. If not specified, it will fall back to using
+`secrets.yaml` to store the connection credentials by default.
+
 ### Local binaries
 
 Please note a folder `~/.local/bin` will be automatically created and added to the PATH so that
@@ -238,6 +245,7 @@ The following table lists the configurable parameters of the Airflow chart and t
 | `workers.pod.annotations`                | annotations for the worker pods                         | `{}`                      |
 | `workers.secretsDir`                     | directory in which to mount secrets on worker nodes     | /var/airflow/secrets      |
 | `workers.secrets`                        | secrets to mount as volumes on worker nodes             | []                        |
+| `existingAirflowSecret`                  | secret to use for postgres and redis connection         |                           |
 | `ingress.enabled`                        | enable ingress                                          | `false`                   |
 | `ingress.web.host`                       | hostname for the webserver ui                           | ""                        |
 | `ingress.web.path`                       | path of the werbserver ui (read `values.yaml`)          | ``                        |

--- a/stable/airflow/templates/_helpers.tpl
+++ b/stable/airflow/templates/_helpers.tpl
@@ -64,3 +64,14 @@ Create a random string if the supplied key does not exist
 {{- randAlphaNum 10 | b64enc | quote -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name for the airflow secret.
+*/}}
+{{- define "airflow.secret" -}}
+    {{- if .Values.existingAirflowSecret -}}
+        {{- .Values.existingAirflowSecret -}}
+    {{- else -}}
+        {{ template "airflow.fullname" . }}
+    {{- end -}}
+{{- end -}}

--- a/stable/airflow/templates/deployments-flower.yaml
+++ b/stable/airflow/templates/deployments-flower.yaml
@@ -48,17 +48,17 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: postgresUser
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: postgresPassword
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: redisPassword
           ports:
             - name: flower

--- a/stable/airflow/templates/deployments-scheduler.yaml
+++ b/stable/airflow/templates/deployments-scheduler.yaml
@@ -66,17 +66,17 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: postgresUser
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: postgresPassword
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: redisPassword
           volumeMounts:
           {{- if .Values.persistence.enabled }}

--- a/stable/airflow/templates/deployments-web.yaml
+++ b/stable/airflow/templates/deployments-web.yaml
@@ -69,17 +69,17 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: postgresUser
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: postgresPassword
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: redisPassword
           volumeMounts:
           {{- if .Values.persistence.enabled }}

--- a/stable/airflow/templates/secrets.yaml
+++ b/stable/airflow/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingAirflowSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   postgresUser: {{ .Values.postgresql.postgresUser | b64enc | quote }}
   postgresPassword: {{ .Values.postgresql.postgresPassword | b64enc | quote }}
   redisPassword: {{ .Values.redis.password | b64enc | quote }}
+{{- end -}}

--- a/stable/airflow/templates/statefulsets-workers.yaml
+++ b/stable/airflow/templates/statefulsets-workers.yaml
@@ -74,17 +74,17 @@ spec:
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: postgresUser
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: postgresPassword
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "airflow.fullname" . }}
+                  name: {{ template "airflow.secret" . }}
                   key: redisPassword
           volumeMounts:
           {{- $secretsDir := .Values.workers.secretsDir -}}

--- a/stable/airflow/values.yaml
+++ b/stable/airflow/values.yaml
@@ -307,6 +307,11 @@ serviceAccount:
   name:
 
 ##
+## Define existing secret for postgresql and redis
+## If not specified, creates secret with postgres and redis values
+existingAirflowSecret: ""
+
+##
 ## Configuration values for the postgresql dependency.
 ## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
 postgresql:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Adds the ability to specify your own predefined secret to configure the connection credentials to both postgresql and redis.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
