### PR TITLE
[stable/joomla] Document the correct format for pullSecrets in README

### DIFF
--- a/stable/joomla/Chart.yaml
+++ b/stable/joomla/Chart.yaml
@@ -1,5 +1,5 @@
 name: joomla
-version: 4.0.1
+version: 4.0.2
 appVersion: 3.9.1
 description: PHP content management system (CMS) for publishing web content
 keywords:

--- a/stable/joomla/README.md
+++ b/stable/joomla/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the Joomla! chart and t
 | `image.repository`                   | Joomla! Image name                                          | `bitnami/joomla`                               |
 | `image.tag`                          | Joomla! Image tag                                           | `{VERSION}`                                    |
 | `image.pullPolicy`                   | Image pull policy                                           | `Always`                                       |
-| `image.pullSecrets`                  | Specify image pull secrets                                  | `nil`                                          |
+| `image.pullSecrets`                  | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed pods) |
 | `joomlaUsername`                     | User of the application                                     | `user`                                         |
 | `joomlaPassword`                     | Application password                                        | _random 10 character long alphanumeric string_ |
 | `joomlaEmail`                        | Admin email                                                 | `user@example.com`                             |
@@ -77,8 +77,8 @@ The following table lists the configurable parameters of the Joomla! chart and t
 | `mariadb.db.password`                | Password for the database                                   | `nil`                                          |
 | `mariadb.root.password`              | MariaDB admin password                                      | `nil`                                          |
 | `service.type`                       | Kubernetes Service type                                     | `LoadBalancer`                                 |
-| `service.port`                    | Service HTTP port                    | `80`                                          |
-| `service.httpsPort`                    | Service HTTPS port                    | `443`                                          |
+| `service.port`                       | Service HTTP port                                           | `80`                                           |
+| `service.httpsPort`                  | Service HTTPS port                                          | `443`                                          |
 | `service.loadBalancer`               | Kubernetes LoadBalancerIP to request                        | `nil`                                          |
 | `service.externalTrafficPolicy`      | Enable client source IP preservation                        | `Cluster`                                      |
 | `service.nodePorts.http`             | Kubernetes http node port                                   | `""`                                           |
@@ -116,15 +116,15 @@ The following table lists the configurable parameters of the Joomla! chart and t
 | `nodeSelector`                       | Node labels for pod assignment                              | `{}`                                           |
 | `tolerations`                        | List of node taints to tolerate                             | `[]`                                           |
 | `affinity`                           | Map of node/pod affinities                                  | `{}`                                           |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `nil`                                                |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
+| `podAnnotations`                     | Pod annotations                                             | `{}`                                           |
+| `metrics.enabled`                    | Start a side-car prometheus exporter                        | `false`                                        |
+| `metrics.image.registry`             | Apache exporter image registry                              | `docker.io`                                    |
+| `metrics.image.repository`           | Apache exporter image name                                  | `lusotycoon/apache-exporter`                   |
+| `metrics.image.tag`                  | Apache exporter image tag                                   | `v0.5.0`                                       |
+| `metrics.image.pullPolicy`           | Image pull policy                                           | `IfNotPresent`                                 |
+| `metrics.image.pullSecrets`          | Specify docker-registry secret names as an array            | `[]` (does not add image pull secrets to deployed    |
+| `metrics.podAnnotations`             | Additional annotations for Metrics exporter pod             | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`                  | Exporter resource requests/limit                            | {}                                              |
 
 The above parameters map to the env variables defined in [bitnami/joomla](http://github.com/bitnami/bitnami-docker-joomla). For more information please refer to the [bitnami/joomla](http://github.com/bitnami/bitnami-docker-joomla) image documentation.
 


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
