### PR TITLE
[stable/drupal] Document the correct format for pullSecrets in README

### DIFF
--- a/stable/drupal/Chart.yaml
+++ b/stable/drupal/Chart.yaml
@@ -1,5 +1,5 @@
 name: drupal
-version: 3.0.2
+version: 3.0.3
 appVersion: 8.6.5
 description: One of the most versatile open source content management systems.
 keywords:

--- a/stable/drupal/README.md
+++ b/stable/drupal/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the Drupal chart and th
 | `image.repository`                | Drupal Image name                          | `bitnami/drupal`                                          |
 | `image.tag`                       | Drupal Image tag                           | `{VERSION}`                                               |
 | `image.pullPolicy`                | Drupal image pull policy                   | `Always` if `imageTag` is `latest`, else `IfNotPresent`   |
-| `image.pullSecrets`               | Specify image pull secrets                 | `nil` (does not add image pull secrets to deployed pods)  |
+| `image.pullSecrets`               | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)  |
 | `drupalProfile`                   | Drupal installation profile                | `standard`                                                |
 | `drupalUsername`                  | User of the application                    | `user`                                                    |
 | `drupalPassword`                  | Application password                       | _random 10 character long alphanumeric string_            |
@@ -80,12 +80,12 @@ The following table lists the configurable parameters of the Drupal chart and th
 | `mariadb.db.name`                 | Database name to create                    | `bitnami_drupal`                                          |
 | `mariadb.db.user`                 | Database user to create                    | `bn_drupal`                                               |
 | `mariadb.db.password`             | Password for the database                  | _random 10 character long alphanumeric string_            |
-| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                          |
-| `service.port`                    | Service HTTP port                    | `80`                                          |
-| `service.httpsPort`                    | Service HTTPS port                    | `443`                                          |
-| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                               |
-| `service.nodePorts.http`                 | Kubernetes http node port                  | `""`                                                    |
-| `service.nodePorts.https`                | Kubernetes https node port                 | `""`                                                    |
+| `service.type`                    | Kubernetes Service type                    | `LoadBalancer`                                            |
+| `service.port`                    | Service HTTP port                          | `80`                                                      |
+| `service.httpsPort`               | Service HTTPS port                         | `443`                                                     |
+| `service.externalTrafficPolicy`   | Enable client source IP preservation       | `Cluster`                                                 |
+| `service.nodePorts.http`          | Kubernetes http node port                  | `""`                                                      |
+| `service.nodePorts.https`         | Kubernetes https node port                 | `""`                                                      |
 | `persistence.enabled`             | Enable persistence using PVC               | `true`                                                    |
 | `persistence.apache.storageClass` | PVC Storage Class for Apache volume        | `nil` (uses alpha storage class annotation)               |
 | `persistence.apache.accessMode`   | PVC Access Mode for Apache volume          | `ReadWriteOnce`                                           |
@@ -98,15 +98,15 @@ The following table lists the configurable parameters of the Drupal chart and th
 | `resources`                       | CPU/Memory resource requests/limits        | Memory: `512Mi`, CPU: `300m`                              |
 | `volumeMounts.drupal.mountPath`   | Drupal data volume mount path              | `/bitnami/drupal`                                         |
 | `volumeMounts.apache.mountPath`   | Apache data volume mount path              | `/bitnami/apache`                                         |
-| `podAnnotations`                | Pod annotations                                   | `{}`                                                       |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                           | `false`                                              |
-| `metrics.image.registry`                   | Apache exporter image registry                                                                                  | `docker.io`                                          |
-| `metrics.image.repository`                 | Apache exporter image name                                                                                      | `lusotycoon/apache-exporter`                           |
-| `metrics.image.tag`                        | Apache exporter image tag                                                                                       | `v0.5.0`                                            |
-| `metrics.image.pullPolicy`                 | Image pull policy                                                                                              | `IfNotPresent`                                       |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                               | `nil`                                                |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}`                                                   |
-| `metrics.resources`                        | Exporter resource requests/limit                                                                               | {}                        |
+| `podAnnotations`                  | Pod annotations                            | `{}`                                                      |
+| `metrics.enabled`                 | Start a side-car prometheus exporter       | `false`                                                   |
+| `metrics.image.registry`          | Apache exporter image registry             | `docker.io`                                               |
+| `metrics.image.repository`        | Apache exporter image name                 | `lusotycoon/apache-exporter`                              |
+| `metrics.image.tag`               | Apache exporter image tag                  | `v0.5.0`                                                  |
+| `metrics.image.pullPolicy`        | Image pull policy                          | `IfNotPresent`                                            |
+| `metrics.image.pullSecrets`       | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
+| `metrics.podAnnotations`          | Additional annotations for Metrics exporter pod  | `{prometheus.io/scrape: "true", prometheus.io/port: "9117"}` |
+| `metrics.resources`               | Exporter resource requests/limit           | {}                                                         |
 
 The above parameters map to the env variables defined in [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal). For more information please refer to the [bitnami/drupal](http://github.com/bitnami/bitnami-docker-drupal) image documentation.
 


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
