### PR TITLE
Add interval as option to the External-DNS chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description:
+  Configure external DNS servers (AWS Route53, Google CloudDNS and others)
+  for Kubernetes Ingresses and Services
+name: external-dns
+version: 1.3.4
+appVersion: 0.5.9
+home: https://github.com/kubernetes-incubator/external-dns
+sources:
+  - https://github.com/kubernetes-incubator/external-dns
+engine: gotpl
+maintainers:
+- name: rabadin
+  email: rabadin@cisco.com

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,216 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels: {{ include "external-dns.labels" . | indent 4 }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  name: {{ template "external-dns.fullname" . }}
+spec:
+  template:
+    metadata:
+    {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8}}
+    {{- end }}
+      labels: {{ include "external-dns.labels" . | indent 8 }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $sec := .Values.image.pullSecrets }}
+        - name: {{$sec | quote }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      containers:
+        - name: {{ template "external-dns.name" . }}
+          image: "{{.Values.image.name}}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          args:
+          {{- if .Values.logLevel }}
+            - --log-level={{ .Values.logLevel }}
+          {{- end }}
+          {{- if .Values.publishInternalServices }}
+            - --publish-internal-services
+          {{- end }}
+          {{- range .Values.domainFilters }}
+            - --domain-filter={{ . }}
+          {{- end }}
+          {{- range .Values.zoneIdFilters }}
+            - --zone-id-filter={{ . }}
+          {{- end }}
+            - --policy={{ .Values.policy }}
+            - --provider={{ .Values.provider }}
+            - --registry={{ .Values.registry }}
+            - --interval={{ .Values.interval }}
+          {{- if .Values.txtOwnerId }}
+            - --txt-owner-id={{ .Values.txtOwnerId }}
+          {{- end }}
+          {{- if .Values.txtPrefix }}
+            - --txt-prefix={{ .Values.txtPrefix }}
+          {{- end }}
+          {{- if .Values.annotationFilter }}
+            - --annotation-filter={{ .Values.annotationFilter }}
+          {{- end }}
+          {{- range .Values.sources }}
+            - --source={{ . }}
+          {{- end }}
+          {{- range $key, $value := .Values.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+          {{- end }}
+          {{- if eq .Values.provider "cloudflare" }}
+            {{- if .Values.cloudflare.proxied }}
+            - --cloudflare-proxied
+            {{- end }}
+          {{- end }}
+          {{- if .Values.aws.zoneType }}
+            - --aws-zone-type={{ .Values.aws.zoneType }}
+          {{- end }}
+          {{- if .Values.google.project }}
+            - --google-project={{ .Values.google.project }}
+          {{- end }}
+          {{- if eq .Values.provider "infoblox" }}
+            - --infoblox-grid-host={{ .Values.infoblox.gridHost }}
+            {{- if .Values.infoblox.domainFilter }}
+            - --domain-filter={{ .Values.infoblox.domainFilter }}
+            {{- end }}
+            {{- if .Values.infoblox.wapiPort }}
+            - --infoblox-wapi-port={{ .Values.infoblox.wapiPort }}
+            {{- end }}
+            {{- if .Values.infoblox.wapiVersion }}
+            - --infoblox-wapi-version={{ .Values.infoblox.wapiVersion }}
+            {{- end }}
+            {{- if .Values.infoblox.noSslVerify }}
+            - --no-infoblox-ssl-verify
+            {{- else }}
+            - --infoblox-ssl-verify
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+          {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
+          - name: google-service-account
+            mountPath: /etc/secrets/service-account/
+          {{- end}}
+          {{- if eq .Values.provider "azure" }}
+          - name: azure-config-file
+            {{- if not .Values.azure.secretName }}
+            mountPath: /etc/kubernetes/azure.json
+            {{- else }}
+            mountPath: /etc/kubernetes/
+            {{- end }}
+            readOnly: true
+          {{- end }}
+          {{- if (and .Values.aws.secretKey .Values.aws.accessKey) }}
+          - name: aws-credentials
+            mountPath: {{ .Values.aws.credentialsPath }}
+            readOnly: true
+          {{- end }}
+          env:
+        {{- if or .Values.google.serviceAccountSecret .Values.google.serviceAccountKey }}
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/secrets/service-account/credentials.json
+        {{- end }}
+        {{- if or (eq .Values.provider "aws") (eq .Values.provider "aws-sd") }}
+        {{- if .Values.aws.region }}
+          - name: AWS_DEFAULT_REGION
+            value: {{ .Values.aws.region }}
+        {{- end }}
+        {{- end }}
+        {{- if and .Values.cloudflare.apiKey .Values.cloudflare.email }}
+          - name: CF_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: cloudflare_api_key
+          - name: CF_API_EMAIL
+            value: "{{ .Values.cloudflare.email }}"
+        {{- end }}
+        {{- if .Values.infoblox.wapiConnectionPoolSize }}
+          - name: EXTERNAL_DNS_INFOBLOX_HTTP_POOL_CONNECTIONS
+            value: "{{ .Values.infoblox.wapiConnectionPoolSize }}"
+        {{- end }}
+        {{- if .Values.infoblox.wapiHttpTimeout }}
+          - name: EXTERNAL_DNS_INFOBLOX_HTTP_REQUEST_TIMEOUT
+            value: "{{ .Values.infoblox.wapiHttpTimeout }}"
+        {{- end }}
+        {{- if and .Values.infoblox.wapiUsername .Values.infoblox.wapiPassword }}
+          - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: infoblox_wapi_username
+          - name: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" . }}
+                key: infoblox_wapi_password
+        {{- end }}
+        {{- $root := . -}}
+        {{- range .Values.extraEnv }}
+          - name: {{ .name }}
+            valueFrom:
+          {{- if .valueFrom }}
+{{ toYaml .valueFrom | indent 14 }}
+          {{- else }}
+              secretKeyRef:
+                name: {{ template "external-dns.fullname" $root }}
+                key: {{ .name }}
+          {{- end }}
+        {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 7979
+          ports:
+            - containerPort: 7979
+        {{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+        {{- end }}
+        {{- if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        {{- end }}
+      volumes:
+      {{- if .Values.google.serviceAccountSecret }}
+      - name: google-service-account
+        secret:
+          secretName: {{ .Values.google.serviceAccountSecret | quote }}
+      {{- else if .Values.google.serviceAccountKey }}
+      - name: google-service-account
+        secret:
+          secretName: {{ template "external-dns.fullname" . }}
+      {{- end}}
+      {{- if eq .Values.provider "azure" }}
+      - name: azure-config-file
+        {{- if (not .Values.azure.secretName)}}
+        hostPath:
+          path: /etc/kubernetes/azure.json
+          type: File
+        {{- else}}
+        secret:
+          secretName: {{.Values.azure.secretName}}
+        {{- end}}
+      {{- end }}
+      {{- if (and .Values.aws.secretKey .Values.aws.accessKey) }}
+      - name: aws-credentials
+        secret:
+          secretName: {{ template "external-dns.fullname" . }}
+      {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+      serviceAccountName: {{ if .Values.rbac.create }}{{ template "external-dns.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,149 @@
+## Details about the image to be pulled.
+image:
+  name: registry.opensource.zalan.do/teapot/external-dns
+  tag: v0.5.9
+  pullSecrets: []
+  pullPolicy: IfNotPresent
+
+## This controls which types of resource external-dns should 'watch' for new
+## DNS entries.
+sources:
+  - service
+  - ingress
+
+# Allow external-dns to publish DNS records for ClusterIP services (optional)
+publishInternalServices: false
+
+## The DNS provider where the DNS records will be created (options: aws, google, inmemory, azure )
+provider: aws
+
+# AWS Access keys to inject as environment variables
+aws:
+  secretKey: ""
+  accessKey: ""
+  # pre external-dns 0.5.9 home dir should be `/root/.aws`
+  credentialsPath: "/.aws"
+  roleArn: ""
+  region: "us-east-1"
+  # Filter for zones of this type (optional, options: public, private)
+  zoneType: ""
+
+azure:
+# If you don't specify a secret to load azure.json from, you will get the host's /etc/kubernetes/azure.json
+  secretName: ""
+
+# Cloudflare keys to inject as environment variables
+cloudflare:
+  apiKey: ""
+  email: ""
+  proxied: true
+# When using the Google provider, specify the Google project (required when provider=google)
+google:
+  project: ""
+  serviceAccountSecret: ""
+  serviceAccountKey: ""
+
+# Infoblox keys to inject
+infoblox:
+  # Required keys:
+  wapiUsername: ""
+  wapiPassword: ""
+  gridHost: ""
+  # Optional keys:
+  domainFilter: ""
+  noSslVerify: false
+  wapiPort: ""
+  wapiVersion: ""
+  wapiConnectionPoolSize: ""
+  wapiHttpTimeout: ""
+
+## Limit possible target zones by domain suffixes (optional)
+domainFilters: []
+## Limit possible target zones by zone id (optional)
+zoneIdFilters: []
+# Filter sources managed by external-dns via annotation using label selector semantics (default: all sources)
+annotationFilter: ""
+# Adjust the interval for DNS updates
+interval: "1m"
+
+# Registry to use for ownership (txt or noop)
+registry: "txt"
+
+# When using the TXT registry, a name that identifies this instance of ExternalDNS
+txtOwnerId: ""
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## List of node taints to tolerate (requires Kubernetes >= 1.6)
+tolerations: []
+
+## Modify how DNS records are sychronized between sources and providers (options: sync, upsert-only )
+policy: upsert-only
+
+## Annotations to be added to pods
+##
+podAnnotations: {}
+
+podLabels: {}
+
+# Verbosity of the logs (options: panic, debug, info, warn, error, fatal)
+logLevel: info
+
+extraArgs: {}
+
+# Extra environment variables which will be saved in a release-specific secret
+# or retrieved via valueFrom.
+# extraEnv:
+# - name: SECRET_TO_SAVE
+#   value: secret_value
+# - name: AWS_ACCESS_KEY_ID
+#   valueFrom:
+#     secretKeyRef:
+#       name: existing-secret
+#       key: access-key-id
+extraEnv: []
+
+## CPU and Memory limit and request for external-dns
+resources: {}
+#  limits:
+#    memory: 50Mi
+#  requests:
+#    memory: 50Mi
+#    cpu: 10m
+
+rbac:
+  ## If true, create & use RBAC resources
+  ##
+  create: false
+  # Beginning with Kubernetes 1.8, the api is stable and v1 can be used.
+  apiVersion: v1beta1
+
+  ## Ignored if rbac.create is true
+  ##
+  serviceAccountName: default
+
+securityContext: {}
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 65534 # 65534 is nobody - revise aws.credentialsPath when changing uid
+  # capabilities:
+  #   drop: ["ALL"]
+
+service:
+  annotations: {}
+  clusterIP: ""
+
+  ## List of IP addresses at which the service is available
+  ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
+  ##
+  externalIPs: []
+
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  servicePort: 7979
+  type: ClusterIP
+
+priorityClassName: ""


### PR DESCRIPTION
Add interval as an option to the Chart.
    The default is 1m and this has caused some issues with AWS route53 ratelimit.
    This option give you the capability to set the interval
    
    Signed-off-by: Colm Monks <colmomonks@gmail.com>

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Currently the hidden default option for interval = 1 minute
We encountered issues with rate Limit exceeded on AWS route53.
Adjusting the interval helps reduce this issue. Useful for test systems.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
