### PR TITLE
[stable/chartmuseum] Update chartmuseum to 0.8.1

### DIFF
--- a/stable/chartmuseum/Chart.yaml
+++ b/stable/chartmuseum/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 1.8.3
-appVersion: 0.8.0
+version: 1.8.4
+appVersion: 0.8.1
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png
 keywords:

--- a/stable/chartmuseum/values.yaml
+++ b/stable/chartmuseum/values.yaml
@@ -5,7 +5,7 @@ strategy:
     maxUnavailable: 0
 image:
   repository: chartmuseum/chartmuseum
-  tag: v0.8.0
+  tag: v0.8.1
   pullPolicy: IfNotPresent
 env:
   open:


### PR DESCRIPTION
Update chartmuseum to 0.8.1 due to security vulnerability:

https://helm.sh/blog/chartmuseum-security-notice-2019/
