### PR TITLE
Mysqldump service account injection

### DIFF
--- a/stable/mysqldump/Chart.yaml
+++ b/stable/mysqldump/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.0.0
 description: A Helm chart to help backup MySQL databases using mysqldump
 name: mysqldump
-version: 2.0.2
+version: 2.1.2
 keywords:
 - mysql
 - mysqldump

--- a/stable/mysqldump/README.md
+++ b/stable/mysqldump/README.md
@@ -72,6 +72,9 @@ housekeeping.keepDays           | keep last x days of backups in PVC        | 10
 upload.googlestoragebucket.enabled | upload backups to google storage       | false
 upload.googlestoragebucket.bucketname | google storage address              | gs://mybucket/test
 upload.googlestoragebucket.jsonKeyfile | json keyfile for serviceaccount    | ""
+upload.googlestoragebucket.existingSecret | specify a secretname to use     | nil
+upload.googlestoragebucket.usingGCPController | enable the use of the GCP Service Account Controller     | false
+upload.googlestoragebucket.serviceAccountName | specify a service account name to use     | nil
 upload.ssh.enabled              | upload backups via ssh                    | false
 upload.ssh.user                 | ssh user                                  | backup
 upload.ssh.host                 | ssh server url                            | yourdomain.com
@@ -81,6 +84,9 @@ resources                       | resource definitions                      | {}
 nodeSelector                    | node selector                             | {}
 tolerations                     | tolerations                               | []
 affinity                        | affinity                                  | {}
