### PR TITLE
skip null values for traefik dns config

### DIFF
--- a/stable/traefik/Chart.yaml
+++ b/stable/traefik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: traefik
-version: 1.58.0
+version: 1.59.0
 appVersion: 1.7.6
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 keywords:

--- a/stable/traefik/templates/deployment.yaml
+++ b/stable/traefik/templates/deployment.yaml
@@ -85,12 +85,14 @@ spec:
           timeoutSeconds: 2
         {{- if and .Values.acme.enabled (eq .Values.acme.challengeType "dns-01") .Values.acme.dnsProvider.name }}
         env:
-        {{- range $k, $_ := (index .Values.acme.dnsProvider .Values.acme.dnsProvider.name) }}
+        {{- range $k, $v := (index .Values.acme.dnsProvider .Values.acme.dnsProvider.name) }}
+          {{- if $v }}
           - name: {{ $k }}
             valueFrom:
               secretKeyRef:
                 name: {{ template "traefik.fullname" $ }}-dnsprovider-config
                 key: {{ $k }}
+          {{- end }}
         {{- end }}
         {{- end }}
         volumeMounts:

--- a/stable/traefik/templates/dns-provider-secret.yaml
+++ b/stable/traefik/templates/dns-provider-secret.yaml
@@ -11,6 +11,8 @@ metadata:
 type: Opaque
 data:
 {{- range $k, $v := (index .Values.acme.dnsProvider .Values.acme.dnsProvider.name) }}
-  {{ $k }}: {{ $v | b64enc | quote }}
+  {{- if $v }}
+    {{ $k }}: {{ $v | b64enc | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

goolge dns can be used with scopes and therefor we dont need a secrets file.
for example:
```
acme:
  challengeType: dns-01
  dnsProvider:
    gcloud:
      GCE_PROJECT: PROJECT_ID
      GCE_SERVICE_ACCOUNT_FILE: null
```
this PR skips null values for dns config options


#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
