### PR TITLE
[stable/wordpress] Document the correct format for pullSecrets in README

### DIFF
--- a/stable/wordpress/Chart.yaml
+++ b/stable/wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 name: wordpress
-version: 5.1.1
+version: 5.1.2
 appVersion: 5.0.3
 description: Web publishing platform for building blogs and websites.
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png

--- a/stable/wordpress/README.md
+++ b/stable/wordpress/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the WordPress chart and
 | `image.repository`               | WordPress image name                       | `bitnami/wordpress`                                     |
 | `image.tag`                      | WordPress image tag                        | `{VERSION}`                                             |
 | `image.pullPolicy`               | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `image.pullSecrets`              | Specify image pull secrets                 | `nil`                                                   |
+| `image.pullSecrets`              | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
 | `wordpressUsername`              | User of the application                    | `user`                                                  |
 | `wordpressPassword`              | Application password                       | _random 10 character long alphanumeric string_          |
 | `wordpressEmail`                 | Admin email                                | `user@example.com`                                      |
@@ -108,15 +108,15 @@ The following table lists the configurable parameters of the WordPress chart and
 | `nodeSelector`                   | Node labels for pod assignment             | `{}`                                                    |
 | `tolerations`                    | List of node taints to tolerate            | `[]`                                                    |
 | `affinity`                       | Map of node/pod affinities                 | `{}`                                                    |
-| `podAnnotations`                 | Pod annotations                                         | `{}`                                                           |
-| `metrics.enabled`                | Start a side-car prometheus exporter                    | `false`                                                        |
-| `metrics.image.registry`         | Apache exporter image registry                          | `docker.io`                                                    |
-| `metrics.image.repository`       | Apache exporter image name                              | `lusotycoon/apache-exporter`                                   |
-| `metrics.image.tag`              | Apache exporter image tag                               | `v0.5.0`                                                       |
-| `metrics.image.pullPolicy`       | Image pull policy                                       | `IfNotPresent`                                                 |
-| `metrics.image.pullSecrets`      | Specify docker-registry secret names as an array        | `nil`                                                          |
+| `podAnnotations`                 | Pod annotations                            | `{}`                                                    |
+| `metrics.enabled`                | Start a side-car prometheus exporter       | `false`                                                 |
+| `metrics.image.registry`         | Apache exporter image registry             | `docker.io`                                             |
+| `metrics.image.repository`       | Apache exporter image name                 | `lusotycoon/apache-exporter`                            |
+| `metrics.image.tag`              | Apache exporter image tag                  | `v0.5.0`                                                |
+| `metrics.image.pullPolicy`       | Image pull policy                          | `IfNotPresent`                                          |
+| `metrics.image.pullSecrets`      | Specify docker-registry secret names as an array        | `[]` (does not add image pull secrets to deployed pods)        |
 | `metrics.podAnnotations`         | Additional annotations for Metrics exporter pod         | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`   |
-| `metrics.resources`              | Exporter resource requests/limit                        | {}                                                             |
+| `metrics.resources`              | Exporter resource requests/limit           | {}                                                      |
 
 The above parameters map to the env variables defined in [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](http://github.com/bitnami/bitnami-docker-wordpress) image documentation.
 


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
