### PR TITLE
[stable/prestashop] Document the correct format for pullSecrets in RE…

### DIFF
--- a/stable/prestashop/Chart.yaml
+++ b/stable/prestashop/Chart.yaml
@@ -1,5 +1,5 @@
 name: prestashop
-version: 6.1.0
+version: 6.1.1
 appVersion: 1.7.5-0
 description: A popular open source ecommerce solution. Professional tools are easily accessible to increase online sales including instant guest checkout, abandoned cart reminders and automated Email marketing.
 keywords:

--- a/stable/prestashop/README.md
+++ b/stable/prestashop/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the PrestaShop chart an
 | `image.repository`                    | PrestaShop image name                                                                        | `bitnami/prestashop`                                         |
 | `image.tag`                           | PrestaShop image tag                                                                         | `{VERSION}`                                                  |
 | `image.pullPolicy`                    | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent`      |
-| `image.pullSecrets`                   | Specify image pull secrets                                                                   | `nil`                                                        |
+| `image.pullSecrets`                   | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
 | `service.type`                        | Kubernetes Service type                                                                      | `LoadBalancer`                                               |
 | `service.port`                        | Service HTTP port                                                                            | `80`                                                         |
 | `service.httpsPort`                   | Service HTTPS port                                                                           | `443`                                                        |
@@ -120,7 +120,7 @@ The following table lists the configurable parameters of the PrestaShop chart an
 | `metrics.image.repository`            | Apache exporter image name                                                                   | `lusotycoon/apache-exporter`                                 |
 | `metrics.image.tag`                   | Apache exporter image tag                                                                    | `v0.5.0`                                                     |
 | `metrics.image.pullPolicy`            | Image pull policy                                                                            | `IfNotPresent`                                               |
-| `metrics.image.pullSecrets`           | Specify docker-registry secret names as an array                                             | `nil`                                                        |
+| `metrics.image.pullSecrets`           | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods)      |
 | `metrics.podAnnotations`              | Additional annotations for Metrics exporter pod                                              | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
 | `metrics.resources`                   | Exporter resource requests/limit                                                             | {}                                                           |
 


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
