### PR TITLE
Add ability to configure nodeSelector for fluentd-cloudwatch chart

### DIFF
--- a/incubator/fluentd-cloudwatch/Chart.yaml
+++ b/incubator/fluentd-cloudwatch/Chart.yaml
@@ -1,5 +1,5 @@
 name: fluentd-cloudwatch
-version: 0.6.4
+version: 0.7.0
 appVersion: v0.12.43-cloudwatch
 description: A Fluentd CloudWatch Helm chart for Kubernetes.
 home: https://www.fluentd.org/

--- a/incubator/fluentd-cloudwatch/README.md
+++ b/incubator/fluentd-cloudwatch/README.md
@@ -66,6 +66,7 @@ The following table lists the configurable parameters of the Fluentd Cloudwatch 
 | `rbac.create`                   | If true, create & use RBAC resources                                      | `false`                               |
 | `rbac.serviceAccountName`       | existing ServiceAccount to use (ignored if rbac.create=true)              | `default`                             |
 | `tolerations`                   | Add tolerations                                                           | `[]`                                  |
+| `nodeSelector`                  | Node selector                                                             | `nil`                                 |
 | `extraVars`                     | Add pod environment variables (must be specified as a single line object) | `[]`                                  |
 | `updateStrategy`                | Define daemonset update strategy                                          | `OnDelete`                            |
 

--- a/incubator/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/incubator/fluentd-cloudwatch/templates/daemonset.yaml
@@ -86,5 +86,9 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
   updateStrategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}

--- a/incubator/fluentd-cloudwatch/values.yaml
+++ b/incubator/fluentd-cloudwatch/values.yaml
@@ -25,6 +25,8 @@ tolerations: []
 #     operator: Exists
 #     effect: NoSchedule
 
+nodeSelector: {}
+
 podAnnotations: {}
 
 awsRegion: us-east-1


### PR DESCRIPTION
Signed-off-by: David McDonald <idavidmcdonald@me.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

Add ability to configure nodeSelector - https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#running-pods-on-only-some-nodes

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
@jmcarp 
@icereval 
@kenden 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
