### PR TITLE
[stable/verdaccio] add optional fixed nodePort to service when NodePort service type used

### DIFF
--- a/stable/verdaccio/Chart.yaml
+++ b/stable/verdaccio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A lightweight private npm proxy registry (sinopia fork)
 name: verdaccio
-version: 0.6.0
+version: 0.6.1
 appVersion: 3.10.0
 home: http://www.verdaccio.org
 icon: https://raw.githubusercontent.com/verdaccio/verdaccio/master/assets/bitmap/logo/logo-twitter.png

--- a/stable/verdaccio/README.md
+++ b/stable/verdaccio/README.md
@@ -55,7 +55,7 @@ and their default values.
 | `customConfigMap`                  | Use a custom ConfigMap                                          | `false`                                                  |
 | `image.pullPolicy`                 | Image pull policy                                               | `IfNotPresent`                                           |
 | `image.repository`                 | Verdaccio container image repository                            | `verdaccio/verdaccio`                                    |
-| `image.tag`                        | Verdaccio container image tag                                   | `3.10.0`                                                    |
+| `image.tag`                        | Verdaccio container image tag                                   | `3.10.0`                                                 |
 | `nodeSelector`                     | Node labels for pod assignment                                  | `{}`                                                     |
 | `persistence.accessMode`           | PVC Access Mode for Verdaccio volume                            | `ReadWriteOnce`                                          |
 | `persistence.enabled`              | Enable persistence using PVC                                    | `true`                                                   |
@@ -73,6 +73,7 @@ and their default values.
 | `service.loadBalancerIP`           | IP address to assign to load balancer (if supported)            | `""`                                                     |
 | `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported) | `[]`                                                     |
 | `service.port`                     | Service port to expose                                          | `4873`                                                   |
+| `service.nodePort`                 | Service port to expose                                          | none                                                     |
 | `service.type`                     | Type of service to create                                       | `ClusterIP`                                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/stable/verdaccio/templates/service.yaml
+++ b/stable/verdaccio/templates/service.yaml
@@ -29,6 +29,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: {{ .Values.service.name }}
+      {{- if contains "NodePort" .Values.service.type }}
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+      {{- end }}
   selector:
     app: {{ template "verdaccio.name" . }}
     release: {{ .Release.Name }}

--- a/stable/verdaccio/values.yaml
+++ b/stable/verdaccio/values.yaml
@@ -16,6 +16,7 @@ service:
   loadBalancerSourceRanges: []
   port: 4873
   type: ClusterIP
+  # nodePort: 31873
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
Signed-off-by: James Sidhu <james.thomas.sidhu@gmail.com>

#### What this PR does / why we need it:
With local kube it is sometimes helpful to have a local npm registry when working on development of node.js services. The nodePort allows us to fix the local NodePort service to expose from the local kube cluster so it can be accessible from a local kubernetes cluster.

#### Which issue this PR fixes:
nodePort not being exposed on service to configure for local development.

#### Special notes for your reviewer:
I've resubmitted this PR following new DCO format after comment from @cpanato - please let me know if there is anything you need to be updated.

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->
