### PR TITLE
[stable/mongodb] Add parameter to enable debug logs on MongoDB images

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 5.1.1
+version: 5.1.2
 appVersion: 4.0.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `image.tag`                             | MongoDB Image tag                                                                            | `{VERSION}`                                 |
 | `image.pullPolicy`                      | Image pull policy                                                                            | `Always`                                    |
 | `image.pullSecrets`                     | Specify image pull secrets                                                                   | `nil`                                       |
+| `image.debug`                           | Specify if debug logs should be enabled                                                      | `false`                                     |
 | `usePassword`                           | Enable password authentication                                                               | `true`                                      |
 | `existingSecret`                        | Existing secret with MongoDB credentials                                                     | `nil`                                       |
 | `mongodbRootPassword`                   | MongoDB admin password                                                                       | `random alhpanumeric string (10)`           |

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -60,6 +60,10 @@ spec:
         image: {{ template "mongodb.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        {{- if .Values.image.debug}}
+        - name: NAMI_DEBUG
+          value: "1"
+        {{- end }}
         {{- if .Values.usePassword }}
         - name: MONGODB_ROOT_PASSWORD
           valueFrom:

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -62,6 +62,10 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          {{- if .Values.image.debug}}
+          - name: NAMI_DEBUG
+            value: "1"
+          {{- end }}
           - name: MONGODB_SYSTEM_LOG_VERBOSITY
             value: {{ .Values.mongodbSystemLogVerbosity | quote}}
           - name: MONGODB_POD_NAME

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -67,6 +67,10 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          {{- if .Values.image.debug}}
+          - name: NAMI_DEBUG
+            value: "1"
+          {{- end }}
           - name: MONGODB_SYSTEM_LOG_VERBOSITY
             value: {{ .Values.mongodbSystemLogVerbosity | quote}}
           - name: MONGODB_POD_NAME

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -68,6 +68,10 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          {{- if .Values.image.debug}}
+          - name: NAMI_DEBUG
+            value: "1"
+          {{- end }}
           - name: MONGODB_SYSTEM_LOG_VERBOSITY
             value: {{ .Values.mongodbSystemLogVerbosity | quote}}
           - name: MONGODB_POD_NAME

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -27,6 +27,11 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+  ## Set to true if you would like to see extra information on logs
+  ## It turns NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-nami-debugging
+  debug: false
+
 ## Enable authentication
 ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
 #

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -27,6 +27,11 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
+  ## Set to true if you would like to see extra information on logs
+  ## It turns NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-nami-debugging
+  debug: false
+
 ## Enable authentication
 ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
 #


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

#### What this PR does / why we need it:

This PR adds a parameter that allows the users to enable debug logs on MongoDB containers.

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
