### PR TITLE
[stable/grafana] Add extraConfigmapMounts for certs/dashboards in specific folders

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.24.2
+version: 1.25.0
 appVersion: 5.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -64,6 +64,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `envFromSecret`                           | Name of a Kubenretes secret (must be manually created in the same namespace) containing values to be added to the environment | `""` |
 | `extraSecretMounts`                       | Additional grafana server secret mounts       | `[]`                                                    |
 | `extraVolumeMounts`                       | Additional grafana server volume mounts       | `[]`                                                    |
+| `extraConfigmapMounts`                    | Additional grafana server configMap volume mounts  | `[]`                                               |
 | `plugins`                                 | Plugins to be loaded along with Grafana       | `[]`                                                    |
 | `datasources`                             | Configure grafana datasources                 | `{}`                                                    |
 | `dashboardProviders`                      | Configure grafana dashboard providers         | `{}`                                                    |

--- a/stable/grafana/templates/deployment.yaml
+++ b/stable/grafana/templates/deployment.yaml
@@ -137,6 +137,11 @@ spec:
               mountPath: "/etc/grafana/ldap.toml"
               subPath: ldap.toml
             {{- end }}
+            {{- range .Values.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
             - name: storage
               mountPath: "/var/lib/grafana"
 {{- if .Values.persistence.subPath }}
@@ -258,6 +263,11 @@ spec:
         - name: config
           configMap:
             name: {{ template "grafana.fullname" . }}
+      {{- range .Values.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+      {{- end }}
         {{- if .Values.dashboards }}
           {{- range keys .Values.dashboards }}
         - name: dashboards-{{ . }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -39,6 +39,14 @@ securityContext:
   runAsUser: 472
   fsGroup: 472
 
+
+extraConfigmapMounts: []
+  # - name: certs-configmap
+  #   mountPath: /etc/grafana/ssl/
+  #   configMap: certs-configmap
+  #   readOnly: true
+
+
 ## Assign a PriorityClassName to pods if set
 # priorityClassName:
 


### PR DESCRIPTION
Signed-off-by: Derek Heldt-Werle <derek.heldt-werle@viasat.com>

#### What this PR does / why we need it:
Adds the ability for users to specify extra configmaps to be mounted into the grafana pod. This can be useful for mounting in certs for working with ldaps, mounting certain dashboards to a desired location (useful when only allowing certain orgs access to certain dashboards), and any other potential needs for mounting in a configmap future looking.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
