### PR TITLE
[stable/spinnaker] add external secret support for GCS

### DIFF
--- a/stable/spinnaker/Chart.yaml
+++ b/stable/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 1.1.8
+version: 1.2.0
 appVersion: 1.9.1
 home: http://spinnaker.io/
 sources:

--- a/stable/spinnaker/templates/secrets/gcs.yaml
+++ b/stable/spinnaker/templates/secrets/gcs.yaml
@@ -2,10 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-{{ if .Values.gce.secret }}
-  name: {{ .Values.gce.secret }}
-{{ else }}
+{{- if .Values.gcs.secret }}
+  name: {{ .Values.gcs.secret }}
+{{- else }}
   name: {{ template "spinnaker.fullname" . }}-gcs
+{{- end }}
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
     component: halyard

--- a/stable/spinnaker/templates/secrets/gcs.yaml
+++ b/stable/spinnaker/templates/secrets/gcs.yaml
@@ -1,7 +1,10 @@
-{{ if .Values.gcs.enabled }}
+{{ if and .Values.gcs.enabled .Values.gcs.jsonKey }}
 apiVersion: v1
 kind: Secret
 metadata:
+{{ if .Values.gce.secret }}
+  name: {{ .Values.gce.secret }}
+{{ else }}
   name: {{ template "spinnaker.fullname" . }}-gcs
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -54,10 +54,11 @@ spec:
       {{- if .Values.gcs.enabled }}
       - name: gcs-key
         secret:
-        {{- if .Values.gce.secretName }}
+        {{- if .Values.gcs.secretName }}
           secretName: {{ .Values.gce.secretName }}
         {{- else }}
           secretName: {{ template "spinnaker.fullname" . }}-gcs
+        {{- end }}
       {{- end }}
       - name: reg-secrets
         secret:

--- a/stable/spinnaker/templates/statefulsets/halyard.yaml
+++ b/stable/spinnaker/templates/statefulsets/halyard.yaml
@@ -54,6 +54,9 @@ spec:
       {{- if .Values.gcs.enabled }}
       - name: gcs-key
         secret:
+        {{- if .Values.gce.secretName }}
+          secretName: {{ .Values.gce.secretName }}
+        {{- else }}
           secretName: {{ template "spinnaker.fullname" . }}-gcs
       {{- end }}
       - name: reg-secrets

--- a/stable/spinnaker/values.yaml
+++ b/stable/spinnaker/values.yaml
@@ -131,7 +131,12 @@ gcs:
   enabled: false
   project: my-project-name
   bucket: "<GCS-BUCKET-NAME>"
+  ## if jsonKey is set, will create a secret containing it
   jsonKey: '<INSERT CLOUD STORAGE JSON HERE>'
+  ## override the name of the secret to use for jsonKey, if `jsonKey`
+  ## is empty, it will not create a secret assuming you are creating one
+  ## external to the chart. the key for that secret should be `key.json`.
+  secretName:
 
 # AWS Simple Storage Service
 s3:


### PR DESCRIPTION
Allow user to supply their own pre-created secret for GCS storage

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
