### PR TITLE
incorrect value for readiness probe path

### DIFF
--- a/stable/karma/Chart.yaml
+++ b/stable/karma/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/prymitive/karma
 sources:
   - https://hub.docker.com/r/lmierzwa/karma/
   - https://github.com/prymitive/karma
-version: 1.1.7
+version: 1.1.8
 maintainers:
 - name: davidkarlsen
   email: david@davidkarlsen.com

--- a/stable/karma/templates/deployment.yaml
+++ b/stable/karma/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               periodSeconds: {{ .Values.livenessProbe.period }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.livenessProbePath }}
+              path: {{ .Values.livenessProbe.path }}
               port: http
               initialDelaySeconds: {{ .Values.livenessProbe.delay }}
               periodSeconds: {{ .Values.livenessProbe.period }}


### PR DESCRIPTION
#### What this PR does / why we need it:
I introduced an error in the previous update when reorganizing the livenessProbe values. This results in pods not becoming ready when using a custom prefix for Karma.

#### Special notes for your reviewer:
@prymitive 
@davidkarlsen 

#### Checklist
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
