### PR TITLE
[stable/grafana] Add gerrit server as dashboard origin

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 1.25.2
+version: 1.25.3
 appVersion: 5.4.3
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/README.md
+++ b/stable/grafana/README.md
@@ -91,6 +91,17 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.pspEnabled`                         | Create PodSecurityPolicy (with `rbac.create`, grant roles permissions as well) | `true` |
 | `rbac.pspUseAppArmor`                     | Enforce AppArmor in created PodSecurityPolicy (requires `rbac.pspEnabled`)  | `true` |
 
+## BASE64 dashboards
+
+Dashboards could be storaged in a server that does not return JSON directly and instead of it returns a Base64 encoded file (e.g. Gerrit)
+A new parameter has been added to the url use case so if you specify a b64content value equals to true after the url entry a Base64 decoding is applied before save the file to disk. 
+If this entry is not set or is equals to false not decoding is applied to the file before saving it to disk.
+
+### Gerrit use case: 
+Gerrit API for download files has the following schema: https://yourgerritserver/a/{project-name}/branches/{branch-id}/files/{file-id}/content where {project-name} and
+{file-id} usualy has '/' in their values and so they MUST be replaced by %2F so if project-name is user/repo, branch-id is master and file-id is equals to dir1/dir2/dashboard 
+the url value is https://yourgerritserver/a/user%2Frepo/branches/master/files/dir1%2Fdir2%2Fdashboard/content
+
 ## Sidecar for dashboards
 
 If the parameter `sidecar.dashboards.enabled` is set, a sidecar container is deployed in the grafana pod. This container watches all config maps in the cluster and filters out the ones with a label as defined in `sidecar.dashboards.label`. The files defined in those configmaps are written to a folder and accessed by grafana. Changes to the configmaps are monitored and the imported dashboards are deleted/updated. A recommendation is to use one configmap per dashboard, as an reduction of multiple dashboards inside one configmap is currently not properly mirrored in grafana.

--- a/stable/grafana/templates/configmap.yaml
+++ b/stable/grafana/templates/configmap.yaml
@@ -52,11 +52,13 @@ data:
     curl -sk \
     --connect-timeout 60 \
     --max-time 60 \
+      {{- if not $value.b64content }}
     -H "Accept: application/json" \
     -H "Content-Type: application/json;charset=UTF-8" \
-    {{- if $value.url -}}{{ $value.url }}{{- else -}} https://grafana.com/api/dashboards/{{ $value.gnetId }}/revisions/{{- if $value.revision -}}{{ $value.revision }}{{- else -}}1{{- end -}}/download{{- end -}}{{ if $value.datasource }}| sed 's|\"datasource\":[^,]*|\"datasource\": \"{{ $value.datasource }}\"|g'{{ end }} \
-    > /var/lib/grafana/dashboards/{{ $provider }}/{{ $key }}.json
       {{- end }}
+    {{- if $value.url -}}{{ $value.url }}{{- else -}} https://grafana.com/api/dashboards/{{ $value.gnetId }}/revisions/{{- if $value.revision -}}{{ $value.revision }}{{- else -}}1{{- end -}}/download{{- end -}}{{ if $value.datasource }}| sed 's|\"datasource\":[^,]*|\"datasource\": \"{{ $value.datasource }}\"|g'{{ end }}{{- if $value.b64content -}} | base64 -d {{- end -}} \
+    > /var/lib/grafana/dashboards/{{ $provider }}/{{ $key }}.json
+      {{- end -}}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -215,8 +215,15 @@ dashboards: {}
 #      gnetId: 2
 #      revision: 2
 #      datasource: Prometheus
-#    local-dashboard:
+#    local-dashboard-no-base64-impicit:
 #      url: https://example.com/repository/test.json
+#    local-dashboard-no-base64-expicit:
+#      url: https://example.com/repository/test.json
+#      b64content: false
+#    local-dashboard-base64:
+#      url: https://example.com/repository/test-b64.json
+#      url: https://user:pass@gerritserver.com/a/projects/owner%2Frepo/branches/branchname/files/dir1%2Fdir2%2Ffile.json/content
+#      b64content: true
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfiMap name as value.
 ## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.

--- a/stable/grafana/values.yaml
+++ b/stable/grafana/values.yaml
@@ -215,14 +215,10 @@ dashboards: {}
 #      gnetId: 2
 #      revision: 2
 #      datasource: Prometheus
-#    local-dashboard-no-base64-impicit:
+#    local-dashboard:
 #      url: https://example.com/repository/test.json
-#    local-dashboard-no-base64-expicit:
-#      url: https://example.com/repository/test.json
-#      b64content: false
 #    local-dashboard-base64:
 #      url: https://example.com/repository/test-b64.json
-#      url: https://user:pass@gerritserver.com/a/projects/owner%2Frepo/branches/branchname/files/dir1%2Fdir2%2Ffile.json/content
 #      b64content: true
 
 ## Reference to external ConfigMap per provider. Use provider name as key and ConfiMap name as value.


### PR DESCRIPTION
Signed-off-by: cesaralbloz <cesaralbloz@hotmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

Add support for getting dashboard from a gerrit server. Git respositories hosted in a gerrit server does not allow to get files with a normal curl like github so you need to use the Gerrit REST API. This API allows you to get individual files. This files are Base64 encoded so an aditional step is needed. 

New functioanlity

Curl command used by the grafana and url use cases is using some headers that interferes with the downloaded file. This one together the base64 decoding makes necessary to add a new condition in downloading script.

- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
