### PR TITLE
[stable/ghost] Document the correct format for pullSecrets in README

### DIFF
--- a/stable/ghost/Chart.yaml
+++ b/stable/ghost/Chart.yaml
@@ -1,5 +1,5 @@
 name: ghost
-version: 6.3.1
+version: 6.3.2
 appVersion: 2.10.1
 description: A simple, powerful publishing platform that allows you to share your stories with the world
 keywords:

--- a/stable/ghost/README.md
+++ b/stable/ghost/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the Ghost chart and the
 | `image.repository`                  | Ghost Image name                                              | `bitnami/ghost`                                          |
 | `image.tag`                         | Ghost Image tag                                               | `{VERSION}`                                              |
 | `image.pullPolicy`                  | Image pull policy                                             | `Always` if `imageTag` is `latest`, else `IfNotPresent`  |
-| `image.pullSecrets`                 | Specify image pull secrets                                    | `nil`                                                    |
+| `image.pullSecrets`                 | Specify docker-registry secret names as an array              | `[]` (does not add image pull secrets to deployed pods)  |
 | `volumePermissions.image.registry`  | Init container volume-permissions image registry              | `docker.io`                                              |
 | `volumePermissions.image.repository`| Init container volume-permissions image name                  | `bitnami/minideb`                                        |
 | `volumePermissions.image.tag`       | Init container volume-permissions image tag                   | `latest`                                                 |


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

#### What this PR does / why we need it:

`XXX.pullSecrets` should be an array of secrets, this PR add some comments in the README to clarify it.
Basically, it replaces different ways of
```
| `image.pullSecrets` | Specify image pull secrets | `nil` |
```
by
```
| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
