### PR TITLE
[stable/dokuwiki] Document the correct format for pullSecrets in README

### DIFF
--- a/stable/dokuwiki/Chart.yaml
+++ b/stable/dokuwiki/Chart.yaml
@@ -1,5 +1,5 @@
 name: dokuwiki
-version: 4.0.0
+version: 4.0.1
 appVersion: 0.20180422.201805030840
 description: DokuWiki is a standards-compliant, simple to use wiki optimized for creating
   documentation. It is targeted at developer teams, workgroups, and small companies.

--- a/stable/dokuwiki/README.md
+++ b/stable/dokuwiki/README.md
@@ -52,16 +52,16 @@ The following table lists the configurable parameters of the DokuWiki chart and 
 | `image.repository`                   | DokuWiki image name                                        | `bitnami/dokuwiki`                            |
 | `image.tag`                          | DokuWiki image tag                                         | `{VERSION}`                                   |
 | `image.pullPolicy`                   | Image pull policy                                          | `Always`                                      |
-| `image.pullSecrets`                  | Specify image pull secrets                                 | `nil`                                         |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array           | `[]` (does not add image pull secrets to deployed pods) |
 | `dokuwikiUsername`                   | User of the application                                    | `user`                                        |
 | `dokuwikiFullName`                   | User's full name                                           | `User Name`                                   |
 | `dokuwikiPassword`                   | Application password                                       | _random 10 character alphanumeric string_     |
 | `dokuwikiEmail`                      | User email                                                 | `user@example.com`                            |
 | `dokuwikiWikiName`                   | Wiki name                                                  | `My Wiki`                                     |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                    | `80`                                          |
-| `service.httpsPort`                    | Service HTTPS port                    | `443`                                          |
-| `service.loadBalancerIP`               | Kubernetes LoadBalancerIP to request                       | `nil`                                         |
+| `service.type`                       | Kubernetes Service type                                    | `LoadBalancer`                                |
+| `service.port`                       | Service HTTP port                                          | `80`                                          |
+| `service.httpsPort`                  | Service HTTPS port                                         | `443`                                         |
+| `service.loadBalancerIP`             | Kubernetes LoadBalancerIP to request                       | `nil`                                         |
 | `service.externalTrafficPolicy`      | Enable client source IP preservation                       | `Cluster`                                     |
 | `service.nodePorts.http`             | Kubernetes http node port                                  | `""`                                          |
 | `service.nodePorts.https`            | Kubernetes https node port                                 | `""`                                          |
@@ -98,15 +98,15 @@ The following table lists the configurable parameters of the DokuWiki chart and 
 | `nodeSelector`                       | Node labels for pod assignment                             | `{}`                                          |
 | `affinity`                           | Affinity settings for pod assignment                       | `{}`                                          |
 | `tolerations`                        | Toleration labels for pod assignment                       | `[]`                                          |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `nil`                                                |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
+| `podAnnotations`                     | Pod annotations                                            | `{}`                                          |
+| `metrics.enabled`                    | Start a side-car prometheus exporter                       | `false`                                       |
+| `metrics.image.registry`             | Apache exporter image registry                             | `docker.io`                                   |
+| `metrics.image.repository`           | Apache exporter image name                                 | `lusotycoon/apache-exporter`                  |
+| `metrics.image.tag`                  | Apache exporter image tag                                  | `v0.5.0`                                      |
+| `metrics.image.pullPolicy`           | Image pull policy                                          | `IfNotPresent`                                |
+| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array           | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod            | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                  | Exporter resource requests/limit                           | {}                                            |
 
 
 The above parameters map to the env variables defined in [bitnami/dokuwiki](http://github.com/bitnami/bitnami-docker-dokuwiki). For more information please refer to the [bitnami/dokuwiki](http://github.com/bitnami/bitnami-docker-dokuwiki) image documentation.


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