+
+### Auto generating the gcp service account
+By enabling the flag `upload.googlestoragebucket.usingGCPController` and having a GCP Service Account Controller deployed in your cluster, it is possible to autogenerate and inject the service account used for the storage bucket access. For more information see https://github.com/kiwigrid/helm-charts/tree/master/charts/gcp-serviceaccount-controller
 
 ```console
 $ helm install stable/mysqldump --name my-release \

--- a/stable/mysqldump/files/job.tpl
+++ b/stable/mysqldump/files/job.tpl
@@ -65,6 +65,6 @@ spec:
 {{- if .Values.upload.googlestoragebucket.enabled }}
   - name: gcloud-keyfile
     secret:
-      secretName: {{ template "mysqldump.fullname" . }}-gcloud-keyfile
+      secretName: {{ template "mysqldump.gcpsecretName" . }}
       defaultMode: 256
 {{ end }}

--- a/stable/mysqldump/templates/_helpers.tpl
+++ b/stable/mysqldump/templates/_helpers.tpl
@@ -30,3 +30,17 @@ Create chart name and version as used by the chart label.
 {{- define "mysqldump.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Generate gcp service account secret name
+*/}}
+{{- define "mysqldump.gcpsecretName" -}}
+{{ default ( printf "%s-%s" (include "mysqldump.fullname" .) "gcloud-keyfile" ) .Values.upload.googlestoragebucket.existingSecret }}
+{{- end -}}
+
+{{/*
+Generate gcp service account name
+*/}}
+{{- define "mysqldump.serviceAccountName" -}}
+{{ default (include "mysqldump.fullname" .) .Values.upload.googlestoragebucket.serviceAccountName }}
+{{- end -}}

--- a/stable/mysqldump/templates/configmap.yaml
+++ b/stable/mysqldump/templates/configmap.yaml
@@ -78,7 +78,7 @@ data:
 
     {{ if .Values.upload.googlestoragebucket.enabled }}
     echo "upload files to google storage bucket {{ .Values.upload.googlestoragebucket.bucketname }}"
-    gcloud auth activate-service-account --key-file /root/gcloud/keyfile.json
+    gcloud auth activate-service-account --key-file /root/gcloud/{{ .Values.upload.googlestoragebucket.secretFileName }}
     gsutil -m rsync -x '.*\.state' -d ${BACKUP_DIR}/ {{ .Values.upload.googlestoragebucket.bucketname }}
     rcu=$?
     {{ end }}

--- a/stable/mysqldump/templates/gcpserviceaccount.yaml
+++ b/stable/mysqldump/templates/gcpserviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.upload.googlestoragebucket.usingGCPController }}
+apiVersion: gcp.kiwigrid.com/v1beta1
+kind: GcpServiceAccount
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: {{ template "mysqldump.fullname" . }}
+spec:
+  serviceAccountIdentifier: {{ template "mysqldump.serviceAccountName" . }}
+  serviceAccountDescription: Service account for accessing a storage bucket for mysql backups
+  secretName: {{ template "mysqldump.gcpsecretName" . }}
+  bindings:
+  - resource: buckets/{{ .Values.upload.googlestoragebucket.bucketname | replace "gs://" "" }}
+    roles:
+    - roles/storage.objectAdmin
+    - roles/storage.legacyBucketOwner
+{{ end }}

--- a/stable/mysqldump/templates/gcpserviceaccount.yaml
+++ b/stable/mysqldump/templates/gcpserviceaccount.yaml
@@ -17,5 +17,4 @@ spec:
   - resource: buckets/{{ .Values.upload.googlestoragebucket.bucketname | replace "gs://" "" }}
     roles:
     - roles/storage.objectAdmin
-    - roles/storage.legacyBucketOwner
 {{ end }}

--- a/stable/mysqldump/templates/gcpserviceaccount.yaml
+++ b/stable/mysqldump/templates/gcpserviceaccount.yaml
@@ -4,6 +4,10 @@ kind: GcpServiceAccount
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
+    app.kubernetes.io/name: {{ include "mysqldump.name" . }}
+    helm.sh/chart: {{ include "mysqldump.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ template "mysqldump.fullname" . }}
 spec:
   serviceAccountIdentifier: {{ template "mysqldump.serviceAccountName" . }}

--- a/stable/mysqldump/templates/secret.yaml
+++ b/stable/mysqldump/templates/secret.yaml
@@ -29,6 +29,7 @@ stringData:
 ---
 {{- end }}
 {{- if .Values.upload.googlestoragebucket.enabled }}
+{{- if not .Values.upload.googlestoragebucket.existingSecret }}
 {{- if not .Values.upload.googlestoragebucket.usingGCPController }}
 apiVersion: v1
 kind: Secret
@@ -42,5 +43,6 @@ metadata:
 type: Opaque
 stringData:
   {{ .Values.upload.googlestoragebucket.secretFileName }}: {{ .Values.upload.googlestoragebucket.jsonKeyfile | quote }}
+{{ end }}
 {{ end }}
 {{ end }}

--- a/stable/mysqldump/templates/secret.yaml
+++ b/stable/mysqldump/templates/secret.yaml
@@ -29,10 +29,11 @@ stringData:
 ---
 {{- end }}
 {{- if .Values.upload.googlestoragebucket.enabled }}
+{{- if not .Values.upload.googlestoragebucket.usingGCPController }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ template "mysqldump.fullname" . }}-gcloud-keyfile"
+  name: {{ template "mysqldump.gcpsecretName" . }}
   labels:
     app.kubernetes.io/name: {{ include "mysqldump.name" . }}
     helm.sh/chart: {{ include "mysqldump.chart" . }}
@@ -41,4 +42,5 @@ metadata:
 type: Opaque
 stringData:
   keyfile.json: {{ .Values.upload.googlestoragebucket.jsonKeyfile | quote }}
+{{ end }}
 {{ end }}

--- a/stable/mysqldump/templates/secret.yaml
+++ b/stable/mysqldump/templates/secret.yaml
@@ -41,6 +41,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 stringData:
-  keyfile.json: {{ .Values.upload.googlestoragebucket.jsonKeyfile | quote }}
+  {{ .Values.upload.googlestoragebucket.secretFileName }}: {{ .Values.upload.googlestoragebucket.jsonKeyfile | quote }}
 {{ end }}
 {{ end }}

--- a/stable/mysqldump/values.yaml
+++ b/stable/mysqldump/values.yaml
@@ -68,6 +68,14 @@ upload:
     bucketname: gs://mybucket/test
     # jsonKeyfile of you serviceaccount as string
     jsonKeyfile: ""
+    # secretFileName specifies the keyfile name inside the secret
+    secretFileName: keyfile.json
+    #existingSecret can be enabled to use an existing secret
+    #existingSecret: mysecret
+    #serviceAccountName to set a specific service account name
+    #serviceAccountName
+    #usingGCPController to enable autogeneration and injection of the service account
+    usingGCPController: false
   ssh:
     enabled: false
     user: backup

--- a/stable/mysqldump/values.yaml
+++ b/stable/mysqldump/values.yaml
@@ -70,11 +70,11 @@ upload:
     jsonKeyfile: ""
     # secretFileName specifies the keyfile name inside the secret
     secretFileName: keyfile.json
-    #existingSecret can be enabled to use an existing secret
-    #existingSecret: mysecret
-    #serviceAccountName to set a specific service account name
-    #serviceAccountName
-    #usingGCPController to enable autogeneration and injection of the service account
+    # existingSecret can be enabled to use an existing secret
+    # existingSecret: mysecret
+    # serviceAccountName to set a specific service account name
+    # serviceAccountName
+    # usingGCPController to enable autogeneration and injection of the service account
     usingGCPController: false
   ssh:
     enabled: false


### PR DESCRIPTION
Signed-off-by: tim.smyth <tim.smyth@kiwigrid.com>


#### What this PR does / why we need it:
Adds support for the gcp service account controller to the mysqldump (https://github.com/kiwigrid/gcp-serviceaccount-controller). The controller will create a service account that allows access to the storage bucket and inject the key into the mysqldump.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
