### PR TITLE
[stable/mysql] Improve empty MySQL passwords

### DIFF
--- a/stable/mysql/Chart.yaml
+++ b/stable/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 name: mysql
-version: 0.13.1
+version: 0.13.2
 appVersion: 5.7.14
 description: Fast, reliable, scalable, and easy to use open-source relational database
   system.

--- a/stable/mysql/templates/deployment.yaml
+++ b/stable/mysql/templates/deployment.yaml
@@ -52,18 +52,23 @@ spec:
         {{- if .Values.mysqlAllowEmptyPassword }}
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        {{- else }}
+        {{- end }}
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mysql.secretName" . }}
               key: mysql-root-password
+              {{- if .Values.mysqlAllowEmptyPassword }}
+              optional: true
+              {{- end }}
         - name: MYSQL_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mysql.secretName" . }}
               key: mysql-password
-        {{- end }}
+              {{- if or .Values.mysqlAllowEmptyPassword (empty .Values.mysqlUser) }}
+              optional: true
+              {{- end }}
         - name: MYSQL_USER
           value: {{ default "" .Values.mysqlUser | quote }}
         - name: MYSQL_DATABASE


### PR DESCRIPTION
#### What this PR does / why we need it:

This commit contains two changes related to passwords:

Make secret referenced env vars optional when mysqlAllowEmptyPassword is true
This allows setting a password AND making empty passwords possible.

Make user password optional when there is no username
User password is used to create a user which happens only when
the user is also defined in the chart values.
However, the user is not required, so the chart install
fails when an existing secret does not have a user password configured.

#### Which issue this PR fixes

Fixes chart installation when user is not defined and an existing secret does not have a user password configured.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [x] Chart Version bumped
