### PR TITLE
Fix/prometheus adapter image pull secrets

### DIFF
--- a/stable/prometheus-adapter/Chart.yaml
+++ b/stable/prometheus-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: prometheus-adapter
-version: v0.4.0
+version: v0.4.1
 appVersion: v0.4.1
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
+++ b/stable/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -67,12 +67,6 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- end }}
-{{- if .Values.image.pullSecrets }}
-      imagePullSecrets:
-{{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
-{{- end }}
-{{- end }}
         securityContext:
           readOnlyRootFilesystem: true
         volumeMounts:
@@ -98,6 +92,12 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
Related with already merged PR #10269 (cc @cpanato ). This has been my bad, sorry guys! I've properly tested it and now it's working fine!

➜ helm upgrade --install --namespace custom-metrics custom-metrics . --set prometheus-adapter.image.pullSecrets={registry.internal-cluster.io.lan} --debug
[debug] Created tunnel using local port: '55514'

[debug] SERVER: "127.0.0.1:55514"

REVISION: 11
RELEASED: Thu Jan 17 12:24:26 2019
CHART: custom-metrics-0.3.0
USER-SUPPLIED VALUES:
prometheus-adapter:
  image:
    pullSecrets:
    - registry.internal-cluster.io.lan

COMPUTED VALUES:
prometheus-adapter:
  affinity: {}
  global: {}
  image:
    pullPolicy: IfNotPresent
    pullSecrets:
    - registry.internal-cluster.io.lan