### PR TITLE
[stable/mongodb] Document the correct format for pullSecrets in README

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: mongodb
-version: 5.1.2
+version: 5.1.3
 appVersion: 4.0.3
 description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
 keywords:

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `image.repository`                      | MongoDB Image name                                                                           | `bitnami/mongodb`                           |
 | `image.tag`                             | MongoDB Image tag                                                                            | `{VERSION}`                                 |
 | `image.pullPolicy`                      | Image pull policy                                                                            | `Always`                                    |
-| `image.pullSecrets`                     | Specify image pull secrets                                                                   | `nil`                                       |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
 | `image.debug`                           | Specify if debug logs should be enabled                                                      | `false`                                     |
 | `usePassword`                           | Enable password authentication                                                               | `true`                                      |
 | `existingSecret`                        | Existing secret with MongoDB credentials                                                     | `nil`                                       |
@@ -105,10 +105,10 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `configmap`                             | MongoDB configuration file to be used                                                        | `nil`                                       |
 | `metrics.enabled`                       | Start a side-car prometheus exporter                                                         | `false`                                     |
 | `metrics.image.registry`                | MongoDB exporter image registry                                                              | `docker.io`                                 |
-| `metrics.image.repository`              | MongoDB exporter image name                                                                  | `forekshub/percona-mongodb-exporter`                           |
+| `metrics.image.repository`              | MongoDB exporter image name                                                                  | `forekshub/percona-mongodb-exporter`        |
 | `metrics.image.tag`                     | MongoDB exporter image tag                                                                   | `latest`                                    |
 | `metrics.image.pullPolicy`              | Image pull policy                                                                            | `IfNotPresent`                              |
-| `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array                                             | `nil`                                       |
+| `metrics.image.pullSecrets`             | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
 | `metrics.podAnnotations`                | Additional annotations for Metrics exporter pod                                              | {}                                          |
 | `metrics.resources`                     | Exporter resource requests/limit                                                             | Memory: `256Mi`, CPU: `100m`             |
 | `metrics.serviceMonitor.enabled`        | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                 | `false`                                     |


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
