### PR TITLE
[stable/postgresql] Stop using POD IP for liveness checks so that it works with Istio mTLS

### DIFF
--- a/stable/postgresql/Chart.yaml
+++ b/stable/postgresql/Chart.yaml
@@ -1,5 +1,5 @@
 name: postgresql
-version: 3.9.1
+version: 3.9.2
 appVersion: 10.6.0
 description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
 keywords:

--- a/stable/postgresql/templates/statefulset-slaves.yaml
+++ b/stable/postgresql/templates/statefulset-slaves.yaml
@@ -106,8 +106,6 @@ spec:
           value: {{ template "postgresql.fullname" . }}
         - name: POSTGRESQL_MASTER_PORT_NUMBER
           value: {{ .Values.service.port | quote }}
-        - name: POD_IP
-          valueFrom: { fieldRef: { fieldPath: status.podIP } }
         ports:
         - name: postgresql
           containerPort: {{ .Values.service.port }}
@@ -117,7 +115,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} --host $POD_IP
+            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -h localhost
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -130,7 +128,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} --host $POD_IP
+            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -h localhost
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/stable/postgresql/templates/statefulset.yaml
+++ b/stable/postgresql/templates/statefulset.yaml
@@ -130,8 +130,6 @@ spec:
         - name: POSTGRESQL_DATABASE
           value: {{ .Values.postgresqlDatabase | quote }}
         {{- end }}
-        - name: POD_IP
-          valueFrom: { fieldRef: { fieldPath: status.podIP } }
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}
 {{- end }}
@@ -144,7 +142,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} --host $POD_IP
+            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -h localhost
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -157,7 +155,7 @@ spec:
             command:
             - sh
             - -c
-            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} --host $POD_IP
+            - exec pg_isready -U {{ .Values.postgresqlUsername | quote }} -h localhost
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
If mutual TLS is enabled in strict mode with Istio, then the Postgresql
liveness and readiness checks fail to succeed, as traffic to pod IPs is
blocked by the sidecar proxy.

See: https://istio.io/help/faq/security/#k8s-health-checks

Signed-off-by: Adam Eijdenberg <adam.eijdenberg@digital.gov.au>

#### What this PR does / why we need it:

Istio can be used to provide mutual TLS between services. Without this change Postgresql fails readiness and liveness checks if Istio mutual TLS is enabled.

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
