### PR TITLE
[stable/nginx-ingress] Allow setting of NodePort

### DIFF
--- a/stable/nginx-ingress/Chart.yaml
+++ b/stable/nginx-ingress/Chart.yaml
@@ -1,5 +1,5 @@
 name: nginx-ingress
-version: 1.3.1
+version: 1.3.2
 appVersion: 0.22.0
 home: https://github.com/kubernetes/ingress-nginx
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.

--- a/stable/nginx-ingress/README.md
+++ b/stable/nginx-ingress/README.md
@@ -95,8 +95,8 @@ Parameter | Description | Default
 `controller.service.targetPorts.http` | Sets the targetPort that maps to the Ingress' port 80 | `80`
 `controller.service.targetPorts.https` | Sets the targetPort that maps to the Ingress' port 443 | `443`
 `controller.service.type` | type of controller service to create | `LoadBalancer`
-`controller.service.nodePorts.http` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 80 | `""`
-`controller.service.nodePorts.https` | If `controller.service.type` is `NodePort` and this is non-empty, it sets the nodePort that maps to the Ingress' port 443 | `""`
+`controller.service.nodePorts.http` | Sets the nodePort that maps to the Ingress' port 80 | `""`
+`controller.service.nodePorts.https` | Sets the nodePort that maps to the Ingress' port 443 | `""`
 `controller.livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | 10
 `controller.livenessProbe.periodSeconds` | How often to perform the probe | 10
 `controller.livenessProbe.timeoutSeconds` | When the probe times out | 5

--- a/stable/nginx-ingress/templates/controller-service.yaml
+++ b/stable/nginx-ingress/templates/controller-service.yaml
@@ -42,7 +42,7 @@ spec:
       port: 80
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
-      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
+      {{- if (not (empty .Values.controller.service.nodePorts.http)) }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
       {{- end }}
     {{- end }}
@@ -51,7 +51,7 @@ spec:
       port: 443
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
-      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
+      {{- if (not (empty .Values.controller.service.nodePorts.https)) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
- Allows the setting of the NodePort for the exposed service regardless
of the `type` that the service is being deployed as.

Reviewers per Chart.yaml: @mgoodness @jackzampolin

#### Special notes for your reviewer:
In our case there are issues with the NLB's ability to update the
SG IDs with the loadBalancerRanges attribute so we started creating
external security groups to manage this.  Without having a consistent
set of ports we could rely on, it became a bit of a chicken and egg
problem.  This enables us to know ahead of the creation of the
TargetGroup what ports we should be whitelisting in the ingress rules

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
