### PR TITLE
[stable/redis-ha] Fix for using existing secret value

### DIFF
--- a/stable/redis-ha/Chart.yaml
+++ b/stable/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.1.2
+version: 3.1.3
 appVersion: 5.0.3
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/stable/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/stable/redis-ha/templates/redis-ha-statefulset.yaml
@@ -59,7 +59,7 @@ spec:
               name: {{ .Values.existingSecret }}
             {{- else }}
               name: {{ template "redis-ha.fullname" . }}
-            {{- end }}  
+            {{- end }}
               key: auth
 {{- end }}
         volumeMounts:
@@ -81,7 +81,11 @@ spec:
         - name: AUTH
           valueFrom:
             secretKeyRef:
+            {{- if .Values.existingSecret }}
+              name: {{ .Values.existingSecret }}
+            {{- else }}
               name: {{ template "redis-ha.fullname" . }}
+            {{- end }}
               key: auth
 {{- end }}
         livenessProbe:
@@ -116,7 +120,11 @@ spec:
         - name: AUTH
           valueFrom:
             secretKeyRef:
+            {{- if .Values.existingSecret }}
+              name: {{ .Values.existingSecret }}
+            {{- else }}
               name: {{ template "redis-ha.fullname" . }}
+            {{- end }}
               key: auth
 {{- end }}
         livenessProbe:


### PR DESCRIPTION
The PR https://github.com/helm/charts/pull/10032 injects the AUTH
secret into the redis and sentinel containers but does not
consider the existingSecret parameter.

Signed-off-by: Thomas Schmitt <thomas.schmitt@ni.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
