### PR TITLE
[stable/parse] Document the correct format for pullSecrets in README

### DIFF
--- a/stable/parse/Chart.yaml
+++ b/stable/parse/Chart.yaml
@@ -1,5 +1,5 @@
 name: parse
-version: 6.0.1
+version: 6.0.2
 appVersion: 3.1.3
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
 keywords:

--- a/stable/parse/README.md
+++ b/stable/parse/README.md
@@ -57,7 +57,7 @@ The following table lists the configurable parameters of the Parse chart and the
 | `server.image.repository`             | Parse image name                         | `bitnami/parse`                                         |
 | `server.image.tag`                    | Parse image tag                          | `{VERSION}`                                             |
 | `server.image.pullPolicy`             | Image pull policy                        | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `server.image.pullSecrets`            | Specify image pull secrets               | `nil`                                                   |
+| `server.image.pullSecrets`            | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods) |
 | `server.securityContext.enabled`      | Enable security context for Parse Server | `true`                                                  |
 | `server.securityContext.fsGroup`      | Group ID for Parse Server container      | `1001`                                                  |
 | `server.securityContext.runAsUser`    | User ID for Parse Server container       | `1001`                                                  |
@@ -74,7 +74,7 @@ The following table lists the configurable parameters of the Parse chart and the
 | `dashboard.securityContext.enabled`   | Enable security context for Dashboard    | `true`                                                  |
 | `dashboard.securityContext.fsGroup`   | Group ID for Dashboard container         | `1001`                                                  |
 | `dashboard.securityContext.runAsUser` | User ID for Dashboard container          | `1001`                                                  |
-| `dashboard.image.pullSecrets`         | Specify image pull secrets               | `nil`                                                   |
+| `dashboard.image.pullSecrets`         | Specify docker-registry secret names as an array               | `[]` (does not add image pull secrets to deployed pods) |
 | `dashboard.username`                  | Dashboard username                       | `user`                                                  |
 | `dashboard.password`                  | Dashboard user password                  | `random 10 character alphanumeric string`               |
 | `dashboard.appName`                   | Dashboard application name               | `MyDashboard`                                           |


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
