### PR TITLE
[stable/kube-state-metrics] add configmap and secret collectors

### DIFF
--- a/stable/kube-state-metrics/Chart.yaml
+++ b/stable/kube-state-metrics/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - metric
 - monitoring
 - prometheus
-version: 0.12.1
+version: 0.12.2
 appVersion: 1.4.0
 home: https://github.com/kubernetes/kube-state-metrics/
 sources:

--- a/stable/kube-state-metrics/README.md
+++ b/stable/kube-state-metrics/README.md
@@ -29,6 +29,7 @@ $ helm install stable/kube-state-metrics
 | `tolerations`                         | Tolerations for pod assignment	                      | []                                          |
 | `podAnnotations`                      | Annotations to be added to the pod                      | {}                                          |
 | `resources`                           | kube-state-metrics resource requests and limits         | {}                                          |
+| `collectors.configmaps`               | Enable the configmaps collector.                        | true                                        |
 | `collectors.cronjobs`                 | Enable the cronjobs collector.                          | true                                        |
 | `collectors.daemonsets`               | Enable the daemonsets collector.                        | true                                        |
 | `collectors.deployments`              | Enable the deployments collector.                       | true                                        |
@@ -44,5 +45,6 @@ $ helm install stable/kube-state-metrics
 | `collectors.replicasets`              | Enable the replicasets collector.                       | true                                        |
 | `collectors.replicationcontrollers`   | Enable the replicationcontrollers collector.            | true                                        |
 | `collectors.resourcequotas`           | Enable the resourcequotas collector.                    | true                                        |
+| `collectors.secrets`                  | Enable the secrets collector.                           | true                                        |
 | `collectors.services`                 | Enable the services collector.                          | true                                        |
 | `collectors.statefulsets`             | Enable the statefulsets collector.                      | true                                        |

--- a/stable/kube-state-metrics/templates/clusterrole.yaml
+++ b/stable/kube-state-metrics/templates/clusterrole.yaml
@@ -9,6 +9,12 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "kube-state-metrics.fullname" . }}
 rules:
+{{ if .Values.collectors.configmaps }}
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+{{ end -}}
 {{ if .Values.collectors.cronjobs }}
 - apiGroups: ["batch"]
   resources:
@@ -97,6 +103,12 @@ rules:
 - apiGroups: [""]
   resources:
   - resourcequotas
+  verbs: ["list", "watch"]
+{{ end -}}
+{{ if .Values.collectors.secrets }}
+- apiGroups: [""]
+  resources:
+  - secrets
   verbs: ["list", "watch"]
 {{ end -}}
 {{ if .Values.collectors.services }}

--- a/stable/kube-state-metrics/templates/deployment.yaml
+++ b/stable/kube-state-metrics/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         args:
+{{  if .Values.collectors.configmaps  }}
+        - --collectors=configmaps
+{{  end  }}
 {{  if .Values.collectors.cronjobs  }}
         - --collectors=cronjobs
 {{  end  }}
@@ -75,6 +78,9 @@ spec:
 {{  end  }}
 {{  if .Values.collectors.resourcequotas  }}
         - --collectors=resourcequotas
+{{  end  }}
+{{  if .Values.collectors.secrets  }}
+        - --collectors=secrets
 {{  end  }}
 {{  if .Values.collectors.services  }}
         - --collectors=services

--- a/stable/kube-state-metrics/values.yaml
+++ b/stable/kube-state-metrics/values.yaml
@@ -38,6 +38,7 @@ podAnnotations: {}
 # Available collectors for kube-state-metrics. By default all available
 # collectors are enabled.
 collectors:
+  configmaps: true
   cronjobs: true
   daemonsets: true
   deployments: true
@@ -53,6 +54,7 @@ collectors:
   replicasets: true
   replicationcontrollers: true
   resourcequotas: true
+  secrets: true
   services: true
   statefulsets: true
 


### PR DESCRIPTION
Signed-off-by: Louise Champ louise@livewyer.com

#### What this PR does / why we need it:

Configmap and secret collectors were added in kube-state-metrics 1.3. This PR adds templating and switches for these two collectors.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
