### PR TITLE
[stable/moodle] Document the correct format for pullSecrets in README

### DIFF
--- a/stable/moodle/Chart.yaml
+++ b/stable/moodle/Chart.yaml
@@ -1,5 +1,5 @@
 name: moodle
-version: 4.0.3
+version: 4.0.4
 appVersion: 3.6.2
 description: Moodle is a learning platform designed to provide educators, administrators and learners with a single robust, secure and integrated system to create personalised learning environments
 keywords:

--- a/stable/moodle/README.md
+++ b/stable/moodle/README.md
@@ -49,80 +49,80 @@ The following table lists the configurable parameters of the Moodle chart and th
 
 |              Parameter                |                                       Description                                            |                   Default                               |
 |---------------------------------------|----------------------------------------------------------------------------------------------|-------------------------------------------------------- |
-| `global.imageRegistry`                | Global Docker image registry                                                                 | `nil`                                                   |
-| `image.registry`                      | Moodle image registry                                                                        | `docker.io`                                             |
-| `image.repository`                    | Moodle Image name                                                                            | `bitnami/moodle`                                        |
-| `image.tag`                           | Moodle Image tag                                                                             | `{VERSION}`                                             |
-| `image.pullPolicy`                    | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
-| `image.pullSecrets`                   | Specify image pull secrets                                                                   | `nil`                                                   |
-| `moodleUsername`                      | User of the application                                                                      | `user`                                                  |
-| `moodlePassword`                      | Application password                                                                         | _random 10 character alphanumeric string_               |
-| `moodleEmail`                         | Admin email                                                                                  | `user@example.com`                                      |
-| `smtpHost`                            | SMTP host                                                                                    | `nil`                                                   |
-| `smtpPort`                            | SMTP port                                                                                    | `nil` (but moodle internal default is 25)               |
-| `smtpProtocol`                        | SMTP Protocol (options: ssl,tls, nil)                                                        | `nil`                                                   |
-| `smtpUser`                            | SMTP user                                                                                    | `nil`                                                   |
-| `smtpPassword`                        | SMTP password                                                                                | `nil`                                                   |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                    | `80`                                          |
-| `service.httpsPort`                    | Service HTTPS port                    | `443`                                          |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
-| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
-| `service.nodePorts.https`                | Kubernetes https node port                 | `""`                                                    |
-| `ingress.enabled`                     | Enable ingress controller resource                                                           | `false`                                                 |
-| `ingress.hosts[0].name`               | Hostname to your Moodle installation                                                         | `moodle.local`                                          |
-| `ingress.hosts[0].path`               | Path within the url structure                                                                | `/`                                                     |
-| `ingress.hosts[0].tls`                | Utilize TLS backend in ingress                                                               | `false`                                                 |
-| `ingress.hosts[0].certManager`        | Add annotations for cert-manager                                                             | `false`                                                 |
-| `ingress.hosts[0].tlsSecret`          | TLS Secret (certificates)                                                                    | `moodle.local-tls-secret`                               |
-| `ingress.hosts[0].annotations`        | Annotations for this host's ingress record                                                   | `[]`                                                    |
-| `ingress.secrets[0].name`             | TLS Secret Name                                                                              | `nil`                                                   |
-| `ingress.secrets[0].certificate`      | TLS Secret Certificate                                                                       | `nil`                                                   |
-| `ingress.secrets[0].key`              | TLS Secret Key                                                                               | `nil`                                                   |
-| `affinity`                            | Set affinity for the moodle pods                                                             | `nil`                                                   |
-| `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                            |
-| `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                                  |
-| `persistence.storageClass`            | PVC Storage Class for Moodle volume                                                          | `nil` (uses alpha storage class annotation)             |
-| `persistence.accessMode`              | PVC Access Mode for Moodle volume                                                            | `ReadWriteOnce`                                         |
-| `persistence.size`                    | PVC Storage Request for Moodle volume                                                        | `8Gi`                                                   |
-| `persistence.existingClaim`           | If PVC exists&bounded for Moodle                                                             | `nil` (when nil, new one is requested)                  |
-| `allowEmptyPassword`                  | Allow DB blank passwords                                                                     | `yes`                                                   |
-| `externalDatabase.host`               | Host of the external database                                                                | `nil`                                                   |
-| `externalDatabase.port`               | Port of the external database                                                                | `3306`                                                  |
-| `externalDatabase.user`               | Existing username in the external db                                                         | `bn_moodle`                                             |
-| `externalDatabase.password`           | Password for the above username                                                              | `nil`                                                   |
-| `externalDatabase.database`           | Name of the existing database                                                                | `bitnami_moodle`                                        |
-| `mariadb.enabled`                     | Whether to install the MariaDB chart                                                         | `true`                                                  |
-| `mariadb.db.name`                     | Database name to create                                                                      | `bitnami_moodle`                                        |
-| `mariadb.db.user`                     | Database user to create                                                                      | `bn_moodle`                                             |
-| `mariadb.db.password`                 | Password for the database                                                                    | `nil`                                                   |
-| `mariadb.rootUser.password`           | MariaDB admin password                                                                       | `nil`                                                   |
-| `mariadb.persistence.enabled`         | Enable MariaDB persistence using PVC                                                         | `true`                                                  |
-| `mariadb.persistence.storageClass`    | PVC Storage Class for MariaDB volume                                                         | `generic`                                               |
-| `mariadb.persistence.accessMode`      | PVC Access Mode for MariaDB volume                                                           | `ReadWriteOnce`                                         |
-| `mariadb.persistence.size`            | PVC Storage Request for MariaDB volume                                                       | `8Gi`                                                   |
-| `mariadb.persistence.existingClaim`   | If PVC exists&bounded for MariaDB                                                            | `nil` (when nil, new one is requested)                  |
-| `mariadb.affinity`                    | Set affinity for the MariaDB pods                                                            | `nil`                                                   |
-| `mariadb.resources`                   | CPU/Memory resource requests/limits                                                          | Memory: `256Mi`, CPU: `250m`                            |
-| `livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                     | 600                                                     |
-| `livenessProbe.periodSeconds`         | How often to perform the probe                                                               | 3                                                       |
-| `livenessProbe.timeoutSeconds`        | When the probe times out                                                                     | 5                                                       |
-| `livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                       |
-| `livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                       |
-| `readinessProbe.initialDelaySeconds`  | Delay before readiness probe is initiated                                                    | 30                                                      |
-| `readinessProbe.periodSeconds`        | How often to perform the probe                                                               | 3                                                       |
-| `readinessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                                       |
-| `readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                                       |
-| `readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                                       |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `nil`                                                |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
+| `global.imageRegistry`                | Global Docker image registry                                                                 | `nil`                                         |
+| `image.registry`                      | Moodle image registry                                                                        | `docker.io`                                   |
+| `image.repository`                    | Moodle Image name                                                                            | `bitnami/moodle`                              |
+| `image.tag`                           | Moodle Image tag                                                                             | `{VERSION}`                                   |
+| `image.pullPolicy`                    | Image pull policy                                                                            | `Always` if `imageTag` is `latest`, else `IfNotPresent`|
+| `image.pullSecrets`                   | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
+| `moodleUsername`                      | User of the application                                                                      | `user`                                         |
+| `moodlePassword`                      | Application password                                                                         | _random 10 character alphanumeric string_      |
+| `moodleEmail`                         | Admin email                                                                                  | `user@example.com`                             |
+| `smtpHost`                            | SMTP host                                                                                    | `nil`                                          |
+| `smtpPort`                            | SMTP port                                                                                    | `nil` (but moodle internal default is 25)      |
+| `smtpProtocol`                        | SMTP Protocol (options: ssl,tls, nil)                                                        | `nil`                                          |
+| `smtpUser`                            | SMTP user                                                                                    | `nil`                                          |
+| `smtpPassword`                        | SMTP password                                                                                | `nil`                                          |
+| `service.type`                        | Kubernetes Service type                                                                      | `LoadBalancer`                                 |
+| `service.port`                        | Service HTTP port                                                                            | `80`                                           |
+| `service.httpsPort`                   | Service HTTPS port                                                                           | `443`                                          |
+| `service.externalTrafficPolicy`       | Enable client source IP preservation                                                         | `Cluster`                                      |
+| `service.nodePorts.http`              | Kubernetes http node port                                                                    | `""`                                           |
+| `service.nodePorts.https`             | Kubernetes https node port                                                                   | `""`                                           |
+| `ingress.enabled`                     | Enable ingress controller resource                                                           | `false`                                        |
+| `ingress.hosts[0].name`               | Hostname to your Moodle installation                                                         | `moodle.local`                                 |
+| `ingress.hosts[0].path`               | Path within the url structure                                                                | `/`                                            |
+| `ingress.hosts[0].tls`                | Utilize TLS backend in ingress                                                               | `false`                                        |
+| `ingress.hosts[0].certManager`        | Add annotations for cert-manager                                                             | `false`                                        |
+| `ingress.hosts[0].tlsSecret`          | TLS Secret (certificates)                                                                    | `moodle.local-tls-secret`                      |
+| `ingress.hosts[0].annotations`        | Annotations for this host's ingress record                                                   | `[]`                                           |
+| `ingress.secrets[0].name`             | TLS Secret Name                                                                              | `nil`                                          |
+| `ingress.secrets[0].certificate`      | TLS Secret Certificate                                                                       | `nil`                                          |
+| `ingress.secrets[0].key`              | TLS Secret Key                                                                               | `nil`                                          |
+| `affinity`                            | Set affinity for the moodle pods                                                             | `nil`                                          |
+| `resources`                           | CPU/Memory resource requests/limits                                                          | Memory: `512Mi`, CPU: `300m`                   |
+| `persistence.enabled`                 | Enable persistence using PVC                                                                 | `true`                                         |
+| `persistence.storageClass`            | PVC Storage Class for Moodle volume                                                          | `nil` (uses alpha storage class annotation)    |
+| `persistence.accessMode`              | PVC Access Mode for Moodle volume                                                            | `ReadWriteOnce`                                |
+| `persistence.size`                    | PVC Storage Request for Moodle volume                                                        | `8Gi`                                          |
+| `persistence.existingClaim`           | If PVC exists&bounded for Moodle                                                             | `nil` (when nil, new one is requested)         |
+| `allowEmptyPassword`                  | Allow DB blank passwords                                                                     | `yes`                                          |
+| `externalDatabase.host`               | Host of the external database                                                                | `nil`                                          |
+| `externalDatabase.port`               | Port of the external database                                                                | `3306`                                         |
+| `externalDatabase.user`               | Existing username in the external db                                                         | `bn_moodle`                                    |
+| `externalDatabase.password`           | Password for the above username                                                              | `nil`                                          |
+| `externalDatabase.database`           | Name of the existing database                                                                | `bitnami_moodle`                               |
+| `mariadb.enabled`                     | Whether to install the MariaDB chart                                                         | `true`                                         |
+| `mariadb.db.name`                     | Database name to create                                                                      | `bitnami_moodle`                               |
+| `mariadb.db.user`                     | Database user to create                                                                      | `bn_moodle`                                    |
+| `mariadb.db.password`                 | Password for the database                                                                    | `nil`                                          |
+| `mariadb.rootUser.password`           | MariaDB admin password                                                                       | `nil`                                          |
+| `mariadb.persistence.enabled`         | Enable MariaDB persistence using PVC                                                         | `true`                                         |
+| `mariadb.persistence.storageClass`    | PVC Storage Class for MariaDB volume                                                         | `generic`                                      |
+| `mariadb.persistence.accessMode`      | PVC Access Mode for MariaDB volume                                                           | `ReadWriteOnce`                                |
+| `mariadb.persistence.size`            | PVC Storage Request for MariaDB volume                                                       | `8Gi`                                          |
+| `mariadb.persistence.existingClaim`   | If PVC exists&bounded for MariaDB                                                            | `nil` (when nil, new one is requested)         |
+| `mariadb.affinity`                    | Set affinity for the MariaDB pods                                                            | `nil`                                          |
+| `mariadb.resources`                   | CPU/Memory resource requests/limits                                                          | Memory: `256Mi`, CPU: `250m`                   |
+| `livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                     | 600                                            |
+| `livenessProbe.periodSeconds`         | How often to perform the probe                                                               | 3                                              |
+| `livenessProbe.timeoutSeconds`        | When the probe times out                                                                     | 5                                              |
+| `livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                              |
+| `livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                              |
+| `readinessProbe.initialDelaySeconds`  | Delay before readiness probe is initiated                                                    | 30                                             |
+| `readinessProbe.periodSeconds`        | How often to perform the probe                                                               | 3                                              |
+| `readinessProbe.timeoutSeconds`       | When the probe times out                                                                     | 5                                              |
+| `readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | 6                                              |
+| `readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed. | 1                                              |
+| `podAnnotations`                      | Pod annotations                                                                              | `{}`                                           |
+| `metrics.enabled`                     | Start a side-car prometheus exporter                                                         | `false`                                        |
+| `metrics.image.registry`              | Apache exporter image registry                                                               | `docker.io`                                    |
+| `metrics.image.repository`            | Apache exporter image name                                                                   | `lusotycoon/apache-exporter`                   |
+| `metrics.image.tag`                   | Apache exporter image tag                                                                    | `v0.5.0`                                       |
+| `metrics.image.pullPolicy`            | Image pull policy                                                                            | `IfNotPresent`                                 |
+| `metrics.image.pullSecrets`           | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
+| `metrics.podAnnotations`              | Additional annotations for Metrics exporter pod                                              | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                   | Exporter resource requests/limit                                                             | {}                                                       |
 
 The above parameters map to the env variables defined in [bitnami/moodle](http://github.com/bitnami/bitnami-docker-moodle). For more information please refer to the [bitnami/moodle](http://github.com/bitnami/bitnami-docker-moodle) image documentation.
 


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
